### PR TITLE
Avoid top-level `with ...;` in `pkgs/development/haskell-modules`

### DIFF
--- a/pkgs/development/haskell-modules/configuration-arm.nix
+++ b/pkgs/development/haskell-modules/configuration-arm.nix
@@ -23,9 +23,15 @@
 
 let
   inherit (pkgs) lib;
-in
 
-with haskellLib;
+  inherit (haskellLib)
+    doDistribute
+    dontCheck
+    dontHaddock
+    overrideCabal
+    triggerRebuild
+    ;
+in
 
 self: super: {
   # COMMON ARM OVERRIDES

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -14,9 +14,36 @@
 let
   inherit (pkgs) fetchpatch fetchpatch2 lib;
   inherit (lib) throwIfNot versionOlder versions;
-in
 
-with haskellLib;
+  inherit (haskellLib)
+    addBuildDepend
+    addBuildDepends
+    addBuildTool
+    addBuildTools
+    addExtraLibrary
+    addTestToolDepends
+    appendConfigureFlag
+    appendConfigureFlags
+    appendPatch
+    appendPatches
+    disableCabalFlag
+    disableHardening
+    disableLibraryProfiling
+    doCheck
+    doDistribute
+    doHaddock
+    doJailbreak
+    dontCheck
+    dontCheckIf
+    dontDistribute
+    dontHaddock
+    generateOptparseApplicativeCompletions
+    markBroken
+    overrideCabal
+    overrideSrc
+    unmarkBroken
+    ;
+in
 
 self: super: {
   # Make sure that Cabal 3.10.* can be built as-is

--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -4,9 +4,21 @@
 
 let
   inherit (pkgs) lib darwin;
-in
 
-with haskellLib;
+  inherit (haskellLib)
+    addBuildDepend
+    addExtraLibraries
+    addExtraLibrary
+    addPkgconfigDepends
+    addTestToolDepends
+    appendConfigureFlag
+    appendPatch
+    disableCabalFlag
+    doCheck
+    dontCheck
+    overrideCabal
+    ;
+in
 
 self: super: ({
 

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -1,8 +1,20 @@
 { pkgs, haskellLib }:
 
-with haskellLib;
-
 let
+  inherit (haskellLib)
+    addBuildDepend
+    addBuildDepends
+    disableOptimization
+    doDistribute
+    doJailbreak
+    dontCheck
+    dontHaddock
+    generateOptparseApplicativeCompletions
+    markUnbroken
+    overrideCabal
+    unmarkBroken
+    ;
+
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
   inherit (pkgs) lib;
 in

--- a/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
@@ -1,9 +1,16 @@
 { pkgs, haskellLib }:
 
-with haskellLib;
-
 let
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
+
+  inherit (haskellLib)
+    addBuildDepend
+    disableOptimization
+    doDistribute
+    doJailbreak
+    dontCheck
+    markUnbroken
+    ;
 in
 
 self: super: {

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -1,8 +1,17 @@
 { pkgs, haskellLib }:
 
-with haskellLib;
-
 let
+  inherit (haskellLib)
+    addBuildDepend
+    addBuildDepends
+    appendConfigureFlags
+    doDistribute
+    doJailbreak
+    dontCheck
+    overrideCabal
+    unmarkBroken
+    ;
+
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
   inherit (pkgs) lib;
 in

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -1,10 +1,22 @@
 { pkgs, haskellLib }:
 
-with haskellLib;
-
 let
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
   inherit (pkgs) lib;
+
+  inherit (haskellLib)
+    addBuildDepends
+    appendConfigureFlags
+    disableCabalFlag
+    doDistribute
+    doJailbreak
+    dontCheck
+    dontDistribute
+    enableCabalFlag
+    markBroken
+    overrideCabal
+    unmarkBroken
+    ;
 in
 
 self: super: {

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -6,9 +6,17 @@ let
     if builtins.compareVersions pkg.version ver <= 0 then act
     else
       builtins.throw "Check if '${msg}' was resolved in ${pkg.pname} ${pkg.version} and update or remove this";
-in
 
-with haskellLib;
+  inherit (haskellLib)
+    addBuildDepends
+    allowInconsistentDependencies
+    doDistribute
+    doJailbreak
+    dontCheck
+    dontHaddock
+    overrideCabal
+    ;
+in
 self: super: let
   jailbreakForCurrentVersion = p: v: checkAgainAfter p v "bad bounds" (doJailbreak p);
 in {

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -1,7 +1,5 @@
 { pkgs, haskellLib }:
 
-with haskellLib;
-
 let
   inherit (pkgs) lib;
 
@@ -17,7 +15,18 @@ let
 
   # Workaround for a ghc-9.6 issue: https://gitlab.haskell.org/ghc/ghc/-/issues/23392
   disableParallelBuilding = overrideCabal (drv: { enableParallelBuilding = false; });
+
+  inherit (haskellLib)
+    appendConfigureFlag
+    appendPatch
+    appendPatches
+    doDistribute
+    dontCheck
+    doJailbreak
+    overrideCabal
+    ;
 in
+
 
 self: super: {
   llvmPackages = lib.dontRecurseIntoAttrs self.ghc.llvmPackages;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -1,9 +1,16 @@
 { pkgs, haskellLib }:
 
-with haskellLib;
-
 let
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
+
+  inherit (haskellLib)
+    addBuildDepends
+    appendConfigureFlag
+    appendPatch
+    doDistribute
+    doJailbreak
+    dontCheck
+    ;
 in
 
 self: super: {

--- a/pkgs/development/haskell-modules/configuration-ghcjs-8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs-8.x.nix
@@ -7,9 +7,15 @@
 let
   removeLibraryHaskellDepends = pnames: depends:
     builtins.filter (e: !(builtins.elem (e.pname or "") pnames)) depends;
-in
 
-with haskellLib;
+  inherit (haskellLib)
+    appendPatch
+    doJailbreak
+    dontCheck
+    markUnbroken
+    overrideCabal
+    ;
+in
 
 self: super:
 

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -29,9 +29,38 @@
 
 let
   inherit (pkgs) lib;
-in
 
-with haskellLib;
+  inherit (haskellLib)
+    addBuildDepend
+    addBuildDepends
+    addBuildTool
+    addBuildTools
+    addExtraLibraries
+    addExtraLibrary
+    addPkgconfigDepend
+    addTestToolDepend
+    addTestToolDepends
+    appendConfigureFlag
+    appendConfigureFlags
+    appendPatch
+    disableCabalFlag
+    disableHardening
+    disableSharedExecutables
+    doCheck
+    doDistribute
+    doJailbreak
+    dontCheck
+    dontCheckIf
+    enableCabalFlag
+    enableSeparateBinOutput
+    enableSharedExecutables
+    generateOptparseApplicativeCompletions
+    justStaticExecutables
+    markBroken
+    overrideCabal
+    overrideSrc
+    ;
+in
 
 # All of the overrides in this set should look like:
 #

--- a/pkgs/development/haskell-modules/configuration-tensorflow.nix
+++ b/pkgs/development/haskell-modules/configuration-tensorflow.nix
@@ -1,6 +1,8 @@
 { pkgs, haskellLib }:
 
-with haskellLib;
+let
+  inherit (haskellLib) doJailbreak overrideCabal;
+in
 
 self: super:
 let


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is no functional change contained in this PR.

I used the refactor strategy that looks for the uses of names [coming from `lib`, `pkgs`, and `haskellLib`](https://gist.github.com/philiptaron/04326000d5ff20cb72c2805efd09701c). 

<del>Following advice, I also preferred to inherit names from `lib` instead of `builtins` where there was a choice. I also preferred to inherit from `lib` in one place, rather than to have a mixture of `lib.thing`, `pkgs.lib.thing`, and `inherit (lib) thing`. **I can revert these changes if you all feel them to be net-negative.**</del> I have reverted them.

<del>There are no rebuilds when I run `nixpkgs-review rev HEAD`, so I've targeted master with this PR.</del> @maralorn asked me to target `haskell-updates`, so I have done so.

On a personal note, I don't particularly like the long list of inherited names in (say) `configuration-common.nix` but I think it's better than a top-level with statement.

## Things done

- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev HEAD`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).