### PR TITLE
python310Packages.pyqt5: add withXmlPatterns

### DIFF
--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -20,6 +20,7 @@
 , withLocation ? false
 , withSerialPort ? false
 , withTools ? false
+, withXmlPatterns ? false
 , pkgsBuildTarget
 , buildPackages
 , dbusSupport ? !stdenv.isDarwin
@@ -138,6 +139,7 @@ buildPythonPackage rec {
     ++ lib.optional withLocation qtlocation
     ++ lib.optional withSerialPort qtserialport
     ++ lib.optional withTools qttools
+    ++ lib.optional withXmlPatterns qtxmlpatterns
   );
 
   buildInputs = with libsForQt5; [
@@ -155,6 +157,7 @@ buildPythonPackage rec {
     ++ lib.optional withLocation qtlocation
     ++ lib.optional withSerialPort qtserialport
     ++ lib.optional withTools qttools
+    ++ lib.optional withXmlPatterns qtxmlpatterns
   ;
 
   propagatedBuildInputs = [
@@ -171,6 +174,7 @@ buildPythonPackage rec {
     locationEnabled = withLocation;
     serialPortEnabled = withSerialPort;
     toolsEnabled = withTools;
+    xmlPatternsEnabled = withXmlPatterns;
   };
 
   dontConfigure = true;
@@ -192,6 +196,7 @@ buildPythonPackage rec {
     ++ lib.optional withLocation "PyQt5.QtPositioning"
     ++ lib.optional withSerialPort "PyQt5.QtSerialPort"
     ++ lib.optional withTools "PyQt5.QtDesigner"
+    ++ lib.optional withXmlPatterns "PyQt5.QtXmlPatterns"
   ;
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

This PR adds an option to the `pyqt5` python package that makes it possible to compile the package with `XmlPatterns` support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
