### PR TITLE
antares: init at 0.7.22

### DIFF
--- a/pkgs/by-name/an/antares/package.nix
+++ b/pkgs/by-name/an/antares/package.nix
@@ -1,0 +1,49 @@
+{ fetchFromGitHub
+, lib
+, buildNpmPackage
+, electron
+, nodejs
+}:
+
+buildNpmPackage rec {
+  pname = "antares";
+  version = "0.7.22";
+
+  src = fetchFromGitHub {
+    owner = "antares-sql";
+    repo = "antares";
+    rev = "v${version}";
+    hash = "sha256-SYnhrwxoyVw+bwfN1PGMsoul+mTfi8UkiP0fNOvVTBc=";
+  };
+
+  npmDepsHash = "sha256-5khFw8Igu2d5SYLh7OiCpUDMOVH5gAje+VnvoESQboo=";
+
+  buildInputs = [ nodejs ];
+
+  buildPhase = ''
+    runHook preBuild
+    npm run compile
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    npmInstallHook
+    cp -rf dist/* $out/lib/node_modules/antares
+    find -name "*.ts" | xargs rm -f
+    makeWrapper ${lib.getExe electron} $out/bin/antares \
+      --add-flags $out/lib/node_modules/antares/main.js
+    runHook postInstall
+  '';
+
+  dontNpmBuild = true;
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+
+  meta = with lib; {
+    description = "Modern, fast and productivity driven SQL client with a focus in UX";
+    homepage = "https://github.com/antares-sql/antares";
+    license = licenses.mit;
+    maintainers = with maintainers; [ eymeric ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Package Antares, an SQL client.

## Things done

I package Antares.
It is an electron app using typescript and vue.
So nix has to compile the ts to JS.
However, I think my method is not perfect because in the end, the output directory has the .ts and the .js.
But only the .js are needed. 
If anyone has an idea on how to do it cleaner, it will be helpful.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
