### PR TITLE
Avoid top-level `with ...;` in the Python packages in `pkgs/tools/`

### DIFF
--- a/pkgs/tools/admin/awscli2/default.nix
+++ b/pkgs/tools/admin/awscli2/default.nix
@@ -56,8 +56,37 @@ let
     });
   };
 
+
+  inherit (lib) licenses maintainers optionalString;
+
+  inherit (py.pkgs)
+    awscrt
+    bcdoc
+    bootstrap
+    botocore
+    buildPythonApplication
+    colorama
+    cryptography
+    distro
+    docutils
+    flit-core
+    jmespath
+    jsonschema
+    mock
+    prompt-toolkit
+    pytestCheckHook
+    python-dateutil
+    pyyaml
+    ruamel-yaml
+    setuptools
+    sphinx
+    toml
+    urllib3
+    wheel
+    ;
 in
-with py.pkgs; buildPythonApplication rec {
+
+buildPythonApplication rec {
   pname = "awscli2";
   version = "2.15.32"; # N.B: if you change this, check if overrides are still up-to-date
   pyproject = true;
@@ -119,7 +148,7 @@ with py.pkgs; buildPythonApplication rec {
     installShellCompletion --cmd aws \
       --bash <(echo "complete -C $out/bin/aws_completer aws") \
       --zsh $out/bin/aws_zsh_completer.sh
-  '' + lib.optionalString (!stdenv.hostPlatform.isWindows) ''
+  '' + optionalString (!stdenv.hostPlatform.isWindows) ''
     rm $out/bin/aws.cmd
   '';
 
@@ -161,7 +190,7 @@ with py.pkgs; buildPythonApplication rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Unified tool to manage your AWS services";
     homepage = "https://aws.amazon.com/cli/";
     changelog = "https://github.com/aws/aws-cli/blob/${version}/CHANGELOG.rst";

--- a/pkgs/tools/admin/chkcrontab/default.nix
+++ b/pkgs/tools/admin/chkcrontab/default.nix
@@ -1,6 +1,8 @@
 { lib, python3, fetchPypi }:
 
-with python3.pkgs;
+let
+  inherit (python3.pkgs) buildPythonApplication crontab;
+in
 
 buildPythonApplication rec {
   pname = "chkcrontab";

--- a/pkgs/tools/admin/mycli/default.nix
+++ b/pkgs/tools/admin/mycli/default.nix
@@ -4,7 +4,26 @@
 , glibcLocales
 }:
 
-with python3.pkgs;
+let
+  inherit (python3.pkgs)
+    buildPythonApplication
+    click
+    cli-helpers
+    configobj
+    cryptography
+    importlib-resources
+    paramiko
+    prompt-toolkit
+    pyaes
+    pycrypto
+    pygments
+    pymysql
+    pyperclip
+    pytestCheckHook
+    sqlglot
+    sqlparse
+    ;
+in
 
 buildPythonApplication rec {
   pname = "mycli";

--- a/pkgs/tools/admin/oci-cli/default.nix
+++ b/pkgs/tools/admin/oci-cli/default.nix
@@ -32,8 +32,26 @@ let
 
     };
   };
+
+  inherit (py.pkgs)
+    arrow
+    buildPythonApplication
+    certifi
+    click
+    cryptography
+    jmespath
+    oci
+    prompt-toolkit
+    pyopenssl
+    python-dateutil
+    pytz
+    pyyaml
+    retrying
+    setuptools
+    six
+    terminaltables
+    ;
 in
-with py.pkgs;
 
 buildPythonApplication rec {
   pname = "oci-cli";

--- a/pkgs/tools/graphics/escrotum/default.nix
+++ b/pkgs/tools/graphics/escrotum/default.nix
@@ -6,7 +6,24 @@
 , wrapGAppsHook
 }:
 
-with python3Packages; buildPythonApplication {
+let
+  inherit (lib)
+    licenses
+    maintainers
+    makeBinPath
+    platforms
+    ;
+
+  inherit (python3Packages)
+    buildPythonApplication
+    numpy
+    pycairo
+    pygobject3
+    xcffib
+    ;
+in
+
+buildPythonApplication {
   pname = "escrotum";
   version = "unstable-2020-12-07";
 
@@ -34,14 +51,14 @@ with python3Packages; buildPythonApplication {
 
   outputs = [ "out" "man" ];
 
-  makeWrapperArgs = ["--prefix PATH : ${lib.makeBinPath [ ffmpeg-full ]}"];
+  makeWrapperArgs = ["--prefix PATH : ${makeBinPath [ ffmpeg-full ]}"];
 
   postInstall = ''
     mkdir -p $man/share/man/man1
     cp man/escrotum.1 $man/share/man/man1/
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/Roger/escrotum";
     description = "Linux screen capture using pygtk, inspired by scrot";
     platforms = platforms.linux;

--- a/pkgs/tools/misc/adafruit-ampy/default.nix
+++ b/pkgs/tools/misc/adafruit-ampy/default.nix
@@ -1,6 +1,14 @@
 { lib, python3, fetchPypi }:
 
-with python3.pkgs;
+let
+  inherit (python3.pkgs)
+    buildPythonApplication
+    click
+    pyserial
+    python-dotenv
+    setuptools-scm
+    ;
+in
 
 buildPythonApplication rec {
   pname = "adafruit-ampy";

--- a/pkgs/tools/misc/bkyml/default.nix
+++ b/pkgs/tools/misc/bkyml/default.nix
@@ -3,7 +3,14 @@
 , fetchPypi
 }:
 
-with python3.pkgs;
+let
+  inherit (python3.pkgs)
+    buildPythonApplication
+    pyscaffold
+    ruamel-yaml
+    setuptools
+    ;
+in
 
 buildPythonApplication rec {
   pname = "bkyml";

--- a/pkgs/tools/misc/csvs-to-sqlite/default.nix
+++ b/pkgs/tools/misc/csvs-to-sqlite/default.nix
@@ -1,6 +1,21 @@
 { lib, python3, fetchFromGitHub, fetchpatch }:
 
-with python3.pkgs; buildPythonApplication rec {
+let
+  inherit (python3.pkgs)
+    buildPythonApplication
+    click
+    cogapp
+    dateparser
+    pandas
+    py-lru-cache
+    pytestCheckHook
+    pythonRelaxDepsHook
+    setuptools
+    six
+    ;
+in
+
+buildPythonApplication rec {
   pname = "csvs-to-sqlite";
   version = "1.3";
   format = "setuptools";

--- a/pkgs/tools/misc/cyclonedx-python/default.nix
+++ b/pkgs/tools/misc/cyclonedx-python/default.nix
@@ -19,8 +19,19 @@ let
       });
     };
   };
+
+  inherit (py.pkgs)
+    buildPythonApplication
+    chardet
+    cyclonedx-python-lib
+    packageurl-python
+    pip-requirements-parser
+    poetry-core
+    pythonRelaxDepsHook
+    setuptools
+    toml
+    ;
 in
-with py.pkgs;
 
 python3.pkgs.buildPythonApplication rec {
   pname = "cyclonedx-python";
@@ -34,12 +45,12 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "sha256-jU/0FkQCyph59TnEE+lckJXsU9whfvWp7dkdfzprYw8=";
   };
 
-  nativeBuildInputs = with py.pkgs; [
+  nativeBuildInputs = [
     poetry-core
     pythonRelaxDepsHook
   ];
 
-  propagatedBuildInputs = with py.pkgs; [
+  propagatedBuildInputs = [
     chardet
     cyclonedx-python-lib
     packageurl-python

--- a/pkgs/tools/misc/kargo/default.nix
+++ b/pkgs/tools/misc/kargo/default.nix
@@ -1,6 +1,20 @@
 { lib, fetchurl, python3Packages }:
 
-with python3Packages;
+let
+  inherit (python3Packages)
+    ansible-core
+    boto
+    buildPythonApplication
+    cffi
+    cryptography
+    libcloud
+    markupsafe
+    netaddr
+    pyasn1
+    requests
+    setuptools
+    ;
+in
 
 buildPythonApplication rec {
   version = "0.4.8";

--- a/pkgs/tools/misc/noteshrink/default.nix
+++ b/pkgs/tools/misc/noteshrink/default.nix
@@ -1,6 +1,13 @@
 { lib, fetchFromGitHub, python3, imagemagick }:
 
-with python3.pkgs;
+let
+  inherit (python3.pkgs)
+    buildPythonApplication
+    numpy
+    pillow
+    scipy
+    ;
+in
 
 buildPythonApplication rec {
   pname = "noteshrink";

--- a/pkgs/tools/misc/parquet-tools/default.nix
+++ b/pkgs/tools/misc/parquet-tools/default.nix
@@ -3,7 +3,23 @@
 , python3Packages
 }:
 
-with python3Packages;
+let
+  inherit (python3Packages)
+    boto3
+    buildPythonApplication
+    colorama
+    halo
+    moto
+    pandas
+    poetry-core
+    pyarrow
+    pytestCheckHook
+    pytest-mock
+    pythonRelaxDepsHook
+    tabulate
+    thrift
+    ;
+in
 
 buildPythonApplication rec {
   pname = "parquet-tools";

--- a/pkgs/tools/misc/pipreqs/default.nix
+++ b/pkgs/tools/misc/pipreqs/default.nix
@@ -1,6 +1,8 @@
 { lib, python3, fetchPypi }:
 
-with python3.pkgs;
+let
+  inherit (python3.pkgs) buildPythonApplication docopt yarg;
+in
 
 buildPythonApplication rec {
   pname = "pipreqs";

--- a/pkgs/tools/misc/pre-commit/default.nix
+++ b/pkgs/tools/misc/pre-commit/default.nix
@@ -15,7 +15,28 @@
 , pre-commit
 }:
 
-with python3Packages;
+let
+  inherit (lib) licenses maintainers optionalString;
+
+  inherit (python3Packages)
+    buildPythonApplication
+    cfgv
+    identify
+    nodeenv
+    pytestCheckHook
+    pytest-env
+    pytest-forked
+    pytest-xdist
+    pythonOlder
+    pyyaml
+    re-assert
+    setuptools
+    stdenv
+    toml
+    virtualenv
+    ;
+in
+
 buildPythonApplication rec {
   pname = "pre-commit";
   version = "3.6.2";
@@ -81,7 +102,7 @@ buildPythonApplication rec {
     "--forked"
   ];
 
-  preCheck = lib.optionalString (!(stdenv.isLinux && stdenv.isAarch64)) ''
+  preCheck = optionalString (!(stdenv.isLinux && stdenv.isAarch64)) ''
     # Disable outline atomics for rust tests on aarch64-linux.
     export RUSTFLAGS="-Ctarget-feature=-outline-atomics"
   '' + ''
@@ -182,7 +203,7 @@ buildPythonApplication rec {
     package = pre-commit;
   };
 
-  meta = with lib; {
+  meta = {
     description = "A framework for managing and maintaining multi-language pre-commit hooks";
     homepage = "https://pre-commit.com/";
     license = licenses.mit;

--- a/pkgs/tools/misc/sonota/default.nix
+++ b/pkgs/tools/misc/sonota/default.nix
@@ -3,9 +3,14 @@
 , coreSize    ? "1MB"    # size of the binary image to flash
 , coreSha256  ? "0pkb2nmml0blrfiqpc46xpjc2dw927i89k1lfyqx827wanhc704x" }:
 
-with python3Packages;
-
 let
+  inherit (python3Packages)
+    buildPythonApplication
+    httplib2
+    netifaces
+    tornado
+    ;
+
   core = fetchurl {
     url    = "https://github.com/xoseperez/espurna/releases/download/${coreVersion}/espurna-${coreVersion}-espurna-core-${coreSize}.bin";
     sha256 = coreSha256;

--- a/pkgs/tools/misc/wlc/default.nix
+++ b/pkgs/tools/misc/wlc/default.nix
@@ -3,7 +3,18 @@
 , fetchPypi
 }:
 
-with python3.pkgs;
+let
+  inherit (python3.pkgs)
+    argcomplete
+    buildPythonPackage
+    pytestCheckHook
+    python-dateutil
+    pyxdg
+    requests
+    responses
+    twine
+    ;
+in
 
 buildPythonPackage rec {
   pname = "wlc";

--- a/pkgs/tools/misc/woeusb-ng/default.nix
+++ b/pkgs/tools/misc/woeusb-ng/default.nix
@@ -7,7 +7,14 @@
 , grub2
 }:
 
-with python3Packages;
+let
+  inherit (python3Packages)
+    buildPythonApplication
+    six
+    termcolor
+    wxpython
+    ;
+in
 
 buildPythonApplication rec {
   pname = "woeusb-ng";

--- a/pkgs/tools/networking/mutt-ics/default.nix
+++ b/pkgs/tools/networking/mutt-ics/default.nix
@@ -1,6 +1,10 @@
 { lib, python3, fetchPypi }:
 
-with python3.pkgs; buildPythonApplication rec {
+let
+  inherit (python3.pkgs) buildPythonApplication icalendar;
+in
+
+buildPythonApplication rec {
   pname = "mutt-ics";
   version = "0.9.2";
 

--- a/pkgs/tools/networking/nyx/default.nix
+++ b/pkgs/tools/networking/nyx/default.nix
@@ -1,6 +1,8 @@
 { lib, python3Packages, fetchPypi }:
 
-with python3Packages;
+let
+  inherit (python3Packages) buildPythonApplication stem;
+in
 
 buildPythonApplication rec {
   pname = "nyx";

--- a/pkgs/tools/networking/pirate-get/default.nix
+++ b/pkgs/tools/networking/pirate-get/default.nix
@@ -1,6 +1,13 @@
 { lib, python3Packages, fetchPypi }:
 
-with python3Packages;
+let
+  inherit (python3Packages)
+    buildPythonApplication
+    colorama
+    pyperclip
+    veryprettytable
+    ;
+in
 
 buildPythonApplication rec {
   pname = "pirate-get";

--- a/pkgs/tools/package-management/pdm/default.nix
+++ b/pkgs/tools/package-management/pdm/default.nix
@@ -30,9 +30,40 @@ let
     };
     self = python;
   };
-in
 
-with python.pkgs;
+  inherit (python.pkgs)
+    blinker
+    buildPythonApplication
+    cachecontrol
+    certifi
+    dep-logic
+    findpython
+    first
+    importlib-metadata
+    installer
+    packaging
+    pdm-backend
+    platformdirs
+    pyproject-hooks
+    pytestCheckHook
+    pytest-httpserver
+    pytest-mock
+    pytest-rerunfailures
+    pytest-xdist
+    pythonAtLeast
+    python-dotenv
+    pythonOlder
+    requests-toolbelt
+    resolvelib
+    rich
+    shellingham
+    tomli
+    tomlkit
+    truststore
+    unearth
+    virtualenv
+    ;
+in
 buildPythonApplication rec {
   pname = "pdm";
   version = "2.12.4";

--- a/pkgs/tools/package-management/poetry2conda/default.nix
+++ b/pkgs/tools/package-management/poetry2conda/default.nix
@@ -4,7 +4,20 @@
 , python3
 }:
 
-with python3.pkgs; buildPythonApplication rec {
+let
+  inherit (python3.pkgs)
+    buildPythonApplication
+    poetry2conda
+    poetry-core
+    poetry-semver
+    pytestCheckHook
+    pytest-mock
+    pyyaml
+    toml
+    ;
+in
+
+buildPythonApplication rec {
   pname = "poetry2conda";
   version = "0.3.0";
 

--- a/pkgs/tools/security/expliot/default.nix
+++ b/pkgs/tools/security/expliot/default.nix
@@ -16,8 +16,28 @@ let
       });
     };
   };
+
+  inherit (py.pkgs)
+    aiocoap
+    awsiotpythonsdk
+    bluepy
+    buildPythonApplication
+    can
+    cmd2
+    cryptography
+    paho-mqtt
+    pyi2cflash
+    pymodbus
+    pynetdicom
+    pyparsing
+    pyserial
+    pyspiflash
+    pythonRelaxDepsHook
+    upnpy
+    xmltodict
+    zeroconf
+    ;
 in
-with py.pkgs;
 
 buildPythonApplication rec {
   pname = "expliot";

--- a/pkgs/tools/security/ssh-mitm/default.nix
+++ b/pkgs/tools/security/ssh-mitm/default.nix
@@ -17,8 +17,21 @@ let
       });
     };
   };
+
+  inherit (py.pkgs)
+    argcomplete
+    buildPythonApplication
+    colored
+    icecream
+    packaging
+    paramiko
+    pytz
+    pyyaml
+    rich
+    setuptools
+    sshpubkeys
+    ;
 in
-with py.pkgs;
 
 buildPythonApplication rec {
   pname = "ssh-mitm";

--- a/pkgs/tools/typesetting/rfc-bibtex/default.nix
+++ b/pkgs/tools/typesetting/rfc-bibtex/default.nix
@@ -3,7 +3,16 @@
 , python3
 }:
 
-with python3.pkgs; buildPythonApplication rec {
+let
+  inherit (python3.pkgs)
+    buildPythonApplication
+    pytestCheckHook
+    setuptools
+    vcrpy
+    ;
+in
+
+buildPythonApplication rec {
   pname = "rfc-bibtex";
   version = "0.3.2";
   format = "setuptools";


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is no functional change contained in this PR.

I really wish to use `callPackage` style dependency injection for these Python packages, rather than the style I've used in this PR. I don't know how to do that refactor, however. 

I used the refactor strategy that looks for the uses of names [coming from `lib`, `pkgs`, `python3Packages`, and more](https://gist.github.com/philiptaron/04326000d5ff20cb72c2805efd09701c). 

Following advice, I also preferred to inherit names from `lib` instead of `builtins` where there was a choice. I also preferred to inherit from `lib` in one place, rather than to have a mixture of `lib.thing` and `inherit (lib) thing`. I can drop those changes if package owners desire.

There are no rebuilds when I run `nixpkgs-review rev HEAD`, so I've targeted master with this PR.

## Things done

- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev HEAD`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).