### PR TITLE
gnuradioPackages.osmosdr: fix source URL

### DIFF
--- a/pkgs/development/gnuradio-modules/osmosdr/default.nix
+++ b/pkgs/development/gnuradio-modules/osmosdr/default.nix
@@ -33,7 +33,7 @@ let
     "3.10" = "0.2.4";
   }.${gnuradio.versionAttr.major};
   src = fetchgit {
-    url = "git://git.osmocom.org/gr-osmosdr";
+    url = "https://gitea.osmocom.org/sdr/gr-osmosdr";
     rev = "v${version}";
     sha256 = {
       "3.7" = "0bf9bnc1c3c4yqqqgmg3nhygj6rcfmyk6pybi27f7461d2cw1drv";


### PR DESCRIPTION
## Description of changes

The current URL doesn't work anymore:

```
  $ nix-build -A gnuradioPackages.osmosdr.src --check
  checking outputs of '/nix/store/3jmqk57y5214iadfi6ivbgfd1rr9fyib-gr-osmosdr.drv'...
  exporting git://git.osmocom.org/gr-osmosdr (rev v0.2.4) into /nix/store/m1qa9ipmdf4xrc6gl1r0zd0c5r0ns7bk-gr-osmosdr
  Initialized empty Git repository in /nix/store/m1qa9ipmdf4xrc6gl1r0zd0c5r0ns7bk-gr-osmosdr/.git/
  fatal: unable to connect to git.osmocom.org:
  git.osmocom.org[0: 78.46.96.155]: errno=Connection refused
  git.osmocom.org[1: 2a01:4f8:120:8470::2]: errno=Network is unreachable
```

Fixes https://github.com/NixOS/nixpkgs/issues/298876.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
