### PR TITLE
python311Packages.robotframework-pythonlibcore: 4.3.0 -> 4.4.0

### DIFF
--- a/pkgs/development/python-modules/approvaltests/default.nix
+++ b/pkgs/development/python-modules/approvaltests/default.nix
@@ -5,6 +5,7 @@
 , buildPythonPackage
 , empty-files
 , fetchFromGitHub
+, fetchpatch2
 , mock
 , mrjob
 , numpy
@@ -20,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "approvaltests";
-  version = "11.1.2";
+  version = "11.1.3";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -29,14 +30,21 @@ buildPythonPackage rec {
     owner = "approvals";
     repo = "ApprovalTests.Python";
     rev = "refs/tags/v${version}";
-    hash = "sha256-VM4TP98bS9NmhxZz+YHMJrHKr5g6E6aYidxjKQyXp7k=";
+    hash = "sha256-VqE2Oj3b+ZfKT+fhJ9DxBClfa8Wz8w/puAnAotN3eG4=";
   };
 
-  nativeBuildInputs = [
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/approvals/ApprovalTests.Python/commit/dac7c8a8aa62f31dca7a687d4dbf08158351d5e1.patch";
+      hash = "sha256-TMyfXNtzpGci6tdFRhxiKJRjCWRD5LkaffPY8EVj53E=";
+    })
+  ];
+
+  build-system = [
     setuptools
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     allpairspy
     approval-utilities
     beautifulsoup4
@@ -56,7 +64,7 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # Tests expects paths below ApprovalTests.Python directory
+    # Tests expect paths below ApprovalTests.Python directory
     "test_received_filename"
     "test_pytest_namer"
   ];

--- a/pkgs/development/python-modules/robotframework-pythonlibcore/default.nix
+++ b/pkgs/development/python-modules/robotframework-pythonlibcore/default.nix
@@ -2,16 +2,18 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
+, fetchpatch2
 , setuptools
+, robotframework
+, approvaltests
 , pytest-mockito
 , pytestCheckHook
-, robotframework
 , typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "robotframework-pythonlibcore";
-  version = "4.3.0";
+  version = "4.4.0";
 
   disabled = pythonOlder "3.8";
 
@@ -21,23 +23,30 @@ buildPythonPackage rec {
     owner = "robotframework";
     repo = "PythonLibCore";
     rev = "refs/tags/v${version}";
-    hash = "sha256-5ayOQyOhCg4nLpAyH/eQ6NYEApix0wsL2nhJzEXKJRo=";
+    hash = "sha256-282A4EW88z6ODSIEIIeBbN8YO491rwI4M7njI7kL3XQ=";
   };
 
-  nativeBuildInputs = [
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/robotframework/PythonLibCore/commit/8b756a4bd119d660109437023789bfada21bdc78.patch";
+      hash = "sha256-4NtgkGbIj9gH9Det6VNh1MpGSGroESxQ8X2ZTeoX/zU=";
+    })
+  ];
+
+  build-system = [
     setuptools
   ];
 
-  nativeCheckInputs = [
-    pytest-mockito
-    pytestCheckHook
+  dependencies = [
     robotframework
-    typing-extensions
   ];
 
-  preCheck = ''
-    export PYTHONPATH="atest:utest/helpers:$PYTHONPATH"
-  '';
+  nativeCheckInputs = [
+    approvaltests
+    pytest-mockito
+    pytestCheckHook
+    typing-extensions
+  ];
 
   pythonImportsCheck = [ "robotlibcore" ];
 


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/robotframework/PythonLibCore/compare/refs/tags/v4.3.0...v4.4.0

Changelog: https://github.com/robotframework/PythonLibCore/blob/refs/tags/v4.4.0/docs/PythonLibCore-4.4.0.rst
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
