### PR TITLE
scion: use buildGo121Module

### DIFF
--- a/pkgs/by-name/sc/scion/package.nix
+++ b/pkgs/by-name/sc/scion/package.nix
@@ -1,5 +1,5 @@
 { lib
-, buildGoModule
+, buildGo121Module
 , fetchFromGitHub
 }:
 let
@@ -18,7 +18,7 @@ let
     '';
 in
 
-buildGoModule {
+buildGo121Module {
   pname = "scion";
 
   inherit version;


### PR DESCRIPTION
## Description of changes

Fixes a failing upstream test that fails when using `buildGo122Module`

```
--- FAIL: TestEncoding (0.00s)
    --- FAIL: TestEncoding/error_list (0.00s)
        errors_test.go:256: 
                Error Trace:    /build/source/pkg/private/serrors/errors_test.go:256
                Error:          Not equal: 
                                expected: "{\"err\":[{\"ctx1\":\"val1\",\"msg\":\"test err\",\"stacktrace\":[\"pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:227\",\"testing.tRunner src/testing/testing.go:1595\",\"runtime.goexit src/runtime/asm_amd64.s:1650\"]},{\"msg\":\"test err2\",\"stacktrace\":[\"pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:228\",\"testing.tRunner src/testing/testing.go:1595\",\"runtime.goexit src/runtime/asm_amd64.s:1650\"]}],\"level\":\"info\",\"msg\":\"Failed to do thing\"}"
                                actual  : "{\"err\":[{\"ctx1\":\"val1\",\"msg\":\"test err\",\"stacktrace\":[\"pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:227\",\"testing.tRunner src/testing/testing.go:1689\",\"runtime.goexit src/runtime/asm_amd64.s:1695\"]},{\"msg\":\"test err2\",\"stacktrace\":[\"pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:228\",\"testing.tRunner src/testing/testing.go:1689\",\"runtime.goexit src/runtime/asm_amd64.s:1695\"]}],\"level\":\"info\",\"msg\":\"Failed to do thing\"}"
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -{"err":[{"ctx1":"val1","msg":"test err","stacktrace":["pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:227","testing.tRunner src/testing/testing.go:1595","runtime.goexit src/runtime/asm_amd64.s:1650"]},{"msg":"test err2","stacktrace":["pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:228","testing.tRunner src/testing/testing.go:1595","runtime.goexit src/runtime/asm_amd64.s:1650"]}],"level":"info","msg":"Failed to do thing"}
                                +{"err":[{"ctx1":"val1","msg":"test err","stacktrace":["pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:227","testing.tRunner src/testing/testing.go:1689","runtime.goexit src/runtime/asm_amd64.s:1695"]},{"msg":"test err2","stacktrace":["pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:228","testing.tRunner src/testing/testing.go:1689","runtime.goexit src/runtime/asm_amd64.s:1695"]}],"level":"info","msg":"Failed to do thing"}
                Test:           TestEncoding/error_list
    --- FAIL: TestEncoding/new_with_context (0.00s)
        errors_test.go:256: 
                Error Trace:    /build/source/pkg/private/serrors/errors_test.go:256
                Error:          Not equal: 
                                expected: "{\"err\":{\"k0\":\"v0\",\"k1\":1,\"msg\":\"err msg\",\"stacktrace\":[\"pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:191\",\"testing.tRunner src/testing/testing.go:1595\",\"runtime.goexit src/runtime/asm_amd64.s:1650\"]},\"level\":\"info\",\"msg\":\"Failed to do thing\"}"
                                actual  : "{\"err\":{\"k0\":\"v0\",\"k1\":1,\"msg\":\"err msg\",\"stacktrace\":[\"pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:191\",\"testing.tRunner src/testing/testing.go:1689\",\"runtime.goexit src/runtime/asm_amd64.s:1695\"]},\"level\":\"info\",\"msg\":\"Failed to do thing\"}"
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -{"err":{"k0":"v0","k1":1,"msg":"err msg","stacktrace":["pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:191","testing.tRunner src/testing/testing.go:1595","runtime.goexit src/runtime/asm_amd64.s:1650"]},"level":"info","msg":"Failed to do thing"}
                                +{"err":{"k0":"v0","k1":1,"msg":"err msg","stacktrace":["pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:191","testing.tRunner src/testing/testing.go:1689","runtime.goexit src/runtime/asm_amd64.s:1695"]},"level":"info","msg":"Failed to do thing"}
                Test:           TestEncoding/new_with_context
    --- FAIL: TestEncoding/wrapped_string (0.00s)
        errors_test.go:256: 
                Error Trace:    /build/source/pkg/private/serrors/errors_test.go:256
                Error:          Not equal: 
                                expected: "{\"err\":{\"cause\":{\"msg\":\"msg cause\",\"stacktrace\":[\"pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:197\",\"testing.tRunner src/testing/testing.go:1595\",\"runtime.goexit src/runtime/asm_amd64.s:1650\"]},\"k0\":\"v0\",\"k1\":1,\"msg\":\"msg error\"},\"level\":\"info\",\"msg\":\"Failed to do thing\"}"
                                actual  : "{\"err\":{\"cause\":{\"msg\":\"msg cause\",\"stacktrace\":[\"pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:197\",\"testing.tRunner src/testing/testing.go:1689\",\"runtime.goexit src/runtime/asm_amd64.s:1695\"]},\"k0\":\"v0\",\"k1\":1,\"msg\":\"msg error\"},\"level\":\"info\",\"msg\":\"Failed to do thing\"}"
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -{"err":{"cause":{"msg":"msg cause","stacktrace":["pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:197","testing.tRunner src/testing/testing.go:1595","runtime.goexit src/runtime/asm_amd64.s:1650"]},"k0":"v0","k1":1,"msg":"msg error"},"level":"info","msg":"Failed to do thing"}
                                +{"err":{"cause":{"msg":"msg cause","stacktrace":["pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:197","testing.tRunner src/testing/testing.go:1689","runtime.goexit src/runtime/asm_amd64.s:1695"]},"k0":"v0","k1":1,"msg":"msg error"},"level":"info","msg":"Failed to do thing"}
                Test:           TestEncoding/wrapped_string
    --- FAIL: TestEncoding/wrapped_with_context (0.00s)
        errors_test.go:256: 
                Error Trace:    /build/source/pkg/private/serrors/errors_test.go:256
                Error:          Not equal: 
                                expected: "{\"err\":{\"cause\":{\"cause_ctx_key\":\"cause_ctx_val\",\"msg\":\"msg cause\",\"stacktrace\":[\"pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:206\",\"testing.tRunner src/testing/testing.go:1595\",\"runtime.goexit src/runtime/asm_amd64.s:1650\"]},\"k0\":\"v0\",\"k1\":1,\"msg\":\"msg error\"},\"level\":\"info\",\"msg\":\"Failed to do thing\"}"
                                actual  : "{\"err\":{\"cause\":{\"cause_ctx_key\":\"cause_ctx_val\",\"msg\":\"msg cause\",\"stacktrace\":[\"pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:206\",\"testing.tRunner src/testing/testing.go:1689\",\"runtime.goexit src/runtime/asm_amd64.s:1695\"]},\"k0\":\"v0\",\"k1\":1,\"msg\":\"msg error\"},\"level\":\"info\",\"msg\":\"Failed to do thing\"}"
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -{"err":{"cause":{"cause_ctx_key":"cause_ctx_val","msg":"msg cause","stacktrace":["pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:206","testing.tRunner src/testing/testing.go:1595","runtime.goexit src/runtime/asm_amd64.s:1650"]},"k0":"v0","k1":1,"msg":"msg error"},"level":"info","msg":"Failed to do thing"}
                                +{"err":{"cause":{"cause_ctx_key":"cause_ctx_val","msg":"msg cause","stacktrace":["pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:206","testing.tRunner src/testing/testing.go:1689","runtime.goexit src/runtime/asm_amd64.s:1695"]},"k0":"v0","k1":1,"msg":"msg error"},"level":"info","msg":"Failed to do thing"}
                Test:           TestEncoding/wrapped_with_context
    --- FAIL: TestEncoding/wrapped_error (0.00s)
        errors_test.go:256: 
                Error Trace:    /build/source/pkg/private/serrors/errors_test.go:256
                Error:          Not equal: 
                                expected: "{\"err\":{\"cause\":{\"msg\":\"msg cause\",\"stacktrace\":[\"pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:215\",\"testing.tRunner src/testing/testing.go:1595\",\"runtime.goexit src/runtime/asm_amd64.s:1650\"]},\"k0\":\"v0\",\"k1\":1,\"msg\":{\"msg\":\"msg error\",\"stacktrace\":[\"pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:214\",\"testing.tRunner src/testing/testing.go:1595\",\"runtime.goexit src/runtime/asm_amd64.s:1650\"]}},\"level\":\"info\",\"msg\":\"Failed to do thing\"}"
                                actual  : "{\"err\":{\"cause\":{\"msg\":\"msg cause\",\"stacktrace\":[\"pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:215\",\"testing.tRunner src/testing/testing.go:1689\",\"runtime.goexit src/runtime/asm_amd64.s:1695\"]},\"k0\":\"v0\",\"k1\":1,\"msg\":{\"msg\":\"msg error\",\"stacktrace\":[\"pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:214\",\"testing.tRunner src/testing/testing.go:1689\",\"runtime.goexit src/runtime/asm_amd64.s:1695\"]}},\"level\":\"info\",\"msg\":\"Failed to do thing\"}"
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -{"err":{"cause":{"msg":"msg cause","stacktrace":["pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:215","testing.tRunner src/testing/testing.go:1595","runtime.goexit src/runtime/asm_amd64.s:1650"]},"k0":"v0","k1":1,"msg":{"msg":"msg error","stacktrace":["pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:214","testing.tRunner src/testing/testing.go:1595","runtime.goexit src/runtime/asm_amd64.s:1650"]}},"level":"info","msg":"Failed to do thing"}
                                +{"err":{"cause":{"msg":"msg cause","stacktrace":["pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:215","testing.tRunner src/testing/testing.go:1689","runtime.goexit src/runtime/asm_amd64.s:1695"]},"k0":"v0","k1":1,"msg":{"msg":"msg error","stacktrace":["pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:214","testing.tRunner src/testing/testing.go:1689","runtime.goexit src/runtime/asm_amd64.s:1695"]}},"level":"info","msg":"Failed to do thing"}
                Test:           TestEncoding/wrapped_error
    --- FAIL: TestEncoding/error_with_context (0.00s)
        errors_test.go:256: 
                Error Trace:    /build/source/pkg/private/serrors/errors_test.go:256
                Error:          Not equal: 
                                expected: "{\"err\":{\"msg\":{\"msg\":\"simple err\",\"stacktrace\":[\"pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:222\",\"testing.tRunner src/testing/testing.go:1595\",\"runtime.goexit src/runtime/asm_amd64.s:1650\"]},\"someCtx\":\"someValue\"},\"level\":\"info\",\"msg\":\"Failed to do thing\"}"
                                actual  : "{\"err\":{\"msg\":{\"msg\":\"simple err\",\"stacktrace\":[\"pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:222\",\"testing.tRunner src/testing/testing.go:1689\",\"runtime.goexit src/runtime/asm_amd64.s:1695\"]},\"someCtx\":\"someValue\"},\"level\":\"info\",\"msg\":\"Failed to do thing\"}"
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -{"err":{"msg":{"msg":"simple err","stacktrace":["pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:222","testing.tRunner src/testing/testing.go:1595","runtime.goexit src/runtime/asm_amd64.s:1650"]},"someCtx":"someValue"},"level":"info","msg":"Failed to do thing"}
                                +{"err":{"msg":{"msg":"simple err","stacktrace":["pkg/private/serrors/go_default_test_test.TestEncoding pkg/private/serrors/errors_test.go:222","testing.tRunner src/testing/testing.go:1689","runtime.goexit src/runtime/asm_amd64.s:1695"]},"someCtx":"someValue"},"level":"info","msg":"Failed to do thing"}
                Test:           TestEncoding/error_with_context
FAIL
FAIL    github.com/scionproto/scion/pkg/private/serrors 0.005s
FAIL
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
