### PR TITLE
emulationstation-de: 2.2.1 -> 3.0.2

### DIFF
--- a/pkgs/by-name/em/emulationstation-de/package.nix
+++ b/pkgs/by-name/em/emulationstation-de/package.nix
@@ -15,13 +15,13 @@
   SDL2
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "emulationstation-de";
-  version = "2.2.1";
+  version = "3.0.2";
 
   src = fetchzip {
-    url = "https://gitlab.com/es-de/emulationstation-de/-/archive/v2.2.1/emulationstation-de-v2.2.1.tar.gz";
-    hash = "sha256:1kp9p3fndnx4mapgfvy742zwisyf0y5k57xkqkis0kxyibx0z8i6";
+    url = "https://gitlab.com/es-de/emulationstation-de/-/archive/v${finalAttrs.version}/emulationstation-de-v${finalAttrs.version}.tar.gz";
+    hash = "sha256:RGlXFybbXYx66Hpjp2N3ovK4T5VyS4w0DWRGNvbwugs=";
   };
 
   patches = [ ./001-add-nixpkgs-retroarch-cores.patch ];
@@ -44,8 +44,25 @@ stdenv.mkDerivation {
   ];
 
   installPhase = ''
-    install -D ../emulationstation $out/bin/emulationstation
-    cp -r ../resources/ $out/bin/resources/
+    # Binary
+    install -D ../es-de $out/bin/es-de
+
+    # Resources
+    mkdir -p $out/share/es-de/
+    cp -r ../resources/ $out/share/es-de/resources/
+
+    # Desktop file
+    mkdir -p $out/share/applications
+    cp ../es-app/assets/org.es_de.frontend.desktop $out/share/applications/
+
+    # Icon
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+    cp ../es-app/assets/org.es_de.frontend.svg $out/share/icons/hicolor/scalable/apps/
+  '';
+
+  postInstall = ''
+    substituteInPlace $out/share/applications/org.es_de.frontend.desktop \
+      --replace "Exec=es-de" "Exec=$out/bin/es-de"
   '';
 
   meta = {
@@ -54,6 +71,6 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [ ivarmedi ];
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    mainProgram = "emulationstation";
+    mainProgram = "es-de";
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Update ES-DE from 2.2.1 to 3.0.2.

There has been some sort of rebranding, from the changelog:
> Renamed the application from EmulationStation Desktop Edition to ES-DE

Hence the new name of the binary, etc. Not sure how to handle this, should it be a new package? Should the folder be renamed to reflect the new name? Keep it as is? 😕

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
