### PR TITLE
lib/attrsets: add mapCartesianProduct function

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -5,7 +5,7 @@
 
 let
   inherit (builtins) head length;
-  inherit (lib.trivial) mergeAttrs warn;
+  inherit (lib.trivial) isInOldestRelease mergeAttrs warn warnIf;
   inherit (lib.strings) concatStringsSep concatMapStringsSep escapeNixIdentifier sanitizeDerivationName;
   inherit (lib.lists) foldr foldl' concatMap elemAt all partition groupBy take foldl;
 in
@@ -885,15 +885,15 @@ rec {
     # Type
 
     ```
-    cartesianProductOfSets :: AttrSet -> [AttrSet]
+    cartesianProduct :: AttrSet -> [AttrSet]
     ```
 
     # Examples
     :::{.example}
-    ## `lib.attrsets.cartesianProductOfSets` usage example
+    ## `lib.attrsets.cartesianProduct` usage example
 
     ```nix
-    cartesianProductOfSets { a = [ 1 2 ]; b = [ 10 20 ]; }
+    cartesianProduct { a = [ 1 2 ]; b = [ 10 20 ]; }
     => [
          { a = 1; b = 10; }
          { a = 1; b = 20; }
@@ -904,7 +904,7 @@ rec {
 
     :::
   */
-  cartesianProductOfSets =
+  cartesianProduct =
     attrsOfLists:
     foldl' (listOfAttrs: attrName:
       concatMap (attrs:
@@ -1999,4 +1999,8 @@ rec {
   # DEPRECATED
   zip = warn
     "lib.zip is a deprecated alias of lib.zipAttrsWith." zipAttrsWith;
+
+  # DEPRECATED
+  cartesianProductOfSets = warnIf (isInOldestRelease 2405)
+    "lib.cartesianProductOfSets is a deprecated alias of lib.cartesianProduct." cartesianProduct;
 }

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -914,6 +914,40 @@ rec {
 
 
   /**
+    Return the result of function f applied to the cartesian product of attribute set value combinations.
+    Equivalent to using cartesianProduct followed by map.
+
+    # Inputs
+
+    `f`
+
+    : A function, given an attribute set, it returns a new value.
+
+    `attrsOfLists`
+
+    : Attribute set with attributes that are lists of values
+
+    # Type
+
+    ```
+    mapCartesianProduct :: (AttrSet -> a) -> AttrSet -> [a]
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.attrsets.mapCartesianProduct` usage example
+
+    ```nix
+    mapCartesianProduct ({a, b}: "${a}-${b}") { a = [ "1" "2" ]; b = [ "3" "4" ]; }
+    => [ "1-3" "1-4" "2-3" "2-4" ]
+    ```
+
+    :::
+
+  */
+  mapCartesianProduct = f: attrsOfLists: map f (cartesianProduct attrsOfLists);
+
+  /**
     Utility function that creates a `{name, value}` pair as expected by `builtins.listToAttrs`.
 
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -87,7 +87,7 @@ let
       recursiveUpdate matchAttrs mergeAttrsList overrideExisting showAttrPath getOutput
       getBin getLib getDev getMan chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProduct cartesianProductOfSets
-      updateManyAttrsByPath;
+      mapCartesianProduct updateManyAttrsByPath;
     inherit (self.lists) singleton forEach foldr fold foldl foldl' imap0 imap1
       concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range replicate partition zipListsWith zipLists

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -86,7 +86,7 @@ let
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs mergeAttrsList overrideExisting showAttrPath getOutput
       getBin getLib getDev getMan chooseDevOutputs zipWithNames zip
-      recurseIntoAttrs dontRecurseIntoAttrs cartesianProductOfSets
+      recurseIntoAttrs dontRecurseIntoAttrs cartesianProduct cartesianProductOfSets
       updateManyAttrsByPath;
     inherit (self.lists) singleton forEach foldr fold foldl foldl' imap0 imap1
       concatMap flatten remove findSingle findFirst any all count

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1688,16 +1688,32 @@ rec {
     ## `lib.lists.crossLists` usage example
 
     ```nix
-    crossLists (x:y: "${toString x}${toString y}") [[1 2] [3 4]]
+    crossLists (x: y: "${toString x}${toString y}") [[1 2] [3 4]]
     => [ "13" "14" "23" "24" ]
     ```
 
+    The following function call is equivalent to the one deprecated above:
+
+    ```nix
+    mapCartesianProduct (x: "${toString x.a}${toString x.b}") { a = [1 2]; b = [3 4]; }
+    => [ "13" "14" "23" "24" ]
+    ```
     :::
   */
   crossLists = warn
-    "lib.crossLists is deprecated, use lib.cartesianProductOfSets instead."
-    (f: foldl (fs: args: concatMap (f: map f args) fs) [f]);
+    ''lib.crossLists is deprecated, use lib.mapCartesianProduct instead.
 
+    For example, the following function call:
+
+    nix-repl> lib.crossLists (x: y: x+y) [[1 2] [3 4]]
+    [ 4 5 5 6 ]
+
+    Can now be replaced by the following one:
+
+    nix-repl> lib.mapCartesianProduct ({x,y}: x+y) { x = [1 2]; y = [3 4]; }
+    [ 4 5 5 6 ]
+    ''
+    (f: foldl (fs: args: concatMap (f: map f args) fs) [f]);
 
   /**
     Remove duplicate elements from the `list`. O(n^2) complexity.

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -33,7 +33,7 @@ let
     boolToString
     callPackagesWith
     callPackageWith
-    cartesianProductOfSets
+    cartesianProduct
     cli
     composeExtensions
     composeManyExtensions
@@ -1686,17 +1686,17 @@ runTests {
   };
 
   testCartesianProductOfEmptySet = {
-    expr = cartesianProductOfSets {};
+    expr = cartesianProduct {};
     expected = [ {} ];
   };
 
   testCartesianProductOfOneSet = {
-    expr = cartesianProductOfSets { a = [ 1 2 3 ]; };
+    expr = cartesianProduct { a = [ 1 2 3 ]; };
     expected = [ { a = 1; } { a = 2; } { a = 3; } ];
   };
 
   testCartesianProductOfTwoSets = {
-    expr = cartesianProductOfSets { a = [ 1 ]; b = [ 10 20 ]; };
+    expr = cartesianProduct { a = [ 1 ]; b = [ 10 20 ]; };
     expected = [
       { a = 1; b = 10; }
       { a = 1; b = 20; }
@@ -1704,12 +1704,12 @@ runTests {
   };
 
   testCartesianProductOfTwoSetsWithOneEmpty = {
-    expr = cartesianProductOfSets { a = [ ]; b = [ 10 20 ]; };
+    expr = cartesianProduct { a = [ ]; b = [ 10 20 ]; };
     expected = [ ];
   };
 
   testCartesianProductOfThreeSets = {
-    expr = cartesianProductOfSets {
+    expr = cartesianProduct {
       a = [   1   2   3 ];
       b = [  10  20  30 ];
       c = [ 100 200 300 ];

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -75,7 +75,6 @@ let
     matchAttrs
     mergeAttrs
     meta
-    mkOption
     mod
     nameValuePair
     optionalDrvAttr
@@ -118,7 +117,6 @@ let
     expr = (builtins.tryEval expr).success;
     expected = true;
   };
-  testingDeepThrow = expr: testingThrow (builtins.deepSeq expr expr);
 
   testSanitizeDerivationName = { name, expected }:
   let
@@ -1416,7 +1414,7 @@ runTests {
     };
 
   testToPrettyMultiline = {
-    expr = mapAttrs (const (generators.toPretty { })) rec {
+    expr = mapAttrs (const (generators.toPretty { })) {
       list = [ 3 4 [ false ] ];
       attrs = { foo = null; bar.foo = "baz"; };
       newlinestring = "\n";
@@ -1430,7 +1428,7 @@ runTests {
         there
         test'';
     };
-    expected = rec {
+    expected = {
       list = ''
         [
           3
@@ -1468,13 +1466,10 @@ runTests {
     expected  = "«foo»";
   };
 
-  testToPlist =
-    let
-      deriv = derivation { name = "test"; builder = "/bin/sh"; system = "aarch64-linux"; };
-    in {
+  testToPlist = {
     expr = mapAttrs (const (generators.toPlist { })) {
       value = {
-        nested.values = rec {
+        nested.values = {
           int = 42;
           float = 0.1337;
           bool = true;

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -71,6 +71,7 @@ let
     makeIncludePath
     makeOverridable
     mapAttrs
+    mapCartesianProduct
     matchAttrs
     mergeAttrs
     meta
@@ -1751,6 +1752,30 @@ runTests {
       { a = 3; b = 30; c = 200; }
       { a = 3; b = 30; c = 300; }
     ];
+  };
+
+  testMapCartesianProductOfOneSet = {
+    expr = mapCartesianProduct ({a}: a * 2) { a = [ 1 2 3 ]; };
+    expected = [ 2 4 6 ];
+  };
+
+  testMapCartesianProductOfTwoSets = {
+    expr = mapCartesianProduct ({a,b}: a + b) { a = [ 1 ]; b = [ 10 20 ]; };
+    expected = [ 11 21 ];
+  };
+
+  testMapCartesianProcutOfTwoSetsWithOneEmpty = {
+    expr = mapCartesianProduct (x: x.a + x.b) { a = [ ]; b = [ 10 20 ]; };
+    expected = [ ];
+  };
+
+  testMapCartesianProductOfThreeSets = {
+    expr = mapCartesianProduct ({a,b,c}: a + b + c) {
+      a = [ 1 2 3 ];
+      b = [ 10 20 30 ];
+      c = [ 100 200 300 ];
+    };
+    expected = [ 111 211 311 121 221 321 131 231 331 112 212 312 122 222 322 132 232 332 113 213 313 123 223 323 133 233 333 ];
   };
 
   # The example from the showAttrPath documentation

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -284,7 +284,7 @@ in
       in
         # We will generate every possible pair of WM and DM.
         concatLists (
-            builtins.map
+            lib.mapCartesianProduct
             ({dm, wm}: let
               sessionName = "${dm.name}${optionalString (wm.name != "none") ("+" + wm.name)}";
               script = xsession dm wm;
@@ -312,7 +312,7 @@ in
                   providedSessions = [ sessionName ];
                 })
             )
-            (cartesianProductOfSets { dm = dms; wm = wms; })
+            { dm = dms; wm = wms; }
           );
   };
 

--- a/nixos/tests/predictable-interface-names.nix
+++ b/nixos/tests/predictable-interface-names.nix
@@ -5,7 +5,7 @@
 
 let
   inherit (import ../lib/testing-python.nix { inherit system pkgs; }) makeTest;
-  testCombinations = pkgs.lib.cartesianProductOfSets {
+  testCombinations = pkgs.lib.cartesianProduct {
     predictable = [true false];
     withNetworkd = [true false];
     systemdStage1 = [true false];

--- a/pkgs/by-name/so/solo5/package.nix
+++ b/pkgs/by-name/so/solo5/package.nix
@@ -63,16 +63,15 @@ in stdenv.mkDerivation {
     runHook postCheck
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Sandboxed execution environment";
     homepage = "https://github.com/solo5/solo5";
-    license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ ehmry ];
-    platforms = builtins.map ({arch, os}: "${arch}-${os}")
-      (lib.cartesianProductOfSets {
-        arch = [ "aarch64" "x86_64" ];
-        os = [ "freebsd" "genode" "linux" "openbsd" ];
-      });
+    license = licenses.isc;
+    maintainers = [ maintainers.ehmry ];
+    platforms = mapCartesianProduct ({ arch, os }: "${arch}-${os}") {
+      arch = [ "aarch64" "x86_64" ];
+      os = [ "freebsd" "genode" "linux" "openbsd" ];
+    };
   };
 
 }

--- a/pkgs/data/fonts/junicode/tests.nix
+++ b/pkgs/data/fonts/junicode/tests.nix
@@ -15,14 +15,13 @@ let
       '');
 in
 builtins.listToAttrs (
-  map
-    texTest
-    (lib.attrsets.cartesianProductOfSets {
+  lib.mapCartesianProduct texTest
+    {
       tex = [ "xelatex" "lualatex" ];
       fonttype = [ "ttf" "otf" ];
       package = [ "junicode" ];
       file = [ ./test.tex ];
-    })
+    }
   ++
   [
     (texTest {

--- a/pkgs/data/icons/catppuccin-cursors/default.nix
+++ b/pkgs/data/icons/catppuccin-cursors/default.nix
@@ -9,9 +9,8 @@ let
     palette = [ "Frappe" "Latte" "Macchiato" "Mocha" ];
     color = [ "Blue" "Dark" "Flamingo" "Green" "Lavender" "Light" "Maroon" "Mauve" "Peach" "Pink" "Red" "Rosewater" "Sapphire" "Sky" "Teal" "Yellow" ];
   };
-  product = lib.attrsets.cartesianProductOfSets dimensions;
   variantName = { palette, color }: (lib.strings.toLower palette) + color;
-  variants = map variantName product;
+  variants = lib.mapCartesianProduct variantName dimensions;
 in
 stdenvNoCC.mkDerivation rec {
   pname = "catppuccin-cursors";

--- a/pkgs/data/icons/comixcursors/default.nix
+++ b/pkgs/data/icons/comixcursors/default.nix
@@ -7,14 +7,13 @@ let
     thickness = [ "" "Slim_" ];  # Thick or slim edges.
     handedness = [ "" "LH_" ];   # Right- or left-handed.
   };
-  product = lib.cartesianProductOfSets dimensions;
   variantName =
     { color, opacity, thickness, handedness }:
     "${handedness}${opacity}${thickness}${color}";
   variants =
     # (The order of this list is already good looking enough to show in the
     # meta.longDescription.)
-    map variantName product;
+    lib.mapCartesianProduct variantName dimensions;
 in
 stdenvNoCC.mkDerivation rec {
   pname = "comixcursors";

--- a/pkgs/development/ocaml-modules/ocaml-freestanding/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-freestanding/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.sternenseemann ];
     homepage = "https://github.com/mirage/ocaml-freestanding";
     platforms = builtins.map ({ arch, os }: "${arch}-${os}")
-      (cartesianProductOfSets {
+      (cartesianProduct {
           arch = [ "aarch64" "x86_64" ];
           os = [ "linux" ];
       } ++ [


### PR DESCRIPTION
## Description of changes

The `cartesianProductOfSets` function was [added some time ago](https://github.com/NixOS/nixpkgs/pull/110787) (aka ~`transpose` or~ `sequence` in other functional languages), while deprecating the `crossLists` function. I have come across the deprecation message "use cartesianProductOfSets instead" without further details, which motivated me to improve the situation by adding a new convenient function. Example:

```nix
λ lib.mapCartesianProduct ({a,b}: a+b) {a=[1 2]; b=[3 4];}
[ 4 5 5 6 ]
```

It's the equivalent of using the former followed by `map`, which seems to be quite a common pattern to justify a single function:

```nix
λ builtins.map ({a,b}: a+b) (lib.cartesianProductOfSets {a=[1 2]; b=[3 4];})
[ 4 5 5 6 ]
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
