### PR TITLE
jffi: clean up and make deterministic

### DIFF
--- a/pkgs/development/libraries/java/jffi/default.nix
+++ b/pkgs/development/libraries/java/jffi/default.nix
@@ -1,40 +1,66 @@
-{ lib, stdenv, fetchFromGitHub, jdk, jre, ant, libffi, texinfo, pkg-config }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, ant
+, jdk
+, libffi
+, pkg-config
+, texinfo
+, stripJavaArchivesHook
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "jffi";
   version = "1.3.13";
 
   src = fetchFromGitHub {
     owner = "jnr";
     repo = "jffi";
-    rev = "jffi-${version}";
-    sha256 = "sha256-aBQkkZyXZkaJc4sr/jHnIRaJYP116u4Jqsr9XXzfOBA=";
+    rev = "jffi-${finalAttrs.version}";
+    hash = "sha256-aBQkkZyXZkaJc4sr/jHnIRaJYP116u4Jqsr9XXzfOBA=";
   };
 
-  nativeBuildInputs = [ jdk ant texinfo pkg-config ];
-  buildInputs = [ libffi ] ;
+  nativeBuildInputs = [
+    ant
+    jdk
+    pkg-config
+    texinfo
+    stripJavaArchivesHook
+  ];
+
+  buildInputs = [ libffi ];
+
+  # The pkg-config script in the build.xml doesn't work propery
+  # set the lib path manually to work around this.
+  env.LIBFFI_LIBS = "${libffi}/lib/libffi${stdenv.hostPlatform.extensions.sharedLibrary}";
+  env.ANT_ARGS = "-Duse.system.libffi=1";
 
   buildPhase = ''
-    # The pkg-config script in the build.xml doesn't work propery
-    # set the lib path manually to work around this.
-    export LIBFFI_LIBS="${libffi}/lib/libffi.so"
-
-    ant -Duse.system.libffi=1 jar
-    ant -Duse.system.libffi=1 archive-platform-jar
-  '';
-
-  installPhase = ''
-    mkdir -p $out/share/java
-    cp -r dist/* $out/share/java
+    runHook preBuild
+    ant jar
+    ant archive-platform-jar
+    runHook postBuild
   '';
 
   doCheck = true;
-  checkPhase = ''
-    # The pkg-config script in the build.xml doesn't work propery
-    # set the lib path manually to work around this.
-    export LIBFFI_LIBS="${libffi}/lib/libffi.so"
 
-    ant -Duse.system.libffi=1 test
+  checkPhase = ''
+    runHook preCheck
+    ant test
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm644 dist/*.jar -t $out/share/java
+    runHook postInstall
+  '';
+
+  # nix can't detect libffi as a dependency inside the jar file, so we create
+  # a dummy file with the path to libffi, to make sure that nix knows about it
+  postFixup = ''
+    mkdir -p $out/nix-support
+    echo ${libffi} > $out/nix-support/depends
   '';
 
   meta = with lib; {
@@ -45,4 +71,4 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ bachp ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Related tracking issue: https://github.com/NixOS/nixpkgs/issues/278518

This PR makes some changes to the `jffi` package.

## Things done
- use `finalAttrs` instead of `rec`
- use `hash` instead of `sha256`
- use `env.` to set environment variables instead of `export`
  - use the `ANT_ARGS` environment variable to reduce repetition
- add `runHook` calls to the appropriate places
- add a `postFixup` phase which creates a dummy file with the path to `libffi` to make sure that `nix` does not forget about it (as it did before this PR)
- add `stripJavaArchivesHook` to make the build deterministic

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
