### PR TITLE
alsa-scarlett-mixer: 0.3.3 -> 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12495,6 +12495,12 @@
       fingerprint = "D709 03C8 0BE9 ACDC 14F0  3BFB 77BF E531 397E DE94";
     }];
   };
+  mdorman = {
+    email = "mdorman@jaunder.io";
+    github = "mdorman";
+    githubId = 333344;
+    name = "Michael Alan Dorman";
+  };
   mdr = {
     email = "MattRussellUK@gmail.com";
     github = "mdr";

--- a/pkgs/applications/audio/alsa-scarlett-gui/default.nix
+++ b/pkgs/applications/audio/alsa-scarlett-gui/default.nix
@@ -6,18 +6,19 @@
 , alsa-utils
 , alsa-lib
 , gtk4
+, openssl
 , wrapGAppsHook4
 }:
 
 stdenv.mkDerivation rec {
   pname = "alsa-scarlett-gui";
-  version = "0.3.3";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "geoffreybennett";
     repo = pname;
     rev = version;
-    sha256 = "sha256-lIwDNyzuvolDhTVCslCtUfbsC/TxKtxQF97h0zYxp9k=";
+    sha256 = "sha256-+74JRQn2xwgPHZSrp5b+uny0+aLnsFvx/cOKIdj4J40=";
   };
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=deprecated-declarations" ];
@@ -25,7 +26,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "DESTDIR=\${out}" "PREFIX=''" ];
   sourceRoot = "${src.name}/src";
   nativeBuildInputs = [ pkg-config wrapGAppsHook4 makeWrapper ];
-  buildInputs = [ gtk4 alsa-lib ];
+  buildInputs = [ gtk4 alsa-lib openssl ];
   postInstall = ''
     wrapProgram $out/bin/alsa-scarlett-gui --prefix PATH : ${lib.makeBinPath [ alsa-utils ]}
 
@@ -37,11 +38,11 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "fortify3" ];
 
   meta = with lib; {
-    description = "GUI for alsa controls presented by Focusrite Scarlett Gen 2/3 Mixer Driver";
+    description = "GUI for alsa controls presented by Focusrite Scarlett Gen 2/3/4 Mixer Driver";
     mainProgram = "alsa-scarlett-gui";
     homepage = "https://github.com/geoffreybennett/alsa-scarlett-gui";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ sebtm ];
+    maintainers = with maintainers; [ mdorman ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
This update enables support for newer hardware. 

I am putting myself down as maintainer, and removing the prior maintainer, @sebtm, at his specific suggestion.

This seems reasonable to me as I do own the hardware and therefore can do some actual testing--in fact I actually had to build this in order to fix the hardware configuration that had gotten screwed up using the prior version.

## Description of changes

https://github.com/geoffreybennett/alsa-scarlett-gui/releases/tag/0.4.0

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).