### PR TITLE
Avoid top-level `with ...;` in `pkgs/development/compilers/dotnet/`

### DIFF
--- a/pkgs/development/compilers/dotnet/combine-deps.nix
+++ b/pkgs/development/compilers/dotnet/combine-deps.nix
@@ -4,11 +4,22 @@
   otherRids,
   pkgs ? import ../../../.. {}
 }:
-with pkgs.lib;
 let
   inherit (pkgs) writeText;
 
+  inherit (pkgs.lib)
+    concatMap
+    concatMapStringsSep
+    generators
+    optionals
+    replaceStrings
+    sortOn
+    strings
+    unique
+    ;
+
   fns = map (file: import file) list;
+
   packages = unique
     (concatMap (fn: fn { fetchNuGet = package: package; }) fns);
 


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is no functional change contained in this PR.

I used the refactor strategy that looks for the uses of names [coming from `lib`, `pkgs`, `python3Packages`, and more](https://gist.github.com/philiptaron/04326000d5ff20cb72c2805efd09701c). 

Following advice, I also preferred to inherit names from `lib` instead of `builtins` where there was a choice. I also preferred to inherit from `lib` in one place, rather than to have a mixture of `lib.thing` and `inherit (lib) thing`.

There are no rebuilds when I run `nixpkgs-review rev HEAD`, so I've targeted master with this PR.

## Things done

- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev HEAD`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).