### PR TITLE
reshape: fix compilation on Darwin

### DIFF
--- a/pkgs/development/tools/reshape/default.nix
+++ b/pkgs/development/tools/reshape/default.nix
@@ -1,8 +1,10 @@
 { lib
 , rustPlatform
 , fetchCrate
+, darwin
 , postgresqlTestHook
 , postgresql
+, stdenv
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -15,6 +17,9 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoHash = "sha256-VTJ3FNhVLgxo/VVBhk1yF9UUktLXcbrEkYwoyoWFhXA=";
+
+  buildInputs =
+    lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.SystemConfiguration ];
 
   nativeCheckInputs = [
     postgresqlTestHook


### PR DESCRIPTION
## Description of changes

Fixes ld being unable to link reshape on Darwin

<details>
<summary>the error</summary>
<pre>
   Compiling reshape v0.7.0 (/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz)
error: linking with `/nix/store/24ljvc5iwbs01svv9s8zvfcl5qs876kp-clang-wrapper-16.0.6/bin/cc` failed: exit status: 1
  |
  = note: env -u IPHONEOS_DEPLOYMENT_TARGET -u TVOS_DEPLOYMENT_TARGET LC_ALL="C" PATH="/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/bin:/nix/store/f3376cqfq2pdc4jbphq6gg44ispbmj01-cargo-1.76.0/bin:/nix/store/nrhcd8vhl7wbigmk4zd2gdb8p64jhpc2-cargo-auditable-0.6.2/bin:/nix/store/wfjvmmz1xpynvldk3w1rqq0rs6iqdcb1-auditable-cargo-1.76.0/bin:/nix/store/f3376cqfq2pdc4jbphq6gg44ispbmj01-cargo-1.76.0/bin:/nix/store/7zzn279z3j7a0k1w0lkx4mjwvlq6r180-rustc-wrapper-1.76.0/bin:/nix/store/wwrr3lii4bq1jq7f0m1fqzmhqan54nv9-postgresql-15.6/bin:/nix/store/24ljvc5iwbs01svv9s8zvfcl5qs876kp-clang-wrapper-16.0.6/bin:/nix/store/7pjm6a27mp71q9sm0gbip3ij0h5kh099-clang-16.0.6/bin:/nix/store/7cifxhcdg7a6f0sj6fw68d97mqa6bkbb-coreutils-9.4/bin:/nix/store/3j0f71qijrdylpqndvx5d15rj38famjd-cctools-binutils-darwin-wrapper-16.0.6-973.0.1/bin:/nix/store/5rwj9a10f01jhfb8hbzizzhnmr55976p-cctools-binutils-darwin-16.0.6-973.0.1/bin:/nix/store/7cifxhcdg7a6f0sj6fw68d97mqa6bkbb-coreutils-9.4/bin:/nix/store/mxvqp1mpk5a7n4k25pn000lribabn92k-findutils-4.9.0/bin:/nix/store/575sjnqgcparl0i5jp1h5glghg6c9wnw-diffutils-3.10/bin:/nix/store/051x0h9iyrbqibxn8nm2p88yasx8gz3b-gnused-4.9/bin:/nix/store/i93m7189qp888xfhcibfb7qs1ak184p6-gnugrep-3.11/bin:/nix/store/i4idzdx3w7cng03h362byhvsjcv6rnqm-gawk-5.2.2/bin:/nix/store/dzdai6qhgni7x5pzhf0dw05l79jaqlxj-gnutar-1.35/bin:/nix/store/vzxgdh6r14h41n86nscgagwmri8n0zb2-gzip-1.13/bin:/nix/store/31myqd4x8mp2gpjgf81g8h4k033rgww8-bzip2-1.0.8-bin/bin:/nix/store/d9wnf8z9xpl90kghagl5jh3lncqc893q-gnumake-4.4.1/bin:/nix/store/bsa1v1mr7c42a0yd90ncnchcs18ylm4b-bash-5.2p26/bin:/nix/store/9lrgbyjppdicfshvw6361aw2q61p5wzb-patch-2.7.6/bin:/nix/store/im2m6bwm98nr7qgpf7a1hfh655i8vgn2-xz-5.6.1-bin/bin:/nix/store/iam0z9had9ram6gv1xgyv9d936jpdb5n-file-5.45/bin" VSLANG="1033" ZERO_AR_DATE="1" "/nix/store/24ljvc5iwbs01svv9s8zvfcl5qs876kp-clang-wrapper-16.0.6/bin/cc" "-arch" "arm64" "/private/tmp/nix-build-reshape-0.7.0.drv-0/rustcDTQONN/symbols.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.00.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.01.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.02.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.03.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.04.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.05.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.06.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.07.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.08.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.09.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.10.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.11.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.12.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.13.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.14.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.15.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.54khaiv1jamcrdok.rcgu.o" "-L" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps" "-L" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/release/deps" "-L" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtoml-c7d3b8bd70ec60cb.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/liblexical_sort-6ee59074d24df59e.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libany_ascii-95a63b5d47eea6df.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libdotenv-cc000c6cdb0476ff.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libreshape-9cb4e652e0e15443.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtypetag-8a709f82ccaedc18.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/liberased_serde-9688d42719fe2f04.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libinventory-f227977eed18a43d.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libversion-598e4f8561a7a5e8.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libpostgres-b821e140b9e9961a.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtokio_postgres-51e8177eda5ece6e.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libphf-9350bc68bc0c0253.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libphf_shared-acb965e0b1c8d172.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libsiphasher-498d180b4a2994c6.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libwhoami-12098cebf13a9118.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libpercent_encoding-08fd2d46e267932e.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/liblog-3d7eb5e391fae20f.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtokio_util-79fc571b048b5474.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtracing-97ec7d086027b030.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtracing_core-a84474dfa794a665.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libparking_lot-f2104a777a542d12.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libparking_lot_core-4572ec80678f438f.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libsmallvec-8fb9a2803252896f.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/liblock_api-af81cb0be8418ce6.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libscopeguard-a20de17d2a3d6c0e.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libfutures_channel-ac6237bfee495e74.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtokio-ef7b57395aed4ea1.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libsocket2-dfe0649674a29bac.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libmio-5899a5917dd6c496.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libpostgres_types-36149103fdd1ba8f.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libserde_json-99dd61e9b02341fc.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libryu-606e771f3486a689.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libitoa-3067975dd823b25c.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libserde-38f7981614457943.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libpostgres_protocol-6b4014ac51e9486d.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libstringprep-02f440266cedacee.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libunicode_normalization-fba9cd51ee0cc24b.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtinyvec-33fdc46360ac3e3e.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtinyvec_macros-6cbdcbcbd1c3d32d.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libunicode_bidi-e36e4a3ba8afde91.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libfinl_unicode-da925ad9a4d9a15e.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libmemchr-4fa0103e314ce995.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libsha2-d1302b23146cff51.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/librand-872096564d2168a4.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/librand_chacha-3210351bbd0693a2.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libppv_lite86-23f3491591096967.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/librand_core-bdffc19aa393f64b.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libgetrandom-a14ec1ab94d1e00b.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libhmac-6d2dd5cc43d80f80.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libbase64-57c71f8fd5bf7f4e.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libmd5-da2b9cf1343da89f.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libcfg_if-960fb055dda3c736.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libdigest-622ab198d156a552.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libsubtle-3c167b5de01033c1.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libblock_buffer-50c7475f66a0901f.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libcrypto_common-26925ee55f0a98fa.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libgeneric_array-ab39c529a6ba438a.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtypenum-2f9a0baf10bf1ada.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libfutures_util-1e926732d92c7fdd.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libslab-4d59c7a1cd9c9c39.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libpin_project_lite-65dbbac739b77c89.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libfutures_sink-f43bdbf036974bee.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libfutures_task-4d51abdaf106b7ba.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libpin_utils-768e7edf4dce7c2b.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libfutures_core-02f22d69fdb9360d.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libbytes-867489ebed426141.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libbyteorder-c063cc21499b10c4.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libfallible_iterator-fa80353eb64f5799.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libcolored-3e8d3ff92c9eb40c.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/liblazy_static-154efcf205244c5e.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libclap-2236c443c53b98cb.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libatty-d73d1eac97edc7a5.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/liblibc-df3a89c0efaef4e9.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libstrsim-f5ccfd6c9908fd45.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtermcolor-aa7c362af56829f4.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtextwrap-73bd00efef0ff43a.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libclap_lex-d4f0f2e6225eec7c.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libos_str_bytes-2bb60cfe4259db88.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libindexmap-244d376049411635.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libhashbrown-4fce0ff4d2903608.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libbitflags-b20fe9e0f0bcab99.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libonce_cell-8fc1bdf1b7915e2b.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libanyhow-7d2934eade50ea0a.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libstd-6028e45e9a024429.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libpanic_unwind-71a7061a148dac09.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libobject-f8df57dadcce1af2.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libmemchr-e6d1ce0e530e78dd.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libaddr2line-d3801ae106a39452.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libgimli-e995dccbe46e4fc4.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/librustc_demangle-6207df48edf2fcb0.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libstd_detect-a4856153b2f20324.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libhashbrown-0fd4f766b1c38ff2.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/librustc_std_workspace_alloc-a6eb3291996ea2f5.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libminiz_oxide-b0f2c598fdae5ecd.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libadler-72fba4ae63735ea8.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libunwind-6bc43616d5144f3a.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libcfg_if-9d383a1b9a6f4df0.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/liblibc-364a2950fc5ceedd.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/liballoc-e1691210a145868b.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/librustc_std_workspace_core-320279287cfd687e.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libcore-5a5ae12102ad5fd1.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libcompiler_builtins-d475131a524ae651.rlib" "-framework" "CoreFoundation" "-framework" "SystemConfiguration" "-liconv" "-lSystem" "-lc" "-lm" "-L" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib" "-o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53" "-Wl,-dead_strip" "-nodefaultlibs" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape_audit_data.o" "-Wl,-u,_AUDITABLE_VERSION_INFO"
  = note: ld: framework not found SystemConfiguration
          clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
          

error: could not compile `reshape` (bin "reshape") due to 1 previous error
error: builder for '/nix/store/9rgh2marqh9pl9qsqnnig3899w7v6lvb-reshape-0.7.0.drv' failed with exit code 101;
       last 10 log lines:
       >    Compiling postgres v0.19.7
       >    Compiling reshape v0.7.0 (/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz)
       > error: linking with `/nix/store/24ljvc5iwbs01svv9s8zvfcl5qs876kp-clang-wrapper-16.0.6/bin/cc` failed: exit status: 1
       >   |
       >   = note: env -u IPHONEOS_DEPLOYMENT_TARGET -u TVOS_DEPLOYMENT_TARGET LC_ALL="C" PATH="/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/bin:/nix/store/f3376cqfq2pdc4jbphq6gg44ispbmj01-cargo-1.76.0/bin:/nix/store/nrhcd8vhl7wbigmk4zd2gdb8p64jhpc2-cargo-auditable-0.6.2/bin:/nix/store/wfjvmmz1xpynvldk3w1rqq0rs6iqdcb1-auditable-cargo-1.76.0/bin:/nix/store/f3376cqfq2pdc4jbphq6gg44ispbmj01-cargo-1.76.0/bin:/nix/store/7zzn279z3j7a0k1w0lkx4mjwvlq6r180-rustc-wrapper-1.76.0/bin:/nix/store/wwrr3lii4bq1jq7f0m1fqzmhqan54nv9-postgresql-15.6/bin:/nix/store/24ljvc5iwbs01svv9s8zvfcl5qs876kp-clang-wrapper-16.0.6/bin:/nix/store/7pjm6a27mp71q9sm0gbip3ij0h5kh099-clang-16.0.6/bin:/nix/store/7cifxhcdg7a6f0sj6fw68d97mqa6bkbb-coreutils-9.4/bin:/nix/store/3j0f71qijrdylpqndvx5d15rj38famjd-cctools-binutils-darwin-wrapper-16.0.6-973.0.1/bin:/nix/store/5rwj9a10f01jhfb8hbzizzhnmr55976p-cctools-binutils-darwin-16.0.6-973.0.1/bin:/nix/store/7cifxhcdg7a6f0sj6fw68d97mqa6bkbb-coreutils-9.4/bin:/nix/store/mxvqp1mpk5a7n4k25pn000lribabn92k-findutils-4.9.0/bin:/nix/store/575sjnqgcparl0i5jp1h5glghg6c9wnw-diffutils-3.10/bin:/nix/store/051x0h9iyrbqibxn8nm2p88yasx8gz3b-gnused-4.9/bin:/nix/store/i93m7189qp888xfhcibfb7qs1ak184p6-gnugrep-3.11/bin:/nix/store/i4idzdx3w7cng03h362byhvsjcv6rnqm-gawk-5.2.2/bin:/nix/store/dzdai6qhgni7x5pzhf0dw05l79jaqlxj-gnutar-1.35/bin:/nix/store/vzxgdh6r14h41n86nscgagwmri8n0zb2-gzip-1.13/bin:/nix/store/31myqd4x8mp2gpjgf81g8h4k033rgww8-bzip2-1.0.8-bin/bin:/nix/store/d9wnf8z9xpl90kghagl5jh3lncqc893q-gnumake-4.4.1/bin:/nix/store/bsa1v1mr7c42a0yd90ncnchcs18ylm4b-bash-5.2p26/bin:/nix/store/9lrgbyjppdicfshvw6361aw2q61p5wzb-patch-2.7.6/bin:/nix/store/im2m6bwm98nr7qgpf7a1hfh655i8vgn2-xz-5.6.1-bin/bin:/nix/store/iam0z9had9ram6gv1xgyv9d936jpdb5n-file-5.45/bin" VSLANG="1033" ZERO_AR_DATE="1" "/nix/store/24ljvc5iwbs01svv9s8zvfcl5qs876kp-clang-wrapper-16.0.6/bin/cc" "-arch" "arm64" "/private/tmp/nix-build-reshape-0.7.0.drv-0/rustcDTQONN/symbols.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.00.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.01.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.02.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.03.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.04.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.05.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.06.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.07.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.08.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.09.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.10.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.11.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.12.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.13.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.14.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.reshape.17f19f348d6994fb-cgu.15.rcgu.o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53.54khaiv1jamcrdok.rcgu.o" "-L" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps" "-L" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/release/deps" "-L" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtoml-c7d3b8bd70ec60cb.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/liblexical_sort-6ee59074d24df59e.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libany_ascii-95a63b5d47eea6df.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libdotenv-cc000c6cdb0476ff.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libreshape-9cb4e652e0e15443.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtypetag-8a709f82ccaedc18.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/liberased_serde-9688d42719fe2f04.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libinventory-f227977eed18a43d.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libversion-598e4f8561a7a5e8.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libpostgres-b821e140b9e9961a.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtokio_postgres-51e8177eda5ece6e.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libphf-9350bc68bc0c0253.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libphf_shared-acb965e0b1c8d172.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libsiphasher-498d180b4a2994c6.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libwhoami-12098cebf13a9118.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libpercent_encoding-08fd2d46e267932e.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/liblog-3d7eb5e391fae20f.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtokio_util-79fc571b048b5474.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtracing-97ec7d086027b030.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtracing_core-a84474dfa794a665.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libparking_lot-f2104a777a542d12.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libparking_lot_core-4572ec80678f438f.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libsmallvec-8fb9a2803252896f.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/liblock_api-af81cb0be8418ce6.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libscopeguard-a20de17d2a3d6c0e.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libfutures_channel-ac6237bfee495e74.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtokio-ef7b57395aed4ea1.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libsocket2-dfe0649674a29bac.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libmio-5899a5917dd6c496.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libpostgres_types-36149103fdd1ba8f.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libserde_json-99dd61e9b02341fc.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libryu-606e771f3486a689.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libitoa-3067975dd823b25c.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libserde-38f7981614457943.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libpostgres_protocol-6b4014ac51e9486d.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libstringprep-02f440266cedacee.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libunicode_normalization-fba9cd51ee0cc24b.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtinyvec-33fdc46360ac3e3e.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtinyvec_macros-6cbdcbcbd1c3d32d.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libunicode_bidi-e36e4a3ba8afde91.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libfinl_unicode-da925ad9a4d9a15e.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libmemchr-4fa0103e314ce995.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libsha2-d1302b23146cff51.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/librand-872096564d2168a4.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/librand_chacha-3210351bbd0693a2.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libppv_lite86-23f3491591096967.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/librand_core-bdffc19aa393f64b.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libgetrandom-a14ec1ab94d1e00b.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libhmac-6d2dd5cc43d80f80.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libbase64-57c71f8fd5bf7f4e.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libmd5-da2b9cf1343da89f.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libcfg_if-960fb055dda3c736.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libdigest-622ab198d156a552.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libsubtle-3c167b5de01033c1.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libblock_buffer-50c7475f66a0901f.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libcrypto_common-26925ee55f0a98fa.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libgeneric_array-ab39c529a6ba438a.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtypenum-2f9a0baf10bf1ada.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libfutures_util-1e926732d92c7fdd.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libslab-4d59c7a1cd9c9c39.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libpin_project_lite-65dbbac739b77c89.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libfutures_sink-f43bdbf036974bee.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libfutures_task-4d51abdaf106b7ba.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libpin_utils-768e7edf4dce7c2b.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libfutures_core-02f22d69fdb9360d.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libbytes-867489ebed426141.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libbyteorder-c063cc21499b10c4.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libfallible_iterator-fa80353eb64f5799.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libcolored-3e8d3ff92c9eb40c.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/liblazy_static-154efcf205244c5e.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libclap-2236c443c53b98cb.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libatty-d73d1eac97edc7a5.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/liblibc-df3a89c0efaef4e9.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libstrsim-f5ccfd6c9908fd45.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtermcolor-aa7c362af56829f4.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libtextwrap-73bd00efef0ff43a.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libclap_lex-d4f0f2e6225eec7c.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libos_str_bytes-2bb60cfe4259db88.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libindexmap-244d376049411635.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libhashbrown-4fce0ff4d2903608.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libbitflags-b20fe9e0f0bcab99.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libonce_cell-8fc1bdf1b7915e2b.rlib" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/libanyhow-7d2934eade50ea0a.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libstd-6028e45e9a024429.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libpanic_unwind-71a7061a148dac09.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libobject-f8df57dadcce1af2.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libmemchr-e6d1ce0e530e78dd.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libaddr2line-d3801ae106a39452.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libgimli-e995dccbe46e4fc4.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/librustc_demangle-6207df48edf2fcb0.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libstd_detect-a4856153b2f20324.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libhashbrown-0fd4f766b1c38ff2.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/librustc_std_workspace_alloc-a6eb3291996ea2f5.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libminiz_oxide-b0f2c598fdae5ecd.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libadler-72fba4ae63735ea8.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libunwind-6bc43616d5144f3a.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libcfg_if-9d383a1b9a6f4df0.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/liblibc-364a2950fc5ceedd.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/liballoc-e1691210a145868b.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/librustc_std_workspace_core-320279287cfd687e.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libcore-5a5ae12102ad5fd1.rlib" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib/libcompiler_builtins-d475131a524ae651.rlib" "-framework" "CoreFoundation" "-framework" "SystemConfiguration" "-liconv" "-lSystem" "-lc" "-lm" "-L" "/nix/store/hd7b0c67zpzmglmax0k01an0ndibrf28-rustc-1.76.0/lib/rustlib/aarch64-apple-darwin/lib" "-o" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape-349169a24a136e53" "-Wl,-dead_strip" "-nodefaultlibs" "/private/tmp/nix-build-reshape-0.7.0.drv-0/reshape-0.7.0.tar.gz/target/aarch64-apple-darwin/release/deps/reshape_audit_data.o" "-Wl,-u,_AUDITABLE_VERSION_INFO"
       >   = note: ld: framework not found SystemConfiguration
       >           clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
       >           
       >
       > error: could not compile `reshape` (bin "reshape") due to 1 previous error
       For full logs, run 'nix-store -l /nix/store/9rgh2marqh9pl9qsqnnig3899w7v6lvb-reshape-0.7.0.drv'.
</pre>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
