### PR TITLE
cruft: init at 2.15.0

### DIFF
--- a/pkgs/by-name/cr/cruft/package.nix
+++ b/pkgs/by-name/cr/cruft/package.nix
@@ -1,0 +1,62 @@
+{
+  python3Packages,
+  fetchFromGitHub,
+  lib,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "cruft";
+  version = "2.15.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cruft";
+    repo = "cruft";
+    rev = version;
+    hash = "sha256-qIVyNMoI3LsoOV/6XPa60Y1vTRvkezesF7wF9WVSLGk=";
+  };
+
+  build-system = with python3Packages; [
+    poetry-core
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytest7CheckHook
+  ];
+
+  dependencies = with python3Packages; [
+    click
+    cookiecutter
+    gitpython
+    typer
+  ];
+
+  pythonImportsCheck = "cruft";
+
+  # Unfortunately, some tests require internet access to fully clone
+  # https://github.com/cruft/cookiecutter-test (including all branches)
+  # which is possible to package, but is annoying and may be not always pure
+  #
+  # See https://discourse.nixos.org/t/keep-git-folder-in-when-fetching-a-git-repo/8590/6
+  #
+  # There are only 13 tests which do not require internet access on moment of the writing.
+  # But some tests are better than none, right?
+  disabledTests = [
+    "test_get_diff_with_add"
+    "test_get_diff_with_delete"
+    "test_get_diff_with_unicode"
+  ];
+
+  disabledTestPaths = [
+    "tests/test_api.py" # only 2 tests pass, and 24 fail. I am going to ignore entire file
+    "tests/test_cli.py"
+  ];
+
+  meta = {
+    changelog = "https://github.com/cruft/cruft/blob/${version}/CHANGELOG.md";
+    description = "Allows you to maintain all the necessary boilerplate for building projects";
+    homepage = "https://github.com/cruft/cruft";
+    license = lib.licenses.mit;
+    mainProgram = "cruft";
+    maintainers = with lib.maintainers; [ perchun ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/cruft/cruft

Supersedes https://github.com/NixOS/nixpkgs/pull/259529 and https://github.com/NixOS/nixpkgs/pull/275243.

Also, turns out that library [`examples`](https://github.com/NixOS/nixpkgs/pull/299322) is only needed in `tests/test_api.py` which is disabled (see comment on line 37), so `cruft` is not dependent on `examples`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (`python3Packages.cruft`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
