### PR TITLE
modules.nixosTest.setPackage: init

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -249,5 +249,24 @@
         */
         readOnlyPkgs = ./nixos/modules/misc/nixpkgs/read-only.nix;
       };
+
+      /**
+        Modules by module class: `modules.<class>.<name> = module;`
+      */
+      modules = {
+        /**
+          Modules that extend the NixOS test framework.
+
+          See https://nixos.org/manual/nixos/unstable/#sec-nixos-tests
+        */
+        nixosTest = {
+          /**
+            Adds a `setPackage` function to the NixOS test to make it overridable.
+
+            Beyond what the `extendNixOS` offers in this regard, this module and function have logic to make sure platform differences and package overrides are handled correctly.
+          */
+          set-package = ./nixos/tests/common/set-package.nix;
+        };
+      };
     };
 }

--- a/nixos/tests/common/set-package.nix
+++ b/nixos/tests/common/set-package.nix
@@ -1,0 +1,159 @@
+{
+  lib,
+  config,
+  hostPkgs,
+  options,
+  ...
+}:
+let
+  inherit (lib)
+    mkOption
+    optionalAttrs
+    types
+    ;
+
+  # TODO (lib): Dedup with run.nix, add to lib/options.nix
+  mkOneUp = opt: f: lib.mkOverride (opt.highestPrio - 1) (f opt.value);
+
+  /**
+    Return the package to test.
+
+    # Inputs
+
+    - `pkgs`: The package set to use if `config.packageOverride` is incompatible but not overridden.
+  */
+  getPackage =
+    pkgs:
+    if
+      options.packageOverride.isDefined
+      && config.node.pkgs.stdenv.hostPlatform.canExecute config.packageOverride.stdenv.hostPlatform
+    then
+      config.packageOverride
+    else if
+      options.defaultPackage.isDefined
+      &&
+        builtins.addErrorContext
+          "while trying to figure out whether the package override for a NixOS test is the un-overridden package for the host package set, so that we can hopefully just pick the un-overridden package from the guest package set instead, to make things like nixosTests.foo work on non-Linux hosts"
+          (config.packageOverride == config.defaultPackage config.hostPkgs)
+    then
+      config.defaultPackage pkgs
+    else
+      throw ''
+        ${
+          if options.defaultPackage.isDefined then
+            "It seems that you are trying to run a NixOS test which is part of a package that has been overridden."
+          else
+            ''
+              It seems that you are either
+
+              a. trying to run a NixOS test which is part of a package that has been overridden.
+              b. trying to run a package test on a non-overridden package, but the test does not have a `defaultPackage` definition.
+
+              If it's the latter, you can fix it by adding a `defaultPackage` definition to the test file, like this:
+
+                  {
+                    imports = [ ./set-package.nix ]; # etc
+
+                    name = "foo";
+                    # add this line where foo is your default package attribute:
+                    defaultPackage = pkgs: pkgs.foo;
+                  }
+
+              Otherwise, it seems that you are trying to run a test from an overriden package.''
+        }
+        This can be done - just not through the package `tests` attribute, because this package only knows about its own overrides, not the ones that should be applied to the Linux variation of it.
+        You can construct the correct test, e.g.:
+
+            let
+              # Let's assume you have package sets like this:
+              pkgsForLinux = nixpkgs { system = ...; }; # e.g. ${config.node.pkgs.stdenv.hostPlatform.system}
+              nativePkgs = nixpkgs { system = ...; }; # e.g. ${hostPkgs.stdenv.hostPlatform.system}
+
+              myOverrides = ...;
+
+              # You just invoked something like myFoo.tests where
+              #   myFoo = nativePkgs.foo.overrideAttrs myOverrides;
+              # or it might have been:
+              #   nativePkgs.nixosTests.foo.setPackage myFoo
+
+              # Instead, create
+              myFooForLinux = pkgsLinux.foo.overrideAttrs myOverrides;
+            in
+              # So that you can construct the correct test like this:
+              nativePkgs.nixosTests.foo.setPackage myFooForLinux
+
+        Or if you're defining the test file outside of Nixpkgs, it might look like this:
+
+            (nativePkgs.testers.runNixOSTest ./foo-test.nix).setPackage myFooForLinux
+      '';
+
+in
+{
+  _class = "nixosTest";
+
+  options = {
+    defaultPackage = mkOption {
+      description = ''
+        The default package to test, given a `pkgs`.
+
+        This is set by the test.
+      '';
+      type = types.functionTo types.package;
+    };
+
+    packageOverride = mkOption {
+      internal = true;
+      description = ''
+        The package to test, given a `pkgs`.
+
+        This is set by the `setPackage` attribute on the test returned by the test framework.
+      '';
+      type = types.raw;
+    };
+
+    setPackage = mkOption {
+      description = ''
+        Given a package, return a module that sets the package in NixOS.
+
+        This option is set by the test.
+
+        Its argument is the same as that of the `setPackage` function on the test returned by the test framework.
+      '';
+      type = types.functionTo types.deferredModule;
+      example = lib.literalExpression ''
+        pkg: { services.foo.package = pkg; }
+      '';
+    };
+
+    node.package = mkOption {
+      description = ''
+        The package to test, taken from ${options.node.pkgs}.
+
+        This is set by the test framework.
+      '';
+      type = types.package;
+    };
+  };
+  config = {
+    node.package = config.defaultPackage config.node.pkgs;
+
+    passthru = {
+      setPackage =
+        getPkg:
+        config.passthru.extend {
+          modules = [
+            {
+              _file = ./set-package.nix;
+              packageOverride = mkOneUp options.packageOverride (lib.toFunction getPkg);
+            }
+          ];
+        };
+    };
+    extraBaseModules = optionalAttrs options.packageOverride.isDefined (
+      { pkgs, ... }:
+      {
+        imports = [ (config.setPackage (getPackage pkgs)) ];
+      }
+    );
+  };
+}

