### PR TITLE
stdenv/generic/setup.sh: extract Make logic

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -772,6 +772,10 @@ Hook executed at the start of the configure phase.
 
 Hook executed at the end of the configure phase.
 
+::: {.note}
+If you wish to run `$configureScript` with flags compiled via all the variables described above, but wish to avoid running `{pre,post}Configure` hooks, you can run the shell function `scriptConfigure`.
+:::
+
 ### The build phase {#build-phase}
 
 The build phase is responsible for actually building the package (e.g. compiling it). The default `buildPhase` calls `make` if a file named `Makefile`, `makefile` or `GNUmakefile` exists in the current directory (or the `makefile` is explicitly set); otherwise it does nothing.
@@ -828,6 +832,10 @@ You can set flags for `make` through the `makeFlags` variable.
 
 Before and after running `make`, the hooks `preBuild` and `postBuild` are called, respectively.
 
+::: {.note}
+If you wish to run `make` with flags compiled via all the variables described above, but wish to avoid running `{pre,post}Build` hooks, you can run the shell function `makeBuild`.
+:::
+
 ### The check phase {#ssec-check-phase}
 
 The check phase checks whether the package was built correctly by running its test suite. The default `checkPhase` calls `make $checkTarget`, but only if the [`doCheck` variable](#var-stdenv-doCheck) is enabled.
@@ -875,6 +883,10 @@ Hook executed at the start of the check phase.
 
 Hook executed at the end of the check phase.
 
+::: {.note}
+If you wish to run `make $checkTarget` with flags compiled via all the variables described above, but wish to avoid running `{pre,post}Check` hooks, you can run the shell function `makeCheck`.
+:::
+
 ### The install phase {#ssec-install-phase}
 
 The install phase is responsible for installing the package in the Nix store under `out`. The default `installPhase` creates the directory `$out` and calls `make install`.
@@ -908,6 +920,10 @@ Hook executed at the start of the install phase.
 ##### `postInstall` {#var-stdenv-postInstall}
 
 Hook executed at the end of the install phase.
+
+::: {.note}
+If you wish to run `make $installTargets` with flags compiled via all the variables described above, but wish to avoid running `{pre,post}Install` hooks, you can run the shell function `makeInstall`.
+:::
 
 ### The fixup phase {#ssec-fixup-phase}
 
@@ -1106,6 +1122,10 @@ Hook executed at the start of the installCheck phase.
 
 Hook executed at the end of the installCheck phase.
 
+::: {.note}
+If you wish to run `make $installCheckTarget` with flags compiled via all the variables described above, but wish to avoid running `{pre,post}InstallCheck` hooks, you can run the shell function `makeInstallCheck`.
+:::
+
 ### The distribution phase {#ssec-distribution-phase}
 
 The distribution phase is intended to produce a source distribution of the package. The default `distPhase` first calls `make dist`, then it copies the resulting source tarballs to `$out/tarballs/`. This phase is only executed if the attribute `doDist` is set.
@@ -1139,6 +1159,10 @@ Hook executed at the start of the distribution phase.
 ##### `postDist` {#var-stdenv-postDist}
 
 Hook executed at the end of the distribution phase.
+
+::: {.note}
+If you wish to run `make $distTarget` with flags compiled via all the variables described above, but wish to avoid running `{pre,post}Dist` hooks, you can run the shell function `makeDist`.
+:::
 
 ## Shell functions and utilities {#ssec-stdenv-functions}
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1422,7 +1422,11 @@ fixLibtool() {
 
 configurePhase() {
     runHook preConfigure
+    scriptConfigure
+    runHook postConfigure
+}
 
+scriptConfigure() {
     # set to empty if unset
     : "${configureScript=}"
 
@@ -1498,14 +1502,16 @@ configurePhase() {
     else
         echo "no configure script, doing nothing"
     fi
-
-    runHook postConfigure
 }
 
 
 buildPhase() {
     runHook preBuild
+    makeBuild
+    runHook postBuild
+}
 
+makeBuild() {
     if [[ -z "${makeFlags-}" && -z "${makefile:-}" && ! ( -e Makefile || -e makefile || -e GNUmakefile ) ]]; then
         echo "no Makefile or custom buildPhase, doing nothing"
     else
@@ -1522,14 +1528,16 @@ buildPhase() {
         make ${makefile:+-f $makefile} "${flagsArray[@]}"
         unset flagsArray
     fi
-
-    runHook postBuild
 }
 
 
 checkPhase() {
     runHook preCheck
+    makeCheck
+    runHook postCheck
+}
 
+makeCheck() {
     if [[ -z "${foundMakefile:-}" ]]; then
         echo "no Makefile or custom checkPhase, doing nothing"
         runHook postCheck
@@ -1569,11 +1577,14 @@ checkPhase() {
 
 installPhase() {
     runHook preInstall
+    makeInstall
+    runHook postInstall
+}
 
+makeInstall() {
     # Dont reuse 'foundMakefile' set in buildPhase, a makefile may have been created in buildPhase
     if [[ -z "${makeFlags-}" && -z "${makefile:-}" && ! ( -e Makefile || -e makefile || -e GNUmakefile ) ]]; then
         echo "no Makefile or custom installPhase, doing nothing"
-        runHook postInstall
         return
     else
         foundMakefile=1
@@ -1594,8 +1605,6 @@ installPhase() {
     echoCmd 'install flags' "${flagsArray[@]}"
     make ${makefile:+-f $makefile} "${flagsArray[@]}"
     unset flagsArray
-
-    runHook postInstall
 }
 
 
@@ -1656,7 +1665,11 @@ fixupPhase() {
 
 installCheckPhase() {
     runHook preInstallCheck
+    makeInstallCheck
+    runHook postInstallCheck
+}
 
+makeInstallCheck() {
     if [[ -z "${foundMakefile:-}" ]]; then
         echo "no Makefile or custom installCheckPhase, doing nothing"
     #TODO(@oxij): should flagsArray influence make -n?
@@ -1678,14 +1691,15 @@ installCheckPhase() {
         make ${makefile:+-f $makefile} "${flagsArray[@]}"
         unset flagsArray
     fi
-
-    runHook postInstallCheck
 }
 
 
 distPhase() {
     runHook preDist
-
+    makeDist
+    runHook postDist
+}
+makeDist() {
     local flagsArray=()
     concatTo flagsArray distFlags distFlagsArray distTarget=dist
 
@@ -1700,8 +1714,6 @@ distPhase() {
         # shellcheck disable=SC2086
         cp -pvd ${tarballs[*]:-*.tar.gz} "$out/tarballs"
     fi
-
-    runHook postDist
 }
 
 


### PR DESCRIPTION
## Description of changes

Extract `Make-based` build process into separated Bash functions to make them reusable by packages, making them reusable by packages using a language- or framework-specific build helpers that rewrite the phases.

Proposed Bash functions containing the make-related logic:
- `scriptConfigure`
- `makeBuild`
- `makeCheck`
- `makeInstall`
- `makeInstallCheck`

~Name each Make-based phases `make*Phase` and specify `*Phase=make*Phase` by default. This makes it align with build process based on other build tools such as CMake.~ Withhold due to the scale of fixes regarding the wide-spread "phases are Bash function" assumption. See #299045.

Use `apptainer` as an example how packages using `buildGoModule` could benefit from the Make-based build commands provided by `stdenv.mkDerivation`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
