### PR TITLE
python3Packages.cocotb: fix build

### DIFF
--- a/pkgs/development/python-modules/cocotb/0002-Patch-remove-test_unicode_handle_assignment_deprecated-test.patch
+++ b/pkgs/development/python-modules/cocotb/0002-Patch-remove-test_unicode_handle_assignment_deprecated-test.patch
@@ -1,0 +1,25 @@
+diff --git a/tests/test_cases/test_cocotb/test_deprecated.py b/tests/test_cases/test_cocotb/test_deprecated.py
+index 523b93ba..b4f1701e 100644
+--- a/tests/test_cases/test_cocotb/test_deprecated.py
++++ b/tests/test_cases/test_cocotb/test_deprecated.py
+@@ -26,20 +26,6 @@ async def test_returnvalue_deprecated(dut):
+     assert val == 42
+ 
+ 
+-# strings are not supported on Icarus (gh-2585) or GHDL (gh-2584)
+-@cocotb.test(
+-    expect_error=AttributeError
+-    if cocotb.SIM_NAME.lower().startswith("icarus")
+-    else TypeError
+-    if cocotb.SIM_NAME.lower().startswith("ghdl")
+-    else ()
+-)
+-async def test_unicode_handle_assignment_deprecated(dut):
+-    with pytest.warns(DeprecationWarning, match=".*bytes.*"):
+-        dut.stream_in_string.value = "Bad idea"
+-        await cocotb.triggers.ReadWrite()
+-
+-
+ @cocotb.test()
+ async def test_convert_handle_to_string_deprecated(dut):
+     dut.stream_in_data.value = 0

--- a/pkgs/development/python-modules/cocotb/default.nix
+++ b/pkgs/development/python-modules/cocotb/default.nix
@@ -52,6 +52,10 @@ buildPythonPackage rec {
   patches = [
     # Fix "can't link with bundle (MH_BUNDLE) only dylibs (MH_DYLIB) file" error
     ./0001-Patch-LDCXXSHARED-for-macOS-along-with-LDSHARED.patch
+
+    # For the 1.8.1 release only: remove the test_unicode_handle_assignment_deprecated test
+    # It's more thoroughly removed upstream master with 425e1edb8e7133f4a891f2f87552aa2748cd8d2c
+    ./0002-Patch-remove-test_unicode_handle_assignment_deprecated-test.patch
   ];
 
   nativeCheckInputs = [ cocotb-bus pytestCheckHook swig verilog ghdl ];


### PR DESCRIPTION
## Description of changes

I removed the test as it currently fails on master and is removed upstream in the as-yet-unreleased next version. See https://github.com/cocotb/cocotb/commit/425e1edb8e7133f4a891f2f87552aa2748cd8d2c (https://github.com/cocotb/cocotb/pull/3455).

The test that fails looks like this:

```
Traceback (most recent call last):
  File "/build/source/tests/test_cases/test_cocotb/test_deprecated.py", line 39, in test_unicode_handle_assignment_deprecated
    dut.stream_in_string.value = "Bad idea"
    ^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/yvcizx3fwkm044jpw9sfpnb0kx0g2bfl-python3.11-cocotb-1.8.1/lib/python3.11/site-packages/cocotb/handle.py", line 370, in __getattr__
    raise AttributeError(f"{self._name} contains no object named {name}")
AttributeError: sample_module contains no object named stream_in_string

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/build/source/tests/test_cases/test_cocotb/test_deprecated.py", line 38, in test_unicode_handle_assignment_deprecated
    with pytest.warns(DeprecationWarning, match=".*bytes.*"):
  File "/nix/store/5ipi1f14ji1nrvqnf8h8fqvr0zny183d-python3.11-pytest-8.0.2/lib/python3.11/site-packages/_pytest/recwarn.py", line 332, in __exit__
    fail(
  File "/nix/store/5ipi1f14ji1nrvqnf8h8fqvr0zny183d-python3.11-pytest-8.0.2/lib/python3.11/site-packages/_pytest/outcomes.py", line 188, in fail
    raise Failed(msg=reason, pytrace=pytrace)
Failed: DID NOT WARN. No warnings of type (<class 'DeprecationWarning'>,) were emitted.
 Emitted warnings: [].
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).