### PR TITLE
mousecape: move to by-name/mo

### DIFF
--- a/pkgs/by-name/mo/mousecape/package.nix
+++ b/pkgs/by-name/mo/mousecape/package.nix
@@ -1,27 +1,22 @@
 { lib
 , stdenvNoCC
-, fetchurl
-, unzip
+, fetchzip
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mousecape";
   version = "1813";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://github.com/alexzielenski/Mousecape/releases/download/${finalAttrs.version}/Mousecape_${finalAttrs.version}.zip";
-    hash = "sha256-lp7HFGr1J+iQCUWVDplF8rFcTrGf+DX4baYzLsUi/9I=";
+    hash = "sha256-VjbvrXfsRFpbTJfIHFvyCxRdDcGNv0zzLToWn7lyLM8=";
   };
-
-  sourceRoot = ".";
-
-  nativeBuildInputs = [ unzip ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/Applications
-    mv Mousecape.app $out/Applications
+    mkdir -p $out/Applications/Mousecape.app
+    cp -R . $out/Applications/Mousecape.app/
 
     runHook postInstall
   '';
@@ -30,7 +25,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "A cursor manager for macOS built using private, nonintrusive CoreGraphics APIs";
     homepage = "https://github.com/alexzielenski/Mousecape";
     license = with lib; licenses.free;
-    maintainers = with lib; with maintainers; [ DontEatOreo ];
+    maintainers = with lib; with maintainers; [ donteatoreo ];
     platforms = with lib; platforms.darwin;
     sourceProvenance = with lib; with sourceTypes; [ binaryNativeCode ];
   };


### PR DESCRIPTION
## Description of changes

- Previously package resided in darwin/mousecape due to confusion, this breaks the pkgs category hierarchy as mentioned by https://github.com/NixOS/nixpkgs/pull/299032#issuecomment-2021684755
- Also switched to using fetchzip
- Fixed maintainer name

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc