### PR TITLE
treewide: Use `genericBuild` or `runPhase` to run phases manually whenever appropriate

### DIFF
--- a/doc/packages/linux.section.md
+++ b/doc/packages/linux.section.md
@@ -87,8 +87,7 @@ To edit the `.config` file for Linux X.Y from within Nix, proceed as follows:
 
 ```ShellSession
 $ nix-shell '<nixpkgs>' -A linuxKernel.kernels.linux_X_Y.configEnv
-$ unpackPhase
-$ cd linux-*
+$ runPhase unpackPhase # Unpack and cd $sourceRoot
 $ make nconfig
 ```
 
@@ -104,8 +103,7 @@ See the snippet below as an example.
 ```ShellSession
 $ nix-build '<nixpkgs>' -A linuxPackages.kernel.dev
 $ nix-shell '<nixpkgs>' -A linuxPackages.kernel
-$ unpackPhase
-$ cd linux-*
+$ runPhase unpackPhase
 $ make -C $dev/lib/modules/*/build M=$(pwd)/drivers/net/ethernet/mellanox modules
 # insmod ./drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko
 ```

--- a/pkgs/applications/emulators/wine/packages.nix
+++ b/pkgs/applications/emulators/wine/packages.nix
@@ -1,4 +1,4 @@
-{ stdenv_32bit, lib, pkgs, pkgsi686Linux, pkgsCross, callPackage, substituteAll, moltenvk,
+{ stdenv_32bit, lib, pkgs, buildPackages, pkgsi686Linux, pkgsCross, callPackage, substituteAll, moltenvk,
   wineRelease ? "stable",
   supportFlags
 }:
@@ -38,6 +38,9 @@ in with src; {
         src = ./builder-wow.sh;
         # pkgconfig has trouble picking the right architecture
         pkgconfig64remove = lib.makeSearchPathOutput "dev" "lib/pkgconfig" [ pkgs.glib pkgs.gst_all_1.gstreamer ];
+        postInstall = ''
+          ${lib.getExe buildPackages.shellcheck-minimal} "$target"
+        '';
       };
     platforms = [ "x86_64-linux" ];
     mainProgram = "wine64";

--- a/pkgs/applications/misc/k2pdfopt/default.nix
+++ b/pkgs/applications/misc/k2pdfopt/default.nix
@@ -36,7 +36,7 @@ let
   # Create a patch against src based on changes applied in patchCommands
   mkPatch = { name, src, patchCommands }: runCommand "${name}-k2pdfopt.patch" { inherit src; } ''
     source $stdenv/setup
-    unpackPhase
+    eval "''${unpackPhase:-unpackPhase}"
 
     orig=$sourceRoot
     new=$sourceRoot-modded

--- a/pkgs/applications/science/logic/tlaplus/toolbox.nix
+++ b/pkgs/applications/science/logic/tlaplus/toolbox.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     cp -r "$src" "$out/toolbox"
     chmod -R +w "$out/toolbox"
 
-    fixupPhase
+    runPhase fixupPhase
     gappsWrapperArgsHook
 
     patchelf \

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -137,9 +137,8 @@ let
   } ''
     addToSearchPathWithCustomDelimiter : PYTHONPATH "${mercurial}/${python.sitePackages}"
 
-    unpackPhase
-    cd "$sourceRoot"
-    patchPhase
+    # Run unpackPhase and patchPhase
+    phases="''${prePhases[*]-} unpackPhase patchPhase" genericBuild
 
     cat << EOF > tests/blacklists/nix
     # tests enforcing "/usr/bin/env" shebangs, which are patched for nix

