### PR TITLE
xwayland-run: 0.0.2 -> 0.0.3

### DIFF
--- a/pkgs/by-name/xw/xwayland-run/package.nix
+++ b/pkgs/by-name/xw/xwayland-run/package.nix
@@ -1,6 +1,4 @@
-{ cage
-, fetchFromGitLab
-, gnome
+{ fetchFromGitLab
 , lib
 , meson
 , ninja
@@ -8,25 +6,28 @@
 , weston
 , xorg
 , xwayland
-, withMutter ? false
-, withCage ? false
+, withCage ? false , cage
+, withKwin ? false , kdePackages
+, withMutter ? false, gnome
+, withDbus ? withMutter , dbus # Since 0.0.3, mutter compositors run with their own DBUS sessions
 }:
 let
   compositors = [ weston ]
-    ++ lib.optional withMutter gnome.mutter
     ++ lib.optional withCage cage
+    ++ lib.optional withKwin kdePackages.kwin
+    ++ lib.optional withMutter gnome.mutter ++ lib.optional withDbus dbus
   ;
 in
 python3.pkgs.buildPythonApplication rec {
   pname = "xwayland-run";
-  version = "0.0.2";
+  version = "0.0.3";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "ofourdan";
     repo = "xwayland-run";
     rev = version;
-    hash = "sha256-+HdRLIizEdtKWD8HadQQf750e2t1AWa14U/Xwu3xPK4=";
+    hash = "sha256-yYULbbcFDT1zRFn1UWS0dyuchGYnOZypDmxqc14RYF4=";
   };
 
   pyproject = false;
@@ -37,7 +38,6 @@ python3.pkgs.buildPythonApplication rec {
     meson
     ninja
   ];
-
 
   postInstall = ''
     wrapProgram $out/bin/wlheadless-run \


### PR DESCRIPTION
## Description of changes
Updated the version, sorted some stuff, added kwin support and fixed mutter support (adding D-Bus support).

Changelog: https://gitlab.freedesktop.org/ofourdan/xwayland-run/-/releases/0.0.3
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
