### PR TITLE
use botan3 in more places

### DIFF
--- a/pkgs/applications/editors/rehex/default.nix
+++ b/pkgs/applications/editors/rehex/default.nix
@@ -5,7 +5,7 @@
 , which
 , zip
 , libicns
-, botan2
+, botan3
 , capstone
 , jansson
 , libunistring
@@ -32,14 +32,17 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config which zip ]
     ++ lib.optionals stdenv.isDarwin [ libicns ];
 
-  buildInputs = [ botan2 capstone jansson libunistring wxGTK32 ]
+  buildInputs = [ botan3 capstone jansson libunistring wxGTK32 ]
     ++ (with lua53Packages; [ lua busted ])
     ++ (with perlPackages; [ perl TemplateToolkit ])
     ++ lib.optionals stdenv.isLinux [ gtk3 ]
     ++ lib.optionals stdenv.isDarwin [ Carbon Cocoa IOKit ];
 
-  makeFlags = [ "prefix=${placeholder "out"}" ]
-    ++ lib.optionals stdenv.isDarwin [ "-f Makefile.osx" ];
+  makeFlags = [
+    "prefix=${placeholder "out"}"
+    "BOTAN_PKG=botan-3"
+    "CXXSTD=-std=c++20"
+  ] ++ lib.optionals stdenv.isDarwin [ "-f Makefile.osx" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/misc/corectrl/default.nix
+++ b/pkgs/applications/misc/corectrl/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv
 , fetchFromGitLab
 , extra-cmake-modules
-, botan2
+, botan3
 , karchive
 , kauth
 , libdrm
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec{
     wrapQtAppsHook
   ];
   buildInputs = [
-    botan2
+    botan3
     karchive
     kauth
     libdrm

--- a/pkgs/applications/misc/keepassxc/default.nix
+++ b/pkgs/applications/misc/keepassxc/default.nix
@@ -5,7 +5,7 @@
 , qttools
 
 , asciidoctor
-, botan2
+, botan3
 , curl
 , libXi
 , libXtst
@@ -114,7 +114,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     curl
-    botan2
+    botan3
     libXi
     libXtst
     libargon2

--- a/pkgs/development/libraries/botan/3.0.nix
+++ b/pkgs/development/libraries/botan/3.0.nix
@@ -1,7 +1,9 @@
-{ callPackage, ... } @ args:
+{ callPackage, stdenv, lib, ... } @ args:
 
 callPackage ./generic.nix (args // {
   baseVersion = "3.4";
   revision = "0";
   hash = "sha256-cYQ6/MCixYX48z+jBPC1iuS5xdgwb4lGZ7N0YEQndVc=";
+  # this patch fixes build errors on MacOS with SDK 10.12, recheck to remove this again
+  extraPatches = lib.optionals stdenv.hostPlatform.isDarwin [ ./botan3-macos.patch ];
 })

--- a/pkgs/development/libraries/botan/botan3-macos.patch
+++ b/pkgs/development/libraries/botan/botan3-macos.patch
@@ -1,0 +1,48 @@
+diff --git a/src/lib/prov/commoncrypto/commoncrypto_block.cpp b/src/lib/prov/commoncrypto/commoncrypto_block.cpp
+index a07fe118d..f059ee497 100644
+--- a/src/lib/prov/commoncrypto/commoncrypto_block.cpp
++++ b/src/lib/prov/commoncrypto/commoncrypto_block.cpp
+@@ -11,6 +11,7 @@
+ #include <botan/hex.h>
+ #include <botan/internal/commoncrypto_utils.h>
+ 
++#include <CommonCrypto/CommonCryptoError.h>
+ #include <CommonCrypto/CommonCrypto.h>
+ 
+ namespace Botan {
+diff --git a/src/lib/prov/commoncrypto/commoncrypto_hash.cpp b/src/lib/prov/commoncrypto/commoncrypto_hash.cpp
+index 1fb79c419..faf9575c2 100644
+--- a/src/lib/prov/commoncrypto/commoncrypto_hash.cpp
++++ b/src/lib/prov/commoncrypto/commoncrypto_hash.cpp
+@@ -11,6 +11,7 @@
+ #include <botan/internal/stl_util.h>
+ #include <unordered_map>
+ 
++#include <CommonCrypto/CommonCryptoError.h>
+ #include <CommonCrypto/CommonCrypto.h>
+ 
+ namespace Botan {
+diff --git a/src/lib/prov/commoncrypto/commoncrypto_utils.h b/src/lib/prov/commoncrypto/commoncrypto_utils.h
+index b1c7411fd..9becab2d1 100644
+--- a/src/lib/prov/commoncrypto/commoncrypto_utils.h
++++ b/src/lib/prov/commoncrypto/commoncrypto_utils.h
+@@ -10,6 +10,7 @@
+ 
+ #include <botan/sym_algo.h>
+ 
++#include <CommonCrypto/CommonCryptoError.h>
+ #include <CommonCrypto/CommonCrypto.h>
+ 
+ namespace Botan {
+diff --git a/src/lib/rng/system_rng/system_rng.cpp b/src/lib/rng/system_rng/system_rng.cpp
+index b2f7b4c45..f4933b1e3 100644
+--- a/src/lib/rng/system_rng/system_rng.cpp
++++ b/src/lib/rng/system_rng/system_rng.cpp
+@@ -20,6 +20,7 @@
+    #include <bcrypt.h>
+    #include <windows.h>
+ #elif defined(BOTAN_TARGET_OS_HAS_CCRANDOM)
++   #include <CommonCrypto/CommonCryptoError.h>
+    #include <CommonCrypto/CommonRandom.h>
+ #elif defined(BOTAN_TARGET_OS_HAS_ARC4RANDOM)
+    #include <stdlib.h>


### PR DESCRIPTION
## Description of changes

Botan 3.x is the current major version of Botan. Botan 2.x is mostly addressed with bug fixes and minor features these days. As with OpenSSL 1.1.x -> 3.x, try to switch over packages to Botan where possible.

Build successfull/change made in this PR:
* keepassxc
* corectrl
* rehex

Currently not possible:
* https://github.com/rnpgp/rnp main already supports botan3, no version with botan3 support released
* monotone will likely never support botan3
* softhsm currently does not support botan3, see e.g. https://github.com/opendnssec/SoftHSMv2/issues/719
* qownnotes currently does not work with botan3 https://github.com/pbek/QOwnNotes/issues/2786
* biboumi does not support botan3, even in upstream git

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
