### PR TITLE
kile: 2.9.93 -> 2.9.94

### DIFF
--- a/pkgs/applications/editors/kile/default.nix
+++ b/pkgs/applications/editors/kile/default.nix
@@ -1,63 +1,43 @@
-{ mkDerivation
-, lib
+{ lib
+, stdenv
 , fetchurl
-, extra-cmake-modules
-, kdoctools
-, wrapGAppsHook
-, qtscript
-, kconfig
-, kcrash
-, kdbusaddons
-, kdelibs4support
-, kguiaddons
-, kiconthemes
-, kinit
-, khtml
-, konsole
-, kparts
-, ktexteditor
-, kwindowsystem
-, okular
-, poppler
+, cmake
+, kdePackages
+, qt6
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "kile";
-  version = "2.9.93";
+  version = "2.9.94";
 
   src = fetchurl {
     url = "mirror://sourceforge/kile/kile-${version}.tar.bz2";
-    sha256 = "BEmSEv/LJPs6aCkUmnyuTGrV15WYXwgIANbfcviMXfA=";
+    sha256 = "U8Z0K9g/sJXL3ImLA/344Vq2gKgWk8yvnFB2uTrRo8o=";
   };
 
   nativeBuildInputs = [
-    extra-cmake-modules
-    wrapGAppsHook
-    kdoctools
+    cmake
+    kdePackages.extra-cmake-modules
+    qt6.wrapQtAppsHook
+    kdePackages.kdoctools
   ];
 
   buildInputs = [
-    kconfig
-    kcrash
-    kdbusaddons
-    kdelibs4support
-    kguiaddons
-    kiconthemes
-    kinit
-    khtml
-    kparts
-    ktexteditor
-    kwindowsystem
-    okular
-    poppler
-    qtscript
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qt5compat
+    kdePackages.kconfig
+    kdePackages.kcrash
+    kdePackages.kdbusaddons
+    kdePackages.kguiaddons
+    kdePackages.kiconthemes
+    kdePackages.konsole
+    kdePackages.kparts
+    kdePackages.ktexteditor
+    kdePackages.kwindowsystem
+    kdePackages.okular
+    kdePackages.poppler
   ];
-  dontWrapGApps = true;
-  preFixup = ''
-    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
-  '';
-
-  propagatedUserEnvPkgs = [ konsole ];
 
   meta = {
     description = "User-friendly TeX/LaTeX authoring tool for the KDE desktop environment";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32387,7 +32387,7 @@ with pkgs;
   kid3-qt = qt6Packages.callPackage ../applications/audio/kid3 { withCLI = true; withKDE = false; withQt = true; };
   kid3 = kid3-kde;
 
-  kile = libsForQt5.callPackage ../applications/editors/kile { };
+  kile = callPackage ../applications/editors/kile { };
 
   kitsas = libsForQt5.callPackage ../applications/office/kitsas { };
 


### PR DESCRIPTION
## Description of changes

Update to Kile 2.9.94 (= 3.0b4), which switches to Qt6/KF6.

More information in https://planet.kde.org/gruenich-2024-03-17-kile-2-9-95-3-0-beta-4-released/. The version 3.0b4 actually equals to 2.9.94. 2.9.95 is an error in the blog post (see https://kile.sourceforge.io/download.php).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
