### PR TITLE
kshutdown: init at 5.91-beta

### DIFF
--- a/pkgs/by-name/ks/kshutdown/package.nix
+++ b/pkgs/by-name/ks/kshutdown/package.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, lib
+, fetchurl
+, extra-cmake-modules
+, unzip
+, libsForQt5
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kshutdown";
+  version = "5.91-beta";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/kshutdown/KShutdown/${finalAttrs.version}/kshutdown-source-${finalAttrs.version}.zip";
+    hash = "sha256-gWXpVBhoZ57kaQV1C+xCBYc2gZjzJfFViD/SI9D+BRc=";
+    name = "kshutdown-source-${finalAttrs.version}.zip";
+  };
+
+  nativeBuildInputs = [ extra-cmake-modules unzip libsForQt5.wrapQtAppsHook ];
+
+  buildInputs = with libsForQt5; [ qtbase kxmlgui knotifyconfig kidletime ];
+
+  meta = with lib; {
+    homepage = "https://kshutdown.sourceforge.io/";
+    description = "A graphical shutdown utility for Linux and Windows";
+    mainProgram = "kshutdown";
+    license = with licenses; [ gpl3 ];
+    maintainers = with maintainers ; [ eymeric ];
+    platforms = platforms.linux;
+  };
+})
+


### PR DESCRIPTION
## Description of changes

Add the KDE package kshutdown.

Closes #264247

## Things done

Write a derivation for kshutdown and include it in the different location needed.

- Built on platform(s)
  - [ x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ x ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ x ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
