### PR TITLE
darwin: setup hook to fix dylib references

### DIFF
--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -101,7 +101,11 @@ stdenv.mkDerivation rec {
     ++ lib.optional (stdenv.isDarwin && (enableGL || enableX11)) desktopToDarwinBundle
     ++ lib.optionals (enableCxx || enablePython) [ python3 python3.pkgs.setuptools python3.pkgs.libclang ]
     ++ lib.optionals (enablePython) [ which swig ]
-    ++ lib.optionals stdenv.isDarwin [ fixDarwinDylibNames xcbuild ];
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.fixDylibReferences
+      fixDarwinDylibNames
+      xcbuild
+    ];
 
   buildInputs = [ freetype harfbuzz openjpeg jbig2dec libjpeg gumbo ]
     ++ lib.optionals enableX11 [ libX11 libXext libXi libXrandr ]
@@ -166,11 +170,7 @@ stdenv.mkDerivation rec {
     EOF
 
     moveToOutput "bin" "$bin"
-  '' + (lib.optionalString (stdenv.isDarwin) ''
-    for exe in $bin/bin/*; do
-      install_name_tool -change build/shared-release/libmupdf.dylib $out/lib/libmupdf.dylib "$exe"
-    done
-  '') + (lib.optionalString (enableX11 || enableGL) ''
+  '' + (lib.optionalString (enableX11 || enableGL) ''
     mkdir -p $bin/share/icons/hicolor/48x48/apps
     cp docs/logo/mupdf.png $bin/share/icons/hicolor/48x48/apps
   '') + (if enableGL then ''

--- a/pkgs/development/libraries/libcs50/default.nix
+++ b/pkgs/development/libraries/libcs50/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenv, fetchFromGitHub, fixDarwinDylibNames }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libcs50";
@@ -10,6 +10,8 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-A4CEU5wfwykVTDIsKZnQ8co+6RwBGYGZEZxRFzQTKBI=";
   };
+
+  nativeBuildInputs = lib.optionals stdenv.isDarwin [ fixDarwinDylibNames ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/os-specific/darwin/fix-dylib-references-in-binaries.sh
+++ b/pkgs/os-specific/darwin/fix-dylib-references-in-binaries.sh
@@ -1,0 +1,47 @@
+# A setup-hook for Darwin that acts like auto patchelf: for any executable in
+# $out/bin, for any dynamic libraries it depends on which don’t have a full
+# path, this hook looks for those libraries in all this package’s dependencies
+# (and in this package’s own lib folder).
+
+# First, for every dependency that has a /lib/ dir, put it in a search path.
+fixDarwinDylibReferencesHook() {
+    addToSearchPath FIX_DYNLIB_PATH "$1/lib"
+}
+addEnvHooks "$targetOffset" fixDarwinDylibReferencesHook
+
+# After which, in a fixup phase, find every binary and search that path for
+# unresolved libraries.
+fixupOutputHooks+=('fixDarwinDylibReferences')
+
+fixDarwinDylibReferencesBin() {
+    bin="$1"
+    # “Handle” errors by just bailing on this file, which is equivalent to
+    # iterating over empty output, because this tool prints errors on stderr not
+    # stdout.
+    (otool -L "$bin" 2>/dev/null | tail -n +2 || true) | while read libpath rest ; do
+        if [[ "$libpath" != /* ]]; then
+            # This is not an absolute path: try to find it in our
+            # dependencies
+            libname="$(basename "$libpath")"
+            # How to handle $lib?
+            IFS=: read -a dirs <<<"$out/lib:$FIX_DYNLIB_PATH"
+            for dir in "${dirs[@]}"; do
+                # Only check for the raw lib name because the path is
+                # usually just some build-dependent cruft. We are looking
+                # for libs directly here.
+                if [[ -f "$dir/$libname" ]]; then
+                    install_name_tool -change "$libpath" "$dir/$libname" "$bin"
+                    break
+                fi
+            done
+        fi
+    done
+}
+
+fixDarwinDylibReferences() {
+    if [[ -d "$prefix/bin" ]]; then
+        find "$prefix/bin" -type f -executable -print0 | while IFS= read -r -d $'\0' bin; do
+            fixDarwinDylibReferencesBin "$bin"
+        done
+    fi
+}

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -133,6 +133,11 @@ impure-cmds // appleSourcePackages // chooseLibs // {
 
   darwin-stubs = callPackage ../os-specific/darwin/darwin-stubs { };
 
+  fixDylibReferences = pkgs.makeSetupHook {
+    name = "fix-darwin-dylib-references-hook";
+    substitutions = { inherit (pkgs.binutils) targetPrefix; };
+  } ../os-specific/darwin/fix-dylib-references-in-binaries.sh;
+
   print-reexports = callPackage ../os-specific/darwin/print-reexports { };
 
   rewrite-tbd = callPackage ../os-specific/darwin/rewrite-tbd { };


### PR DESCRIPTION
## Description of changes
A setuphook that automatically looks for .dylibs in a package's dependencies.

Comments very welcome, as I have, at best, only medium experience in:
- patchelf
- setup hooks (particularly: how does this fare wrt cross compilation? how can I / should I test?)
- Darwin
- linking in general tbh

I'm actually wondering if there isn't already an existing hook for this? I only found a few manual instances of install_name_tool -change throughout the code, you'd expect there to be way more. As I understand it, on Linux the fixupPhase does this automatically, correct? So I would assume on Darwin for the same to happen, but it doesn't look like it...?

And now that I have your attention: should we move the `fixDarwinDylibNames` setup hook to `darwin.fixDylibNames`?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
