### PR TITLE
steampipe: enable tests on darwin

### DIFF
--- a/pkgs/by-name/st/steampipe/package.nix
+++ b/pkgs/by-name/st/steampipe/package.nix
@@ -68,7 +68,7 @@ buildGoModule rec {
 
   meta = {
     changelog = "https://github.com/turbot/steampipe/blob/v${version}/CHANGELOG.md";
-    description = "select * from cloud;";
+    description = "Dynamically query your cloud, code, logs & more with SQL";
     homepage = "https://steampipe.io/";
     license = lib.licenses.agpl3Only;
     mainProgram = "steampipe";

--- a/pkgs/by-name/st/steampipe/package.nix
+++ b/pkgs/by-name/st/steampipe/package.nix
@@ -70,7 +70,7 @@ buildGoModule rec {
     description = "select * from cloud;";
     license = licenses.agpl3Only;
     mainProgram = "steampipe";
-    maintainers = with maintainers; [ hardselius ];
+    maintainers = with maintainers; [ hardselius anthonyroussel ];
     changelog = "https://github.com/turbot/steampipe/blob/v${version}/CHANGELOG.md";
   };
 }

--- a/pkgs/by-name/st/steampipe/package.nix
+++ b/pkgs/by-name/st/steampipe/package.nix
@@ -4,7 +4,6 @@
   installShellFiles,
   lib,
   nix-update-script,
-  stdenv,
   steampipe,
   testers,
 }:
@@ -36,8 +35,18 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" ];
 
-  # panic: could not create backups directory: mkdir /var/empty/.steampipe: operation not permitted
-  doCheck = !stdenv.isDarwin;
+  doCheck = true;
+
+  checkFlags =
+    let
+      skippedTests = [
+        # panic: could not create backups directory: mkdir /var/empty/.steampipe: operation not permitted
+        "TestTrimBackups"
+        # Skip tests that require network access
+        "TestIsPortBindable"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   postInstall = ''
     INSTALL_DIR=$(mktemp -d)

--- a/pkgs/by-name/st/steampipe/package.nix
+++ b/pkgs/by-name/st/steampipe/package.nix
@@ -15,25 +15,26 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "turbot";
     repo = "steampipe";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-Oz1T9koeXnmHc5oru1apUtmhhvKi/gAtg/Hb7HKkkP0=";
   };
 
   vendorHash = "sha256-U0BeGCRLjL56ZmVKcKqrrPTCXpShJzJq5/wnXDKax6g=";
   proxyVendor = true;
 
-  patchPhase = ''
-    runHook prePatch
+  postPatch = ''
     # Patch test that relies on looking up homedir in user struct to prefer ~
     substituteInPlace pkg/steampipeconfig/shared_test.go \
-      --replace 'filehelpers "github.com/turbot/go-kit/files"' "" \
-      --replace 'filepaths.SteampipeDir, _ = filehelpers.Tildefy("~/.steampipe")' 'filepaths.SteampipeDir = "~/.steampipe"';
-    runHook postPatch
+      --replace-fail 'filehelpers "github.com/turbot/go-kit/files"' "" \
+      --replace-fail 'filepaths.SteampipeDir, _ = filehelpers.Tildefy("~/.steampipe")' 'filepaths.SteampipeDir = "~/.steampipe"';
   '';
 
   nativeBuildInputs = [ installShellFiles ];
 
-  ldflags = [ "-s" "-w" ];
+  ldflags = [
+    "-s"
+    "-w"
+  ];
 
   doCheck = true;
 
@@ -65,12 +66,12 @@ buildGoModule rec {
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
-    homepage = "https://steampipe.io/";
-    description = "select * from cloud;";
-    license = licenses.agpl3Only;
-    mainProgram = "steampipe";
-    maintainers = with maintainers; [ hardselius anthonyroussel ];
+  meta = {
     changelog = "https://github.com/turbot/steampipe/blob/v${version}/CHANGELOG.md";
+    description = "select * from cloud;";
+    homepage = "https://steampipe.io/";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "steampipe";
+    maintainers = with lib.maintainers; [ hardselius anthonyroussel ];
   };
 }

--- a/pkgs/by-name/st/steampipe/package.nix
+++ b/pkgs/by-name/st/steampipe/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   installShellFiles,
   lib,
+  makeWrapper,
   nix-update-script,
   steampipe,
   testers,
@@ -29,7 +30,10 @@ buildGoModule rec {
       --replace-fail 'filepaths.SteampipeDir, _ = filehelpers.Tildefy("~/.steampipe")' 'filepaths.SteampipeDir = "~/.steampipe"';
   '';
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
 
   ldflags = [
     "-s"
@@ -50,6 +54,10 @@ buildGoModule rec {
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   postInstall = ''
+    wrapProgram $out/bin/steampipe \
+      --set-default STEAMPIPE_UPDATE_CHECK false \
+      --set-default STEAMPIPE_TELEMETRY none
+
     INSTALL_DIR=$(mktemp -d)
     installShellCompletion --cmd steampipe \
       --bash <($out/bin/steampipe --install-dir $INSTALL_DIR completion bash) \


### PR DESCRIPTION
## Description of changes

* Enable tests on Darwin
* Added myself to maintainers
* Updated meta.description
* Removed `with lib;` and used `--replace-fail` for substitutions
* Disable telemetry and update check by default

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