--- a/nixos/tests/ghostunnel.nix
+++ b/nixos/tests/ghostunnel.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ hostPkgs, lib, ... }:
 {
   name = "ghostunnel";
   nodes = {
@@ -58,21 +58,21 @@
         raise Exception(f"Command {command} failed with exit code {r}")
 
     # Create CA
-    cmd("${pkgs.openssl}/bin/openssl genrsa -out ca-key.pem 4096")
-    cmd("${pkgs.openssl}/bin/openssl req -new -x509 -days 365 -key ca-key.pem -sha256 -subj '/C=NL/ST=Zuid-Holland/L=The Hague/O=Stevige Balken en Planken B.V./OU=OpSec/CN=Certificate Authority' -out ca.pem")
+    cmd("${hostPkgs.openssl}/bin/openssl genrsa -out ca-key.pem 4096")
+    cmd("${hostPkgs.openssl}/bin/openssl req -new -x509 -days 365 -key ca-key.pem -sha256 -subj '/C=NL/ST=Zuid-Holland/L=The Hague/O=Stevige Balken en Planken B.V./OU=OpSec/CN=Certificate Authority' -out ca.pem")
 
     # Create service
-    cmd("${pkgs.openssl}/bin/openssl genrsa -out service-key.pem 4096")
-    cmd("${pkgs.openssl}/bin/openssl req -subj '/CN=service' -sha256 -new -key service-key.pem -out service.csr")
+    cmd("${hostPkgs.openssl}/bin/openssl genrsa -out service-key.pem 4096")
+    cmd("${hostPkgs.openssl}/bin/openssl req -subj '/CN=service' -sha256 -new -key service-key.pem -out service.csr")
     cmd("echo subjectAltName = DNS:service,IP:127.0.0.1 >> extfile.cnf")
     cmd("echo extendedKeyUsage = serverAuth >> extfile.cnf")
-    cmd("${pkgs.openssl}/bin/openssl x509 -req -days 365 -sha256 -in service.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out service-cert.pem -extfile extfile.cnf")
+    cmd("${hostPkgs.openssl}/bin/openssl x509 -req -days 365 -sha256 -in service.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out service-cert.pem -extfile extfile.cnf")
 
     # Create client
-    cmd("${pkgs.openssl}/bin/openssl genrsa -out client-key.pem 4096")
-    cmd("${pkgs.openssl}/bin/openssl req -subj '/CN=client' -new -key client-key.pem -out client.csr")
+    cmd("${hostPkgs.openssl}/bin/openssl genrsa -out client-key.pem 4096")
+    cmd("${hostPkgs.openssl}/bin/openssl req -subj '/CN=client' -new -key client-key.pem -out client.csr")
     cmd("echo extendedKeyUsage = clientAuth > extfile-client.cnf")
-    cmd("${pkgs.openssl}/bin/openssl x509 -req -days 365 -sha256 -in client.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out client-cert.pem -extfile extfile-client.cnf")
+    cmd("${hostPkgs.openssl}/bin/openssl x509 -req -days 365 -sha256 -in client.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out client-cert.pem -extfile extfile-client.cnf")
 
     cmd("ls -al")
 
@@ -108,7 +108,7 @@
     client.fail("bash -c 'diff <(curl -v --no-progress-meter --cacert /root/ca.pem https://service:1443/hi.txt) <(echo hi)'")
   '';
 
-  meta.maintainers = with pkgs.lib.maintainers; [
+  meta.maintainers = with lib.maintainers; [
     roberth
   ];
 }

--- a/nixos/tests/ghostunnel.nix
+++ b/nixos/tests/ghostunnel.nix
@@ -1,6 +1,14 @@
 { hostPkgs, lib, ... }:
 {
+  imports = [
+    ./common/set-package.nix
+  ];
+
   name = "ghostunnel";
+
+  setPackage = pkg: { services.ghostunnel.package = pkg; };
+  defaultPackage = pkgs: pkgs.ghostunnel;
+
   nodes = {
     backend =
       { pkgs, ... }:

--- a/pkgs/by-name/gh/ghostunnel/package.nix
+++ b/pkgs/by-name/gh/ghostunnel/package.nix
@@ -8,14 +8,14 @@
   darwinMinVersionHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "ghostunnel";
   version = "1.8.4";
 
   src = fetchFromGitHub {
     owner = "ghostunnel";
     repo = "ghostunnel";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-NnRm1HEdfK6WI5ntilLSwdR2B5czG5CIcMFzl2TzEds=";
   };
 
@@ -50,4 +50,4 @@ buildGoModule rec {
     ];
     mainProgram = "ghostunnel";
   };
-}
+})

