### PR TITLE
jre_minimal: convert `passthru.tests` to an attribute set and fix pre/post hook running

### DIFF
--- a/pkgs/development/compilers/openjdk/jre.nix
+++ b/pkgs/development/compilers/openjdk/jre.nix
@@ -30,10 +30,10 @@ let
 
     passthru = {
       home = "${jre}";
-      tests = [
-        (callPackage ./tests/test_jre_minimal.nix {})
-        (callPackage ./tests/test_jre_minimal_with_logging.nix {})
-      ];
+      tests = {
+        jre_minimal-hello = callPackage ./tests/test_jre_minimal.nix {};
+        jre_minimal-hello-logging = callPackage ./tests/test_jre_minimal_with_logging.nix {};
+      };
     };
   };
 in jre

--- a/pkgs/development/compilers/openjdk/tests/hello-logging.nix
+++ b/pkgs/development/compilers/openjdk/tests/hello-logging.nix
@@ -25,12 +25,12 @@ in
     src = source;
 
     buildPhase = ''
-      runHook preBuildPhase
+      runHook preBuild
       ${jdk}/bin/javac src/Hello.java
-      runHook postBuildPhase
+      runHook postBuild
     '';
     installPhase = ''
-      runHook preInstallPhase
+      runHook preInstall
 
       mkdir -p $out/lib
       cp src/Hello.class $out/lib
@@ -42,6 +42,6 @@ in
       EOF
       chmod a+x $out/bin/hello
 
-      runHook postInstallPhase
+      runHook postInstall
     '';
   }

--- a/pkgs/development/compilers/openjdk/tests/hello.nix
+++ b/pkgs/development/compilers/openjdk/tests/hello.nix
@@ -20,12 +20,12 @@ in
     src = source;
 
     buildPhase = ''
-      runHook preBuildPhase
+      runHook preBuild
       ${jdk}/bin/javac src/Hello.java
-      runHook postBuildPhase
+      runHook postBuild
     '';
     installPhase = ''
-      runHook preInstallPhase
+      runHook preInstall
 
       mkdir -p $out/lib
       cp src/Hello.class $out/lib
@@ -37,6 +37,6 @@ in
       EOF
       chmod a+x $out/bin/hello
 
-      runHook postInstallPhase
+      runHook postInstall
     '';
   }


### PR DESCRIPTION
## Description of changes

Convert jre_minimal.tests from  a list to an attribute set, making it easier to invoke each one individually.

Fix `runHook preBuildPhase` -> `runHook preBuild` and sort like that for package tests.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
