### PR TITLE
plemoljp, plemoljp-nf, plemoljp-hs: init at 1.7.1

### DIFF
--- a/pkgs/by-name/pl/plemoljp-hs/package.nix
+++ b/pkgs/by-name/pl/plemoljp-hs/package.nix
@@ -1,0 +1,30 @@
+{ lib, stdenvNoCC, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "plemoljp-hs";
+  version = "1.7.1";
+
+  src = fetchzip {
+    url = "https://github.com/yuru7/PlemolJP/releases/download/v${version}/PlemolJP_HS_v${version}.zip";
+    hash = "sha256-JbuKBU1TT0qE89N61jX+WF25PBRHo/RSAtdPa5Ni8og=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 PlemolJP_HS/*.ttf -t $out/share/fonts/truetype/${pname}
+    install -Dm444 PlemolJP35_HS/*.ttf -t $out/share/fonts/truetype/${pname}-35
+    install -Dm444 PlemolJPConsole_HS/*.ttf -t $out/share/fonts/truetype/${pname}-console
+    install -Dm444 PlemolJP35Console_HS/*.ttf -t $out/share/fonts/truetype/${pname}-35console
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A composite font of IBM Plex Mono, IBM Plex Sans JP and hidden full-width space";
+    homepage = "https://github.com/yuru7/PlemolJP";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ kachick ];
+  };
+}

--- a/pkgs/by-name/pl/plemoljp-nf/package.nix
+++ b/pkgs/by-name/pl/plemoljp-nf/package.nix
@@ -1,0 +1,28 @@
+{ lib, stdenvNoCC, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "plemoljp-nf";
+  version = "1.7.1";
+
+  src = fetchzip {
+    url = "https://github.com/yuru7/PlemolJP/releases/download/v${version}/PlemolJP_NF_v${version}.zip";
+    hash = "sha256-nxGvaHLs65z4CSy/smy+koQyuYcDXJKjPZt5NusUN3E=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 PlemolJPConsole_NF/*.ttf -t $out/share/fonts/truetype/${pname}-console
+    install -Dm444 PlemolJP35Console_NF/*.ttf -t $out/share/fonts/truetype/${pname}-35console
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A composite font of IBM Plex Mono, IBM Plex Sans JP and nerd-fonts";
+    homepage = "https://github.com/yuru7/PlemolJP";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ kachick ];
+  };
+}

--- a/pkgs/by-name/pl/plemoljp/package.nix
+++ b/pkgs/by-name/pl/plemoljp/package.nix
@@ -1,0 +1,30 @@
+{ lib, stdenvNoCC, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "plemoljp";
+  version = "1.7.1";
+
+  src = fetchzip {
+    url = "https://github.com/yuru7/PlemolJP/releases/download/v${version}/PlemolJP_v${version}.zip";
+    hash = "sha256-YH1c/2jk8QZNyPvzRZjxNHyNeci9tjn+oOW8xLd8kjk=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 PlemolJP/*.ttf -t $out/share/fonts/truetype/${pname}
+    install -Dm444 PlemolJP35/*.ttf -t $out/share/fonts/truetype/${pname}-35
+    install -Dm444 PlemolJPConsole/*.ttf -t $out/share/fonts/truetype/${pname}-console
+    install -Dm444 PlemolJP35Console/*.ttf -t $out/share/fonts/truetype/${pname}-35console
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A composite font of IBM Plex Mono and IBM Plex Sans JP";
+    homepage = "https://github.com/yuru7/PlemolJP";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ kachick ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/yuru7/PlemolJP

A Japanese composite font, based on "IBM Plex Mono" and "IBM Plex Sans JP".  
Both IBM Plex and PlemolJP are licensed under the "OFL-1.1" license.

- https://github.com/IBM/plex/blob/a4e292151ee177d98a370ae442895d10d79ccb2b/LICENSE.txt#L9
- https://github.com/yuru7/PlemolJP/blob/f8f7abb07f7d44c3bdbf09d87f527dbe17764dc9/LICENSE#L8-L19

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true` (default)
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
