### PR TITLE
epub-thumbnailer: init at unstable-2024-03-16

### DIFF
--- a/pkgs/by-name/ep/epub-thumbnailer/package.nix
+++ b/pkgs/by-name/ep/epub-thumbnailer/package.nix
@@ -1,0 +1,40 @@
+{ lib
+, python3
+, fetchFromGitHub
+, unstableGitUpdater
+}:
+
+python3.pkgs.buildPythonApplication {
+  pname = "epub-thumbnailer";
+  version = "0-unstable-2024-03-16";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "marianosimone";
+    repo = "epub-thumbnailer";
+    rev = "035c31e9269bcb30dcc20fed31b6dc54e9bfed63";
+    hash = "sha256-G/CeYmr+wgJidbavfvIuCbRLJGQzoxAnpo3t4YFJq0c=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    setuptools
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pillow
+  ];
+
+  postInstall = ''
+    mv $out/bin/epub-thumbnailer.py $out/bin/epub-thumbnailer
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = with lib; {
+    description = "Script to extract the cover of an epub book and create a thumbnail for it";
+    homepage = "https://github.com/marianosimone/epub-thumbnailer";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ GaetanLepage ];
+    mainProgram = "epub-thumbnailer";
+  };
+}


### PR DESCRIPTION
## Description of changes

Add [epub-thumbnailer](https://github.com/marianosimone/epub-thumbnailer).
I went with the minimal (i.e. script only) installation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
