### PR TITLE
blender: 4.0.2 -> 4.1.0

### DIFF
--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -16,7 +16,6 @@
   cudaSupport ? config.cudaSupport,
   dbus,
   embree,
-  fetchpatch,
   fetchurl,
   fetchzip,
   ffmpeg,
@@ -68,7 +67,7 @@
   pkg-config,
   potrace,
   pugixml,
-  python310Packages, # must use instead of python3.pkgs, see https://github.com/NixOS/nixpkgs/issues/211340
+  python311Packages, # must use instead of python3.pkgs, see https://github.com/NixOS/nixpkgs/issues/211340
   rocmPackages, # comes with a significantly larger closure size
   runCommand,
   spaceNavSupport ? stdenv.isLinux,
@@ -82,7 +81,7 @@
 }:
 
 let
-  python3Packages = python310Packages;
+  python3Packages = python311Packages;
   python3 = python3Packages.python;
   pyPkgsOpenusd = python3Packages.openusd.override { withOsl = false; };
 
@@ -100,25 +99,14 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "blender";
-  version = "4.0.2";
+  version = "4.1.0";
 
   src = fetchurl {
     url = "https://download.blender.org/source/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
-    hash = "sha256-qqDnKdp1kc+/RXcq92NFl32qp7EaCvNdmPkxPiRgd6M=";
+    hash = "sha256-3AAtguPDQMk4VcZoRzDQGAG2aaKbHMa3XuuZC6aecj8=";
   };
 
