### PR TITLE
qolibri: 2.1.4 -> 2.1.5-unstable-2024-03-17

### DIFF
--- a/pkgs/applications/misc/qolibri/default.nix
+++ b/pkgs/applications/misc/qolibri/default.nix
@@ -1,32 +1,65 @@
-{ stdenv, lib, fetchFromGitHub, pkg-config, cmake, libeb, lzo
-, qtmultimedia, qttools, qtwebengine, wrapQtAppsHook }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, ninja
+, qttools
+, qtwebengine
+, wrapQtAppsHook
+}:
 
-stdenv.mkDerivation rec {
+let
+  eb = fetchFromGitHub {
+    owner = "mvf";
+    repo = "eb";
+    rev = "58e1c3bb9847ed5d05863f478f21e7a8ca3d74c8";
+    hash = "sha256-gZP+2P6fFADWht2c0hXmljVJQX8RpCq2mWP+KDi+GzE=";
+  };
+in
+
+stdenv.mkDerivation {
   pname = "qolibri";
-  version = "2.1.4";
+  version = "2.1.5-unstable-2024-03-17";
 
   src = fetchFromGitHub {
-    owner = "ludios";
+    owner = "mvf";
     repo = "qolibri";
-    rev = version;
-    sha256 = "jyLF1MKDVH0Lt8lw+O93b+LQ4J+s42O3hebthJk83hg=";
+    rev = "99f0771184fcb2c5f47aad11c16002ebb8469a3f";
+    hash = "sha256-ArupqwejOO2YK9a3Ky0j20dIHs1jIqJksNIb4K2jwgI=";
   };
 
-  nativeBuildInputs = [ pkg-config cmake qttools wrapQtAppsHook ];
+  nativeBuildInputs = [
+    cmake
+    ninja
+    qttools
+    wrapQtAppsHook
+  ];
+
   buildInputs = [
-    libeb lzo qtmultimedia qtwebengine
+    qtwebengine
+  ];
+
+  cmakeFlags = [
+    "-DQOLIBRI_EB_SOURCE_DIR=${eb}"
   ];
 
   postInstall = ''
-    install -D $src/qolibri.desktop -t $out/share/applications
+    install -Dm644 $src/qolibri.desktop -t $out/share/applications
+
+    for size in 16 32 48 64 128; do
+      install -Dm644 \
+        $src/images/qolibri-$size.png \
+        $out/share/icons/hicolor/''${size}x''${size}/apps/qolibri.png
+    done
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/ludios/qolibri";
     description = "EPWING reader for viewing Japanese dictionaries";
-    mainProgram = "qolibri";
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ ];
+    homepage = "https://github.com/mvf/qolibri";
     license = licenses.gpl2;
+    maintainers = with maintainers; [ azahi ];
+    platforms = platforms.unix;
+    broken = stdenv.isDarwin && stdenv.isx86_64; # Looks like a libcxx version mismatch problem.
+    mainProgram = "qolibri";
   };
 }


### PR DESCRIPTION
## Description of changes

- Switch upstream to mvf/qolibri
- Use patched upstream version of libeb
- Build with CMake
- Fix desktop icons
- Refactor the derivation
- Add azahi as a maintainer
- Allow building on MacOS

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
