### PR TITLE
nixos/systemd: Make kbrequest.target configurable

### DIFF
--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -279,7 +279,7 @@ in rec {
         # Stupid misc. symlinks.
         ln -s ${cfg.defaultUnit} $out/default.target
         ln -s ${cfg.ctrlAltDelUnit} $out/ctrl-alt-del.target
-        ln -s rescue.target $out/kbrequest.target
+        ln -s ${cfg.kbrequestUnit} $out/kbrequest.target
 
         mkdir -p $out/getty.target.wants/
         ln -s ../autovt@tty1.service $out/getty.target.wants/

--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -279,7 +279,9 @@ in rec {
         # Stupid misc. symlinks.
         ln -s ${cfg.defaultUnit} $out/default.target
         ln -s ${cfg.ctrlAltDelUnit} $out/ctrl-alt-del.target
-        ln -s ${cfg.kbrequestUnit} $out/kbrequest.target
+        ${optionalString (cfg.kbrequestUnit != null) ''
+          ln -s ${cfg.kbrequestUnit} $out/kbrequest.target
+        ''}
 
         mkdir -p $out/getty.target.wants/
         ln -s ../autovt@tty1.service $out/getty.target.wants/

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -293,6 +293,14 @@ in
       '';
     };
 
+    systemd.kbrequestUnit = mkOption {
+      type = types.str;
+      example = "rescue.target";
+      description = ''
+        Target that should be started when Alt+ArrowUp is pressed on the console.
+      '';
+    };
+
     globalEnvironment = mkOption {
       type = with types; attrsOf (nullOr (oneOf [ str path package ]));
       default = {};

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -293,11 +293,13 @@ in
       '';
     };
 
-    systemd.kbrequestUnit = mkOption {
-      type = types.str;
+    kbrequestUnit = mkOption {
+      default = "rescue.target";
+      type = types.nullOr types.str;
       example = "rescue.target";
       description = ''
-        Target that should be started when Alt+ArrowUp is pressed on the console.
+        Target that should be started when Alt+ArrowUp is pressed on the console;
+        see {manpage}`systemd.special(7)`.
       '';
     };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Successor to #181783.

Adds an option for kbrequest.target rather than hard-coding a symlink to rescue.target, and changes the old default from `rescue.target` to not creating a symlink at all (if null is set).

Rationale: https://github.com/systemd/systemd/issues/6451

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
