### PR TITLE
postgresql{12,13}Packages.pg_safeupdate: 1.5 -> 1.4

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
@@ -1,8 +1,31 @@
 { lib, stdenv, fetchFromGitHub, postgresql }:
 
+with {
+  "12" = {
+    version = "1.4";
+    sha256 = "sha256-1cyvVEC9MQGMr7Tg6EUbsVBrMc8ahdFS3+CmDkmAq4Y=";
+  };
+  "13" = {
+    version = "1.4";
+    sha256 = "sha256-1cyvVEC9MQGMr7Tg6EUbsVBrMc8ahdFS3+CmDkmAq4Y=";
+  };
+  "14" = {
+    version = "1.5";
+    sha256 = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
+  };
+  "15" = {
+    version = "1.5";
+    sha256 = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
+  };
+  "16" = {
+    version = "1.5";
+    sha256 = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
+  };
+}."${lib.versions.major postgresql.version}" or (throw "pg_safeupdate: version specification for pg ${postgresql.version} missing.");
+
 stdenv.mkDerivation rec {
   pname = "pg-safeupdate";
-  version = "1.5";
+  inherit version;
 
   buildInputs = [ postgresql ];
 
@@ -10,7 +33,7 @@ stdenv.mkDerivation rec {
     owner  = "eradman";
     repo   = pname;
     rev    = version;
-    sha256 = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
+    inherit sha256;
   };
 
   installPhase = ''
@@ -24,6 +47,5 @@ stdenv.mkDerivation rec {
     platforms   = postgresql.meta.platforms;
     maintainers = with maintainers; [ wolfgangwalther ];
     license     = licenses.postgresql;
-    broken      = versionOlder postgresql.version "14";
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://github.com/eradman/pg-safeupdate";
     changelog   = "https://github.com/eradman/pg-safeupdate/raw/${src.rev}/NEWS";
     platforms   = postgresql.meta.platforms;
+    maintainers = with maintainers; [ wolfgangwalther ];
     license     = licenses.postgresql;
     broken      = versionOlder postgresql.version "14";
   };

--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation rec {
     homepage = "https://postgis.net/";
     changelog = "https://git.osgeo.org/gitea/postgis/postgis/raw/tag/${version}/NEWS";
     license = licenses.gpl2;
-    maintainers = with maintainers; teams.geospatial.members ++ [ marcweber ];
+    maintainers = with maintainers; teams.geospatial.members ++ [ marcweber wolfgangwalther ];
     inherit (postgresql.meta) platforms;
   };
 }


### PR DESCRIPTION
pg_safeupdate was updated to 1.5 in #269755 (@marsam). v1.5 is not compatible with PostgreSQL 12 and 13 anymore, so those were marked as broken.

However, this blocks anyone using PostgreSQL 12 or 13 with pg_safeupdate from updating nixpkgs.

Instead, the old version should have been kept for PG 12 and 13. If we don't do this, then it's kind of pointless to keep older versions of PostgreSQL in nixpkgs at all.

A general guideline would be:
- It's fine to introduce a new extension only supporting some of the PG versions.
- It's not fine to remove an extension via update + marking broken.

One case where this is blocking an update is CI/devtools for PostgREST:

https://github.com/PostgREST/postgrest/blob/a5bb20bbf8e96cdc024bedfacf3b2df186305efe/default.nix#L59-L63

Here we test with all PG versions down to v12 - but can't update now, because pg_safeupdate won't build for 12 and 13 anymore.

Note: The same happened with `timescaledb` in #257439. Updating to v2.12 removed support for PostgreSQL 12 (this was marked broken in a later commit). From what I can tell, no other packages are currently affected. Let's discuss the general approach how to deal with this first, before I fix that, too.


## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
