### PR TITLE
Avoid top-level `with ...;` in several packages in `pkgs/tools/`

### DIFF
--- a/pkgs/tools/backup/ugarit-manifest-maker/default.nix
+++ b/pkgs/tools/backup/ugarit-manifest-maker/default.nix
@@ -1,7 +1,10 @@
 { pkgs, lib, eggDerivation, fetchegg }:
+
 let
   eggs = import ./eggs.nix { inherit eggDerivation fetchegg; };
-in with pkgs; eggDerivation rec {
+in
+
+eggDerivation rec {
   pname = "ugarit-manifest-maker";
   version = "0.1";
   name = "${pname}-${version}";

--- a/pkgs/tools/backup/ugarit/default.nix
+++ b/pkgs/tools/backup/ugarit/default.nix
@@ -1,7 +1,10 @@
-{ pkgs, lib, eggDerivation, fetchegg }:
+{ lib, eggDerivation, fetchegg, z3 }:
+
 let
   eggs = import ./eggs.nix { inherit eggDerivation fetchegg; };
-in with pkgs; eggDerivation rec {
+in
+
+eggDerivation rec {
   pname = "ugarit";
   version = "2.0";
   name = "${pname}-${version}";

--- a/pkgs/tools/graphics/astc-encoder/default.nix
+++ b/pkgs/tools/graphics/astc-encoder/default.nix
@@ -5,11 +5,20 @@
 , simdExtensions ? null
 }:
 
-with rec {
+let
+  inherit (lib)
+    head
+    licenses
+    maintainers
+    platforms
+    replaceStrings
+    toList
+    ;
+
   # SIMD instruction sets to compile for. If none are specified by the user,
   # an appropriate one is selected based on the detected host system
   isas = with stdenv.hostPlatform;
-    if simdExtensions != null then lib.toList simdExtensions
+    if simdExtensions != null then toList simdExtensions
     else if avx2Support then [ "AVX2" ]
     else if sse4_1Support then [ "SSE41" ]
     else if isx86_64 then [ "SSE2" ]
@@ -21,11 +30,11 @@ with rec {
   isaFlags = map ( isa: "-DASTCENC_ISA_${isa}=ON" ) isas;
 
   # The suffix of the binary to link as 'astcenc'
-  mainBinary = builtins.replaceStrings
+  mainBinary = replaceStrings
     [ "AVX2" "SSE41"  "SSE2" "NEON" "NONE" "NATIVE" ]
     [ "avx2" "sse4.1" "sse2" "neon" "none" "native" ]
-    ( builtins.head isas );
-};
+    ( head isas );
+in
 
 stdenv.mkDerivation rec {
   pname = "astc-encoder";
@@ -57,7 +66,7 @@ stdenv.mkDerivation rec {
     ln -s $out/bin/astcenc-${mainBinary} $out/bin/astcenc
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/ARM-software/astc-encoder";
     description = "An encoder for the ASTC texture compression format";
     longDescription = ''

--- a/pkgs/tools/misc/bepasty/default.nix
+++ b/pkgs/tools/misc/bepasty/default.nix
@@ -2,6 +2,7 @@
 , python3
 , fetchPypi
 }:
+
 let
   # bepasty 1.2 needs xstatic-font-awesome < 5, see
   # https://github.com/bepasty/bepasty-server/issues/305
@@ -17,16 +18,18 @@ let
       });
     };
   };
+in
 
-#We need to use buildPythonPackage here to get the PYTHONPATH build correctly.
-#This is needed for services.bepasty
-#https://github.com/NixOS/nixpkgs/pull/38300
-in with bepastyPython.pkgs; buildPythonPackage rec {
+# We need to use buildPythonPackage here to get the PYTHONPATH build correctly.
+# This is needed for services.bepasty
+# https://github.com/NixOS/nixpkgs/pull/38300
+
+bepastyPython.pkgs.buildPythonPackage rec {
   pname = "bepasty";
   version = "1.2.1";
   format = "pyproject";
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with bepastyPython.pkgs; [
     flask
     markupsafe
     pygments
@@ -42,14 +45,14 @@ in with bepastyPython.pkgs; buildPythonPackage rec {
     xstatic-pygments
   ];
 
-  buildInputs = [ setuptools-scm ];
+  buildInputs = with bepastyPython.pkgs; [ setuptools-scm ];
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-08cyr2AruGAfHAwHHS8WMfJh7DBKymaYyz4AxI/ubkE=";
   };
 
-  nativeCheckInputs = [
+  nativeCheckInputs = with bepastyPython.pkgs; [
     build
     codecov
     flake8
@@ -70,10 +73,10 @@ in with bepastyPython.pkgs; buildPythonPackage rec {
     "src/bepasty/tests/test_website.py"
   ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/bepasty/bepasty-server";
     description = "Binary pastebin server";
-    license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ aither64 makefu ];
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ aither64 makefu ];
   };
 }

--- a/pkgs/tools/misc/graylog/plugins.nix
+++ b/pkgs/tools/misc/graylog/plugins.nix
@@ -1,8 +1,13 @@
 { lib, stdenv, fetchurl, unzip, graylog-5_1 }:
 
-with lib;
-
 let
+  inherit (lib)
+    licenses
+    maintainers
+    platforms
+    sourceTypes
+    ;
+
   glPlugin = a@{
     pluginName,
     version,
@@ -78,7 +83,7 @@ in {
     meta = {
       homepage = "https://docs.graylog.org/en/3.3/pages/integrations.html#enterprise";
       description = "Integrations are tools that help Graylog work with external systems (unfree enterprise integrations)";
-      license = lib.licenses.unfree;
+      license = licenses.unfree;
     };
   };
   filter-messagesize = glPlugin rec {
@@ -227,7 +232,7 @@ in {
     meta = {
       homepage = "https://bitbucket.org/proximus/smseagle-graylog/";
       description = "Alert/notification callback plugin for integrating the SMSEagle into Graylog";
-      license = lib.licenses.gpl3Only;
+      license = licenses.gpl3Only;
     };
   };
   snmp = glPlugin rec {
@@ -267,7 +272,7 @@ in {
     meta = {
       homepage = "https://github.com/graylog-labs/graylog-plugin-splunk";
       description = "Graylog output plugin that forwards one or more streams of data to Splunk via TCP";
-      license = lib.licenses.gpl3Only;
+      license = licenses.gpl3Only;
     };
   };
   twiliosms = glPlugin rec {

--- a/pkgs/tools/networking/dd-agent/integrations-core.nix
+++ b/pkgs/tools/networking/dd-agent/integrations-core.nix
@@ -35,9 +35,9 @@
 
 { pkgs, python, extraIntegrations ? {} }:
 
-with pkgs.lib;
-
 let
+  inherit (pkgs.lib) attrValues mapAttrs;
+
   src = pkgs.fetchFromGitHub {
     owner = "DataDog";
     repo = "integrations-core";

--- a/pkgs/tools/security/pass/extensions/default.nix
+++ b/pkgs/tools/security/pass/extensions/default.nix
@@ -1,6 +1,8 @@
 { pkgs, ... }:
 
-with pkgs;
+let
+  inherit (pkgs) callPackage python3Packages;
+in
 
 {
   pass-audit = callPackage ./audit {

--- a/pkgs/tools/virtualization/awsebcli/default.nix
+++ b/pkgs/tools/virtualization/awsebcli/default.nix
@@ -1,4 +1,5 @@
 { lib, python3, fetchFromGitHub, glibcLocales, git }:
+
 let
   changeVersion = overrideFunc: version: hash: overrideFunc (oldAttrs: rec {
     inherit version;
@@ -13,8 +14,10 @@ let
       cement = changeVersion super.cement.overridePythonAttrs "2.8.2" "sha256-h2XtBSwGHXTk0Bia3cM9Jo3lRMohmyWdeXdB9yXkItI=";
     };
   };
+
 in
-with localPython.pkgs; buildPythonApplication rec {
+
+localPython.pkgs.buildPythonApplication rec {
   pname = "awsebcli";
   version = "3.20.10";
   format = "setuptools";
@@ -31,7 +34,7 @@ with localPython.pkgs; buildPythonApplication rec {
     substituteInPlace setup.py --replace "scripts=['bin/eb']," ""
   '';
 
-  nativeBuildInputs = [
+  nativeBuildInputs = with localPython.pkgs; [
     pythonRelaxDepsHook
   ];
 
@@ -39,7 +42,7 @@ with localPython.pkgs; buildPythonApplication rec {
     glibcLocales
   ];
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with localPython.pkgs; [
     blessed
     botocore
     cement
@@ -64,7 +67,7 @@ with localPython.pkgs; buildPythonApplication rec {
     "termcolor"
   ];
 
-  nativeCheckInputs = [
+  nativeCheckInputs = with localPython.pkgs; [
     pytestCheckHook
     pytest-socket
     mock


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is no functional change contained in this PR.

I really wish to use `callPackage` style dependency injection for the two Python packages here, rather than the style I've used in this PR. I don't know how to do that refactor, however. 

I used the refactor strategy that looks for the uses of names [coming from `lib`, `pkgs`, `python3Packages`, and more](https://gist.github.com/philiptaron/04326000d5ff20cb72c2805efd09701c). 

Following advice, I also preferred to inherit names from `lib` instead of `builtins` where there was a choice. I also preferred to inherit from `lib` in one place, rather than to have a mixture of `with lib;`, `lib.thing` and `inherit (lib) thing`. **I can drop those changes if reviewers desire.**

There are no rebuilds when I run `nixpkgs-review rev HEAD`, so I've targeted master with this PR.

## Things done

- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev HEAD`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).