### PR TITLE
treewide: Fix AST of Nix in all markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -557,7 +557,7 @@ Names of files and directories should be in lowercase, with dashes between words
 
   ```nix
   foo {
-    arg = ...;
+    arg = "...";
   }
   ```
 
@@ -566,14 +566,14 @@ Names of files and directories should be in lowercase, with dashes between words
   ```nix
   foo
   {
-    arg = ...;
+    arg = "...";
   }
   ```
 
   Also fine is
 
   ```nix
-  foo { arg = ...; }
+  foo { arg = "..."; }
   ```
 
   if it's a short call.
@@ -581,41 +581,45 @@ Names of files and directories should be in lowercase, with dashes between words
 - In attribute sets or lists that span multiple lines, the attribute names or list elements should be aligned:
 
   ```nix
-  # A long list.
-  list = [
-    elem1
-    elem2
-    elem3
-  ];
+  {
+    # A long list.
+    list = [
+      elem1
+      elem2
+      elem3
+    ];
 
-  # A long attribute set.
-  attrs = {
-    attr1 = short_expr;
-    attr2 =
-      if true then big_expr else big_expr;
-  };
+    # A long attribute set.
+    attrs = {
+      attr1 = short_expr;
+      attr2 =
+        if true then big_expr else big_expr;
+    };
 
-  # Combined
-  listOfAttrs = [
-    {
-      attr1 = 3;
-      attr2 = "fff";
-    }
-    {
-      attr1 = 5;
-      attr2 = "ggg";
-    }
-  ];
+    # Combined
+    listOfAttrs = [
+      {
+        attr1 = 3;
+        attr2 = "fff";
+      }
+      {
+        attr1 = 5;
+        attr2 = "ggg";
+      }
+    ];
+  }
   ```
 
 - Short lists or attribute sets can be written on one line:
 
   ```nix
-  # A short list.
-  list = [ elem1 elem2 elem3 ];
+  {
+    # A short list.
+    list = [ elem1 elem2 elem3 ];
 
-  # A short set.
-  attrs = { x = 1280; y = 1024; };
+    # A short set.
+    attrs = { x = 1280; y = 1024; };
+  }
   ```
 
 - Breaking in the middle of a function argument can give hard-to-read code, like
@@ -649,7 +653,7 @@ Names of files and directories should be in lowercase, with dashes between words
   ```nix
   { arg1, arg2 }:
   assert system == "i686-linux";
-  stdenv.mkDerivation { ...
+  stdenv.mkDerivation { /* ... */ }
   ```
 
   not
@@ -657,41 +661,41 @@ Names of files and directories should be in lowercase, with dashes between words
   ```nix
   { arg1, arg2 }:
     assert system == "i686-linux";
-      stdenv.mkDerivation { ...
+      stdenv.mkDerivation { /* ... */ }
   ```
 
 - Function formal arguments are written as:
 
   ```nix
-  { arg1, arg2, arg3 }:
+  { arg1, arg2, arg3 }: { /* ... */ }
   ```
 
   but if they don't fit on one line they're written as:
 
   ```nix
   { arg1, arg2, arg3
-  , arg4, ...
-  , # Some comment...
-    argN
-  }:
+  , arg4
+  # Some comment...
+  ,  argN
+  }: { }
   ```
 
 - Functions should list their expected arguments as precisely as possible. That is, write
 
   ```nix
-  { stdenv, fetchurl, perl }: ...
+  { stdenv, fetchurl, perl }: "..."
   ```
 
   instead of
 
   ```nix
-  args: with args; ...
+  args: with args; "..."
   ```
 
   or
 
   ```nix
-  { stdenv, fetchurl, perl, ... }: ...
+  { stdenv, fetchurl, perl, ... }: "..."
   ```
 
   For functions that are truly generic in the number of arguments (such as wrappers around `mkDerivation`) that have some required arguments, you should write them using an `@`-pattern:
@@ -700,7 +704,7 @@ Names of files and directories should be in lowercase, with dashes between words
   { stdenv, doCoverageAnalysis ? false, ... } @ args:
 
   stdenv.mkDerivation (args // {
-    ... if doCoverageAnalysis then "bla" else "" ...
+    foo = if doCoverageAnalysis then "bla" else "";
   })
   ```
 
@@ -710,32 +714,40 @@ Names of files and directories should be in lowercase, with dashes between words
   args:
 
   args.stdenv.mkDerivation (args // {
-    ... if args ? doCoverageAnalysis && args.doCoverageAnalysis then "bla" else "" ...
+    foo = if args ? doCoverageAnalysis && args.doCoverageAnalysis then "bla" else "";
   })
   ```
 
 - Unnecessary string conversions should be avoided. Do
 
   ```nix
-  rev = version;
+  {
+    rev = version;
+  }
   ```
 
   instead of
 
   ```nix
-  rev = "${version}";
+  {
+    rev = "${version}";
+  }
   ```
 
 - Building lists conditionally _should_ be done with `lib.optional(s)` instead of using `if cond then [ ... ] else null` or `if cond then [ ... ] else [ ]`.
 
   ```nix
-  buildInputs = lib.optional stdenv.isDarwin iconv;
+  {
+    buildInputs = lib.optional stdenv.isDarwin iconv;
+  }
   ```
 
   instead of
 
   ```nix
-  buildInputs = if stdenv.isDarwin then [ iconv ] else null;
+  {
+    buildInputs = if stdenv.isDarwin then [ iconv ] else null;
+  }
   ```
 
   As an exception, an explicit conditional expression with null can be used when fixing a important bug without triggering a mass rebuild.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -557,7 +557,7 @@ Names of files and directories should be in lowercase, with dashes between words
 
   ```nix
   foo {
-    arg = "...";
+    arg = <...>;
   }
   ```
 
@@ -566,14 +566,14 @@ Names of files and directories should be in lowercase, with dashes between words
   ```nix
   foo
   {
-    arg = "...";
+    arg = <...>;
   }
   ```
 
   Also fine is
 
   ```nix
-  foo { arg = "..."; }
+  foo { arg = <...>; }
   ```
 
   if it's a short call.
@@ -683,19 +683,19 @@ Names of files and directories should be in lowercase, with dashes between words
 - Functions should list their expected arguments as precisely as possible. That is, write
 
   ```nix
-  { stdenv, fetchurl, perl }: "..."
+  { stdenv, fetchurl, perl }: <...>
   ```
 
   instead of
 
   ```nix
-  args: with args; "..."
+  args: with args; <...>
   ```
 
   or
 
   ```nix
-  { stdenv, fetchurl, perl, ... }: "..."
+  { stdenv, fetchurl, perl, ... }: <...>
   ```
 
   For functions that are truly generic in the number of arguments (such as wrappers around `mkDerivation`) that have some required arguments, you should write them using an `@`-pattern:

--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -243,7 +243,7 @@ This is a useful last-resort workaround for license restrictions that prohibit r
 If the requested file is present in the Nix store, the resulting derivation will not be built, because its expected output is already available.
 Otherwise, the builder will run, but fail with a message explaining to the user how to provide the file. The following code, for example:
 
