### PR TITLE
jextract: unstable-2023-11-27 -> unstable-2024-03-13

### DIFF
--- a/pkgs/by-name/je/jextract-21/package.nix
+++ b/pkgs/by-name/je/jextract-21/package.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , emptyDirectory
 , writeText
-, makeWrapper
+, makeBinaryWrapper
 , gradle
 , jdk21
 , llvmPackages
@@ -49,7 +49,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     gradle
-    makeWrapper
+    makeBinaryWrapper
   ];
 
   env = {
@@ -79,18 +79,16 @@ stdenv.mkDerivation {
 
     mkdir -p $out/opt/
     cp -r ./build/jextract $out/opt/jextract
+    makeBinaryWrapper "$out/opt/jextract/bin/jextract" "$out/bin/jextract"
 
     runHook postInstall
-  '';
-
-  postFixup = ''
-    makeWrapper "$out/opt/jextract/bin/jextract" "$out/bin/jextract"
   '';
 
   meta = with lib; {
     description = "A tool which mechanically generates Java bindings from a native library headers";
     mainProgram = "jextract";
     homepage = "https://github.com/openjdk/jextract";
+    platforms = jdk21.meta.platforms;
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ sharzy ];
   };

--- a/pkgs/by-name/je/jextract/package.nix
+++ b/pkgs/by-name/je/jextract/package.nix
@@ -1,0 +1,95 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, emptyDirectory
+, writeText
+, makeBinaryWrapper
+, gradle
+, jdk22
+, llvmPackages
+}:
+
+let
+  gradleInit = writeText "init.gradle" ''
+    logger.lifecycle 'Replacing Maven repositories with empty directory...'
+    gradle.projectsLoaded {
+      rootProject.allprojects {
+        buildscript {
+          repositories {
+            clear()
+            maven { url '${emptyDirectory}' }
+          }
+        }
+        repositories {
+          clear()
+          maven { url '${emptyDirectory}' }
+        }
+      }
+    }
+    settingsEvaluated { settings ->
+      settings.pluginManagement {
+        repositories {
+          maven { url '${emptyDirectory}' }
+        }
+      }
+    }
+  '';
+in
+
+stdenv.mkDerivation {
+  pname = "jextract";
+  version = "unstable-2024-03-13";
+
+  src = fetchFromGitHub {
+    owner = "openjdk";
+    repo = "jextract";
+    rev = "b9ec8879cff052b463237fdd76382b3a5cd8ff2b";
+    hash = "sha256-+4AM8pzXPIO/CS3+Rd/jJf2xDvAo7K7FRyNE8rXvk5U=";
+  };
+
+  nativeBuildInputs = [
+    gradle
+    makeBinaryWrapper
+  ];
+
+  env = {
+    ORG_GRADLE_PROJECT_llvm_home = llvmPackages.libclang.lib;
+    ORG_GRADLE_PROJECT_jdk22_home = jdk22;
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    export GRADLE_USER_HOME=$(mktemp -d)
+    gradle --console plain --init-script "${gradleInit}" assemble
+
+    runHook postBuild
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    gradle --console plain --init-script "${gradleInit}" verify
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/opt/
+    cp -r ./build/jextract $out/opt/jextract
+    makeBinaryWrapper "$out/opt/jextract/bin/jextract" "$out/bin/jextract"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A tool which mechanically generates Java bindings from a native library headers";
+    mainProgram = "jextract";
+    homepage = "https://github.com/openjdk/jextract";
+    platforms = jdk22.meta.platforms;
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ jlesquembre sharzy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25382,8 +25382,6 @@ with pkgs;
 
   fastjar = callPackage ../development/tools/java/fastjar { };
 
-  jextract = callPackage ../development/tools/java/jextract { };
-
   httpunit = callPackage ../development/libraries/java/httpunit { };
 
   javaCup = callPackage ../development/libraries/java/cup {


### PR DESCRIPTION
Closes #293102, as requested there, I'm keeping a jextract version compatible with JDK21

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
