### PR TITLE
Avoid top-level `with ...;` in the Python packages in `pkgs/development/`

### DIFF
--- a/pkgs/development/embedded/fpga/tinyprog/default.nix
+++ b/pkgs/development/embedded/fpga/tinyprog/default.nix
@@ -3,10 +3,27 @@
 , fetchFromGitHub
 }:
 
-with python3Packages; buildPythonApplication rec {
+let
+  inherit (lib) licenses maintainers substring;
+
+  inherit (python3Packages)
+    buildPythonApplication
+    intelhex
+    jsonmerge
+    packaging
+    pyserial
+    pyusb
+    setuptools
+    setuptools-scm
+    six
+    tqdm
+    ;
+in
+
+buildPythonApplication rec {
   pname = "tinyprog";
   # `python setup.py --version` from repo checkout
-  version = "1.0.24.dev114+g${lib.substring 0 7 src.rev}";
+  version = "1.0.24.dev114+g${substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
     owner = "tinyfpga";
@@ -30,7 +47,7 @@ with python3Packages; buildPythonApplication rec {
 
   nativeBuildInputs = [ setuptools-scm ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/tinyfpga/TinyFPGA-Bootloader/tree/master/programmer";
     description = "Programmer for FPGA boards using the TinyFPGA USB Bootloader";
     mainProgram = "tinyprog";

--- a/pkgs/development/embedded/platformio/core.nix
+++ b/pkgs/development/embedded/platformio/core.nix
@@ -8,8 +8,38 @@
 , substituteAll
 }:
 
+let
+  inherit (lib) licenses maintainers optionals;
 
-with python3Packages; buildPythonApplication rec {
+  inherit (python3Packages)
+    aiofiles
+    ajsonrpc
+    bottle
+    buildPythonApplication
+    chardet
+    click
+    click-completion
+    colorama
+    jsondiff
+    lockfile
+    marshmallow
+    pyelftools
+    pyserial
+    pytestCheckHook
+    python
+    pythonRelaxDepsHook
+    requests
+    semantic-version
+    setuptools
+    starlette
+    stdenv
+    tabulate
+    uvicorn
+    wsproto
+    zeroconf
+    ;
+in
+buildPythonApplication rec {
   pname = "platformio";
   version = "6.1.11";
   pyproject = true;
@@ -27,7 +57,7 @@ with python3Packages; buildPythonApplication rec {
   patches = [
     (substituteAll {
       src = ./interpreter.patch;
-      interpreter = (python3Packages.python.withPackages (_: propagatedBuildInputs)).interpreter;
+      interpreter = (python.withPackages (_: propagatedBuildInputs)).interpreter;
     })
     (substituteAll {
       src = ./use-local-spdx-license-list.patch;
@@ -77,7 +107,7 @@ with python3Packages; buildPythonApplication rec {
     uvicorn
     wsproto
     zeroconf
-  ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
+  ] ++ optionals (stdenv.isDarwin && stdenv.isAarch64) [
     chardet
   ];
 
@@ -194,10 +224,10 @@ with python3Packages; buildPythonApplication rec {
   ]);
 
   passthru = {
-    python = python3Packages.python;
+    inherit python;
   };
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/platformio/platformio-core/releases/tag/v${version}";
     description = "An open source ecosystem for IoT development";
     downloadPage = "https://github.com/platformio/platformio-core";

--- a/pkgs/development/python-modules/asn1crypto/default.nix
+++ b/pkgs/development/python-modules/asn1crypto/default.nix
@@ -13,8 +13,8 @@
 # Switch version based on python version, as the situation isn't easy:
 #   https://github.com/wbond/asn1crypto/issues/269
 #   https://github.com/MatthiasValvekens/certomancer/issues/12
-with (
-  if lib.versionOlder python.version "3.12" then rec {
+let
+  provenance = if lib.versionOlder python.version "3.12" then rec {
     version = "1.5.1";
     rev = version;
     hash = "sha256-M8vASxhaJPgkiTrAckxz7gk/QHkrFlNz7fFbnLEBT+M=";
@@ -22,19 +22,19 @@ with (
     version = "1.5.1-unstable-2023-11-03";
     rev = "b763a757bb2bef2ab63620611ddd8006d5e9e4a2";
     hash = "sha256-11WajEDtisiJsKQjZMSd5sDog3DuuBzf1PcgSY+uuXY=";
-  }
-);
+  };
+in
 
 buildPythonPackage rec {
   pname = "asn1crypto";
   pyproject = true;
-  inherit version;
+  inherit (provenance) version;
 
   # Pulling from Github to run tests
   src = fetchFromGitHub {
     owner = "wbond";
     repo = "asn1crypto";
-    inherit rev hash;
+    inherit (provenance) rev hash;
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pillow/generic.nix
+++ b/pkgs/development/python-modules/pillow/generic.nix
@@ -5,10 +5,35 @@
 , patches ? []
 , meta
 , passthru ? {}
+, buildPythonPackage
+, format
+, lib
+, stdenv
+, olefile
+, defusedxml
+, pytestCheckHook
+, numpy
+, setuptools
+, freetype
+, libjpeg
+, openjpeg
+, libimagequant
+, zlib
+, libtiff
+, libwebp
+, libxcrypt
+, tcl
+, lcms2
+, libxcb
+, isPyPy
+, tk
+, libX11
 , ...
-}@args:
+}:
 
-with args;
+let
+  inherit (lib) optionals optionalString versionAtLeast;
+in
 
 buildPythonPackage rec {
   inherit pname version format src meta passthru patches;
@@ -27,7 +52,7 @@ buildPythonPackage rec {
     "test_roundtrip"
     "test_basic"
     "test_custom_metadata"
-  ] ++ lib.optionals stdenv.isDarwin [
+  ] ++ optionals stdenv.isDarwin [
     # Disable darwin tests which require executables: `iconutil` and `screencapture`
     "test_grab"
     "test_grabclipboard"
@@ -35,15 +60,15 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [ olefile ]
-    ++ lib.optionals (lib.versionAtLeast version "8.2.0") [ defusedxml ];
+    ++ optionals (versionAtLeast version "8.2.0") [ defusedxml ];
 
   nativeCheckInputs = [ pytestCheckHook numpy ];
 
   nativeBuildInputs = [ setuptools ];
 
   buildInputs = [ freetype libjpeg openjpeg libimagequant zlib libtiff libwebp libxcrypt tcl lcms2 ]
-    ++ lib.optionals (lib.versionAtLeast version "7.1.0") [ libxcb ]
-    ++ lib.optionals (isPyPy) [ tk libX11 ];
+    ++ optionals (versionAtLeast version "7.1.0") [ libxcb ]
+    ++ optionals (isPyPy) [ tk libX11 ];
 
   # NOTE: we use LCMS_ROOT as WEBP root since there is not other setting for webp.
   # NOTE: The Pillow install script will, by default, add paths like /usr/lib
@@ -70,7 +95,7 @@ buildPythonPackage rec {
             s|self\.disable_platform_guessing = None|self.disable_platform_guessing = True|g ;'
     export LDFLAGS="$LDFLAGS -L${libwebp}/lib"
     export CFLAGS="$CFLAGS -I${libwebp}/include"
-  '' + lib.optionalString (lib.versionAtLeast version "7.1.0") ''
+  '' + optionalString (versionAtLeast version "7.1.0") ''
     export LDFLAGS="$LDFLAGS -L${libxcb}/lib"
     export CFLAGS="$CFLAGS -I${libxcb.dev}/include"
   '';

--- a/pkgs/development/python-modules/tasklib/default.nix
+++ b/pkgs/development/python-modules/tasklib/default.nix
@@ -5,13 +5,22 @@
 , writeShellScriptBin
 }:
 
-with pythonPackages;
-
 let
+  inherit (lib) licenses maintainers platforms;
 
-wsl_stub = writeShellScriptBin "wsl" "true";
+  inherit (pythonPackages)
+    buildPythonPackage
+    pytz
+    setuptools
+    six
+    tzlocal
+    ;
 
-in buildPythonPackage rec {
+  wsl_stub = writeShellScriptBin "wsl" "true";
+
+in
+
+buildPythonPackage rec {
   pname = "tasklib";
   version = "2.5.1";
   format = "setuptools";
@@ -32,7 +41,7 @@ in buildPythonPackage rec {
     wsl_stub
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/robgolding/tasklib";
     description = "Library for interacting with taskwarrior databases";
     changelog = "https://github.com/GothenburgBitFactory/tasklib/releases/tag/${version}";

--- a/pkgs/development/tools/agda-pkg/default.nix
+++ b/pkgs/development/tools/agda-pkg/default.nix
@@ -3,7 +3,26 @@
 , fetchPypi
 }:
 
-with python3Packages;
+let
+  inherit (lib) licenses maintainers;
+
+  inherit (python3Packages)
+    buildPythonApplication
+    click
+    click-log
+    distlib
+    gitpython
+    humanize
+    jinja2
+    natsort
+    pony
+    ponywhoosh
+    pythonOlder
+    pyyaml
+    requests
+    whoosh
+    ;
+in
 
 buildPythonApplication rec {
   pname = "agda-pkg";
@@ -38,7 +57,7 @@ buildPythonApplication rec {
     ponywhoosh
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://agda.github.io/agda-pkg/";
     description = "Package manager for Agda";
     license = licenses.mit;

--- a/pkgs/development/tools/analysis/uefi-firmware-parser/default.nix
+++ b/pkgs/development/tools/analysis/uefi-firmware-parser/default.nix
@@ -1,6 +1,9 @@
 { lib, python3, fetchFromGitHub }:
 
-with python3.pkgs;
+let
+  inherit (lib) licenses maintainers platforms;
+  inherit (python3.pkgs) buildPythonApplication;
+in
 
 buildPythonApplication rec {
   pname = "uefi-firmware-parser";
@@ -14,7 +17,7 @@ buildPythonApplication rec {
     sha256 = "1yn9vi91j1yxkn0icdnjhgl0qrqqkzyhccj39af4f19q1gdw995l";
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/theopolis/uefi-firmware-parser/";
     description = "Parse BIOS/Intel ME/UEFI firmware related structures: Volumes, FileSystems, Files, etc";
     mainProgram = "uefi-firmware-parser";

--- a/pkgs/development/tools/check-jsonschema/default.nix
+++ b/pkgs/development/tools/check-jsonschema/default.nix
@@ -1,6 +1,22 @@
 { lib, fetchFromGitHub, python3 }:
 
-with python3.pkgs;
+let
+  inherit (lib) licenses maintainers;
+
+  inherit (python3.pkgs)
+    buildPythonApplication
+    click
+    jsonschema
+    pytestCheckHook
+    pytest-xdist
+    pythonOlder
+    regress
+    requests
+    responses
+    ruamel-yaml
+    setuptools
+    ;
+in
 
 buildPythonApplication rec {
   pname = "check-jsonschema";
@@ -39,7 +55,7 @@ buildPythonApplication rec {
     "test_schemaloader_yaml_data"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "A jsonschema CLI and pre-commit hook";
     mainProgram = "check-jsonschema";
     homepage = "https://github.com/python-jsonschema/check-jsonschema";

--- a/pkgs/development/tools/cppclean/default.nix
+++ b/pkgs/development/tools/cppclean/default.nix
@@ -1,6 +1,9 @@
 { lib, fetchFromGitHub, python3Packages }:
 
-with python3Packages;
+let
+  inherit (lib) licenses maintainers platforms;
+  inherit (python3Packages) buildPythonApplication;
+in
 
 buildPythonApplication rec {
   pname = "cppclean";
@@ -21,7 +24,7 @@ buildPythonApplication rec {
     ./test.bash
     '';
 
-  meta = with lib; {
+  meta = {
     description = "Finds problems in C++ source that slow development of large code bases";
     mainProgram = "cppclean";
     homepage    = "https://github.com/myint/cppclean";

--- a/pkgs/development/tools/google-app-engine-go-sdk/default.nix
+++ b/pkgs/development/tools/google-app-engine-go-sdk/default.nix
@@ -1,6 +1,10 @@
 { lib, stdenv, fetchzip, python3Packages, makeWrapper }:
 
-with python3Packages;
+let
+  inherit (lib) licenses maintainers platforms sourceTypes;
+
+  inherit (python3Packages) cffi cryptography pyopenssl python;
+in
 
 stdenv.mkDerivation rec {
   pname = "google-app-engine-go-sdk";
@@ -32,7 +36,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Google App Engine SDK for Go";
     version = version;
     homepage = "https://cloud.google.com/appengine/docs/go/";

--- a/pkgs/development/tools/mbed-cli/default.nix
+++ b/pkgs/development/tools/mbed-cli/default.nix
@@ -1,6 +1,9 @@
 { lib, python3Packages, fetchPypi, git, mercurial }:
 
-with python3Packages;
+let
+  inherit (lib) licenses maintainers;
+  inherit (python3Packages) buildPythonApplication pytest;
+in
 
 buildPythonApplication rec {
   pname = "mbed-cli";
@@ -24,11 +27,10 @@ buildPythonApplication rec {
     pytest test
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/ARMmbed/mbed-cli";
     description = "Arm Mbed Command Line Interface";
     license = licenses.asl20;
     maintainers = with maintainers; [ ];
   };
 }
-

--- a/pkgs/development/tools/misc/nrfutil/default.nix
+++ b/pkgs/development/tools/misc/nrfutil/default.nix
@@ -1,10 +1,29 @@
 { lib
-, stdenv
 , fetchFromGitHub
 , python3
 }:
 
-with python3.pkgs;
+let
+  inherit (lib) licenses maintainers platforms;
+
+  inherit (python3.pkgs)
+    behave
+    buildPythonApplication
+    click
+    crcmod
+    ecdsa
+    intelhex
+    libusb1
+    nose
+    pc-ble-driver-py
+    piccata
+    protobuf
+    pyserial
+    pyspinel
+    pyyaml
+    tqdm
+    ;
+in
 
 buildPythonApplication rec {
   pname = "nrfutil";
@@ -45,7 +64,7 @@ buildPythonApplication rec {
       --replace "protobuf >=3.17.3, < 4.0.0" "protobuf"
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Device Firmware Update tool for nRF chips";
     homepage = "https://github.com/NordicSemiconductor/pc-nrfutil";
     license = licenses.unfreeRedistributable;

--- a/pkgs/development/tools/pew/default.nix
+++ b/pkgs/development/tools/pew/default.nix
@@ -1,6 +1,13 @@
-{ lib, python3, fetchPypi }:
+{ lib, python3Packages, fetchPypi }:
 
-with python3.pkgs;
+let
+  inherit (python3Packages)
+    buildPythonApplication
+    setuptools
+    virtualenv
+    virtualenv-clone
+    ;
+in
 
 buildPythonApplication rec {
   pname = "pew";

--- a/pkgs/development/tools/pipenv/default.nix
+++ b/pkgs/development/tools/pipenv/default.nix
@@ -5,9 +5,23 @@
 , installShellFiles
 }:
 
-with python3.pkgs;
-
 let
+  inherit (lib)
+    licenses
+    maintainers
+    optionals
+    platforms
+    ;
+
+  # This file is a bit special due to runtimeDeps below.
+  inherit (python3.pkgs)
+    buildPythonApplication
+    mock
+    pytestCheckHook
+    pytest-xdist
+    pytz
+    requests
+    ;
 
   runtimeDeps = ps: with ps; [
     certifi
@@ -16,7 +30,7 @@ let
     virtualenv
     virtualenv-clone
   ]
-  ++ lib.optionals stdenv.hostPlatform.isAndroid [
+  ++ optionals stdenv.hostPlatform.isAndroid [
     pyjnius
   ];
 
@@ -36,7 +50,7 @@ in buildPythonApplication rec {
 
   env.LC_ALL = "en_US.UTF-8";
 
-  nativeBuildInputs = [
+  nativeBuildInputs = with python3.pkgs; [
     installShellFiles
     setuptools
     wheel
@@ -81,7 +95,7 @@ in buildPythonApplication rec {
       --fish <(_PIPENV_COMPLETE=fish_source $out/bin/pipenv)
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Python Development Workflow for Humans";
     license = licenses.mit;
     platforms = platforms.all;

--- a/pkgs/development/tools/pylint-exit/default.nix
+++ b/pkgs/development/tools/pylint-exit/default.nix
@@ -1,6 +1,10 @@
 { lib, fetchFromGitHub, python3Packages }:
 
-with python3Packages; buildPythonApplication rec {
+let
+  inherit (python3Packages) buildPythonApplication m2r python;
+in
+
+buildPythonApplication rec {
   pname = "pylint-exit";
   version = "1.2.0";
 

--- a/pkgs/development/tools/rdbtools/default.nix
+++ b/pkgs/development/tools/rdbtools/default.nix
@@ -1,6 +1,9 @@
 { lib, python, fetchPypi }:
 
-with python.pkgs;
+let
+  inherit (lib) licenses maintainers;
+  inherit (python.pkgs) buildPythonApplication python-lzf redis;
+in
 
 buildPythonApplication rec {
   pname = "rdbtools";
@@ -16,7 +19,7 @@ buildPythonApplication rec {
   # No tests in published package
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Parse Redis dump.rdb files, Analyze Memory, and Export Data to JSON";
     homepage = "https://github.com/sripathikrishnan/redis-rdb-tools";
     license = licenses.mit;

--- a/pkgs/development/tools/reno/default.nix
+++ b/pkgs/development/tools/reno/default.nix
@@ -5,7 +5,25 @@
 , fetchPypi
 }:
 
-with python3Packages; buildPythonApplication rec {
+let
+  inherit (lib) licenses maintainers;
+
+  inherit (python3Packages)
+    buildPythonApplication
+    docutils
+    dulwich
+    fixtures
+    pbr
+    pytestCheckHook
+    pyyaml
+    setuptools
+    sphinx
+    testscenarios
+    testtools
+    ;
+in
+
+buildPythonApplication rec {
   pname = "reno";
   version = "3.1.0";
 
@@ -50,7 +68,7 @@ with python3Packages; buildPythonApplication rec {
     $out/bin/reno -h
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Release Notes Manager";
     mainProgram = "reno";
     homepage = "https://docs.openstack.org/reno/latest";

--- a/pkgs/development/tools/skjold/default.nix
+++ b/pkgs/development/tools/skjold/default.nix
@@ -4,6 +4,8 @@
 }:
 
 let
+  inherit (lib) licenses maintainers;
+
   py = python3.override {
     packageOverrides = self: super: {
       packaging = super.packaging.overridePythonAttrs (oldAttrs: rec {
@@ -17,8 +19,19 @@ let
       });
     };
   };
+
+  inherit (py.pkgs)
+    buildPythonApplication
+    click
+    packaging
+    poetry-core
+    pytestCheckHook
+    pytest-mock
+    pytest-watch
+    pyyaml
+    toml
+    ;
 in
-with py.pkgs;
 
 buildPythonApplication rec {
   pname = "skjold";
@@ -32,18 +45,18 @@ buildPythonApplication rec {
     hash = "sha256-rsdstzNZvokYfTjEyPrWR+0SJpf9wL0HAesq8+A+tPY=";
   };
 
-  nativeBuildInputs = with py.pkgs; [
+  nativeBuildInputs = [
     poetry-core
   ];
 
-  propagatedBuildInputs = with py.pkgs; [
+  propagatedBuildInputs = [
     click
     packaging
     pyyaml
     toml
   ];
 
-  nativeCheckInputs = with py.pkgs; [
+  nativeCheckInputs = [
     pytest-mock
     pytest-watch
     pytestCheckHook
@@ -71,7 +84,7 @@ buildPythonApplication rec {
     "skjold"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool to Python dependencies against security advisory databases";
     homepage = "https://github.com/twu/skjold";
     changelog = "https://github.com/twu/skjold/releases/tag/v${version}";

--- a/pkgs/development/tools/vcstool/default.nix
+++ b/pkgs/development/tools/vcstool/default.nix
@@ -1,7 +1,10 @@
 { lib, python3Packages, fetchPypi
 , git, breezy, subversion }:
 
-with python3Packages;
+let
+  inherit (lib) licenses maintainers makeBinPath;
+  inherit (python3Packages) buildPythonApplication pyyaml setuptools;
+in
 
 buildPythonApplication rec {
   pname = "vcstool";
@@ -14,11 +17,11 @@ buildPythonApplication rec {
 
   propagatedBuildInputs = [ pyyaml setuptools ];
 
-  makeWrapperArgs = ["--prefix" "PATH" ":" (lib.makeBinPath [ git breezy subversion ])];
+  makeWrapperArgs = ["--prefix" "PATH" ":" (makeBinPath [ git breezy subversion ])];
 
   doCheck = false; # requires network
 
-  meta = with lib; {
+  meta = {
     description = "Provides a command line tool to invoke vcs commands on multiple repositories";
     homepage = "https://github.com/dirk-thomas/vcstool";
     license = licenses.asl20;

--- a/pkgs/development/tools/vim-vint/default.nix
+++ b/pkgs/development/tools/vim-vint/default.nix
@@ -1,6 +1,20 @@
 { lib, python3Packages, fetchPypi }:
 
-with python3Packages;
+let
+  inherit (lib) licenses maintainers platforms;
+
+  inherit (python3Packages)
+    ansicolor
+    buildPythonApplication
+    chardet
+    mock
+    pytest
+    pytest-cov
+    pythonAtLeast
+    pyyaml
+    setuptools
+    ;
+in
 
 buildPythonApplication rec {
   pname = "vim-vint";
@@ -23,7 +37,7 @@ buildPythonApplication rec {
     sed -i 's/mock == 1.0.1/mock/g' setup.py
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Fast and Highly Extensible Vim script Language Lint implemented by Python";
     homepage = "https://github.com/Kuniwak/vint";
     license = licenses.mit;


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is no functional change contained in this PR.

I really wish to use `callPackage` style dependency injection for these Python packages, rather than the style I've used in this PR. I don't know how to do that refactor, however. 

I used the refactor strategy that looks for the uses of names [coming from `lib`, `pkgs`, `python3Packages`, and more](https://gist.github.com/philiptaron/04326000d5ff20cb72c2805efd09701c). 

Following advice, I also preferred to inherit names from `lib` instead of `builtins` where there was a choice. I also preferred to inherit from `lib` in one place, rather than to have a mixture of `lib.thing` and `inherit (lib) thing`. I can drop those changes if package owners desire.

There are no rebuilds when I run `nixpkgs-review rev HEAD`, so I've targeted master with this PR.

## Things done

- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev HEAD`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).