-```
+```nix
 requireFile {
   name = "jdk-${version}_linux-x64_bin.tar.gz";
   url = "https://www.oracle.com/java/technologies/javase-jdk11-downloads.html";
@@ -270,7 +270,7 @@ It produces packages that cannot be built automatically.
 
 `fetchtorrent` expects two arguments. `url` which can either be a Magnet URI (Magnet Link) such as `magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c` or an HTTP URL pointing to a `.torrent` file. It can also take a `config` argument which will craft a `settings.json` configuration file and give it to `transmission`, the underlying program that is performing the fetch. The available config options for `transmission` can be found [here](https://github.com/transmission/transmission/blob/main/docs/Editing-Configuration-Files.md#options)
 
-```
+```nix
 { fetchtorrent }:
 
 fetchtorrent {

--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -30,7 +30,7 @@ For example, consider the following fetcher:
 fetchurl {
   url = "http://www.example.org/hello-1.0.tar.gz";
   hash = "sha256-lTeyxzJNQeMdu1IVdovNMtgn77jRIhSybLdMbTkf2Ww=";
-};
+}
 ```
 
 A common mistake is to update a fetcher’s URL, or a version parameter, without updating the hash.
@@ -39,7 +39,7 @@ A common mistake is to update a fetcher’s URL, or a version parameter, without
 fetchurl {
   url = "http://www.example.org/hello-1.1.tar.gz";
   hash = "sha256-lTeyxzJNQeMdu1IVdovNMtgn77jRIhSybLdMbTkf2Ww=";
-};
+}
 ```
 
 **This will reuse the old contents**.
@@ -49,7 +49,7 @@ Remember to invalidate the hash argument, in this case by setting the `hash` att
 fetchurl {
   url = "http://www.example.org/hello-1.1.tar.gz";
   hash = "";
-};
+}
 ```
 
 Use the resulting error message to determine the correct hash.
@@ -123,7 +123,7 @@ Here is an example of `fetchDebianPatch` in action:
 buildPythonPackage rec {
   pname = "pysimplesoap";
   version = "1.16.2";
-  src = ...;
+  src = "...";
 
   patches = [
     (fetchDebianPatch {
@@ -134,7 +134,7 @@ buildPythonPackage rec {
     })
   ];
 
-  ...
+  # ...
 }
 ```
 

--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -123,7 +123,7 @@ Here is an example of `fetchDebianPatch` in action:
 buildPythonPackage rec {
   pname = "pysimplesoap";
   version = "1.16.2";
-  src = "...";
+  src = <...>;
 
   patches = [
     (fetchDebianPatch {

--- a/doc/build-helpers/images/dockertools.section.md
+++ b/doc/build-helpers/images/dockertools.section.md
@@ -1177,6 +1177,7 @@ dockerTools.buildImage {
     hello
     dockerTools.binSh
   ];
+}
 ```
 
 After building the image and loading it in Docker, we can create a container based on it and enter a shell inside the container.

--- a/doc/build-helpers/special/checkpoint-build.section.md
+++ b/doc/build-helpers/special/checkpoint-build.section.md
@@ -9,13 +9,17 @@ However, we can tell Nix explicitly what the previous build state was, by repres
 To change a normal derivation to a checkpoint based build, these steps must be taken:
   - apply `prepareCheckpointBuild` on the desired derivation, e.g.
 ```nix
-checkpointArtifacts = (pkgs.checkpointBuildTools.prepareCheckpointBuild pkgs.virtualbox);
+{
+  checkpointArtifacts = (pkgs.checkpointBuildTools.prepareCheckpointBuild pkgs.virtualbox);
+}
 ```
   - change something you want in the sources of the package, e.g. use a source override:
 ```nix
-changedVBox = pkgs.virtualbox.overrideAttrs (old: {
-  src = path/to/vbox/sources;
-});
+{
+  changedVBox = pkgs.virtualbox.overrideAttrs (old: {
+    src = path/to/vbox/sources;
+  });
+}
 ```
   - use `mkCheckpointBuild changedVBox checkpointArtifacts`
   - enjoy shorter build times

--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -14,11 +14,13 @@ If the `moduleNames` argument is omitted, `hasPkgConfigModules` will use `meta.p
 # Check that `pkg-config` modules are exposed using default values
 
 ```nix
-passthru.tests.pkg-config = testers.hasPkgConfigModules {
-  package = finalAttrs.finalPackage;
-};
+{
+  passthru.tests.pkg-config = testers.hasPkgConfigModules {
+    package = finalAttrs.finalPackage;
+  };
 
-meta.pkgConfigModules = [ "libfoo" ];
+  meta.pkgConfigModules = [ "libfoo" ];
+}
 ```
 
 :::
@@ -28,10 +30,12 @@ meta.pkgConfigModules = [ "libfoo" ];
 # Check that `pkg-config` modules are exposed using explicit module names
 
 ```nix
-passthru.tests.pkg-config = testers.hasPkgConfigModules {
-  package = finalAttrs.finalPackage;
-  moduleNames = [ "libfoo" ];
-};
+{
+  passthru.tests.pkg-config = testers.hasPkgConfigModules {
+    package = finalAttrs.finalPackage;
+    moduleNames = [ "libfoo" ];
+  };
+}
 ```
 
 :::
@@ -55,7 +59,9 @@ The default argument to the command is `--version`, and the version to be checke
 This example will run the command `hello --version`, and then check that the version of the `hello` package is in the output of the command.
 
 ```nix
-passthru.tests.version = testers.testVersion { package = hello; };
+{
+  passthru.tests.version = testers.testVersion { package = hello; };
+}
 ```
 
 :::
@@ -70,13 +76,15 @@ This means that an output like "leetcode 0.4.21" would fail the tests, and an ou
 A common usage of the `version` attribute is to specify `version = "v${version}"`.
 
 ```nix
-version = "0.4.2";
+{
+  version = "0.4.2";
 
-passthru.tests.version = testers.testVersion {
-  package = leetcode-cli;
-  command = "leetcode -V";
-  version = "leetcode ${version}";
-};
+  passthru.tests.version = testers.testVersion {
+    package = leetcode-cli;
+    command = "leetcode -V";
+    version = "leetcode ${version}";
+  };
+}
 ```
 
 :::
@@ -116,7 +124,7 @@ runCommand "example" {
   grep -F 'failing though' $failed/testBuildFailure.log
   [[ 3 = $(cat $failed/testBuildFailure.exit) ]]
   touch $out
-'';
+''
 ```
 
 :::
@@ -193,12 +201,14 @@ once to get a derivation hash, and again to produce the final fixed output deriv
 # Prevent nix from reusing the output of a fetcher
 
 ```nix
-tests.fetchgit = testers.invalidateFetcherByDrvHash fetchgit {
-  name = "nix-source";
-  url = "https://github.com/NixOS/nix";
-  rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
-  hash = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
-};
+{
+  tests.fetchgit = testers.invalidateFetcherByDrvHash fetchgit {
+    name = "nix-source";
+    url = "https://github.com/NixOS/nix";
+    rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
+    hash = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
+  };
+}
 ```
 
 :::

--- a/doc/build-helpers/trivial-build-helpers.chapter.md
+++ b/doc/build-helpers/trivial-build-helpers.chapter.md
@@ -76,12 +76,14 @@ If you need to refer to the resulting files somewhere else in a Nix expression, 
 For example, if the file destination is a directory:
 
 ```nix
-my-file = writeTextFile {
-  name = "my-file";
-  text = ''
-    Contents of File
-  '';
-  destination = "/share/my-file";
+{
+  my-file = writeTextFile {
+    name = "my-file";
+    text = ''
+      Contents of File
+    '';
+    destination = "/share/my-file";
+  };
 }
 ```
 
@@ -90,7 +92,7 @@ Remember to append "/share/my-file" to the resulting store path when using it el
 ```nix
 writeShellScript "evaluate-my-file.sh" ''
   cat ${my-file}/share/my-file
-'';
+''
 ```
 ::::
 
@@ -287,7 +289,7 @@ writeTextFile {
   };
   allowSubstitutes = true;
   preferLocalBuild = false;
-};
+}
 ```
 :::
 
@@ -351,7 +353,7 @@ Write the string `Contents of File` to `/nix/store/<store path>`:
 writeText "my-file"
   ''
   Contents of File
-  '';
+  ''
 ```
 :::
 
@@ -391,7 +393,7 @@ Write the string `Contents of File` to `/nix/store/<store path>/share/my-file`:
 writeTextDir "share/my-file"
   ''
   Contents of File
-  '';
+  ''
 ```
 :::
 
@@ -433,7 +435,7 @@ Write the string `Contents of File` to `/nix/store/<store path>` and make the fi
 writeScript "my-file"
   ''
   Contents of File
-  '';
+  ''
 ```
 :::
 
@@ -475,7 +477,7 @@ The store path will include the the name, and it will be a directory.
 writeScriptBin "my-script"
   ''
   echo "hi"
-  '';
+  ''
 ```
 :::
 
@@ -519,7 +521,7 @@ This function is almost exactly like [](#trivial-builder-writeScript), except th
 writeShellScript "my-script"
   ''
   echo "hi"
-  '';
+  ''
 ```
 :::
 
@@ -562,7 +564,7 @@ This function is a combination of [](#trivial-builder-writeShellScript) and [](#
 writeShellScriptBin "my-script"
   ''
   echo "hi"
-  '';
+  ''
 ```
 :::
 
@@ -674,7 +676,7 @@ writeClosure [ (writeScriptBin "hi" ''${hello}/bin/hello'') ]
 
 produces an output path `/nix/store/<hash>-runtime-deps` containing
 
-```nix
+```
 /nix/store/<hash>-hello-2.10
 /nix/store/<hash>-hi
 /nix/store/<hash>-libidn2-2.3.0
@@ -700,7 +702,7 @@ writeDirectReferencesToFile (writeScriptBin "hi" ''${hello}/bin/hello'')
 
 produces an output path `/nix/store/<hash>-runtime-references` containing
 
-```nix
+```
 /nix/store/<hash>-hello-2.10
 ```
 

--- a/doc/functions/nix-gitignore.section.md
+++ b/doc/functions/nix-gitignore.section.md
@@ -7,27 +7,30 @@
 `pkgs.nix-gitignore` exports a number of functions, but you'll most likely need either `gitignoreSource` or `gitignoreSourcePure`. As their first argument, they both accept either 1. a file with gitignore lines or 2. a string with gitignore lines, or 3. a list of either of the two. They will be concatenated into a single big string.
 
 ```nix
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> {} }: {
 
- nix-gitignore.gitignoreSource [] ./source
+ src = nix-gitignore.gitignoreSource [] ./source;
      # Simplest version
 
- nix-gitignore.gitignoreSource "supplemental-ignores\n" ./source
+ src = nix-gitignore.gitignoreSource "supplemental-ignores\n" ./source;
      # This one reads the ./source/.gitignore and concats the auxiliary ignores
 
- nix-gitignore.gitignoreSourcePure "ignore-this\nignore-that\n" ./source
+ src = nix-gitignore.gitignoreSourcePure "ignore-this\nignore-that\n" ./source;
      # Use this string as gitignore, don't read ./source/.gitignore.
 
- nix-gitignore.gitignoreSourcePure ["ignore-this\nignore-that\n", ~/.gitignore] ./source
+ src = nix-gitignore.gitignoreSourcePure ["ignore-this\nignore-that\n" ~/.gitignore] ./source;
      # It also accepts a list (of strings and paths) that will be concatenated
      # once the paths are turned to strings via readFile.
+}
 ```
 
 These functions are derived from the `Filter` functions by setting the first filter argument to `(_: _: true)`:
 
 ```nix
-gitignoreSourcePure = gitignoreFilterSourcePure (_: _: true);
-gitignoreSource = gitignoreFilterSource (_: _: true);
+{
+  gitignoreSourcePure = gitignoreFilterSourcePure (_: _: true);
+  gitignoreSource = gitignoreFilterSource (_: _: true);
+}
 ```
 
 Those filter functions accept the same arguments the `builtins.filterSource` function would pass to its filters, thus `fn: gitignoreFilterSourcePure fn ""` should be extensionally equivalent to `filterSource`. The file is blacklisted if it's blacklisted by either your filter or the gitignoreFilter.
@@ -35,7 +38,9 @@ Those filter functions accept the same arguments the `builtins.filterSource` fun
 If you want to make your own filter from scratch, you may use
 
 ```nix
-gitignoreFilter = ign: root: filterPattern (gitignoreToPatterns ign) root;
+{
+  gitignoreFilter = ign: root: filterPattern (gitignoreToPatterns ign) root;
+}
 ```
 
 ## gitignore files in subdirectories {#sec-pkgs-nix-gitignore-usage-recursive}
@@ -43,7 +48,9 @@ gitignoreFilter = ign: root: filterPattern (gitignoreToPatterns ign) root;
 If you wish to use a filter that would search for .gitignore files in subdirectories, just like git does by default, use this function:
 
 ```nix
-gitignoreFilterRecursiveSource = filter: patterns: root:
-# OR
-gitignoreRecursiveSource = gitignoreFilterSourcePure (_: _: true);
+{
+  # gitignoreFilterRecursiveSource = filter: patterns: root:
+  # OR
+  gitignoreRecursiveSource = gitignoreFilterSourcePure (_: _: true);
+}
 ```

--- a/doc/hooks/breakpoint.section.md
+++ b/doc/hooks/breakpoint.section.md
@@ -3,7 +3,9 @@
 This hook will make a build pause instead of stopping when a failure happens. It prevents nix from cleaning up the build environment immediately and allows the user to attach to a build environment using the `cntr` command. Upon build error it will print instructions on how to use `cntr`, which can be used to enter the environment for debugging. Installing cntr and running the command will provide shell access to the build sandbox of failed build. At `/var/lib/cntr` the sandboxed filesystem is mounted. All commands and files of the system are still accessible within the shell. To execute commands from the sandbox use the cntr exec subcommand. `cntr` is only supported on Linux-based platforms. To use it first add `cntr` to your `environment.systemPackages` on NixOS or alternatively to the root user on non-NixOS systems. Then in the package that is supposed to be inspected, add `breakpointHook` to `nativeBuildInputs`.
 
 ```nix
-nativeBuildInputs = [ breakpointHook ];
+{
+  nativeBuildInputs = [ breakpointHook ];
+}
 ```
 
 When a build failure happens there will be an instruction printed that shows how to attach with `cntr` to the build sandbox.

--- a/doc/hooks/installShellFiles.section.md
+++ b/doc/hooks/installShellFiles.section.md
@@ -7,19 +7,21 @@ The `installManPage` function takes one or more paths to manpages to install. Th
 The `installShellCompletion` function takes one or more paths to shell completion files. By default it will autodetect the shell type from the completion file extension, but you may also specify it by passing one of `--bash`, `--fish`, or `--zsh`. These flags apply to all paths listed after them (up until another shell flag is given). Each path may also have a custom installation name provided by providing a flag `--name NAME` before the path. If this flag is not provided, zsh completions will be renamed automatically such that `foobar.zsh` becomes `_foobar`. A root name may be provided for all paths using the flag `--cmd NAME`; this synthesizes the appropriate name depending on the shell (e.g. `--cmd foo` will synthesize the name `foo.bash` for bash and `_foo` for zsh). The path may also be a fifo or named fd (such as produced by `<(cmd)`), in which case the shell and name must be provided.
 
 ```nix
-nativeBuildInputs = [ installShellFiles ];
-postInstall = ''
-  installManPage doc/foobar.1 doc/barfoo.3
-  # explicit behavior
-  installShellCompletion --bash --name foobar.bash share/completions.bash
-  installShellCompletion --fish --name foobar.fish share/completions.fish
-  installShellCompletion --zsh --name _foobar share/completions.zsh
-  # implicit behavior
-  installShellCompletion share/completions/foobar.{bash,fish,zsh}
-  # using named fd
-  installShellCompletion --cmd foobar \
-    --bash <($out/bin/foobar --bash-completion) \
-    --fish <($out/bin/foobar --fish-completion) \
-    --zsh <($out/bin/foobar --zsh-completion)
-'';
+{
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = ''
+    installManPage doc/foobar.1 doc/barfoo.3
+    # explicit behavior
+    installShellCompletion --bash --name foobar.bash share/completions.bash
+    installShellCompletion --fish --name foobar.fish share/completions.fish
+    installShellCompletion --zsh --name _foobar share/completions.zsh
+    # implicit behavior
+    installShellCompletion share/completions/foobar.{bash,fish,zsh}
+    # using named fd
+    installShellCompletion --cmd foobar \
+      --bash <($out/bin/foobar --bash-completion) \
+      --fish <($out/bin/foobar --fish-completion) \
+      --zsh <($out/bin/foobar --zsh-completion)
+  '';
+}
 ```

--- a/doc/hooks/mpi-check-hook.section.md
+++ b/doc/hooks/mpi-check-hook.section.md
@@ -12,13 +12,14 @@ Example:
 
 ```nix
   { mpiCheckPhaseHook, mpi, ... }:
+  {
+    # ...
 
-  ...
-
-  nativeCheckInputs = [
-    openssh
-    mpiCheckPhaseHook
-  ];
+    nativeCheckInputs = [
+      openssh
+      mpiCheckPhaseHook
+    ];
+  }
 ```
 
 

--- a/doc/languages-frameworks/agda.section.md
+++ b/doc/languages-frameworks/agda.section.md
@@ -194,7 +194,7 @@ mkDerivation {
   version = "1.5.0";
   pname = "iowa-stdlib";
 
-  src = "...";
+  src = <...>;
 
   libraryFile = "";
   libraryName = "IAL-1.3";

--- a/doc/languages-frameworks/agda.section.md
+++ b/doc/languages-frameworks/agda.section.md
@@ -114,7 +114,7 @@ This can be overridden by a different version of `ghc` as follows:
 
 ```nix
 agda.withPackages {
-  pkgs = [ ... ];
+  pkgs = [ /* ... */ ];
   ghc = haskell.compiler.ghcHEAD;
 }
 ```
@@ -180,6 +180,7 @@ To add an Agda package to `nixpkgs`, the derivation should be written to `pkgs/d
 
 ```nix
 { mkDerivation, standard-library, fetchFromGitHub }:
+{}
 ```
 
 Note that the derivation function is called with `mkDerivation` set to `agdaPackages.mkDerivation`, therefore you
@@ -193,7 +194,7 @@ mkDerivation {
   version = "1.5.0";
   pname = "iowa-stdlib";
 
-  src = ...
+  src = "...";
 
   libraryFile = "";
   libraryName = "IAL-1.3";

--- a/doc/languages-frameworks/android.section.md
+++ b/doc/languages-frameworks/android.section.md
@@ -104,18 +104,20 @@ pull from:
   repo.json to the Nix store based on the given repository XMLs.
 
 ```nix
-repoXmls = {
-  packages = [ ./xml/repository2-1.xml ];
-  images = [
-    ./xml/android-sys-img2-1.xml
-    ./xml/android-tv-sys-img2-1.xml
-    ./xml/android-wear-sys-img2-1.xml
-    ./xml/android-wear-cn-sys-img2-1.xml
-    ./xml/google_apis-sys-img2-1.xml
-    ./xml/google_apis_playstore-sys-img2-1.xml
-  ];
-  addons = [ ./xml/addon2-1.xml ];
-};
+{
+  repoXmls = {
+    packages = [ ./xml/repository2-1.xml ];
+    images = [
+      ./xml/android-sys-img2-1.xml
+      ./xml/android-tv-sys-img2-1.xml
+      ./xml/android-wear-sys-img2-1.xml
+      ./xml/android-wear-cn-sys-img2-1.xml
+      ./xml/google_apis-sys-img2-1.xml
+      ./xml/google_apis_playstore-sys-img2-1.xml
+    ];
+    addons = [ ./xml/addon2-1.xml ];
+  };
+}
 ```
 
 When building the above expression with:

--- a/doc/languages-frameworks/beam.section.md
+++ b/doc/languages-frameworks/beam.section.md
@@ -117,6 +117,7 @@ If there are git dependencies.
 - From the mix_deps.nix file, remove the dependencies that had git versions and pass them as an override to the import function.
 
 ```nix
+{
   mixNixDeps = import ./mix.nix {
     inherit beamPackages lib;
     overrides = (final: prev: {
@@ -138,8 +139,9 @@ If there are git dependencies.
         # you can re-use the same beamDeps argument as generated
         beamDeps = with final; [ prometheus ];
       };
-  });
-};
+    });
+  };
+}
 ```
 
 You will need to run the build process once to fix the hash to correspond to your new git src.
@@ -153,11 +155,13 @@ Practical steps
 - start with the following argument to mixRelease
 
 ```nix
+{
   mixFodDeps = fetchMixDeps {
     pname = "mix-deps-${pname}";
     inherit src version;
     hash = lib.fakeHash;
   };
+}
 ```
 
 The first build will complain about the hash value, you can replace with the suggested value after that.

--- a/doc/languages-frameworks/bower.section.md
+++ b/doc/languages-frameworks/bower.section.md
@@ -28,7 +28,7 @@ buildEnv { name = "bower-env"; ignoreCollisions = true; paths = [
   (fetchbower "angular" "1.5.3" "~1.5.0" "1749xb0firxdra4rzadm4q9x90v6pzkbd7xmcyjk6qfza09ykk9y")
   (fetchbower "bootstrap" "3.3.6" "~3.3.6" "1vvqlpbfcy0k5pncfjaiskj3y6scwifxygfqnw393sjfxiviwmbv")
   (fetchbower "jquery" "2.2.2" "1.9.1 - 2" "10sp5h98sqwk90y4k6hbdviwqzvzwqf47r3r51pakch5ii2y7js1")
-];
+]; }
 ```
 
 Using the `bower2nix` command line arguments, the output can be redirected to a file. A name like `bower-packages.nix` would be fine.
@@ -42,11 +42,13 @@ The function is implemented in [pkgs/development/bower-modules/generic/default.n
 ### Example buildBowerComponents {#ex-buildBowerComponents}
 
 ```nix
-bowerComponents = buildBowerComponents {
-  name = "my-web-app";
-  generated = ./bower-packages.nix; # note 1
-  src = myWebApp; # note 2
-};
+{
+  bowerComponents = buildBowerComponents {
+    name = "my-web-app";
+    generated = ./bower-packages.nix; # note 1
+    src = myWebApp; # note 2
+  };
+}
 ```
 
 In ["buildBowerComponents" example](#ex-buildBowerComponents) the following arguments are of special significance to the function:

--- a/doc/languages-frameworks/chicken.section.md
+++ b/doc/languages-frameworks/chicken.section.md
@@ -13,10 +13,12 @@ done in the typical Nix fashion. For example, to include support for [SRFI
 might write:
 
 ```nix
+{
   buildInputs = [
     chicken
     chickenPackages.chickenEggs.srfi-189
   ];
+}
 ```
 
 Both `chicken` and its eggs have a setup hook which configures the environment
@@ -67,12 +69,12 @@ let
       chickenEggs = super.chickenEggs.overrideScope' (eggself: eggsuper: {
         srfi-180 = eggsuper.srfi-180.overrideAttrs {
           # path to a local copy of srfi-180
-          src = ...
+          src = "...";
         };
       });
   });
 in
 # Here, `myChickenPackages.chickenEggs.json-rpc`, which depends on `srfi-180` will use
 # the local copy of `srfi-180`.
-# ...
+"..."
 ```

--- a/doc/languages-frameworks/chicken.section.md
+++ b/doc/languages-frameworks/chicken.section.md
@@ -69,12 +69,12 @@ let
       chickenEggs = super.chickenEggs.overrideScope' (eggself: eggsuper: {
         srfi-180 = eggsuper.srfi-180.overrideAttrs {
           # path to a local copy of srfi-180
-          src = "...";
+          src = <...>;
         };
       });
   });
 in
 # Here, `myChickenPackages.chickenEggs.json-rpc`, which depends on `srfi-180` will use
 # the local copy of `srfi-180`.
-"..."
+<...>
 ```

--- a/doc/languages-frameworks/crystal.section.md
+++ b/doc/languages-frameworks/crystal.section.md
@@ -33,22 +33,26 @@ crystal.buildCrystalPackage rec {
   # Insert the path to your shards.nix file here
   shardsFile = ./shards.nix;
 
-  ...
+  # ...
 }
 ```
 
 This won't build anything yet, because we haven't told it what files build. We can specify a mapping from binary names to source files with the `crystalBinaries` attribute. The project's compilation instructions should show this. For Mint, the binary is called "mint", which is compiled from the source file `src/mint.cr`, so we'll specify this as follows:
 
 ```nix
+{
   crystalBinaries.mint.src = "src/mint.cr";
 
   # ...
+}
 ```
 
 Additionally you can override the default `crystal build` options (which are currently `--release --progress --no-debug --verbose`) with
 
 ```nix
+{
   crystalBinaries.mint.options = [ "--release" "--verbose" ];
+}
 ```
 
 Depending on the project, you might need additional steps to get it to compile successfully. In Mint's case, we need to link against openssl, so in the end the Nix file looks as follows:

--- a/doc/languages-frameworks/cuda.section.md
+++ b/doc/languages-frameworks/cuda.section.md
@@ -16,24 +16,28 @@ To use one or more CUDA packages in an expression, give the expression a `cudaPa
 , cudaSupport ? config.cudaSupport
 , cudaPackages ? { }
 , ...
-}:
+}: {}
 ```
 
 When using `callPackage`, you can choose to pass in a different variant, e.g.
 when a different version of the toolkit suffices
 ```nix
-mypkg = callPackage { cudaPackages = cudaPackages_11_5; }
+{
+  mypkg = callPackage { cudaPackages = cudaPackages_11_5; };
+}
 ```
 
 If another version of say `cudnn` or `cutensor` is needed, you can override the
 package set to make it the default. This guarantees you get a consistent package
 set.
 ```nix
-mypkg = let
-  cudaPackages = cudaPackages_11_5.overrideScope (final: prev: {
-    cudnn = prev.cudnn_8_3;
-  }});
-in callPackage { inherit cudaPackages; };
+{
+  mypkg = let
+    cudaPackages = cudaPackages_11_5.overrideScope (final: prev: {
+      cudnn = prev.cudnn_8_3;
+    });
+  in callPackage { inherit cudaPackages; };
+}
 ```
 
 The CUDA NVCC compiler requires flags to determine which hardware you

--- a/doc/languages-frameworks/cuelang.section.md
+++ b/doc/languages-frameworks/cuelang.section.md
@@ -26,7 +26,7 @@ Cuelang schemas are similar to JSON, here is a quick cheatsheet:
 Nixpkgs provides a `pkgs.writeCueValidator` helper, which will write a validation script based on the provided Cuelang schema.
 
 Here is an example:
-```
+```nix
 pkgs.writeCueValidator
   (pkgs.writeText "schema.cue" ''
     #Def1: {
@@ -42,7 +42,7 @@ pkgs.writeCueValidator
 `document` : match your input data against this fragment of structure or definition, e.g. you may use the same schema file but different documents based on the data you are validating.
 
 Another example, given the following `validator.nix` :
-```
+```nix
 { pkgs ? import <nixpkgs> {} }:
 let
   genericValidator = version:

--- a/doc/languages-frameworks/dhall.section.md
+++ b/doc/languages-frameworks/dhall.section.md
@@ -187,6 +187,7 @@ wish to specify `source = true` for all Dhall packages, then you can amend the
 Dhall overlay like this:
 
 ```nix
+{
   dhallOverrides = self: super: {
     # Enable source for all Dhall packages
     buildDhallPackage =
@@ -194,6 +195,7 @@ Dhall overlay like this:
 
     true = self.callPackage ./true.nix { };
   };
+}
 ```
 
 … and now the Prelude will contain the fully decoded result of interpreting
@@ -429,22 +431,26 @@ $ dhall-to-nixpkgs github https://github.com/dhall-lang/dhall-lang.git \
 the Prelude globally for all packages, like this:
 
 ```nix
+{
   dhallOverrides = self: super: {
     true = self.callPackage ./true.nix { };
 
     Prelude = self.callPackage ./Prelude.nix { };
   };
+}
 ```
 
 … or selectively overriding the Prelude dependency for just the `true` package,
 like this:
 
 ```nix
+{
   dhallOverrides = self: super: {
     true = self.callPackage ./true.nix {
       Prelude = self.callPackage ./Prelude.nix { };
     };
   };
+}
 ```
 
 ## Overrides {#ssec-dhall-overrides}
@@ -454,11 +460,13 @@ You can override any of the arguments to `buildDhallGitHubPackage` or
 For example, suppose we wanted to selectively enable `source = true` just for the Prelude.  We can do that like this:
 
 ```nix
+{
   dhallOverrides = self: super: {
     Prelude = super.Prelude.overridePackage { source = true; };
 
-    …
+    # ...
   };
+}
 ```
 
 [semantic-integrity-checks]: https://docs.dhall-lang.org/tutorials/Language-Tour.html#installing-packages

--- a/doc/languages-frameworks/dotnet.section.md
+++ b/doc/languages-frameworks/dotnet.section.md
@@ -134,7 +134,7 @@ Here is an example `default.nix`, using some of the previously discussed argumen
 { lib, buildDotnetModule, dotnetCorePackages, ffmpeg }:
 
 let
-  referencedProject = import ../../bar { ... };
+  referencedProject = import ../../bar { /* ... */ };
 in buildDotnetModule rec {
   pname = "someDotnetApplication";
   version = "0.1";

--- a/doc/languages-frameworks/dotnet.section.md
+++ b/doc/languages-frameworks/dotnet.section.md
@@ -236,7 +236,7 @@ the packages inside the `out` directory.
 $ nuget-to-nix out > deps.nix
 ```
 Which `nuget-to-nix` will generate an output similar to below
-```
+```nix
 { fetchNuGet }: [
   (fetchNuGet { pname = "FosterFramework"; version = "0.1.15-alpha"; sha256 = "0pzsdfbsfx28xfqljcwy100xhbs6wyx0z1d5qxgmv3l60di9xkll"; })
   (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-x64"; version = "8.0.1"; sha256 = "1gjz379y61ag9whi78qxx09bwkwcznkx2mzypgycibxk61g11da1"; })

--- a/doc/languages-frameworks/go.section.md
+++ b/doc/languages-frameworks/go.section.md
@@ -38,24 +38,26 @@ The `buildGoModule` function accepts the following parameters in addition to the
 The following is an example expression using `buildGoModule`:
 
 ```nix
-pet = buildGoModule rec {
-  pname = "pet";
-  version = "0.3.4";
+{
+  pet = buildGoModule rec {
+    pname = "pet";
+    version = "0.3.4";
 
-  src = fetchFromGitHub {
-    owner = "knqyf263";
-    repo = "pet";
-    rev = "v${version}";
-    hash = "sha256-Gjw1dRrgM8D3G7v6WIM2+50r4HmTXvx0Xxme2fH9TlQ=";
-  };
+    src = fetchFromGitHub {
+      owner = "knqyf263";
+      repo = "pet";
+      rev = "v${version}";
+      hash = "sha256-Gjw1dRrgM8D3G7v6WIM2+50r4HmTXvx0Xxme2fH9TlQ=";
+    };
 
-  vendorHash = "sha256-ciBIR+a1oaYH+H1PcC8cD8ncfJczk1IiJ8iYNM+R6aA=";
+    vendorHash = "sha256-ciBIR+a1oaYH+H1PcC8cD8ncfJczk1IiJ8iYNM+R6aA=";
 
-  meta = {
-    description = "Simple command-line snippet manager, written in Go";
-    homepage = "https://github.com/knqyf263/pet";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kalbasit ];
+    meta = {
+      description = "Simple command-line snippet manager, written in Go";
+      homepage = "https://github.com/knqyf263/pet";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ kalbasit ];
+    };
   };
 }
 ```
@@ -72,20 +74,22 @@ In the following is an example expression using `buildGoPackage`, the following 
 - `goDeps` is where the Go dependencies of a Go program are listed as a list of package source identified by Go import path. It could be imported as a separate `deps.nix` file for readability. The dependency data structure is described below.
 
 ```nix
-deis = buildGoPackage rec {
-  pname = "deis";
-  version = "1.13.0";
+{
+  deis = buildGoPackage rec {
+    pname = "deis";
+    version = "1.13.0";
 
-  goPackagePath = "github.com/deis/deis";
+    goPackagePath = "github.com/deis/deis";
 
-  src = fetchFromGitHub {
-    owner = "deis";
-    repo = "deis";
-    rev = "v${version}";
-    hash = "sha256-XCPD4LNWtAd8uz7zyCLRfT8rzxycIUmTACjU03GnaeM=";
+    src = fetchFromGitHub {
+      owner = "deis";
+      repo = "deis";
+      rev = "v${version}";
+      hash = "sha256-XCPD4LNWtAd8uz7zyCLRfT8rzxycIUmTACjU03GnaeM=";
+    };
+
+    goDeps = ./deps.nix;
   };
-
-  goDeps = ./deps.nix;
 }
 ```
 
@@ -153,10 +157,12 @@ A string list of flags to pass to the Go linker tool via the `-ldflags` argument
 The most common use case for this argument is to make the resulting executable aware of its own version by injecting the value of string variable using the `-X` flag. For example:
 
 ```nix
+{
   ldflags = [
     "-X main.Version=${version}"
     "-X main.Commit=${version}"
   ];
+}
 ```
 
 ### `tags` {#var-go-tags}
@@ -164,16 +170,20 @@ The most common use case for this argument is to make the resulting executable a
 A string list of [Go build tags (also called build constraints)](https://pkg.go.dev/cmd/go#hdr-Build_constraints) that are passed via the `-tags` argument of `go build`.  These constraints control whether Go files from the source should be included in the build. For example:
 
 ```nix
+{
   tags = [
     "production"
     "sqlite"
   ];
+}
 ```
 
 Tags can also be set conditionally:
 
 ```nix
+{
   tags = [ "production" ] ++ lib.optionals withSqlite [ "sqlite" ];
+}
 ```
 
 ### `deleteVendor` {#var-go-deleteVendor}
@@ -188,10 +198,12 @@ Many Go projects keep the main package in a `cmd` directory.
 Following example could be used to only build the example-cli and example-server binaries:
 
 ```nix
-subPackages = [
-  "cmd/example-cli"
-  "cmd/example-server"
-];
+{
+  subPackages = [
+    "cmd/example-cli"
+    "cmd/example-server"
+  ];
+}
 ```
 
 ### `excludedPackages` {#var-go-excludedPackages}
@@ -213,10 +225,12 @@ on a per package level using build tags (`tags`). In case CGO is disabled, these
 When a Go program depends on C libraries, place those dependencies in `buildInputs`:
 
 ```nix
+{
   buildInputs = [
     libvirt
     libxml2
   ];
+}
 ```
 
 `CGO_ENABLED` defaults to `1`.
@@ -245,15 +259,18 @@ This is done with the [`-skip` or `-run`](https://pkg.go.dev/cmd/go#hdr-Testing_
 For example, only a selection of tests could be run with:
 
 ```nix
+{
   # -run and -skip accept regular expressions
   checkFlags = [
     "-run=^Test(Simple|Fast)$"
   ];
+}
 ```
 
 If a larger amount of tests should be skipped, the following pattern can be used:
 
 ```nix
+{
   checkFlags =
     let
       # Skip tests that require network access
@@ -264,6 +281,7 @@ If a larger amount of tests should be skipped, the following pattern can be used
       ];
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+}
 ```
 
 To disable tests altogether, set `doCheck = false;`.

--- a/doc/languages-frameworks/idris.section.md
+++ b/doc/languages-frameworks/idris.section.md
@@ -134,9 +134,9 @@ For example you could set
 
 ```nix
 build-idris-package {
-  idrisBuildOptions = [ "--log" "1" "--verbose" ]
+  idrisBuildOptions = [ "--log" "1" "--verbose" ];
 
-  ...
+  # ...
 }
 ```
 

--- a/doc/languages-frameworks/java.section.md
+++ b/doc/languages-frameworks/java.section.md
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
   pname = "...";
   version = "...";
 
-  src = fetchurl { ... };
+  src = fetchurl { /* ... */ };
 
   nativeBuildInputs = [
     ant
@@ -48,8 +48,10 @@ installs a JAR named `foo.jar` in its `share/java` directory, and
 another package declares the attribute
 
 ```nix
-buildInputs = [ libfoo ];
-nativeBuildInputs = [ jdk ];
+{
+  buildInputs = [ libfoo ];
+  nativeBuildInputs = [ jdk ];
+}
 ```
 
 then `CLASSPATH` will be set to
@@ -62,13 +64,15 @@ If your Java package provides a program, you need to generate a wrapper
 script to run it using a JRE. You can use `makeWrapper` for this:
 
 ```nix
-nativeBuildInputs = [ makeWrapper ];
+{
+  nativeBuildInputs = [ makeWrapper ];
 
-installPhase = ''
-  mkdir -p $out/bin
-  makeWrapper ${jre}/bin/java $out/bin/foo \
-    --add-flags "-cp $out/share/java/foo.jar org.foo.Main"
-'';
+  installPhase = ''
+    mkdir -p $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/foo \
+      --add-flags "-cp $out/share/java/foo.jar org.foo.Main"
+  '';
+}
 ```
 
 Since the introduction of the Java Platform Module System in Java 9,
@@ -92,16 +96,18 @@ let
   something = (pkgs.something.override { jre = my_jre; });
   other = (pkgs.other.override { jre = my_jre; });
 in
-  ...
+  "..."
 ```
 
 You can also specify what JDK your JRE should be based on, for example
 selecting a 'headless' build to avoid including a link to GTK+:
 
 ```nix
-my_jre = pkgs.jre_minimal.override {
-  jdk = jdk11_headless;
-};
+{
+  my_jre = pkgs.jre_minimal.override {
+    jdk = jdk11_headless;
+  };
+}
 ```
 
 Note all JDKs passthru `home`, so if your application requires
@@ -116,7 +122,9 @@ It is possible to use a different Java compiler than `javac` from the
 OpenJDK. For instance, to use the GNU Java Compiler:
 
 ```nix
-nativeBuildInputs = [ gcj ant ];
+{
+  nativeBuildInputs = [ gcj ant ];
+}
 ```
 
 Here, Ant will automatically use `gij` (the GNU Java Runtime) instead of

--- a/doc/languages-frameworks/java.section.md
+++ b/doc/languages-frameworks/java.section.md
@@ -96,7 +96,7 @@ let
   something = (pkgs.something.override { jre = my_jre; });
   other = (pkgs.other.override { jre = my_jre; });
 in
-  "..."
+  <...>
 ```
 
 You can also specify what JDK your JRE should be based on, for example

--- a/doc/languages-frameworks/lisp.section.md
+++ b/doc/languages-frameworks/lisp.section.md
@@ -45,7 +45,7 @@ $ sbcl
 
 Also one can create a `pkgs.mkShell` environment in `shell.nix`/`flake.nix`:
 
-```
+```nix
 let
   sbcl' = sbcl.withPackages (ps: [ ps.alexandria ]);
 in mkShell {
@@ -55,7 +55,7 @@ in mkShell {
 
 Such a Lisp can be now used e.g. to compile your sources:
 
-```
+```nix
 buildPhase = ''
   ${sbcl'}/bin/sbcl --load my-build-file.lisp
 ''
@@ -173,7 +173,7 @@ into the package scope with `withOverrides`.
 A package defined outside Nixpkgs using `buildASDFSystem` can be woven into the
 Nixpkgs-provided scope like this:
 
-```
+```nix
 let
   alexandria = sbcl.buildASDFSystem rec {
     pname = "alexandria";
@@ -199,7 +199,7 @@ new package with different parameters.
 
 Example of overriding `alexandria`:
 
-```
+```nix
 sbcl.pkgs.alexandria.overrideLispAttrs (oldAttrs: rec {
   version = "1.4";
   src = fetchFromGitLab {
@@ -225,7 +225,7 @@ vice versa.
 
 To package slashy systems, use `overrideLispAttrs`, like so:
 
-```
+```nix
 ecl.pkgs.alexandria.overrideLispAttrs (oldAttrs: {
   systems = oldAttrs.systems ++ [ "alexandria/tests" ];
   lispLibs = oldAttrs.lispLibs ++ [ ecl.pkgs.rt ];
@@ -290,7 +290,7 @@ derivation.
 
 This example wraps CLISP:
 
-```
+```nix
 wrapLisp {
   pkg = clisp;
   faslExt = "fas";

--- a/doc/languages-frameworks/lisp.section.md
+++ b/doc/languages-frameworks/lisp.section.md
@@ -56,9 +56,11 @@ in mkShell {
 Such a Lisp can be now used e.g. to compile your sources:
 
 ```nix
-buildPhase = ''
-  ${sbcl'}/bin/sbcl --load my-build-file.lisp
-''
+{
+  buildPhase = ''
+    ${sbcl'}/bin/sbcl --load my-build-file.lisp
+  '';
+}
 ```
 
 ## Importing packages from Quicklisp {#lisp-importing-packages-from-quicklisp}

--- a/doc/languages-frameworks/lua.section.md
+++ b/doc/languages-frameworks/lua.section.md
@@ -87,6 +87,7 @@ final: prev:
         pname = "luarocks-nix";
         src = /home/my_luarocks/repository;
       });
+    };
   };
 
   luaPackages = lua.pkgs;
@@ -154,7 +155,9 @@ You can develop your package as you usually would, just don't forget to wrap it
 within a `toLuaModule` call, for instance
 
 ```nix
-mynewlib = toLuaModule ( stdenv.mkDerivation { ... });
+{
+  mynewlib = toLuaModule ( stdenv.mkDerivation { /* ... */ });
+}
 ```
 
 There is also the `buildLuaPackage` function that can be used when lua modules
@@ -182,24 +185,26 @@ Each interpreter has the following attributes:
 The `buildLuarocksPackage` function is implemented in `pkgs/development/interpreters/lua-5/build-luarocks-package.nix`
 The following is an example:
 ```nix
-luaposix = buildLuarocksPackage {
-  pname = "luaposix";
-  version = "34.0.4-1";
+{
+  luaposix = buildLuarocksPackage {
+    pname = "luaposix";
+    version = "34.0.4-1";
 
-  src = fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/luaposix-34.0.4-1.src.rock";
-    hash = "sha256-4mLJG8n4m6y4Fqd0meUDfsOb9RHSR0qa/KD5KCwrNXs=";
-  };
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
-  propagatedBuildInputs = [ bit32 lua std_normalize ];
+    src = fetchurl {
+      url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/luaposix-34.0.4-1.src.rock";
+      hash = "sha256-4mLJG8n4m6y4Fqd0meUDfsOb9RHSR0qa/KD5KCwrNXs=";
+    };
+    disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+    propagatedBuildInputs = [ bit32 lua std_normalize ];
 
-  meta = {
-    homepage = "https://github.com/luaposix/luaposix/";
-    description = "Lua bindings for POSIX";
-    maintainers = with lib.maintainers; [ vyp lblasc ];
-    license.fullName = "MIT/X11";
+    meta = {
+      homepage = "https://github.com/luaposix/luaposix/";
+      description = "Lua bindings for POSIX";
+      maintainers = with lib.maintainers; [ vyp lblasc ];
+      license.fullName = "MIT/X11";
+    };
   };
-};
+}
 ```
 
 The `buildLuarocksPackage` delegates most tasks to luarocks:

--- a/doc/languages-frameworks/maven.section.md
+++ b/doc/languages-frameworks/maven.section.md
@@ -40,7 +40,7 @@ maven.buildMavenPackage rec {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ majiir ];
   };
-}:
+}
 ```
 
 This package calls `maven.buildMavenPackage` to do its work. The primary difference from `stdenv.mkDerivation` is the `mvnHash` variable, which is a hash of all of the Maven dependencies.

--- a/doc/languages-frameworks/ocaml.section.md
+++ b/doc/languages-frameworks/ocaml.section.md
@@ -92,6 +92,7 @@ buildDunePackage rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ sternenseemann ];
   };
+}
 ```
 
 Here is a second example, this time using a source archive generated with `dune-release`. It is a good idea to use this archive when it is available as it will usually contain substituted variables such as a `%%VERSION%%` field. This library does not depend on any other OCaml library and no tests are run after building it.

--- a/doc/languages-frameworks/perl.section.md
+++ b/doc/languages-frameworks/perl.section.md
@@ -34,23 +34,27 @@ Nixpkgs provides a function `buildPerlPackage`, a generic package builder functi
 Perl packages from CPAN are defined in [pkgs/top-level/perl-packages.nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/perl-packages.nix) rather than `pkgs/all-packages.nix`. Most Perl packages are so straight-forward to build that they are defined here directly, rather than having a separate function for each package called from `perl-packages.nix`. However, more complicated packages should be put in a separate file, typically in `pkgs/development/perl-modules`. Here is an example of the former:
 
 ```nix
-ClassC3 = buildPerlPackage rec {
-  pname = "Class-C3";
-  version = "0.21";
-  src = fetchurl {
-    url = "mirror://cpan/authors/id/F/FL/FLORA/${pname}-${version}.tar.gz";
-    hash = "sha256-/5GE5xHT0uYGOQxroqj6LMU7CtKn2s6vMVoSXxL4iK4=";
+{
+  ClassC3 = buildPerlPackage rec {
+    pname = "Class-C3";
+    version = "0.21";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/F/FL/FLORA/${pname}-${version}.tar.gz";
+      hash = "sha256-/5GE5xHT0uYGOQxroqj6LMU7CtKn2s6vMVoSXxL4iK4=";
+    };
   };
-};
+}
 ```
 
 Note the use of `mirror://cpan/`, and the `pname` and `version` in the URL definition to ensure that the `pname` attribute is consistent with the source that we’re actually downloading. Perl packages are made available in `all-packages.nix` through the variable `perlPackages`. For instance, if you have a package that needs `ClassC3`, you would typically write
 
 ```nix
-foo = import ../path/to/foo.nix {
-  inherit stdenv fetchurl ...;
-  inherit (perlPackages) ClassC3;
-};
+{
+  foo = import ../path/to/foo.nix {
+    inherit stdenv fetchurl /* ... */;
+    inherit (perlPackages) ClassC3;
+  };
+}
 ```
 
 in `all-packages.nix`. You can test building a Perl package as follows:
@@ -91,17 +95,19 @@ buildPerlPackage rec {
 Dependencies on other Perl packages can be specified in the `buildInputs` and `propagatedBuildInputs` attributes. If something is exclusively a build-time dependency, use `buildInputs`; if it’s (also) a runtime dependency, use `propagatedBuildInputs`. For instance, this builds a Perl module that has runtime dependencies on a bunch of other modules:
 
 ```nix
-ClassC3Componentised = buildPerlPackage rec {
-  pname = "Class-C3-Componentised";
-  version = "1.0004";
-  src = fetchurl {
-    url = "mirror://cpan/authors/id/A/AS/ASH/${pname}-${version}.tar.gz";
-    hash = "sha256-ASO9rV/FzJYZ0BH572Fxm2ZrFLMZLFATJng1NuU4FHc=";
+{
+  ClassC3Componentised = buildPerlPackage rec {
+    pname = "Class-C3-Componentised";
+    version = "1.0004";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/A/AS/ASH/${pname}-${version}.tar.gz";
+      hash = "sha256-ASO9rV/FzJYZ0BH572Fxm2ZrFLMZLFATJng1NuU4FHc=";
+    };
+    propagatedBuildInputs = [
+      ClassC3 ClassInspector TestException MROCompat
+    ];
   };
-  propagatedBuildInputs = [
-    ClassC3 ClassInspector TestException MROCompat
-  ];
-};
+}
 ```
 
 On Darwin, if a script has too many `-Idir` flags in its first line (its “shebang line”), it will not run. This can be worked around by calling the `shortenPerlShebang` function from the `postInstall` phase:
@@ -109,20 +115,22 @@ On Darwin, if a script has too many `-Idir` flags in its first line (its “sheb
 ```nix
 { lib, stdenv, buildPerlPackage, fetchurl, shortenPerlShebang }:
 
-ImageExifTool = buildPerlPackage {
-  pname = "Image-ExifTool";
-  version = "12.50";
+{
+  ImageExifTool = buildPerlPackage {
+    pname = "Image-ExifTool";
+    version = "12.50";
 
-  src = fetchurl {
-    url = "https://exiftool.org/${pname}-${version}.tar.gz";
-    hash = "sha256-vOhB/FwQMC8PPvdnjDvxRpU6jAZcC6GMQfc0AH4uwKg=";
+    src = fetchurl {
+      url = "https://exiftool.org/${pname}-${version}.tar.gz";
+      hash = "sha256-vOhB/FwQMC8PPvdnjDvxRpU6jAZcC6GMQfc0AH4uwKg=";
+    };
+
+    nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
+    postInstall = lib.optionalString stdenv.isDarwin ''
+      shortenPerlShebang $out/bin/exiftool
+    '';
   };
-
-  nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
-  postInstall = lib.optionalString stdenv.isDarwin ''
-    shortenPerlShebang $out/bin/exiftool
-  '';
-};
+}
 ```
 
 This will remove the `-I` flags from the shebang line, rewrite them in the `use lib` form, and put them on the next line instead. This function can be given any number of Perl scripts as arguments; it will modify them in-place.

--- a/doc/languages-frameworks/php.section.md
+++ b/doc/languages-frameworks/php.section.md
@@ -97,7 +97,7 @@ let
   myPhp = php.withExtensions ({ all, ... }: with all; [ imagick opcache ]);
 in {
   services.phpfpm.pools."foo".phpPackage = myPhp;
-};
+}
 ```
 
 ```nix
@@ -108,7 +108,7 @@ let
   };
 in {
   services.phpfpm.pools."foo".phpPackage = myPhp;
-};
+}
 ```
 
 #### Example usage with `nix-shell` {#ssec-php-user-guide-installing-with-extensions-nix-shell}
@@ -149,7 +149,7 @@ php.override {
     extensions = prev.extensions // {
       mysqlnd = prev.extensions.mysqlnd.overrideAttrs (attrs: {
         patches = attrs.patches or [] ++ [
-          …
+          # ...
         ];
       });
     };

--- a/doc/languages-frameworks/pkg-config.section.md
+++ b/doc/languages-frameworks/pkg-config.section.md
@@ -16,14 +16,14 @@ A good example of all these things is zlib:
 { pkg-config, testers, ... }:
 
 stdenv.mkDerivation (finalAttrs: {
-  ...
+  /* ... */
 
   nativeBuildInputs = [ pkg-config validatePkgConfig ];
 
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
 
   meta = {
-    ...
+    /* ... */
     pkgConfigModules = [ "zlib" ];
   };
 })

--- a/doc/languages-frameworks/pkg-config.section.md
+++ b/doc/languages-frameworks/pkg-config.section.md
@@ -12,7 +12,7 @@ Additionally, the [`validatePkgConfig` setup hook](https://nixos.org/manual/nixp
 
 A good example of all these things is zlib:
 
-```
+```nix
 { pkg-config, testers, ... }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -254,17 +254,19 @@ The next example shows a non trivial overriding of the `blas` implementation to
 be used through out all of the Python package set:
 
 ```nix
-python3MyBlas = pkgs.python3.override {
-  packageOverrides = self: super: {
-    # We need toPythonModule for the package set to evaluate this
-    blas = super.toPythonModule(super.pkgs.blas.override {
-      blasProvider = super.pkgs.mkl;
-    });
-    lapack = super.toPythonModule(super.pkgs.lapack.override {
-      lapackProvider = super.pkgs.mkl;
-    });
+{
+  python3MyBlas = pkgs.python3.override {
+    packageOverrides = self: super: {
+      # We need toPythonModule for the package set to evaluate this
+      blas = super.toPythonModule(super.pkgs.blas.override {
+        blasProvider = super.pkgs.mkl;
+      });
+      lapack = super.toPythonModule(super.pkgs.lapack.override {
+        lapackProvider = super.pkgs.mkl;
+      });
+    };
   };
-};
+}
 ```
 
 This is particularly useful for numpy and scipy users who want to gain speed with other blas implementations.
@@ -322,7 +324,9 @@ python3Packages.buildPythonApplication rec {
 This is then added to `all-packages.nix` just as any other application would be.
 
 ```nix
-luigi = callPackage ../applications/networking/cluster/luigi { };
+{
+  luigi = callPackage ../applications/networking/cluster/luigi { };
+}
 ```
 
 Since the package is an application, a consumer doesn't need to care about
@@ -342,7 +346,9 @@ the attribute in `python-packages.nix`, and the `toPythonApplication` shall be
 applied to the reference:
 
 ```nix
-youtube-dl = with python3Packages; toPythonApplication youtube-dl;
+{
+  youtube-dl = with python3Packages; toPythonApplication youtube-dl;
+}
 ```
 
 #### `toPythonModule` function {#topythonmodule-function}
@@ -354,10 +360,12 @@ bindings should be made available from `python-packages.nix`. The
 modifications.
 
 ```nix
-opencv = toPythonModule (pkgs.opencv.override {
-  enablePython = true;
-  pythonPackages = self;
-});
+{
+  opencv = toPythonModule (pkgs.opencv.override {
+    enablePython = true;
+    pythonPackages = self;
+  });
+}
 ```
 
 Do pay attention to passing in the right Python version!
@@ -1198,6 +1206,7 @@ Pytest is the most common test runner for python repositories. A trivial
 test run would be:
 
 ```nix
+{
   nativeCheckInputs = [ pytest ];
   checkPhase = ''
     runHook preCheck
@@ -1206,6 +1215,7 @@ test run would be:
 
     runHook postCheck
   '';
+}
 ```
 
 However, many repositories' test suites do not translate well to nix's build
@@ -1214,6 +1224,7 @@ sandbox, and will generally need many tests to be disabled.
 To filter tests using pytest, one can do the following:
 
 ```nix
+{
   nativeCheckInputs = [ pytest ];
   # avoid tests which need additional data or touch network
   checkPhase = ''
@@ -1223,6 +1234,7 @@ To filter tests using pytest, one can do the following:
 
     runHook postCheck
   '';
+}
 ```
 
 `--ignore` will tell pytest to ignore that file or directory from being
@@ -1249,6 +1261,7 @@ when a package may need many items disabled to run the test suite.
 Using the example above, the analogous `pytestCheckHook` usage would be:
 
 ```nix
+{
   nativeCheckInputs = [
     pytestCheckHook
   ];
@@ -1268,12 +1281,14 @@ Using the example above, the analogous `pytestCheckHook` usage would be:
   disabledTestPaths = [
     "tests/test_failing.py"
   ];
+}
 ```
 
 This is especially useful when tests need to be conditionally disabled,
 for example:
 
 ```nix
+{
   disabledTests = [
     # touches network
     "download"
@@ -1285,6 +1300,7 @@ for example:
     # can fail when building with other packages
     "socket"
   ];
+}
 ```
 
 Trying to concatenate the related strings to disable tests in a regular
@@ -1299,19 +1315,23 @@ To help ensure the package still works, [`pythonImportsCheck`](#using-pythonimpo
 the listed modules.
 
 ```nix
+{
   pythonImportsCheck = [
     "requests"
     "urllib"
   ];
+}
 ```
 
 roughly translates to:
 
 ```nix
+{
   postCheck = ''
     PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
     python -c "import requests; import urllib"
   '';
+}
 ```
 
 However, this is done in its own phase, and not dependent on whether [`doCheck = true;`](#var-stdenv-doCheck).
@@ -1343,6 +1363,7 @@ pkg3>=1.0,<=2.0
 we can do:
 
 ```nix
+{
   nativeBuildInputs = [
     pythonRelaxDepsHook
   ];
@@ -1353,6 +1374,7 @@ we can do:
   pythonRemoveDeps = [
     "pkg2"
   ];
+}
 ```
 
 which would result in the following `requirements.txt` file:
@@ -1366,8 +1388,10 @@ Another option is to pass `true`, that will relax/remove all dependencies, for
 example:
 
 ```nix
+{
   nativeBuildInputs = [ pythonRelaxDepsHook ];
   pythonRelaxDeps = true;
+}
 ```
 
 which would result in the following `requirements.txt` file:
@@ -1393,6 +1417,7 @@ work with any of the [existing hooks](#setup-hooks).
 `unittestCheckHook` is a hook which will substitute the setuptools `test` command for a [`checkPhase`](#ssec-check-phase) which runs `python -m unittest discover`:
 
 ```nix
+{
   nativeCheckInputs = [
     unittestCheckHook
   ];
@@ -1400,6 +1425,7 @@ work with any of the [existing hooks](#setup-hooks).
   unittestFlagsArray = [
     "-s" "tests" "-v"
   ];
+}
 ```
 
 #### Using sphinxHook {#using-sphinxhook}
@@ -1410,6 +1436,7 @@ It is setup to automatically find common documentation source paths and
 render them using the default `html` style.
 
 ```nix
+{
   outputs = [
     "out"
     "doc"
@@ -1418,6 +1445,7 @@ render them using the default `html` style.
   nativeBuildInputs = [
     sphinxHook
   ];
+}
 ```
 
 The hook will automatically build and install the artifact into the
@@ -1425,6 +1453,7 @@ The hook will automatically build and install the artifact into the
 for the artifacts of the `man` builder into the `man` target.
 
 ```nix
+{
   outputs = [
     "out"
     "doc"
@@ -1436,14 +1465,17 @@ for the artifacts of the `man` builder into the `man` target.
     "singlehtml"
     "man"
   ];
+}
 ```
 
 Overwrite `sphinxRoot` when the hook is unable to find your
 documentation source root.
 
 ```nix
+{
   # Configure sphinxRoot for uncommon paths
   sphinxRoot = "weird/docs/path";
+}
 ```
 
 The hook is also available to packages outside the python ecosystem by
@@ -1827,6 +1859,7 @@ folder and not downloaded again.
 If you need to change a package's attribute(s) from `configuration.nix` you could do:
 
 ```nix
+{
   nixpkgs.config.packageOverrides = super: {
     python3 = super.python3.override {
       packageOverrides = python-self: python-super: {
@@ -1841,6 +1874,7 @@ If you need to change a package's attribute(s) from `configuration.nix` you coul
       };
     };
   };
+}
 ```
 
 `python3Packages.twisted` is now globally overridden.
@@ -1853,11 +1887,13 @@ To modify only a Python package set instead of a whole Python derivation, use
 this snippet:
 
 ```nix
+{
   myPythonPackages = python3Packages.override {
     overrides = self: super: {
-      twisted = ...;
+      twisted = "...";
     };
-  }
+  };
+}
 ```
 
 ### How to override a Python package using overlays? {#how-to-override-a-python-package-using-overlays}
@@ -1893,7 +1929,7 @@ final: prev: {
     (
       python-final: python-prev: {
         foo = python-prev.foo.overridePythonAttrs (oldAttrs: {
-          ...
+          # ...
         });
       }
     )
@@ -1938,17 +1974,21 @@ Some packages define optional dependencies for additional features. With
 `extras-require`, while PEP 621 calls these `optional-dependencies`.
 
 ```nix
-optional-dependencies = {
-  complete = [ distributed ];
-};
+{
+  optional-dependencies = {
+    complete = [ distributed ];
+  };
+}
 ```
 
 and letting the package requiring the extra add the list to its dependencies
 
 ```nix
-dependencies = [
-  ...
-] ++ dask.optional-dependencies.complete;
+{
+  dependencies = [
+    # ...
+  ] ++ dask.optional-dependencies.complete;
+}
 ```
 
 This method is using `passthru`, meaning that changing `optional-dependencies` of a package won't cause it to rebuild.

--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1197,7 +1197,7 @@ a good indication that the package is not in a valid state.
 Pytest is the most common test runner for python repositories. A trivial
 test run would be:
 
-```
+```nix
   nativeCheckInputs = [ pytest ];
   checkPhase = ''
     runHook preCheck
@@ -1213,7 +1213,7 @@ sandbox, and will generally need many tests to be disabled.
 
 To filter tests using pytest, one can do the following:
 
-```
+```nix
   nativeCheckInputs = [ pytest ];
   # avoid tests which need additional data or touch network
   checkPhase = ''
@@ -1248,7 +1248,7 @@ when a package may need many items disabled to run the test suite.
 
 Using the example above, the analogous `pytestCheckHook` usage would be:
 
-```
+```nix
   nativeCheckInputs = [
     pytestCheckHook
   ];
@@ -1273,7 +1273,7 @@ Using the example above, the analogous `pytestCheckHook` usage would be:
 This is especially useful when tests need to be conditionally disabled,
 for example:
 
-```
+```nix
   disabledTests = [
     # touches network
     "download"
@@ -1298,7 +1298,7 @@ all packages have test suites that can be run easily, and some have none at all.
 To help ensure the package still works, [`pythonImportsCheck`](#using-pythonimportscheck) can attempt to import
 the listed modules.
 
-```
+```nix
   pythonImportsCheck = [
     "requests"
     "urllib"
@@ -1307,7 +1307,7 @@ the listed modules.
 
 roughly translates to:
 
-```
+```nix
   postCheck = ''
     PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
     python -c "import requests; import urllib"
@@ -1342,7 +1342,7 @@ pkg3>=1.0,<=2.0
 
 we can do:
 
-```
+```nix
   nativeBuildInputs = [
     pythonRelaxDepsHook
   ];
@@ -1365,7 +1365,7 @@ pkg3
 Another option is to pass `true`, that will relax/remove all dependencies, for
 example:
 
-```
+```nix
   nativeBuildInputs = [ pythonRelaxDepsHook ];
   pythonRelaxDeps = true;
 ```
@@ -1392,7 +1392,7 @@ work with any of the [existing hooks](#setup-hooks).
 
 `unittestCheckHook` is a hook which will substitute the setuptools `test` command for a [`checkPhase`](#ssec-check-phase) which runs `python -m unittest discover`:
 
-```
+```nix
   nativeCheckInputs = [
     unittestCheckHook
   ];
@@ -1409,7 +1409,7 @@ using the popular Sphinx documentation generator.
 It is setup to automatically find common documentation source paths and
 render them using the default `html` style.
 
-```
+```nix
   outputs = [
     "out"
     "doc"
@@ -1424,7 +1424,7 @@ The hook will automatically build and install the artifact into the
 `doc` output, if it exists. It also provides an automatic diversion
 for the artifacts of the `man` builder into the `man` target.
 
-```
+```nix
   outputs = [
     "out"
     "doc"
@@ -1441,7 +1441,7 @@ for the artifacts of the `man` builder into the `man` target.
 Overwrite `sphinxRoot` when the hook is unable to find your
 documentation source root.
 
-```
+```nix
   # Configure sphinxRoot for uncommon paths
   sphinxRoot = "weird/docs/path";
 ```
@@ -1920,7 +1920,7 @@ The Python interpreters are by default not built with optimizations enabled, bec
 the builds are in that case not reproducible. To enable optimizations, override the
 interpreter of interest, e.g using
 
-```
+```nix
 let
   pkgs = import ./. {};
   mypython = pkgs.python3.override {

--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1890,7 +1890,7 @@ this snippet:
 {
   myPythonPackages = python3Packages.override {
     overrides = self: super: {
-      twisted = "...";
+      twisted = <...>;
     };
   };
 }

--- a/doc/languages-frameworks/ruby.section.md
+++ b/doc/languages-frameworks/ruby.section.md
@@ -124,11 +124,13 @@ mkShell { buildInputs = [ gems (lowPrio gems.wrappedRuby) ]; }
 Sometimes a Gemfile references other files. Such as `.ruby-version` or vendored gems. When copying the Gemfile to the nix store we need to copy those files alongside. This can be done using `extraConfigPaths`. For example:
 
 ```nix
+{
   gems = bundlerEnv {
     name = "gems-for-some-project";
     gemdir = ./.;
     extraConfigPaths = [ "${./.}/.ruby-version" ];
   };
+}
 ```
 
 ### Gem-specific configurations and workarounds {#gem-specific-configurations-and-workarounds}

--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -458,7 +458,7 @@ function does not require a hash (unless git dependencies are used)
 and fetches every dependency as a separate fixed-output derivation.
 `importCargoLock` can be used as follows:
 
-```
+```nix
 cargoDeps = rustPlatform.importCargoLock {
   lockFile = ./Cargo.lock;
 };
@@ -468,7 +468,7 @@ If the `Cargo.lock` file includes git dependencies, then their output
 hashes need to be specified since they are not available through the
 lock file. For example:
 
-```
+```nix
 cargoDeps = rustPlatform.importCargoLock {
   lockFile = ./Cargo.lock;
   outputHashes = {

--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -3,10 +3,12 @@
 To install the rust compiler and cargo put
 
 ```nix
-environment.systemPackages = [
-  rustc
-  cargo
-];
+{
+  environment.systemPackages = [
+    rustc
+    cargo
+  ];
+}
 ```
 
 into your `configuration.nix` or bring them into scope with `nix-shell -p rustc cargo`.
@@ -51,7 +53,9 @@ preferred over `cargoSha256` which was used for traditional Nix SHA-256 hashes.
 For example:
 
 ```nix
+{
   cargoHash = "sha256-l1vL2ZdtDRxSGvP0X/l3nMw8+6WF67KPutJEzUROjg8=";
+}
 ```
 
 Exception: If the application has cargo `git` dependencies, the `cargoHash`/`cargoSha256`
@@ -67,13 +71,17 @@ then be taken from the failed build. A fake hash can be used for
 `cargoHash` as follows:
 
 ```nix
+{
   cargoHash = lib.fakeHash;
+}
 ```
 
 For `cargoSha256` you can use:
 
 ```nix
+{
   cargoSha256 = lib.fakeSha256;
+}
 ```
 
 Per the instructions in the [Cargo Book](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html)
@@ -162,9 +170,11 @@ doesn't add a `Cargo.lock` to your `src`, and a `Cargo.lock` is still
 required to build a rust package. A simple fix is to use:
 
 ```nix
-postPatch = ''
-  ln -s ${./Cargo.lock} Cargo.lock
-'';
+{
+  postPatch = ''
+    ln -s ${./Cargo.lock} Cargo.lock
+  '';
+}
 ```
 
 The output hash of each dependency that uses a git source must be
@@ -409,7 +419,7 @@ the `cargoPatches` attribute to update or add it.
 
 ```nix
 rustPlatform.buildRustPackage rec {
-  (...)
+  # ...
   cargoPatches = [
     # a patch file to add/update Cargo.lock in the source code
     ./add-Cargo.lock.patch
@@ -433,10 +443,12 @@ containing `Cargo.toml` and `Cargo.lock`, `fetchCargoTarball`
 can be used as follows:
 
 ```nix
-cargoDeps = rustPlatform.fetchCargoTarball {
-  inherit src;
-  hash = "sha256-BoHIN/519Top1NUBjpB/oEMqi86Omt3zTQcXFWqrek0=";
-};
+{
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    hash = "sha256-BoHIN/519Top1NUBjpB/oEMqi86Omt3zTQcXFWqrek0=";
+  };
+}
 ```
 
 The `src` attribute is required, as well as a hash specified through
@@ -459,9 +471,11 @@ and fetches every dependency as a separate fixed-output derivation.
 `importCargoLock` can be used as follows:
 
 ```nix
-cargoDeps = rustPlatform.importCargoLock {
-  lockFile = ./Cargo.lock;
-};
+{
+  cargoDeps = rustPlatform.importCargoLock {
+    lockFile = ./Cargo.lock;
+  };
+}
 ```
 
 If the `Cargo.lock` file includes git dependencies, then their output
@@ -469,12 +483,14 @@ hashes need to be specified since they are not available through the
 lock file. For example:
 
 ```nix
-cargoDeps = rustPlatform.importCargoLock {
-  lockFile = ./Cargo.lock;
-  outputHashes = {
-    "rand-0.8.3" = "0ya2hia3cn31qa8894s3av2s8j5bjwb6yq92k0jsnlx7jid0jwqa";
+{
+  cargoDeps = rustPlatform.importCargoLock {
+    lockFile = ./Cargo.lock;
+    outputHashes = {
+      "rand-0.8.3" = "0ya2hia3cn31qa8894s3av2s8j5bjwb6yq92k0jsnlx7jid0jwqa";
+    };
   };
-};
+}
 ```
 
 If you do not specify an output hash for a git dependency, building
@@ -792,27 +808,27 @@ general. A number of other parameters can be overridden:
 - The version of `rustc` used to compile the crate:
 
   ```nix
-  (hello {}).override { rust = pkgs.rust; };
+  (hello {}).override { rust = pkgs.rust; }
   ```
 
 - Whether to build in release mode or debug mode (release mode by
   default):
 
   ```nix
-  (hello {}).override { release = false; };
+  (hello {}).override { release = false; }
   ```
 
 - Whether to print the commands sent to `rustc` when building
   (equivalent to `--verbose` in cargo:
 
   ```nix
-  (hello {}).override { verbose = false; };
+  (hello {}).override { verbose = false; }
   ```
 
 - Extra arguments to be passed to `rustc`:
 
   ```nix
-  (hello {}).override { extraRustcOpts = "-Z debuginfo=2"; };
+  (hello {}).override { extraRustcOpts = "-Z debuginfo=2"; }
   ```
 
 - Phases, just like in any other derivation, can be specified using
@@ -828,7 +844,7 @@ general. A number of other parameters can be overridden:
     preConfigure = ''
        echo "pub const PATH=\"${hi.out}\";" >> src/path.rs"
     '';
-  };
+  }
   ```
 
 ### Setting Up `nix-shell` {#setting-up-nix-shell}

--- a/doc/languages-frameworks/swift.section.md
+++ b/doc/languages-frameworks/swift.section.md
@@ -147,7 +147,7 @@ them, we need to make them writable.
 A special function `swiftpmMakeMutable` is available to replace the symlink
 with a writable copy:
 
-```
+```nix
 configurePhase = generated.configure ++ ''
   # Replace the dependency symlink with a writable copy.
   swiftpmMakeMutable swift-crypto

--- a/doc/languages-frameworks/swift.section.md
+++ b/doc/languages-frameworks/swift.section.md
@@ -112,13 +112,17 @@ stdenv.mkDerivation rec {
 If you'd like to build a different configuration than `release`:
 
 ```nix
-swiftpmBuildConfig = "debug";
+{
+  swiftpmBuildConfig = "debug";
+}
 ```
 
 It is also possible to provide additional flags to `swift build`:
 
 ```nix
-swiftpmFlags = [ "--disable-dead-strip" ];
+{
+  swiftpmFlags = [ "--disable-dead-strip" ];
+}
 ```
 
 The default `buildPhase` already passes `-j` for parallel building.
@@ -132,7 +136,9 @@ Including `swiftpm` in your `nativeBuildInputs` also provides a default
 `checkPhase`, but it must be enabled with:
 
 ```nix
-doCheck = true;
+{
+  doCheck = true;
+}
 ```
 
 This essentially runs: `swift test -c release`
@@ -148,12 +154,14 @@ A special function `swiftpmMakeMutable` is available to replace the symlink
 with a writable copy:
 
 ```nix
-configurePhase = generated.configure ++ ''
-  # Replace the dependency symlink with a writable copy.
-  swiftpmMakeMutable swift-crypto
-  # Now apply a patch.
-  patch -p1 -d .build/checkouts/swift-crypto -i ${./some-fix.patch}
-'';
+{
+  configurePhase = generated.configure ++ ''
+    # Replace the dependency symlink with a writable copy.
+    swiftpmMakeMutable swift-crypto
+    # Now apply a patch.
+    patch -p1 -d .build/checkouts/swift-crypto -i ${./some-fix.patch}
+  '';
+}
 ```
 
 ## Considerations for custom build tools {#ssec-swift-considerations-for-custom-build-tools}

--- a/doc/languages-frameworks/vim.section.md
+++ b/doc/languages-frameworks/vim.section.md
@@ -219,9 +219,11 @@ After running the updater, if nvim-treesitter received an update, also run [`nvi
 Some plugins require overrides in order to function properly. Overrides are placed in [overrides.nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/vim/plugins/overrides.nix). Overrides are most often required when a plugin requires some dependencies, or extra steps are required during the build process. For example `deoplete-fish` requires both `deoplete-nvim` and `vim-fish`, and so the following override was added:
 
 ```nix
-deoplete-fish = super.deoplete-fish.overrideAttrs(old: {
-  dependencies = with super; [ deoplete-nvim vim-fish ];
-});
+{
+  deoplete-fish = super.deoplete-fish.overrideAttrs(old: {
+    dependencies = with super; [ deoplete-nvim vim-fish ];
+  });
+}
 ```
 
 Sometimes plugins require an override that must be changed when the plugin is updated. This can cause issues when Vim plugins are auto-updated but the associated override isn't updated. For these plugins, the override should be written so that it specifies all information required to install the plugin, and running `./update.py` doesn't change the derivation for the plugin. Manually updating the override is required to update these types of plugins. An example of such a plugin is `LanguageClient-neovim`.
@@ -264,8 +266,10 @@ pwntester/octo.nvim,,
 You can then reference the generated vim plugins via:
 
 ```nix
-myVimPlugins = pkgs.vimPlugins.extend (
-  (pkgs.callPackage ./generated.nix {})
-);
+{
+  myVimPlugins = pkgs.vimPlugins.extend (
+    (pkgs.callPackage ./generated.nix {})
+  );
+}
 ```
 

--- a/doc/packages/darwin-builder.section.md
+++ b/doc/packages/darwin-builder.section.md
@@ -81,7 +81,7 @@ $ sudo launchctl kickstart -k system/org.nixos.nix-daemon
 
 ## Example flake usage {#sec-darwin-builder-example-flake}
 
-```
+```nix
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-22.11-darwin";
@@ -153,7 +153,7 @@ you may use it to build a modified remote builder with additional storage or mem
 To do this, you just need to set the `virtualisation.darwin-builder.*` parameters as
 in the example below and rebuild.
 
-```
+```nix
     darwin-builder = nixpkgs.lib.nixosSystem {
       system = linuxSystem;
       modules = [

--- a/doc/packages/darwin-builder.section.md
+++ b/doc/packages/darwin-builder.section.md
@@ -154,6 +154,7 @@ To do this, you just need to set the `virtualisation.darwin-builder.*` parameter
 in the example below and rebuild.
 
 ```nix
+  {
     darwin-builder = nixpkgs.lib.nixosSystem {
       system = linuxSystem;
       modules = [
@@ -166,6 +167,8 @@ in the example below and rebuild.
           virtualisation.darwin-builder.workingDirectory = "/var/lib/darwin-builder";
         }
       ];
+    };
+  }
 ```
 
 You may make any other changes to your VM in this attribute set. For example,

--- a/doc/packages/eclipse.section.md
+++ b/doc/packages/eclipse.section.md
@@ -13,11 +13,13 @@ Once an Eclipse variant is installed, it can be run using the `eclipse` command,
 If you prefer to install plugins in a more declarative manner, then Nixpkgs also offer a number of Eclipse plugins that can be installed in an _Eclipse environment_. This type of environment is created using the function `eclipseWithPlugins` found inside the `nixpkgs.eclipses` attribute set. This function takes as argument `{ eclipse, plugins ? [], jvmArgs ? [] }` where `eclipse` is a one of the Eclipse packages described above, `plugins` is a list of plugin derivations, and `jvmArgs` is a list of arguments given to the JVM running the Eclipse. For example, say you wish to install the latest Eclipse Platform with the popular Eclipse Color Theme plugin and also allow Eclipse to use more RAM. You could then add:
 
 ```nix
-packageOverrides = pkgs: {
-  myEclipse = with pkgs.eclipses; eclipseWithPlugins {
-    eclipse = eclipse-platform;
-    jvmArgs = [ "-Xmx2048m" ];
-    plugins = [ plugins.color-theme ];
+{
+  packageOverrides = pkgs: {
+    myEclipse = with pkgs.eclipses; eclipseWithPlugins {
+      eclipse = eclipse-platform;
+      jvmArgs = [ "-Xmx2048m" ];
+      plugins = [ plugins.color-theme ];
+    };
   };
 }
 ```
@@ -33,32 +35,34 @@ If there is a need to install plugins that are not available in Nixpkgs then it 
 Expanding the previous example with two plugins using the above functions, we have:
 
 ```nix
-packageOverrides = pkgs: {
-  myEclipse = with pkgs.eclipses; eclipseWithPlugins {
-    eclipse = eclipse-platform;
-    jvmArgs = [ "-Xmx2048m" ];
-    plugins = [
-      plugins.color-theme
-      (plugins.buildEclipsePlugin {
-        name = "myplugin1-1.0";
-        srcFeature = fetchurl {
-          url = "http://…/features/myplugin1.jar";
-          hash = "sha256-123…";
-        };
-        srcPlugin = fetchurl {
-          url = "http://…/plugins/myplugin1.jar";
-          hash = "sha256-123…";
-        };
-      });
-      (plugins.buildEclipseUpdateSite {
-        name = "myplugin2-1.0";
-        src = fetchurl {
-          stripRoot = false;
-          url = "http://…/myplugin2.zip";
-          hash = "sha256-123…";
-        };
-      });
-    ];
+{
+  packageOverrides = pkgs: {
+    myEclipse = with pkgs.eclipses; eclipseWithPlugins {
+      eclipse = eclipse-platform;
+      jvmArgs = [ "-Xmx2048m" ];
+      plugins = [
+        plugins.color-theme
+        (plugins.buildEclipsePlugin {
+          name = "myplugin1-1.0";
+          srcFeature = fetchurl {
+            url = "http://…/features/myplugin1.jar";
+            hash = "sha256-123…";
+          };
+          srcPlugin = fetchurl {
+            url = "http://…/plugins/myplugin1.jar";
+            hash = "sha256-123…";
+          };
+        })
+        (plugins.buildEclipseUpdateSite {
+          name = "myplugin2-1.0";
+          src = fetchurl {
+            stripRoot = false;
+            url = "http://…/myplugin2.zip";
+            hash = "sha256-123…";
+          };
+        })
+      ];
+    };
   };
 }
 ```

--- a/doc/packages/emacs.section.md
+++ b/doc/packages/emacs.section.md
@@ -16,7 +16,7 @@ The Emacs package comes with some extra helpers to make it easier to configure. 
       projectile
       use-package
     ]));
-  }
+  };
 }
 ```
 
@@ -102,10 +102,12 @@ This provides a fairly full Emacs start file. It will load in addition to the us
 Sometimes `emacs.pkgs.withPackages` is not enough, as this package set has some priorities imposed on packages (with the lowest priority assigned to GNU-devel ELPA, and the highest for packages manually defined in `pkgs/applications/editors/emacs/elisp-packages/manual-packages`). But you can't control these priorities when some package is installed as a dependency. You can override it on a per-package-basis, providing all the required dependencies manually, but it's tedious and there is always a possibility that an unwanted dependency will sneak in through some other package. To completely override such a package, you can use `overrideScope`.
 
 ```nix
-overrides = self: super: rec {
-  haskell-mode = self.melpaPackages.haskell-mode;
-  ...
-};
+let
+  overrides = self: super: rec {
+    haskell-mode = self.melpaPackages.haskell-mode;
+    # ...
+  };
+in
 ((emacsPackagesFor emacs).overrideScope overrides).withPackages
   (p: with p; [
     # here both these package will use haskell-mode of our own choice
@@ -113,3 +115,4 @@ overrides = self: super: rec {
     dante
   ])
 ```
+}

--- a/doc/packages/steam.section.md
+++ b/doc/packages/steam.section.md
@@ -51,7 +51,7 @@ Use `programs.steam.enable = true;` if you want to add steam to `systemPackages`
     you need to add:
 
     ```nix
-    steam.override { withJava = true; };
+    steam.override { withJava = true; }
     ```
 
 ## steam-run {#sec-steam-run}

--- a/doc/packages/urxvt.section.md
+++ b/doc/packages/urxvt.section.md
@@ -65,7 +65,9 @@ A plugin can be any kind of derivation, the only requirement is that it should a
 If the plugin is itself a Perl package that needs to be imported from other plugins or scripts, add the following passthrough:
 
 ```nix
-passthru.perlPackages = [ "self" ];
+{
+  passthru.perlPackages = [ "self" ];
+}
 ```
 
 This will make the urxvt wrapper pick up the dependency and set up the Perl path accordingly.

--- a/doc/packages/weechat.section.md
+++ b/doc/packages/weechat.section.md
@@ -3,9 +3,9 @@
 WeeChat can be configured to include your choice of plugins, reducing its closure size from the default configuration which includes all available plugins. To make use of this functionality, install an expression that overrides its configuration, such as:
 
 ```nix
-weechat.override {configure = {availablePlugins, ...}: {
+weechat.override {configure = ({availablePlugins, ...}: {
     plugins = with availablePlugins; [ python perl ];
-  }
+  });
 }
 ```
 
@@ -59,7 +59,7 @@ weechat.override {
     ];
     init = ''
       /set plugins.var.python.jabber.key "val"
-    '':
+    '';
   };
 }
 ```

--- a/doc/stdenv/cross-compilation.chapter.md
+++ b/doc/stdenv/cross-compilation.chapter.md
@@ -15,7 +15,9 @@ Nixpkgs follows the [conventions of GNU autoconf](https://gcc.gnu.org/onlinedocs
 In Nixpkgs, these three platforms are defined as attribute sets under the names `buildPlatform`, `hostPlatform`, and `targetPlatform`. They are always defined as attributes in the standard environment. That means one can access them like:
 
 ```nix
-{ stdenv, fooDep, barDep, ... }: ...stdenv.buildPlatform...
+{ stdenv, fooDep, barDep, ... }: {
+  # ...stdenv.buildPlatform...
+}
 ```
 
 `buildPlatform`
@@ -127,7 +129,9 @@ Some frequently encountered problems when packaging for cross-compilation should
 Many packages assume that an unprefixed binutils (`cc`/`ar`/`ld` etc.) is available, but Nix doesn't provide one. It only provides a prefixed one, just as it only does for all the other binutils programs. It may be necessary to patch the package to fix the build system to use a prefix. For instance, instead of `cc`, use `${stdenv.cc.targetPrefix}cc`.
 
 ```nix
-makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+{
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+}
 ```
 
 #### How do I avoid compiling a GCC cross-compiler from source? {#cross-qa-avoid-compiling-gcc-cross-compiler}
@@ -142,7 +146,9 @@ $ nix-build '<nixpkgs>' -A pkgsCross.raspberryPi.hello
 Add the following to your `mkDerivation` invocation.
 
 ```nix
-depsBuildBuild = [ buildPackages.stdenv.cc ];
+{
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+}
 ```
 
 #### My package’s testsuite needs to run host platform code. {#cross-testsuite-runs-host-code}
@@ -150,7 +156,9 @@ depsBuildBuild = [ buildPackages.stdenv.cc ];
 Add the following to your `mkDerivation` invocation.
 
 ```nix
-doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+{
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+}
 ```
 
 #### Package using Meson needs to run binaries for the host platform during build. {#cross-meson-runs-host-code}
@@ -160,11 +168,13 @@ Add `mesonEmulatorHook` to `nativeBuildInputs` conditionally on if the target bi
 e.g.
 
 ```nix
-nativeBuildInputs = [
-  meson
-] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-  mesonEmulatorHook
-];
+{
+  nativeBuildInputs = [
+    meson
+  ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    mesonEmulatorHook
+  ];
+}
 ```
 
 Example of an error which this fixes.

--- a/doc/stdenv/cross-compilation.chapter.md
+++ b/doc/stdenv/cross-compilation.chapter.md
@@ -159,7 +159,7 @@ Add `mesonEmulatorHook` to `nativeBuildInputs` conditionally on if the target bi
 
 e.g.
 
-```
+```nix
 nativeBuildInputs = [
   meson
 ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -3,17 +3,19 @@
 Nix packages can declare *meta-attributes* that contain information about a package such as a description, its homepage, its license, and so on. For instance, the GNU Hello package has a `meta` declaration like this:
 
 ```nix
-meta = {
-  description = "A program that produces a familiar, friendly greeting";
-  longDescription = ''
-    GNU Hello is a program that prints "Hello, world!" when you run it.
-    It is fully customizable.
-  '';
-  homepage = "https://www.gnu.org/software/hello/manual/";
-  license = lib.licenses.gpl3Plus;
-  maintainers = with lib.maintainers; [ eelco ];
-  platforms = lib.platforms.all;
-};
+{
+  meta = {
+    description = "A program that produces a familiar, friendly greeting";
+    longDescription = ''
+      GNU Hello is a program that prints "Hello, world!" when you run it.
+      It is fully customizable.
+    '';
+    homepage = "https://www.gnu.org/software/hello/manual/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ eelco ];
+    platforms = lib.platforms.all;
+  };
+}
 ```
 
 Meta-attributes are not passed to the builder of the package. Thus, a change to a meta-attribute doesn’t trigger a recompilation of the package.
@@ -82,7 +84,9 @@ The *priority* of the package, used by `nix-env` to resolve file name conflicts 
 The list of Nix platform types on which the package is supported. Hydra builds packages according to the platform specified. If no platform is specified, the package does not have prebuilt binaries. An example is:
 
 ```nix
-meta.platforms = lib.platforms.linux;
+{
+  meta.platforms = lib.platforms.linux;
+}
 ```
 
 Attribute Set `lib.platforms` defines [various common lists](https://github.com/NixOS/nixpkgs/blob/master/lib/systems/doubles.nix) of platforms types.
@@ -95,8 +99,10 @@ In general it is preferable to set `meta.platforms = lib.platforms.all` and then
 For example, a package which requires dynamic linking and cannot be linked statically could use this:
 
 ```nix
-meta.platforms = lib.platforms.all;
-meta.badPlatforms = [ lib.systems.inspect.patterns.isStatic ];
+{
+  meta.platforms = lib.platforms.all;
+  meta.badPlatforms = [ lib.systems.inspect.patterns.isStatic ];
+}
 ```
 
 The [`lib.meta.availableOn`](https://github.com/NixOS/nixpkgs/blob/b03ac42b0734da3e7be9bf8d94433a5195734b19/lib/meta.nix#L95-L106) function can be used to test whether or not a package is available (i.e. buildable) on a given platform.
@@ -136,7 +142,7 @@ For more on how to write and run package tests, see [](#sec-package-tests).
 The NixOS tests are available as `nixosTests` in parameters of derivations. For instance, the OpenSMTPD derivation includes lines similar to:
 
 ```nix
-{ /* ... */, nixosTests }:
+{ /* ... , */ nixosTests }:
 {
   # ...
   passthru.tests = {
@@ -194,8 +200,10 @@ To be effective, it must be presented directly to an evaluation process that han
 The list of Nix platform types for which the [Hydra](https://github.com/nixos/hydra) [instance at `hydra.nixos.org`](https://nixos.org/hydra) will build the package. (Hydra is the Nix-based continuous build system.) It defaults to the value of `meta.platforms`. Thus, the only reason to set `meta.hydraPlatforms` is if you want `hydra.nixos.org` to build the package on a subset of `meta.platforms`, or not at all, e.g.
 
 ```nix
-meta.platforms = lib.platforms.linux;
-meta.hydraPlatforms = [];
+{
+  meta.platforms = lib.platforms.linux;
+  meta.hydraPlatforms = [];
+}
 ```
 
 ### `broken` {#var-meta-broken}
@@ -209,13 +217,17 @@ This means that `broken` can be used to express constraints, for example:
 - Does not cross compile
 
   ```nix
-   meta.broken = !(stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+  {
+    meta.broken = !(stdenv.buildPlatform.canExecute stdenv.hostPlatform);
+  }
   ```
 
 - Broken if all of a certain set of its dependencies are broken
 
   ```nix
-  meta.broken = lib.all (map (p: p.meta.broken) [ glibc musl ])
+  {
+    meta.broken = lib.all (map (p: p.meta.broken) [ glibc musl ]);
+  }
   ```
 
 This makes `broken` strictly more powerful than `meta.badPlatforms`.

--- a/doc/stdenv/multiple-output.chapter.md
+++ b/doc/stdenv/multiple-output.chapter.md
@@ -30,7 +30,9 @@ Here you find how to write a derivation that produces multiple outputs.
 In nixpkgs there is a framework supporting multiple-output derivations. It tries to cover most cases by default behavior. You can find the source separated in `<nixpkgs/pkgs/build-support/setup-hooks/multiple-outputs.sh>`; it’s relatively well-readable. The whole machinery is triggered by defining the `outputs` attribute to contain the list of desired output names (strings).
 
 ```nix
-outputs = [ "bin" "dev" "out" "doc" ];
+{
+  outputs = [ "bin" "dev" "out" "doc" ];
+}
 ```
 
 Often such a single line is enough. For each output an equally named environment variable is passed to the builder and contains the path in nix store for that output. Typically you also want to have the main `out` output, as it catches any files that didn’t get elsewhere.

--- a/doc/using/configuration.chapter.md
+++ b/doc/using/configuration.chapter.md
@@ -176,7 +176,7 @@ You can define a function called `packageOverrides` in your local `~/.config/nix
 ```nix
 {
   packageOverrides = pkgs: rec {
-    foo = pkgs.foo.override { ... };
+    foo = pkgs.foo.override { /* ... */ };
   };
 }
 ```

--- a/doc/using/overlays.chapter.md
+++ b/doc/using/overlays.chapter.md
@@ -141,7 +141,7 @@ For BLAS/LAPACK switching to work correctly, all packages must depend on `blas` 
 assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation {
-  ...
+  # ...
 }
 ```
 

--- a/doc/using/overrides.chapter.md
+++ b/doc/using/overrides.chapter.md
@@ -13,13 +13,13 @@ It is used to override the arguments passed to a function.
 Example usages:
 
 ```nix
-pkgs.foo.override { arg1 = val1; arg2 = val2; ... }
+pkgs.foo.override { arg1 = val1; arg2 = val2; /* ... */ }
 ```
 
 It's also possible to access the previous arguments.
 
 ```nix
-pkgs.foo.override (previous: { arg1 = previous.arg1; ... })
+pkgs.foo.override (previous: { arg1 = previous.arg1; /* ... */ })
 ```
 
 <!-- TODO: move below programlisting to a new section about extending and overlays and reference it -->
@@ -27,13 +27,15 @@ pkgs.foo.override (previous: { arg1 = previous.arg1; ... })
 ```nix
 import pkgs.path { overlays = [ (self: super: {
   foo = super.foo.override { barSupport = true ; };
-  })]};
+  })];}
 ```
 
 ```nix
-mypkg = pkgs.callPackage ./mypkg.nix {
-  mydep = pkgs.mydep.override { ... };
-  }
+{
+  mypkg = pkgs.callPackage ./mypkg.nix {
+    mydep = pkgs.mydep.override { /* ... */ };
+  };
+}
 ```
 
 In the first example, `pkgs.foo` is the result of a function call with some default arguments, usually a derivation. Using `pkgs.foo.override` will call the same function with the given new arguments.
@@ -45,9 +47,11 @@ The function `overrideAttrs` allows overriding the attribute set passed to a `st
 Example usages:
 
 ```nix
-helloBar = pkgs.hello.overrideAttrs (finalAttrs: previousAttrs: {
-  pname = previousAttrs.pname + "-bar";
-});
+{
+  helloBar = pkgs.hello.overrideAttrs (finalAttrs: previousAttrs: {
+    pname = previousAttrs.pname + "-bar";
+  });
+}
 ```
 
 In the above example, "-bar" is appended to the pname attribute, while all other attributes will be retained from the original `hello` package.
@@ -61,9 +65,11 @@ If only a one-argument function is written, the argument has the meaning of `pre
 Function arguments can be omitted entirely if there is no need to access `previousAttrs` or `finalAttrs`.
 
 ```nix
-helloWithDebug = pkgs.hello.overrideAttrs {
-  separateDebugInfo = true;
-};
+{
+  helloWithDebug = pkgs.hello.overrideAttrs {
+    separateDebugInfo = true;
+  };
+}
 ```
 
 In the above example, the `separateDebugInfo` attribute is overridden to be true, thus building debug info for `helloWithDebug`.
@@ -87,14 +93,16 @@ The function `overrideDerivation` creates a new derivation based on an existing 
 Example usage:
 
 ```nix
-mySed = pkgs.gnused.overrideDerivation (oldAttrs: {
-  name = "sed-4.2.2-pre";
-  src = fetchurl {
-    url = "ftp://alpha.gnu.org/gnu/sed/sed-4.2.2-pre.tar.bz2";
-    hash = "sha256-MxBJRcM2rYzQYwJ5XKxhXTQByvSg5jZc5cSHEZoB2IY=";
-  };
-  patches = [];
-});
+{
+  mySed = pkgs.gnused.overrideDerivation (oldAttrs: {
+    name = "sed-4.2.2-pre";
+    src = fetchurl {
+      url = "ftp://alpha.gnu.org/gnu/sed/sed-4.2.2-pre.tar.bz2";
+      hash = "sha256-MxBJRcM2rYzQYwJ5XKxhXTQByvSg5jZc5cSHEZoB2IY=";
+    };
+    patches = [];
+  });
+}
 ```
 
 In the above example, the `name`, `src`, and `patches` of the derivation will be overridden, while all other attributes will be retained from the original derivation.
@@ -112,8 +120,10 @@ The function `lib.makeOverridable` is used to make the result of a function easi
 Example usage:
 
 ```nix
-f = { a, b }: { result = a+b; };
-c = lib.makeOverridable f { a = 1; b = 2; };
+{
+  f = { a, b }: { result = a+b; };
+  c = lib.makeOverridable f { a = 1; b = 2; };
+}
 ```
 
 The variable `c` is the value of the `f` function applied with some default arguments. Hence the value of `c.result` is `3`, in this example.

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -87,8 +87,8 @@ checks should be performed:
       keys = [{
         fingerprint = "0000 0000 2A70 6423 0AED  3C11 F04F 7A19 AAA6 3AFE";
       }];
-    }
-  };
+    };
+  }
   ```
 
   First receive their key from a keyserver:
@@ -133,8 +133,8 @@ checks should be performed:
       name = "Example User";
       github = "ghost";
       githubId = 10137;
-    }
-  };
+    };
+  }
   ```
 
   First, make sure that the listed GitHub handle matches the author of

--- a/nixos/doc/manual/administration/cleaning-store.chapter.md
+++ b/nixos/doc/manual/administration/cleaning-store.chapter.md
@@ -21,8 +21,10 @@ You can tell NixOS in `configuration.nix` to run this unit automatically
 at certain points in time, for instance, every night at 03:15:
 
 ```nix
-nix.gc.automatic = true;
-nix.gc.dates = "03:15";
+{
+  nix.gc.automatic = true;
+  nix.gc.dates = "03:15";
+}
 ```
 
 The commands above do not remove garbage collector roots, such as old

--- a/nixos/doc/manual/administration/container-networking.section.md
+++ b/nixos/doc/manual/administration/container-networking.section.md
@@ -26,9 +26,11 @@ host to rewrite container traffic to use your external IP address. This
 can be accomplished using the following configuration on the host:
 
 ```nix
-networking.nat.enable = true;
-networking.nat.internalInterfaces = ["ve-+"];
-networking.nat.externalInterface = "eth0";
+{
+  networking.nat.enable = true;
+  networking.nat.internalInterfaces = ["ve-+"];
+  networking.nat.externalInterface = "eth0";
+}
 ```
 
 where `eth0` should be replaced with the desired external interface.
@@ -38,7 +40,9 @@ If you are using Network Manager, you need to explicitly prevent it from
 managing container interfaces:
 
 ```nix
-networking.networkmanager.unmanaged = [ "interface-name:ve-*" ];
+{
+  networking.networkmanager.unmanaged = [ "interface-name:ve-*" ];
+}
 ```
 
 You may need to restart your system for the changes to take effect.

--- a/nixos/doc/manual/administration/control-groups.chapter.md
+++ b/nixos/doc/manual/administration/control-groups.chapter.md
@@ -39,7 +39,9 @@ they were in the same cgroup, then the PostgreSQL process would get
 `configuration.nix`:
 
 ```nix
-systemd.services.httpd.serviceConfig.CPUShares = 512;
+{
+  systemd.services.httpd.serviceConfig.CPUShares = 512;
+}
 ```
 
 By default, every cgroup has 1024 CPU shares, so this will halve the CPU
@@ -52,7 +54,9 @@ limits can be specified in `configuration.nix`; for instance, to limit
 `httpd.service` to 512 MiB of RAM (excluding swap):
 
 ```nix
-systemd.services.httpd.serviceConfig.MemoryLimit = "512M";
+{
+  systemd.services.httpd.serviceConfig.MemoryLimit = "512M";
+}
 ```
 
 The command `systemd-cgtop` shows a continuously updated list of all

--- a/nixos/doc/manual/administration/declarative-containers.section.md
+++ b/nixos/doc/manual/administration/declarative-containers.section.md
@@ -5,13 +5,15 @@ You can also specify containers and their configuration in the host's
 shall be a container named `database` running PostgreSQL:
 
 ```nix
-containers.database =
-  { config =
-      { config, pkgs, ... }:
-      { services.postgresql.enable = true;
-      services.postgresql.package = pkgs.postgresql_14;
-      };
-  };
+{
+  containers.database =
+    { config =
+        { config, pkgs, ... }:
+        { services.postgresql.enable = true;
+        services.postgresql.package = pkgs.postgresql_14;
+        };
+    };
+}
 ```
 
 If you run `nixos-rebuild switch`, the container will be built. If the
@@ -25,11 +27,13 @@ cannot change the network configuration. You can give a container its
 own network as follows:
 
 ```nix
-containers.database = {
-  privateNetwork = true;
-  hostAddress = "192.168.100.10";
-  localAddress = "192.168.100.11";
-};
+{
+  containers.database = {
+    privateNetwork = true;
+    hostAddress = "192.168.100.10";
+    localAddress = "192.168.100.11";
+  };
+}
 ```
 
 This gives the container a private virtual Ethernet interface with IP

--- a/nixos/doc/manual/administration/service-mgmt.chapter.md
+++ b/nixos/doc/manual/administration/service-mgmt.chapter.md
@@ -82,7 +82,9 @@ In order to enable a systemd *system* service with provided upstream
 package, use (e.g):
 
 ```nix
-systemd.packages = [ pkgs.packagekit ];
+{
+  systemd.packages = [ pkgs.packagekit ];
+}
 ```
 
 Usually NixOS modules written by the community do the above, plus take

--- a/nixos/doc/manual/configuration/abstractions.section.md
+++ b/nixos/doc/manual/configuration/abstractions.section.md
@@ -47,9 +47,9 @@ You can write a `let` wherever an expression is allowed. Thus, you also could ha
 ```nix
 {
   services.httpd.virtualHosts =
-    let commonConfig = ...; in
-    { "blog.example.org" = (commonConfig // { ... })
-      "wiki.example.org" = (commonConfig // { ... })
+    let commonConfig = { /* ... */ }; in
+    { "blog.example.org" = (commonConfig // { /* ... */ });
+      "wiki.example.org" = (commonConfig // { /* ... */ });
     };
 }
 ```

--- a/nixos/doc/manual/configuration/ad-hoc-network-config.section.md
+++ b/nixos/doc/manual/configuration/ad-hoc-network-config.section.md
@@ -6,8 +6,10 @@ is useful for doing network configuration not covered by the existing NixOS
 modules. For instance, to statically configure an IPv6 address:
 
 ```nix
-networking.localCommands =
-  ''
-    ip -6 addr add 2001:610:685:1::1/64 dev eth0
-  '';
+{
+  networking.localCommands =
+    ''
+      ip -6 addr add 2001:610:685:1::1/64 dev eth0
+    '';
+}
 ```

--- a/nixos/doc/manual/configuration/adding-custom-packages.section.md
+++ b/nixos/doc/manual/configuration/adding-custom-packages.section.md
@@ -23,7 +23,9 @@ Then you write and test the package as described in the Nixpkgs manual.
 Finally, you add it to [](#opt-environment.systemPackages), e.g.
 
 ```nix
-environment.systemPackages = [ pkgs.my-package ];
+{
+  environment.systemPackages = [ pkgs.my-package ];
+}
 ```
 
 and you run `nixos-rebuild`, specifying your own Nixpkgs tree:
@@ -38,24 +40,28 @@ tree. For instance, here is how you specify a build of the
 `configuration.nix`:
 
 ```nix
-environment.systemPackages =
-  let
-    my-hello = with pkgs; stdenv.mkDerivation rec {
-      name = "hello-2.8";
-      src = fetchurl {
-        url = "mirror://gnu/hello/${name}.tar.gz";
-        hash = "sha256-5rd/gffPfa761Kn1tl3myunD8TuM+66oy1O7XqVGDXM=";
+{
+  environment.systemPackages =
+    let
+      my-hello = with pkgs; stdenv.mkDerivation rec {
+        name = "hello-2.8";
+        src = fetchurl {
+          url = "mirror://gnu/hello/${name}.tar.gz";
+          hash = "sha256-5rd/gffPfa761Kn1tl3myunD8TuM+66oy1O7XqVGDXM=";
+        };
       };
-    };
-  in
-  [ my-hello ];
+    in
+    [ my-hello ];
+}
 ```
 
 Of course, you can also move the definition of `my-hello` into a
 separate Nix expression, e.g.
 
 ```nix
-environment.systemPackages = [ (import ./my-hello.nix) ];
+{
+  environment.systemPackages = [ (import ./my-hello.nix) ];
+}
 ```
 
 where `my-hello.nix` contains:
@@ -88,7 +94,9 @@ section](#module-services-flatpak). AppImages will not run "as-is" on NixOS.
 First you need to install `appimage-run`: add to `/etc/nixos/configuration.nix`
 
 ```nix
-environment.systemPackages = [ pkgs.appimage-run ];
+{
+  environment.systemPackages = [ pkgs.appimage-run ];
+}
 ```
 
 Then instead of running the AppImage "as-is", run `appimage-run foo.appimage`.

--- a/nixos/doc/manual/configuration/config-file.section.md
+++ b/nixos/doc/manual/configuration/config-file.section.md
@@ -5,7 +5,7 @@ The NixOS configuration file generally looks like this:
 ```nix
 { config, pkgs, ... }:
 
-{ option definitions
+{ /* option definitions */
 }
 ```
 
@@ -80,7 +80,9 @@ Strings
 :   Strings are enclosed in double quotes, e.g.
 
     ```nix
-    networking.hostName = "dexter";
+    {
+      networking.hostName = "dexter";
+    }
     ```
 
     Special characters can be escaped by prefixing them with a backslash
@@ -89,11 +91,13 @@ Strings
     Multi-line strings can be enclosed in *double single quotes*, e.g.
 
     ```nix
-    networking.extraHosts =
-      ''
-        127.0.0.2 other-localhost
-        10.0.0.1 server
-      '';
+    {
+      networking.extraHosts =
+        ''
+          127.0.0.2 other-localhost
+          10.0.0.1 server
+        '';
+    }
     ```
 
     The main difference is that it strips from each line a number of
@@ -108,8 +112,10 @@ Booleans
 :   These can be `true` or `false`, e.g.
 
     ```nix
-    networking.firewall.enable = true;
-    networking.firewall.allowPing = false;
+    {
+      networking.firewall.enable = true;
+      networking.firewall.allowPing = false;
+    }
     ```
 
 Integers
@@ -117,7 +123,9 @@ Integers
 :   For example,
 
     ```nix
-    boot.kernel.sysctl."net.ipv4.tcp_keepalive_time" = 60;
+    {
+      boot.kernel.sysctl."net.ipv4.tcp_keepalive_time" = 60;
+    }
     ```
 
     (Note that here the attribute name `net.ipv4.tcp_keepalive_time` is
@@ -132,11 +140,13 @@ Sets
     braces, as in the option definition
 
     ```nix
-    fileSystems."/boot" =
-      { device = "/dev/sda1";
-        fsType = "ext4";
-        options = [ "rw" "data=ordered" "relatime" ];
-      };
+    {
+      fileSystems."/boot" =
+        { device = "/dev/sda1";
+          fsType = "ext4";
+          options = [ "rw" "data=ordered" "relatime" ];
+        };
+    }
     ```
 
 Lists
@@ -145,13 +155,17 @@ Lists
     separated by whitespace, like this:
 
     ```nix
-    boot.kernelModules = [ "fuse" "kvm-intel" "coretemp" ];
+    {
+      boot.kernelModules = [ "fuse" "kvm-intel" "coretemp" ];
+    }
     ```
 
     List elements can be any other type, e.g. sets:
 
     ```nix
-    swapDevices = [ { device = "/dev/disk/by-label/swap"; } ];
+    {
+      swapDevices = [ { device = "/dev/disk/by-label/swap"; } ];
+    }
     ```
 
 Packages
@@ -161,12 +175,14 @@ Packages
     argument `pkgs`. Typical uses:
 
     ```nix
-    environment.systemPackages =
-      [ pkgs.thunderbird
-        pkgs.emacs
-      ];
+    {
+      environment.systemPackages =
+        [ pkgs.thunderbird
+          pkgs.emacs
+        ];
 
-    services.postgresql.package = pkgs.postgresql_14;
+      services.postgresql.package = pkgs.postgresql_14;
+    }
     ```
 
     The latter option definition changes the default PostgreSQL package

--- a/nixos/doc/manual/configuration/customizing-packages.section.md
+++ b/nixos/doc/manual/configuration/customizing-packages.section.md
@@ -16,18 +16,20 @@ Examples include:
 
 You can use them like this:
 ```nix
-environment.systemPackages = with pkgs; [
-  sl
-  (pass.withExtensions (subpkgs: with subpkgs; [
-    pass-audit
-    pass-otp
-    pass-genphrase
-  ]))
-  (python3.withPackages (subpkgs: with subpkgs; [
-      requests
-  ]))
-  cowsay
-];
+{
+  environment.systemPackages = with pkgs; [
+    sl
+    (pass.withExtensions (subpkgs: with subpkgs; [
+      pass-audit
+      pass-otp
+      pass-genphrase
+    ]))
+    (python3.withPackages (subpkgs: with subpkgs; [
+        requests
+    ]))
+    cowsay
+  ];
+}
 ```
 :::
 
@@ -38,7 +40,9 @@ dependency on GTK 2. If you want to build it against GTK 3, you can
 specify that as follows:
 
 ```nix
-environment.systemPackages = [ (pkgs.emacs.override { gtk = pkgs.gtk3; }) ];
+{
+  environment.systemPackages = [ (pkgs.emacs.override { gtk = pkgs.gtk3; }) ];
+}
 ```
 
 The function `override` performs the call to the Nix function that
@@ -58,12 +62,14 @@ of the package, such as the source code. For instance, if you want to
 override the source code of Emacs, you can say:
 
 ```nix
-environment.systemPackages = [
-  (pkgs.emacs.overrideAttrs (oldAttrs: {
-    name = "emacs-25.0-pre";
-    src = /path/to/my/emacs/tree;
-  }))
-];
+{
+  environment.systemPackages = [
+    (pkgs.emacs.overrideAttrs (oldAttrs: {
+      name = "emacs-25.0-pre";
+      src = /path/to/my/emacs/tree;
+    }))
+  ];
+}
 ```
 
 Here, `overrideAttrs` takes the Nix derivation specified by `pkgs.emacs`
@@ -80,9 +86,11 @@ two instances of the package. If you want to have everything depend on
 your customised instance, you can apply a *global* override as follows:
 
 ```nix
-nixpkgs.config.packageOverrides = pkgs:
-  { emacs = pkgs.emacs.override { gtk = pkgs.gtk3; };
-  };
+{
+  nixpkgs.config.packageOverrides = pkgs:
+    { emacs = pkgs.emacs.override { gtk = pkgs.gtk3; };
+    };
+}
 ```
 
 The effect of this definition is essentially equivalent to modifying the

--- a/nixos/doc/manual/configuration/declarative-packages.section.md
+++ b/nixos/doc/manual/configuration/declarative-packages.section.md
@@ -7,7 +7,9 @@ following line to `configuration.nix` enables the Mozilla Thunderbird
 email application:
 
 ```nix
-environment.systemPackages = [ pkgs.thunderbird ];
+{
+  environment.systemPackages = [ pkgs.thunderbird ];
+}
 ```
 
 The effect of this specification is that the Thunderbird package from

--- a/nixos/doc/manual/configuration/file-systems.chapter.md
+++ b/nixos/doc/manual/configuration/file-systems.chapter.md
@@ -6,10 +6,12 @@ Ext4 file system on device `/dev/disk/by-label/data` onto the mount
 point `/data`:
 
 ```nix
-fileSystems."/data" =
-  { device = "/dev/disk/by-label/data";
-    fsType = "ext4";
-  };
+{
+  fileSystems."/data" =
+    { device = "/dev/disk/by-label/data";
+      fsType = "ext4";
+    };
+}
 ```
 
 This will create an entry in `/etc/fstab`, which will generate a

--- a/nixos/doc/manual/configuration/firewall.section.md
+++ b/nixos/doc/manual/configuration/firewall.section.md
@@ -5,14 +5,18 @@ and other unexpected packets. The firewall applies to both IPv4 and IPv6
 traffic. It is enabled by default. It can be disabled as follows:
 
 ```nix
-networking.firewall.enable = false;
+{
+  networking.firewall.enable = false;
+}
 ```
 
 If the firewall is enabled, you can open specific TCP ports to the
 outside world:
 
 ```nix
-networking.firewall.allowedTCPPorts = [ 80 443 ];
+{
+  networking.firewall.allowedTCPPorts = [ 80 443 ];
+}
 ```
 
 Note that TCP port 22 (ssh) is opened automatically if the SSH daemon is
@@ -22,10 +26,12 @@ enabled (`services.openssh.enable = true`). UDP ports can be opened through
 To open ranges of TCP ports:
 
 ```nix
-networking.firewall.allowedTCPPortRanges = [
-  { from = 4000; to = 4007; }
-  { from = 8000; to = 8010; }
-];
+{
+  networking.firewall.allowedTCPPortRanges = [
+    { from = 4000; to = 4007; }
+    { from = 8000; to = 8010; }
+  ];
+}
 ```
 
 Similarly, UDP port ranges can be opened through

--- a/nixos/doc/manual/configuration/gpu-accel.chapter.md
+++ b/nixos/doc/manual/configuration/gpu-accel.chapter.md
@@ -55,9 +55,11 @@ supported through the rocmPackages.clr.icd package. Adding this package to
 enables OpenCL support:
 
 ```nix
-hardware.opengl.extraPackages = [
-  rocmPackages.clr.icd
-];
+{
+  hardware.opengl.extraPackages = [
+    rocmPackages.clr.icd
+  ];
+}
 ```
 
 ### Intel {#sec-gpu-accel-opencl-intel}
@@ -74,9 +76,11 @@ to enable OpenCL support. For example, for Gen8 and later GPUs, the following
 configuration can be used:
 
 ```nix
-hardware.opengl.extraPackages = [
-  intel-compute-runtime
-];
+{
+  hardware.opengl.extraPackages = [
+    intel-compute-runtime
+  ];
+}
 ```
 
 ## Vulkan {#sec-gpu-accel-vulkan}
@@ -141,20 +145,22 @@ makes amdvlk the default driver and hides radv and lavapipe from the device list
 A specific driver can be forced as follows:
 
 ```nix
-hardware.opengl.extraPackages = [
-  pkgs.amdvlk
-];
+{
+  hardware.opengl.extraPackages = [
+    pkgs.amdvlk
+  ];
 
-# To enable Vulkan support for 32-bit applications, also add:
-hardware.opengl.extraPackages32 = [
-  pkgs.driversi686Linux.amdvlk
-];
+  # To enable Vulkan support for 32-bit applications, also add:
+  hardware.opengl.extraPackages32 = [
+    pkgs.driversi686Linux.amdvlk
+  ];
 
-# Force radv
-environment.variables.AMD_VULKAN_ICD = "RADV";
-# Or
-environment.variables.VK_ICD_FILENAMES =
-  "/run/opengl-driver/share/vulkan/icd.d/radeon_icd.x86_64.json";
+  # Force radv
+  environment.variables.AMD_VULKAN_ICD = "RADV";
+  # Or
+  environment.variables.VK_ICD_FILENAMES =
+    "/run/opengl-driver/share/vulkan/icd.d/radeon_icd.x86_64.json";
+}
 ```
 
 ## VA-API {#sec-gpu-accel-va-api}
@@ -178,17 +184,21 @@ $ nix-shell -p libva-utils --run vainfo
 Modern Intel GPUs use the iHD driver, which can be installed with:
 
 ```nix
-hardware.opengl.extraPackages = [
-  intel-media-driver
-];
+{
+  hardware.opengl.extraPackages = [
+    intel-media-driver
+  ];
+}
 ```
 
 Older Intel GPUs use the i965 driver, which can be installed with:
 
 ```nix
-hardware.opengl.extraPackages = [
-  intel-vaapi-driver
-];
+{
+  hardware.opengl.extraPackages = [
+    intel-vaapi-driver
+  ];
+}
 ```
 
 ## Common issues {#sec-gpu-accel-common-issues}

--- a/nixos/doc/manual/configuration/ipv4-config.section.md
+++ b/nixos/doc/manual/configuration/ipv4-config.section.md
@@ -5,18 +5,22 @@ configure network interfaces. However, you can configure an interface
 manually as follows:
 
 ```nix
-networking.interfaces.eth0.ipv4.addresses = [ {
-  address = "192.168.1.2";
-  prefixLength = 24;
-} ];
+{
+  networking.interfaces.eth0.ipv4.addresses = [ {
+    address = "192.168.1.2";
+    prefixLength = 24;
+  } ];
+}
 ```
 
 Typically you'll also want to set a default gateway and set of name
 servers:
 
 ```nix
-networking.defaultGateway = "192.168.1.1";
-networking.nameservers = [ "8.8.8.8" ];
+{
+  networking.defaultGateway = "192.168.1.1";
+  networking.nameservers = [ "8.8.8.8" ];
+}
 ```
 
 ::: {.note}
@@ -28,7 +32,9 @@ configuration is performed by `network-setup.service`.
 The host name is set using [](#opt-networking.hostName):
 
 ```nix
-networking.hostName = "cartman";
+{
+  networking.hostName = "cartman";
+}
 ```
 
 The default host name is `nixos`. Set it to the empty string (`""`) to

--- a/nixos/doc/manual/configuration/ipv6-config.section.md
+++ b/nixos/doc/manual/configuration/ipv6-config.section.md
@@ -9,34 +9,42 @@ may be overridden on a per-interface basis by
 IPv6 support globally by setting:
 
 ```nix
-networking.enableIPv6 = false;
+{
+  networking.enableIPv6 = false;
+}
 ```
 
 You can disable IPv6 on a single interface using a normal sysctl (in
 this example, we use interface `eth0`):
 
 ```nix
-boot.kernel.sysctl."net.ipv6.conf.eth0.disable_ipv6" = true;
+{
+  boot.kernel.sysctl."net.ipv6.conf.eth0.disable_ipv6" = true;
+}
 ```
 
 As with IPv4 networking interfaces are automatically configured via
 DHCPv6. You can configure an interface manually:
 
 ```nix
-networking.interfaces.eth0.ipv6.addresses = [ {
-  address = "fe00:aa:bb:cc::2";
-  prefixLength = 64;
-} ];
+{
+  networking.interfaces.eth0.ipv6.addresses = [ {
+    address = "fe00:aa:bb:cc::2";
+    prefixLength = 64;
+  } ];
+}
 ```
 
 For configuring a gateway, optionally with explicitly specified
 interface:
 
 ```nix
-networking.defaultGateway6 = {
-  address = "fe00::1";
-  interface = "enp0s3";
-};
+{
+  networking.defaultGateway6 = {
+    address = "fe00::1";
+    interface = "enp0s3";
+  };
+}
 ```
 
 See [](#sec-ipv4) for similar examples and additional information.

--- a/nixos/doc/manual/configuration/kubernetes.chapter.md
+++ b/nixos/doc/manual/configuration/kubernetes.chapter.md
@@ -7,14 +7,16 @@ There are generally two ways of enabling Kubernetes on NixOS. One way is
 to enable and configure cluster components appropriately by hand:
 
 ```nix
-services.kubernetes = {
-  apiserver.enable = true;
-  controllerManager.enable = true;
-  scheduler.enable = true;
-  addonManager.enable = true;
-  proxy.enable = true;
-  flannel.enable = true;
-};
+{
+  services.kubernetes = {
+    apiserver.enable = true;
+    controllerManager.enable = true;
+    scheduler.enable = true;
+    addonManager.enable = true;
+    proxy.enable = true;
+    flannel.enable = true;
+  };
+}
 ```
 
 Another way is to assign cluster roles ("master" and/or "node") to
@@ -22,20 +24,26 @@ the host. This enables apiserver, controllerManager, scheduler,
 addonManager, kube-proxy and etcd:
 
 ```nix
-services.kubernetes.roles = [ "master" ];
+{
+  services.kubernetes.roles = [ "master" ];
+}
 ```
 
 While this will enable the kubelet and kube-proxy only:
 
 ```nix
-services.kubernetes.roles = [ "node" ];
+{
+  services.kubernetes.roles = [ "node" ];
+}
 ```
 
 Assigning both the master and node roles is usable if you want a single
 node Kubernetes cluster for dev or testing purposes:
 
 ```nix
-services.kubernetes.roles = [ "master" "node" ];
+{
+  services.kubernetes.roles = [ "master" "node" ];
+}
 ```
 
 Note: Assigning either role will also default both

--- a/nixos/doc/manual/configuration/linux-kernel.chapter.md
+++ b/nixos/doc/manual/configuration/linux-kernel.chapter.md
@@ -5,7 +5,9 @@ option `boot.kernelPackages`. For instance, this selects the Linux 3.10
 kernel:
 
 ```nix
-boot.kernelPackages = pkgs.linuxKernel.packages.linux_3_10;
+{
+  boot.kernelPackages = pkgs.linuxKernel.packages.linux_3_10;
+}
 ```
 
 Note that this not only replaces the kernel, but also packages that are
@@ -40,13 +42,15 @@ If you want to change the kernel configuration, you can use the
 instance, to enable support for the kernel debugger KGDB:
 
 ```nix
-nixpkgs.config.packageOverrides = pkgs: pkgs.lib.recursiveUpdate pkgs {
-  linuxKernel.kernels.linux_5_10 = pkgs.linuxKernel.kernels.linux_5_10.override {
-    extraConfig = ''
-      KGDB y
-    '';
+{
+  nixpkgs.config.packageOverrides = pkgs: pkgs.lib.recursiveUpdate pkgs {
+    linuxKernel.kernels.linux_5_10 = pkgs.linuxKernel.kernels.linux_5_10.override {
+      extraConfig = ''
+        KGDB y
+      '';
+    };
   };
-};
+}
 ```
 
 `extraConfig` takes a list of Linux kernel configuration options, one
@@ -59,14 +63,18 @@ by `udev`. You can force a module to be loaded via
 [](#opt-boot.kernelModules), e.g.
 
 ```nix
-boot.kernelModules = [ "fuse" "kvm-intel" "coretemp" ];
+{
+  boot.kernelModules = [ "fuse" "kvm-intel" "coretemp" ];
+}
 ```
 
 If the module is required early during the boot (e.g. to mount the root
 file system), you can use [](#opt-boot.initrd.kernelModules):
 
 ```nix
-boot.initrd.kernelModules = [ "cifs" ];
+{
+  boot.initrd.kernelModules = [ "cifs" ];
+}
 ```
 
 This causes the specified modules and their dependencies to be added to
@@ -76,7 +84,9 @@ Kernel runtime parameters can be set through
 [](#opt-boot.kernel.sysctl), e.g.
 
 ```nix
-boot.kernel.sysctl."net.ipv4.tcp_keepalive_time" = 120;
+{
+  boot.kernel.sysctl."net.ipv4.tcp_keepalive_time" = 120;
+}
 ```
 
 sets the kernel's TCP keepalive time to 120 seconds. To see the
@@ -89,7 +99,9 @@ Please refer to the Nixpkgs manual for the various ways of [building a custom ke
 To use your custom kernel package in your NixOS configuration, set
 
 ```nix
-boot.kernelPackages = pkgs.linuxPackagesFor yourCustomKernel;
+{
+  boot.kernelPackages = pkgs.linuxPackagesFor yourCustomKernel;
+}
 ```
 
 ## Rust {#sec-linux-rust}
@@ -99,15 +111,17 @@ default. For kernel versions 6.7 or newer, experimental Rust support
 can be enabled. In a NixOS configuration, set:
 
 ```nix
-boot.kernelPatches = [
-  {
-    name = "Rust Support";
-    patch = null;
-    features = {
-      rust = true;
-    };
-  }
-];
+{
+  boot.kernelPatches = [
+    {
+      name = "Rust Support";
+      patch = null;
+      features = {
+        rust = true;
+      };
+    }
+  ];
+}
 ```
 
 ## Developing kernel modules {#sec-linux-config-developing-modules}

--- a/nixos/doc/manual/configuration/luks-file-systems.section.md
+++ b/nixos/doc/manual/configuration/luks-file-systems.section.md
@@ -29,15 +29,19 @@ system is automatically mounted at boot time as `/`, add the following
 to `configuration.nix`:
 
 ```nix
-boot.initrd.luks.devices.crypted.device = "/dev/disk/by-uuid/3f6b0024-3a44-4fde-a43a-767b872abe5d";
-fileSystems."/".device = "/dev/mapper/crypted";
+{
+  boot.initrd.luks.devices.crypted.device = "/dev/disk/by-uuid/3f6b0024-3a44-4fde-a43a-767b872abe5d";
+  fileSystems."/".device = "/dev/mapper/crypted";
+}
 ```
 
 Should grub be used as bootloader, and `/boot` is located on an
 encrypted partition, it is necessary to add the following grub option:
 
 ```nix
-boot.loader.grub.enableCryptodisk = true;
+{
+  boot.loader.grub.enableCryptodisk = true;
+}
 ```
 
 ## FIDO2 {#sec-luks-file-systems-fido2}
@@ -68,8 +72,10 @@ To ensure that this file system is decrypted using the FIDO2 compatible
 key, add the following to `configuration.nix`:
 
 ```nix
-boot.initrd.luks.fido2Support = true;
-boot.initrd.luks.devices."/dev/sda2".fido2.credential = "f1d00200108b9d6e849a8b388da457688e3dd653b4e53770012d8f28e5d3b269865038c346802f36f3da7278b13ad6a3bb6a1452e24ebeeaa24ba40eef559b1b287d2a2f80b7";
+{
+  boot.initrd.luks.fido2Support = true;
+  boot.initrd.luks.devices."/dev/sda2".fido2.credential = "f1d00200108b9d6e849a8b388da457688e3dd653b4e53770012d8f28e5d3b269865038c346802f36f3da7278b13ad6a3bb6a1452e24ebeeaa24ba40eef559b1b287d2a2f80b7";
+}
 ```
 
 You can also use the FIDO2 passwordless setup, but for security reasons,
@@ -77,7 +83,9 @@ you might want to enable it only when your device is PIN protected, such
 as [Trezor](https://trezor.io/).
 
 ```nix
-boot.initrd.luks.devices."/dev/sda2".fido2.passwordLess = true;
+{
+  boot.initrd.luks.devices."/dev/sda2".fido2.passwordLess = true;
+}
 ```
 
 ### systemd Stage 1 {#sec-luks-file-systems-fido2-systemd}
@@ -88,13 +96,15 @@ unlocking the existing LUKS2 volume `root` using any enrolled FIDO2 compatible
 tokens.
 
 ```nix
-boot.initrd = {
-  luks.devices.root = {
-    crypttabExtraOpts = [ "fido2-device=auto" ];
-    device = "/dev/sda2";
+{
+  boot.initrd = {
+    luks.devices.root = {
+      crypttabExtraOpts = [ "fido2-device=auto" ];
+      device = "/dev/sda2";
+    };
+    systemd.enable = true;
   };
-  systemd.enable = true;
-};
+}
 ```
 
 All tokens that should be used for unlocking the LUKS2-encrypted volume must

--- a/nixos/doc/manual/configuration/modularity.section.md
+++ b/nixos/doc/manual/configuration/modularity.section.md
@@ -16,7 +16,7 @@ including them from `configuration.nix`, e.g.:
 { imports = [ ./vpn.nix ./kde.nix ];
   services.httpd.enable = true;
   environment.systemPackages = [ pkgs.emacs ];
-  ...
+  # ...
 }
 ```
 
@@ -42,7 +42,9 @@ merged last, so for list-type options, it will appear at the end of the
 merged list. If you want it to appear first, you can use `mkBefore`:
 
 ```nix
-boot.kernelModules = mkBefore [ "kvm-intel" ];
+{
+  boot.kernelModules = mkBefore [ "kvm-intel" ];
+}
 ```
 
 This causes the `kvm-intel` kernel module to be loaded before any other
@@ -60,7 +62,9 @@ When that happens, it's possible to force one definition take precedence
 over the others:
 
 ```nix
-services.httpd.adminAddr = pkgs.lib.mkForce "bob@example.org";
+{
+  services.httpd.adminAddr = pkgs.lib.mkForce "bob@example.org";
+}
 ```
 
 When using multiple modules, you may need to access configuration values

--- a/nixos/doc/manual/configuration/network-manager.section.md
+++ b/nixos/doc/manual/configuration/network-manager.section.md
@@ -4,7 +4,9 @@ To facilitate network configuration, some desktop environments use
 NetworkManager. You can enable NetworkManager by setting:
 
 ```nix
-networking.networkmanager.enable = true;
+{
+  networking.networkmanager.enable = true;
+}
 ```
 
 some desktop managers (e.g., GNOME) enable NetworkManager automatically
@@ -14,7 +16,9 @@ All users that should have permission to change network settings must
 belong to the `networkmanager` group:
 
 ```nix
-users.users.alice.extraGroups = [ "networkmanager" ];
+{
+  users.users.alice.extraGroups = [ "networkmanager" ];
+}
 ```
 
 NetworkManager is controlled using either `nmcli` or `nmtui`
@@ -32,9 +36,11 @@ can be used together if desired. To do this you need to instruct
 NetworkManager to ignore those interfaces like:
 
 ```nix
-networking.networkmanager.unmanaged = [
-   "*" "except:type:wwan" "except:type:gsm"
-];
+{
+  networking.networkmanager.unmanaged = [
+     "*" "except:type:wwan" "except:type:gsm"
+  ];
+}
 ```
 
 Refer to the option description for the exact syntax and references to

--- a/nixos/doc/manual/configuration/overlayfs.section.md
+++ b/nixos/doc/manual/configuration/overlayfs.section.md
@@ -4,21 +4,23 @@ NixOS offers a convenient abstraction to create both read-only as well writable
 overlays.
 
 ```nix
-fileSystems = {
-  "/writable-overlay" = {
-    overlay = {
-      lowerdir = [ writableOverlayLowerdir ];
-      upperdir = "/.rw-writable-overlay/upper";
-      workdir = "/.rw-writable-overlay/work";
+{
+  fileSystems = {
+    "/writable-overlay" = {
+      overlay = {
+        lowerdir = [ writableOverlayLowerdir ];
+        upperdir = "/.rw-writable-overlay/upper";
+        workdir = "/.rw-writable-overlay/work";
+      };
+      # Mount the writable overlay in the initrd.
+      neededForBoot = true;
     };
-    # Mount the writable overlay in the initrd.
-    neededForBoot = true;
+    "/readonly-overlay".overlay.lowerdir = [
+      writableOverlayLowerdir
+      writableOverlayLowerdir2
+    ];
   };
-  "/readonly-overlay".overlay.lowerdir = [
-    writableOverlayLowerdir
-    writableOverlayLowerdir2
-  ];
-};
+}
 ```
 
 If `upperdir` and `workdir` are not null, they will be created before the

--- a/nixos/doc/manual/configuration/profiles.chapter.md
+++ b/nixos/doc/manual/configuration/profiles.chapter.md
@@ -8,9 +8,11 @@ is to say, expected usage is to add them to the imports list of your
 `/etc/configuration.nix` as such:
 
 ```nix
-imports = [
-  <nixpkgs/nixos/modules/profiles/profile-name.nix>
-];
+{
+  imports = [
+    <nixpkgs/nixos/modules/profiles/profile-name.nix>
+  ];
+}
 ```
 
 Even if some of these profiles seem only useful in the context of

--- a/nixos/doc/manual/configuration/renaming-interfaces.section.md
+++ b/nixos/doc/manual/configuration/renaming-interfaces.section.md
@@ -25,10 +25,12 @@ we assign the name `wan` to the interface with MAC address
 `52:54:00:12:01:01` using a netword link unit:
 
 ```nix
-systemd.network.links."10-wan" = {
-  matchConfig.PermanentMACAddress = "52:54:00:12:01:01";
-  linkConfig.Name = "wan";
-};
+{
+  systemd.network.links."10-wan" = {
+    matchConfig.PermanentMACAddress = "52:54:00:12:01:01";
+    linkConfig.Name = "wan";
+  };
+}
 ```
 
 Note that links are directly read by udev, *not networkd*, and will work
@@ -37,10 +39,12 @@ even if networkd is disabled.
 Alternatively, we can use a plain old udev rule:
 
 ```nix
-boot.initrd.services.udev.rules = ''
-  SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", \
-  ATTR{address}=="52:54:00:12:01:01", KERNEL=="eth*", NAME="wan"
-'';
+{
+  boot.initrd.services.udev.rules = ''
+    SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", \
+    ATTR{address}=="52:54:00:12:01:01", KERNEL=="eth*", NAME="wan"
+  '';
+}
 ```
 
 ::: {.warning}

--- a/nixos/doc/manual/configuration/ssh.section.md
+++ b/nixos/doc/manual/configuration/ssh.section.md
@@ -3,7 +3,9 @@
 Secure shell (SSH) access to your machine can be enabled by setting:
 
 ```nix
-services.openssh.enable = true;
+{
+  services.openssh.enable = true;
+}
 ```
 
 By default, root logins using a password are disallowed. They can be
@@ -14,6 +16,8 @@ You can declaratively specify authorised RSA/DSA public keys for a user
 as follows:
 
 ```nix
-users.users.alice.openssh.authorizedKeys.keys =
-  [ "ssh-dss AAAAB3NzaC1kc3MAAACBAPIkGWVEt4..." ];
+{
+  users.users.alice.openssh.authorizedKeys.keys =
+    [ "ssh-dss AAAAB3NzaC1kc3MAAACBAPIkGWVEt4..." ];
+}
 ```

--- a/nixos/doc/manual/configuration/subversion.chapter.md
+++ b/nixos/doc/manual/configuration/subversion.chapter.md
@@ -21,9 +21,11 @@ Apache HTTP, setting [](#opt-services.httpd.adminAddr)
 appropriately:
 
 ```nix
-services.httpd.enable = true;
-services.httpd.adminAddr = ...;
-networking.firewall.allowedTCPPorts = [ 80 443 ];
+{
+  services.httpd.enable = true;
+  services.httpd.adminAddr = "...";
+  networking.firewall.allowedTCPPorts = [ 80 443 ];
+}
 ```
 
 For a simple Subversion server with basic authentication, configure the
@@ -34,25 +36,28 @@ the `.authz` file describing access permission, and `AuthUserFile` to
 the password file.
 
 ```nix
-services.httpd.extraModules = [
-    # note that order is *super* important here
-    { name = "dav_svn"; path = "${pkgs.apacheHttpdPackages.subversion}/modules/mod_dav_svn.so"; }
-    { name = "authz_svn"; path = "${pkgs.apacheHttpdPackages.subversion}/modules/mod_authz_svn.so"; }
-  ];
-  services.httpd.virtualHosts = {
-    "svn" = {
-       hostName = HOSTNAME;
-       documentRoot = DOCUMENTROOT;
-       locations."/svn".extraConfig = ''
-           DAV svn
-           SVNParentPath REPO_PARENT
-           AuthzSVNAccessFile ACCESS_FILE
-           AuthName "SVN Repositories"
-           AuthType Basic
-           AuthUserFile PASSWORD_FILE
-           Require valid-user
-      '';
-    }
+{
+  services.httpd.extraModules = [
+      # note that order is *super* important here
+      { name = "dav_svn"; path = "${pkgs.apacheHttpdPackages.subversion}/modules/mod_dav_svn.so"; }
+      { name = "authz_svn"; path = "${pkgs.apacheHttpdPackages.subversion}/modules/mod_authz_svn.so"; }
+    ];
+    services.httpd.virtualHosts = {
+      "svn" = {
+         hostName = HOSTNAME;
+         documentRoot = DOCUMENTROOT;
+         locations."/svn".extraConfig = ''
+             DAV svn
+             SVNParentPath REPO_PARENT
+             AuthzSVNAccessFile ACCESS_FILE
+             AuthName "SVN Repositories"
+             AuthType Basic
+             AuthUserFile PASSWORD_FILE
+             Require valid-user
+        '';
+      };
+    };
+}
 ```
 
 The key `"svn"` is just a symbolic name identifying the virtual host.
@@ -90,7 +95,7 @@ $ htpasswd -s PASSWORD_FILE USER_NAME
 The file describing access permissions `ACCESS_FILE` will look something
 like the following:
 
-```nix
+```
 [/]
 * = r
 

--- a/nixos/doc/manual/configuration/user-mgmt.chapter.md
+++ b/nixos/doc/manual/configuration/user-mgmt.chapter.md
@@ -6,13 +6,15 @@ management. In the declarative style, users are specified in
 account named `alice` shall exist:
 
 ```nix
-users.users.alice = {
-  isNormalUser = true;
-  home = "/home/alice";
-  description = "Alice Foobar";
-  extraGroups = [ "wheel" "networkmanager" ];
-  openssh.authorizedKeys.keys = [ "ssh-dss AAAAB3Nza... alice@foobar" ];
-};
+{
+  users.users.alice = {
+    isNormalUser = true;
+    home = "/home/alice";
+    description = "Alice Foobar";
+    extraGroups = [ "wheel" "networkmanager" ];
+    openssh.authorizedKeys.keys = [ "ssh-dss AAAAB3Nza... alice@foobar" ];
+  };
+}
 ```
 
 Note that `alice` is a member of the `wheel` and `networkmanager`
@@ -38,7 +40,9 @@ A user ID (uid) is assigned automatically. You can also specify a uid
 manually by adding
 
 ```nix
-uid = 1000;
+{
+  uid = 1000;
+}
 ```
 
 to the user specification.
@@ -47,7 +51,9 @@ Groups can be specified similarly. The following states that a group
 named `students` shall exist:
 
 ```nix
-users.groups.students.gid = 1000;
+{
+  users.groups.students.gid = 1000;
+}
 ```
 
 As with users, the group ID (gid) is optional and will be assigned
@@ -100,7 +106,9 @@ Instead of using a custom perl script to create users and groups, you can use
 systemd-sysusers:
 
 ```nix
-systemd.sysusers.enable = true;
+{
+  systemd.sysusers.enable = true;
+}
 ```
 
 The primary benefit of this is to remove a dependency on perl.

--- a/nixos/doc/manual/configuration/wayland.chapter.md
+++ b/nixos/doc/manual/configuration/wayland.chapter.md
@@ -9,7 +9,9 @@ a Wayland Compositor such as sway without separately enabling a Wayland
 server:
 
 ```nix
+{
 programs.sway.enable = true;
+}
 ```
 
 This installs the sway compositor along with some essential utilities.
@@ -19,7 +21,9 @@ If you are using a wlroots-based compositor, like sway, and want to be
 able to share your screen, you might want to activate this option:
 
 ```nix
-xdg.portal.wlr.enable = true;
+{
+  xdg.portal.wlr.enable = true;
+}
 ```
 
 and configure Pipewire using

--- a/nixos/doc/manual/configuration/wireless.section.md
+++ b/nixos/doc/manual/configuration/wireless.section.md
@@ -7,25 +7,29 @@ skip the rest of this section on wireless networks.
 NixOS will start wpa_supplicant for you if you enable this setting:
 
 ```nix
-networking.wireless.enable = true;
+{
+  networking.wireless.enable = true;
+}
 ```
 
 NixOS lets you specify networks for wpa_supplicant declaratively:
 
 ```nix
-networking.wireless.networks = {
-  echelon = {                # SSID with no spaces or special characters
-    psk = "abcdefgh";
+{
+  networking.wireless.networks = {
+    echelon = {                # SSID with no spaces or special characters
+      psk = "abcdefgh";
+    };
+    "echelon's AP" = {         # SSID with spaces and/or special characters
+      psk = "ijklmnop";
+    };
+    echelon = {                # Hidden SSID
+      hidden = true;
+      psk = "qrstuvwx";
+    };
+    free.wifi = {};            # Public wireless network
   };
-  "echelon's AP" = {         # SSID with spaces and/or special characters
-    psk = "ijklmnop";
-  };
-  echelon = {                # Hidden SSID
-    hidden = true;
-    psk = "qrstuvwx";
-  };
-  free.wifi = {};            # Public wireless network
-};
+}
 ```
 
 Be aware that keys will be written to the nix store in plaintext! When
@@ -46,11 +50,13 @@ network={
 ```
 
 ```nix
-networking.wireless.networks = {
-  echelon = {
-    pskRaw = "dca6d6ed41f4ab5a984c9f55f6f66d4efdc720ebf66959810f4329bb391c5435";
+{
+  networking.wireless.networks = {
+    echelon = {
+      pskRaw = "dca6d6ed41f4ab5a984c9f55f6f66d4efdc720ebf66959810f4329bb391c5435";
+    };
   };
-};
+}
 ```
 
 or you can use it to directly generate the `wpa_supplicant.conf`:

--- a/nixos/doc/manual/configuration/x-windows.chapter.md
+++ b/nixos/doc/manual/configuration/x-windows.chapter.md
@@ -4,7 +4,9 @@ The X Window System (X11) provides the basis of NixOS' graphical user
 interface. It can be enabled as follows:
 
 ```nix
-services.xserver.enable = true;
+{
+  services.xserver.enable = true;
+}
 ```
 
 The X server will automatically detect and use the appropriate video
@@ -12,7 +14,9 @@ driver from a set of X.org drivers (such as `vesa` and `intel`). You can
 also specify a driver manually, e.g.
 
 ```nix
-services.xserver.videoDrivers = [ "r128" ];
+{
+  services.xserver.videoDrivers = [ "r128" ];
+}
 ```
 
 to enable X.org's `xf86-video-r128` driver.
@@ -22,15 +26,17 @@ Otherwise, you can only log into a plain undecorated `xterm` window.
 Thus you should pick one or more of the following lines:
 
 ```nix
-services.xserver.desktopManager.plasma5.enable = true;
-services.xserver.desktopManager.xfce.enable = true;
-services.xserver.desktopManager.gnome.enable = true;
-services.xserver.desktopManager.mate.enable = true;
-services.xserver.windowManager.xmonad.enable = true;
-services.xserver.windowManager.twm.enable = true;
-services.xserver.windowManager.icewm.enable = true;
-services.xserver.windowManager.i3.enable = true;
-services.xserver.windowManager.herbstluftwm.enable = true;
+{
+  services.xserver.desktopManager.plasma5.enable = true;
+  services.xserver.desktopManager.xfce.enable = true;
+  services.xserver.desktopManager.gnome.enable = true;
+  services.xserver.desktopManager.mate.enable = true;
+  services.xserver.windowManager.xmonad.enable = true;
+  services.xserver.windowManager.twm.enable = true;
+  services.xserver.windowManager.icewm.enable = true;
+  services.xserver.windowManager.i3.enable = true;
+  services.xserver.windowManager.herbstluftwm.enable = true;
+}
 ```
 
 NixOS's default *display manager* (the program that provides a graphical
@@ -38,22 +44,28 @@ login prompt and manages the X server) is LightDM. You can select an
 alternative one by picking one of the following lines:
 
 ```nix
-services.xserver.displayManager.sddm.enable = true;
-services.xserver.displayManager.gdm.enable = true;
+{
+  services.xserver.displayManager.sddm.enable = true;
+  services.xserver.displayManager.gdm.enable = true;
+}
 ```
 
 You can set the keyboard layout (and optionally the layout variant):
 
 ```nix
-services.xserver.xkb.layout = "de";
-services.xserver.xkb.variant = "neo";
+{
+  services.xserver.xkb.layout = "de";
+  services.xserver.xkb.variant = "neo";
+}
 ```
 
 The X server is started automatically at boot time. If you don't want
 this to happen, you can set:
 
 ```nix
-services.xserver.autorun = false;
+{
+  services.xserver.autorun = false;
+}
 ```
 
 The X server can then be started manually:
@@ -66,7 +78,9 @@ On 64-bit systems, if you want OpenGL for 32-bit programs such as in
 Wine, you should also set the following:
 
 ```nix
-hardware.opengl.driSupport32Bit = true;
+{
+  hardware.opengl.driSupport32Bit = true;
+}
 ```
 
 ## Auto-login {#sec-x11-auto-login}
@@ -84,16 +98,20 @@ desktop environment. If you wanted no desktop environment and i3 as your
 your window manager, you'd define:
 
 ```nix
-services.xserver.displayManager.defaultSession = "none+i3";
+{
+  services.xserver.displayManager.defaultSession = "none+i3";
+}
 ```
 
 Every display manager in NixOS supports auto-login, here is an example
 using lightdm for a user `alice`:
 
 ```nix
-services.xserver.displayManager.lightdm.enable = true;
-services.xserver.displayManager.autoLogin.enable = true;
-services.xserver.displayManager.autoLogin.user = "alice";
+{
+  services.xserver.displayManager.lightdm.enable = true;
+  services.xserver.displayManager.autoLogin.enable = true;
+  services.xserver.displayManager.autoLogin.user = "alice";
+}
 ```
 
 ## Intel Graphics drivers {#sec-x11--graphics-cards-intel}
@@ -119,18 +137,22 @@ drivers. Use the option
 to set one. The recommended configuration for modern systems is:
 
 ```nix
-services.xserver.videoDrivers = [ "modesetting" ];
+{
+  services.xserver.videoDrivers = [ "modesetting" ];
+}
 ```
 
 If you experience screen tearing no matter what, this configuration was
 reported to resolve the issue:
 
 ```nix
-services.xserver.videoDrivers = [ "intel" ];
-services.xserver.deviceSection = ''
-  Option "DRI" "2"
-  Option "TearFree" "true"
-'';
+{
+  services.xserver.videoDrivers = [ "intel" ];
+  services.xserver.deviceSection = ''
+    Option "DRI" "2"
+    Option "TearFree" "true"
+  '';
+}
 ```
 
 Note that this will likely downgrade the performance compared to
@@ -143,15 +165,19 @@ better 3D performance than the X.org drivers. It is not enabled by
 default because it's not free software. You can enable it as follows:
 
 ```nix
-services.xserver.videoDrivers = [ "nvidia" ];
+{
+  services.xserver.videoDrivers = [ "nvidia" ];
+}
 ```
 
 If you have an older card, you may have to use one of the legacy drivers:
 
 ```nix
-hardware.nvidia.package = config.boot.kernelPackages.nvidiaPackages.legacy_470;
-hardware.nvidia.package = config.boot.kernelPackages.nvidiaPackages.legacy_390;
-hardware.nvidia.package = config.boot.kernelPackages.nvidiaPackages.legacy_340;
+{
+  hardware.nvidia.package = config.boot.kernelPackages.nvidiaPackages.legacy_470;
+  hardware.nvidia.package = config.boot.kernelPackages.nvidiaPackages.legacy_390;
+  hardware.nvidia.package = config.boot.kernelPackages.nvidiaPackages.legacy_340;
+}
 ```
 
 You may need to reboot after enabling this driver to prevent a clash
@@ -166,7 +192,9 @@ performance. If you still want to use it anyway, you need to explicitly
 set:
 
 ```nix
-services.xserver.videoDrivers = [ "amdgpu-pro" ];
+{
+  services.xserver.videoDrivers = [ "amdgpu-pro" ];
+}
 ```
 
 You will need to reboot after enabling this driver to prevent a clash
@@ -178,14 +206,18 @@ Support for Synaptics touchpads (found in many laptops such as the Dell
 Latitude series) can be enabled as follows:
 
 ```nix
-services.xserver.libinput.enable = true;
+{
+  services.xserver.libinput.enable = true;
+}
 ```
 
 The driver has many options (see [](#ch-options)).
 For instance, the following disables tap-to-click behavior:
 
 ```nix
-services.xserver.libinput.touchpad.tapping = false;
+{
+  services.xserver.libinput.touchpad.tapping = false;
+}
 ```
 
 Note: the use of `services.xserver.synaptics` is deprecated since NixOS
@@ -198,9 +230,11 @@ GTK themes can be installed either to user profile or system-wide (via
 GTK ones, you can use the following configuration:
 
 ```nix
-qt.enable = true;
-qt.platformTheme = "gtk2";
-qt.style = "gtk2";
+{
+  qt.enable = true;
+  qt.platformTheme = "gtk2";
+  qt.style = "gtk2";
+}
 ```
 
 ## Custom XKB layouts {#custom-xkb-layouts}
@@ -217,7 +251,7 @@ Create a file called `us-greek` with the following content (under a
 directory called `symbols`; it's an XKB peculiarity that will help with
 testing):
 
-```nix
+```
 xkb_symbols "us-greek"
 {
   include "us(basic)"            // includes the base US keys
@@ -234,11 +268,13 @@ xkb_symbols "us-greek"
 A minimal layout specification must include the following:
 
 ```nix
-services.xserver.xkb.extraLayouts.us-greek = {
-  description = "US layout with alt-gr greek";
-  languages   = [ "eng" ];
-  symbolsFile = /yourpath/symbols/us-greek;
-};
+{
+  services.xserver.xkb.extraLayouts.us-greek = {
+    description = "US layout with alt-gr greek";
+    languages   = [ "eng" ];
+    symbolsFile = /yourpath/symbols/us-greek;
+  };
+}
 ```
 
 ::: {.note}
@@ -275,7 +311,7 @@ Use the *xev* utility from `pkgs.xorg.xev` to find the codes of the keys
 of interest, then create a `media-key` file to hold the keycodes
 definitions
 
-```nix
+```
 xkb_keycodes "media"
 {
  <volUp>   = 123;
@@ -285,7 +321,7 @@ xkb_keycodes "media"
 
 Now use the newly define keycodes in `media-sym`:
 
-```nix
+```
 xkb_symbols "media"
 {
  key.type = "ONE_LEVEL";
@@ -297,12 +333,14 @@ xkb_symbols "media"
 As before, to install the layout do
 
 ```nix
-services.xserver.xkb.extraLayouts.media = {
-  description  = "Multimedia keys remapping";
-  languages    = [ "eng" ];
-  symbolsFile  = /path/to/media-key;
-  keycodesFile = /path/to/media-sym;
-};
+{
+  services.xserver.xkb.extraLayouts.media = {
+    description  = "Multimedia keys remapping";
+    languages    = [ "eng" ];
+    symbolsFile  = /path/to/media-key;
+    keycodesFile = /path/to/media-sym;
+  };
+}
 ```
 
 ::: {.note}
@@ -318,7 +356,9 @@ workaround, you can set the keymap using `setxkbmap` at the start of the
 session with:
 
 ```nix
-services.xserver.displayManager.sessionCommands = "setxkbmap -keycodes media";
+{
+  services.xserver.displayManager.sessionCommands = "setxkbmap -keycodes media";
+}
 ```
 
 If you are manually starting the X server, you should set the argument

--- a/nixos/doc/manual/configuration/xfce.chapter.md
+++ b/nixos/doc/manual/configuration/xfce.chapter.md
@@ -3,21 +3,25 @@
 To enable the Xfce Desktop Environment, set
 
 ```nix
-services.xserver.desktopManager.xfce.enable = true;
-services.xserver.displayManager.defaultSession = "xfce";
+{
+  services.xserver.desktopManager.xfce.enable = true;
+  services.xserver.displayManager.defaultSession = "xfce";
+}
 ```
 
 Optionally, *picom* can be enabled for nice graphical effects, some
 example settings:
 
 ```nix
-services.picom = {
-  enable = true;
-  fade = true;
-  inactiveOpacity = 0.9;
-  shadow = true;
-  fadeDelta = 4;
-};
+{
+  services.picom = {
+    enable = true;
+    fade = true;
+    inactiveOpacity = 0.9;
+    shadow = true;
+    fadeDelta = 4;
+  };
+}
 ```
 
 Some Xfce programs are not installed automatically. To install them

--- a/nixos/doc/manual/development/activation-script.section.md
+++ b/nixos/doc/manual/development/activation-script.section.md
@@ -17,13 +17,15 @@ activation script will take these dependencies into account and order the
 snippets accordingly. As a simple example:
 
 ```nix
-system.activationScripts.my-activation-script = {
-  deps = [ "etc" ];
-  # supportsDryActivation = true;
-  text = ''
-    echo "Hallo i bims"
-  '';
-};
+{
+  system.activationScripts.my-activation-script = {
+    deps = [ "etc" ];
+    # supportsDryActivation = true;
+    text = ''
+      echo "Hallo i bims"
+    '';
+  };
+}
 ```
 
 This example creates an activation script snippet that is run after the `etc`

--- a/nixos/doc/manual/development/assertions.section.md
+++ b/nixos/doc/manual/development/assertions.section.md
@@ -18,7 +18,7 @@ This is an example of using `warnings`.
                This is known to cause some specific problems in certain situations.
                '' ]
       else [];
-  }
+  };
 }
 ```
 
@@ -35,6 +35,6 @@ This example, extracted from the [`syslogd` module](https://github.com/NixOS/nix
           message = "rsyslogd conflicts with syslogd";
         }
       ];
-  }
+  };
 }
 ```

--- a/nixos/doc/manual/development/etc-overlay.section.md
+++ b/nixos/doc/manual/development/etc-overlay.section.md
@@ -9,7 +9,9 @@ Instead of using a custom perl script to activate `/etc`, you activate it via an
 overlay filesystem:
 
 ```nix
-system.etc.overlay.enable = true;
+{
+  system.etc.overlay.enable = true;
+}
 ```
 
 Using an overlay has two benefits:
@@ -22,7 +24,9 @@ upper layer). However, you can also mount `/etc` immutably (i.e. read-only) by
 setting:
 
 ```nix
-system.etc.overlay.mutable = false;
+{
+  system.etc.overlay.mutable = false;
+}
 ```
 
 The overlay is atomically replaced during system switch. However, files that

--- a/nixos/doc/manual/development/meta-attributes.section.md
+++ b/nixos/doc/manual/development/meta-attributes.section.md
@@ -14,11 +14,11 @@ file.
 { config, lib, pkgs, ... }:
 {
   options = {
-    ...
+    # ...
   };
 
   config = {
-    ...
+    # ...
   };
 
   meta = {

--- a/nixos/doc/manual/development/non-switchable-systems.section.md
+++ b/nixos/doc/manual/development/non-switchable-systems.section.md
@@ -9,7 +9,7 @@ profile:
 
 ```nix
 { modulesPath, ... }: {
-  imports = [ "${modulesPath}/profiles/image-based-appliance.nix" ]
+  imports = [ "${modulesPath}/profiles/image-based-appliance.nix" ];
 }
 ```
 

--- a/nixos/doc/manual/development/option-declarations.section.md
+++ b/nixos/doc/manual/development/option-declarations.section.md
@@ -6,14 +6,16 @@ hasn't been declared in any module. An option declaration generally
 looks like this:
 
 ```nix
-options = {
-  name = mkOption {
-    type = type specification;
-    default = default value;
-    example = example value;
-    description = lib.mdDoc "Description for use in the NixOS manual.";
+{
+  options = {
+    name = mkOption {
+      type = type specification;
+      default = default value;
+      example = example value;
+      description = lib.mdDoc "Description for use in the NixOS manual.";
+    };
   };
-};
+}
 ```
 
 The attribute names within the `name` attribute path must be camel
@@ -221,28 +223,34 @@ enforces that there can only be a single display manager enabled.
 ::: {#ex-option-declaration-eot-service .example}
 ### Extensible type placeholder in the service module
 ```nix
-services.xserver.displayManager.enable = mkOption {
-  description = "Display manager to use";
-  type = with types; nullOr (enum [ ]);
-};
+{
+  services.xserver.displayManager.enable = mkOption {
+    description = "Display manager to use";
+    type = with types; nullOr (enum [ ]);
+  };
+}
 ```
 :::
 
 ::: {#ex-option-declaration-eot-backend-gdm .example}
 ### Extending `services.xserver.displayManager.enable` in the `gdm` module
 ```nix
-services.xserver.displayManager.enable = mkOption {
-  type = with types; nullOr (enum [ "gdm" ]);
-};
+{
+  services.xserver.displayManager.enable = mkOption {
+    type = with types; nullOr (enum [ "gdm" ]);
+  };
+}
 ```
 :::
 
 ::: {#ex-option-declaration-eot-backend-sddm .example}
 ### Extending `services.xserver.displayManager.enable` in the `sddm` module
 ```nix
-services.xserver.displayManager.enable = mkOption {
-  type = with types; nullOr (enum [ "sddm" ]);
-};
+{
+  services.xserver.displayManager.enable = mkOption {
+    type = with types; nullOr (enum [ "sddm" ]);
+  };
+}
 ```
 :::
 

--- a/nixos/doc/manual/development/option-def.section.md
+++ b/nixos/doc/manual/development/option-def.section.md
@@ -4,9 +4,11 @@ Option definitions are generally straight-forward bindings of values to
 option names, like
 
 ```nix
-config = {
-  services.httpd.enable = true;
-};
+{
+  config = {
+    services.httpd.enable = true;
+  };
+}
 ```
 
 However, sometimes you need to wrap an option definition or set of
@@ -18,10 +20,12 @@ If a set of option definitions is conditional on the value of another
 option, you may need to use `mkIf`. Consider, for instance:
 
 ```nix
-config = if config.services.httpd.enable then {
-  environment.systemPackages = [ ... ];
-  ...
-} else {};
+{
+  config = if config.services.httpd.enable then {
+    environment.systemPackages = [ /* ... */ ];
+    # ...
+  } else {};
+}
 ```
 
 This definition will cause Nix to fail with an "infinite recursion"
@@ -30,30 +34,36 @@ on the value being constructed here. After all, you could also write the
 clearly circular and contradictory:
 
 ```nix
-config = if config.services.httpd.enable then {
-  services.httpd.enable = false;
-} else {
-  services.httpd.enable = true;
-};
+{
+  config = if config.services.httpd.enable then {
+    services.httpd.enable = false;
+  } else {
+    services.httpd.enable = true;
+  };
+}
 ```
 
 The solution is to write:
 
 ```nix
-config = mkIf config.services.httpd.enable {
-  environment.systemPackages = [ ... ];
-  ...
-};
+{
+  config = mkIf config.services.httpd.enable {
+    environment.systemPackages = [ /* ... */ ];
+    # ...
+  };
+}
 ```
 
 The special function `mkIf` causes the evaluation of the conditional to
 be "pushed down" into the individual definitions, as if you had written:
 
 ```nix
-config = {
-  environment.systemPackages = if config.services.httpd.enable then [ ... ] else [];
-  ...
-};
+{
+  config = {
+    environment.systemPackages = if config.services.httpd.enable then [ /* ... */ ] else [];
+    # ...
+  };
+}
 ```
 
 ## Setting Priorities {#sec-option-definitions-setting-priorities}
@@ -65,7 +75,9 @@ priority 100 and option defaults have priority 1500.
 You can specify an explicit priority by using `mkOverride`, e.g.
 
 ```nix
-services.openssh.enable = mkOverride 10 false;
+{
+  services.openssh.enable = mkOverride 10 false;
+}
 ```
 
 This definition causes all other definitions with priorities above 10 to
@@ -80,7 +92,9 @@ The functions `mkBefore` and `mkAfter` are equal to `mkOrder 500` and `mkOrder 1
 As an example,
 
 ```nix
-hardware.firmware = mkBefore [ myFirmware ];
+{
+  hardware.firmware = mkBefore [ myFirmware ];
+}
 ```
 
 This definition ensures that `myFirmware` comes before other unordered
@@ -97,13 +111,15 @@ they were declared in separate modules. This can be done using
 `mkMerge`:
 
 ```nix
-config = mkMerge
-  [ # Unconditional stuff.
-    { environment.systemPackages = [ ... ];
-    }
-    # Conditional stuff.
-    (mkIf config.services.bla.enable {
-      environment.systemPackages = [ ... ];
-    })
-  ];
+{
+  config = mkMerge
+    [ # Unconditional stuff.
+      { environment.systemPackages = [ /* ... */ ];
+      }
+      # Conditional stuff.
+      (mkIf config.services.bla.enable {
+        environment.systemPackages = [ /* ... */ ];
+      })
+    ];
+}
 ```

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -374,19 +374,21 @@ if you want to allow users to leave it undefined.
 ::: {#ex-submodule-direct .example}
 ### Directly defined submodule
 ```nix
-options.mod = mkOption {
-  description = "submodule example";
-  type = with types; submodule {
-    options = {
-      foo = mkOption {
-        type = int;
-      };
-      bar = mkOption {
-        type = str;
+{
+  options.mod = mkOption {
+    description = "submodule example";
+    type = with types; submodule {
+      options = {
+        foo = mkOption {
+          type = int;
+        };
+        bar = mkOption {
+          type = str;
+        };
       };
     };
   };
-};
+}
 ```
 :::
 
@@ -405,10 +407,12 @@ let
     };
   };
 in
-options.mod = mkOption {
-  description = "submodule example";
-  type = with types; submodule modOptions;
-};
+{
+  options.mod = mkOption {
+    description = "submodule example";
+    type = with types; submodule modOptions;
+  };
+}
 ```
 :::
 
@@ -421,29 +425,33 @@ multiple definitions of the submodule option set
 ::: {#ex-submodule-listof-declaration .example}
 ### Declaration of a list of submodules
 ```nix
-options.mod = mkOption {
-  description = "submodule example";
-  type = with types; listOf (submodule {
-    options = {
-      foo = mkOption {
-        type = int;
+{
+  options.mod = mkOption {
+    description = "submodule example";
+    type = with types; listOf (submodule {
+      options = {
+        foo = mkOption {
+          type = int;
+        };
+        bar = mkOption {
+          type = str;
+        };
       };
-      bar = mkOption {
-        type = str;
-      };
-    };
-  });
-};
+    });
+  };
+}
 ```
 :::
 
 ::: {#ex-submodule-listof-definition .example}
 ### Definition of a list of submodules
 ```nix
-config.mod = [
-  { foo = 1; bar = "one"; }
-  { foo = 2; bar = "two"; }
-];
+{
+  config.mod = [
+    { foo = 1; bar = "one"; }
+    { foo = 2; bar = "two"; }
+  ];
+}
 ```
 :::
 
@@ -455,27 +463,31 @@ multiple named definitions of the submodule option set
 ::: {#ex-submodule-attrsof-declaration .example}
 ### Declaration of attribute sets of submodules
 ```nix
-options.mod = mkOption {
-  description = "submodule example";
-  type = with types; attrsOf (submodule {
-    options = {
-      foo = mkOption {
-        type = int;
+{
+  options.mod = mkOption {
+    description = "submodule example";
+    type = with types; attrsOf (submodule {
+      options = {
+        foo = mkOption {
+          type = int;
+        };
+        bar = mkOption {
+          type = str;
+        };
       };
-      bar = mkOption {
-        type = str;
-      };
-    };
-  });
-};
+    });
+  };
+}
 ```
 :::
 
 ::: {#ex-submodule-attrsof-definition .example}
 ### Definition of attribute sets of submodules
 ```nix
-config.mod.one = { foo = 1; bar = "one"; };
-config.mod.two = { foo = 2; bar = "two"; };
+{
+  config.mod.one = { foo = 1; bar = "one"; };
+  config.mod.two = { foo = 2; bar = "two"; };
+}
 ```
 :::
 
@@ -495,10 +507,12 @@ Types are mainly characterized by their `check` and `merge` functions.
     ### Adding a type check
 
     ```nix
-    byte = mkOption {
-      description = "An integer between 0 and 255.";
-      type = types.addCheck types.int (x: x >= 0 && x <= 255);
-    };
+    {
+      byte = mkOption {
+        description = "An integer between 0 and 255.";
+        type = types.addCheck types.int (x: x >= 0 && x <= 255);
+      };
+    }
     ```
     :::
 
@@ -506,12 +520,14 @@ Types are mainly characterized by their `check` and `merge` functions.
     ### Overriding a type check
 
     ```nix
-    nixThings = mkOption {
-      description = "words that start with 'nix'";
-      type = types.str // {
-        check = (x: lib.hasPrefix "nix" x)
+    {
+      nixThings = mkOption {
+        description = "words that start with 'nix'";
+        type = types.str // {
+          check = (x: lib.hasPrefix "nix" x);
+        };
       };
-    };
+    }
     ```
     :::
 

--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -248,28 +248,30 @@ up in the manual.
 ::: {#ex-settings-typed-attrs .example}
 ### Declaring a type-checked `settings` attribute
 ```nix
-settings = lib.mkOption {
-  type = lib.types.submodule {
+{
+  settings = lib.mkOption {
+    type = lib.types.submodule {
 
-    freeformType = settingsFormat.type;
+      freeformType = settingsFormat.type;
 
-    # Declare an option for the port such that the type is checked and this option
-    # is shown in the manual.
-    options.port = lib.mkOption {
-      type = lib.types.port;
-      default = 8080;
-      description = ''
-        Which port this service should listen on.
-      '';
+      # Declare an option for the port such that the type is checked and this option
+      # is shown in the manual.
+      options.port = lib.mkOption {
+        type = lib.types.port;
+        default = 8080;
+        description = ''
+          Which port this service should listen on.
+        '';
+      };
+
     };
-
+    default = {};
+    description = ''
+      Configuration for Foo, see
+      <link xlink:href="https://example.com/docs/foo"/>
+      for supported values.
+    '';
   };
-  default = {};
-  description = ''
-    Configuration for Foo, see
-    <link xlink:href="https://example.com/docs/foo"/>
-    for supported values.
-  '';
-};
+}
 ```
 :::

--- a/nixos/doc/manual/development/unit-handling.section.md
+++ b/nixos/doc/manual/development/unit-handling.section.md
@@ -94,11 +94,13 @@ To make an existing sysinit service restart correctly during system switch, you
 have to declare:
 
 ```nix
-systemd.services.my-sysinit = {
-  requiredBy = [ "sysinit-reactivation.target" ];
-  before = [ "sysinit-reactivation.target" ];
-  restartTriggers = [ config.environment.etc."my-sysinit.d".source ];
-};
+{
+  systemd.services.my-sysinit = {
+    requiredBy = [ "sysinit-reactivation.target" ];
+    before = [ "sysinit-reactivation.target" ];
+    restartTriggers = [ config.environment.etc."my-sysinit.d".source ];
+  };
+}
 ```
 
 You need to configure appropriate `restartTriggers` specific to your service.

--- a/nixos/doc/manual/development/writing-modules.chapter.md
+++ b/nixos/doc/manual/development/writing-modules.chapter.md
@@ -28,7 +28,7 @@ NixOS modules:
 ```nix
 { config, pkgs, ... }:
 
-{ option definitions
+{ # option definitions
 }
 ```
 
@@ -43,15 +43,15 @@ is shown in [Example: Structure of NixOS Modules](#ex-module-syntax).
 
 {
   imports =
-    [ paths of other modules
+    [ # paths of other modules
     ];
 
   options = {
-    option declarations
+    # option declarations
   };
 
   config = {
-    option definitions
+    # option definitions
   };
 }
 ```

--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -8,10 +8,10 @@ A NixOS test is a module that has the following structure:
   # One or more machines:
   nodes =
     { machine =
-        { config, pkgs, ... }: { … };
+        { config, pkgs, ... }: { /* ... */ };
       machine2 =
-        { config, pkgs, ... }: { … };
-      …
+        { config, pkgs, ... }: { /* ... */ };
+      # …
     };
 
   testScript =
@@ -46,16 +46,20 @@ Tests are invoked differently depending on whether the test is part of NixOS or 
 Tests that are part of NixOS are added to [`nixos/tests/all-tests.nix`](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests/all-tests.nix).
 
 ```nix
+{
   hostname = runTest ./hostname.nix;
+}
 ```
 
 Overrides can be added by defining an anonymous module in `all-tests.nix`.
 
 ```nix
+{
   hostname = runTest {
     imports = [ ./hostname.nix ];
     defaults.networking.firewall.enable = false;
   };
+}
 ```
 
 You can run a test with attribute name `hostname` in `nixos/tests/all-tests.nix` by invoking:
@@ -161,7 +165,7 @@ For faster dev cycles it's also possible to disable the code-linters
   skipLint = true;
   nodes.machine =
     { config, pkgs, ... }:
-    { configuration…
+    { # configuration…
     };
 
   testScript =
@@ -177,12 +181,14 @@ linter directly (again, don't commit this within the Nixpkgs
 repository):
 
 ```nix
+{
   testScript =
     ''
       # fmt: off
       Python code…
       # fmt: on
     '';
+}
 ```
 
 Similarly, the type checking of test scripts can be disabled in the following
@@ -193,7 +199,7 @@ way:
   skipTypeCheck = true;
   nodes.machine =
     { config, pkgs, ... }:
-    { configuration…
+    { # configuration…
     };
 }
 ```

--- a/nixos/doc/manual/installation/building-images-via-systemd-repart.chapter.md
+++ b/nixos/doc/manual/installation/building-images-via-systemd-repart.chapter.md
@@ -18,11 +18,11 @@ An example of how to build an image:
     partitions = {
       "esp" = {
         contents = {
-          ...
+          # ...
         };
         repartConfig = {
           Type = "esp";
-          ...
+          # ...
         };
       };
       "root" = {
@@ -30,7 +30,7 @@ An example of how to build an image:
         repartConfig = {
           Type = "root";
           Label = "nixos";
-          ...
+          # ...
         };
       };
     };
@@ -47,19 +47,21 @@ determined by the mount point, you have to set `stripNixStorePrefix = true;` so
 that the prefix is stripped from the paths before copying them into the image.
 
 ```nix
-fileSystems."/nix/store".device = "/dev/disk/by-partlabel/nix-store"
+{
+  fileSystems."/nix/store".device = "/dev/disk/by-partlabel/nix-store";
 
-image.repart.partitions = {
-  "store" = {
-    storePaths = [ config.system.build.toplevel ];
-    stripNixStorePrefix = true;
-    repartConfig = {
-      Type = "linux-generic";
-      Label = "nix-store";
-      ...
+  image.repart.partitions = {
+    "store" = {
+      storePaths = [ config.system.build.toplevel ];
+      stripNixStorePrefix = true;
+      repartConfig = {
+        Type = "linux-generic";
+        Label = "nix-store";
+        # ...
+      };
     };
   };
-};
+}
 ```
 
 ## Appliance Image {#sec-image-repart-appliance}

--- a/nixos/doc/manual/installation/changing-config.chapter.md
+++ b/nixos/doc/manual/installation/changing-config.chapter.md
@@ -87,7 +87,9 @@ set `mutableUsers = false`. Another way is to temporarily add the
 following to your configuration:
 
 ```nix
-users.users.your-user.initialHashedPassword = "test";
+{
+  users.users.your-user.initialHashedPassword = "test";
+}
 ```
 
 *Important:* delete the \$hostname.qcow2 file if you have started the

--- a/nixos/doc/manual/installation/installing-behind-a-proxy.section.md
+++ b/nixos/doc/manual/installation/installing-behind-a-proxy.section.md
@@ -7,8 +7,10 @@ To install NixOS behind a proxy, do the following before running
     keep the internet accessible after reboot.
 
     ```nix
-    networking.proxy.default = "http://user:password@proxy:port/";
-    networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";
+    {
+      networking.proxy.default = "http://user:password@proxy:port/";
+      networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";
+    }
     ```
 
 1.  Setup the proxy environment variables in the shell where you are

--- a/nixos/doc/manual/installation/installing-from-other-distro.section.md
+++ b/nixos/doc/manual/installation/installing-from-other-distro.section.md
@@ -89,12 +89,14 @@ The first steps to all these are the same:
     want to add something like this to your `configuration.nix`:
 
     ```nix
-    boot.loader.grub.extraEntries = ''
-      menuentry "Ubuntu" {
-        search --set=ubuntu --fs-uuid 3cc3e652-0c1f-4800-8451-033754f68e6e
-        configfile "($ubuntu)/boot/grub/grub.cfg"
-      }
-    '';
+    {
+      boot.loader.grub.extraEntries = ''
+        menuentry "Ubuntu" {
+          search --set=ubuntu --fs-uuid 3cc3e652-0c1f-4800-8451-033754f68e6e
+          configfile "($ubuntu)/boot/grub/grub.cfg"
+        }
+      '';
+    }
     ```
 
     (You can find the appropriate UUID for your partition in
@@ -164,7 +166,9 @@ The first steps to all these are the same:
     `sudo passwd -l root` if you use `sudo`)
 
     ```nix
-    users.users.root.initialHashedPassword = "";
+    {
+      users.users.root.initialHashedPassword = "";
+    }
     ```
 
 1.  Build the NixOS closure and install it in the `system` profile:

--- a/nixos/doc/manual/installation/installing-virtualbox-guest.section.md
+++ b/nixos/doc/manual/installation/installing-virtualbox-guest.section.md
@@ -29,14 +29,18 @@ There are a few modifications you should make in configuration.nix.
 Enable booting:
 
 ```nix
-boot.loader.grub.device = "/dev/sda";
+{
+  boot.loader.grub.device = "/dev/sda";
+}
 ```
 
 Also remove the fsck that runs at startup. It will always fail to run,
 stopping your boot until you press `*`.
 
 ```nix
-boot.initrd.checkJournalingFS = false;
+{
+  boot.initrd.checkJournalingFS = false;
+}
 ```
 
 Shared folders can be given a name and a path in the host system in the

--- a/nixos/doc/manual/installation/upgrading.chapter.md
+++ b/nixos/doc/manual/installation/upgrading.chapter.md
@@ -101,8 +101,10 @@ You can keep a NixOS system up-to-date automatically by adding the
 following to `configuration.nix`:
 
 ```nix
-system.autoUpgrade.enable = true;
-system.autoUpgrade.allowReboot = true;
+{
+  system.autoUpgrade.enable = true;
+  system.autoUpgrade.allowReboot = true;
+}
 ```
 
 This enables a periodically executed systemd service named
@@ -114,5 +116,7 @@ the new generation contains a different kernel, initrd or kernel
 modules. You can also specify a channel explicitly, e.g.
 
 ```nix
-system.autoUpgrade.channel = "https://channels.nixos.org/nixos-23.11";
+{
+  system.autoUpgrade.channel = "https://channels.nixos.org/nixos-23.11";
+}
 ```

--- a/nixos/doc/manual/release-notes/rl-1509.section.md
+++ b/nixos/doc/manual/release-notes/rl-1509.section.md
@@ -253,9 +253,9 @@ Installing Haskell _libraries_ this way, however, is no longer supported. See th
 
   {
     options = {
-      foo = mkOption { … };
+      foo = mkOption { /* … */ };
     };
-    config = mkIf config.foo { … };
+    config = mkIf config.foo { /* … */ };
   }
   ```
 
@@ -268,9 +268,9 @@ Installing Haskell _libraries_ this way, however, is no longer supported. See th
 
   {
     options = {
-      foo = mkOption { option declaration };
+      foo = mkOption { /* option declaration */ };
     };
-    config = mkIf config.foo { option definition };
+    config = mkIf config.foo { /* option definition */ };
   }
   ```
 

--- a/nixos/doc/manual/release-notes/rl-1703.section.md
+++ b/nixos/doc/manual/release-notes/rl-1703.section.md
@@ -246,7 +246,7 @@ When upgrading from a previous release, please be aware of the following incompa
   let
     pkgs = import <nixpkgs> {};
   in
-    pkgs.overridePackages (self: super: ...)
+    pkgs.overridePackages (self: super: { /* ... */ })
   ```
 
   should be replaced by:
@@ -255,7 +255,7 @@ When upgrading from a previous release, please be aware of the following incompa
   let
     pkgs = import <nixpkgs> {};
   in
-    import pkgs.path { overlays = [(self: super: ...)]; }
+    import pkgs.path { overlays = [(self: super: { /* ... */ })]; }
   ```
 
 - Autoloading connection tracking helpers is now disabled by default. This default was also changed in the Linux kernel and is considered insecure if not configured properly in your firewall. If you need connection tracking helpers (i.e. for active FTP) please enable `networking.firewall.autoLoadConntrackHelpers` and tune `networking.firewall.connectionTrackingModules` to suit your needs.

--- a/nixos/doc/manual/release-notes/rl-2009.section.md
+++ b/nixos/doc/manual/release-notes/rl-2009.section.md
@@ -334,22 +334,18 @@ When upgrading from a previous release, please be aware of the following incompa
 - The remaining configuration flags can now be set directly on the `php` attribute. For example, instead of
 
   ```nix
-  {
-    php.override {
-      config.php.embed = true;
-      config.php.apxs2 = false;
-    }
+  php.override {
+    config.php.embed = true;
+    config.php.apxs2 = false;
   }
   ```
 
   you should now write
 
   ```nix
-  {
-    php.override {
-      embedSupport = true;
-      apxs2Support = false;
-    }
+  php.override {
+    embedSupport = true;
+    apxs2Support = false;
   }
   ```
 
@@ -383,9 +379,10 @@ When upgrading from a previous release, please be aware of the following incompa
   {
     specialisation.example-sub-configuration = {
       configuration = {
-        ...
+        # ...
       };
-  };
+    };
+  }
   ```
 
   Replace a `nesting.children` entry with:
@@ -395,9 +392,10 @@ When upgrading from a previous release, please be aware of the following incompa
     specialisation.example-sub-configuration = {
       inheritParentConfig = false;
       configuration = {
-        ...
+        # ...
       };
-  };
+    };
+  }
   ```
 
   To switch to a specialised configuration at runtime you need to run:
@@ -469,7 +467,7 @@ When upgrading from a previous release, please be aware of the following incompa
     services.bitcoind = {
       enable = true;
       extraConfig = "...";
-      ...
+      # ...
     };
   }
   ```
@@ -483,7 +481,7 @@ When upgrading from a previous release, please be aware of the following incompa
       dataDir = "/var/lib/bitcoind";
       user = "bitcoin";
       extraConfig = "...";
-      ...
+      # ...
     };
   }
   ```
@@ -502,7 +500,7 @@ When upgrading from a previous release, please be aware of the following incompa
   {
     services.dokuwiki = {
       enable = true;
-      ...
+      # ...
     };
   }
   ```
@@ -517,7 +515,7 @@ When upgrading from a previous release, please be aware of the following incompa
         forceSSL = true;
         enableACME = true;
       };
-      ...
+      # ...
     };
   }
   ```

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -462,6 +462,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
   Before:
   ```nix
+  {
     services.keycloak = {
       enable = true;
       httpPort = "8080";
@@ -471,10 +472,12 @@ In addition to numerous new and upgraded packages, this release has the followin
         "subsystem=undertow"."server=default-server"."http-listener=default".proxy-address-forwarding = true;
       };
     };
+  }
   ```
 
   After:
   ```nix
+  {
     services.keycloak = {
       enable = true;
       settings = {
@@ -485,6 +488,7 @@ In addition to numerous new and upgraded packages, this release has the followin
       };
       database.passwordFile = "/run/keys/db_password";
     };
+  }
   ```
 
 - The MoinMoin wiki engine (`services.moinmoin`) has been removed, because Python 2 is being retired from nixpkgs.

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -255,9 +255,11 @@ In addition to numerous new and upgraded packages, this release includes the fol
 - `services.github-runner` and `services.github-runners.<name>` gained the option `serviceOverrides` which allows overriding the systemd `serviceConfig`. If you have been overriding the systemd service configuration (i.e., by defining `systemd.services.github-runner.serviceConfig`), you have to use the `serviceOverrides` option now. Example:
 
   ```nix
-  services.github-runner.serviceOverrides.SupplementaryGroups = [
-    "docker"
-  ];
+  {
+    services.github-runner.serviceOverrides.SupplementaryGroups = [
+      "docker"
+    ];
+  }
   ```
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -254,7 +254,7 @@ In addition to numerous new and upgraded packages, this release includes the fol
 
 - `services.github-runner` and `services.github-runners.<name>` gained the option `serviceOverrides` which allows overriding the systemd `serviceConfig`. If you have been overriding the systemd service configuration (i.e., by defining `systemd.services.github-runner.serviceConfig`), you have to use the `serviceOverrides` option now. Example:
 
-  ```
+  ```nix
   services.github-runner.serviceOverrides.SupplementaryGroups = [
     "docker"
   ];

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -25,7 +25,9 @@ In addition to numerous new and updated packages, this release has the following
 
 - NixOS now defaults to using [nsncd](https://github.com/twosigma/nsncd), a non-caching reimplementation of nscd in Rust, as its NSS lookup dispatcher. This replaces the buggy and deprecated nscd implementation provided through glibc. When you find problems, you can switch back by disabling it:
   ```nix
-  services.nscd.enableNsncd = false;
+  {
+    services.nscd.enableNsncd = false;
+  }
   ```
 
 - The internal option `boot.bootspec.enable` is now enabled by default because [RFC 0125](https://github.com/NixOS/rfcs/pull/125) was merged. This means you will have a bootspec document called `boot.json` generated for each system and specialisation in the top-level. This is useful to enable advanced boot use cases in NixOS, such as Secure Boot.
@@ -190,11 +192,13 @@ In addition to numerous new and updated packages, this release has the following
 - MAC-then-encrypt algorithms were removed from the default selection of `services.openssh.settings.Macs`. If you still require these [MACs](https://en.wikipedia.org/wiki/Message_authentication_code), for example when you are relying on libssh2 (e.g. VLC) or the SSH library shipped on the iPhone, you can re-add them like this:
 
   ```nix
-  services.openssh.settings.Macs = [
-    "hmac-sha2-512"
-    "hmac-sha2-256"
-    "umac-128@openssh.com"
-  ];
+  {
+    services.openssh.settings.Macs = [
+      "hmac-sha2-512"
+      "hmac-sha2-256"
+      "umac-128@openssh.com"
+    ];
+  }
   ```
 
 - `podman` now uses the `netavark` network stack. Users will need to delete all of their local containers, images, volumes, etc, by running `podman system reset --force` once before upgrading their systems.
@@ -227,21 +231,25 @@ In addition to numerous new and updated packages, this release has the following
 - The attributes used by `services.snapper.configs.<name>` have changed. Migrate from this:
 
   ```nix
-  services.snapper.configs.example = {
-    subvolume = "/example";
-    extraConfig = ''
-      ALLOW_USERS="alice"
-    '';
-  };
+  {
+    services.snapper.configs.example = {
+      subvolume = "/example";
+      extraConfig = ''
+        ALLOW_USERS="alice"
+      '';
+    };
+  }
   ```
 
   to this:
 
   ```nix
-  services.snapper.configs.example = {
-    SUBVOLUME = "/example";
-    ALLOW_USERS = [ "alice" ];
-  };
+  {
+    services.snapper.configs.example = {
+      SUBVOLUME = "/example";
+      ALLOW_USERS = [ "alice" ];
+    };
+  }
   ```
 
 - The default module options for [services.snapserver.openFirewall](#opt-services.snapserver.openFirewall), [services.tmate-ssh-server.openFirewall](#opt-services.tmate-ssh-server.openFirewall) and [services.unifi-video.openFirewall](#opt-services.unifi-video.openFirewall) have been changed from `true` to `false`. You will need to explicitly set this option to `true`, or configure your firewall.
@@ -446,15 +454,17 @@ In addition to numerous new and updated packages, this release has the following
 - NixOS swap partitions with random encryption can now control the sector size, cipher, and key size used to set up the plain encryption device over the underlying block device rather than allowing them to be determined by `cryptsetup(8)`. One can use these features like so:
 
   ```nix
-  swapDevices = [ {
-    device = "/dev/disk/by-partlabel/swapspace";
-    randomEncryption = {
-      enable = true;
-      cipher = "aes-xts-plain64";
-      keySize = 512;
-      sectorSize = 4096;
-    };
-  } ];
+  {
+    swapDevices = [ {
+      device = "/dev/disk/by-partlabel/swapspace";
+      randomEncryption = {
+        enable = true;
+        cipher = "aes-xts-plain64";
+        keySize = 512;
+        sectorSize = 4096;
+      };
+    } ];
+  }
   ```
 
 - New option `security.pam.zfs` to enable unlocking and mounting of encrypted ZFS home dataset at login.
@@ -465,7 +475,9 @@ In addition to numerous new and updated packages, this release has the following
 
 - PostgreSQL has added opt-in support for [JIT compilation](https://www.postgresql.org/docs/current/jit-reason.html). It can be enabled like this:
   ```nix
-  services.postgresql.enableJIT = true;
+  {
+    services.postgresql.enableJIT = true;
+  }
   ```
 
 - `services.netdata` offers a [`services.netdata.deadlineBeforeStopSec`](#opt-services.netdata.deadlineBeforeStopSec) option which will control the deadline (in seconds) after which systemd will consider your netdata instance as dead if it didn't start in the elapsed time. It is helpful when your netdata instance takes longer to start because of a large amount of state or upgrades.

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -1228,7 +1228,7 @@ Make sure to also check the many updates in the [Nixpkgs library](#sec-release-2
 - CoreDNS may be built with external plugins now. This may be done by
   overriding `externalPlugins` and `vendorHash` arguments like this:
 
-  ```
+  ```nix
   services.coredns = {
     enable = true;
     package = pkgs.coredns.override {

--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -700,11 +700,13 @@ Make sure to also check the many updates in the [Nixpkgs library](#sec-release-2
   will probably be removed eventually.
 
   ```nix
-  qt = {
-    enable = true;
-    platformTheme = "gnome";
-    style = "adwaita";
-  };
+  {
+    qt = {
+      enable = true;
+      platformTheme = "gnome";
+      style = "adwaita";
+    };
+  }
   ```
 
 - DocBook option documentation is no longer supported, all module documentation
@@ -885,11 +887,13 @@ Make sure to also check the many updates in the [Nixpkgs library](#sec-release-2
   to a compatible major version, so they can move at their own pace.
 
   ```nix
-  python = python3.override {
-    packageOverrides = self: super: {
-      django = super.django_3;
+  {
+    python = python3.override {
+      packageOverrides = self: super: {
+        django = super.django_3;
+      };
     };
-  };
+  }
   ```
 
 - The `qemu-vm.nix` module by default now identifies block devices via
@@ -1229,15 +1233,17 @@ Make sure to also check the many updates in the [Nixpkgs library](#sec-release-2
   overriding `externalPlugins` and `vendorHash` arguments like this:
 
   ```nix
-  services.coredns = {
-    enable = true;
-    package = pkgs.coredns.override {
-      externalPlugins = [
-        {name = "fanout"; repo = "github.com/networkservicemesh/fanout"; version = "v1.9.1";}
-      ];
-      vendorHash = "<SRI hash>";
+  {
+    services.coredns = {
+      enable = true;
+      package = pkgs.coredns.override {
+        externalPlugins = [
+          {name = "fanout"; repo = "github.com/networkservicemesh/fanout"; version = "v1.9.1";}
+        ];
+        vendorHash = "<SRI hash>";
+      };
     };
-  };
+  }
   ```
 
   To get the necessary SRI hash, set `vendorHash = "";`. The build will fail

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -57,7 +57,7 @@ Use `services.pipewire.extraConfig` or `services.pipewire.configPackages` for Pi
   without perl). Previously, the NixOS activation depended on two perl scripts
   which can now be replaced via an opt-in mechanism. To make your system
   perlless, you can use the new perlless profile:
-  ```
+  ```nix
   { modulesPath, ... }: {
     imports = [ "${modulesPath}/profiles/perlless.nix" ];
   }

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -220,13 +220,14 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
   Example:
 
   ```nix
+  {
     locations."/".extraConfig = ''
       add_header Alt-Svc 'h3=":$server_port"; ma=86400';
     '';
     locations."^~ /assets/".extraConfig = ''
       add_header Alt-Svc 'h3=":$server_port"; ma=86400';
     '';
-
+  }
   ```
 
 - The package `optparse-bash` is now dropped due to upstream inactivity. Alternatives available in Nixpkgs include [`argc`](https://github.com/sigoden/argc), [`argbash`](https://github.com/matejak/argbash), [`bashly`](https://github.com/DannyBen/bashly) and [`gum`](https://github.com/charmbracelet/gum), to name a few.

--- a/nixos/modules/i18n/input-method/default.md
+++ b/nixos/modules/i18n/input-method/default.md
@@ -22,7 +22,7 @@ friendly input method user interface.
 
 The following snippet can be used to configure IBus:
 
-```
+```nix
 i18n.inputMethod = {
   enabled = "ibus";
   ibus.engines = with pkgs.ibus-engines; [ anthy hangul mozc ];
@@ -48,7 +48,7 @@ Available extra IBus engines are:
     methods, it must appear in the list of engines along with
     `table`. For example:
 
-    ```
+    ```nix
     ibus.engines = with pkgs.ibus-engines; [ table table-others ];
     ```
 
@@ -74,7 +74,7 @@ built-in Input Method Engine, Pinyin, QuWei and Table-based input methods.
 
 The following snippet can be used to configure Fcitx:
 
-```
+```nix
 i18n.inputMethod = {
   enabled = "fcitx5";
   fcitx5.addons = with pkgs; [ fcitx5-mozc fcitx5-hangul fcitx5-m17n ];
@@ -110,7 +110,7 @@ phonetic Korean characters (hangul) and pictographic Korean characters
 
 The following snippet can be used to configure Nabi:
 
-```
+```nix
 i18n.inputMethod = {
   enabled = "nabi";
 };
@@ -123,7 +123,7 @@ framework. Applications can use it through so-called bridges.
 
 The following snippet can be used to configure uim:
 
-```
+```nix
 i18n.inputMethod = {
   enabled = "uim";
 };
@@ -141,7 +141,7 @@ etc...
 
 The following snippet can be used to configure Hime:
 
-```
+```nix
 i18n.inputMethod = {
   enabled = "hime";
 };
@@ -153,7 +153,7 @@ Kime is Korean IME. it's built with Rust language and let you get simple, safe, 
 
 The following snippet can be used to configure Kime:
 
-```
+```nix
 i18n.inputMethod = {
   enabled = "kime";
 };

--- a/nixos/modules/i18n/input-method/default.md
+++ b/nixos/modules/i18n/input-method/default.md
@@ -23,10 +23,12 @@ friendly input method user interface.
 The following snippet can be used to configure IBus:
 
 ```nix
-i18n.inputMethod = {
-  enabled = "ibus";
-  ibus.engines = with pkgs.ibus-engines; [ anthy hangul mozc ];
-};
+{
+  i18n.inputMethod = {
+    enabled = "ibus";
+    ibus.engines = with pkgs.ibus-engines; [ anthy hangul mozc ];
+  };
+}
 ```
 
 `i18n.inputMethod.ibus.engines` is optional and can be used
@@ -49,7 +51,9 @@ Available extra IBus engines are:
     `table`. For example:
 
     ```nix
-    ibus.engines = with pkgs.ibus-engines; [ table table-others ];
+    {
+      ibus.engines = with pkgs.ibus-engines; [ table table-others ];
+    }
     ```
 
 To use any input method, the package must be added in the configuration, as
@@ -75,10 +79,12 @@ built-in Input Method Engine, Pinyin, QuWei and Table-based input methods.
 The following snippet can be used to configure Fcitx:
 
 ```nix
-i18n.inputMethod = {
-  enabled = "fcitx5";
-  fcitx5.addons = with pkgs; [ fcitx5-mozc fcitx5-hangul fcitx5-m17n ];
-};
+{
+  i18n.inputMethod = {
+    enabled = "fcitx5";
+    fcitx5.addons = with pkgs; [ fcitx5-mozc fcitx5-hangul fcitx5-m17n ];
+  };
+}
 ```
 
 `i18n.inputMethod.fcitx5.addons` is optional and can be
@@ -111,9 +117,11 @@ phonetic Korean characters (hangul) and pictographic Korean characters
 The following snippet can be used to configure Nabi:
 
 ```nix
-i18n.inputMethod = {
-  enabled = "nabi";
-};
+{
+  i18n.inputMethod = {
+    enabled = "nabi";
+  };
+}
 ```
 
 ## Uim {#module-services-input-methods-uim}
@@ -124,9 +132,11 @@ framework. Applications can use it through so-called bridges.
 The following snippet can be used to configure uim:
 
 ```nix
-i18n.inputMethod = {
-  enabled = "uim";
-};
+{
+  i18n.inputMethod = {
+    enabled = "uim";
+  };
+}
 ```
 
 Note: The [](#opt-i18n.inputMethod.uim.toolbar) option can be
@@ -142,9 +152,11 @@ etc...
 The following snippet can be used to configure Hime:
 
 ```nix
-i18n.inputMethod = {
-  enabled = "hime";
-};
+{
+  i18n.inputMethod = {
+    enabled = "hime";
+  };
+}
 ```
 
 ## Kime {#module-services-input-methods-kime}
@@ -154,7 +166,9 @@ Kime is Korean IME. it's built with Rust language and let you get simple, safe, 
 The following snippet can be used to configure Kime:
 
 ```nix
-i18n.inputMethod = {
-  enabled = "kime";
-};
+{
+  i18n.inputMethod = {
+    enabled = "kime";
+  };
+}
 ```

--- a/nixos/modules/programs/digitalbitbox/default.md
+++ b/nixos/modules/programs/digitalbitbox/default.md
@@ -4,7 +4,7 @@ Digital Bitbox is a hardware wallet and second-factor authenticator.
 
 The `digitalbitbox` programs module may be installed by setting
 `programs.digitalbitbox` to `true` in a manner similar to
-```
+```nix
 programs.digitalbitbox.enable = true;
 ```
 and bundles the `digitalbitbox` package (see [](#sec-digitalbitbox-package)),
@@ -21,7 +21,7 @@ For more information, see <https://digitalbitbox.com/start_linux>.
 
 The binaries, `dbb-app` (a GUI tool) and `dbb-cli` (a CLI tool), are available
 through the `digitalbitbox` package which could be installed as follows:
-```
+```nix
 environment.systemPackages = [
   pkgs.digitalbitbox
 ];
@@ -31,13 +31,13 @@ environment.systemPackages = [
 
 The digitalbitbox hardware package enables the udev rules for Digital Bitbox
 devices and may be installed as follows:
-```
+```nix
 hardware.digitalbitbox.enable = true;
 ```
 
 In order to alter the udev rules, one may provide different values for the
 `udevRule51` and `udevRule52` attributes by means of overriding as follows:
-```
+```nix
 programs.digitalbitbox = {
   enable = true;
   package = pkgs.digitalbitbox.override {

--- a/nixos/modules/programs/digitalbitbox/default.md
+++ b/nixos/modules/programs/digitalbitbox/default.md
@@ -5,7 +5,9 @@ Digital Bitbox is a hardware wallet and second-factor authenticator.
 The `digitalbitbox` programs module may be installed by setting
 `programs.digitalbitbox` to `true` in a manner similar to
 ```nix
-programs.digitalbitbox.enable = true;
+{
+  programs.digitalbitbox.enable = true;
+}
 ```
 and bundles the `digitalbitbox` package (see [](#sec-digitalbitbox-package)),
 which contains the `dbb-app` and `dbb-cli` binaries, along with the hardware
@@ -22,9 +24,11 @@ For more information, see <https://digitalbitbox.com/start_linux>.
 The binaries, `dbb-app` (a GUI tool) and `dbb-cli` (a CLI tool), are available
 through the `digitalbitbox` package which could be installed as follows:
 ```nix
-environment.systemPackages = [
-  pkgs.digitalbitbox
-];
+{
+  environment.systemPackages = [
+    pkgs.digitalbitbox
+  ];
+}
 ```
 
 ## Hardware {#sec-digitalbitbox-hardware-module}
@@ -32,16 +36,20 @@ environment.systemPackages = [
 The digitalbitbox hardware package enables the udev rules for Digital Bitbox
 devices and may be installed as follows:
 ```nix
-hardware.digitalbitbox.enable = true;
+{
+  hardware.digitalbitbox.enable = true;
+}
 ```
 
 In order to alter the udev rules, one may provide different values for the
 `udevRule51` and `udevRule52` attributes by means of overriding as follows:
 ```nix
-programs.digitalbitbox = {
-  enable = true;
-  package = pkgs.digitalbitbox.override {
-    udevRule51 = "something else";
+{
+  programs.digitalbitbox = {
+    enable = true;
+    package = pkgs.digitalbitbox.override {
+      udevRule51 = "something else";
+    };
   };
-};
+}
 ```

--- a/nixos/modules/programs/plotinus.md
+++ b/nixos/modules/programs/plotinus.md
@@ -13,5 +13,7 @@ palette provides a searchable list of of all menu items in the application.
 To enable Plotinus, add the following to your
 {file}`configuration.nix`:
 ```nix
-programs.plotinus.enable = true;
+{
+  programs.plotinus.enable = true;
+}
 ```

--- a/nixos/modules/programs/plotinus.md
+++ b/nixos/modules/programs/plotinus.md
@@ -12,6 +12,6 @@ palette provides a searchable list of of all menu items in the application.
 
 To enable Plotinus, add the following to your
 {file}`configuration.nix`:
-```
+```nix
 programs.plotinus.enable = true;
 ```

--- a/nixos/modules/programs/zsh/oh-my-zsh.md
+++ b/nixos/modules/programs/zsh/oh-my-zsh.md
@@ -9,7 +9,7 @@ prompt themes.
 The module uses the `oh-my-zsh` package with all available
 features. The initial setup using Nix expressions is fairly similar to the
 configuration format of `oh-my-zsh`.
-```
+```nix
 {
   programs.zsh.ohMyZsh = {
     enable = true;
@@ -33,7 +33,7 @@ environment variable for this which points to a directory with additional
 scripts.
 
 The module can do this as well:
-```
+```nix
 {
   programs.zsh.ohMyZsh.custom = "~/path/to/custom/scripts";
 }
@@ -48,7 +48,7 @@ which bundles completion scripts and a plugin for `oh-my-zsh`.
 
 Rather than using a single mutable path for `ZSH_CUSTOM`,
 it's also possible to generate this path from a list of Nix packages:
-```
+```nix
 { pkgs, ... }:
 {
   programs.zsh.ohMyZsh.customPkgs = [
@@ -89,7 +89,7 @@ If third-party customizations (e.g. new themes) are supposed to be added to
     [upstream repo.](https://github.com/robbyrussell/oh-my-zsh/tree/91b771914bc7c43dd7c7a43b586c5de2c225ceb7/plugins)
 
 A derivation for `oh-my-zsh` may look like this:
-```
+```nix
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {

--- a/nixos/modules/services/audio/castopod.md
+++ b/nixos/modules/services/audio/castopod.md
@@ -7,16 +7,18 @@ Castopod is an open-source hosting platform made for podcasters who want to enga
 Use the following configuration to start a public instance of Castopod on `castopod.example.com` domain:
 
 ```nix
-networking.firewall.allowedTCPPorts = [ 80 443 ];
-services.castopod = {
-  enable = true;
-  database.createLocally = true;
-  nginx.virtualHost = {
-    serverName = "castopod.example.com";
-    enableACME = true;
-    forceSSL = true;
+{
+  networking.firewall.allowedTCPPorts = [ 80 443 ];
+  services.castopod = {
+    enable = true;
+    database.createLocally = true;
+    nginx.virtualHost = {
+      serverName = "castopod.example.com";
+      enableACME = true;
+      forceSSL = true;
+    };
   };
-};
+}
 ```
 
 Go to `https://castopod.example.com/cp-install` to create superadmin account after applying the above configuration.

--- a/nixos/modules/services/backup/borgbackup.md
+++ b/nixos/modules/services/backup/borgbackup.md
@@ -21,7 +21,7 @@ A complete list of options for the Borgbase module may be found
 ## Basic usage for a local backup {#opt-services-backup-borgbackup-local-directory}
 
 A very basic configuration for backing up to a locally accessible directory is:
-```
+```nix
 {
     opt.services.borgbackup.jobs = {
       { rootBackup = {
@@ -59,7 +59,7 @@ ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID78zmOyA+5uPG4Ot0hfAy+sLDPU1L4AiIoRYEIVbbQ/
 ```
 
 Add the following snippet to your NixOS configuration:
-```
+```nix
 {
   services.borgbackup.repos = {
     my_borg_repo = {
@@ -80,7 +80,7 @@ that you have stored a secret passphrasse in the file
 {file}`/run/keys/borgbackup_passphrase`, which should be only
 accessible by root
 
-```
+```nix
 {
   services.borgbackup.jobs = {
     backupToLocalServer = {

--- a/nixos/modules/services/backup/borgbackup.md
+++ b/nixos/modules/services/backup/borgbackup.md
@@ -24,19 +24,18 @@ A very basic configuration for backing up to a locally accessible directory is:
 ```nix
 {
     opt.services.borgbackup.jobs = {
-      { rootBackup = {
-          paths = "/";
-          exclude = [ "/nix" "/path/to/local/repo" ];
-          repo = "/path/to/local/repo";
-          doInit = true;
-          encryption = {
-            mode = "repokey";
-            passphrase = "secret";
-          };
-          compression = "auto,lzma";
-          startAt = "weekly";
+      rootBackup = {
+        paths = "/";
+        exclude = [ "/nix" "/path/to/local/repo" ];
+        repo = "/path/to/local/repo";
+        doInit = true;
+        encryption = {
+          mode = "repokey";
+          passphrase = "secret";
         };
-      }
+        compression = "auto,lzma";
+        startAt = "weekly";
+      };
     };
 }
 ```
@@ -96,7 +95,7 @@ accessible by root
       startAt = "hourly";
     };
   };
-};
+}
 ```
 
 The following few commands (run as root) let you test your backup.

--- a/nixos/modules/services/databases/foundationdb.md
+++ b/nixos/modules/services/databases/foundationdb.md
@@ -15,7 +15,7 @@ key-value store.
 
 To enable FoundationDB, add the following to your
 {file}`configuration.nix`:
-```
+```nix
 services.foundationdb.enable = true;
 services.foundationdb.package = pkgs.foundationdb71; # FoundationDB 7.1.x
 ```
@@ -109,7 +109,7 @@ default configuration. See below for more on scaling to increase this.
 FoundationDB stores all data for all server processes under
 {file}`/var/lib/foundationdb`. You can override this using
 {option}`services.foundationdb.dataDir`, e.g.
-```
+```nix
 services.foundationdb.dataDir = "/data/fdb";
 ```
 
@@ -265,7 +265,7 @@ directories.
 For example, to create backups in {command}`/opt/fdb-backups`, first
 set up the paths in the module options:
 
-```
+```nix
 services.foundationdb.extraReadWritePaths = [ "/opt/fdb-backups" ];
 ```
 

--- a/nixos/modules/services/databases/foundationdb.md
+++ b/nixos/modules/services/databases/foundationdb.md
@@ -16,8 +16,10 @@ key-value store.
 To enable FoundationDB, add the following to your
 {file}`configuration.nix`:
 ```nix
-services.foundationdb.enable = true;
-services.foundationdb.package = pkgs.foundationdb71; # FoundationDB 7.1.x
+{
+  services.foundationdb.enable = true;
+  services.foundationdb.package = pkgs.foundationdb71; # FoundationDB 7.1.x
+}
 ```
 
 The {option}`services.foundationdb.package` option is required, and
@@ -110,7 +112,9 @@ FoundationDB stores all data for all server processes under
 {file}`/var/lib/foundationdb`. You can override this using
 {option}`services.foundationdb.dataDir`, e.g.
 ```nix
-services.foundationdb.dataDir = "/data/fdb";
+{
+  services.foundationdb.dataDir = "/data/fdb";
+}
 ```
 
 Similarly, logs are stored under {file}`/var/log/foundationdb`
@@ -266,7 +270,9 @@ For example, to create backups in {command}`/opt/fdb-backups`, first
 set up the paths in the module options:
 
 ```nix
-services.foundationdb.extraReadWritePaths = [ "/opt/fdb-backups" ];
+{
+  services.foundationdb.extraReadWritePaths = [ "/opt/fdb-backups" ];
+}
 ```
 
 Restart the FoundationDB service, and it will now be able to write to this

--- a/nixos/modules/services/databases/postgresql.md
+++ b/nixos/modules/services/databases/postgresql.md
@@ -16,8 +16,10 @@ PostgreSQL is an advanced, free relational database.
 
 To enable PostgreSQL, add the following to your {file}`configuration.nix`:
 ```nix
-services.postgresql.enable = true;
-services.postgresql.package = pkgs.postgresql_15;
+{
+  services.postgresql.enable = true;
+  services.postgresql.package = pkgs.postgresql_15;
+}
 ```
 Note that you are required to specify the desired version of PostgreSQL (e.g. `pkgs.postgresql_15`). Since upgrading your PostgreSQL version requires a database dump and reload (see below), NixOS cannot provide a default value for [](#opt-services.postgresql.package) such as the most recent release of PostgreSQL.
 
@@ -36,7 +38,9 @@ alice=>
 
 By default, PostgreSQL stores its databases in {file}`/var/lib/postgresql/$psqlSchema`. You can override this using [](#opt-services.postgresql.dataDir), e.g.
 ```nix
-services.postgresql.dataDir = "/data/postgresql";
+{
+  services.postgresql.dataDir = "/data/postgresql";
+}
 ```
 
 ## Initializing {#module-services-postgres-initializing}
@@ -95,16 +99,19 @@ databases from `ensureDatabases` and `extraUser1` from `ensureUsers`
 are already created.
 
 ```nix
+  {
     systemd.services.postgresql.postStart = lib.mkAfter ''
       $PSQL service1 -c 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO "extraUser1"'
       $PSQL service1 -c 'GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO "extraUser1"'
       # ....
     '';
+  }
 ```
 
 ##### in intermediate oneshot service {#module-services-postgres-initializing-extra-permissions-superuser-oneshot}
 
 ```nix
+  {
     systemd.services."migrate-service1-db1" = {
       serviceConfig.Type = "oneshot";
       requiredBy = "service1.service";
@@ -119,6 +126,7 @@ are already created.
         # ....
       '';
     };
+  }
 ```
 
 #### as service user {#module-services-postgres-initializing-extra-permissions-service-user}
@@ -130,6 +138,7 @@ are already created.
 ##### in service `preStart` {#module-services-postgres-initializing-extra-permissions-service-user-pre-start}
 
 ```nix
+  {
     environment.PSQL = "psql --port=${toString services.postgresql.port}";
     path = [ postgresql ];
     systemd.services."service1".preStart = ''
@@ -137,11 +146,13 @@ are already created.
       $PSQL -c 'GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO "extraUser1"'
       # ....
     '';
+  }
 ```
 
 ##### in intermediate oneshot service {#module-services-postgres-initializing-extra-permissions-service-user-oneshot}
 
 ```nix
+  {
     systemd.services."migrate-service1-db1" = {
       serviceConfig.Type = "oneshot";
       requiredBy = "service1.service";
@@ -156,6 +167,7 @@ are already created.
         # ....
       '';
     };
+  }
 ```
 
 ## Upgrading {#module-services-postgres-upgrading}
@@ -257,11 +269,13 @@ postgresql_15.pkgs.pg_partman        postgresql_15.pkgs.pgroonga
 
 To add plugins via NixOS configuration, set `services.postgresql.extraPlugins`:
 ```nix
-services.postgresql.package = pkgs.postgresql_12;
-services.postgresql.extraPlugins = ps: with ps; [
-  pg_repack
-  postgis
-];
+{
+  services.postgresql.package = pkgs.postgresql_12;
+  services.postgresql.extraPlugins = ps: with ps; [
+    pg_repack
+    postgis
+  ];
+}
 ```
 
 You can build custom PostgreSQL-with-plugins (to be used outside of NixOS) using function `.withPackages`. For example, creating a custom PostgreSQL package in an overlay can look like:

--- a/nixos/modules/services/databases/postgresql.md
+++ b/nixos/modules/services/databases/postgresql.md
@@ -15,7 +15,7 @@ PostgreSQL is an advanced, free relational database.
 ## Configuring {#module-services-postgres-configuring}
 
 To enable PostgreSQL, add the following to your {file}`configuration.nix`:
-```
+```nix
 services.postgresql.enable = true;
 services.postgresql.package = pkgs.postgresql_15;
 ```
@@ -35,7 +35,7 @@ alice=>
 -->
 
 By default, PostgreSQL stores its databases in {file}`/var/lib/postgresql/$psqlSchema`. You can override this using [](#opt-services.postgresql.dataDir), e.g.
-```
+```nix
 services.postgresql.dataDir = "/data/postgresql";
 ```
 
@@ -174,7 +174,7 @@ $ nix-instantiate --eval -A postgresql_13.psqlSchema
 "13"
 ```
 For an upgrade, a script like this can be used to simplify the process:
-```
+```nix
 { config, pkgs, ... }:
 {
   environment.systemPackages = [
@@ -256,7 +256,7 @@ postgresql_15.pkgs.pg_partman        postgresql_15.pkgs.pgroonga
 ```
 
 To add plugins via NixOS configuration, set `services.postgresql.extraPlugins`:
-```
+```nix
 services.postgresql.package = pkgs.postgresql_12;
 services.postgresql.extraPlugins = ps: with ps; [
   pg_repack
@@ -265,7 +265,7 @@ services.postgresql.extraPlugins = ps: with ps; [
 ```
 
 You can build custom PostgreSQL-with-plugins (to be used outside of NixOS) using function `.withPackages`. For example, creating a custom PostgreSQL package in an overlay can look like:
-```
+```nix
 self: super: {
   postgresql_custom = self.postgresql_12.withPackages (ps: [
     ps.pg_repack
@@ -275,7 +275,7 @@ self: super: {
 ```
 
 Here's a recipe on how to override a particular plugin through an overlay:
-```
+```nix
 self: super: {
   postgresql_15 = super.postgresql_15// {
     pkgs = super.postgresql_15.pkgs // {

--- a/nixos/modules/services/databases/tigerbeetle.md
+++ b/nixos/modules/services/databases/tigerbeetle.md
@@ -8,7 +8,9 @@ TigerBeetle is a distributed financial accounting database designed for mission 
 
 To enable TigerBeetle, add the following to your {file}`configuration.nix`:
 ```nix
+{
   services.tigerbeetle.enable = true;
+}
 ```
 
 When first started, the TigerBeetle service will create its data file at {file}`/var/lib/tigerbeetle` unless the file already exists, in which case it will just use the existing file.
@@ -21,12 +23,14 @@ To configure it to listen on a different interface (and to configure it to conne
 Note that the TigerBeetle module won't open any firewall ports automatically, so if you configure it to listen on an external interface, you'll need to ensure that connections can reach it:
 
 ```nix
+{
   services.tigerbeetle = {
     enable = true;
     addresses = [ "0.0.0.0:3001" ];
   };
 
   networking.firewall.allowedTCPPorts = [ 3001 ];
+}
 ```
 
 A complete list of options for TigerBeetle can be found [here](#opt-services.tigerbeetle.enable).

--- a/nixos/modules/services/databases/tigerbeetle.md
+++ b/nixos/modules/services/databases/tigerbeetle.md
@@ -7,7 +7,7 @@
 TigerBeetle is a distributed financial accounting database designed for mission critical safety and performance.
 
 To enable TigerBeetle, add the following to your {file}`configuration.nix`:
-```
+```nix
   services.tigerbeetle.enable = true;
 ```
 
@@ -20,7 +20,7 @@ By default, TigerBeetle will only listen on a local interface.
 To configure it to listen on a different interface (and to configure it to connect to other replicas, if you're creating more than one), you'll have to set the `addresses` option.
 Note that the TigerBeetle module won't open any firewall ports automatically, so if you configure it to listen on an external interface, you'll need to ensure that connections can reach it:
 
-```
+```nix
   services.tigerbeetle = {
     enable = true;
     addresses = [ "0.0.0.0:3001" ];

--- a/nixos/modules/services/desktops/flatpak.md
+++ b/nixos/modules/services/desktops/flatpak.md
@@ -9,7 +9,9 @@ applications on Linux.
 
 To enable Flatpak, add the following to your {file}`configuration.nix`:
 ```nix
+{
   services.flatpak.enable = true;
+}
 ```
 
 For the sandboxed apps to work correctly, desktop integration portals need to
@@ -17,8 +19,10 @@ be installed. If you run GNOME, this will be handled automatically for you;
 in other cases, you will need to add something like the following to your
 {file}`configuration.nix`:
 ```nix
+{
   xdg.portal.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
   xdg.portal.config.common.default = "gtk";
+}
 ```
 
 Then, you will need to add a repository, for example,

--- a/nixos/modules/services/desktops/flatpak.md
+++ b/nixos/modules/services/desktops/flatpak.md
@@ -8,7 +8,7 @@ Flatpak is a system for building, distributing, and running sandboxed desktop
 applications on Linux.
 
 To enable Flatpak, add the following to your {file}`configuration.nix`:
-```
+```nix
   services.flatpak.enable = true;
 ```
 
@@ -16,7 +16,7 @@ For the sandboxed apps to work correctly, desktop integration portals need to
 be installed. If you run GNOME, this will be handled automatically for you;
 in other cases, you will need to add something like the following to your
 {file}`configuration.nix`:
-```
+```nix
   xdg.portal.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
   xdg.portal.config.common.default = "gtk";
 ```

--- a/nixos/modules/services/development/athens.md
+++ b/nixos/modules/services/development/athens.md
@@ -42,7 +42,7 @@ To use the local proxy in Go builds, you can set the proxy as environment variab
 ```nix
 {
   environment.variables = {
-    GOPROXY = "http://localhost:3000"
+    GOPROXY = "http://localhost:3000";
   };
 }
 ```

--- a/nixos/modules/services/development/athens.md
+++ b/nixos/modules/services/development/athens.md
@@ -18,7 +18,7 @@ A complete list of options for the Athens module may be found
 ## Basic usage for a caching proxy configuration {#opt-services-development-athens-caching-proxy}
 
 A very basic configuration for Athens that acts as a caching and forwarding HTTP proxy is:
-```
+```nix
 {
     services.athens = {
       enable = true;
@@ -28,7 +28,7 @@ A very basic configuration for Athens that acts as a caching and forwarding HTTP
 
 If you want to prevent Athens from writing to disk, you can instead configure it to cache modules only in memory:
 
-```
+```nix
 {
     services.athens = {
       enable = true;
@@ -39,7 +39,7 @@ If you want to prevent Athens from writing to disk, you can instead configure it
 
 To use the local proxy in Go builds, you can set the proxy as environment variable:
 
-```
+```nix
 {
   environment.variables = {
     GOPROXY = "http://localhost:3000"

--- a/nixos/modules/services/development/blackfire.md
+++ b/nixos/modules/services/development/blackfire.md
@@ -7,7 +7,7 @@
 [Blackfire](https://blackfire.io) is a proprietary tool for profiling applications. There are several languages supported by the product but currently only PHP support is packaged in Nixpkgs. The back-end consists of a module that is loaded into the language runtime (called *probe*) and a service (*agent*) that the probe connects to and that sends the profiles to the server.
 
 To use it, you will need to enable the agent and the probe on your server. The exact method will depend on the way you use PHP but here is an example of NixOS configuration for PHP-FPM:
-```
+```nix
 let
   php = pkgs.php.withExtensions ({ enabled, all }: enabled ++ (with all; [
     blackfire

--- a/nixos/modules/services/development/livebook.md
+++ b/nixos/modules/services/development/livebook.md
@@ -9,7 +9,7 @@ Enabling the `livebook` service creates a user
 [`systemd`](https://www.freedesktop.org/wiki/Software/systemd/) unit
 which runs the server.
 
-```
+```nix
 { ... }:
 
 {
@@ -51,6 +51,6 @@ some features require additional packages.  For example, the machine
 learning Kinos require `gcc` and `gnumake`.  To add these, use
 `extraPackages`:
 
-```
+```nix
 services.livebook.extraPackages = with pkgs; [ gcc gnumake ];
 ```

--- a/nixos/modules/services/development/livebook.md
+++ b/nixos/modules/services/development/livebook.md
@@ -52,5 +52,7 @@ learning Kinos require `gcc` and `gnumake`.  To add these, use
 `extraPackages`:
 
 ```nix
-services.livebook.extraPackages = with pkgs; [ gcc gnumake ];
+{
+  services.livebook.extraPackages = with pkgs; [ gcc gnumake ];
+}
 ```

--- a/nixos/modules/services/editors/emacs.md
+++ b/nixos/modules/services/editors/emacs.md
@@ -178,7 +178,7 @@ file {file}`configuration.nix` to make it contain:
 ::: {.example #module-services-emacs-configuration-nix}
 ### Custom Emacs in `configuration.nix`
 
-```
+```nix
 {
  environment.systemPackages = [
    # [...]
@@ -203,7 +203,7 @@ adding it to your {file}`~/.config/nixpkgs/config.nix` (see
 ::: {.example #module-services-emacs-config-nix}
 ### Custom Emacs in `~/.config/nixpkgs/config.nix`
 
-```
+```nix
 {
   packageOverrides = super: let self = super.pkgs; in {
     myemacs = import ./emacs.nix { pkgs = self; };
@@ -228,7 +228,7 @@ only use {command}`emacsclient`), you can change your file
 ::: {.example #ex-emacsGtk3Nix}
 ### Custom Emacs build
 
-```
+```nix
 { pkgs ? import <nixpkgs> {} }:
 let
   myEmacs = (pkgs.emacs.override {
@@ -262,7 +262,7 @@ with the user's login session.
 
 To install and enable the {command}`systemd` user service for Emacs
 daemon, add the following to your {file}`configuration.nix`:
-```
+```nix
 services.emacs.enable = true;
 ```
 
@@ -323,7 +323,7 @@ In general, {command}`systemd` user services are globally enabled
 by symlinks in {file}`/etc/systemd/user`. In the case where
 Emacs daemon is not wanted for all users, it is possible to install the
 service but not globally enable it:
-```
+```nix
 services.emacs.enable = false;
 services.emacs.install = true;
 ```

--- a/nixos/modules/services/editors/emacs.md
+++ b/nixos/modules/services/editors/emacs.md
@@ -242,7 +242,7 @@ let
       rm $out/share/applications/emacs.desktop
     '';
   });
-in [...]
+in [ /* ... */ ]
 ```
 :::
 
@@ -263,7 +263,9 @@ with the user's login session.
 To install and enable the {command}`systemd` user service for Emacs
 daemon, add the following to your {file}`configuration.nix`:
 ```nix
-services.emacs.enable = true;
+{
+  services.emacs.enable = true;
+}
 ```
 
 The {var}`services.emacs.package` option allows a custom
@@ -324,8 +326,10 @@ by symlinks in {file}`/etc/systemd/user`. In the case where
 Emacs daemon is not wanted for all users, it is possible to install the
 service but not globally enable it:
 ```nix
-services.emacs.enable = false;
-services.emacs.install = true;
+{
+  services.emacs.enable = false;
+  services.emacs.install = true;
+}
 ```
 
 To enable the {command}`systemd` user service for just the

--- a/nixos/modules/services/mail/mailman.md
+++ b/nixos/modules/services/mail/mailman.md
@@ -9,7 +9,7 @@ an existing, securely configured Postfix setup, as it does not automatically con
 ## Basic usage with Postfix {#module-services-mailman-basic-usage}
 
 For a basic configuration with Postfix as the MTA, the following settings are suggested:
-```
+```nix
 { config, ... }: {
   services.postfix = {
     enable = true;
@@ -50,7 +50,7 @@ necessary, but outside the scope of the Mailman module.
 ## Using with other MTAs {#module-services-mailman-other-mtas}
 
 Mailman also supports other MTA, though with a little bit more configuration. For example, to use Mailman with Exim, you can use the following settings:
-```
+```nix
 { config, ... }: {
   services = {
     mailman = {

--- a/nixos/modules/services/matrix/maubot.md
+++ b/nixos/modules/services/matrix/maubot.md
@@ -10,7 +10,9 @@ framework for Matrix.
 2. If you want to use PostgreSQL instead of SQLite, do this:
 
    ```nix
-   services.maubot.settings.database = "postgresql://maubot@localhost/maubot";
+   {
+     services.maubot.settings.database = "postgresql://maubot@localhost/maubot";
+   }
    ```
 
    If the PostgreSQL connection requires a password, you will have to
@@ -18,54 +20,58 @@ framework for Matrix.
 3. If you plan to expose your Maubot interface to the web, do something
    like this:
    ```nix
-   services.nginx.virtualHosts."matrix.example.org".locations = {
-     "/_matrix/maubot/" = {
-       proxyPass = "http://127.0.0.1:${toString config.services.maubot.settings.server.port}";
-       proxyWebsockets = true;
+   {
+     services.nginx.virtualHosts."matrix.example.org".locations = {
+       "/_matrix/maubot/" = {
+         proxyPass = "http://127.0.0.1:${toString config.services.maubot.settings.server.port}";
+         proxyWebsockets = true;
+       };
      };
-   };
-   services.maubot.settings.server.public_url = "matrix.example.org";
-   # do the following only if you want to use something other than /_matrix/maubot...
-   services.maubot.settings.server.ui_base_path = "/another/base/path";
+     services.maubot.settings.server.public_url = "matrix.example.org";
+     # do the following only if you want to use something other than /_matrix/maubot...
+     services.maubot.settings.server.ui_base_path = "/another/base/path";
+   }
    ```
 4. Optionally, set `services.maubot.pythonPackages` to a list of python3
    packages to make available for Maubot plugins.
 5. Optionally, set `services.maubot.plugins` to a list of Maubot
    plugins (full list available at https://plugins.maubot.xyz/):
    ```nix
-   services.maubot.plugins = with config.services.maubot.package.plugins; [
-     reactbot
-     # This will only change the default config! After you create a
-     # plugin instance, the default config will be copied into that
-     # instance's config in Maubot's database, and further base config
-     # changes won't affect the running plugin.
-     (rss.override {
-       base_config = {
-         update_interval = 60;
-         max_backoff = 7200;
-         spam_sleep = 2;
-         command_prefix = "rss";
-         admins = [ "@chayleaf:pavluk.org" ];
-       };
-     })
-   ];
-   # ...or...
-   services.maubot.plugins = config.services.maubot.package.plugins.allOfficialPlugins;
-   # ...or...
-   services.maubot.plugins = config.services.maubot.package.plugins.allPlugins;
-   # ...or...
-   services.maubot.plugins = with config.services.maubot.package.plugins; [
-     (weather.override {
-       # you can pass base_config as a string
-       base_config = ''
-         default_location: New York
-         default_units: M
-         default_language:
-         show_link: true
-         show_image: false
-       '';
-     })
-   ];
+   {
+     services.maubot.plugins = with config.services.maubot.package.plugins; [
+       reactbot
+       # This will only change the default config! After you create a
+       # plugin instance, the default config will be copied into that
+       # instance's config in Maubot's database, and further base config
+       # changes won't affect the running plugin.
+       (rss.override {
+         base_config = {
+           update_interval = 60;
+           max_backoff = 7200;
+           spam_sleep = 2;
+           command_prefix = "rss";
+           admins = [ "@chayleaf:pavluk.org" ];
+         };
+       })
+     ];
+     # ...or...
+     services.maubot.plugins = config.services.maubot.package.plugins.allOfficialPlugins;
+     # ...or...
+     services.maubot.plugins = config.services.maubot.package.plugins.allPlugins;
+     # ...or...
+     services.maubot.plugins = with config.services.maubot.package.plugins; [
+       (weather.override {
+         # you can pass base_config as a string
+         base_config = ''
+           default_location: New York
+           default_units: M
+           default_language:
+           show_link: true
+           show_image: false
+         '';
+       })
+     ];
+   }
    ```
 6. Start Maubot at least once before doing the following steps (it's
    necessary to generate the initial config).

--- a/nixos/modules/services/matrix/mjolnir.md
+++ b/nixos/modules/services/matrix/mjolnir.md
@@ -46,7 +46,7 @@ autoconfigure a new Pantalaimon instance, which will connect to the homeserver
 set in [services.mjolnir.homeserverUrl](#opt-services.mjolnir.homeserverUrl) and Mjolnir itself
 will be configured to connect to the new Pantalaimon instance.
 
-```
+```nix
 {
   services.mjolnir = {
     enable = true;
@@ -78,7 +78,7 @@ uses across an entire homeserver.
 To use the Antispam Module, add `matrix-synapse-plugins.matrix-synapse-mjolnir-antispam`
 to the Synapse plugin list and enable the `mjolnir.Module` module.
 
-```
+```nix
 {
   services.matrix-synapse = {
     plugins = with pkgs; [

--- a/nixos/modules/services/matrix/synapse.md
+++ b/nixos/modules/services/matrix/synapse.md
@@ -23,7 +23,7 @@ synapse server for the `example.org` domain, served from
 the host `myhostname.example.org`. For more information,
 please refer to the
 [installation instructions of Synapse](https://element-hq.github.io/synapse/latest/setup/installation.html) .
-```
+```nix
 { pkgs, lib, config, ... }:
 let
   fqdn = "${config.networking.hostName}.${config.networking.domain}";
@@ -158,7 +158,7 @@ in an additional file like this:
     by `matrix-synapse`.
   - Include the file like this in your configuration:
 
-    ```
+    ```nix
     {
       services.matrix-synapse.extraConfigFiles = [
         "/run/secrets/matrix-shared-secret"
@@ -190,7 +190,7 @@ fill in the required connection details automatically when you enter your
 Matrix Identifier. See
 [Try Matrix Now!](https://matrix.org/docs/projects/try-matrix-now.html)
 for a list of existing clients and their supported featureset.
-```
+```nix
 {
   services.nginx.virtualHosts."element.${fqdn}" = {
     enableACME = true;

--- a/nixos/modules/services/misc/anki-sync-server.md
+++ b/nixos/modules/services/misc/anki-sync-server.md
@@ -16,7 +16,7 @@ unit which runs the sync server with an isolated user using the systemd
 `DynamicUser` option.
 
 This can be done by enabling the `anki-sync-server` service:
-```
+```nix
 { ... }:
 
 {
@@ -27,7 +27,7 @@ This can be done by enabling the `anki-sync-server` service:
 It is necessary to set at least one username-password pair under
 {option}`services.anki-sync-server.users`. For example
 
-```
+```nix
 {
   services.anki-sync-server.users = [
     {
@@ -50,7 +50,7 @@ you want to expose the sync server directly to other computers (not recommended
 in most circumstances, because the sync server doesn't use HTTPS), then set the
 following options:
 
-```
+```nix
 {
   services.anki-sync-server.host = "0.0.0.0";
   services.anki-sync-server.openFirewall = true;

--- a/nixos/modules/services/misc/forgejo.md
+++ b/nixos/modules/services/misc/forgejo.md
@@ -57,23 +57,25 @@ locations and database, instead of having to copy or rename them.
 Make sure to disable `services.gitea`, when doing this.
 
 ```nix
-services.gitea.enable = false;
+{
+  services.gitea.enable = false;
 
-services.forgejo = {
-  enable = true;
-  user = "gitea";
-  group = "gitea";
-  stateDir = "/var/lib/gitea";
-  database.name = "gitea";
-  database.user = "gitea";
-};
+  services.forgejo = {
+    enable = true;
+    user = "gitea";
+    group = "gitea";
+    stateDir = "/var/lib/gitea";
+    database.name = "gitea";
+    database.user = "gitea";
+  };
 
-users.users.gitea = {
-  home = "/var/lib/gitea";
-  useDefaultShell = true;
-  group = "gitea";
-  isSystemUser = true;
-};
+  users.users.gitea = {
+    home = "/var/lib/gitea";
+    useDefaultShell = true;
+    group = "gitea";
+    isSystemUser = true;
+  };
 
-users.groups.gitea = {};
+  users.groups.gitea = {};
+}
 ```

--- a/nixos/modules/services/misc/gitlab.md
+++ b/nixos/modules/services/misc/gitlab.md
@@ -11,18 +11,20 @@ configure a webserver to proxy HTTP requests to the socket.
 For instance, the following configuration could be used to use nginx as
 frontend proxy:
 ```nix
-services.nginx = {
-  enable = true;
-  recommendedGzipSettings = true;
-  recommendedOptimisation = true;
-  recommendedProxySettings = true;
-  recommendedTlsSettings = true;
-  virtualHosts."git.example.com" = {
-    enableACME = true;
-    forceSSL = true;
-    locations."/".proxyPass = "http://unix:/run/gitlab/gitlab-workhorse.socket";
+{
+  services.nginx = {
+    enable = true;
+    recommendedGzipSettings = true;
+    recommendedOptimisation = true;
+    recommendedProxySettings = true;
+    recommendedTlsSettings = true;
+    virtualHosts."git.example.com" = {
+      enableACME = true;
+      forceSSL = true;
+      locations."/".proxyPass = "http://unix:/run/gitlab/gitlab-workhorse.socket";
+    };
   };
-};
+}
 ```
 
 ## Configuring {#module-services-gitlab-configuring}
@@ -36,35 +38,37 @@ all data like the repositories and uploads will be stored.
 
 A basic configuration with some custom settings could look like this:
 ```nix
-services.gitlab = {
-  enable = true;
-  databasePasswordFile = "/var/keys/gitlab/db_password";
-  initialRootPasswordFile = "/var/keys/gitlab/root_password";
-  https = true;
-  host = "git.example.com";
-  port = 443;
-  user = "git";
-  group = "git";
-  smtp = {
+{
+  services.gitlab = {
     enable = true;
-    address = "localhost";
-    port = 25;
-  };
-  secrets = {
-    dbFile = "/var/keys/gitlab/db";
-    secretFile = "/var/keys/gitlab/secret";
-    otpFile = "/var/keys/gitlab/otp";
-    jwsFile = "/var/keys/gitlab/jws";
-  };
-  extraConfig = {
-    gitlab = {
-      email_from = "gitlab-no-reply@example.com";
-      email_display_name = "Example GitLab";
-      email_reply_to = "gitlab-no-reply@example.com";
-      default_projects_features = { builds = false; };
+    databasePasswordFile = "/var/keys/gitlab/db_password";
+    initialRootPasswordFile = "/var/keys/gitlab/root_password";
+    https = true;
+    host = "git.example.com";
+    port = 443;
+    user = "git";
+    group = "git";
+    smtp = {
+      enable = true;
+      address = "localhost";
+      port = 25;
+    };
+    secrets = {
+      dbFile = "/var/keys/gitlab/db";
+      secretFile = "/var/keys/gitlab/secret";
+      otpFile = "/var/keys/gitlab/otp";
+      jwsFile = "/var/keys/gitlab/jws";
+    };
+    extraConfig = {
+      gitlab = {
+        email_from = "gitlab-no-reply@example.com";
+        email_display_name = "Example GitLab";
+        email_reply_to = "gitlab-no-reply@example.com";
+        default_projects_features = { builds = false; };
+      };
     };
   };
-};
+}
 ```
 
 If you're setting up a new GitLab instance, generate new

--- a/nixos/modules/services/misc/gitlab.md
+++ b/nixos/modules/services/misc/gitlab.md
@@ -10,7 +10,7 @@ configure a webserver to proxy HTTP requests to the socket.
 
 For instance, the following configuration could be used to use nginx as
 frontend proxy:
-```
+```nix
 services.nginx = {
   enable = true;
   recommendedGzipSettings = true;
@@ -35,7 +35,7 @@ The default state dir is `/var/gitlab/state`. This is where
 all data like the repositories and uploads will be stored.
 
 A basic configuration with some custom settings could look like this:
-```
+```nix
 services.gitlab = {
   enable = true;
   databasePasswordFile = "/var/keys/gitlab/db_password";

--- a/nixos/modules/services/misc/sourcehut/default.md
+++ b/nixos/modules/services/misc/sourcehut/default.md
@@ -12,7 +12,7 @@ This NixOS module also provides basic configuration integrating Sourcehut into l
 and `services.postgresql` services.
 
 A very basic configuration may look like this:
-```
+```nix
 { pkgs, ... }:
 let
   fqdn =

--- a/nixos/modules/services/misc/sourcehut/default.md
+++ b/nixos/modules/services/misc/sourcehut/default.md
@@ -66,9 +66,9 @@ in {
     # Settings to setup what certificates are used for which endpoint.
     virtualHosts = {
       "${fqdn}".enableACME = true;
-      "meta.${fqdn}".useACMEHost = fqdn:
-      "man.${fqdn}".useACMEHost = fqdn:
-      "git.${fqdn}".useACMEHost = fqdn:
+      "meta.${fqdn}".useACMEHost = fqdn;
+      "man.${fqdn}".useACMEHost = fqdn;
+      "git.${fqdn}".useACMEHost = fqdn;
     };
   };
 }

--- a/nixos/modules/services/misc/weechat.md
+++ b/nixos/modules/services/misc/weechat.md
@@ -12,7 +12,7 @@ unit which runs the chat client in a detached
 session.
 
 This can be done by enabling the `weechat` service:
-```
+```nix
 { ... }:
 
 {
@@ -30,7 +30,7 @@ allow your another user to attach to this session, the
 `screenrc` needs to be tweaked by adding
 [multiuser](https://www.gnu.org/software/screen/manual/html_node/Multiuser.html#Multiuser)
 support:
-```
+```nix
 {
   programs.screen.screenrc = ''
     multiuser on

--- a/nixos/modules/services/monitoring/certspotter.md
+++ b/nixos/modules/services/monitoring/certspotter.md
@@ -9,17 +9,19 @@ A basic config that notifies you of all certificate changes for your
 domain would look as follows:
 
 ```nix
-services.certspotter = {
-  enable = true;
-  # replace example.org with your domain name
-  watchlist = [ ".example.org" ];
-  emailRecipients = [ "webmaster@example.org" ];
-};
+{
+  services.certspotter = {
+    enable = true;
+    # replace example.org with your domain name
+    watchlist = [ ".example.org" ];
+    emailRecipients = [ "webmaster@example.org" ];
+  };
 
-# Configure an SMTP client
-programs.msmtp.enable = true;
-# Or you can use any other module that provides sendmail, like
-# services.nullmailer, services.opensmtpd, services.postfix
+  # Configure an SMTP client
+  programs.msmtp.enable = true;
+  # Or you can use any other module that provides sendmail, like
+  # services.nullmailer, services.opensmtpd, services.postfix
+}
 ```
 
 In this case, the leading dot in `".example.org"` means that Cert
@@ -59,16 +61,18 @@ For example, you can remove `emailRecipients` and send email
 notifications manually using the following hook:
 
 ```nix
-services.certspotter.hooks = [
-  (pkgs.writeShellScript "certspotter-hook" ''
-    function print_email() {
-      echo "Subject: [certspotter] $SUMMARY"
-      echo "Mime-Version: 1.0"
-      echo "Content-Type: text/plain; charset=US-ASCII"
-      echo
-      cat "$TEXT_FILENAME"
-    }
-    print_email | ${config.services.certspotter.sendmailPath} -i webmaster@example.org
-  '')
-];
+{
+  services.certspotter.hooks = [
+    (pkgs.writeShellScript "certspotter-hook" ''
+      function print_email() {
+        echo "Subject: [certspotter] $SUMMARY"
+        echo "Mime-Version: 1.0"
+        echo "Content-Type: text/plain; charset=US-ASCII"
+        echo
+        cat "$TEXT_FILENAME"
+      }
+      print_email | ${config.services.certspotter.sendmailPath} -i webmaster@example.org
+    '')
+  ];
+}
 ```

--- a/nixos/modules/services/monitoring/goss.md
+++ b/nixos/modules/services/monitoring/goss.md
@@ -7,7 +7,7 @@ for validating a server's configuration.
 
 A minimal configuration looks like this:
 
-```
+```nix
 {
   services.goss = {
     enable = true;

--- a/nixos/modules/services/monitoring/parsedmarc.md
+++ b/nixos/modules/services/monitoring/parsedmarc.md
@@ -11,15 +11,17 @@ email address and saves them to a local Elasticsearch instance looks
 like this:
 
 ```nix
-services.parsedmarc = {
-  enable = true;
-  settings.imap = {
-    host = "imap.example.com";
-    user = "alice@example.com";
-    password = "/path/to/imap_password_file";
+{
+  services.parsedmarc = {
+    enable = true;
+    settings.imap = {
+      host = "imap.example.com";
+      user = "alice@example.com";
+      password = "/path/to/imap_password_file";
+    };
+    provision.geoIp = false; # Not recommended!
   };
-  provision.geoIp = false; # Not recommended!
-};
+}
 ```
 
 Note that GeoIP provisioning is disabled in the example for
@@ -37,16 +39,18 @@ configured in the domain's dmarc policy is
 `dmarc@monitoring.example.com`.
 
 ```nix
-services.parsedmarc = {
-  enable = true;
-  provision = {
-    localMail = {
-      enable = true;
-      hostname = monitoring.example.com;
+{
+  services.parsedmarc = {
+    enable = true;
+    provision = {
+      localMail = {
+        enable = true;
+        hostname = monitoring.example.com;
+      };
+      geoIp = false; # Not recommended!
     };
-    geoIp = false; # Not recommended!
   };
-};
+}
 ```
 
 ## Grafana and GeoIP {#module-services-parsedmarc-grafana-geoip}
@@ -58,55 +62,57 @@ is automatically added as a Grafana datasource, and the dashboard is
 added to Grafana as well.
 
 ```nix
-services.parsedmarc = {
-  enable = true;
-  provision = {
-    localMail = {
-      enable = true;
-      hostname = url;
+{
+  services.parsedmarc = {
+    enable = true;
+    provision = {
+      localMail = {
+        enable = true;
+        hostname = url;
+      };
+      grafana = {
+        datasource = true;
+        dashboard = true;
+      };
     };
-    grafana = {
-      datasource = true;
-      dashboard = true;
+  };
+
+  # Not required, but recommended for full functionality
+  services.geoipupdate = {
+    settings = {
+      AccountID = 000000;
+      LicenseKey = "/path/to/license_key_file";
     };
   };
-};
 
-# Not required, but recommended for full functionality
-services.geoipupdate = {
-  settings = {
-    AccountID = 000000;
-    LicenseKey = "/path/to/license_key_file";
+  services.grafana = {
+    enable = true;
+    addr = "0.0.0.0";
+    domain = url;
+    rootUrl = "https://" + url;
+    protocol = "socket";
+    security = {
+      adminUser = "admin";
+      adminPasswordFile = "/path/to/admin_password_file";
+      secretKeyFile = "/path/to/secret_key_file";
+    };
   };
-};
 
-services.grafana = {
-  enable = true;
-  addr = "0.0.0.0";
-  domain = url;
-  rootUrl = "https://" + url;
-  protocol = "socket";
-  security = {
-    adminUser = "admin";
-    adminPasswordFile = "/path/to/admin_password_file";
-    secretKeyFile = "/path/to/secret_key_file";
+  services.nginx = {
+    enable = true;
+    recommendedTlsSettings = true;
+    recommendedOptimisation = true;
+    recommendedGzipSettings = true;
+    recommendedProxySettings = true;
+    upstreams.grafana.servers."unix:/${config.services.grafana.socket}" = {};
+    virtualHosts.${url} = {
+      root = config.services.grafana.staticRootPath;
+      enableACME = true;
+      forceSSL = true;
+      locations."/".tryFiles = "$uri @grafana";
+      locations."@grafana".proxyPass = "http://grafana";
+    };
   };
-};
-
-services.nginx = {
-  enable = true;
-  recommendedTlsSettings = true;
-  recommendedOptimisation = true;
-  recommendedGzipSettings = true;
-  recommendedProxySettings = true;
-  upstreams.grafana.servers."unix:/${config.services.grafana.socket}" = {};
-  virtualHosts.${url} = {
-    root = config.services.grafana.staticRootPath;
-    enableACME = true;
-    forceSSL = true;
-    locations."/".tryFiles = "$uri @grafana";
-    locations."@grafana".proxyPass = "http://grafana";
-  };
-};
-users.users.nginx.extraGroups = [ "grafana" ];
+  users.users.nginx.extraGroups = [ "grafana" ];
+}
 ```

--- a/nixos/modules/services/monitoring/prometheus/exporters.md
+++ b/nixos/modules/services/monitoring/prometheus/exporters.md
@@ -9,7 +9,7 @@ One of the most common exporters is the
 [node exporter](https://github.com/prometheus/node_exporter),
 it provides hardware and OS metrics from the host it's
 running on. The exporter could be configured as follows:
-```
+```nix
   services.prometheus.exporters.node = {
     enable = true;
     port = 9100;
@@ -35,7 +35,7 @@ configuration see `man configuration.nix` or search through
 the [available options](https://nixos.org/nixos/options.html#prometheus.exporters).
 
 Prometheus can now be configured to consume the metrics produced by the exporter:
-```
+```nix
     services.prometheus = {
       # ...
 
@@ -75,7 +75,7 @@ example:
     `nixos/modules/services/monitoring/prometheus/exporters/`
     directory, which will be called postfix.nix and contains all exporter
     specific options and configuration:
-    ```
+    ```nix
     # nixpkgs/nixos/modules/services/prometheus/exporters/postfix.nix
     { config, lib, pkgs, options }:
 
@@ -148,7 +148,7 @@ example:
 Should an exporter option change at some point, it is possible to add
 information about the change to the exporter definition similar to
 `nixpkgs/nixos/modules/rename.nix`:
-```
+```nix
 { config, lib, pkgs, options }:
 
 with lib;

--- a/nixos/modules/services/monitoring/prometheus/exporters.md
+++ b/nixos/modules/services/monitoring/prometheus/exporters.md
@@ -10,6 +10,7 @@ One of the most common exporters is the
 it provides hardware and OS metrics from the host it's
 running on. The exporter could be configured as follows:
 ```nix
+{
   services.prometheus.exporters.node = {
     enable = true;
     port = 9100;
@@ -23,6 +24,7 @@ running on. The exporter could be configured as follows:
     openFirewall = true;
     firewallFilter = "-i br0 -p tcp -m tcp --dport 9100";
   };
+}
 ```
 It should now serve all metrics from the collectors that are explicitly
 enabled and the ones that are
@@ -36,6 +38,7 @@ the [available options](https://nixos.org/nixos/options.html#prometheus.exporter
 
 Prometheus can now be configured to consume the metrics produced by the exporter:
 ```nix
+{
     services.prometheus = {
       # ...
 
@@ -49,7 +52,8 @@ Prometheus can now be configured to consume the metrics produced by the exporter
       ];
 
       # ...
-    }
+    };
+}
 ```
 
 ## Adding a new exporter {#module-services-prometheus-exporters-new-exporter}

--- a/nixos/modules/services/network-filesystems/litestream/default.md
+++ b/nixos/modules/services/network-filesystems/litestream/default.md
@@ -8,7 +8,7 @@ replication tool for SQLite.
 Litestream service is managed by a dedicated user named `litestream`
 which needs permission to the database file. Here's an example config which gives
 required permissions to access [grafana database](#opt-services.grafana.settings.database.path):
-```
+```nix
 { pkgs, ... }:
 {
   users.users.litestream.extraGroups = [ "grafana" ];

--- a/nixos/modules/services/networking/firefox-syncserver.md
+++ b/nixos/modules/services/networking/firefox-syncserver.md
@@ -7,19 +7,21 @@ A storage server for Firefox Sync that you can easily host yourself.
 The absolute minimal configuration for the sync server looks like this:
 
 ```nix
-services.mysql.package = pkgs.mariadb;
+{
+  services.mysql.package = pkgs.mariadb;
 
-services.firefox-syncserver = {
-  enable = true;
-  secrets = builtins.toFile "sync-secrets" ''
-    SYNC_MASTER_SECRET=this-secret-is-actually-leaked-to-/nix/store
-  '';
-  singleNode = {
+  services.firefox-syncserver = {
     enable = true;
-    hostname = "localhost";
-    url = "http://localhost:5000";
+    secrets = builtins.toFile "sync-secrets" ''
+      SYNC_MASTER_SECRET=this-secret-is-actually-leaked-to-/nix/store
+    '';
+    singleNode = {
+      enable = true;
+      hostname = "localhost";
+      url = "http://localhost:5000";
+    };
   };
-};
+}
 ```
 
 This will start a sync server that is only accessible locally. Once the services is

--- a/nixos/modules/services/networking/mosquitto.md
+++ b/nixos/modules/services/networking/mosquitto.md
@@ -7,14 +7,16 @@ Mosquitto is a MQTT broker often used for IoT or home automation data transport.
 A minimal configuration for Mosquitto is
 
 ```nix
-services.mosquitto = {
-  enable = true;
-  listeners = [ {
-    acl = [ "pattern readwrite #" ];
-    omitPasswordAuth = true;
-    settings.allow_anonymous = true;
-  } ];
-};
+{
+  services.mosquitto = {
+    enable = true;
+    listeners = [ {
+      acl = [ "pattern readwrite #" ];
+      omitPasswordAuth = true;
+      settings.allow_anonymous = true;
+    } ];
+  };
+}
 ```
 
 This will start a broker on port 1883, listening on all interfaces of the machine, allowing
@@ -25,37 +27,42 @@ full read access to a user `monitor` and restricted write access to a user `serv
 like
 
 ```nix
-services.mosquitto = {
-  enable = true;
-  listeners = [ {
-    users = {
-      monitor = {
-        acl = [ "read #" ];
-        password = "monitor";
+{
+  services.mosquitto = {
+    enable = true;
+    listeners = [ {
+      users = {
+        monitor = {
+          acl = [ "read #" ];
+          password = "monitor";
+        };
+        service = {
+          acl = [ "write service/#" ];
+          password = "service";
+        };
       };
-      service = {
-        acl = [ "write service/#" ];
-        password = "service";
-      };
-    };
-  } ];
-};
+    } ];
+  };
+}
 ```
 
 TLS authentication is configured by setting TLS-related options of the listener:
 
 ```nix
-services.mosquitto = {
-  enable = true;
-  listeners = [ {
-    port = 8883; # port change is not required, but helpful to avoid mistakes
-    # ...
-    settings = {
-      cafile = "/path/to/mqtt.ca.pem";
-      certfile = "/path/to/mqtt.pem";
-      keyfile = "/path/to/mqtt.key";
-    };
-  } ];
+{
+  services.mosquitto = {
+    enable = true;
+    listeners = [ {
+      port = 8883; # port change is not required, but helpful to avoid mistakes
+      # ...
+      settings = {
+        cafile = "/path/to/mqtt.ca.pem";
+        certfile = "/path/to/mqtt.pem";
+        keyfile = "/path/to/mqtt.key";
+      };
+    } ];
+  };
+}
 ```
 
 ## Configuration {#module-services-mosquitto-config}

--- a/nixos/modules/services/networking/netbird.md
+++ b/nixos/modules/services/networking/netbird.md
@@ -5,7 +5,9 @@
 The absolute minimal configuration for the netbird daemon looks like this:
 
 ```nix
-services.netbird.enable = true;
+{
+  services.netbird.enable = true;
+}
 ```
 
 This will set up a netbird service listening on the port `51820` associated to the
@@ -14,7 +16,9 @@ This will set up a netbird service listening on the port `51820` associated to t
 It is strictly equivalent to setting:
 
 ```nix
-services.netbird.tunnels.wt0.stateDir = "netbird";
+{
+  services.netbird.tunnels.wt0.stateDir = "netbird";
+}
 ```
 
 The `enable` option is mainly kept for backward compatibility, as defining netbird
@@ -29,11 +33,13 @@ The following configuration will start a netbird daemon using the interface `wt1
 the port 51830. Its configuration file will then be located at `/var/lib/netbird-wt1/config.json`.
 
 ```nix
-services.netbird.tunnels = {
-  wt1 = {
-    port = 51830;
+{
+  services.netbird.tunnels = {
+    wt1 = {
+      port = 51830;
+    };
   };
-};
+}
 ```
 
 To interact with it, you will need to specify the correct daemon address:
@@ -48,9 +54,11 @@ It is also possible to overwrite default options passed to the service, for
 example:
 
 ```nix
-services.netbird.tunnels.wt1.environment = {
-  NB_DAEMON_ADDR = "unix:///var/run/toto.sock"
-};
+{
+  services.netbird.tunnels.wt1.environment = {
+    NB_DAEMON_ADDR = "unix:///var/run/toto.sock";
+  };
+}
 ```
 
 This will set the socket to interact with the netbird service to `/var/run/toto.sock`.

--- a/nixos/modules/services/networking/pleroma.md
+++ b/nixos/modules/services/networking/pleroma.md
@@ -17,7 +17,7 @@ The `config.exs` file can be further customized following the instructions on th
 ## Initializing the database {#module-services-pleroma-initialize-db}
 
 First, the Postgresql service must be enabled in the NixOS configuration
-```
+```nix
 services.postgresql = {
   enable = true;
   package = pkgs.postgresql_13;
@@ -38,7 +38,7 @@ $ sudo -u postgres psql -f setup.psql
 In this section we will enable the Pleroma service only locally, so its configurations can be improved incrementally.
 
 This is an example of configuration, where [](#opt-services.pleroma.configs) option contains the content of the file `config.exs`, generated [in the first section](#module-services-pleroma-generate-config), but with the secrets (database password, endpoint secret key, salts, etc.) removed. Removing secrets is important, because otherwise they will be stored publicly in the Nix store.
-```
+```nix
 services.pleroma = {
   enable = true;
   secretConfigFile = "/var/lib/pleroma/secrets.exs";
@@ -121,7 +121,7 @@ $ pleroma_ctl user new <nickname> <email>  --admin --moderator --password <passw
 
 In this configuration, Pleroma is listening only on the local port 4000. Nginx can be configured as a Reverse Proxy, for forwarding requests from public ports to the Pleroma service. This is an example of configuration, using
 [Let's Encrypt](https://letsencrypt.org/) for the TLS certificates
-```
+```nix
 security.acme = {
   email = "root@example.net";
   acceptTerms = true;

--- a/nixos/modules/services/networking/pleroma.md
+++ b/nixos/modules/services/networking/pleroma.md
@@ -18,10 +18,12 @@ The `config.exs` file can be further customized following the instructions on th
 
 First, the Postgresql service must be enabled in the NixOS configuration
 ```nix
-services.postgresql = {
-  enable = true;
-  package = pkgs.postgresql_13;
-};
+{
+  services.postgresql = {
+    enable = true;
+    package = pkgs.postgresql_13;
+  };
+}
 ```
 and activated with the usual
 ```ShellSession
@@ -39,42 +41,44 @@ In this section we will enable the Pleroma service only locally, so its configur
 
 This is an example of configuration, where [](#opt-services.pleroma.configs) option contains the content of the file `config.exs`, generated [in the first section](#module-services-pleroma-generate-config), but with the secrets (database password, endpoint secret key, salts, etc.) removed. Removing secrets is important, because otherwise they will be stored publicly in the Nix store.
 ```nix
-services.pleroma = {
-  enable = true;
-  secretConfigFile = "/var/lib/pleroma/secrets.exs";
-  configs = [
-    ''
-    import Config
+{
+  services.pleroma = {
+    enable = true;
+    secretConfigFile = "/var/lib/pleroma/secrets.exs";
+    configs = [
+      ''
+      import Config
 
-    config :pleroma, Pleroma.Web.Endpoint,
-      url: [host: "pleroma.example.net", scheme: "https", port: 443],
-      http: [ip: {127, 0, 0, 1}, port: 4000]
+      config :pleroma, Pleroma.Web.Endpoint,
+        url: [host: "pleroma.example.net", scheme: "https", port: 443],
+        http: [ip: {127, 0, 0, 1}, port: 4000]
 
-    config :pleroma, :instance,
-      name: "Test",
-      email: "admin@example.net",
-      notify_email: "admin@example.net",
-      limit: 5000,
-      registrations_open: true
+      config :pleroma, :instance,
+        name: "Test",
+        email: "admin@example.net",
+        notify_email: "admin@example.net",
+        limit: 5000,
+        registrations_open: true
 
-    config :pleroma, :media_proxy,
-      enabled: false,
-      redirect_on_failure: true
+      config :pleroma, :media_proxy,
+        enabled: false,
+        redirect_on_failure: true
 
-    config :pleroma, Pleroma.Repo,
-      adapter: Ecto.Adapters.Postgres,
-      username: "pleroma",
-      database: "pleroma",
-      hostname: "localhost"
+      config :pleroma, Pleroma.Repo,
+        adapter: Ecto.Adapters.Postgres,
+        username: "pleroma",
+        database: "pleroma",
+        hostname: "localhost"
 
-    # Configure web push notifications
-    config :web_push_encryption, :vapid_details,
-      subject: "mailto:admin@example.net"
+      # Configure web push notifications
+      config :web_push_encryption, :vapid_details,
+        subject: "mailto:admin@example.net"
 
-    # ... TO CONTINUE ...
-    ''
-  ];
-};
+      # ... TO CONTINUE ...
+      ''
+    ];
+  };
+}
 ```
 
 Secrets must be moved into a file pointed by [](#opt-services.pleroma.secretConfigFile), in our case `/var/lib/pleroma/secrets.exs`. This file can be created copying the previously generated `config.exs` file and then removing all the settings, except the secrets. This is an example
@@ -122,59 +126,61 @@ $ pleroma_ctl user new <nickname> <email>  --admin --moderator --password <passw
 In this configuration, Pleroma is listening only on the local port 4000. Nginx can be configured as a Reverse Proxy, for forwarding requests from public ports to the Pleroma service. This is an example of configuration, using
 [Let's Encrypt](https://letsencrypt.org/) for the TLS certificates
 ```nix
-security.acme = {
-  email = "root@example.net";
-  acceptTerms = true;
-};
+{
+  security.acme = {
+    email = "root@example.net";
+    acceptTerms = true;
+  };
 
-services.nginx = {
-  enable = true;
-  addSSL = true;
+  services.nginx = {
+    enable = true;
+    addSSL = true;
 
-  recommendedTlsSettings = true;
-  recommendedOptimisation = true;
-  recommendedGzipSettings = true;
+    recommendedTlsSettings = true;
+    recommendedOptimisation = true;
+    recommendedGzipSettings = true;
 
-  recommendedProxySettings = false;
-  # NOTE: if enabled, the NixOS proxy optimizations will override the Pleroma
-  # specific settings, and they will enter in conflict.
+    recommendedProxySettings = false;
+    # NOTE: if enabled, the NixOS proxy optimizations will override the Pleroma
+    # specific settings, and they will enter in conflict.
 
-  virtualHosts = {
-    "pleroma.example.net" = {
-      http2 = true;
-      enableACME = true;
-      forceSSL = true;
+    virtualHosts = {
+      "pleroma.example.net" = {
+        http2 = true;
+        enableACME = true;
+        forceSSL = true;
 
-      locations."/" = {
-        proxyPass = "http://127.0.0.1:4000";
+        locations."/" = {
+          proxyPass = "http://127.0.0.1:4000";
 
-        extraConfig = ''
-          etag on;
-          gzip on;
+          extraConfig = ''
+            etag on;
+            gzip on;
 
-          add_header 'Access-Control-Allow-Origin' '*' always;
-          add_header 'Access-Control-Allow-Methods' 'POST, PUT, DELETE, GET, PATCH, OPTIONS' always;
-          add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Idempotency-Key' always;
-          add_header 'Access-Control-Expose-Headers' 'Link, X-RateLimit-Reset, X-RateLimit-Limit, X-RateLimit-Remaining, X-Request-Id' always;
-          if ($request_method = OPTIONS) {
-            return 204;
-          }
-          add_header X-XSS-Protection "1; mode=block";
-          add_header X-Permitted-Cross-Domain-Policies none;
-          add_header X-Frame-Options DENY;
-          add_header X-Content-Type-Options nosniff;
-          add_header Referrer-Policy same-origin;
-          add_header X-Download-Options noopen;
-          proxy_http_version 1.1;
-          proxy_set_header Upgrade $http_upgrade;
-          proxy_set_header Connection "upgrade";
-          proxy_set_header Host $host;
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'POST, PUT, DELETE, GET, PATCH, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Idempotency-Key' always;
+            add_header 'Access-Control-Expose-Headers' 'Link, X-RateLimit-Reset, X-RateLimit-Limit, X-RateLimit-Remaining, X-Request-Id' always;
+            if ($request_method = OPTIONS) {
+              return 204;
+            }
+            add_header X-XSS-Protection "1; mode=block";
+            add_header X-Permitted-Cross-Domain-Policies none;
+            add_header X-Frame-Options DENY;
+            add_header X-Content-Type-Options nosniff;
+            add_header Referrer-Policy same-origin;
+            add_header X-Download-Options noopen;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
 
-          client_max_body_size 16m;
-          # NOTE: increase if users need to upload very big files
-        '';
+            client_max_body_size 16m;
+            # NOTE: increase if users need to upload very big files
+          '';
+        };
       };
     };
   };
-};
+}
 ```

--- a/nixos/modules/services/networking/prosody.md
+++ b/nixos/modules/services/networking/prosody.md
@@ -26,24 +26,26 @@ A good configuration to start with, including a
 endpoint as well as a [HTTP File Upload](https://xmpp.org/extensions/xep-0363.html)
 endpoint will look like this:
 ```nix
-services.prosody = {
-  enable = true;
-  admins = [ "root@example.org" ];
-  ssl.cert = "/var/lib/acme/example.org/fullchain.pem";
-  ssl.key = "/var/lib/acme/example.org/key.pem";
-  virtualHosts."example.org" = {
-      enabled = true;
-      domain = "example.org";
-      ssl.cert = "/var/lib/acme/example.org/fullchain.pem";
-      ssl.key = "/var/lib/acme/example.org/key.pem";
+{
+  services.prosody = {
+    enable = true;
+    admins = [ "root@example.org" ];
+    ssl.cert = "/var/lib/acme/example.org/fullchain.pem";
+    ssl.key = "/var/lib/acme/example.org/key.pem";
+    virtualHosts."example.org" = {
+        enabled = true;
+        domain = "example.org";
+        ssl.cert = "/var/lib/acme/example.org/fullchain.pem";
+        ssl.key = "/var/lib/acme/example.org/key.pem";
+    };
+    muc = [ {
+        domain = "conference.example.org";
+    } ];
+    uploadHttp = {
+        domain = "upload.example.org";
+    };
   };
-  muc = [ {
-      domain = "conference.example.org";
-  } ];
-  uploadHttp = {
-      domain = "upload.example.org";
-  };
-};
+}
 ```
 
 ## Let's Encrypt Configuration {#module-services-prosody-letsencrypt}
@@ -58,15 +60,17 @@ certificate by leveraging the ACME
 Provided the setup detailed in the previous section, you'll need the following acme configuration to generate
 a TLS certificate for the three endponits:
 ```nix
-security.acme = {
-  email = "root@example.org";
-  acceptTerms = true;
-  certs = {
-    "example.org" = {
-      webroot = "/var/www/example.org";
-      email = "root@example.org";
-      extraDomainNames = [ "conference.example.org" "upload.example.org" ];
+{
+  security.acme = {
+    email = "root@example.org";
+    acceptTerms = true;
+    certs = {
+      "example.org" = {
+        webroot = "/var/www/example.org";
+        email = "root@example.org";
+        extraDomainNames = [ "conference.example.org" "upload.example.org" ];
+      };
     };
   };
-};
+}
 ```

--- a/nixos/modules/services/networking/prosody.md
+++ b/nixos/modules/services/networking/prosody.md
@@ -25,7 +25,7 @@ A good configuration to start with, including a
 [Multi User Chat (MUC)](https://xmpp.org/extensions/xep-0045.html)
 endpoint as well as a [HTTP File Upload](https://xmpp.org/extensions/xep-0363.html)
 endpoint will look like this:
-```
+```nix
 services.prosody = {
   enable = true;
   admins = [ "root@example.org" ];
@@ -57,7 +57,7 @@ certificate by leveraging the ACME
 
 Provided the setup detailed in the previous section, you'll need the following acme configuration to generate
 a TLS certificate for the three endponits:
-```
+```nix
 security.acme = {
   email = "root@example.org";
   acceptTerms = true;

--- a/nixos/modules/services/networking/yggdrasil.md
+++ b/nixos/modules/services/networking/yggdrasil.md
@@ -12,7 +12,7 @@ self-arranging IPv6 network.
 ### Simple ephemeral node {#module-services-networking-yggdrasil-configuration-simple}
 
 An annotated example of a simple configuration:
-```
+```nix
 {
   services.yggdrasil = {
     enable = true;
@@ -39,7 +39,7 @@ An annotated example of a simple configuration:
 ### Persistent node with prefix {#module-services-networking-yggdrasil-configuration-prefix}
 
 A node with a fixed address that announces a prefix:
-```
+```nix
 let
   address = "210:5217:69c0:9afc:1b95:b9f:8718:c3d2";
   prefix = "310:5217:69c0:9afc";
@@ -90,7 +90,7 @@ in {
 
 A NixOS container attached to the Yggdrasil network via a node running on the
 host:
-```
+```nix
 let
   yggPrefix64 = "310:5217:69c0:9afc";
     # Again, taken from the output of "yggdrasilctl getself".

--- a/nixos/modules/services/search/meilisearch.md
+++ b/nixos/modules/services/search/meilisearch.md
@@ -7,7 +7,9 @@ Meilisearch is a lightweight, fast and powerful search engine. Think elastic sea
 the minimum to start meilisearch is
 
 ```nix
-services.meilisearch.enable = true;
+{
+  services.meilisearch.enable = true;
+}
 ```
 
 this will start the http server included with meilisearch on port 7700.

--- a/nixos/modules/services/web-apps/c2fmzq-server.md
+++ b/nixos/modules/services/web-apps/c2fmzq-server.md
@@ -4,7 +4,7 @@ c2FmZQ is an application that can securely encrypt, store, and share files,
 including but not limited to pictures and videos.
 
 The service `c2fmzq-server` can be enabled by setting
-```
+```nix
 {
   services.c2fmzq-server.enable = true;
 }
@@ -17,7 +17,7 @@ In principle the server can be exposed directly on a public interface and there
 are command line options to manage HTTPS certificates directly, but the module
 is designed to be served behind a reverse proxy or only accessed via localhost.
 
-```
+```nix
 {
   services.c2fmzq-server = {
     enable = true;

--- a/nixos/modules/services/web-apps/discourse.md
+++ b/nixos/modules/services/web-apps/discourse.md
@@ -6,7 +6,7 @@ modern and open source discussion platform.
 ## Basic usage {#module-services-discourse-basic-usage}
 
 A minimal configuration using Let's Encrypt for TLS certificates looks like this:
-```
+```nix
 services.discourse = {
   enable = true;
   hostname = "discourse.example.com";
@@ -34,7 +34,7 @@ the [](#opt-services.discourse.sslCertificate)
 and [](#opt-services.discourse.sslCertificateKey)
 options:
 
-```
+```nix
 services.discourse = {
   enable = true;
   hostname = "discourse.example.com";
@@ -80,7 +80,7 @@ A basic setup which assumes you want to use your configured
 [hostname](#opt-services.discourse.hostname) as
 email domain can be done like this:
 
-```
+```nix
 services.discourse = {
   enable = true;
   hostname = "discourse.example.com";
@@ -162,7 +162,7 @@ The following example sets the title and description of the
 Discourse instance and enables
 GitHub login in the site settings,
 and changes a few request limits in the backend settings:
-```
+```nix
 services.discourse = {
   enable = true;
   hostname = "discourse.example.com";
@@ -253,7 +253,7 @@ and [discourse-solved](https://github.com/discourse/discourse-solved)
 plugins, and disable `discourse-spoiler-alert`
 by default:
 
-```
+```nix
 services.discourse = {
   enable = true;
   hostname = "discourse.example.com";

--- a/nixos/modules/services/web-apps/discourse.md
+++ b/nixos/modules/services/web-apps/discourse.md
@@ -7,19 +7,21 @@ modern and open source discussion platform.
 
 A minimal configuration using Let's Encrypt for TLS certificates looks like this:
 ```nix
-services.discourse = {
-  enable = true;
-  hostname = "discourse.example.com";
-  admin = {
-    email = "admin@example.com";
-    username = "admin";
-    fullName = "Administrator";
-    passwordFile = "/path/to/password_file";
+{
+  services.discourse = {
+    enable = true;
+    hostname = "discourse.example.com";
+    admin = {
+      email = "admin@example.com";
+      username = "admin";
+      fullName = "Administrator";
+      passwordFile = "/path/to/password_file";
+    };
+    secretKeyBaseFile = "/path/to/secret_key_base_file";
   };
-  secretKeyBaseFile = "/path/to/secret_key_base_file";
-};
-security.acme.email = "me@example.com";
-security.acme.acceptTerms = true;
+  security.acme.email = "me@example.com";
+  security.acme.acceptTerms = true;
+}
 ```
 
 Provided a proper DNS setup, you'll be able to connect to the
@@ -35,19 +37,21 @@ and [](#opt-services.discourse.sslCertificateKey)
 options:
 
 ```nix
-services.discourse = {
-  enable = true;
-  hostname = "discourse.example.com";
-  sslCertificate = "/path/to/ssl_certificate";
-  sslCertificateKey = "/path/to/ssl_certificate_key";
-  admin = {
-    email = "admin@example.com";
-    username = "admin";
-    fullName = "Administrator";
-    passwordFile = "/path/to/password_file";
+{
+  services.discourse = {
+    enable = true;
+    hostname = "discourse.example.com";
+    sslCertificate = "/path/to/ssl_certificate";
+    sslCertificateKey = "/path/to/ssl_certificate_key";
+    admin = {
+      email = "admin@example.com";
+      username = "admin";
+      fullName = "Administrator";
+      passwordFile = "/path/to/password_file";
+    };
+    secretKeyBaseFile = "/path/to/secret_key_base_file";
   };
-  secretKeyBaseFile = "/path/to/secret_key_base_file";
-};
+}
 ```
 
 ## Database access {#module-services-discourse-database}
@@ -81,26 +85,28 @@ A basic setup which assumes you want to use your configured
 email domain can be done like this:
 
 ```nix
-services.discourse = {
-  enable = true;
-  hostname = "discourse.example.com";
-  sslCertificate = "/path/to/ssl_certificate";
-  sslCertificateKey = "/path/to/ssl_certificate_key";
-  admin = {
-    email = "admin@example.com";
-    username = "admin";
-    fullName = "Administrator";
-    passwordFile = "/path/to/password_file";
+{
+  services.discourse = {
+    enable = true;
+    hostname = "discourse.example.com";
+    sslCertificate = "/path/to/ssl_certificate";
+    sslCertificateKey = "/path/to/ssl_certificate_key";
+    admin = {
+      email = "admin@example.com";
+      username = "admin";
+      fullName = "Administrator";
+      passwordFile = "/path/to/password_file";
+    };
+    mail.outgoing = {
+      serverAddress = "smtp.emailprovider.com";
+      port = 587;
+      username = "user@emailprovider.com";
+      passwordFile = "/path/to/smtp_password_file";
+    };
+    mail.incoming.enable = true;
+    secretKeyBaseFile = "/path/to/secret_key_base_file";
   };
-  mail.outgoing = {
-    serverAddress = "smtp.emailprovider.com";
-    port = 587;
-    username = "user@emailprovider.com";
-    passwordFile = "/path/to/smtp_password_file";
-  };
-  mail.incoming.enable = true;
-  secretKeyBaseFile = "/path/to/secret_key_base_file";
-};
+}
 ```
 
 This assumes you have set up an MX record for the address you've
@@ -163,43 +169,45 @@ Discourse instance and enables
 GitHub login in the site settings,
 and changes a few request limits in the backend settings:
 ```nix
-services.discourse = {
-  enable = true;
-  hostname = "discourse.example.com";
-  sslCertificate = "/path/to/ssl_certificate";
-  sslCertificateKey = "/path/to/ssl_certificate_key";
-  admin = {
-    email = "admin@example.com";
-    username = "admin";
-    fullName = "Administrator";
-    passwordFile = "/path/to/password_file";
-  };
-  mail.outgoing = {
-    serverAddress = "smtp.emailprovider.com";
-    port = 587;
-    username = "user@emailprovider.com";
-    passwordFile = "/path/to/smtp_password_file";
-  };
-  mail.incoming.enable = true;
-  siteSettings = {
-    required = {
-      title = "My Cats";
-      site_description = "Discuss My Cats (and be nice plz)";
+{
+  services.discourse = {
+    enable = true;
+    hostname = "discourse.example.com";
+    sslCertificate = "/path/to/ssl_certificate";
+    sslCertificateKey = "/path/to/ssl_certificate_key";
+    admin = {
+      email = "admin@example.com";
+      username = "admin";
+      fullName = "Administrator";
+      passwordFile = "/path/to/password_file";
     };
-    login = {
-      enable_github_logins = true;
-      github_client_id = "a2f6dfe838cb3206ce20";
-      github_client_secret._secret = /run/keys/discourse_github_client_secret;
+    mail.outgoing = {
+      serverAddress = "smtp.emailprovider.com";
+      port = 587;
+      username = "user@emailprovider.com";
+      passwordFile = "/path/to/smtp_password_file";
     };
+    mail.incoming.enable = true;
+    siteSettings = {
+      required = {
+        title = "My Cats";
+        site_description = "Discuss My Cats (and be nice plz)";
+      };
+      login = {
+        enable_github_logins = true;
+        github_client_id = "a2f6dfe838cb3206ce20";
+        github_client_secret._secret = /run/keys/discourse_github_client_secret;
+      };
+    };
+    backendSettings = {
+      max_reqs_per_ip_per_minute = 300;
+      max_reqs_per_ip_per_10_seconds = 60;
+      max_asset_reqs_per_ip_per_10_seconds = 250;
+      max_reqs_per_ip_mode = "warn+block";
+    };
+    secretKeyBaseFile = "/path/to/secret_key_base_file";
   };
-  backendSettings = {
-    max_reqs_per_ip_per_minute = 300;
-    max_reqs_per_ip_per_10_seconds = 60;
-    max_asset_reqs_per_ip_per_10_seconds = 250;
-    max_reqs_per_ip_mode = "warn+block";
-  };
-  secretKeyBaseFile = "/path/to/secret_key_base_file";
-};
+}
 ```
 
 In the resulting site settings file, the
@@ -254,33 +262,35 @@ plugins, and disable `discourse-spoiler-alert`
 by default:
 
 ```nix
-services.discourse = {
-  enable = true;
-  hostname = "discourse.example.com";
-  sslCertificate = "/path/to/ssl_certificate";
-  sslCertificateKey = "/path/to/ssl_certificate_key";
-  admin = {
-    email = "admin@example.com";
-    username = "admin";
-    fullName = "Administrator";
-    passwordFile = "/path/to/password_file";
-  };
-  mail.outgoing = {
-    serverAddress = "smtp.emailprovider.com";
-    port = 587;
-    username = "user@emailprovider.com";
-    passwordFile = "/path/to/smtp_password_file";
-  };
-  mail.incoming.enable = true;
-  plugins = with config.services.discourse.package.plugins; [
-    discourse-spoiler-alert
-    discourse-solved
-  ];
-  siteSettings = {
-    plugins = {
-      spoiler_enabled = false;
+{
+  services.discourse = {
+    enable = true;
+    hostname = "discourse.example.com";
+    sslCertificate = "/path/to/ssl_certificate";
+    sslCertificateKey = "/path/to/ssl_certificate_key";
+    admin = {
+      email = "admin@example.com";
+      username = "admin";
+      fullName = "Administrator";
+      passwordFile = "/path/to/password_file";
     };
+    mail.outgoing = {
+      serverAddress = "smtp.emailprovider.com";
+      port = 587;
+      username = "user@emailprovider.com";
+      passwordFile = "/path/to/smtp_password_file";
+    };
+    mail.incoming.enable = true;
+    plugins = with config.services.discourse.package.plugins; [
+      discourse-spoiler-alert
+      discourse-solved
+    ];
+    siteSettings = {
+      plugins = {
+        spoiler_enabled = false;
+      };
+    };
+    secretKeyBaseFile = "/path/to/secret_key_base_file";
   };
-  secretKeyBaseFile = "/path/to/secret_key_base_file";
-};
+}
 ```

--- a/nixos/modules/services/web-apps/gotosocial.md
+++ b/nixos/modules/services/web-apps/gotosocial.md
@@ -8,17 +8,19 @@ The following configuration sets up the PostgreSQL as database backend and binds
 GoToSocial to `127.0.0.1:8080`, expecting to be run behind a HTTP proxy on `gotosocial.example.com`.
 
 ```nix
-services.gotosocial = {
-  enable = true;
-  setupPostgresqlDB = true;
-  settings = {
-    application-name = "My GoToSocial";
-    host = "gotosocial.example.com";
-    protocol = "https";
-    bind-address = "127.0.0.1";
-    port = 8080;
+{
+  services.gotosocial = {
+    enable = true;
+    setupPostgresqlDB = true;
+    settings = {
+      application-name = "My GoToSocial";
+      host = "gotosocial.example.com";
+      protocol = "https";
+      bind-address = "127.0.0.1";
+      port = 8080;
+    };
   };
-};
+}
 ```
 
 Please refer to the [GoToSocial Documentation](https://docs.gotosocial.org/en/latest/configuration/general/)
@@ -30,24 +32,26 @@ Although it is possible to expose GoToSocial directly, it is common practice to 
 HTTP reverse proxy such as nginx.
 
 ```nix
-networking.firewall.allowedTCPPorts = [ 80 443 ];
-services.nginx = {
-  enable = true;
-  clientMaxBodySize = "40M";
-  virtualHosts = with config.services.gotosocial.settings; {
-    "${host}" = {
-      enableACME = true;
-      forceSSL = true;
-      locations = {
-        "/" = {
-          recommendedProxySettings = true;
-          proxyWebsockets = true;
-          proxyPass = "http://${bind-address}:${toString port}";
+{
+  networking.firewall.allowedTCPPorts = [ 80 443 ];
+  services.nginx = {
+    enable = true;
+    clientMaxBodySize = "40M";
+    virtualHosts = with config.services.gotosocial.settings; {
+      "${host}" = {
+        enableACME = true;
+        forceSSL = true;
+        locations = {
+          "/" = {
+            recommendedProxySettings = true;
+            proxyWebsockets = true;
+            proxyPass = "http://${bind-address}:${toString port}";
+          };
         };
       };
     };
   };
-};
+}
 ```
 
 Please refer to [](#module-security-acme) for details on how to provision an SSL/TLS certificate.

--- a/nixos/modules/services/web-apps/grocy.md
+++ b/nixos/modules/services/web-apps/grocy.md
@@ -6,7 +6,7 @@
 ## Basic usage {#module-services-grocy-basic-usage}
 
 A very basic configuration may look like this:
-```
+```nix
 { pkgs, ... }:
 {
   services.grocy = {
@@ -29,7 +29,7 @@ of the application.
 
 The configuration for `grocy` is located at `/etc/grocy/config.php`.
 By default, the following settings can be defined in the NixOS-configuration:
-```
+```nix
 { pkgs, ... }:
 {
   services.grocy.settings = {
@@ -56,7 +56,7 @@ By default, the following settings can be defined in the NixOS-configuration:
 
 If you want to alter the configuration file on your own, you can do this manually with
 an expression like this:
-```
+```nix
 { lib, ... }:
 {
   environment.etc."grocy/config.php".text = lib.mkAfter ''

--- a/nixos/modules/services/web-apps/jitsi-meet.md
+++ b/nixos/modules/services/web-apps/jitsi-meet.md
@@ -6,7 +6,7 @@ private, self-hosted video conferencing solution.
 ## Basic usage {#module-services-jitsi-basic-usage}
 
 A minimal configuration using Let's Encrypt for TLS certificates looks like this:
-```
+```nix
 {
   services.jitsi-meet = {
     enable = true;
@@ -22,7 +22,7 @@ A minimal configuration using Let's Encrypt for TLS certificates looks like this
 ## Configuration {#module-services-jitsi-configuration}
 
 Here is the minimal configuration with additional configurations:
-```
+```nix
 {
   services.jitsi-meet = {
     enable = true;

--- a/nixos/modules/services/web-apps/keycloak.md
+++ b/nixos/modules/services/web-apps/keycloak.md
@@ -126,7 +126,7 @@ should be set to. See the description of
 ## Example configuration {#module-services-keycloak-example-config}
 
 A basic configuration with some custom settings could look like this:
-```
+```nix
 services.keycloak = {
   enable = true;
   settings = {

--- a/nixos/modules/services/web-apps/keycloak.md
+++ b/nixos/modules/services/web-apps/keycloak.md
@@ -127,15 +127,17 @@ should be set to. See the description of
 
 A basic configuration with some custom settings could look like this:
 ```nix
-services.keycloak = {
-  enable = true;
-  settings = {
-    hostname = "keycloak.example.com";
-    hostname-strict-backchannel = true;
+{
+  services.keycloak = {
+    enable = true;
+    settings = {
+      hostname = "keycloak.example.com";
+      hostname-strict-backchannel = true;
+    };
+    initialAdminPassword = "e6Wcm0RrtegMEHl";  # change on first login
+    sslCertificate = "/run/keys/ssl_cert";
+    sslCertificateKey = "/run/keys/ssl_key";
+    database.passwordFile = "/run/keys/db_password";
   };
-  initialAdminPassword = "e6Wcm0RrtegMEHl";  # change on first login
-  sslCertificate = "/run/keys/ssl_cert";
-  sslCertificateKey = "/run/keys/ssl_key";
-  database.passwordFile = "/run/keys/db_password";
-};
+}
 ```

--- a/nixos/modules/services/web-apps/lemmy.md
+++ b/nixos/modules/services/web-apps/lemmy.md
@@ -7,13 +7,15 @@ Lemmy is a federated alternative to reddit in rust.
 the minimum to start lemmy is
 
 ```nix
-services.lemmy = {
-  enable = true;
-  settings = {
-    hostname = "lemmy.union.rocks";
-    database.createLocally = true;
+{
+  services.lemmy = {
+    enable = true;
+    settings = {
+      hostname = "lemmy.union.rocks";
+      database.createLocally = true;
+    };
+    caddy.enable = true;
   };
-  caddy.enable = true;
 }
 ```
 

--- a/nixos/modules/services/web-apps/nextcloud.md
+++ b/nixos/modules/services/web-apps/nextcloud.md
@@ -25,7 +25,7 @@ to `true`, Nextcloud will automatically be configured to connect to it through
 socket.
 
 A very basic configuration may look like this:
-```
+```nix
 { pkgs, ... }:
 {
   services.nextcloud = {
@@ -130,7 +130,7 @@ settings `listen.owner` &amp; `listen.group` in the
 [corresponding `phpfpm` pool](#opt-services.phpfpm.pools).
 
 An exemplary configuration may look like this:
-```
+```nix
 { config, lib, pkgs, ... }: {
   services.nginx.enable = false;
   services.nextcloud = {
@@ -205,7 +205,7 @@ If major-releases will be abandoned by upstream, we should check first if those 
 in NixOS for a safe upgrade-path before removing those. In that case we should keep those
 packages, but mark them as insecure in an expression like this (in
 `<nixpkgs/pkgs/servers/nextcloud/default.nix>`):
-```
+```nix
 /* ... */
 {
   nextcloud17 = generic {

--- a/nixos/modules/services/web-apps/pict-rs.md
+++ b/nixos/modules/services/web-apps/pict-rs.md
@@ -7,7 +7,9 @@ pict-rs is a  a simple image hosting service.
 the minimum to start pict-rs is
 
 ```nix
-services.pict-rs.enable = true;
+{
+  services.pict-rs.enable = true;
+}
 ```
 
 this will start the http server on port 8080 by default.

--- a/nixos/modules/services/web-apps/plausible.md
+++ b/nixos/modules/services/web-apps/plausible.md
@@ -11,7 +11,7 @@ $ openssl rand -base64 64
 ```
 
 After that, `plausible` can be deployed like this:
-```
+```nix
 {
   services.plausible = {
     enable = true;

--- a/nixos/modules/services/web-apps/suwayomi-server.md
+++ b/nixos/modules/services/web-apps/suwayomi-server.md
@@ -100,7 +100,7 @@ Not all the configuration options are available directly in this module, but you
       server = {
         port = 4567;
         autoDownloadNewChapters = false;
-        maxSourcesInParallel" = 6;
+        maxSourcesInParallel = 6;
         extensionRepos = [
           "https://raw.githubusercontent.com/MY_ACCOUNT/MY_REPO/repo/index.min.json"
         ];

--- a/nixos/modules/services/web-servers/garage.md
+++ b/nixos/modules/services/web-servers/garage.md
@@ -80,7 +80,7 @@ If major-releases will be abandoned by upstream, we should check first if those 
 in NixOS for a safe upgrade-path before removing those. In that case we should keep those
 packages, but mark them as insecure in an expression like this (in
 `<nixpkgs/pkgs/tools/filesystem/garage/default.nix>`):
-```
+```nix
 /* ... */
 {
   garage_0_7_3 = generic {

--- a/nixos/modules/services/x11/desktop-managers/gnome.md
+++ b/nixos/modules/services/x11/desktop-managers/gnome.md
@@ -8,7 +8,7 @@ All of the core apps, optional apps, games, and core developer tools from GNOME 
 
 To enable the GNOME desktop use:
 
-```
+```nix
 services.xserver.desktopManager.gnome.enable = true;
 services.xserver.displayManager.gdm.enable = true;
 ```
@@ -23,7 +23,7 @@ The default applications used in NixOS are very minimal, inspired by the default
 
 If you’d like to only use the GNOME desktop and not the apps, you can disable them with:
 
-```
+```nix
 services.gnome.core-utilities.enable = false;
 ```
 
@@ -37,7 +37,7 @@ Note that this mechanism can only exclude core utilities, games and core develop
 
 It is also possible to disable many of the [core services](https://github.com/NixOS/nixpkgs/blob/b8ec4fd2a4edc4e30d02ba7b1a2cc1358f3db1d5/nixos/modules/services/x11/desktop-managers/gnome.nix#L329-L348). For example, if you do not need indexing files, you can disable Tracker with:
 
-```
+```nix
 services.gnome.tracker-miners.enable = false;
 services.gnome.tracker.enable = false;
 ```
@@ -48,7 +48,7 @@ Note, however, that doing so is not supported and might break some applications.
 
 You can install all of the GNOME games with:
 
-```
+```nix
 services.gnome.games.enable = true;
 ```
 
@@ -56,7 +56,7 @@ services.gnome.games.enable = true;
 
 You can install GNOME core developer tools with:
 
-```
+```nix
 services.gnome.core-developer-tools.enable = true;
 ```
 
@@ -64,7 +64,7 @@ services.gnome.core-developer-tools.enable = true;
 
 GNOME Flashback provides a desktop environment based on the classic GNOME 2 architecture. You can enable the default GNOME Flashback session, which uses the Metacity window manager, with:
 
-```
+```nix
 services.xserver.desktopManager.gnome.flashback.enableMetacity = true;
 ```
 
@@ -72,7 +72,7 @@ It is also possible to create custom sessions that replace Metacity with a diffe
 
 The following example uses `xmonad` window manager:
 
-```
+```nix
 services.xserver.desktopManager.gnome.flashback.customSessions = [
   {
     wmName = "xmonad";
@@ -104,7 +104,7 @@ Some packages that include Shell extensions, like `gnome.gpaste`, don’t have t
 
 You can install them like any other package:
 
-```
+```nix
 environment.systemPackages = [
   gnomeExtensions.dash-to-dock
   gnomeExtensions.gsconnect
@@ -136,7 +136,7 @@ You can use `dconf-editor` tool to explore which GSettings you can set.
 
 ### Example {#sec-gnome-gsettings-overrides-example}
 
-```
+```nix
 services.xserver.desktopManager.gnome = {
   extraGSettingsOverrides = ''
     # Change default background

--- a/nixos/modules/services/x11/desktop-managers/gnome.md
+++ b/nixos/modules/services/x11/desktop-managers/gnome.md
@@ -9,8 +9,10 @@ All of the core apps, optional apps, games, and core developer tools from GNOME 
 To enable the GNOME desktop use:
 
 ```nix
-services.xserver.desktopManager.gnome.enable = true;
-services.xserver.displayManager.gdm.enable = true;
+{
+  services.xserver.desktopManager.gnome.enable = true;
+  services.xserver.displayManager.gdm.enable = true;
+}
 ```
 
 ::: {.note}
@@ -24,7 +26,9 @@ The default applications used in NixOS are very minimal, inspired by the default
 If you’d like to only use the GNOME desktop and not the apps, you can disable them with:
 
 ```nix
-services.gnome.core-utilities.enable = false;
+{
+  services.gnome.core-utilities.enable = false;
+}
 ```
 
 and none of them will be installed.
@@ -38,8 +42,10 @@ Note that this mechanism can only exclude core utilities, games and core develop
 It is also possible to disable many of the [core services](https://github.com/NixOS/nixpkgs/blob/b8ec4fd2a4edc4e30d02ba7b1a2cc1358f3db1d5/nixos/modules/services/x11/desktop-managers/gnome.nix#L329-L348). For example, if you do not need indexing files, you can disable Tracker with:
 
 ```nix
-services.gnome.tracker-miners.enable = false;
-services.gnome.tracker.enable = false;
+{
+  services.gnome.tracker-miners.enable = false;
+  services.gnome.tracker.enable = false;
+}
 ```
 
 Note, however, that doing so is not supported and might break some applications. Notably, GNOME Music cannot work without Tracker.
@@ -49,7 +55,9 @@ Note, however, that doing so is not supported and might break some applications.
 You can install all of the GNOME games with:
 
 ```nix
-services.gnome.games.enable = true;
+{
+  services.gnome.games.enable = true;
+}
 ```
 
 ### GNOME core developer tools {#sec-gnome-core-developer-tools}
@@ -57,7 +65,9 @@ services.gnome.games.enable = true;
 You can install GNOME core developer tools with:
 
 ```nix
-services.gnome.core-developer-tools.enable = true;
+{
+  services.gnome.core-developer-tools.enable = true;
+}
 ```
 
 ## Enabling GNOME Flashback {#sec-gnome-enable-flashback}
@@ -65,7 +75,9 @@ services.gnome.core-developer-tools.enable = true;
 GNOME Flashback provides a desktop environment based on the classic GNOME 2 architecture. You can enable the default GNOME Flashback session, which uses the Metacity window manager, with:
 
 ```nix
-services.xserver.desktopManager.gnome.flashback.enableMetacity = true;
+{
+  services.xserver.desktopManager.gnome.flashback.enableMetacity = true;
+}
 ```
 
 It is also possible to create custom sessions that replace Metacity with a different window manager using [](#opt-services.xserver.desktopManager.gnome.flashback.customSessions).
@@ -73,14 +85,16 @@ It is also possible to create custom sessions that replace Metacity with a diffe
 The following example uses `xmonad` window manager:
 
 ```nix
-services.xserver.desktopManager.gnome.flashback.customSessions = [
-  {
-    wmName = "xmonad";
-    wmLabel = "XMonad";
-    wmCommand = "${pkgs.haskellPackages.xmonad}/bin/xmonad";
-    enableGnomePanel = false;
-  }
-];
+{
+  services.xserver.desktopManager.gnome.flashback.customSessions = [
+    {
+      wmName = "xmonad";
+      wmLabel = "XMonad";
+      wmCommand = "${pkgs.haskellPackages.xmonad}/bin/xmonad";
+      enableGnomePanel = false;
+    }
+  ];
+}
 ```
 
 ## Icons and GTK Themes {#sec-gnome-icons-and-gtk-themes}
@@ -105,11 +119,13 @@ Some packages that include Shell extensions, like `gnome.gpaste`, don’t have t
 You can install them like any other package:
 
 ```nix
-environment.systemPackages = [
-  gnomeExtensions.dash-to-dock
-  gnomeExtensions.gsconnect
-  gnomeExtensions.mpris-indicator-button
-];
+{
+  environment.systemPackages = [
+    gnomeExtensions.dash-to-dock
+    gnomeExtensions.gsconnect
+    gnomeExtensions.mpris-indicator-button
+  ];
+}
 ```
 
 Unfortunately, we lack a way for these to be managed in a completely declarative way.
@@ -137,22 +153,24 @@ You can use `dconf-editor` tool to explore which GSettings you can set.
 ### Example {#sec-gnome-gsettings-overrides-example}
 
 ```nix
-services.xserver.desktopManager.gnome = {
-  extraGSettingsOverrides = ''
-    # Change default background
-    [org.gnome.desktop.background]
-    picture-uri='file://${pkgs.nixos-artwork.wallpapers.mosaic-blue.gnomeFilePath}'
+{
+  services.xserver.desktopManager.gnome = {
+    extraGSettingsOverrides = ''
+      # Change default background
+      [org.gnome.desktop.background]
+      picture-uri='file://${pkgs.nixos-artwork.wallpapers.mosaic-blue.gnomeFilePath}'
 
-    # Favorite apps in gnome-shell
-    [org.gnome.shell]
-    favorite-apps=['org.gnome.Console.desktop', 'org.gnome.Nautilus.desktop']
-  '';
+      # Favorite apps in gnome-shell
+      [org.gnome.shell]
+      favorite-apps=['org.gnome.Console.desktop', 'org.gnome.Nautilus.desktop']
+    '';
 
-  extraGSettingsOverridePackages = [
-    pkgs.gsettings-desktop-schemas # for org.gnome.desktop
-    pkgs.gnome.gnome-shell # for org.gnome.shell
-  ];
-};
+    extraGSettingsOverridePackages = [
+      pkgs.gsettings-desktop-schemas # for org.gnome.desktop
+      pkgs.gnome.gnome-shell # for org.gnome.shell
+    ];
+  };
+}
 ```
 
 ## Frequently Asked Questions {#sec-gnome-faq}

--- a/nixos/modules/services/x11/desktop-managers/pantheon.md
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.md
@@ -6,16 +6,22 @@ Pantheon is the desktop environment created for the elementary OS distribution. 
 
 All of Pantheon is working in NixOS and the applications should be available, aside from a few [exceptions](https://github.com/NixOS/nixpkgs/issues/58161). To enable Pantheon, set
 ```nix
-services.xserver.desktopManager.pantheon.enable = true;
+{
+  services.xserver.desktopManager.pantheon.enable = true;
+}
 ```
 This automatically enables LightDM and Pantheon's LightDM greeter. If you'd like to disable this, set
 ```nix
-services.xserver.displayManager.lightdm.greeters.pantheon.enable = false;
-services.xserver.displayManager.lightdm.enable = false;
+{
+  services.xserver.displayManager.lightdm.greeters.pantheon.enable = false;
+  services.xserver.displayManager.lightdm.enable = false;
+}
 ```
 but please be aware using Pantheon without LightDM as a display manager will break screenlocking from the UI. The NixOS module for Pantheon installs all of Pantheon's default applications. If you'd like to not install Pantheon's apps, set
 ```nix
-services.pantheon.apps.enable = false;
+{
+  services.pantheon.apps.enable = false;
+}
 ```
 You can also use [](#opt-environment.pantheon.excludePackages) to remove any other app (like `elementary-mail`).
 
@@ -34,25 +40,28 @@ wingpanel-with-indicators.override {
   indicators = [
     pkgs.some-special-indicator
   ];
-};
+}
 
+```
+```nix
 switchboard-with-plugs.override {
   plugs = [
     pkgs.some-special-plug
   ];
-};
+}
 ```
 please note that, like how the NixOS options describe these as extra plugins, this would only add to the default plugins included with the programs. If for some reason you'd like to configure which plugins to use exactly, both packages have an argument for this:
 ```nix
 wingpanel-with-indicators.override {
   useDefaultIndicators = false;
   indicators = specialListOfIndicators;
-};
-
+}
+```
+```nix
 switchboard-with-plugs.override {
   useDefaultPlugs = false;
   plugs = specialListOfPlugs;
-};
+}
 ```
 this could be most useful for testing a particular plug-in in isolation.
 

--- a/nixos/modules/services/x11/desktop-managers/pantheon.md
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.md
@@ -5,16 +5,16 @@ Pantheon is the desktop environment created for the elementary OS distribution. 
 ## Enabling Pantheon {#sec-pantheon-enable}
 
 All of Pantheon is working in NixOS and the applications should be available, aside from a few [exceptions](https://github.com/NixOS/nixpkgs/issues/58161). To enable Pantheon, set
-```
+```nix
 services.xserver.desktopManager.pantheon.enable = true;
 ```
 This automatically enables LightDM and Pantheon's LightDM greeter. If you'd like to disable this, set
-```
+```nix
 services.xserver.displayManager.lightdm.greeters.pantheon.enable = false;
 services.xserver.displayManager.lightdm.enable = false;
 ```
 but please be aware using Pantheon without LightDM as a display manager will break screenlocking from the UI. The NixOS module for Pantheon installs all of Pantheon's default applications. If you'd like to not install Pantheon's apps, set
-```
+```nix
 services.pantheon.apps.enable = false;
 ```
 You can also use [](#opt-environment.pantheon.excludePackages) to remove any other app (like `elementary-mail`).
@@ -29,7 +29,7 @@ Wingpanel and Switchboard work differently than they do in other distributions, 
 to configure the programs with plugs or indicators.
 
 The difference in NixOS is both these programs are patched to load plugins from a directory that is the value of an environment variable. All of which is controlled in Nix. If you need to configure the particular packages manually you can override the packages like:
-```
+```nix
 wingpanel-with-indicators.override {
   indicators = [
     pkgs.some-special-indicator
@@ -43,7 +43,7 @@ switchboard-with-plugs.override {
 };
 ```
 please note that, like how the NixOS options describe these as extra plugins, this would only add to the default plugins included with the programs. If for some reason you'd like to configure which plugins to use exactly, both packages have an argument for this:
-```
+```nix
 wingpanel-with-indicators.override {
   useDefaultIndicators = false;
   indicators = specialListOfIndicators;

--- a/nixos/modules/system/boot/clevis.md
+++ b/nixos/modules/system/boot/clevis.md
@@ -39,12 +39,12 @@ For more complete documentation on how to generate a secret with clevis, see the
 
 In order to activate unattended decryption of a resource at boot, enable the `clevis` module:
 
-```
+```nix
 boot.initrd.clevis.enable = true;
 ```
 
 Then, specify the device you want to decrypt using a given clevis secret. Clevis will automatically try to decrypt the device at boot and will fallback to interactive unlocking if the decryption policy is not fulfilled.
-```
+```nix
 boot.initrd.clevis.devices."/dev/nvme0n1p1".secretFile = ./nvme0n1p1.jwe;
 ```
 

--- a/nixos/modules/system/boot/clevis.md
+++ b/nixos/modules/system/boot/clevis.md
@@ -40,12 +40,16 @@ For more complete documentation on how to generate a secret with clevis, see the
 In order to activate unattended decryption of a resource at boot, enable the `clevis` module:
 
 ```nix
-boot.initrd.clevis.enable = true;
+{
+  boot.initrd.clevis.enable = true;
+}
 ```
 
 Then, specify the device you want to decrypt using a given clevis secret. Clevis will automatically try to decrypt the device at boot and will fallback to interactive unlocking if the decryption policy is not fulfilled.
 ```nix
-boot.initrd.clevis.devices."/dev/nvme0n1p1".secretFile = ./nvme0n1p1.jwe;
+{
+  boot.initrd.clevis.devices."/dev/nvme0n1p1".secretFile = ./nvme0n1p1.jwe;
+}
 ```
 
 Only `bcachefs`, `zfs` and `luks` encrypted devices are supported at this time.

--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -564,7 +564,7 @@ We use jbidwatcher as an example for a discontinued project here.
 
     For example in this case:
 
-    ```
+    ```nix
     jbidwatcher = throw "jbidwatcher was discontinued in march 2021"; # added 2021-03-15
     ```
 

--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -417,31 +417,37 @@ In the file `pkgs/top-level/all-packages.nix` you can find fetch helpers, these 
 - Bad: Uses `git://` which won't be proxied.
 
   ```nix
-  src = fetchgit {
-    url = "git://github.com/NixOS/nix.git";
-    rev = "1f795f9f44607cc5bec70d1300150bfefcef2aae";
-    hash = "sha256-7D4m+saJjbSFP5hOwpQq2FGR2rr+psQMTcyb1ZvtXsQ=";
+  {
+    src = fetchgit {
+      url = "git://github.com/NixOS/nix.git";
+      rev = "1f795f9f44607cc5bec70d1300150bfefcef2aae";
+      hash = "sha256-7D4m+saJjbSFP5hOwpQq2FGR2rr+psQMTcyb1ZvtXsQ=";
+    };
   }
   ```
 
 - Better: This is ok, but an archive fetch will still be faster.
 
   ```nix
-  src = fetchgit {
-    url = "https://github.com/NixOS/nix.git";
-    rev = "1f795f9f44607cc5bec70d1300150bfefcef2aae";
-    hash = "sha256-7D4m+saJjbSFP5hOwpQq2FGR2rr+psQMTcyb1ZvtXsQ=";
+  {
+    src = fetchgit {
+      url = "https://github.com/NixOS/nix.git";
+      rev = "1f795f9f44607cc5bec70d1300150bfefcef2aae";
+      hash = "sha256-7D4m+saJjbSFP5hOwpQq2FGR2rr+psQMTcyb1ZvtXsQ=";
+    };
   }
   ```
 
 - Best: Fetches a snapshot archive and you get the rev you want.
 
   ```nix
-  src = fetchFromGitHub {
-    owner = "NixOS";
-    repo = "nix";
-    rev = "1f795f9f44607cc5bec70d1300150bfefcef2aae";
-    hash = "sha256-7D4m+saJjbSFP5hOwpQq2FGR2rr+psQMTcyb1ZvtXsQ=";
+  {
+    src = fetchFromGitHub {
+      owner = "NixOS";
+      repo = "nix";
+      rev = "1f795f9f44607cc5bec70d1300150bfefcef2aae";
+      hash = "sha256-7D4m+saJjbSFP5hOwpQq2FGR2rr+psQMTcyb1ZvtXsQ=";
+    };
   }
   ```
 
@@ -506,13 +512,15 @@ Let's say Man-in-the-Middle (MITM) sits close to your network. Then instead of f
 Patches available online should be retrieved using `fetchpatch`.
 
 ```nix
-patches = [
-  (fetchpatch {
-    name = "fix-check-for-using-shared-freetype-lib.patch";
-    url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=8f5d285";
-    hash = "sha256-uRcxaCjd+WAuGrXOmGfFeu79cUILwkRdBu48mwcBE7g=";
-  })
-];
+{
+  patches = [
+    (fetchpatch {
+      name = "fix-check-for-using-shared-freetype-lib.patch";
+      url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=8f5d285";
+      hash = "sha256-uRcxaCjd+WAuGrXOmGfFeu79cUILwkRdBu48mwcBE7g=";
+    })
+  ];
+}
 ```
 
 Otherwise, you can add a `.patch` file to the `nixpkgs` repository. In the interest of keeping our maintenance burden to a minimum, only patches that are unique to `nixpkgs` should be added in this way.
@@ -520,7 +528,9 @@ Otherwise, you can add a `.patch` file to the `nixpkgs` repository. In the inter
 If a patch is available online but does not cleanly apply, it can be modified in some fixed ways by using additional optional arguments for `fetchpatch`. Check [the `fetchpatch` reference](https://nixos.org/manual/nixpkgs/unstable/#fetchpatch) for details.
 
 ```nix
-patches = [ ./0001-changes.patch ];
+{
+  patches = [ ./0001-changes.patch ];
+}
 ```
 
 If you do need to do create this sort of patch file, one way to do so is with git:
@@ -565,7 +575,9 @@ We use jbidwatcher as an example for a discontinued project here.
     For example in this case:
 
     ```nix
-    jbidwatcher = throw "jbidwatcher was discontinued in march 2021"; # added 2021-03-15
+    {
+      jbidwatcher = throw "jbidwatcher was discontinued in march 2021"; # added 2021-03-15
+    }
     ```
 
     The throw message should explain in short why the package was removed for users that still have it installed.
@@ -617,10 +629,10 @@ Here in the nixpkgs manual we describe mostly _package tests_; for _module tests
 For very simple tests, they can be written inline:
 
 ```nix
-{ …, yq-go }:
+{ /* ... , */ yq-go }:
 
 buildGoModule rec {
-  …
+  # …
 
   passthru.tests = {
     simple = runCommand "${pname}-test" {} ''
@@ -642,13 +654,13 @@ Add the tests in `passthru.tests` to the package definition like this:
 { stdenv, lib, fetchurl, callPackage }:
 
 stdenv.mkDerivation {
-  …
+  # …
 
   passthru.tests = {
     simple-execution = callPackage ./tests.nix { };
   };
 
-  meta = { … };
+  meta = { /* … */ };
 }
 ```
 
@@ -706,13 +718,13 @@ For example, assuming we're packaging `nginx`, we can link its module test via `
 { stdenv, lib, nixosTests }:
 
 stdenv.mkDerivation {
-  ...
+  # ...
 
   passthru.tests = {
     nginx = nixosTests.nginx;
   };
 
-  ...
+  # ...
 }
 ```
 

--- a/pkgs/by-name/README.md
+++ b/pkgs/by-name/README.md
@@ -69,9 +69,11 @@ So instead it is preferable to use the same generic parameter name `libbar`
 and override its value in [`pkgs/top-level/all-packages.nix`](../top-level/all-packages.nix):
 
 ```nix
-libfoo = callPackage ../by-name/so/some-package/package.nix {
-  libbar = libbar_2;
-};
+{
+  libfoo = callPackage ../by-name/so/some-package/package.nix {
+    libbar = libbar_2;
+  };
+}
 ```
 
 ## Manual migration guidelines
@@ -132,13 +134,16 @@ but if you try to move the package to `pkgs/by-name`, it will fail check 2.
 This is often the case for packages with multiple versions, such as
 
 ```nix
+{
   foo_1 = callPackage ../tools/foo/1.nix { };
   foo_2 = callPackage ../tools/foo/2.nix { };
+}
 ```
 
 The best way to resolve this is to not use `callPackage` directly, such that check 1 doesn't trigger.
 This can be done by using `inherit` on a local package set:
 ```nix
+{
   inherit
     ({
       foo_1 = callPackage ../tools/foo/1.nix { };
@@ -147,6 +152,7 @@ This can be done by using `inherit` on a local package set:
     foo_1
     foo_2
     ;
+}
 ```
 
 While this may seem pointless, this can in fact help with future package set refactorings,
@@ -157,8 +163,10 @@ because it establishes a clear connection between related attributes.
 This is not required, but the above solution also allows refactoring the definitions into a separate file:
 
 ```nix
+{
   inherit (import ../tools/foo pkgs)
     foo_1 foo_2;
+}
 ```
 
 ```nix
@@ -173,8 +181,10 @@ Alternatively using [`callPackages`](https://nixos.org/manual/nixpkgs/unstable/#
 if `callPackage` isn't used underneath and you want the same `.override` arguments for all attributes:
 
 ```nix
+{
   inherit (callPackages ../tools/foo { })
     foo_1 foo_2;
+}
 ```
 
 ```nix
@@ -192,9 +202,11 @@ if `callPackage` isn't used underneath and you want the same `.override` argumen
 This is not required, but the above solution also allows exposing the package set as an attribute:
 
 ```nix
+{
   foo-versions = import ../tools/foo pkgs;
   # Or using callPackages
   # foo-versions = callPackages ../tools/foo { };
 
   inherit (foo-versions) foo_1 foo_2;
+}
 ```

--- a/pkgs/development/misc/resholve/README.md
+++ b/pkgs/development/misc/resholve/README.md
@@ -99,20 +99,22 @@ trivial, so I'll also link to some real-world examples:
 - [shell.nix from abathur/tdverpy](https://github.com/abathur/tdverpy/blob/e1f956df3ed1c7097a5164e0c85b178772e277f5/shell.nix#L6-L13)
 
 ```nix
-resholvedScript = resholve.writeScript "name" {
-    inputs = [ file ];
-    interpreter = "${bash}/bin/bash";
-  } ''
-    echo "Hello"
-    file .
-  '';
-resholvedScriptBin = resholve.writeScriptBin "name" {
-    inputs = [ file ];
-    interpreter = "${bash}/bin/bash";
-  } ''
-    echo "Hello"
-    file .
-  '';
+{
+  resholvedScript = resholve.writeScript "name" {
+      inputs = [ file ];
+      interpreter = "${bash}/bin/bash";
+    } ''
+      echo "Hello"
+      file .
+    '';
+  resholvedScriptBin = resholve.writeScriptBin "name" {
+      inputs = [ file ];
+      interpreter = "${bash}/bin/bash";
+    } ''
+      echo "Hello"
+      file .
+    '';
+}
 ```
 
 
@@ -212,29 +214,31 @@ This will hopefully make more sense when you see it. Here are CLI examples
 from the manpage, and the Nix equivalents:
 
 ```nix
-# --fake 'f:setUp;tearDown builtin:setopt source:/etc/bashrc'
-fake = {
-  # fake accepts the initial of valid identifier types as a CLI convenience.
-  # Use full names in the Nix API.
-  function = [ "setUp" "tearDown" ];
-  builtin = [ "setopt" ];
-  source = [ "/etc/bashrc" ];
-};
+{
+  # --fake 'f:setUp;tearDown builtin:setopt source:/etc/bashrc'
+  fake = {
+    # fake accepts the initial of valid identifier types as a CLI convenience.
+    # Use full names in the Nix API.
+    function = [ "setUp" "tearDown" ];
+    builtin = [ "setopt" ];
+    source = [ "/etc/bashrc" ];
+  };
 
-# --fix 'aliases $GIT:gix /bin/bash'
-fix = {
-  # all single-word directives use `true` as value
-  aliases = true;
-  "$GIT" = [ "gix" ];
-  "/bin/bash";
-};
+  # --fix 'aliases $GIT:gix /bin/bash'
+  fix = {
+    # all single-word directives use `true` as value
+    aliases = true;
+    "$GIT" = [ "gix" ];
+    interpreter = "/bin/bash";
+  };
 
-# --keep 'source:$HOME /etc/bashrc ~/.bashrc'
-keep = {
-  source = [ "$HOME" ];
-  "/etc/bashrc" = true;
-  "~/.bashrc" = true;
-};
+  # --keep 'source:$HOME /etc/bashrc ~/.bashrc'
+  keep = {
+    source = [ "$HOME" ];
+    "/etc/bashrc" = true;
+    "~/.bashrc" = true;
+  };
+}
 ```
 
 
@@ -283,27 +287,29 @@ the main lever is the ability to substitute your own lore. This is how you'd
 do it piecemeal:
 
 ```nix
-# --execer 'cannot:${openssl.bin}/bin/openssl can:${openssl.bin}/bin/c_rehash'
-execer = [
-  /*
-    This is the same verdict binlore will
-    come up with. It's a no-op just to demo
-    how to fiddle lore via the Nix API.
-  */
-  "cannot:${openssl.bin}/bin/openssl"
-  # different verdict, but not used
-  "can:${openssl.bin}/bin/c_rehash"
-];
+{
+  # --execer 'cannot:${openssl.bin}/bin/openssl can:${openssl.bin}/bin/c_rehash'
+  execer = [
+    /*
+      This is the same verdict binlore will
+      come up with. It's a no-op just to demo
+      how to fiddle lore via the Nix API.
+    */
+    "cannot:${openssl.bin}/bin/openssl"
+    # different verdict, but not used
+    "can:${openssl.bin}/bin/c_rehash"
+  ];
 
-# --wrapper '${gnugrep}/bin/egrep:${gnugrep}/bin/grep'
-wrapper = [
-  /*
-    This is the same verdict binlore will
-    come up with. It's a no-op just to demo
-    how to fiddle lore via the Nix API.
-  */
-  "${gnugrep}/bin/egrep:${gnugrep}/bin/grep"
-];
+  # --wrapper '${gnugrep}/bin/egrep:${gnugrep}/bin/grep'
+  wrapper = [
+    /*
+      This is the same verdict binlore will
+      come up with. It's a no-op just to demo
+      how to fiddle lore via the Nix API.
+    */
+    "${gnugrep}/bin/egrep:${gnugrep}/bin/grep"
+  ];
+}
 ```
 
 

--- a/pkgs/servers/home-assistant/custom-components/README.md
+++ b/pkgs/servers/home-assistant/custom-components/README.md
@@ -37,7 +37,7 @@ buildHomeAssistantComponent {
 
   meta = with lib; {
     # changelog, description, homepage, license, maintainers
-  }
+  };
 }
 ```
 

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/README.md
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/README.md
@@ -9,5 +9,7 @@ configured.
 The entrypoint used can be overridden in `passthru` like this:
 
 ```nix
-passthru.entrypoint = "demo-card-bundle.js";
+{
+  passthru.entrypoint = "demo-card-bundle.js";
+}
 ```

--- a/pkgs/servers/nextcloud/packages/README.md
+++ b/pkgs/servers/nextcloud/packages/README.md
@@ -24,7 +24,7 @@ After that you can commit and submit the changes.
 The apps will be available in the namespace `nextcloud25Packages.apps`.
 Using it together with the Nextcloud module could look like this:
 
-```
+```nix
 services.nextcloud = {
   enable = true;
   package = pkgs.nextcloud25;

--- a/pkgs/servers/nextcloud/packages/README.md
+++ b/pkgs/servers/nextcloud/packages/README.md
@@ -25,16 +25,18 @@ The apps will be available in the namespace `nextcloud25Packages.apps`.
 Using it together with the Nextcloud module could look like this:
 
 ```nix
-services.nextcloud = {
-  enable = true;
-  package = pkgs.nextcloud25;
-  hostName = "localhost";
-  config.adminpassFile = "${pkgs.writeText "adminpass" "hunter2"}";
-  extraApps = with pkgs.nextcloud25Packages.apps; {
-    inherit mail calendar contact;
+{
+  services.nextcloud = {
+    enable = true;
+    package = pkgs.nextcloud25;
+    hostName = "localhost";
+    config.adminpassFile = "${pkgs.writeText "adminpass" "hunter2"}";
+    extraApps = with pkgs.nextcloud25Packages.apps; {
+      inherit mail calendar contact;
+    };
+    extraAppsEnable = true;
   };
-  extraAppsEnable = true;
-};
+}
 ```
 
 Adapt the version number in the Nextcloud package and nextcloudPackages set

--- a/pkgs/servers/web-apps/wordpress/packages/README.md
+++ b/pkgs/servers/web-apps/wordpress/packages/README.md
@@ -30,17 +30,19 @@ The plugins will be available in the namespace `wordpressPackages.plugins`.
 Using it together with the Wordpress module could look like this:
 
 ```nix
-services.wordpress = {
-  sites."blog.${config.networking.domain}" = {
-    plugins = with pkgs.wordpressPackages.plugins; [
-      anti-spam-bee
-      code-syntax-block
-      cookie-notice
-      lightbox-with-photoswipe
-      wp-gdpr-compliance
-    ];
+{
+  services.wordpress = {
+    sites."blog.${config.networking.domain}" = {
+      plugins = with pkgs.wordpressPackages.plugins; [
+        anti-spam-bee
+        code-syntax-block
+        cookie-notice
+        lightbox-with-photoswipe
+        wp-gdpr-compliance
+      ];
+    };
   };
-};
+}
 ```
 
 The same scheme applies to `themes` and `languages`.

--- a/pkgs/servers/web-apps/wordpress/packages/README.md
+++ b/pkgs/servers/web-apps/wordpress/packages/README.md
@@ -29,7 +29,7 @@ After that you can commit and submit the changes.
 The plugins will be available in the namespace `wordpressPackages.plugins`.
 Using it together with the Wordpress module could look like this:
 
-```
+```nix
 services.wordpress = {
   sites."blog.${config.networking.domain}" = {
     plugins = with pkgs.wordpressPackages.plugins; [


### PR DESCRIPTION
## Description of changes

This PR does 2 things:
- It adds nix-fencing to nix code that had no syntax specifier
- It fixes all Nix ASTs to be parsable at least by nixfmt

The end-goal of this PR is to make the ASTs parsable by the formatter to get RFC-166 into the manual. This is important since the manual is likely to be one of the first contact points of new users and also a place where code is likely to be copied from. This might also make the code compliant with other parsers as well, allowing for future functionality like checking for renamed options.

As outlined above, this does not reformat the code with nixfmt (yet). This is the preparation to do such things in the future. There are however a lot of manual reformats to make the code look "normal" (like when adding `{}` around something that has to be indented now).

I am also aware that there are other places where documentation can be found, which are not in .md files. There's `toPretty` and the examples from the manual but the PR is probably big enough as-is.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
