### PR TITLE
chromium: fix cross compilation

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -1,6 +1,7 @@
 { stdenv, lib, fetchurl, fetchpatch
 , recompressTarball
 , buildPackages
+, buildPlatform
 , pkgsBuildBuild
 , pkgsBuildTarget
 # Channel data:
@@ -107,9 +108,6 @@ let
     # "opus"
   ];
 
-  opusWithCustomModes = libopus.override {
-    withCustomModes = true;
-  };
 
   # build paths and release info
   packageName = extraAttrs.packageName or extraAttrs.name;
@@ -168,7 +166,6 @@ let
       buildPlatformLlvmStdenv.cc
       pkg-config
       libuuid
-      (libpng.override { apngSupport = false; }) # needed for "host/generate_colors_info"
     ]
     # When cross-compiling, chromium builds a huge proportion of its
     # components for both the `buildPlatform` (which it calls
@@ -176,12 +173,39 @@ let
     # half of the dependencies are needed here.  To avoid having to
     # maintain a separate list of buildPlatform-dependencies, we
     # simply throw in the kitchen sink.
-    ++ buildInputs
-    ;
+    # ** Because of overrides, we have to copy the list as it otherwise mess with splicing **
+    ++ [
+      (buildPackages.libpng.override { apngSupport = false; })  # https://bugs.chromium.org/p/chromium/issues/detail?id=752403
+      (buildPackages.libopus.override { withCustomModes = true; })
+      bzip2 flac speex
+      libevent expat libjpeg snappy
+      libcap
+      minizip libwebp
+      libusb1 re2
+      ffmpeg libxslt libxml2
+      nasm
+      nspr nss
+      util-linux alsa-lib
+      libkrb5
+      glib gtk3 dbus-glib
+      libXScrnSaver libXcursor libXtst libxshmfence libGLU libGL
+      mesa # required for libgbm
+      pciutils protobuf speechd libXdamage at-spi2-core
+      pipewire
+      libva
+      libdrm wayland mesa.drivers libxkbcommon
+      curl
+      libepoxy
+      libffi
+      libevdev
+    ] ++ lib.optional systemdSupport systemd
+      ++ lib.optionals cupsSupport [ libgcrypt cups ]
+      ++ lib.optional pulseSupport libpulseaudio;
 
     buildInputs = [
-      (libpng.override { apngSupport = false; }) # https://bugs.chromium.org/p/chromium/issues/detail?id=752403
-      bzip2 flac speex opusWithCustomModes
+      (libpng.override { apngSupport = false; })  # https://bugs.chromium.org/p/chromium/issues/detail?id=752403
+      (libopus.override { withCustomModes = true; })
+      bzip2 flac speex
       libevent expat libjpeg snappy
       libcap
       minizip libwebp

--- a/pkgs/by-name/me/meson/0001-Revert-rust-recursively-pull-proc-macro-dependencies.patch
+++ b/pkgs/by-name/me/meson/0001-Revert-rust-recursively-pull-proc-macro-dependencies.patch
@@ -1,0 +1,92 @@
+From 8304b645c655832c47ee9ca706d182c26d29eaff Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Tue, 9 Apr 2024 06:35:39 +0000
+Subject: [PATCH] Revert "rust: recursively pull proc-macro dependencies as
+ well"
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This reverts commit aee941559c4b88a062e88186819a820c69c200ae.
+
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ mesonbuild/build.py                                   |  2 ++
+ test cases/rust/18 proc-macro/lib.rs                  |  8 --------
+ test cases/rust/18 proc-macro/meson.build             | 11 -----------
+ test cases/rust/18 proc-macro/subdir/meson.build      |  1 -
+ .../rust/18 proc-macro/transitive-proc-macro.rs       |  7 -------
+ 5 files changed, 2 insertions(+), 27 deletions(-)
+ delete mode 100644 test cases/rust/18 proc-macro/lib.rs
+ delete mode 100644 test cases/rust/18 proc-macro/subdir/meson.build
+ delete mode 100644 test cases/rust/18 proc-macro/transitive-proc-macro.rs
+
+diff --git a/mesonbuild/build.py b/mesonbuild/build.py
+index 6f0d6a2dd..7be9b497b 100644
+--- a/mesonbuild/build.py
++++ b/mesonbuild/build.py
+@@ -1295,6 +1295,8 @@ def get_dependencies_recurse(self, result: OrderedSet[BuildTargetTypes], include
+         for t in self.link_targets:
+             if t in result:
+                 continue
++            if t.rust_crate_type == 'proc-macro':
++                continue
+             if include_internals or not t.is_internal():
+                 result.add(t)
+             if isinstance(t, StaticLibrary):
+diff --git a/test cases/rust/18 proc-macro/lib.rs b/test cases/rust/18 proc-macro/lib.rs
+deleted file mode 100644
+index 5242886cc..000000000
+--- a/test cases/rust/18 proc-macro/lib.rs	
++++ /dev/null
+@@ -1,8 +0,0 @@
+-extern crate proc_macro_examples;
+-use proc_macro_examples::make_answer;
+-
+-make_answer!();
+-
+-pub fn func() -> u32 {
+-    answer()
+-}
+diff --git a/test cases/rust/18 proc-macro/meson.build b/test cases/rust/18 proc-macro/meson.build
+index e8b28eda1..c5f0dfc82 100644
+--- a/test cases/rust/18 proc-macro/meson.build	
++++ b/test cases/rust/18 proc-macro/meson.build	
+@@ -31,14 +31,3 @@ main = executable(
+ )
+ 
+ test('main_test2', main)
+-
+-subdir('subdir')
+-
+-staticlib = static_library('staticlib', 'lib.rs',
+-  link_with: pm_in_subdir,
+-  rust_dependency_map : {'proc_macro_examples3' : 'proc_macro_examples'}
+-)
+-
+-executable('transitive-proc-macro', 'transitive-proc-macro.rs',
+-  link_with: staticlib,
+-)
+diff --git a/test cases/rust/18 proc-macro/subdir/meson.build b/test cases/rust/18 proc-macro/subdir/meson.build
+deleted file mode 100644
+index 04842c431..000000000
+--- a/test cases/rust/18 proc-macro/subdir/meson.build	
++++ /dev/null
+@@ -1 +0,0 @@
+-pm_in_subdir = rust.proc_macro('proc_macro_examples3', '../proc.rs')
+diff --git a/test cases/rust/18 proc-macro/transitive-proc-macro.rs b/test cases/rust/18 proc-macro/transitive-proc-macro.rs
+deleted file mode 100644
+index 4c804b3b6..000000000
+--- a/test cases/rust/18 proc-macro/transitive-proc-macro.rs	
++++ /dev/null
+@@ -1,7 +0,0 @@
+-extern crate staticlib;
+-use staticlib::func;
+-
+-
+-fn main() {
+-    assert_eq!(42, func());
+-}
+-- 
+2.44.0
+

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -65,6 +65,10 @@ python3.pkgs.buildPythonApplication rec {
 
     # Nixpkgs cctools does not have bitcode support.
     ./006-disable-bitcode.patch
+
+    # Fix cross-compilation of proc-macro (and mesa)
+    # https://github.com/mesonbuild/meson/issues/12973
+    ./0001-Revert-rust-recursively-pull-proc-macro-dependencies.patch
   ];
 
   buildInputs = lib.optionals (python3.pythonOlder "3.9") [

--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -123,6 +123,12 @@ buildPythonPackage rec {
     "test_partialfunction"
   ];
 
+  disabledTestPaths = [
+    # flaky test under load:
+    # (           index: line    2) broken    http://localhost:7777/#top - HTTPConnectionPool(host='localhost', port=7777): Read timed out. (read timeout=0.05)
+    "tests/test_build_linkcheck.py"
+  ];
+
   meta = {
     description = "Python documentation generator";
     longDescription = ''


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

 - Tested native compilation of chromium with native compilation on x86_64-linux and cross-compilation to aarch64-linux            
 - Before this change we injected cross-compiled libraries into depsDepsBuild inputs.               
   This happens because we override the libpng and libopus package mess                             
   with splicing.                                                                                   

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
