### PR TITLE
scion-bootstrapper: init at 0.0.7

### DIFF
--- a/pkgs/by-name/sc/scion-bootstrapper/package.nix
+++ b/pkgs/by-name/sc/scion-bootstrapper/package.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "scion-bootstrapper";
+  version = "0.0.7";
+
+  src = fetchFromGitHub {
+    owner = "netsec-ethz";
+    repo = "bootstrapper";
+    rev = "v${version}";
+    hash = "sha256-X4lNgd6klIw0NW9NVG+d1JK+WNfOclbu43GYucelB7o=";
+  };
+
+  vendorHash = "sha256-X4bOIvNlyQoAWOd3L6suE64KnlCV6kuE1ieVecVYWOw=";
+
+  doCheck = false;
+
+  ldflags = [ "-s" "-w" ];
+
+  postInstall = ''
+    mv $out/bin/bootstrapper $out/bin/scion-bootstrapper
+  '';
+
+  meta = with lib; {
+    description = "bootstrapper for SCION network configuration";
+    homepage = "https://github.com/netsec-ethz/bootstrapper";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ matthewcroughan sarcasticadmin ];
+    mainProgram = "scion-bootstrapper";
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds `scion-bootstrapper` to nixpkgs.

#### About tests

The tests require `cacert` `openssl` and `scion` in the `nativeBuildInputs`, but fail like this. Help would be appreciated if anyone wants to enable the tests.

```
Running phase: checkPhase
ok      github.com/netsec-ethz/bootstrapper/config      0.002s
t=2024-03-27T12:25:23+0000 lvl=eror msg="Signature verification failed: verifyTopologySignature" err="unable to validate certificate chain: exit status 1"
--- FAIL: TestVerify (0.02s)
--- FAIL: TestExtractSignerInfo (0.00s)
panic: interface conversion: interface {} is nil, not bool [recovered]
        panic: interface conversion: interface {} is nil, not bool

goroutine 10 [running]:
testing.tRunner.func1.2({0x629880, 0xc0000dbef0})
        /nix/store/bp39dh48cdqp89hk5mpdi1lxdf0mjl7x-go-1.22.1/share/go/src/testing/testing.go:1631 +0x24a
testing.tRunner.func1()
        /nix/store/bp39dh48cdqp89hk5mpdi1lxdf0mjl7x-go-1.22.1/share/go/src/testing/testing.go:1634 +0x377
panic({0x629880?, 0xc0000dbef0?})
        /nix/store/bp39dh48cdqp89hk5mpdi1lxdf0mjl7x-go-1.22.1/share/go/src/runtime/panic.go:770 +0x132
github.com/netsec-ethz/bootstrapper/fetcher.smimePk7out({0x6dcaa0, 0xc0000dbec0}, {0xc000020e80, 0x38}, {0xc000020ec0, 0x40})
        /build/source/fetcher/crypto_cmds.go:22 +0x10c
github.com/netsec-ethz/bootstrapper/fetcher.extractSignerInfo({0x6dcaa0, 0xc0000dbec0}, {0xc000020e80, 0x38}, {0xc000030c00, 0x29})
        /build/source/fetcher/scion_cppki_verify.go:170 +0xd7
github.com/netsec-ethz/bootstrapper/fetcher.TestExtractSignerInfo(0xc0000f7520)
        /build/source/fetcher/scion_cppki_verify_test.go:297 +0xa08
testing.tRunner(0xc0000f7520, 0x699150)
        /nix/store/bp39dh48cdqp89hk5mpdi1lxdf0mjl7x-go-1.22.1/share/go/src/testing/testing.go:1689 +0xfb
created by testing.(*T).Run in goroutine 1
        /nix/store/bp39dh48cdqp89hk5mpdi1lxdf0mjl7x-go-1.22.1/share/go/src/testing/testing.go:1742 +0x390
FAIL    github.com/netsec-ethz/bootstrapper/fetcher     0.026s
FAIL
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
