### PR TITLE
stdenv: Add stdenv-wide override of all derivations

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -53,6 +53,14 @@ argsStdenv@{ name ? "stdenv", preHook ? "", initialPath
 , # The implementation of `mkDerivation`, parameterized with the final stdenv so we can tie the knot.
   # This is convient to have as a parameter so the stdenv "adapters" work better
   mkDerivationFromStdenv ? stdenv: (import ./make-derivation.nix { inherit lib config; } stdenv).mkDerivation
+
+, # Function that intercepts and processes the argument attrsets of
+  # ALL `builtins.derivation`s before passing them to
+  # `builtins.derivation` itself. Use carefully to avoid creating
+  # infinite recursions. Since this is part of the bootstrap process
+  # of stdenv itself, it should contain no references to the current
+  # stdenv.
+  derivationArgTransform ? lib.id
 }:
 
 let
@@ -79,7 +87,7 @@ let
 
   # The stdenv that we are producing.
   in
-    derivation (
+    derivation (derivationArgTransform (
     lib.optionalAttrs (allowedRequisites != null) {
       allowedRequisites = allowedRequisites
         ++ defaultNativeBuildInputs ++ defaultBuildInputs;
@@ -129,7 +137,7 @@ let
     // lib.optionalAttrs buildPlatform.isDarwin {
       __sandboxProfile = stdenvSandboxProfile;
       __impureHostDeps = __stdenvImpureHostDeps;
-    })
+    }))
 
     // {
 
@@ -157,6 +165,9 @@ let
       inherit (hostPlatform) system;
 
       mkDerivation = mkDerivationFromStdenv stdenv;
+
+      # Propagate to succeeding stages, if any.
+      inherit derivationArgTransform;
 
       inherit fetchurlBoot;
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -584,7 +584,7 @@ extendDerivation
      # This allows easy building and distributing of all derivations
      # needed to enter a nix-shell with
      #   nix-build shell.nix -A inputDerivation
-     inputDerivation = derivation (derivationArg // {
+     inputDerivation = derivation (stdenv.derivationArgTransform (derivationArg // {
        # Add a name in case the original drv didn't have one
        name = derivationArg.name or "inputDerivation";
        # This always only has one output
@@ -616,7 +616,7 @@ extendDerivation
        allowedRequisites = null;
        disallowedReferences = [ ];
        disallowedRequisites = [ ];
-     });
+     }));
 
      inherit passthru overrideAttrs;
      inherit meta;
@@ -625,7 +625,7 @@ extendDerivation
    # should be made available to Nix expressions using the
    # derivation (e.g., in assertions).
    passthru)
-  (derivation (derivationArg // optionalAttrs envIsExportable checkedEnv));
+  (derivation (stdenv.derivationArgTransform (derivationArg // optionalAttrs envIsExportable checkedEnv)));
 
 in
 {

--- a/pkgs/stdenv/linux/bootstrap-tools-musl/default.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools-musl/default.nix
@@ -1,6 +1,7 @@
-{ system, bootstrapFiles, extraAttrs }:
+# no lib.id so we use (args: args) as a substitute
+{ system, bootstrapFiles, derivationArgTransform ? (args: args), extraAttrs }:
 
-derivation ({
+derivation (derivationArgTransform ({
   name = "bootstrap-tools";
 
   builder = bootstrapFiles.busybox;
@@ -16,4 +17,4 @@ derivation ({
   langCC = true;
   isGNU = true;
   hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" "trivialautovarinit" ];
-} // extraAttrs)
+} // extraAttrs))

--- a/pkgs/stdenv/linux/bootstrap-tools/default.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools/default.nix
@@ -1,6 +1,7 @@
-{ system, bootstrapFiles, extraAttrs }:
+# no lib.id so we use (args: args) as a substitute
+{ system, bootstrapFiles, derivationArgTransform ? (args: args), extraAttrs }:
 
-derivation ({
+derivation (derivationArgTransform ({
   name = "bootstrap-tools";
 
   builder = bootstrapFiles.busybox;
@@ -16,4 +17,4 @@ derivation ({
   langCC = true;
   isGNU = true;
   hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" "trivialautovarinit" ];
-} // extraAttrs)
+} // extraAttrs))

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -38,6 +38,8 @@ bootStages ++ [
 
       fetchurlBoot = prevStage.stdenv.fetchurlBoot;
 
+      derivationArgTransform = prevStage.stdenv.derivationArgTransform;
+
       overrides = self: super: {
         inherit cc;
         inherit (cc) binutils;


### PR DESCRIPTION
## Description of changes
Add the optional attribute `derivationArgTransform` to all stages in the `stdenv` bootstrap. `derivationArgTransform` should be a function that takes an attrset containing the arguments passed to `builtins.derivation` and returns its modified version. It will be placed between the original inputs and the actual call to `derivation` for (assuming I found them all) every single non-builtin derivation involved in building and using a `stdenv`, including the earliest stages of the bootstrap process. The initial intended usecase is for something like #296787, where the userspace emulator is called on a per-derivation basis rather than installed globally. Since Nix will outright refuse to build a derivation with the wrong `system` (even if it would otherwise work), and `mkDerivation` sets the `system` based on `buildPlatform`, this creates a conflict between the need to set `system` to the native arch (for the build to work) and the need to set `buildPlatform` to the foreign arch (the whole point of using an emulated packageset rather than `pkgsCross` is to avoid the complications of `buildPlatform` != `hostPlatform`). The idea is that there is a generic mechanism for the emulated stage (and any other stages in the future requiring this capability) to call one of the native bootstraps and pass a function that transparently replaces `system`s and wraps `builder`s in `binfmt_misc` registration calls so that it can get a foreign arch `stdenv` that is as close as possible to what it would be if it were built natively without making invasive changes to the native bootstrap process. A scope this large is necessary because if even one foreign binary is executed without the wrapper (including the builder itself) the whole build will fail. Other than function signatures nothing about the native `stdenv`s should change.

I suspect there's some kind of stable API I'm breaking or best practice I'm violating in this PR so I expect it not get merged, but if I get the impression that people are actually fine with it I'll add more proper documentation then. 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
