### PR TITLE
renode: use standard nix-update-script

### DIFF
--- a/pkgs/by-name/re/renode-unstable/package.nix
+++ b/pkgs/by-name/re/renode-unstable/package.nix
@@ -1,11 +1,9 @@
 { renode
 , fetchurl
-, buildUnstable ? true
+, writeScript
 }:
 
-(renode.override {
-  inherit buildUnstable;
-}).overrideAttrs (finalAttrs: _: {
+renode.overrideAttrs (finalAttrs: _: {
   pname = "renode-unstable";
   version = "1.15.0+20240320git97be875a3";
 
@@ -13,4 +11,25 @@
     url = "https://builds.renode.io/renode-${finalAttrs.version}.linux-portable.tar.gz";
     hash = "sha256-+1tOZ44fg/Z4n4gjPylRQlRE7KnL0AGcODlue/HLb3I=";
   };
+
+  passthru.updateScript =
+    let
+      versionRegex = "[0-9\.\+]+[^\+]*.";
+    in
+    writeScript "${finalAttrs.pname}-updater" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts curl gnugrep gnused pup
+
+      latestVersion=$(
+        curl -sS https://builds.renode.io \
+          | pup 'a text{}' \
+          | egrep 'renode-${versionRegex}\.linux-portable\.tar\.gz' \
+          | head -n1 \
+          | sed -e 's,renode-\(.*\)\.linux-portable\.tar\.gz,\1,g'
+      )
+
+      update-source-version ${finalAttrs.pname} "$latestVersion" \
+        --file=pkgs/by-name/re/${finalAttrs.pname}/package.nix \
+        --system=x86_64-linux
+    '';
 })

--- a/pkgs/by-name/re/renode/package.nix
+++ b/pkgs/by-name/re/renode/package.nix
@@ -3,13 +3,12 @@
 , fetchurl
 , autoPatchelfHook
 , makeWrapper
-, writeScript
+, nix-update-script
 , glibcLocales
 , python3Packages
 , gtk-sharp-2_0
 , gtk2-x11
 , screen
-, buildUnstable ? false
 }:
 
 let
@@ -69,29 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript =
-    let
-      versionRegex =
-        if buildUnstable
-        then "[0-9\.\+]+[^\+]*."
-        else "[0-9\.]+[^\+]*.";
-    in
-    writeScript "${finalAttrs.pname}-updater" ''
-      #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p common-updater-scripts curl gnugrep gnused pup
-
-      latestVersion=$(
-        curl -sS https://builds.renode.io \
-          | pup 'a text{}' \
-          | egrep 'renode-${versionRegex}\.linux-portable\.tar\.gz' \
-          | head -n1 \
-          | sed -e 's,renode-\(.*\)\.linux-portable\.tar\.gz,\1,g'
-      )
-
-      update-source-version ${finalAttrs.pname} "$latestVersion" \
-        --file=pkgs/by-name/re/${finalAttrs.pname}/package.nix \
-        --system=x86_64-linux
-    '';
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Virtual development framework for complex embedded systems";


### PR DESCRIPTION
We can now use standard `nix-update-script` but the `renode-unstable` still requires the custom
update script so we moved it to the specific `.nix` file.

-------

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc