### PR TITLE
nixos/nvidia: update manual

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.chapter.md
+++ b/nixos/doc/manual/configuration/x-windows.chapter.md
@@ -146,14 +146,12 @@ default because it's not free software. You can enable it as follows:
 services.xserver.videoDrivers = [ "nvidia" ];
 ```
 
-Or if you have an older card, you may have to use one of the legacy
-drivers:
+If you have an older card, you may have to use one of the legacy drivers:
 
 ```nix
-services.xserver.videoDrivers = [ "nvidiaLegacy470" ];
-services.xserver.videoDrivers = [ "nvidiaLegacy390" ];
-services.xserver.videoDrivers = [ "nvidiaLegacy340" ];
-services.xserver.videoDrivers = [ "nvidiaLegacy304" ];
+hardware.nvidia.package = config.boot.kernelPackages.nvidiaPackages.legacy_470;
+hardware.nvidia.package = config.boot.kernelPackages.nvidiaPackages.legacy_390;
+hardware.nvidia.package = config.boot.kernelPackages.nvidiaPackages.legacy_340;
 ```
 
 You may need to reboot after enabling this driver to prevent a clash

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -303,7 +303,7 @@ in
         type = types.listOf types.str;
         default = [ "modesetting" "fbdev" ];
         example = [
-          "nvidia" "nvidiaLegacy390" "nvidiaLegacy340" "nvidiaLegacy304"
+          "nvidia"
           "amdgpu-pro"
         ];
         # TODO(@oxij): think how to easily add the rest, like those nvidia things


### PR DESCRIPTION
Remove the `nvidiaLegacy*` video drivers from the manual: not only are they deprecated, their deprecation notice was removed in https://github.com/NixOS/nixpkgs/pull/244060.