### PR TITLE
python3Packages.examples: init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/examples/default.nix
+++ b/pkgs/development/python-modules/examples/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  pytestCheckHook,
+}:
+buildPythonPackage {
+  pname = "examples";
+  version = "0-unstable-2021-05-26";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "timothycrosley";
+    repo = "examples";
+    # no commits for 3 years and I don't know what revision
+    # uses version on PyPI so I am packaging last commit
+    rev = "2667ad2793c008d4f4c1c62851c99bf7d0d36290";
+    hash = "sha256-4u5SiM9QOMLYFG6thX5bu6Hw2n0MFUvJlkaiUw/CyA4=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  patches = [
+    ./update-poetry.patch
+  ];
+
+  meta = {
+    homepage = "https://github.com/timothycrosley/examples";
+    description = "Tests and Documentation Done by Example";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ perchun ];
+  };
+}

--- a/pkgs/development/python-modules/examples/update-poetry.patch
+++ b/pkgs/development/python-modules/examples/update-poetry.patch
@@ -1,0 +1,24 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 3f162ee..00d5d1f 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -8,7 +8,7 @@ readme = "README.md"
+ 
+ [tool.poetry.dependencies]
+ python = "^3.6"
+-pydantic = ">=0.32.2<2.0.0"
++pydantic = ">=0.32.2,<2.0.0"
+ 
+ [tool.poetry.dev-dependencies]
+ vulture = "^1.0"
+@@ -34,8 +34,8 @@ name = "material"
+ palette = {primary = "orange", accent = "blue"}
+ 
+ [build-system]
+-requires = ["poetry>=0.12"]
+-build-backend = "poetry.masonry.api"
++requires = ["poetry-core>=1.2.0"]
++build-backend = "poetry.core.masonry.api"
+ 
+ [tool.black]
+ line-length = 100

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4204,6 +4204,8 @@ self: super: with self; {
     python3Packages = self;
   });
 
+  examples = callPackage ../development/python-modules/examples { };
+
   exdown = callPackage ../development/python-modules/exdown { };
 
   exceptiongroup = callPackage ../development/python-modules/exceptiongroup { };


### PR DESCRIPTION
## Description of changes

https://github.com/timothycrosley/examples/

~~This is a required dependency for [cruft](https://pypi.org/project/cruft/)'s tests, which I want to package for Nix.~~ Turns out it is not required, but this package still might be useful for someone.

Related: #299346.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
    - Builds on Python 3.10, 3.11, 3.12
    - Fails on Python 3.9, because of `ipython-8.22.2 not supported for interpreter python3.9` (dependency line: examples -> pydantic -> python-dotenv -> ipython; python-dotenv supports IPython runtime (AFAIU), and it is not an optional feature)
    - Fails on Python 3.13 because of `numpy-1.26.4 not supported for interpreter python3.13` (dependency line: examples -> pydantic -> python-dotenv -> ipython -> stack-data -> executing -> rich -> markdown-it-py -> pytest-regressions -> matplotlib)
    - BTW, `examples` uses pydantic only to verify function signature; extremely absurd dependency chain to be honest.
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
