### PR TITLE
flye: init at 2.9.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1784,6 +1784,13 @@
       fingerprint = "C919 E69E A7C0 E147 9E0F  C26E 1EDA D0C6 70BD 062D";
     }];
   };
+  assistant = {
+    email = "assistant.moetron@gmail.com";
+    github = "Assistant";
+    githubId = 2748721;
+    matrix = "@assistant:pygmalion.chat";
+    name = "Assistant Moetron";
+  };
   astavie = {
     email = "astavie@pm.me";
     github = "astavie";

--- a/pkgs/by-name/fl/flye/aarch64-fix.patch
+++ b/pkgs/by-name/fl/flye/aarch64-fix.patch
@@ -1,0 +1,15 @@
+diff --git a/Makefile b/Makefile
+index 75f62aed..91b9571b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -16,6 +16,10 @@ ifeq ($(shell uname -m),arm64)
+ 	export aarch64=1
+ endif
+ 
++ifeq ($(shell uname -m),aarch64)
++	export aarch64=1
++endif
++
+ .PHONY: clean all profile debug minimap2 samtools
+ 
+ .DEFAULT_GOAL := all

--- a/pkgs/by-name/fl/flye/package.nix
+++ b/pkgs/by-name/fl/flye/package.nix
@@ -1,0 +1,51 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+, zlib
+, curl
+, libdeflate
+, bash
+, coreutils
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "flye";
+  version = "2.9.3";
+
+  src = fetchFromGitHub {
+    owner = "fenderglass";
+    repo = "flye";
+    rev = version;
+    hash = "sha256-IALqtIPmvDYoH4w/tk2WB/P/pAcKXxgnsu9PFp+wIes=";
+  };
+
+  nativeCheckInputs = [ python3Packages.pytestCheckHook ];
+
+  propagatedBuildInputs = [ coreutils ];
+
+  buildInputs = [
+    zlib
+    curl
+    libdeflate
+  ];
+
+  patches = [ ./aarch64-fix.patch ];
+
+  postPatch = ''
+    substituteInPlace flye/polishing/alignment.py \
+      --replace-fail "/bin/bash" "${lib.getExe bash}"
+
+    substituteInPlace flye/tests/test_toy.py \
+      --replace-fail "find_executable(\"flye" "find_executable(\"$out/bin/flye" \
+      --replace-fail "[\"flye" "[\"$out/bin/flye"
+  '';
+
+  meta = with lib; {
+    description = "De novo assembler for single molecule sequencing reads using repeat graphs";
+    homepage = "https://github.com/fenderglass/Flye";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    mainProgram = "flye";
+    maintainers = with maintainers; [ assistant ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Add [Flye](https://github.com/fenderglass/Flye), a de novo assembler for single molecule sequencing reads using repeat graphs.
Requested by #299225 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
