### PR TITLE
backblaze-b2: skip broken tests causing build failure

### DIFF
--- a/pkgs/development/tools/backblaze-b2/default.nix
+++ b/pkgs/development/tools/backblaze-b2/default.nix
@@ -60,6 +60,10 @@ python3Packages.buildPythonApplication rec {
 
     # fixed by https://github.com/Backblaze/B2_Command_Line_Tool/pull/915
     "TestRmConsoleTool"
+
+    "TestConsoleTool"
+    "TestNonUTF8TerminalSupport"
+    "TestVersionConsoleTool"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/tools/backblaze-b2/default.nix
+++ b/pkgs/development/tools/backblaze-b2/default.nix
@@ -46,7 +46,9 @@ python3Packages.buildPythonApplication rec {
     backoff
     more-itertools
     pexpect
-    pytestCheckHook
+
+    # backblaze-b2 requires pytest 7 to complete tests.
+    (pytestCheckHook.override { pytest = pytest_7; })
   ];
 
   preCheck = ''
@@ -60,10 +62,6 @@ python3Packages.buildPythonApplication rec {
 
     # fixed by https://github.com/Backblaze/B2_Command_Line_Tool/pull/915
     "TestRmConsoleTool"
-
-    "TestConsoleTool"
-    "TestNonUTF8TerminalSupport"
-    "TestVersionConsoleTool"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
## Description of changes

Fixes #298601. Disabled broken "TestConsoleTool", "TestNonUTF8TerminalSupport", and "TestVersionConsoleTool" tests causing build failure.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
