### PR TITLE
fzf: 0.47.0 -> 0.49.0

### DIFF
--- a/doc/packages/shell-helpers.section.md
+++ b/doc/packages/shell-helpers.section.md
@@ -2,11 +2,11 @@
 
 Some packages provide the shell integration to be more useful. But unlike other systems, nix doesn't have a standard `share` directory location. This is why a bunch `PACKAGE-share` scripts are shipped that print the location of the corresponding shared folder. Current list of such packages is as following:
 
-- `fzf` : `fzf-share`
+- `sk` : `sk-share`
 
-E.g. `fzf` can then be used in the `.bashrc` like this:
+E.g. `sk` can then be used in the `.bashrc` like this:
 
 ```bash
-source "$(fzf-share)/completion.bash"
-source "$(fzf-share)/key-bindings.bash"
+source "$(sk-share)/completion.bash"
+source "$(sk-share)/key-bindings.bash"
 ```

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -77,7 +77,7 @@ In addition to numerous new and updated packages, this release has the following
 
 - [frigate](https://frigate.video), an open source NVR built around real-time AI object detection. Available as [services.frigate](#opt-services.frigate.enable).
 
-- [fzf](https://github.com/junegunn/fzf), a command line fuzzyfinder. Available as [programs.fzf](#opt-programs.fzf.fuzzyCompletion).
+- [fzf](https://github.com/junegunn/fzf), a command line fuzzyfinder. Available as [programs.fzf](#opt-programs.fzf.enable).
 
 - [gemstash](https://github.com/rubygems/gemstash), a RubyGems.org cache and private gem server. Available as [services.gemstash](#opt-services.gemstash.enable).
 

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -248,6 +248,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - `xxd` has been moved from `vim` default output to its own output to reduce closure size. The canonical way to reference it across all platforms is `unixtools.xxd`.
 
+- `programs.fzf.keybindings` and `programs.fzf.fuzzyCompletion` got replaced by `programs.fzf.enabled` as shell-completion is included in the fzf-binary now there is no easy option to load completion and keybindings separately. Please consult fzf-documentation on how to configure/disable certain keybindings.
+
 - The `stalwart-mail` package has been updated to v0.5.3, which includes [breaking changes](https://github.com/stalwartlabs/mail-server/blob/v0.5.3/UPGRADING.md).
 
 - `services.zope2` has been removed as `zope2` is unmaintained and was relying on Python2.

--- a/nixos/modules/programs/fzf.nix
+++ b/nixos/modules/programs/fzf.nix
@@ -9,11 +9,11 @@ in
 {
   imports = [
     (lib.mkRemovedOptionModule [ "programs" "fzf" "keybindings" ] ''
-      Use "programs.fzf.enabled" instead, due to fzf upstream-change it's not possible to load shell-completion and keybindings seperatly.
+      Use "programs.fzf.enabled" instead, due to fzf upstream-change it's not possible to load shell-completion and keybindings separately.
       If you want to change/disable certain keybindings please check the fzf-documentation.
     '')
     (lib.mkRemovedOptionModule [ "programs" "fzf" "fuzzyCompletion" ] ''
-      Use "programs.fzf.enabled" instead, due to fzf upstream-change it's not possible to load shell-completion and keybindings seperatly.
+      Use "programs.fzf.enabled" instead, due to fzf upstream-change it's not possible to load shell-completion and keybindings separately.
       If you want to change/disable certain keybindings please check the fzf-documentation.
     '')
   ];
@@ -30,7 +30,7 @@ in
     '';
 
     programs.fish.interactiveShellInit = ''
-      eval "$(${getExe pkgs.fzf} --fish)"
+      ${getExe pkgs.fzf} --fish | source
     '';
 
     programs.zsh = {

--- a/nixos/modules/programs/fzf.nix
+++ b/nixos/modules/programs/fzf.nix
@@ -1,32 +1,46 @@
 { pkgs, config, lib, ... }:
+
 with lib;
+
 let
   cfg = config.programs.fzf;
+
 in
 {
-  options = {
-    programs.fzf = {
-      fuzzyCompletion = mkEnableOption (mdDoc "fuzzy completion with fzf");
-      keybindings = mkEnableOption (mdDoc "fzf keybindings");
-    };
-  };
-  config = {
-    environment.systemPackages = optional (cfg.keybindings || cfg.fuzzyCompletion) pkgs.fzf;
+  imports = [
+    (lib.mkRemovedOptionModule [ "programs" "fzf" "keybindings" ] ''
+      Use "programs.fzf.enabled" instead, due to fzf upstream-change it's not possible to load shell-completion and keybindings seperatly.
+      If you want to change/disable certain keybindings please check the fzf-documentation.
+    '')
+    (lib.mkRemovedOptionModule [ "programs" "fzf" "fuzzyCompletion" ] ''
+      Use "programs.fzf.enabled" instead, due to fzf upstream-change it's not possible to load shell-completion and keybindings seperatly.
+      If you want to change/disable certain keybindings please check the fzf-documentation.
+    '')
+  ];
 
-    programs.bash.interactiveShellInit = optionalString cfg.fuzzyCompletion ''
-      source ${pkgs.fzf}/share/fzf/completion.bash
-    '' + optionalString cfg.keybindings ''
-      source ${pkgs.fzf}/share/fzf/key-bindings.bash
+  options = {
+    programs.fzf.enable = mkEnableOption (mdDoc "fuzzy completion with fzf and keybindings");
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.fzf ];
+
+    programs.bash.interactiveShellInit = ''
+      eval "$(${getExe pkgs.fzf} --bash)"
     '';
 
-    programs.zsh.interactiveShellInit = optionalString (!config.programs.zsh.ohMyZsh.enable)
-      (optionalString cfg.fuzzyCompletion ''
-        source ${pkgs.fzf}/share/fzf/completion.zsh
-      '' + optionalString cfg.keybindings ''
-        source ${pkgs.fzf}/share/fzf/key-bindings.zsh
-      '');
+    programs.fish.interactiveShellInit = ''
+      eval "$(${getExe pkgs.fzf} --fish)"
+    '';
 
-    programs.zsh.ohMyZsh.plugins = lib.mkIf (cfg.keybindings || cfg.fuzzyCompletion) [ "fzf" ];
+    programs.zsh = {
+      interactiveShellInit = optionalString (!config.programs.zsh.ohMyZsh.enable) ''
+        eval "$(${getExe pkgs.fzf} --zsh)"
+      '';
+
+      ohMyZsh.plugins = mkIf (config.programs.zsh.ohMyZsh.enable) [ "fzf" ];
+    };
   };
+
   meta.maintainers = with maintainers; [ laalsaas ];
 }

--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -1,26 +1,13 @@
-{ stdenv
-, lib
+{ lib
 , buildGoModule
 , fetchFromGitHub
-, writeShellScriptBin
 , installShellFiles
 , bc
 , ncurses
-, perl
 , testers
 , fzf
 }:
 
-let
-  # on Linux, wrap perl in the bash completion scripts with the glibc locales,
-  # so that using the shell completion (ctrl+r, etc) doesn't result in ugly
-  # warnings on non-nixos machines
-  ourPerl = if !stdenv.isLinux then perl else (
-    writeShellScriptBin "perl" ''
-      export PERL_BADLANG=0
-      exec ${perl}/bin/perl "$@"
-    '');
-in
 buildGoModule rec {
   pname = "fzf";
   version = "0.49.0";
@@ -55,14 +42,9 @@ buildGoModule rec {
         exit 1
     fi
 
-    # Has a sneaky dependency on perl
-    # Include first args to make sure we're patching the right thing
-    substituteInPlace shell/key-bindings.bash \
-      --replace "command -v perl" "command -v ${ourPerl}/bin/perl" \
-      --replace " perl -n " " ${ourPerl}/bin/perl -n "
     # fzf-tmux depends on bc
-   substituteInPlace bin/fzf-tmux \
-     --replace "bc" "${bc}/bin/bc"
+    substituteInPlace bin/fzf-tmux \
+      --replace "bc" "${bc}/bin/bc"
   '';
 
   postInstall = ''

--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -3,7 +3,6 @@
 , buildGoModule
 , fetchFromGitHub
 , writeShellScriptBin
-, runtimeShell
 , installShellFiles
 , bc
 , ncurses
@@ -74,14 +73,6 @@ buildGoModule rec {
     install -D plugin/* -t $out/share/vim-plugins/${pname}/plugin
     mkdir -p $out/share/nvim
     ln -s $out/share/vim-plugins/${pname} $out/share/nvim/site
-
-    cat <<SCRIPT > $out/bin/fzf-share
-    #!${runtimeShell}
-    # Run this script to find the fzf shared folder where all the shell
-    # integration scripts are living.
-    echo $out/share/fzf
-    SCRIPT
-    chmod +x $out/bin/fzf-share
   '';
 
   passthru.tests.version = testers.testVersion {

--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -75,15 +75,6 @@ buildGoModule rec {
     mkdir -p $out/share/nvim
     ln -s $out/share/vim-plugins/${pname} $out/share/nvim/site
 
-    # Install shell integrations
-    install -D shell/* -t $out/share/fzf/
-    install -D shell/key-bindings.fish $out/share/fish/vendor_functions.d/fzf_key_bindings.fish
-    mkdir -p $out/share/fish/vendor_conf.d
-    cat << EOF > $out/share/fish/vendor_conf.d/load-fzf-key-bindings.fish
-      status is-interactive; or exit 0
-      fzf_key_bindings
-    EOF
-
     cat <<SCRIPT > $out/bin/fzf-share
     #!${runtimeShell}
     # Run this script to find the fzf shared folder where all the shell

--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -24,16 +24,16 @@ let
 in
 buildGoModule rec {
   pname = "fzf";
-  version = "0.47.0";
+  version = "0.48.1";
 
   src = fetchFromGitHub {
     owner = "junegunn";
     repo = pname;
     rev = version;
-    hash = "sha256-rIRn8g4j/drWEHnvZnJW2sSLq5mrw8Q2pn3LN2sEXDY=";
+    hash = "sha256-xtewDTjytEpQXtjT1WV4KDkQ28s/+U8TUKOQVVNvh5I=";
   };
 
-  vendorHash = "sha256-BOPACUQKcllmA2eWQs+sOfofAQLle2Byb/rZgOhmkVY=";
+  vendorHash = "sha256-lfnBopkzoTD3Xxj0BCN+ZZz2JxZtj8xLOXMUD8kc8/A=";
 
   CGO_ENABLED = 0;
 

--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -24,16 +24,16 @@ let
 in
 buildGoModule rec {
   pname = "fzf";
-  version = "0.48.1";
+  version = "0.49.0";
 
   src = fetchFromGitHub {
     owner = "junegunn";
     repo = pname;
     rev = version;
-    hash = "sha256-xtewDTjytEpQXtjT1WV4KDkQ28s/+U8TUKOQVVNvh5I=";
+    hash = "sha256-XecMHKi5JMWx3RHQRk2FqS3SjyR6KzWjfyQ5JCI45xM=";
   };
 
-  vendorHash = "sha256-lfnBopkzoTD3Xxj0BCN+ZZz2JxZtj8xLOXMUD8kc8/A=";
+  vendorHash = "sha256-ZEwB2GKohmOx8xosj14VII6sQ4a82s7+h9r620MKEeU=";
 
   CGO_ENABLED = 0;
 


### PR DESCRIPTION
## Description of changes

* fzf: 0.47.0 -> 0.48.1
* Update derivation to not install old auto-completions
* Update module to load completion for bash, fish (new) and zsh (or oh-my-zsh plugin) with changed way through fzf-binary
* Added change to release note as it is backwards-incompatible.

Superseeds #295978

Home-Manager [module](https://github.com/nix-community/home-manager/blob/master/modules/programs/fzf.nix#L176) will need also an update (just as note here)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
