### PR TITLE
testers.lycheeLinkCheck: init

### DIFF
--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -38,15 +38,11 @@ passthru.tests.pkg-config = testers.hasPkgConfigModules {
 
 ## `lycheeLinkCheck` {#tester-lycheeLinkCheck}
 
-Check that internal hyperlinks are correct, using the [`lychee` package](https://search.nixos.org/packages?show=lychee&type=packages&query=lychee).
+Check a packaged static site's links with the [`lychee` package](https://search.nixos.org/packages?show=lychee&type=packages&query=lychee).
 
-When building the check, only an offline check is performed, so that network access is not required.
+You may use Nix to reproducibly build documentation sites and other static sites. Some packages will install documentation in their `out` or `doc` outputs, or maybe you have dedicated package where you've made your static site reproducible by running a generator (like [Hugo](https://gohugo.io/), or [mdBook](https://rust-lang.github.io/mdBook/)) in a derivation.
 
-If you'd like to run the check with network access, the returned attribute `online` can be invoked with [`nix run`](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-run) ([experimental](https://nixos.org/manual/nix/stable/contributing/experimental-features#xp-feature-nix-command)). For example:
-
-```shell
-nix run nixpkgs#lychee.tests.ok.online
-```
+If you have a static site that is buildable in Nix, you can use `lycheeLinkCheck` to check that the hyperlinks in your site are correct, and do so as part of your Nix workflow and CI.
 
 :::{.example #ex-lycheelinkcheck}
 
@@ -59,6 +55,20 @@ testers.lycheeLinkCheck {
 ```
 
 :::
+
+### Return value {#tester-lycheeLinkCheck-return}
+
+This tester produces a package that does not produce useful outputs, but only succeeds if the hyperlinks in your site are correct. The build log will list the broken links.
+
+You may use it in two modes:
+
+- Use the returned package directly, and the build process will check that internal hyperlinks are correct. This runs in the sandbox, so it will not check external hyperlinks, but it is quick and reliable.
+
+- Invoke the `.online` with [`nix run`](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-run) ([experimental](https://nixos.org/manual/nix/stable/contributing/experimental-features#xp-feature-nix-command)). This runs outside the sandbox, and check that bith internal and external hyperlinks are correct. Example:
+
+  ```shell
+  nix run nixpkgs#lychee.tests.ok.online
+  ```
 
 ### Parameters {#tester-lycheeLinkCheck-params}
 

--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -40,7 +40,13 @@ passthru.tests.pkg-config = testers.hasPkgConfigModules {
 
 Check that internal hyperlinks are correct, using the [`lychee` package](https://search.nixos.org/packages?show=lychee&type=packages&query=lychee).
 
-Only an offline check is performed, so that network access is not required.
+When building the check, only an offline check is performed, so that network access is not required.
+
+If you'd like to run the check with network access, the returned attribute `online` can be invoked with [`nix run`](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-run) ([experimental](https://nixos.org/manual/nix/stable/contributing/experimental-features#xp-feature-nix-command)). For example:
+
+```shell
+nix run nixpkgs#lychee.tests.ok.online
+```
 
 :::{.example #ex-lycheelinkcheck}
 

--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -36,6 +36,45 @@ passthru.tests.pkg-config = testers.hasPkgConfigModules {
 
 :::
 
+## `lycheeLinkCheck` {#tester-lycheeLinkCheck}
+
+Check that internal hyperlinks are correct, using the [`lychee` package](https://search.nixos.org/packages?show=lychee&type=packages&query=lychee).
+
+Only an offline check is performed, so that network access is not required.
+
+:::{.example #ex-lycheelinkcheck}
+
+# Check hyperlinks in the `nix` documentation
+
+```nix
+testers.lycheeLinkCheck {
+  site = nix.doc + "/share/doc/nix/manual";
+}
+```
+
+:::
+
+### Parameters {#tester-lycheeLinkCheck-params}
+
+#### `site` (required) {#tester-lycheeLinkCheck-param-site}
+
+The path to the files to check.
+
+#### `extraConfig` (optional) {#tester-lycheeLinkCheck-param-extraConfig}
+
+Extra configuration to pass to `lychee` in its [config file](https://github.com/lycheeverse/lychee/blob/master/lychee.example.toml). It is automatically [translated](https://nixos.org/manual/nixos/stable/index.html#sec-settings-nix-representable) to TOML.
+
+Example: `{ "include_verbatim" = true; }`
+
+#### `lychee` (optional) {#tester-lycheeLinkCheck-param-lychee}
+
+The `lychee` package to use.
+
+#### `remapUrl` (optional) {#tester-lycheeLinkCheck-param-remapUrl}
+
+A URL to which the files may be deployed.
+Instead of ignoring this URL because the check is offline, `lychee` will check that the links to this URL are correct, by pretending `site` is deployed there.
+
 ## `testVersion` {#tester-testVersion}
 
 Checks that the output from running a command contains the specified version string in it as a whole word.

--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -89,7 +89,14 @@ It has two modes:
 
   Before checking the existence of a URL, the regular expressions are matched and replaced by their corresponding values.
 
-  Example: `{ "https://blog\\.example\\.com" = site; }`
+  Example:
+
+  ```nix
+  {
+    "https://nix\\.dev/manual/nix/[a-z0-9.-]*" = "${nix.doc}/share/doc/nix/manual";
+    "https://nixos\\.org/manual/nix/(un)?stable" = "${emptyDirectory}/placeholder-to-disallow-old-nix-docs-urls";
+  }
+  ```
 
   Store path in the attribute values are automatically prefixed with `file://`, because lychee requires this for paths in the file system.
   If this is a problem, or if you need to control the order in which replacements are performed, use `extraConfig.remap` instead.

--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -40,9 +40,10 @@ passthru.tests.pkg-config = testers.hasPkgConfigModules {
 
 Check a packaged static site's links with the [`lychee` package](https://search.nixos.org/packages?show=lychee&type=packages&query=lychee).
 
-You may use Nix to reproducibly build documentation sites and other static sites. Some packages will install documentation in their `out` or `doc` outputs, or maybe you have dedicated package where you've made your static site reproducible by running a generator (like [Hugo](https://gohugo.io/), or [mdBook](https://rust-lang.github.io/mdBook/)) in a derivation.
+You may use Nix to reproducibly build documentation sites and other static sites.
+Some packages will install documentation in their `out` or `doc` outputs, or maybe you have dedicated package where you've made your static site reproducible by running a generator, such as [Hugo](https://gohugo.io/) or [mdBook](https://rust-lang.github.io/mdBook/), in a derivation.
 
-If you have a static site that is buildable in Nix, you can use `lycheeLinkCheck` to check that the hyperlinks in your site are correct, and do so as part of your Nix workflow and CI.
+If you have a static site that can be built with Nix, you can use `lycheeLinkCheck` to check that the hyperlinks in your site are correct, and do so as part of your Nix workflow and CI.
 
 :::{.example #ex-lycheelinkcheck}
 
@@ -60,37 +61,33 @@ testers.lycheeLinkCheck {
 
 This tester produces a package that does not produce useful outputs, but only succeeds if the hyperlinks in your site are correct. The build log will list the broken links.
 
-You may use it in two modes:
+It has two modes:
 
 - Use the returned package directly, and the build process will check that internal hyperlinks are correct. This runs in the sandbox, so it will not check external hyperlinks, but it is quick and reliable.
 
-- Invoke the `.online` with [`nix run`](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-run) ([experimental](https://nixos.org/manual/nix/stable/contributing/experimental-features#xp-feature-nix-command)). This runs outside the sandbox, and check that bith internal and external hyperlinks are correct. Example:
+- Invoke the `.online` attribute with [`nix run`](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-run) ([experimental](https://nixos.org/manual/nix/stable/contributing/experimental-features#xp-feature-nix-command)). This runs outside the sandbox, and check that both internal and external hyperlinks are correct.
+  Example:
 
   ```shell
   nix run nixpkgs#lychee.tests.ok.online
   ```
 
-### Parameters {#tester-lycheeLinkCheck-params}
+### Inputs {#tester-lycheeLinkCheck-inputs}
 
-#### `site` (required) {#tester-lycheeLinkCheck-param-site}
+`site` (path or derivation) {#tester-lycheeLinkCheck-param-site}
 
-The path to the files to check.
+: The path to the files to check.
 
-#### `extraConfig` (optional) {#tester-lycheeLinkCheck-param-extraConfig}
+`extraConfig` (attribute set) {#tester-lycheeLinkCheck-param-extraConfig}
 
-Extra configuration to pass to `lychee` in its [config file](https://github.com/lycheeverse/lychee/blob/master/lychee.example.toml). It is automatically [translated](https://nixos.org/manual/nixos/stable/index.html#sec-settings-nix-representable) to TOML.
+: Extra configuration to pass to `lychee` in its [configuration file](https://github.com/lycheeverse/lychee/blob/master/lychee.example.toml).
+  It is automatically [translated](https://nixos.org/manual/nixos/stable/index.html#sec-settings-nix-representable) to TOML.
 
-Example: `{ "include_verbatim" = true; }`
+  Example: `{ "include_verbatim" = true; }`
 
-#### `lychee` (optional) {#tester-lycheeLinkCheck-param-lychee}
+`lychee` (derivation, optional) {#tester-lycheeLinkCheck-param-lychee}
 
-The `lychee` package to use.
-
-#### `remapUrl` (optional) {#tester-lycheeLinkCheck-param-remapUrl}
-
-A URL to which the files may be deployed.
-Instead of ignoring this URL because the check is offline, `lychee` will check that the links to this URL are correct, by pretending `site` is deployed there.
-
+: The `lychee` package to use.
 ## `testVersion` {#tester-testVersion}
 
 Checks that the output from running a command contains the specified version string in it as a whole word.

--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -78,6 +78,19 @@ It has two modes:
 
 : The path to the files to check.
 
+`remap` (attribe set, optional) {#tester-lycheeLinkCheck-param-remap}
+
+: An attribute set where the attribute names are the URLs to remap.
+
+  The values should be store path strings, derivations or path values.
+
+  Before checking the existence of URLs, if it is equal to the attribute name, it is replaced by the value of the attribute.
+  If it is a subpath of the attribute name, it is replaced by a subpath of the value.
+
+  This is useful for remapping URLs that are not accessible from the build environment.
+
+  Example: `{ "https://blog.example.com" = site; }`
+
 `extraConfig` (attribute set) {#tester-lycheeLinkCheck-param-extraConfig}
 
 : Extra configuration to pass to `lychee` in its [configuration file](https://github.com/lycheeverse/lychee/blob/master/lychee.example.toml).
@@ -88,6 +101,7 @@ It has two modes:
 `lychee` (derivation, optional) {#tester-lycheeLinkCheck-param-lychee}
 
 : The `lychee` package to use.
+
 ## `testVersion` {#tester-testVersion}
 
 Checks that the output from running a command contains the specified version string in it as a whole word.

--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -63,9 +63,9 @@ This tester produces a package that does not produce useful outputs, but only su
 
 It has two modes:
 
-- Use the returned package directly, and the build process will check that internal hyperlinks are correct. This runs in the sandbox, so it will not check external hyperlinks, but it is quick and reliable.
+- Build the returned derivation; its build process will check that internal hyperlinks are correct. This runs in the sandbox, so it will not check external hyperlinks, but it is quick and reliable.
 
-- Invoke the `.online` attribute with [`nix run`](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-run) ([experimental](https://nixos.org/manual/nix/stable/contributing/experimental-features#xp-feature-nix-command)). This runs outside the sandbox, and check that both internal and external hyperlinks are correct.
+- Invoke the `.online` attribute with [`nix run`](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-run) ([experimental](https://nixos.org/manual/nix/stable/contributing/experimental-features#xp-feature-nix-command)). This runs outside the sandbox, and checks that both internal and external hyperlinks are correct.
   Example:
 
   ```shell
@@ -80,16 +80,19 @@ It has two modes:
 
 `remap` (attribe set, optional) {#tester-lycheeLinkCheck-param-remap}
 
-: An attribute set where the attribute names are the URLs to remap.
+: An attribute set where the attribute names are regular expressions.
+  The values should be strings, derivations or path values.
 
-  The values should be store path strings, derivations or path values.
+  In the returned check's default configuration, external URLs are only checked when you run the `.online` attribute.
 
-  Before checking the existence of URLs, if it is equal to the attribute name, it is replaced by the value of the attribute.
-  If it is a subpath of the attribute name, it is replaced by a subpath of the value.
+  By adding remappings, you can check offline that URLs to external resources are correct, by providing a file system based stand-in.
 
-  This is useful for remapping URLs that are not accessible from the build environment.
+  Before checking the existence of a URL, the regular expressions are matched and replaced by their corresponding values.
 
-  Example: `{ "https://blog.example.com" = site; }`
+  Example: `{ "https://blog\\.example\\.com" = site; }`
+
+  Store path in the attribute values are automatically prefixed with `file://`, because lychee requires this for paths in the file system.
+  If this is a problem, or if you need to control the order in which replacements are performed, use `extraConfig.remap` instead.
 
 `extraConfig` (attribute set) {#tester-lycheeLinkCheck-param-extraConfig}
 

--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -40,7 +40,7 @@ passthru.tests.pkg-config = testers.hasPkgConfigModules {
 
 Check a packaged static site's links with the [`lychee` package](https://search.nixos.org/packages?show=lychee&type=packages&query=lychee).
 
-You may use Nix to reproducibly build documentation sites and other static sites.
+You may use Nix to reproducibly build static websites, such as for software documentation.
 Some packages will install documentation in their `out` or `doc` outputs, or maybe you have dedicated package where you've made your static site reproducible by running a generator, such as [Hugo](https://gohugo.io/) or [mdBook](https://rust-lang.github.io/mdBook/), in a derivation.
 
 If you have a static site that can be built with Nix, you can use `lycheeLinkCheck` to check that the hyperlinks in your site are correct, and do so as part of your Nix workflow and CI.
@@ -81,11 +81,11 @@ It has two modes:
 `remap` (attribe set, optional) {#tester-lycheeLinkCheck-param-remap}
 
 : An attribute set where the attribute names are regular expressions.
-  The values should be strings, derivations or path values.
+  The values should be strings, derivations, or path values.
 
   In the returned check's default configuration, external URLs are only checked when you run the `.online` attribute.
 
-  By adding remappings, you can check offline that URLs to external resources are correct, by providing a file system based stand-in.
+  By adding remappings, you can check offline that URLs to external resources are correct, by providing a stand-in from the file system.
 
   Before checking the existence of a URL, the regular expressions are matched and replaced by their corresponding values.
 
@@ -98,7 +98,7 @@ It has two modes:
   }
   ```
 
-  Store path in the attribute values are automatically prefixed with `file://`, because lychee requires this for paths in the file system.
+  Store paths in the attribute values are automatically prefixed with `file://`, because lychee requires this for paths in the file system.
   If this is a problem, or if you need to control the order in which replacements are performed, use `extraConfig.remap` instead.
 
 `extraConfig` (attribute set) {#tester-lycheeLinkCheck-param-extraConfig}

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -1,6 +1,10 @@
 { pkgs, pkgsLinux, buildPackages, lib, callPackage, runCommand, stdenv, substituteAll, testers }:
 # Documentation is in doc/builders/testers.chapter.md
 {
+  # See https://nixos.org/manual/nixpkgs/unstable/#tester-lycheeLinkCheck
+  # or doc/builders/testers.chapter.md
+  inherit (callPackage ./lychee.nix {}) lycheeLinkCheck;
+
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-testBuildFailure
   # or doc/builders/testers.chapter.md
   testBuildFailure = drv: drv.overrideAttrs (orig: {

--- a/pkgs/build-support/testers/lychee.nix
+++ b/pkgs/build-support/testers/lychee.nix
@@ -1,0 +1,37 @@
+deps@{ formats, lib, lychee, stdenv }:
+let
+
+  # See https://nixos.org/manual/nixpkgs/unstable/#tester-lycheeLinkCheck
+  # or doc/builders/testers.chapter.md
+  lycheeLinkCheck = {
+    site,
+    remapUrl ? null,
+    lychee ? deps.lychee,
+    extraConfig ? { },
+  }:
+    stdenv.mkDerivation (finalAttrs: {
+      name = "lychee-link-check";
+      inherit site;
+      nativeBuildInputs = [ finalAttrs.passthru.lychee ];
+      configFile = (formats.toml {}).generate "lychee.toml" finalAttrs.passthru.config;
+
+      # These can be overriden with overrideAttrs if needed.
+      passthru = {
+        inherit lychee remapUrl;
+        config = {
+          include_fragments = true;
+        } // lib.optionalAttrs (finalAttrs.passthru.remapUrl != null) {
+          remap = [ "${remapUrl} file://${finalAttrs.site}" ];
+        } // extraConfig;
+      };
+      buildCommand = ''
+        echo Checking internal links on $site
+        lychee --offline --config $configFile $site
+        touch $out
+      '';
+    });
+
+in
+{
+  inherit lycheeLinkCheck;
+}

--- a/pkgs/build-support/testers/lychee.nix
+++ b/pkgs/build-support/testers/lychee.nix
@@ -1,12 +1,13 @@
 deps@{ formats, lib, lychee, stdenv, writeShellApplication }:
 let
-  inherit (lib) concatLists isPath mapAttrsToList;
+  inherit (lib) isPath mapAttrsToList;
   inherit (lib.strings) hasPrefix;
 
   toURL = v:
     if builtins.isString v && hasPrefix builtins.storeDir v
       || isPath v
-    then "file://${v}"
+    then # lychee requires that paths on the file system are prefixed with file://
+      "file://${v}"
     else "${v}";
 
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-lycheeLinkCheck

--- a/pkgs/build-support/testers/lychee.nix
+++ b/pkgs/build-support/testers/lychee.nix
@@ -4,11 +4,11 @@ let
   inherit (lib.strings) hasPrefix;
 
   toURL = v:
-    if builtins.isString v && hasPrefix builtins.storeDir v
-      || isPath v
+    let s = "${v}";
+    in if hasPrefix builtins.storeDir s
     then # lychee requires that paths on the file system are prefixed with file://
-      "file://${v}"
-    else "${v}";
+      "file://${s}"
+    else s;
 
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-lycheeLinkCheck
   # or doc/builders/testers.chapter.md

--- a/pkgs/build-support/testers/lychee.nix
+++ b/pkgs/build-support/testers/lychee.nix
@@ -1,4 +1,4 @@
-deps@{ formats, lib, lychee, stdenv }:
+deps@{ formats, lib, lychee, stdenv, writeShellApplication }:
 let
 
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-lycheeLinkCheck
@@ -23,6 +23,18 @@ let
         } // lib.optionalAttrs (finalAttrs.passthru.remapUrl != null) {
           remap = [ "${remapUrl} file://${finalAttrs.site}" ];
         } // extraConfig;
+        online = writeShellApplication {
+          name = "run-lychee-online";
+          runtimeInputs = [ finalAttrs.passthru.lychee ];
+          # Comment out to run shellcheck:
+          checkPhase = "";
+          text = ''
+            site=${finalAttrs.site}
+            configFile=${finalAttrs.configFile}
+            echo Checking links on $site
+            exec lychee --config $configFile $site "$@"
+          '';
+        };
       };
       buildCommand = ''
         echo Checking internal links on $site

--- a/pkgs/build-support/testers/lychee.nix
+++ b/pkgs/build-support/testers/lychee.nix
@@ -11,9 +11,12 @@ let
     else s;
 
   withCheckedName = name:
-    throwIf
-      (hasInfix " " name)
-      "lycheeLinkCheck: remap patterns must not contain spaces. A space marks the end of the regex in lychee.toml. Please change attribute name remap.${escapeNixString name}";
+    throwIf (hasInfix " " name) ''
+      lycheeLinkCheck: remap patterns must not contain spaces.
+      A space marks the end of the regex in lychee.toml.
+
+      Please change attribute name 'remap.${escapeNixString name}'
+    '';
 
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-lycheeLinkCheck
   # or doc/builders/testers.chapter.md

--- a/pkgs/build-support/testers/test/default.nix
+++ b/pkgs/build-support/testers/test/default.nix
@@ -12,6 +12,8 @@ let
 
 in
 lib.recurseIntoAttrs {
+  lycheeLinkCheck = lib.recurseIntoAttrs pkgs.lychee.tests;
+
   hasPkgConfigModules = pkgs.callPackage ../hasPkgConfigModules/tests.nix { };
 
   runNixOSTest-example = pkgs-with-overlay.testers.runNixOSTest ({ lib, ... }: {

--- a/pkgs/tools/networking/lychee/default.nix
+++ b/pkgs/tools/networking/lychee/default.nix
@@ -48,6 +48,7 @@ rustPlatform.buildRustPackage rec {
     #       Which is true most of the time, but not necessarily after overriding.
     ok = callPackage ./tests/ok.nix { };
     fail = callPackage ./tests/fail.nix { };
+    fail-emptyDirectory = callPackage ./tests/fail-emptyDirectory.nix { };
     network = testers.runNixOSTest ./tests/network.nix;
   };
 

--- a/pkgs/tools/networking/lychee/default.nix
+++ b/pkgs/tools/networking/lychee/default.nix
@@ -1,4 +1,5 @@
-{ lib
+{ callPackage
+, lib
 , stdenv
 , rustPlatform
 , fetchFromGitHub
@@ -40,6 +41,13 @@ rustPlatform.buildRustPackage rec {
     "--skip=collector::tests"
     "--skip=src/lib.rs"
   ];
+
+  passthru.tests = {
+    # NOTE: These assume that testers.lycheeLinkCheck uses this exact derivation.
+    #       Which is true most of the time, but not necessarily after overriding.
+    ok = callPackage ./tests/ok.nix { };
+    fail = callPackage ./tests/fail.nix { };
+  };
 
   meta = with lib; {
     description = "A fast, async, stream-based link checker written in Rust";

--- a/pkgs/tools/networking/lychee/default.nix
+++ b/pkgs/tools/networking/lychee/default.nix
@@ -7,6 +7,7 @@
 , openssl
 , Security
 , SystemConfiguration
+, testers
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -47,6 +48,7 @@ rustPlatform.buildRustPackage rec {
     #       Which is true most of the time, but not necessarily after overriding.
     ok = callPackage ./tests/ok.nix { };
     fail = callPackage ./tests/fail.nix { };
+    network = testers.runNixOSTest ./tests/network.nix;
   };
 
   meta = with lib; {

--- a/pkgs/tools/networking/lychee/tests/fail-emptyDirectory.nix
+++ b/pkgs/tools/networking/lychee/tests/fail-emptyDirectory.nix
@@ -1,0 +1,28 @@
+{ runCommand, testers, emptyDirectory }:
+let
+  sitePkg = runCommand "site" { } ''
+    dist=$out/dist
+    mkdir -p $dist
+    echo "<html><body><a href=\"https://example.com/foo\">foo</a></body></html>" > $dist/index.html
+    echo "<html><body></body></html>" > $dist/foo.html
+  '';
+  check = testers.lycheeLinkCheck {
+    site = sitePkg + "/dist";
+    remap = {
+      # Normally would recommend to append a subpath that hints why it's forbidden; see example in docs.
+      # However, we also want to test that a package is converted to a string *before*
+      # it's tested whether it's a store path. Mistake made during development caused:
+      # cannot check URI: InvalidUrlRemap("The remapping pattern must produce a valid URL, but it is not: /nix/store/4d0ix...empty-directory/foo
+      "https://example.com" = emptyDirectory;
+    };
+  };
+
+  failure = testers.testBuildFailure check;
+in
+  runCommand "link-check-fail" { inherit failure; } ''
+    # The details of the message might change, but we have to make sure the
+    # correct error is reported, so that we know it's not something else that
+    # went wrong.
+    grep 'empty-directory/foo.*Cannot find file' $failure/testBuildFailure.log >/dev/null
+    touch $out
+  ''

--- a/pkgs/tools/networking/lychee/tests/fail.nix
+++ b/pkgs/tools/networking/lychee/tests/fail.nix
@@ -9,7 +9,7 @@ let
 
   linkCheck = testers.lycheeLinkCheck rec {
     site = sitePkg + "/dist";
-    remap = { "https://example.com"= site; };
+    remap = { "https://exampl[e]\\.com" = site; };
   };
 
   failure = testers.testBuildFailure linkCheck;

--- a/pkgs/tools/networking/lychee/tests/fail.nix
+++ b/pkgs/tools/networking/lychee/tests/fail.nix
@@ -1,0 +1,21 @@
+{ runCommand, testers }:
+let
+  sitePkg = runCommand "site" { } ''
+    dist=$out/dist
+    mkdir -p $dist
+    echo "<html><body><a href=\"https://example.com/foo.html#butwhere\">foo</a></body></html>" > $dist/index.html
+    echo "<html><body><a href=\".\">index</a></body></html>" > $dist/foo.html
+  '';
+
+  linkCheck = testers.lycheeLinkCheck {
+    site = sitePkg + "/dist";
+    remapUrl = "https://example.com";
+  };
+
+  failure = testers.testBuildFailure linkCheck;
+
+in
+  runCommand "link-check-fail" { inherit failure; } ''
+    grep -F butwhere $failure/testBuildFailure.log >/dev/null
+    touch $out
+  ''

--- a/pkgs/tools/networking/lychee/tests/fail.nix
+++ b/pkgs/tools/networking/lychee/tests/fail.nix
@@ -3,7 +3,7 @@ let
   sitePkg = runCommand "site" { } ''
     dist=$out/dist
     mkdir -p $dist
-    echo "<html><body><a href=\"https://example.com/foo.html#butwhere\">foo</a></body></html>" > $dist/index.html
+    echo "<html><body><a href=\"https://example.com/foo.html#foos-missing-anchor\">foo</a></body></html>" > $dist/index.html
     echo "<html><body><a href=\".\">index</a></body></html>" > $dist/foo.html
   '';
 
@@ -16,6 +16,6 @@ let
 
 in
   runCommand "link-check-fail" { inherit failure; } ''
-    grep -F butwhere $failure/testBuildFailure.log >/dev/null
+    grep -F foos-missing-anchor $failure/testBuildFailure.log >/dev/null
     touch $out
   ''

--- a/pkgs/tools/networking/lychee/tests/fail.nix
+++ b/pkgs/tools/networking/lychee/tests/fail.nix
@@ -7,9 +7,9 @@ let
     echo "<html><body><a href=\".\">index</a></body></html>" > $dist/foo.html
   '';
 
-  linkCheck = testers.lycheeLinkCheck {
+  linkCheck = testers.lycheeLinkCheck rec {
     site = sitePkg + "/dist";
-    remapUrl = "https://example.com";
+    remap = { "https://example.com"= site; };
   };
 
   failure = testers.testBuildFailure linkCheck;

--- a/pkgs/tools/networking/lychee/tests/network.nix
+++ b/pkgs/tools/networking/lychee/tests/network.nix
@@ -1,0 +1,66 @@
+{ config, hostPkgs, lib, ... }:
+let
+  sitePkg = hostPkgs.runCommand "site" { } ''
+    dist=$out/dist
+    mkdir -p $dist
+    echo "<html><body><a href=\"http://example/foo.html\">foo</a></body></html>" > $dist/index.html
+    echo "<html><body><a href=\".\">index</a></body></html>" > $dist/foo.html
+  '';
+  check = config.node.pkgs.testers.lycheeLinkCheck {
+    site = sitePkg;
+  };
+in
+{
+  name = "testers-lychee-link-check-run";
+  nodes.client = { ... }: { };
+  nodes.example = {
+    networking.firewall.allowedTCPPorts = [ 80 ];
+    services.nginx = {
+      enable = true;
+      virtualHosts."example" = {
+        locations."/" = {
+          root = "/var/www/example";
+          index = "index.html";
+        };
+      };
+    };
+
+  };
+  testScript = ''
+    start_all()
+
+    # SETUP
+
+    example.succeed("""
+        mkdir -p /var/www/example
+        echo '<h1>hi</h1>' > /var/www/example/index.html
+    """)
+    client.wait_until_succeeds("""
+        curl --fail -v http://example
+    """)
+
+    # FAILURE CASE
+
+    client.succeed("""
+        exec 1>&2
+        r=0
+        ${lib.getExe check.online} || {
+          r=$?
+        }
+        if [[ $r -ne 2 ]]; then
+            echo "lycheeLinkCheck unexpected exit code $r"
+            exit 1
+        fi
+    """)
+
+    # SUCCESS CASE
+
+    example.succeed("""
+        echo '<h1>foo</h1>' > /var/www/example/foo.html
+    """)
+
+    client.succeed("""
+        ${lib.getExe check.online}
+    """)
+  '';
+}

--- a/pkgs/tools/networking/lychee/tests/ok.nix
+++ b/pkgs/tools/networking/lychee/tests/ok.nix
@@ -1,0 +1,12 @@
+{ runCommand, testers }:
+let
+  sitePkg = runCommand "site" { } ''
+    dist=$out/dist
+    mkdir -p $dist
+    echo "<html><body><a href=\"https://example.com/foo.html\">foo</a></body></html>" > $dist/index.html
+    echo "<html><body><a href=\".\">index</a></body></html>" > $dist/foo.html
+  '';
+in testers.lycheeLinkCheck {
+  site = sitePkg + "/dist";
+  remapUrl = "https://example.com";
+}

--- a/pkgs/tools/networking/lychee/tests/ok.nix
+++ b/pkgs/tools/networking/lychee/tests/ok.nix
@@ -6,7 +6,7 @@ let
     echo "<html><body><a href=\"https://example.com/foo.html\">foo</a></body></html>" > $dist/index.html
     echo "<html><body><a href=\".\">index</a></body></html>" > $dist/foo.html
   '';
-in testers.lycheeLinkCheck {
+in testers.lycheeLinkCheck rec {
   site = sitePkg + "/dist";
-  remapUrl = "https://example.com";
+  remap = { "https://example.com" = site; };
 }

--- a/pkgs/tools/networking/lychee/tests/ok.nix
+++ b/pkgs/tools/networking/lychee/tests/ok.nix
@@ -3,7 +3,7 @@ let
   sitePkg = runCommand "site" { } ''
     dist=$out/dist
     mkdir -p $dist
-    echo "<html><body><a href=\"https://example.com/foo.html\">foo</a></body></html>" > $dist/index.html
+    echo "<html><body><a href=\"https://example.com/foo.html\">foo</a><a href=\"https://nixos.org/this-is-ignored.html\">bar</a></body></html>" > $dist/index.html
     echo "<html><body><a href=\".\">index</a></body></html>" > $dist/foo.html
   '';
 in testers.lycheeLinkCheck rec {


### PR DESCRIPTION
## Description of changes

- Add a helper to perform an offline, internal link check.

- Add passthru `tests` to the `lychee` package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
