### PR TITLE
gh-notify: init at 0-unstable-2024-03-19

### DIFF
--- a/pkgs/by-name/gh/gh-notify/package.nix
+++ b/pkgs/by-name/gh/gh-notify/package.nix
@@ -1,0 +1,55 @@
+{ lib
+, fetchFromGitHub
+, stdenvNoCC
+, makeWrapper
+, gh
+, gnugrep
+, fzf
+, python3
+, withDelta ? false
+, delta
+, withBat ? false
+, bat
+}:
+let
+  binPath = lib.makeBinPath ([
+    gh
+    gnugrep
+    fzf
+    python3
+  ]
+  ++ lib.optional withBat bat
+  ++ lib.optional withDelta delta);
+in
+stdenvNoCC.mkDerivation {
+  pname = "gh-notify";
+  version = "0-unstable-2024-03-19";
+
+  src = fetchFromGitHub {
+    owner = "meiji163";
+    repo = "gh-notify";
+    rev = "0d8fa377d79cfef0f66d2f03a5921a5e598e6807";
+    hash = "sha256-Ao6gUtgW7enVlWBQhlQDc8ZW/gP90atc2F4rDNUnjj8=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    install -D -m755 "gh-notify" "$out/bin/gh-notify"
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/gh-notify" --prefix PATH : "${binPath}"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/meiji163/gh-notify";
+    description = "GitHub CLI extension to display GitHub notifications";
+    maintainers = with maintainers; [ loicreynier ];
+    license = licenses.unlicense;
+    mainProgram = "gh-notify";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add `gh-notify` GitHub CLI extension.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