-  patches = [
-    ./draco.patch
-    (fetchpatch {
-      url = "https://projects.blender.org/blender/blender/commit/cf4365e555a759d5b3225bce77858374cb07faad.diff";
-      hash = "sha256-Nypd04yFSHYa7RBa8kNmoApqJrU4qpaOle3tkj44d4g=";
-    })
-    (fetchpatch {
-      # https://projects.blender.org/blender/blender/issues/117145
-      url = "https://projects.blender.org/blender/blender/commit/eb99895c972b6c713294f68a34798aa51d36034a.patch";
-      hash = "sha256-95nG5mW408lhKJ2BppgaUwBMMeXeGyBqho6mCfB53GI=";
-    })
-  ] ++ lib.optional stdenv.isDarwin ./darwin.patch;
+  patches = [ ./draco.patch ] ++ lib.optional stdenv.isDarwin ./darwin.patch;
 
   postPatch =
     (
@@ -247,7 +235,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals (!stdenv.isAarch64) [
       embree
-      openimagedenoise
+      (openimagedenoise.override { inherit cudaSupport; })
     ]
     ++ (
       if (!stdenv.isDarwin) then

--- a/pkgs/development/libraries/openimagedenoise/cuda.patch
+++ b/pkgs/development/libraries/openimagedenoise/cuda.patch
@@ -1,0 +1,32 @@
+Remove upstream workarounds for CMake "limitations" that do not appear to exist
+in nixpkgs build environment, but rather break the build, presumably because
+CMAKE_INSTALL_{BIN,LIB}DIR is an absolute path in our build so
+CMAKE_INSTALL_PREFIX has no effect.
+
+diff --git a/devices/CMakeLists.txt b/devices/CMakeLists.txt
+index d5111cd..43986ad 100644
+--- a/devices/CMakeLists.txt
++++ b/devices/CMakeLists.txt
+@@ -53,7 +53,6 @@ if(OIDN_DEVICE_CUDA)
+       -DCMAKE_CXX_COMPILER:FILEPATH=${_host_compiler}
+       -DCMAKE_TOOLCHAIN_FILE:FILEPATH=${CMAKE_TOOLCHAIN_FILE}
+       -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+-      -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/cuda/preinstall
+       -DCMAKE_INSTALL_BINDIR:PATH=${CMAKE_INSTALL_BINDIR}
+       -DCMAKE_INSTALL_LIBDIR:PATH=${CMAKE_INSTALL_LIBDIR}
+       -DCUDAToolkit_ROOT:PATH=${CUDAToolkit_ROOT}
+@@ -69,14 +68,6 @@ if(OIDN_DEVICE_CUDA)
+     DEPENDS
+       OpenImageDenoise_core
+   )
+-
+-  # Due to limitations of CMake, the module is pre-installed at build time to a temporary location,
+-  # and then copied to the real install location at install time.
+-  install(DIRECTORY
+-    ${CMAKE_CURRENT_BINARY_DIR}/cuda/preinstall/
+-    DESTINATION "."
+-    USE_SOURCE_PERMISSIONS
+-  )
+ endif()
+ 
+ if(OIDN_DEVICE_HIP)

--- a/pkgs/development/libraries/openimagedenoise/default.nix
+++ b/pkgs/development/libraries/openimagedenoise/default.nix
@@ -10,12 +10,12 @@
 
 stdenv.mkDerivation rec {
   pname = "openimagedenoise";
-  version = "1.4.3";
+  version = "2.2.2";
 
   # The release tarballs include pretrained weights, which would otherwise need to be fetched with git-lfs
   src = fetchzip {
     url = "https://github.com/OpenImageDenoise/oidn/releases/download/v${version}/oidn-${version}.src.tar.gz";
-    sha256 = "sha256-i73w/Vkr5TPLB1ulPbPU4OVGwdNlky1brfarueD7akE=";
+    sha256 = "sha256-ZIrs4oEb+PzdMh2x2BUFXKyu/HBlFb3CJX24ciEHy3Q=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/openimagedenoise/default.nix
+++ b/pkgs/development/libraries/openimagedenoise/default.nix
@@ -1,5 +1,8 @@
 {
   cmake,
+  config,
+  cudaPackages,
+  cudaSupport ? config.cudaSupport,
   fetchzip,
   ispc,
   lib,
@@ -18,14 +21,23 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ZIrs4oEb+PzdMh2x2BUFXKyu/HBlFb3CJX24ciEHy3Q=";
   };
 
+  patches = lib.optional cudaSupport ./cuda.patch;
+
   nativeBuildInputs = [
     cmake
     python3
     ispc
-  ];
-  buildInputs = [ tbb ];
+  ] ++ lib.optional cudaSupport cudaPackages.cuda_nvcc;
+
+  buildInputs =
+    [ tbb ]
+    ++ lib.optionals cudaSupport [
+      cudaPackages.cuda_cudart
+      cudaPackages.cuda_cccl
+    ];
 
   cmakeFlags = [
+    (lib.cmakeBool "OIDN_DEVICE_CUDA" cudaSupport)
     (lib.cmakeFeature "TBB_INCLUDE_DIR" "${tbb.dev}/include")
     (lib.cmakeFeature "TBB_ROOT" "${tbb}")
   ];

--- a/pkgs/development/libraries/openimagedenoise/default.nix
+++ b/pkgs/development/libraries/openimagedenoise/default.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, fetchzip, cmake, tbb, python3, ispc }:
+{
+  cmake,
+  fetchzip,
+  ispc,
+  lib,
+  python3,
+  stdenv,
+  tbb,
+}:
 
 stdenv.mkDerivation rec {
   pname = "openimagedenoise";
@@ -10,12 +18,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-i73w/Vkr5TPLB1ulPbPU4OVGwdNlky1brfarueD7akE=";
   };
 
-  nativeBuildInputs = [ cmake python3 ispc ];
+  nativeBuildInputs = [
+    cmake
+    python3
+    ispc
+  ];
   buildInputs = [ tbb ];
 
   cmakeFlags = [
-    "-DTBB_ROOT=${tbb}"
-    "-DTBB_INCLUDE_DIR=${tbb.dev}/include"
+    (lib.cmakeFeature "TBB_INCLUDE_DIR" "${tbb.dev}/include")
+    (lib.cmakeFeature "TBB_ROOT" "${tbb}")
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/opensubdiv/default.nix
+++ b/pkgs/development/libraries/opensubdiv/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "opensubdiv";
-  version = "3.5.1";
+  version = "3.6.0";
 
   src = fetchFromGitHub {
     owner = "PixarAnimationStudios";
     repo = "OpenSubdiv";
     rev = "v${lib.replaceStrings ["."] ["_"] version}";
-    sha256 = "sha256-uDKCT0Uoa5WQekMUFm2iZmzm+oWAZ6IWMwfpchkUZY0=";
+    sha256 = "sha256-liy6pQyWMk7rw0usrCoLGzZLO7RAg0z2pV/GF2NnOkE=";
   };
 
   outputs = [ "out" "dev" "static" ];


### PR DESCRIPTION
## Description of changes

Update some dependencies as-needed. Opening draft for now as I want to do some more manual testing later today.

## Things done

- Tested basic CUDA rendering
- Tested rendering 4.1 splash blend file
- Tested OpenImageDenoise GPU acceleration on CUDA
- Tested HDRIs work (as now-removed patch was for this)

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>9 packages built:</summary>
  <ul>
    <li>blender</li>
    <li>blender-hip</li>
    <li>openimagedenoise</li>
    <li>opensubdiv</li>
    <li>opensubdiv.dev</li>
    <li>opensubdiv.static</li>
    <li>openusd</li>
    <li>python311Packages.openusd</li>
    <li>python312Packages.openusd</li>
  </ul>
</details>

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
