### PR TITLE
makeFontsConf: refactor for readibility

### DIFF
--- a/pkgs/development/libraries/fontconfig/make-fonts-conf.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-conf.nix
@@ -1,5 +1,10 @@
-{ runCommand, stdenv, lib, libxslt, fontconfig, dejavu_fonts, fontDirectories
-, impureFontDirectories ? [
+{ runCommand, stdenv, lib, libxslt, fontconfig, dejavu_fonts }:
+
+{
+  # an array of fonts, e.g. `[ pkgs.dejavu_fonts.minimal ]`
+
+  fontDirectories
+  , impureFontDirectories ? [
     # nix user profile
     "~/.nix-profile/lib/X11/fonts" "~/.nix-profile/share/fonts"
   ]
@@ -11,7 +16,8 @@
   # darwin paths
   ++ lib.optionals stdenv.isDarwin [ "/Library/Fonts" "/System/Library/Fonts" ]
   # nix default profile
-  ++ [ "/nix/var/nix/profiles/default/lib/X11/fonts" "/nix/var/nix/profiles/default/share/fonts" ] }:
+  ++ [ "/nix/var/nix/profiles/default/lib/X11/fonts" "/nix/var/nix/profiles/default/share/fonts" ]
+}:
 
 runCommand "fonts.conf"
   {

--- a/pkgs/development/libraries/fontconfig/make-fonts-conf.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-conf.nix
@@ -3,7 +3,8 @@
 {
   # an array of fonts, e.g. `[ pkgs.dejavu_fonts.minimal ]`
 
-  fontDirectories
+  fontconfig ? fontconfig
+,  fontDirectories
   , impureFontDirectories ? [
     # nix user profile
     "~/.nix-profile/lib/X11/fonts" "~/.nix-profile/share/fonts"

--- a/pkgs/development/libraries/fontconfig/make-fonts-conf.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-conf.nix
@@ -1,9 +1,9 @@
 { runCommand, stdenv, lib, libxslt, fontconfig, dejavu_fonts }:
 
+let fontconfig_ = fontconfig; in
 {
+  fontconfig ? fontconfig_
   # an array of fonts, e.g. `[ pkgs.dejavu_fonts.minimal ]`
-
-  fontconfig ? fontconfig
 ,  fontDirectories
   , impureFontDirectories ? [
     # nix user profile

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20995,10 +20995,7 @@ with pkgs;
 
   fortify-headers = callPackage ../development/libraries/fortify-headers { };
 
-  makeFontsConf = let fontconfig_ = fontconfig; in {fontconfig ? fontconfig_, fontDirectories}:
-    callPackage ../development/libraries/fontconfig/make-fonts-conf.nix {
-      inherit fontconfig fontDirectories;
-    };
+  makeFontsConf = callPackage ../development/libraries/fontconfig/make-fonts-conf.nix { };
 
   makeFontsCache = let fontconfig_ = fontconfig; in {fontconfig ? fontconfig_, fontDirectories}:
     callPackage ../development/libraries/fontconfig/make-fonts-cache.nix {


### PR DESCRIPTION
and to ease the possibility to override impureFontsDirectories

follow up of https://github.com/NixOS/nixpkgs/pull/270245#issuecomment-2020686249

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
