### PR TITLE
yabai: 7.0.2 -> 7.0.3

### DIFF
--- a/pkgs/os-specific/darwin/yabai/default.nix
+++ b/pkgs/os-specific/darwin/yabai/default.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "yabai";
-  version = "7.0.2";
+  version = "7.0.3";
 
   src = finalAttrs.passthru.sources.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
@@ -85,14 +85,14 @@ stdenv.mkDerivation (finalAttrs: {
       # See the comments on https://github.com/NixOS/nixpkgs/pull/188322 for more information.
       "aarch64-darwin" = fetchzip {
         url = "https://github.com/koekeishiya/yabai/releases/download/v${finalAttrs.version}/yabai-v${finalAttrs.version}.tar.gz";
-        hash = "sha256-FeNiJJM5vdzFT9s7N9cTjLYxKEfzZnKE9br13lkQhJo=";
+        hash = "sha256-EvtKYYjEmLkJTnc9q6f37hMD1T3DBO+I1LfBvPjCgfc=";
       };
       "x86_64-darwin" = fetchFromGitHub
         {
           owner = "koekeishiya";
           repo = "yabai";
           rev = "v${finalAttrs.version}";
-          hash = "sha256-/MOAKsY7MlRWdvUQwHeITTeGJbCUdX7blZZAl2zXuic=";
+          hash = "sha256-oxQsCvTZqfKZoTuY1NC6h+Fzvyl0gJDhljFY2KrjRQ8=";
         };
     };
 

--- a/pkgs/os-specific/darwin/yabai/default.nix
+++ b/pkgs/os-specific/darwin/yabai/default.nix
@@ -4,9 +4,13 @@
 , fetchzip
 , installShellFiles
 , testers
-, yabai
-, xxd
+, writeShellScript
+, common-updater-scripts
+, curl
+, jq
 , xcodebuild
+, xxd
+, yabai
 , Carbon
 , Cocoa
 , ScriptingBridge
@@ -17,22 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "yabai";
   version = "7.0.2";
 
-  src =
-    # Unfortunately compiling yabai from source on aarch64-darwin is a bit complicated. We use the precompiled binary instead for now.
-    # See the comments on https://github.com/NixOS/nixpkgs/pull/188322 for more information.
-    if stdenv.isAarch64 then
-      (fetchzip {
-        url = "https://github.com/koekeishiya/yabai/releases/download/v${finalAttrs.version}/yabai-v${finalAttrs.version}.tar.gz";
-        hash = "sha256-FeNiJJM5vdzFT9s7N9cTjLYxKEfzZnKE9br13lkQhJo=";
-      })
-    else if stdenv.isx86_64 then
-      (fetchFromGitHub {
-        owner = "koekeishiya";
-        repo = "yabai";
-        rev = "v${finalAttrs.version}";
-        hash = "sha256-/MOAKsY7MlRWdvUQwHeITTeGJbCUdX7blZZAl2zXuic=";
-      })
-    else (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  src = finalAttrs.passthru.sources.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   env = {
     # silence service.h error
@@ -85,9 +74,41 @@ stdenv.mkDerivation (finalAttrs: {
     --replace 'return screen.safeAreaInsets.top;' 'return 0;'
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = yabai;
-    version = "yabai-v${finalAttrs.version}";
+  passthru = {
+    tests.version = testers.testVersion {
+      package = yabai;
+      version = "yabai-v${finalAttrs.version}";
+    };
+
+    sources = {
+      # Unfortunately compiling yabai from source on aarch64-darwin is a bit complicated. We use the precompiled binary instead for now.
+      # See the comments on https://github.com/NixOS/nixpkgs/pull/188322 for more information.
+      "aarch64-darwin" = fetchzip {
+        url = "https://github.com/koekeishiya/yabai/releases/download/v${finalAttrs.version}/yabai-v${finalAttrs.version}.tar.gz";
+        hash = "sha256-FeNiJJM5vdzFT9s7N9cTjLYxKEfzZnKE9br13lkQhJo=";
+      };
+      "x86_64-darwin" = fetchFromGitHub
+        {
+          owner = "koekeishiya";
+          repo = "yabai";
+          rev = "v${finalAttrs.version}";
+          hash = "sha256-/MOAKsY7MlRWdvUQwHeITTeGJbCUdX7blZZAl2zXuic=";
+        };
+    };
+
+    updateScript = writeShellScript "update-yabai" ''
+      set -o errexit
+      export PATH="${lib.makeBinPath [ curl jq common-updater-scripts ]}"
+      NEW_VERSION=$(curl --silent https://api.github.com/repos/koekeishiya/yabai/releases/latest | jq '.tag_name | ltrimstr("v")' --raw-output)
+      if [[ "${finalAttrs.version}" = "$NEW_VERSION" ]]; then
+          echo "The new version same as the old version."
+          exit 0
+      fi
+      for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
+        update-source-version "yabai" "0" "${lib.fakeHash}" --source-key="sources.$platform"
+        update-source-version "yabai" "$NEW_VERSION" --source-key="sources.$platform"
+      done
+    '';
   };
 
   meta = {
@@ -101,7 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/koekeishiya/yabai";
     changelog = "https://github.com/koekeishiya/yabai/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    platforms = lib.platforms.darwin;
+    platforms = builtins.attrNames finalAttrs.passthru.sources;
     mainProgram = "yabai";
     maintainers = with lib.maintainers; [
       cmacrae


### PR DESCRIPTION
## Description of changes
Just refactored a bit in other PR, but saw another package doing updateScript that would support multiple sources easily and wanted to make it easier to maintain the package. Tested updateScript to update this bump and it worked. 

https://github.com/koekeishiya/yabai/blob/master/CHANGELOG.md#703---2024-03-22
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
