### PR TITLE
sddm-sugar-dark: init at 1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4352,6 +4352,12 @@
     githubId = 24708079;
     name = "Dan Eads";
   };
+  danid3v = {
+    email = "sch220233@spengergasse.at";
+    github = "DaniD3v";
+    githubId = 124387056;
+    name = "DaniD3v";
+  };
   danielalvsaaker = {
     email = "daniel.alvsaaker@proton.me";
     github = "danielalvsaaker";

--- a/pkgs/data/themes/sddm-sugar-dark/default.nix
+++ b/pkgs/data/themes/sddm-sugar-dark/default.nix
@@ -1,0 +1,40 @@
+{ pkgs, lib, stdenvNoCC, themeConfig ? null }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "sddm-sugar-dark";
+  version = "1.2";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "MarianArlt";
+    repo = "sddm-sugar-dark";
+    rev = "v${version}";
+    hash = "sha256-C3qB9hFUeuT5+Dos2zFj5SyQegnghpoFV9wHvE9VoD8=";
+  };
+
+  dontWrapQtApps = true;
+
+  buildInputs = with pkgs.libsForQt5.qt5; [ qtgraphicaleffects ];
+
+  installPhase =
+    let
+      iniFormat = pkgs.formats.ini { };
+      configFile = iniFormat.generate "" { General = themeConfig; };
+
+      basePath = "$out/share/sddm/themes/sugar-dark";
+    in
+    ''
+      mkdir -p ${basePath}
+      cp -r $src/* ${basePath}
+    '' + lib.optionalString (themeConfig != null) ''
+      ln -sf ${configFile} ${basePath}/theme.conf.user
+    '';
+
+  meta = {
+    description = "Dark SDDM theme from the sugar family";
+    homepage = "https://github.com/${src.owner}/${pname}";
+    license = lib.licenses.gpl3;
+
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ danid3v ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27658,6 +27658,8 @@ with pkgs;
 
   sddm-chili-theme = libsForQt5.callPackage ../data/themes/chili-sddm { };
 
+  sddm-sugar-dark = libsForQt5.callPackage ../data/themes/sddm-sugar-dark { };
+
   sdparm = callPackage ../os-specific/linux/sdparm { };
 
   sdrangel = libsForQt5.callPackage ../applications/radio/sdrangel {


### PR DESCRIPTION
## Description of changes

Added Package sddm-sugar-dark.
Here's the [homapage](https://github.com/MarianArlt/sddm-sugar-dark).

One of the most popular sddm themes so I was wondering why it wasn't in the nixpkgs already,

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I'm unsure whether I've fulfilled this requirement from Contributing.md. Please take a look.
 `Functions should list their expected arguments as precisely as possible.`)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] _(not applicable)_ Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
