### PR TITLE
rofi-emoji: fix missing dependencies `xdotools` `wtype`

### DIFF
--- a/pkgs/applications/misc/rofi-emoji/default.nix
+++ b/pkgs/applications/misc/rofi-emoji/default.nix
@@ -6,6 +6,9 @@
 , autoreconfHook
 , pkg-config
 
+, waylandSupport ? true
+, x11Support ? true
+
 , cairo
 , glib
 , libnotify
@@ -13,6 +16,8 @@
 , wl-clipboard
 , xclip
 , xsel
+, xdotool
+, wtype
 }:
 
 stdenv.mkDerivation rec {
@@ -38,8 +43,11 @@ stdenv.mkDerivation rec {
   postFixup = ''
     chmod +x $out/share/rofi-emoji/clipboard-adapter.sh
     wrapProgram $out/share/rofi-emoji/clipboard-adapter.sh \
-      --prefix PATH ":" ${lib.makeBinPath [ libnotify wl-clipboard xclip xsel ]}
+     --prefix PATH ":" ${lib.makeBinPath ([ libnotify wl-clipboard xclip xsel ]
+       ++ lib.optionals waylandSupport [ wtype ]
+       ++ lib.optionals x11Support [ xdotool ])}
   '';
+
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
Dear @cole-h, thank you for maintaining `rofi-emoji`.
\cc @Mange 

I have recently installed this package but found a bug. When trying to insert an emoji, and error notification raises:
```
Could not find any tool to handle insertion. Please install xdotool or wtype.
```

I suggest this merge request to fix this bug.
Please let me know if further changes are required.

Best regards,
@juliendiot42


## Description of changes

This commit add those missing dependencies.
To control which of these tools should be installed (one is for x11 and the other for wayland) 2 derivations arguments have been created: `x11Support` and `waylandSupport` defaulting to `true`.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

> Tested on **`x11` only**.
> After `nix build .\#rofi-emoji`
> Previous behaviour: 
>    ```sh
>    echo "the text" | ./result/share/rofi-emoji/clipboard-adapter.sh insert
>    ```
> returns
>    ```
>    Could not find any tool to handle insertion. Please install xdotool or wtype.
>    ```
> Fixed behaviour:
>    ```sh
>    echo "the text" | ./result/share/rofi-emoji/clipboard-adapter.sh insert
>    ```
> returns
>    ```
>    the text
>    ```
> And `the text` is inserted in the terminal.
> When tested with rofi it inserts the emoji without the notification error.


- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [?] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
> I read the guidelines but this is my first contribution, I am not sure the code is formatted correctly, I am sorry. 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
