### PR TITLE
freemind: adopt, refactor and make deterministic

### DIFF
--- a/pkgs/applications/misc/freemind/default.nix
+++ b/pkgs/applications/misc/freemind/default.nix
@@ -1,43 +1,76 @@
-{ lib, stdenv, fetchurl, jdk, jre, ant }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  ant,
+  jdk,
+  jre,
+  makeWrapper,
+  stripJavaArchivesHook,
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "freemind";
   version = "1.0.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/freemind/freemind-src-${version}.tar.gz";
-    sha256 = "06c6pm7hpwh9hbmyah3lj2wp1g957x8znfwc5cwygsi7dc98b0h1";
+    url = "mirror://sourceforge/freemind/freemind-src-${finalAttrs.version}.tar.gz";
+    hash = "sha256-AYKFEmsn6uc5K4w7+1E/Jb1wuZB0QOXrggnyC0+9hhk=";
   };
 
-  buildInputs = [ jdk ant ];
+  nativeBuildInputs = [
+    ant
+    jdk
+    makeWrapper
+    stripJavaArchivesHook
+  ];
+
+  postPatch = ''
+    # disable the <buildnumer> task because it would edit version.properties
+    # and add a "last edited" header to it, which is non-deterministic
+    sed -i  '/<buildnumber/d' build.xml
+
+    # replace dependency on `which`
+    substituteInPlace freemind.sh \
+        --replace-fail "which" "type -p"
+  '';
 
   preConfigure = ''
-    chmod +x check_for_duplicate_resources.sh
-    sed 's,/bin/bash,${stdenv.shell},' -i check_for_duplicate_resources.sh
-
-    ## work around javac encoding errors
-    export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+    chmod +x *.sh
+    patchShebangs *.sh
   '';
 
-  buildPhase = "ant dist";
+  # Workaround for javac encoding errors
+  # Note: not sure if this is still needed
+  env.JAVA_TOOL_OPTIONS = "-Dfile.encoding=UTF8";
+
+  buildPhase = ''
+    runHook preBuild
+    ant build
+    runHook postBuild
+  '';
 
   installPhase = ''
-    mkdir -p $out/{bin,nix-support}
-    cp -r ../bin/dist $out/nix-support
-    sed -i 's/which/type -p/' $out/nix-support/dist/freemind.sh
-
-    cat >$out/bin/freemind <<EOF
-    #! ${stdenv.shell}
-    JAVA_HOME=${jre} $out/nix-support/dist/freemind.sh
-    EOF
-    chmod +x $out/{bin/freemind,nix-support/dist/freemind.sh}
+    runHook preInstall
+    ant dist -Ddist=$out/share/freemind
+    runHook postInstall
   '';
 
-  meta = with lib; {
+  postFixup = ''
+    makeWrapper $out/share/freemind/freemind.sh $out/bin/freemind \
+        --set JAVA_HOME ${jre}
+  '';
+
+  meta = {
     description = "Mind-mapping software";
-    mainProgram = "freemind";
     homepage = "https://freemind.sourceforge.net/wiki/index.php/Main_Page";
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    mainProgram = "freemind";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode # source bundles dependencies as jars
+    ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

This PR overhauls how the `freemind` package's derivation is structured, while also making sure it's deterministic.

Related tracking issue: https://github.com/NixOS/nixpkgs/issues/278518



## Things done
- use `finalAttrs` instead of `rec`
- use `hash` instead of `sha256`
- use `nativeBuildInputs` instead of `buildInputs`
- have separate `postPatch`, `preConfigure`, `buildPhase`, `installPhase` and `postFixup` scripts, while also running the appropriate `runHook` calls
- use `env.` instead of `export` for an environment variable
- put files into `$out/share/freemind` instead of `$out/nix-support`
- use `makeWrapper` instead of using `cat`
- make deterministic
  - use `stripJavaArchivesHook`
  - remove `<buildnumber>` task from `build.xml`, which would edit `version.properties` and put the build timestamp into the file.
- `meta` changes
  - set `maintainers` and add myself to it
  - set `sourceProvenance`

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
