### PR TITLE
xfce.mousepad: Build shortcuts plugin

### DIFF
--- a/pkgs/desktops/xfce/applications/mousepad/default.nix
+++ b/pkgs/desktops/xfce/applications/mousepad/default.nix
@@ -1,10 +1,13 @@
 { lib
 , mkXfceDerivation
+, fetchpatch2
 , gobject-introspection
 , glib
 , gtk3
 , gtksourceview4
 , gspell
+, libxfce4ui
+, xfconf
 , enablePolkit ? true
 , polkit
 }:
@@ -17,6 +20,15 @@ mkXfceDerivation {
 
   sha256 = "sha256-A4siNxbTf9ObJJg8inPuH7Lo4dckLbFljV6aPFQxRto=";
 
+  patches = [
+    # shortcuts-plugin: Fix shortcuts-editor include
+    # https://gitlab.xfce.org/apps/mousepad/-/merge_requests/131
+    (fetchpatch2 {
+      url = "https://gitlab.xfce.org/apps/mousepad/-/commit/d2eb43ae4d692cc4753647111eb3deebfa26abbb.patch";
+      hash = "sha256-Ldn0ZVmCzqG8lOkeaazkodEMip3lTm/lJEhfsL8TyT8=";
+    })
+  ];
+
   nativeBuildInputs = [ gobject-introspection ];
 
   buildInputs = [
@@ -24,6 +36,8 @@ mkXfceDerivation {
     gtk3
     gtksourceview4
     gspell
+    libxfce4ui # for shortcut plugin
+    xfconf # required by libxfce4kbd-private-3
   ] ++ lib.optionals enablePolkit [
     polkit
   ];


### PR DESCRIPTION
See "Edit" -> "Preferences" -> "Plugins" -> "Shortcuts Editor".

https://gitlab.xfce.org/apps/mousepad/-/commit/8de8f04ca5e3e73d62f0acb5f79920dd8038b937



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
