### PR TITLE
Avoid top-level `with ...;` in `pkgs/development/lua-modules`

### DIFF
--- a/pkgs/development/lua-modules/aliases.nix
+++ b/pkgs/development/lua-modules/aliases.nix
@@ -7,31 +7,31 @@ lib: self: super:
 ### Use `./remove-attr.py [attrname]` in this directory to remove your alias
 ### from the `luaPackages` set without regenerating the entire file.
 
-with self;
-
 let
+  inherit (lib) dontDistribute hasAttr isDerivation mapAttrs;
+
   # Removing recurseForDerivation prevents derivations of aliased attribute
   # set to appear while listing all the packages available.
-  removeRecurseForDerivations = alias: with lib;
+  removeRecurseForDerivations = alias:
     if alias.recurseForDerivations or false
     then removeAttrs alias ["recurseForDerivations"]
     else alias;
 
   # Disabling distribution prevents top-level aliases for non-recursed package
   # sets from building on Hydra.
-  removeDistribute = alias: with lib;
+  removeDistribute = alias:
     if isDerivation alias then
       dontDistribute alias
     else alias;
 
   # Make sure that we are not shadowing something from node-packages.nix.
   checkInPkgs = n: alias:
-    if builtins.hasAttr n super
+    if hasAttr n super
     then throw "Alias ${n} is still in generated.nix"
     else alias;
 
   mapAliases = aliases:
-    lib.mapAttrs (n: alias:
+    mapAttrs (n: alias:
       removeDistribute
         (removeRecurseForDerivations
           (checkInPkgs n alias)))


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is no functional change contained in this PR.

This is kind of an odd change. As far as I could tell -- and `nix-instantiate` agrees with me -- `with self;` is dead code.

Following advice, I also preferred to inherit names from `lib` instead of `builtins` where there was a choice. I also preferred to inherit from `lib` in one place, rather than to have a mixture of `lib.thing` and `inherit (lib) thing`. Those are the only other changes in this PR.

There are no rebuilds when I run `nixpkgs-review rev HEAD`, so I've targeted master with this PR.

## Things done

- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev HEAD`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).