### PR TITLE
rhash: Support FreeBSD by adding unreleased patches

### DIFF
--- a/pkgs/tools/security/rhash/default.nix
+++ b/pkgs/tools/security/rhash/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , which
 , enableStatic ? stdenv.hostPlatform.isStatic
+, gettext
 }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +17,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-3CW41ULdXoID4cOgrcG2j85tgIJ/sz5hU7A83qpuxf4=";
   };
 
+  patches = [ ./dont-fail-ln.patch ./do-link-so.patch ];
+
   nativeBuildInputs = [ which ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isFreeBSD [ gettext ];
 
   # configure script is not autotools-based, doesn't support these options
   dontAddStaticConfigureFlags = true;

--- a/pkgs/tools/security/rhash/do-link-so.patch
+++ b/pkgs/tools/security/rhash/do-link-so.patch
@@ -1,0 +1,22 @@
+From b8c91ea6551e99e10352386cd46ea26973bb4a4d Mon Sep 17 00:00:00 2001
+From: Aleksey Kravchenko <rhash.admin@gmail.com>
+Date: Mon, 11 Sep 2023 03:49:20 +0300
+Subject: [PATCH] Fix #238: Build on Unix
+
+---
+ librhash/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/librhash/Makefile b/librhash/Makefile
+index e8ee862..34f1263 100644
+--- a/librhash/Makefile
++++ b/librhash/Makefile
+@@ -27,7 +27,7 @@ install-lib-static: $(LIBRHASH_STATIC)
+ install-lib-shared: $(LIBRHASH_SHARED) $(EXTRA_INSTALL_LIBSHARED)
+ 	$(INSTALL) -d $(SO_DIR)
+ 	$(INSTALL_SHARED) $(LIBRHASH_SHARED) $(SO_DIR)/
+-	test "x$(LIBRHASH_SO_MAJ)" != "x$(LIBRHASH_SHARED)" || ( \
++	test "x$(LIBRHASH_SO_MAJ)" = "x$(LIBRHASH_SHARED)" || ( \
+ 	  rm -f $(LIBDIR)/$(LIBRHASH_SO_MAJ) && \
+ 	  ln -s $(LIBRHASH_SHARED) $(LIBDIR)/$(LIBRHASH_SO_MAJ) )
+ 

--- a/pkgs/tools/security/rhash/dont-fail-ln.patch
+++ b/pkgs/tools/security/rhash/dont-fail-ln.patch
@@ -1,0 +1,59 @@
+From 9ef90b958b7ae50aeeb5c269468034d73d6e2efe Mon Sep 17 00:00:00 2001
+From: Aleksey Kravchenko <rhash.admin@gmail.com>
+Date: Mon, 31 Jul 2023 02:48:15 +0300
+Subject: [PATCH] Fix #238: Build on *BSD
+
+---
+ configure         | 3 ++-
+ librhash/Makefile | 8 ++++----
+ 2 files changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/configure b/configure
+index dae76d5..39ef8c1 100755
+--- a/configure
++++ b/configure
+@@ -567,6 +567,7 @@ qnx()       { test "$OS_LC" = "qnx"; }
+ sunos()     { test "$OS_LC" = "sunos"; }
+ wine()      { test "$OS_LC" = "wine"; }
+ win32()     { cygwin || mingw32 || mingw64 || msys || wine; }
++bsd()       { dragonfly || freebsd || netbsd || openbsd ; }
+ posix_make() { aix || bsdos || hpux || irix || qnx || sunos; }
+ 
+ #####################################################################
+@@ -713,7 +714,7 @@ if win32; then
+ elif darwin; then
+   SHARED_EXT=".${RHASH_VERSION_MAJOR}.dylib"
+   SOLINK_EXT=".dylib"
+-elif linux; then
++elif linux || bsd; then
+   # use the full library version for the library file extension
+   SHARED_EXT=".so.${RHASH_VERSION}"
+ fi
+diff --git a/librhash/Makefile b/librhash/Makefile
+index d48e06e..e8ee862 100644
+--- a/librhash/Makefile
++++ b/librhash/Makefile
+@@ -27,9 +27,9 @@ install-lib-static: $(LIBRHASH_STATIC)
+ install-lib-shared: $(LIBRHASH_SHARED) $(EXTRA_INSTALL_LIBSHARED)
+ 	$(INSTALL) -d $(SO_DIR)
+ 	$(INSTALL_SHARED) $(LIBRHASH_SHARED) $(SO_DIR)/
+-	test "x$(LIBRHASH_SO_MAJ)" != "x$(LIBRHASH_SHARED)" && \
++	test "x$(LIBRHASH_SO_MAJ)" != "x$(LIBRHASH_SHARED)" || ( \
+ 	  rm -f $(LIBDIR)/$(LIBRHASH_SO_MAJ) && \
+-	  ln -s $(LIBRHASH_SHARED) $(LIBDIR)/$(LIBRHASH_SO_MAJ)
++	  ln -s $(LIBRHASH_SHARED) $(LIBDIR)/$(LIBRHASH_SO_MAJ) )
+ 
+ install-implib:
+ 	$(INSTALL) -d $(LIBDIR)
+@@ -175,9 +175,9 @@ $(EXPORTS_FILE): $(LIB_HEADERS)
+ 	  $(LIB_HEADERS) | grep -v "$(EXPORTS_SKIP)" > $@
+ 
+ $(LIBRHASH_SOLINK):
+-	test "x$(LIBRHASH_SO_MAJ)" != "x$(LIBRHASH_SHARED)" && \
++	test "x$(LIBRHASH_SO_MAJ)" = "x$(LIBRHASH_SHARED)" || ( \
+ 	  rm -f $(LIBRHASH_SO_MAJ) && \
+-	  ln -s $(LIBRHASH_SHARED) $(LIBRHASH_SO_MAJ)
++	  ln -s $(LIBRHASH_SHARED) $(LIBRHASH_SO_MAJ) )
+ 	rm -f $(LIBRHASH_SOLINK)
+ 	ln -s $(LIBRHASH_SO_MAJ) $(LIBRHASH_SOLINK)
+ 


### PR DESCRIPTION
## Description of changes

This pulls in unreleased commits from upstream in order to support building rhash for FreeBSD. It also adds some additional deps that FreeBSD needs, platform-gated.

IIRC I attempted to use fetchpatch for this instead of importing the patches but it failed due to rhash being fairly load-bearing in the bootstrap process.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
