### PR TITLE
qt6: fix broken debug mode and dependency build type overriding

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -17,7 +17,6 @@
 , config
 
   # options
-, developerBuild ? false
 , debug ? false
 }:
 
@@ -29,25 +28,25 @@ let
 
   addPackages = self:
     let
-      callPackage = self.newScope ({
+      callPackage = self.newScope {
         inherit (self) qtModule;
-        inherit srcs python3;
+        inherit srcs python3 debug;
         stdenv =
           if stdenv.isDarwin
           then overrideSDK stdenv { darwinMinVersion = "11.0"; darwinSdkVersion = "11.0"; }
           else stdenv;
-      });
+      };
     in
     {
 
       inherit callPackage srcs;
 
-      qtModule = callPackage ./qtModule.nix { };
+      qtModule = callPackage ./qtModule.nix {};
 
       qtbase = callPackage ./modules/qtbase.nix {
         withGtk3 = !stdenv.hostPlatform.isMinGW;
         inherit (srcs.qtbase) src version;
-        inherit developerBuild;
+        inherit debug;
         inherit (darwin.apple_sdk_11_0.frameworks)
           AGL AVFoundation AppKit Contacts CoreBluetooth EventKit GSS MetalKit;
         patches = [

--- a/pkgs/development/libraries/qt-6/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qmake-hook.sh
@@ -18,12 +18,6 @@ qmakePrePhase() {
         "NIX_OUTPUT_PLUGIN=${!outputBin}/${qtPluginPrefix:?}"
     )
 
-    if [ -n "@debug@" ]; then
-        qmakeFlags+=("CONFIG+=debug")
-    else
-        qmakeFlags+=("CONFIG+=release")
-    fi
-
     qmakeFlags+=("${qmakeFlags_orig[@]}")
 }
 prePhases+=" qmakePrePhase"

--- a/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
@@ -15,20 +15,6 @@ else # Only set up Qt once.
     . @fix_qt_builtin_paths@
     . @fix_qt_module_paths@
 
-    # Disable debug symbols if qtbase was built without debugging.
-    # This stops -dev paths from leaking into other outputs.
-    if [ -z "@debug@" ]; then
-        NIX_CFLAGS_COMPILE="${NIX_CFLAGS_COMPILE-}${NIX_CFLAGS_COMPILE:+ }-DQT_NO_DEBUG"
-    fi
-
-    # Integration with CMake:
-    # Set the CMake build type corresponding to how qtbase was built.
-    if [ -n "@debug@" ]; then
-        cmakeBuildType="Debug"
-    else
-        cmakeBuildType="Release"
-    fi
-
     # Build tools are often confused if QMAKE is unset.
     export QMAKE=@out@/bin/qmake
 

--- a/pkgs/development/libraries/qt-6/qtModule.nix
+++ b/pkgs/development/libraries/qt-6/qtModule.nix
@@ -6,6 +6,7 @@
 , moveBuildTree
 , srcs
 , patches ? [ ]
+, debug ? false
 }:
 
 args:
@@ -26,9 +27,16 @@ stdenv.mkDerivation (args // {
     (lib.warnIf (args ? qtInputs) "qt6.qtModule's qtInputs argument is deprecated" args.qtInputs or []) ++
     (args.propagatedBuildInputs or []);
 
+  env.NIX_CFLAGS_COMPILE = let
+    prev = if args ? env && args.env ? NIX_CFLAGS_COMPILE then "${args.env.NIX_CFLAGS_COMPILE} " else "";
+  in "${prev}${if debug then "" else "-DQT_NO_DEBUG"}";
+
   moveToDev = false;
 
   outputs = args.outputs or [ "out" "dev" ];
+
+  cmakeBuildType = if debug then "Debug" else "Release";
+  dontStrip = debug;
 
   dontWrapQtApps = args.dontWrapQtApps or true;
 }) // {


### PR DESCRIPTION
## Description of changes

This fixes two major issues with qt6's packaging. They're fairly linked together so this is done as a single PR.

### First issue:
Previously the qt setup hook would force qtbase's cmake and qmake build types on dependent packages, usually causing them to build in Release mode.This is especially bad in development environments but still bad for distribution if you want RelWithDebInfo.

Now the build type can be set on a per package basis, and does not affect dependent packages.

### Second issue:
Previously the debug and developerBuild argument caused *qtbase* to build in `Release` mode without stripping symbols and all modules to build in `Debug` mode, but stripped them, rendering both entirely useless for debugging. Now the debug works at a per-module level and for the whole qt6 set.

In other words `(pkgs.qt6.override { debug = true; }).module` and `pkgs.qt6.module.override { debug = true; }` now work correctly.

It also removes `developerBuild` entirely, as the only difference was adding GDB to path.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable: (there are no tests I could find for qt)
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I've tested this fully on a local project using qtbase qtdeclarative and qtwayland, and run a full build of qt6.full.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
