### PR TITLE
texpresso: init at 0-unstable-2024-03-24

### DIFF
--- a/pkgs/tools/typesetting/tex/texpresso/default.nix
+++ b/pkgs/tools/typesetting/tex/texpresso/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, makeWrapper
+, writeScript
+, mupdf
+, SDL2
+, re2c
+, freetype
+, jbig2dec
+, harfbuzz
+, openjpeg
+, gumbo
+, libjpeg
+, texpresso-tectonic
+}:
+
+stdenv.mkDerivation rec {
+  pname = "texpresso";
+  version = "0-unstable-2024-03-24";
+
+  nativeBuildInputs = [
+    makeWrapper
+    mupdf
+    SDL2
+    re2c
+    freetype
+    jbig2dec
+    harfbuzz
+    openjpeg
+    gumbo
+    libjpeg
+  ];
+
+  src = fetchFromGitHub {
+    owner = "let-def";
+    repo = "texpresso";
+    rev = "08d4ae8632ef0da349595310d87ac01e70f2c6ae";
+    hash = "sha256-a0yBVtLfmE0oTl599FXp7A10JoiKusofLSeXigx4GvA=";
+  };
+
+  buildFlags = [ "texpresso" ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm0755 -t "$out/bin/" "build/${pname}"
+    runHook postInstall
+  '';
+
+  # needs to have texpresso-tonic on its path
+  postInstall = ''
+    wrapProgram $out/bin/texpresso \
+      --prefix PATH : ${lib.makeBinPath [ texpresso-tectonic ]}
+  '';
+
+  passthru = {
+    tectonic = texpresso-tectonic;
+    updateScript = writeScript "update-texpresso" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl jq nix-update
+
+      tectonic_version="$(curl -s "https://api.github.com/repos/let-def/texpresso/contents/tectonic" | jq -r '.sha')"
+      nix-update --version=branch texpresso
+      nix-update --version=branch=$tectonic_version texpresso.tectonic
+    '';
+  };
+
+  meta = {
+    homepage = "https://github.com/let-def/texpresso";
+    description = "Live rendering and error reporting for LaTeX.";
+    maintainers = with lib.maintainers; [ nickhu ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/tools/typesetting/tex/texpresso/default.nix
+++ b/pkgs/tools/typesetting/tex/texpresso/default.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    homepage = "https://github.com/let-def/texpresso";
+    inherit (src.meta) homepage;
     description = "Live rendering and error reporting for LaTeX.";
     maintainers = with lib.maintainers; [ nickhu ];
     license = lib.licenses.mit;

--- a/pkgs/tools/typesetting/tex/texpresso/tectonic.nix
+++ b/pkgs/tools/typesetting/tex/texpresso/tectonic.nix
@@ -1,0 +1,19 @@
+{ tectonic-unwrapped, fetchFromGitHub }:
+tectonic-unwrapped.override (old: {
+  rustPlatform = old.rustPlatform // {
+    buildRustPackage = args: old.rustPlatform.buildRustPackage (args // {
+      pname = "texpresso-tonic";
+      src = fetchFromGitHub {
+        owner = "let-def";
+        repo = "tectonic";
+        rev = "a6d47e45cd610b271a1428898c76722e26653667";
+        hash = "sha256-CDky1NdSQoXpTVDQ7sJWjcx3fdsBclO9Eun/70iClcI=";
+        fetchSubmodules = true;
+      };
+      cargoHash = "sha256-M4XYjBK2MN4bOrk2zTSyuixmAjZ0t6IYI/MlYWrmkIk=";
+      # binary has a different name, bundled tests won't work
+      doCheck = false;
+      meta.mainProgram = "texpresso-tonic";
+    });
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24870,6 +24870,10 @@ with pkgs;
 
   tet = callPackage ../development/tools/misc/tet { };
 
+  texpresso = callPackage ../tools/typesetting/tex/texpresso {
+    texpresso-tectonic = callPackage ../tools/typesetting/tex/texpresso/tectonic.nix { };
+  };
+
   text-engine = callPackage ../development/libraries/text-engine { };
 
   the-foundation = callPackage ../development/libraries/the-foundation { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Initialise the [TeXpresso](https://github.com/let-def/texpresso): live rendering and error reporting for LaTeX engine, at unstable pre-release.

I also provided an `updaterScript` (which I have tested) to keep this expression up to date.

This isn't in the `by-name` hierarchy because it needs an overridden forked derivation of tectonic, which is also packaged here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
