### PR TITLE
trezor-suite: mark as broken

### DIFF
--- a/pkgs/applications/blockchains/trezor-suite/default.nix
+++ b/pkgs/applications/blockchains/trezor-suite/default.nix
@@ -53,6 +53,9 @@ appimageTools.wrapType2 rec {
   '';
 
   meta = with lib; {
+    # trezor-suite fails to detect a connected hardware wallet
+    # ref: https://github.com/NixOS/nixpkgs/issues/281975
+    broken = true;
     description = "Trezor Suite - Desktop App for managing crypto";
     homepage = "https://suite.trezor.io";
     changelog = "https://github.com/trezor/trezor-suite/releases/tag/v${version}";


### PR DESCRIPTION
```
trezor-suite: mark as broken

This change marks `trezor-suite` as broken, as the application does not perform its core functionality.

Ref: nixos/nixpkgs#281975
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc