### PR TITLE
itsycal: init at 0.15.3

### DIFF
--- a/pkgs/by-name/it/itsycal/package.nix
+++ b/pkgs/by-name/it/itsycal/package.nix
@@ -1,0 +1,32 @@
+{ lib
+, fetchzip
+, stdenvNoCC
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "itsycal";
+  version = "0.15.3";
+
+  src = fetchzip {
+    url = "https://itsycal.s3.amazonaws.com/Itsycal-${finalAttrs.version}.zip";
+    hash = "sha256-jpTlJY7yAARrkHzreQKbFaKj0sYp950R0qPPcDeY6AE=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications/Itsycal.app
+    cp -R . $out/Applications/Itsycal.app
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Itsycal is a tiny menu bar calendar";
+    homepage = "https://www.mowglii.com/itsycal/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ donteatoreo ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Continuation of #299257

I'm really sorry I had to open a new issue, but OfBorg gave errors for a build that works perfectly fine.

OfBorg log: https://gist.github.com/GrahamcOfBorg/bfaae351d6dc61a08283686ab23a0e80
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
