### PR TITLE
mpdevil 1.11.1 -> plattenalbum 2.0.1

### DIFF
--- a/pkgs/applications/audio/mpdevil/default.nix
+++ b/pkgs/applications/audio/mpdevil/default.nix
@@ -1,25 +1,25 @@
 { lib, fetchFromGitHub
-, pkg-config, meson ,ninja
+, pkg-config, meson, ninja
 , python3Packages
-, gdk-pixbuf, glib, gobject-introspection, gtk3
+, gdk-pixbuf, glib, gobject-introspection, gtk4, libadwaita, desktop-file-utils
 , libnotify
 , wrapGAppsHook }:
 
 python3Packages.buildPythonApplication rec {
   pname = "mpdevil";
-  version = "1.11.0";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "SoongNoonien";
     repo = pname;
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-ooNZSsVtIeueqgj9hR9OZp08qm8gGokiq8IU3U/ZV5w=";
+    sha256 = "sha256-rxHtcKbvwoOteSD3gC0uEp+3GCUFpKWoicznELVilpY=";
   };
 
   format = "other";
 
   nativeBuildInputs = [
-    glib.dev gobject-introspection gtk3 pkg-config meson ninja wrapGAppsHook
+    glib.dev gobject-introspection gtk4 pkg-config meson ninja wrapGAppsHook desktop-file-utils libadwaita
   ];
 
   buildInputs = [

--- a/pkgs/by-name/pl/plattenalbum/package.nix
+++ b/pkgs/by-name/pl/plattenalbum/package.nix
@@ -1,9 +1,18 @@
-{ lib, fetchFromGitHub
-, pkg-config, meson, ninja
+{ lib
+, fetchFromGitHub
+, pkg-config
+, meson
+, ninja
 , python3Packages
-, gdk-pixbuf, glib, gobject-introspection, gtk4, libadwaita, desktop-file-utils
+, gdk-pixbuf
+, glib
+, gobject-introspection
+, gtk4
+, libadwaita
+, desktop-file-utils
 , libnotify
-, wrapGAppsHook }:
+, wrapGAppsHook
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "plattenalbum";
@@ -11,23 +20,38 @@ python3Packages.buildPythonApplication rec {
 
   src = fetchFromGitHub {
     owner = "SoongNoonien";
-    repo = pname;
+    repo = "plattenalbum";
     rev = "refs/tags/v${version}";
     sha256 = "sha256-rxHtcKbvwoOteSD3gC0uEp+3GCUFpKWoicznELVilpY=";
   };
 
-  format = "other";
+  pyproject = false;
 
   nativeBuildInputs = [
-    glib.dev gobject-introspection gtk4 pkg-config meson ninja wrapGAppsHook desktop-file-utils libadwaita
+    glib.dev
+    gobject-introspection
+    gtk4
+    pkg-config
+    meson
+    ninja
+    wrapGAppsHook
+    desktop-file-utils
+    libadwaita
   ];
 
   buildInputs = [
-    gdk-pixbuf glib libnotify
+    gdk-pixbuf
+    glib
+    libnotify
   ];
 
   propagatedBuildInputs = with python3Packages; [
-    beautifulsoup4 distutils-extra mpd2 notify-py pygobject3 requests
+    beautifulsoup4
+    distutils-extra
+    mpd2
+    notify-py
+    pygobject3
+    requests
   ];
 
   postInstall = ''

--- a/pkgs/by-name/pl/plattenalbum/package.nix
+++ b/pkgs/by-name/pl/plattenalbum/package.nix
@@ -6,7 +6,7 @@
 , wrapGAppsHook }:
 
 python3Packages.buildPythonApplication rec {
-  pname = "mpdevil";
+  pname = "plattenalbum";
   version = "2.0.1";
 
   src = fetchFromGitHub {
@@ -40,17 +40,17 @@ python3Packages.buildPythonApplication rec {
 
   # Prevent double wrapping.
   dontWrapGApps = true;
-  # Otherwise wrapGAppsHook do not pick up the dependencies correctly.
+  # Otherwise wrapGAppsHook does not pick up the dependencies correctly.
   strictDeps = false;
   # There aren't any checks.
   doCheck = false;
 
   meta = with lib; {
     description = "A simple music browser for MPD";
-    homepage = "https://github.com/SoongNoonien/mpdevil";
+    homepage = "https://github.com/SoongNoonien/plattenalbum";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ apfelkuchen6 ];
-    mainProgram = "mpdevil";
+    mainProgram = "plattenalbum";
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -792,6 +792,7 @@ mapAliases ({
   mozart = throw "'mozart' has been renamed to/replaced by 'mozart2-binary'"; # Converted to throw 2023-09-10
   mpc_cli = mpc-cli; # moved from top-level 2022-01-24
   mpd_clientlib = libmpdclient; # Added 2021-02-11
+  mpdevil = plattenalbum; #  Added 2024-03-24
   mumble_git = throw "'mumble_git' has been renamed to/replaced by 'pkgs.mumble'"; # Converted to throw 2023-09-10
   murmur_git = throw "'murmur_git' has been renamed to/replaced by 'pkgs.murmur'"; # Converted to throw 2023-09-10
   mutt-with-sidebar = mutt; # Added 2022-09-17

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3980,8 +3980,6 @@ with pkgs;
 
   mobilecoin-wallet = callPackage ../applications/misc/mobilecoin-wallet { };
 
-  mpdevil = callPackage ../applications/audio/mpdevil { };
-
   pacparser = callPackage ../tools/networking/pacparser { };
 
   pairdrop = callPackage ../applications/misc/pairdrop { };


### PR DESCRIPTION
## Description of changes

This updates mpdevil to the latest version 2.0.1, which now uses gtk4 and libabwaita.

The project was also rebranded to plattenalbum (See https://github.com/SoongNoonien/mpdevil/discussions/94), so this adjusts the derivation and attribute names accordingly and adds an alias.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
