### PR TITLE
pcre2: add patch to fix JIT support autodetection

### DIFF
--- a/pkgs/development/libraries/pcre2/default.nix
+++ b/pkgs/development/libraries/pcre2/default.nix
@@ -4,14 +4,19 @@
 , withJitSealloc ? true
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pcre2";
   version = "10.43";
 
   src = fetchurl {
-    url = "https://github.com/PhilipHazel/pcre2/releases/download/pcre2-${version}/pcre2-${version}.tar.bz2";
+    url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${finalAttrs.version}/pcre2-${finalAttrs.version}.tar.bz2";
     hash = "sha256-4qU5hP8LB9/bWuRIa7ubIcyo598kNAlsyb8bcow1C8s=";
   };
+
+  patches = [
+    # Remove this patch when version > 10.43.
+   ./fix-jit-support-autodetection.patch
+  ];
 
   configureFlags = [
     "--enable-pcre2-16"
@@ -31,8 +36,10 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://www.pcre.org/";
     description = "Perl Compatible Regular Expressions";
+    changelog = "https://github.com/PCRE2Project/pcre2/blob/pcre2-${finalAttrs.version}/ChangeLog";
     license = licenses.bsd3;
     maintainers = with maintainers; [ ttuegel ];
+    mainProgram = "pcre2grep";
     platforms = platforms.all;
     pkgConfigModules = [
       "libpcre2-posix"
@@ -41,4 +48,4 @@ stdenv.mkDerivation rec {
       "libpcre2-32"
     ];
   };
-}
+})

--- a/pkgs/development/libraries/pcre2/fix-jit-support-autodetection.patch
+++ b/pkgs/development/libraries/pcre2/fix-jit-support-autodetection.patch
@@ -1,0 +1,11 @@
+--- a/configure
++++ b/configure
+@@ -14325,6 +14325,6 @@
+ /* end confdefs.h.  */
+ 
+   #define SLJIT_CONFIG_AUTO 1
+-  #include "src/sljit/sljitConfigInternal.h"
++  #include "src/sljit/sljitConfigCPU.h"
+   #if (defined SLJIT_CONFIG_UNSUPPORTED && SLJIT_CONFIG_UNSUPPORTED)
+   #error unsupported
+Mark set


### PR DESCRIPTION
## Description of changes

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc