### PR TITLE
omniorbpy: init at 4.3.2

### DIFF
--- a/pkgs/by-name/om/omniorbpy/package.nix
+++ b/pkgs/by-name/om/omniorbpy/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  omniorb,
+  pkg-config,
+  python3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "omniorbpy";
+  version = "4.3.2";
+
+  src = fetchurl {
+    url = "http://downloads.sourceforge.net/omniorb/omniORBpy-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-y1cX1BKhAbr0MPWYysfWkjGITa5DctjirfPd7rxffrs=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  propagatedBuildInputs = [
+    omniorb
+  ];
+
+  configureFlags = [
+    "--with-omniorb=${omniorb}"
+    "PYTHON_PREFIX=$out"
+    "PYTHON=${lib.getExe python3}"
+  ];
+
+  # Transform omniidl_be into a PEP420 namespace
+  postInstall = ''
+    rm $out/${python3.sitePackages}/omniidl_be/__init__.py
+    rm $out/${python3.sitePackages}/omniidl_be/__pycache__/__init__.*.pyc
+  '';
+
+  # Ensure both python & cxx backends are available
+  doInstallCheck = true;
+  postInstallCheck = ''
+    export PYTHONPATH=$out/${python3.sitePackages}:${omniorb}/${python3.sitePackages}:$PYTHONPATH
+    ${lib.getExe python3} -c "import omniidl_be.cxx; import omniidl_be.python"
+  '';
+
+
+  meta = with lib; {
+    description = "The python backend for omniorb";
+    homepage = "http://omniorb.sourceforge.net";
+    license = with licenses; [ gpl2Plus lgpl21Plus ];
+    maintainers = with maintainers; [ nim65s ];
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/development/tools/omniorb/default.nix
+++ b/pkgs/development/tools/omniorb/default.nix
@@ -21,6 +21,21 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   hardeningDisable = [ "format" ];
 
+  # Transform omniidl_be into a PEP420 namespace to allow other projects to define
+  # their omniidl backends. Especially useful for omniorbpy, the python backend.
+  postInstall = ''
+    rm $out/${python3.sitePackages}/omniidl_be/__init__.py
+    rm $out/${python3.sitePackages}/omniidl_be/__pycache__/__init__.*.pyc
+  '';
+
+  # Ensure postInstall didn't break cxx backend
+  # Same as 'pythonImportsCheck = ["omniidl_be.cxx"];', but outside buildPythonPackage
+  doInstallCheck = true;
+  postInstallCheck = ''
+    export PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+    ${lib.getExe python3} -c "import omniidl_be.cxx"
+  '';
+
   meta = with lib; {
     description = "A robust high performance CORBA ORB for C++ and Python";
     longDescription = ''


### PR DESCRIPTION
## Description of changes

Add omniORBpy, https://omniorb.sourceforge.io/

ping @grwlf for review omniORB

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
