### PR TITLE
vzic: init at 0-unstable-2024-06-04

### DIFF
--- a/pkgs/by-name/vz/vzic/package.nix
+++ b/pkgs/by-name/vz/vzic/package.nix
@@ -1,0 +1,60 @@
+{
+  stdenv,
+  lib,
+  buildPackages,
+  fetchFromGitHub,
+  pkg-config,
+  glib,
+  libical,
+}:
+stdenv.mkDerivation rec {
+  pname = "vzic";
+  version = "0-unstable-2024-06-04";
+
+  src = fetchFromGitHub {
+    owner = "libical";
+    repo = "vzic";
+    rev = "354296149e65ca31932c514fddb7435cb47671e9";
+    hash = "sha256-L6BIHr3tfw51AoSvZMlP3HWEWXfEaPa8nq1aJOqcNkE=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail 'pkg-config' "$PKG_CONFIG"
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    glib
+    libical
+  ];
+
+  env = {
+    OLSON_DIR = "tzdata2024a";
+    PRODUCT_ID = "-//NixOS//NONSGML Citadel calendar//EN";
+    TZID_PREFIX = "/NixOS/Olson_%D_1/";
+  };
+
+  # no install rule in Makefile
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/vtimezone
+    ${stdenv.hostPlatform.emulator buildPackages} ./vzic --output-dir $out/share/vtimezone
+    install -Dm744 vzic $out/bin/vzic
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/libical/vzic";
+    description = "A program to convert the IANA timezone database files into VTIMEZONE files compatible with the iCalendar specification";
+    changelog = "https://github.com/libical/vzic/blob/${src.rev}/ChangeLog";
+    mainProgram = "vzic";
+    license = with lib.licenses; [ gpl2Plus ];
+    maintainers = with lib.maintainers; [ moraxyc ];
+    broken = !stdenv.hostPlatform.emulatorAvailable buildPackages;
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

A program to convert the IANA (formerly Olson) timezone database files into VTIMEZONE files compatible with the iCalendar specification (RFC2445).

This package is required by cyrus-imapd and libical.

Also provide vtimezone files in share/vtimezone directly.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