--- a/pkgs/by-name/gh/ghostunnel/package.nix
+++ b/pkgs/by-name/gh/ghostunnel/package.nix
@@ -34,10 +34,19 @@ buildGoModule (finalAttrs: {
   # general wherever they are available.
   checkFlags = [ "-skip=^Test(ImportDelete|Signer|Certificate)(RSA|ECDSA|EC)$" ];
 
-  passthru.tests = {
-    nixos = nixosTests.ghostunnel;
-    podman = nixosTests.podman-tls-ghostunnel;
-  };
+  passthru.tests =
+    let
+      module = {
+        services.ghostunnel.package = finalAttrs.finalPackage;
+      };
+    in
+    {
+      nixos = nixosTests.ghostunnel.extendNixOS { inherit module; };
+      /**
+        does not support overriding yet!
+      */
+      podman = nixosTests.podman-tls-ghostunnel;
+    };
 
   meta = {
     description = "TLS proxy with mutual authentication support for securing non-TLS backend applications";

--- a/pkgs/by-name/gh/ghostunnel/package.nix
+++ b/pkgs/by-name/gh/ghostunnel/package.nix
@@ -34,19 +34,13 @@ buildGoModule (finalAttrs: {
   # general wherever they are available.
   checkFlags = [ "-skip=^Test(ImportDelete|Signer|Certificate)(RSA|ECDSA|EC)$" ];
 
-  passthru.tests =
-    let
-      module = {
-        services.ghostunnel.package = finalAttrs.finalPackage;
-      };
-    in
-    {
-      nixos = nixosTests.ghostunnel.extendNixOS { inherit module; };
-      /**
-        does not support overriding yet!
-      */
-      podman = nixosTests.podman-tls-ghostunnel;
-    };
+  passthru.tests = {
+    nixos = nixosTests.ghostunnel.setPackage finalAttrs.finalPackage;
+    /**
+      does not support overriding yet!
+    */
+    podman = nixosTests.podman-tls-ghostunnel;
+  };
 
   meta = {
     description = "TLS proxy with mutual authentication support for securing non-TLS backend applications";


### PR DESCRIPTION
## Description of changes

Add overriding methods to the NixOS test package attrset.

- Originally I wanted to define overriding as part of #176557, but it's never too late to make progress.
- Triggered by https://github.com/NixOS/nixpkgs/pull/273183#discussion_r1538366592

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
