### PR TITLE
treewide: gate `elfutils` on `lib.meta.availableOn stdenv.hostPlatform elfutils`

### DIFF
--- a/pkgs/applications/misc/opencpn/default.nix
+++ b/pkgs/applications/misc/opencpn/default.nix
@@ -108,12 +108,13 @@ stdenv.mkDerivation (finalAttrs: {
     wxGTK32
   ] ++ lib.optionals stdenv.isLinux [
     alsa-utils
-    elfutils
     libselinux
     libsepol
     util-linux
     xorg.libXdmcp
     xorg.libXtst
+  ] ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform elfutils) [
+    elfutils
   ] ++ lib.optionals stdenv.isDarwin [
     lame
   ];

--- a/pkgs/applications/science/electronics/nvc/default.nix
+++ b/pkgs/applications/science/electronics/nvc/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     llvm
     zlib
     zstd
-  ] ++ lib.optionals stdenv.isLinux [
+  ] ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform elfutils) [
     elfutils
   ];
 

--- a/pkgs/development/compilers/gnat-bootstrap/default.nix
+++ b/pkgs/development/compilers/gnat-bootstrap/default.nix
@@ -67,8 +67,9 @@ in {
     zlib
   ] ++ lib.optionals stdenv.buildPlatform.isLinux [
     autoPatchelfHook
-    elfutils
     glibc
+  ] ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform elfutils) [
+    elfutils
   ];
 
   postPatch = lib.optionalString (stdenv.hostPlatform.isDarwin) ''

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -67,6 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optionals stdenv.isLinux [
     libcap
     libunwind
+  ] ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform elfutils) [
     elfutils
   ] ++ lib.optionals stdenv.isDarwin [
     Cocoa

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -254,7 +254,8 @@ self = stdenv.mkDerivation {
   ] ++ [
     python3Packages.python # for shebang
   ] ++ lib.optionals haveWayland [ wayland wayland-protocols ]
-    ++ lib.optionals stdenv.isLinux [ elfutils libomxil-bellagio libva-minimal udev lm_sensors ]
+    ++ lib.optionals stdenv.isLinux [ libomxil-bellagio libva-minimal udev lm_sensors ]
+    ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform elfutils) [ elfutils ]
     ++ lib.optionals enableOpenCL [ llvmPackages.libclc llvmPackages.clang llvmPackages.clang-unwrapped spirv-llvm-translator ]
     ++ lib.optional withValgrind valgrind-light
     ++ lib.optional haveZink vulkan-loader

--- a/pkgs/development/libraries/qt-6/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmultimedia.nix
@@ -30,7 +30,8 @@ qtModule {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ ffmpeg_6 ]
     ++ lib.optionals (!stdenv.hostPlatform.isMinGW) [ libunwind orc ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ libpulseaudio elfutils alsa-lib wayland libXrandr libva ];
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ libpulseaudio alsa-lib wayland libXrandr libva ]
+    ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform elfutils) [ elfutils ];
   propagatedBuildInputs = [ qtbase qtdeclarative qtsvg qtshadertools ]
     ++ lib.optionals (!stdenv.hostPlatform.isMinGW) [ qtquick3d ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ gstreamer gst-plugins-base gst-plugins-good gst-libav gst-vaapi ]

--- a/pkgs/tools/package-management/rpm/default.nix
+++ b/pkgs/tools/package-management/rpm/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   # rpm/rpmlib.h includes popt.h, and then the pkg-config file mentions these as linkage requirements
   propagatedBuildInputs = [ popt nss db bzip2 libarchive libbfd ]
-    ++ lib.optional stdenv.isLinux elfutils;
+    ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform elfutils) elfutils;
 
   env.NIX_CFLAGS_COMPILE = "-I${nspr.dev}/include/nspr -I${nss.dev}/include/nss";
 


### PR DESCRIPTION
## Description of changes

In #298177, @alyssais pointed out that:

> `stdenv.isLinux` is not a sufficient check for whether `elfutils` is supported, because it's not supported on static Linux.

I went through every mention of elfutils and any that were gated on `stdenv.isLinux` are moved to 

1. `lib.meta.availableOn stdenv.hostPlatform elfutils` (if in `buildInputs`) 
2. `lib.meta.availableOn stdenv.buildPlatform elfutils` (if in `nativeBuildInputs`)

... just as #298177 did for `glib`.

There are many other ungated uses of `elfutils`, and I didn't touch those.

I've targeted staging for this PR out of an abundance of caution, though it ought to be a pure refactor.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).