### PR TITLE
gh-f: init at 1.1.5

### DIFF
--- a/pkgs/by-name/gh/gh-f/package.nix
+++ b/pkgs/by-name/gh/gh-f/package.nix
@@ -1,0 +1,41 @@
+{ lib
+, fetchFromGitHub
+, stdenvNoCC
+, makeWrapper
+, fzf
+, coreutils
+, bat
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "gh-f";
+  version = "1.1.5";
+
+  src = fetchFromGitHub {
+    owner = "gennaro-tedesco";
+    repo = "gh-f";
+    rev = "v${version}";
+    hash = "sha256-ITl8T8Oe21m047ygFlxWVjzUYPG4rlcTjfSpsropYJw=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    install -D -m755 "gh-f" "$out/bin/gh-f"
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/gh-f" --prefix PATH : "${lib.makeBinPath [fzf bat coreutils]}"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/gennaro-tedesco/gh-f";
+    description = "GitHub CLI ultimate FZF extension";
+    maintainers = with maintainers; [ loicreynier ];
+    license = licenses.unlicense;
+    mainProgram = "gh-f";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add `gh-f` GitHub CLI `fzf` extension.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
