### PR TITLE
aerospace: init at 0.9.0-beta

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19778,6 +19778,11 @@
     githubId = 26902865;
     name = "Tomas Drtina";
   };
+  t-monaghan = {
+    github = "t-monaghan";
+    githubId = 62273348;
+    name = "Thomas Monaghan";
+  };
   tmountain = {
     email = "tinymountain@gmail.com";
     github = "tmountain";

--- a/pkgs/by-name/ae/aerospace/package.nix
+++ b/pkgs/by-name/ae/aerospace/package.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchzip, lib, callPackage }:
+
+let
+  pname = "aerospace";
+  # Version must be a literal string as package has a capital letter in it
+  # whilst nixpkgs forbids capitals in version names
+  ghReleaseVersion = "0.9.0-Beta";
+  version = lib.strings.toLower ghReleaseVersion;
+  meta = with lib; {
+    license = licenses.mit;
+    mainProgram = "aerospace";
+    homepage = "https://github.com/nikitabobko/AeroSpace";
+    description = "An i3-like tiling window manager for macOS";
+    platforms = [ "aarch64-darwin" ];
+    maintainers = with maintainers; [ t-monaghan ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version meta;
+
+  src = fetchzip {
+    url = "https://github.com/nikitabobko/aerospace/releases/download/v${ghReleaseVersion}/AeroSpace-v${ghReleaseVersion}.zip";
+    hash = "sha256-UVNMjKPMUDuSKPMtLLBb3Lqu5Xocp9X99i+tPjktdbA=";
+  };
+
+  unpackPhase = ''
+    ls -lah $src/
+    cp -r $src/ $out/
+  '';
+
+  passthru.tests.can-print-version = callPackage ./test-can-print-version.nix { };
+}

--- a/pkgs/by-name/ae/aerospace/test-can-print-version.nix
+++ b/pkgs/by-name/ae/aerospace/test-can-print-version.nix
@@ -1,0 +1,18 @@
+{ runCommand, aerospace }:
+
+
+let
+  inherit (aerospace) pname version;
+in
+
+runCommand "${pname}-tests" { meta.timeout = 60; }
+  ''
+    # tr is required as the version has a capital in Beta as of 0.9.0-Beta
+    # whilst nix packages must not have capitals in version names
+    if [[ `${aerospace}/bin/${pname} --version | tr '[:upper:]' '[:lower:]'` != *"${version}"*  ]]; then
+      echo "Error: program version does not match package version"
+      exit 1
+    fi
+    ${aerospace}/bin/aerospace --version >/dev/null
+    touch $out
+  ''


### PR DESCRIPTION
## Description of changes

Introduces aerospace - an i3 like tiling window manager for macOS. I opted to pull from built binaries as the build process is a complex one with some swift dependencies that I couldn't work through after a full days effort. Please let me know if there are any issues with this approach.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