--- a/pkgs/applications/video/avidemux/default.nix
+++ b/pkgs/applications/video/avidemux/default.nix
@@ -73,9 +73,8 @@ stdenv.mkDerivation rec {
     wrapQtApp = wrapWith "wrapQtApp";
     wrapProgram = wrapWith "wrapProgram";
   in ''
-    unpackPhase
-    cd "$sourceRoot"
-    patchPhase
+    # Unpack and patch
+    phases="''${prePhases[*]-} unpackPhase patchPhase" genericBuild
 
     ${stdenv.shell} bootStrap.bash \
       --with-core \
@@ -100,7 +99,7 @@ stdenv.mkDerivation rec {
       mv ''${!outputLib}/lib64 ''${!outputLib}/lib
       ln -s lib ''${!outputLib}/lib64
     fi
-    fixupPhase
+    runPhase fixupPhase
   '';
 
   meta = with lib; {

--- a/pkgs/build-support/make-hardcode-gsettings-patch/default.nix
+++ b/pkgs/build-support/make-hardcode-gsettings-patch/default.nix
@@ -68,9 +68,8 @@ runCommand
     ];
   }
   ''
-    unpackPhase
-    cd "''${sourceRoot:-.}"
-    patchPhase
+    # Unpack and patch
+    phases="''${prePhases[*]-} unpackPhase patchPhase" genericBuild
     set -x
     cp ${builtins.toFile "glib-schema-to-var.json" (builtins.toJSON schemaIdToVariableMapping)} ./glib-schema-to-var.json
     git init

--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -399,9 +399,11 @@ in stdenv.mkDerivation {
       cd $SWIFT_BUILD_ROOT/$1
 
       cmakeDir=$SWIFT_SOURCE_ROOT/''${2-$1}
-      cmakeConfigurePhase
 
-      ninjaBuildPhase
+      phases="configurePhase ''${preBuildPhases[*]-} buildPhase" \
+        configurePhase=cmakeConfigurePhase \
+        buildPhase=ninjaBuildPhase \
+        genericBuild
     }
 
     cmakeFlags="-GNinja"
@@ -583,7 +585,7 @@ in stdenv.mkDerivation {
   checkPhase = ''
     cd $SWIFT_BUILD_ROOT/swift
     checkTarget=check-swift-all
-    ninjaCheckPhase
+    checkPhase=ninjaCheckPhase runPhase checkPhase
     unset checkTarget
   '';
 
@@ -600,20 +602,20 @@ in stdenv.mkDerivation {
     # for private use by Swift only.
     cd $SWIFT_BUILD_ROOT/llvm
     installTargets=install-clang
-    ninjaInstallPhase
+    installPhase=ninjaInstallPhase runPhase installPhase
     unset installTargets
 
     # LLDB is also a private install.
     cd $SWIFT_BUILD_ROOT/lldb
-    ninjaInstallPhase
+    installPhase=ninjaInstallPhase runPhase installPhase
 
     cd $SWIFT_BUILD_ROOT/swift
-    ninjaInstallPhase
+    installPhase=ninjaInstallPhase runPhase installPhase
 
     ${lib.optionalString stdenv.isDarwin ''
     cd $SWIFT_BUILD_ROOT/swift-concurrency-backdeploy
     installTargets=install-back-deployment
-    ninjaInstallPhase
+    installPhase=ninjaInstallPhase runPhase installPhase
     unset installTargets
     ''}
 

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -576,9 +576,8 @@ in package-set { inherit pkgs lib callPackage; } self // {
           ];
           dontUnpack = false;
         } ''
-        unpackPhase
-        cd "''${sourceRoot:-.}"
-        patchPhase
+        # Unpack and patch
+        phases="''${prePhases[*]-} unpackPhase patchPhase" genericBuild
         mkdir out
         HOME=$PWD cabal sdist --output-directory out
         mv out/*.tar.gz $out

--- a/pkgs/development/interpreters/acl2/default.nix
+++ b/pkgs/development/interpreters/acl2/default.nix
@@ -97,7 +97,7 @@ in stdenv.mkDerivation rec {
     pushd $out/share/${pname}/books
     makeFlags="ACL2=$out/share/${pname}/saved_acl2"
     buildFlags="all"
-    buildPhase
+    runPhase buildPhase
 
     # Clean up some stuff to save space
     find -name '*@useless-runes.lsp' -execdir rm {} +  # saves ~1GB of space

--- a/pkgs/development/libraries/boringssl/default.nix
+++ b/pkgs/development/libraries/boringssl/default.nix
@@ -26,7 +26,7 @@ buildGoModule {
   # hack to get both go and cmake configure phase
   # (if we use postConfigure then cmake will loop runHook postConfigure)
   preBuild = ''
-    cmakeConfigurePhase
+    configurePhase=cmakeConfigurePhase runPhase configurePhase
   '' + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
     export GOARCH=$(go env GOHOSTARCH)
   '';
@@ -37,7 +37,7 @@ buildGoModule {
   ]);
 
   buildPhase = ''
-    ninjaBuildPhase
+    buildPhase=ninjaBuildPhase runPhase buildPhase
   '';
 
   # CMAKE_OSX_ARCHITECTURES is set to x86_64 by Nix, but it confuses boringssl on aarch64-linux.

--- a/pkgs/development/libraries/gobject-introspection/wrapper.nix
+++ b/pkgs/development/libraries/gobject-introspection/wrapper.nix
@@ -41,7 +41,7 @@ then
         dontStrip = true;
         depsTargetTargetPropagated = [ overridenTargetUnwrappedGir ];
         buildCommand = ''
-          eval fixupPhase
+          runPhase fixupPhase
           ${lib.concatMapStrings (output: ''
             mkdir -p ${"$" + "${output}"}
             ${lib.getExe buildPackages.xorg.lndir} ${overriddenUnwrappedGir.${output}} ${"$" + "${output}"}
@@ -96,7 +96,7 @@ else
       dontStrip = true;
       depsTargetTargetPropagated = [ overridenTargetUnwrappedGir ];
       buildCommand = ''
-        eval fixupPhase
+        runPhase fixupPhase
         ${lib.concatMapStrings (output: ''
           mkdir -p ${"$" + "${output}"}
           ${lib.getExe buildPackages.xorg.lndir} ${overriddenUnwrappedGir.${output}} ${"$" + "${output}"}

--- a/pkgs/development/libraries/libfprint/default.nix
+++ b/pkgs/development/libraries/libfprint/default.nix
@@ -78,7 +78,9 @@ stdenv.mkDerivation rec {
   installCheckPhase = ''
     runHook preInstallCheck
 
-    ninjaCheckPhase
+    installCheckPhase=ninjaCheckPhase \
+      preCheck="" postCheck="" \
+      runPhase installCheckPhase
 
     runHook postInstallCheck
   '';

--- a/pkgs/development/tools/godot/3/mono/make-deps.nix
+++ b/pkgs/development/tools/godot/3/mono/make-deps.nix
@@ -37,10 +37,10 @@ godot3-mono.overrideAttrs (self: base: {
     wrkdir="$(mktemp -d)"
     trap 'rm -rf -- "$wrkdir"' EXIT
     pushd "$wrkdir" > /dev/null
-      unpackPhase
-      cd source
-      patchPhase
-      configurePhase
+      # Unpack, patch, and configure
+      phases="''${prePhases[*]-} unpackPhase patchPhase \
+        ''${preConfigurePhases[*]-} configurePhase" \
+        genericBuild
 
       # Without RestorePackagesPath set, it restores packages to a temp directory. Specifying
       # a path ensures we have a place to run nuget-to-nix.

--- a/pkgs/development/tools/xcbuild/wrapper.nix
+++ b/pkgs/development/tools/xcbuild/wrapper.nix
@@ -163,5 +163,5 @@ runCommand "xcodebuild-${xcbuild.version}" {
     ln -s ${xcbuild}/bin/$bin $out/bin/$bin
   done
 
-  fixupPhase
+  runPhase fixupPhase
 ''

--- a/pkgs/games/adom/default.nix
+++ b/pkgs/games/adom/default.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation rec {
   buildCommand = ''
     . $stdenv/setup
 
-    unpackPhase
+    # Run unpackPhase without cd to sourceRoot
+    eval "''${unpackPhase:-unpackPhase}"
 
     mkdir -pv $out
     cp -r -t $out adom/*

--- a/pkgs/os-specific/linux/kernel/README.md
+++ b/pkgs/os-specific/linux/kernel/README.md
@@ -16,7 +16,7 @@
 
        ```console
        [nix-shell]$ pushd $(mktemp -d)
-       [nix-shell]$ unpackPhase
+       [nix-shell]$ eval "${unpackPhase:-unpackPhase}"
        ```
 
     3. For each supported platform (`i686`, `x86_64`, `uml`) do the following:

--- a/pkgs/tools/misc/megacli/default.nix
+++ b/pkgs/tools/misc/megacli/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
       $out/opt/MegaRAID/MegaCli/MegaCli64
 
     ln -s $out/opt/MegaRAID/MegaCli/MegaCli64 $out/bin/MegaCli64
-    eval fixupPhase
+    runPhase fixupPhase
   '';
 
   meta = {

--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -166,12 +166,11 @@ stdenv.mkDerivation (finalAttrs: {
     # This avoids gnutls.out -> unbound.lib -> lib.getLib openssl.
     ''
       configureFlags="$configureFlags --with-nettle=${nettle.dev} --with-libunbound-only"
-      configurePhase
-      buildPhase
-      if [ -n "$doCheck" ]; then
-          checkPhase
-      fi
-      installPhase
+      # Run from preConfigurephases to installPhase
+      phases="''${preConfigurePhases[*]-} configurePhase \
+        ''${preBuildPhases[*]-} buildPhase checkPhase \
+        ''${preInstallPhases[*]-} installPhase" \
+        genericBuild
     ''
   # get rid of runtime dependencies on $dev outputs
   + ''substituteInPlace "$lib/lib/libunbound.la" ''


### PR DESCRIPTION
## Description of changes

`stdenv.mkDerivation` phases may come to the builder as a environment[shell variable containing the build command, an empty environment/shell variable, or a bash function. The bash function are generally provided by `stdenv/generic/setup.sh` or setup hooks, and the regular variable from the Nix Language attributes, while setup hooks may still provide string-like phases to refer to another phase implementation, such as `configurePhase=cmakeConfigurePhase` and `buildPhase="ninjaBuildPhase"`.

However, developers sometimes forgot about that, and assume that phases like `unpackPhase`, `patchPhase`, `configurePhase`, `buildPhase` to always be functions and `fixupPhase` strings. Even if it was specified that way, it could be later overridden via `<pkg>.overrideAttrs` into another form.

This PR aims to fix such issues tree-wide, by searching with regular expression `Phase$` and replacing direct call/direct `eval` with `phases="..." genericBuild`, `runPhase` whenever appropriate.

As `runPhase unpackPhase` additionally change the CWD to `$sourceRoot`, `eval "${unpackPhase:-unpackPhase}"` is used when such `cd "$sourceRoot"` is not desired.

This was an initial effort for #298838, in which I originally plan to change some phases implementation provided by `stdenv/generic/setup.sh` to string form (something like `: "${buildPhase:=makeBuildPhase}"`).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
