### PR TITLE
kdePackages.discover: disable PackageKit backend

### DIFF
--- a/pkgs/kde/lib/mk-kde-derivation.nix
+++ b/pkgs/kde/lib/mk-kde-derivation.nix
@@ -78,11 +78,15 @@ in
     extraNativeBuildInputs ? [],
     extraPropagatedBuildInputs ? [],
     extraCmakeFlags ? [],
+    excludeDependencies ? [],
     ...
   } @ args: let
+    depNames = dependencies.${pname} or [];
+    filteredDepNames = builtins.filter (dep: !(builtins.elem dep excludeDependencies)) depNames;
+
     # FIXME(later): this is wrong for cross, some of these things really need to go into nativeBuildInputs,
     # but cross is currently very broken anyway, so we can figure this out later.
-    deps = map (dep: self.${dep}) (dependencies.${pname} or []);
+    deps = map (dep: self.${dep}) filteredDepNames;
 
     defaultArgs = {
       inherit version src;
@@ -109,6 +113,7 @@ in
       "extraNativeBuildInputs"
       "extraPropagatedBuildInputs"
       "extraCmakeFlags"
+      "excludeDependencies"
       "meta"
     ];
 

--- a/pkgs/kde/plasma/discover/default.nix
+++ b/pkgs/kde/plasma/discover/default.nix
@@ -11,4 +11,8 @@ mkKdeDerivation {
 
   extraNativeBuildInputs = [pkg-config];
   extraBuildInputs = [qtwebview discount flatpak fwupd];
+
+  # The PackageKit backend doesn't work for us and causes Discover
+  # to freak out when loading. Disable it to not confuse users.
+  excludeDependencies = ["packagekit-qt"];
 }


### PR DESCRIPTION
## Description of changes

It doesn't work and the errors are confusing.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
