### PR TITLE
Avoid top-level `with ...;` in the OCaml packages in `pkgs/development/`

### DIFF
--- a/pkgs/development/interpreters/eff/default.nix
+++ b/pkgs/development/interpreters/eff/default.nix
@@ -1,6 +1,10 @@
 { lib, fetchFromGitHub, ocamlPackages }:
 
-with ocamlPackages; buildDunePackage rec {
+let
+  inherit (ocamlPackages) buildDunePackage js_of_ocaml menhir;
+in
+
+buildDunePackage rec {
   pname = "eff";
   version = "5.1";
 

--- a/pkgs/development/tools/headache/default.nix
+++ b/pkgs/development/tools/headache/default.nix
@@ -1,6 +1,8 @@
 { lib, fetchFromGitHub, nix-update-script, ocamlPackages }:
 
-with ocamlPackages;
+let
+  inherit (ocamlPackages) buildDunePackage camomile;
+in
 
 buildDunePackage rec {
   pname = "headache";

--- a/pkgs/development/tools/ocaml/ocaml-top/default.nix
+++ b/pkgs/development/tools/ocaml/ocaml-top/default.nix
@@ -1,6 +1,10 @@
 { lib, fetchFromGitHub, ocamlPackages }:
 
-with ocamlPackages; buildDunePackage rec {
+let
+  inherit (ocamlPackages) buildDunePackage lablgtk3-sourceview3 ocp-index;
+in
+
+buildDunePackage rec {
   pname = "ocaml-top";
   version = "1.2.0";
 

--- a/pkgs/development/tools/ocaml/opam-publish/default.nix
+++ b/pkgs/development/tools/ocaml/opam-publish/default.nix
@@ -1,6 +1,17 @@
 { lib, fetchFromGitHub, ocamlPackages }:
 
-with ocamlPackages;
+let
+  inherit (ocamlPackages)
+    buildDunePackage
+    cmdliner
+    github
+    github-unix
+    lwt_ssl
+    opam-core
+    opam-format
+    opam-state
+    ;
+in
 
 buildDunePackage rec {
   pname = "opam-publish";


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is no functional change contained in this PR.

I really wish to use `callPackage` style dependency injection for these OCaml packages, rather than the style I've used in this PR. I don't know how to do that refactor, however. 

I used the refactor strategy that looks for the uses of names [coming from `lib` and `ocamlPackages`](https://gist.github.com/philiptaron/04326000d5ff20cb72c2805efd09701c). 

<del>Following advice, I also preferred to inherit names from `lib` instead of `builtins` where there was a choice. I also preferred to inherit from `lib` in one place, rather than to have a mixture of `lib.thing` and `inherit (lib) thing`. I can drop those changes if package owners desire.</del> This PR only touches what was in the `with` statements.

There are no rebuilds when I run `nixpkgs-review rev HEAD`, so I've targeted master with this PR.

## Things done

- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev HEAD`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).