### PR TITLE
python311Packages.uproot: 5.3.1 -> 5.3.2

### DIFF
--- a/pkgs/development/python-modules/uproot/default.nix
+++ b/pkgs/development/python-modules/uproot/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "uproot";
-  version = "5.3.1";
+  version = "5.3.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     owner = "scikit-hep";
     repo = "uproot5";
     rev = "refs/tags/v${version}";
-    hash = "sha256-cZVdsemaA3ni6xFfrkyLJA+12B7vyURj9OYVuOhqTXU=";
+    hash = "sha256-dq362pevqgLx5KwZ19zQ6aOn5NCyiqynPCF7YdI6tkw=";
   };
 
   nativeBuildInputs = [
@@ -59,13 +59,16 @@ buildPythonPackage rec {
 
   disabledTests = [
     # Tests that try to download files
+    "test_descend_into_path_classname_of"
     "test_fallback"
     "test_file"
     "test_fsspec_cache_http"
     "test_fsspec_cache_http_directory"
     "test_fsspec_chunks"
     "test_fsspec_globbing_http"
+    "test_fsspec_writing_http"
     "test_fsspec_writing_memory"
+    "test_fsspec_writing_ssh"
     "test_http"
     "test_http_fallback"
     "test_http_multipart"
@@ -74,9 +77,11 @@ buildPythonPackage rec {
     "test_http_size_port"
     "test_issue_1054_filename_colons"
     "test_no_multipart"
-    "test_open_fsspec_http"
     "test_open_fsspec_github"
+    "test_open_fsspec_http"
+    "test_open_fsspec_ss"
     "test_pickle_roundtrip_http"
+    "test_split_ranges_if_large_file_in_http"
     # Cyclic dependency with dask-awkward
     "test_decompression_executor_for_dask"
   ];


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/scikit-hep/uproot5/releases/tag/v5.3.2

cc @veprbl 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
