### PR TITLE
floorp: 11.10.5 -> 11.11.2

### DIFF
--- a/pkgs/applications/networking/browsers/floorp/default.nix
+++ b/pkgs/applications/networking/browsers/floorp/default.nix
@@ -7,7 +7,7 @@
 
 ((buildMozillaMach rec {
   pname = "floorp";
-  packageVersion = "11.10.5";
+  packageVersion = "11.11.2";
   applicationName = "Floorp";
   binaryName = "floorp";
   branding = "browser/branding/official";
@@ -15,14 +15,14 @@
   allowAddonSideload = true;
 
   # Must match the contents of `browser/config/version.txt` in the source tree
-  version = "115.8.0";
+  version = "115.10.0";
 
   src = fetchFromGitHub {
     owner = "Floorp-Projects";
     repo = "Floorp";
     fetchSubmodules = true;
     rev = "v${packageVersion}";
-    hash = "sha256-uKgN74xn0v86E/YfqbJNnMIR3gS+3dhdgLJ5VUerurQ=";
+    hash = "sha256-a9f4+t2w8aOOLNaKkr+FuY0ENa/Nkukg9pvJTiUMfWk=";
   };
 
   extraConfigureFlags = [

--- a/pkgs/applications/networking/browsers/floorp/default.nix
+++ b/pkgs/applications/networking/browsers/floorp/default.nix
@@ -31,6 +31,8 @@
     "--with-unsigned-addon-scopes=app,system"
   ];
 
+  updateScript = ./update.sh;
+
   meta = {
     description = "A fork of Firefox, focused on keeping the Open, Private and Sustainable Web alive, built in Japan";
     homepage = "https://floorp.app/";

--- a/pkgs/applications/networking/browsers/floorp/update.sh
+++ b/pkgs/applications/networking/browsers/floorp/update.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl nix-prefetch-github jq gnused
+
+set -e
+
+owner=Floorp-Projects
+repo=Floorp
+dirname="$(dirname "$0")"
+
+updateVersion() {
+    sed -i "s/packageVersion = \"[0-9.]*\";/packageVersion = \"$1\";/g" "$dirname/default.nix"
+}
+
+updateBaseVersion() {
+    local base
+    base=$(curl -s "https://raw.githubusercontent.com/$owner/$repo/v$1/browser/config/version.txt")
+    sed -i "s/version = \"[0-9.]*\";/version = \"$base\";/g" "$dirname/default.nix"
+}
+
+updateHash() {
+    local hash
+    hash=$(nix-prefetch-github --fetch-submodules --rev "v$1" $owner $repo | jq .hash)
+    sed -i "s|hash = \"[a-zA-Z0-9\/+-=]*\";|hash = \"$hash\";|g" "$dirname/default.nix"
+}
+
+currentVersion=$(cd "$dirname" && nix eval --raw -f ../../../../.. floorp.version)
+
+latestTag=$(curl -s https://api.github.com/repos/Floorp-Projects/Floorp/releases/latest | jq -r ".tag_name")
+latestVersion="$(expr "$latestTag" : 'v\(.*\)')"
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "Floorp is up-to-date: ${currentVersion}"
+    exit 0
+fi
+
+updateVersion "$latestVersion"
+updateBaseVersion "$latestVersion"
+updateHash "$latestVersion"


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Summarized Changelog: https://blog.ablaze.one/4115/2024-03-21/
Git changelog: https://github.com/Floorp-Projects/Floorp/compare/v11.10.5...v11.11.2
 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
