### PR TITLE
treewide: CUDA reformat with `nixfmt-rfc-style`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -102,3 +102,6 @@ fb0e5be84331188a69b3edd31679ca6576edb75a
 
 # systemd: break too long lines of Nix code
 67643f8ec84bef1482204709073e417c9f07eb87
+
+# {pkgs/development/cuda-modules,pkgs/test/cuda,pkgs/top-level/cuda-packages.nix}: reformat all CUDA files with nixfmt-rfc-style 2023-03-01
+802a1b4d3338f24cbc4efd704616654456d75a94

--- a/.github/workflows/check-nix-format.yml
+++ b/.github/workflows/check-nix-format.yml
@@ -1,0 +1,50 @@
+# This file was copied mostly from check-maintainers-sorted.yaml.
+# NOTE: Formatting with the RFC-style nixfmt command is not yet stable. See
+# https://github.com/NixOS/rfcs/pull/166.
+# Because of this, this action is not yet enabled for all files -- only for
+# those who have opted in.
+name: Check that Nix files are formatted
+
+on:
+  pull_request_target:
+permissions:
+  contents: read
+
+jobs:
+  nixos:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'NixOS'
+    steps:
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          # pull_request_target checks out the base branch by default
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+        with:
+          # explicitly enable sandbox
+          extra_nix_config: sandbox = true
+      - name: Install nixfmt
+        run: nix-env -f default.nix -iAP nixfmt-rfc-style
+      - name: Check that Nix files are formatted according to the RFC style
+        # Each environment variable beginning with NIX_FMT_PATHS_ is a list of
+        # paths to check with nixfmt.
+        env:
+          # Format paths related to the Nixpkgs CUDA ecosystem.
+          NIX_FMT_PATHS_CUDA: |
+            pkgs/development/cuda-modules
+            pkgs/test/cuda
+            pkgs/top-level/cuda-packages.nix
+        # Iterate over all environment variables beginning with NIX_FMT_PATHS_.
+        run: |
+          for env_var in "${!NIX_FMT_PATHS_@}"; do
+            readarray -t paths <<< "${!env_var}"
+            if [[ "${paths[*]}" == "" ]]; then
+              echo "Error: $env_var is empty."
+              exit 1
+            fi
+            echo "Checking paths: ${paths[@]}"
+            if ! nixfmt --check "${paths[@]}"; then
+              echo "Error: nixfmt failed."
+              exit 1
+            fi
+          done

--- a/pkgs/development/cuda-modules/backend-stdenv.nix
+++ b/pkgs/development/cuda-modules/backend-stdenv.nix
@@ -21,6 +21,6 @@ let
   assertCondition = true;
 in
 
-  /* TODO: Consider testing whether we in fact use the newer libstdc++ */
+# TODO: Consider testing whether we in fact use the newer libstdc++
 
 lib.extendDerivation assertCondition passthruExtra cudaStdenv

--- a/pkgs/development/cuda-modules/cuda-library-samples/extension.nix
+++ b/pkgs/development/cuda-modules/cuda-library-samples/extension.nix
@@ -1,4 +1,4 @@
-{hostPlatform, lib}:
+{ hostPlatform, lib }:
 let
   # Samples are built around the CUDA Toolkit, which is not available for
   # aarch64. Check for both CUDA version and platform.
@@ -8,7 +8,7 @@ let
   extension =
     final: _:
     lib.attrsets.optionalAttrs platformIsSupported {
-      cuda-library-samples = final.callPackage ./generic.nix {};
+      cuda-library-samples = final.callPackage ./generic.nix { };
     };
 in
 extension

--- a/pkgs/development/cuda-modules/cuda-library-samples/generic.nix
+++ b/pkgs/development/cuda-modules/cuda-library-samples/generic.nix
@@ -22,7 +22,7 @@ let
       cmake
       addOpenGLRunpath
     ];
-    buildInputs = [cudatoolkit];
+    buildInputs = [ cudatoolkit ];
     postFixup = ''
       for exe in $out/bin/*; do
         addOpenGLRunpath $exe
@@ -36,7 +36,7 @@ let
         cuSPARSE, cuSOLVER, cuFFT, cuRAND, NPP and nvJPEG.
       '';
       license = lib.licenses.bsd3;
-      maintainers = with lib.maintainers; [obsidian-systems-maintenance] ++ lib.teams.cuda.members;
+      maintainers = with lib.maintainers; [ obsidian-systems-maintenance ] ++ lib.teams.cuda.members;
     };
   };
 in
@@ -69,9 +69,9 @@ in
 
       src = "${src}/cuTENSOR";
 
-      buildInputs = [cutensor];
+      buildInputs = [ cutensor ];
 
-      cmakeFlags = ["-DCUTENSOR_EXAMPLE_BINARY_INSTALL_DIR=${builtins.placeholder "out"}/bin"];
+      cmakeFlags = [ "-DCUTENSOR_EXAMPLE_BINARY_INSTALL_DIR=${builtins.placeholder "out"}/bin" ];
 
       # CUTENSOR_ROOT is double escaped
       postPatch = ''

--- a/pkgs/development/cuda-modules/cuda-samples/generic.nix
+++ b/pkgs/development/cuda-modules/cuda-samples/generic.nix
@@ -15,65 +15,63 @@
 let
   inherit (lib) lists strings;
 in
-backendStdenv.mkDerivation (
-  finalAttrs: {
-    strictDeps = true;
+backendStdenv.mkDerivation (finalAttrs: {
+  strictDeps = true;
 
-    pname = "cuda-samples";
-    version = cudaVersion;
+  pname = "cuda-samples";
+  version = cudaVersion;
 
-    src = fetchFromGitHub {
-      owner = "NVIDIA";
-      repo = finalAttrs.pname;
-      rev = "v${finalAttrs.version}";
-      inherit hash;
-    };
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
+    inherit hash;
+  };
 
-    nativeBuildInputs =
-      [
-        autoAddDriverRunpath
-        pkg-config
-      ]
-      # CMake has to run as a native, build-time dependency for libNVVM samples.
-      # However, it's not the primary build tool -- that's still make.
-      # As such, we disable CMake's build system.
-      ++ lists.optionals (strings.versionAtLeast finalAttrs.version "12.2") [cmake];
+  nativeBuildInputs =
+    [
+      autoAddDriverRunpath
+      pkg-config
+    ]
+    # CMake has to run as a native, build-time dependency for libNVVM samples.
+    # However, it's not the primary build tool -- that's still make.
+    # As such, we disable CMake's build system.
+    ++ lists.optionals (strings.versionAtLeast finalAttrs.version "12.2") [ cmake ];
 
-    dontUseCmakeConfigure = true;
+  dontUseCmakeConfigure = true;
 
-    buildInputs = [
-      cudatoolkit
-      freeimage
-      glfw3
-    ];
+  buildInputs = [
+    cudatoolkit
+    freeimage
+    glfw3
+  ];
 
-    # See https://github.com/NVIDIA/cuda-samples/issues/75.
-    patches = lib.optionals (finalAttrs.version == "11.3") [
-      (fetchpatch {
-        url = "https://github.com/NVIDIA/cuda-samples/commit/5c3ec60faeb7a3c4ad9372c99114d7bb922fda8d.patch";
-        hash = "sha256-0XxdmNK9MPpHwv8+qECJTvXGlFxc+fIbta4ynYprfpU=";
-      })
-    ];
+  # See https://github.com/NVIDIA/cuda-samples/issues/75.
+  patches = lib.optionals (finalAttrs.version == "11.3") [
+    (fetchpatch {
+      url = "https://github.com/NVIDIA/cuda-samples/commit/5c3ec60faeb7a3c4ad9372c99114d7bb922fda8d.patch";
+      hash = "sha256-0XxdmNK9MPpHwv8+qECJTvXGlFxc+fIbta4ynYprfpU=";
+    })
+  ];
 
-    enableParallelBuilding = true;
+  enableParallelBuilding = true;
 
-    preConfigure = ''
-      export CUDA_PATH=${cudatoolkit}
-    '';
+  preConfigure = ''
+    export CUDA_PATH=${cudatoolkit}
+  '';
 
-    installPhase = ''
-      runHook preInstall
+  installPhase = ''
+    runHook preInstall
 
-      install -Dm755 -t $out/bin bin/${backendStdenv.hostPlatform.parsed.cpu.name}/${backendStdenv.hostPlatform.parsed.kernel.name}/release/*
+    install -Dm755 -t $out/bin bin/${backendStdenv.hostPlatform.parsed.cpu.name}/${backendStdenv.hostPlatform.parsed.kernel.name}/release/*
 
-      runHook postInstall
-    '';
+    runHook postInstall
+  '';
 
-    meta = {
-      description = "Samples for CUDA Developers which demonstrates features in CUDA Toolkit";
-      # CUDA itself is proprietary, but these sample apps are not.
-      license = lib.licenses.bsd3;
-      maintainers = with lib.maintainers; [obsidian-systems-maintenance] ++ lib.teams.cuda.members;
-    };
-  }
-)
+  meta = {
+    description = "Samples for CUDA Developers which demonstrates features in CUDA Toolkit";
+    # CUDA itself is proprietary, but these sample apps are not.
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ obsidian-systems-maintenance ] ++ lib.teams.cuda.members;
+  };
+})

--- a/pkgs/development/cuda-modules/cuda/extension.nix
+++ b/pkgs/development/cuda-modules/cuda/extension.nix
@@ -1,4 +1,4 @@
-{cudaVersion, lib}:
+{ cudaVersion, lib }:
 let
   inherit (lib) attrsets modules trivial;
   redistName = "cuda";
@@ -63,23 +63,21 @@ let
             featureRelease
             ;
         }).overrideAttrs
-          (
-            prevAttrs: {
-              # Add the package-specific license.
-              meta = prevAttrs.meta // {
-                license =
-                  let
-                    licensePath =
-                      if redistribRelease.license_path != null then
-                        redistribRelease.license_path
-                      else
-                        "${pname}/LICENSE.txt";
-                    url = "https://developer.download.nvidia.com/compute/cuda/redist/${licensePath}";
-                  in
-                  lib.licenses.nvidiaCudaRedist // {inherit url;};
-              };
-            }
-          );
+          (prevAttrs: {
+            # Add the package-specific license.
+            meta = prevAttrs.meta // {
+              license =
+                let
+                  licensePath =
+                    if redistribRelease.license_path != null then
+                      redistribRelease.license_path
+                    else
+                      "${pname}/LICENSE.txt";
+                  url = "https://developer.download.nvidia.com/compute/cuda/redist/${licensePath}";
+                in
+                lib.licenses.nvidiaCudaRedist // { inherit url; };
+            };
+          });
     in
     drv;
 

--- a/pkgs/development/cuda-modules/cudatoolkit/default.nix
+++ b/pkgs/development/cuda-modules/cudatoolkit/default.nix
@@ -1,6 +1,6 @@
 {
   cudaVersion,
-  runPatches ? [],
+  runPatches ? [ ],
   autoPatchelfHook,
   autoAddDriverRunpath,
   addOpenGLRunpath,
@@ -61,7 +61,7 @@ backendStdenv.mkDerivation rec {
   dontPatchELF = true;
   dontStrip = true;
 
-  src = fetchurl {inherit (release) url sha256;};
+  src = fetchurl { inherit (release) url sha256; };
 
   outputs = [
     "out"
@@ -79,9 +79,9 @@ backendStdenv.mkDerivation rec {
       autoAddDriverRunpath
       markForCudatoolkitRootHook
     ]
-    ++ lib.optionals (lib.versionOlder version "11") [libsForQt5.wrapQtAppsHook]
-    ++ lib.optionals (lib.versionAtLeast version "11.8") [qt6Packages.wrapQtAppsHook];
-  propagatedBuildInputs = [setupCudaHook];
+    ++ lib.optionals (lib.versionOlder version "11") [ libsForQt5.wrapQtAppsHook ]
+    ++ lib.optionals (lib.versionAtLeast version "11.8") [ qt6Packages.wrapQtAppsHook ];
+  propagatedBuildInputs = [ setupCudaHook ];
   buildInputs =
     lib.optionals (lib.versionOlder version "11") [
       libsForQt5.qt5.qtwebengine
@@ -130,7 +130,7 @@ backendStdenv.mkDerivation rec {
       (lib.getLib libtiff)
       qt6Packages.qtwayland
       rdma-core
-      (ucx.override {enableCuda = false;}) # Avoid infinite recursion
+      (ucx.override { enableCuda = false; }) # Avoid infinite recursion
       xorg.libxshmfence
       xorg.libxkbfile
     ]
@@ -144,17 +144,15 @@ backendStdenv.mkDerivation rec {
         gst_all_1.gstreamer
         gst_all_1.gst-plugins-base
       ])
-      ++ (
-        with qt6; [
-          qtmultimedia
-          qttools
-          qtpositioning
-          qtscxml
-          qtsvg
-          qtwebchannel
-          qtwebengine
-        ]
-      )
+      ++ (with qt6; [
+        qtmultimedia
+        qttools
+        qtpositioning
+        qtscxml
+        qtsvg
+        qtwebchannel
+        qtwebengine
+      ])
     ));
 
   # Prepended to runpaths by autoPatchelf.
@@ -170,26 +168,28 @@ backendStdenv.mkDerivation rec {
     "${placeholder "out"}/nvvm/lib64"
   ];
 
-  autoPatchelfIgnoreMissingDeps = [
-    # This is the hardware-dependent userspace driver that comes from
-    # nvidia_x11 package. It must be deployed at runtime in
-    # /run/opengl-driver/lib or pointed at by LD_LIBRARY_PATH variable, rather
-    # than pinned in runpath
-    "libcuda.so.1"
+  autoPatchelfIgnoreMissingDeps =
+    [
+      # This is the hardware-dependent userspace driver that comes from
+      # nvidia_x11 package. It must be deployed at runtime in
+      # /run/opengl-driver/lib or pointed at by LD_LIBRARY_PATH variable, rather
+      # than pinned in runpath
+      "libcuda.so.1"
 
-    # The krb5 expression ships libcom_err.so.3 but cudatoolkit asks for the
-    # older
-    # This dependency is asked for by target-linux-x64/CollectX/RedHat/x86_64/libssl.so.10
-    # - do we even want to use nvidia-shipped libssl?
-    "libcom_err.so.2"
-  ] ++ lib.optionals (lib.versionOlder version "10.1") [
-    # For Cuda 10.0, nVidia also shipped a jre implementation which needed
-    # two old versions of ffmpeg which are not available in nixpkgs
-    "libavcodec.so.54"
-    "libavcodec.so.53"
-    "libavformat.so.54"
-    "libavformat.so.53"
-  ];
+      # The krb5 expression ships libcom_err.so.3 but cudatoolkit asks for the
+      # older
+      # This dependency is asked for by target-linux-x64/CollectX/RedHat/x86_64/libssl.so.10
+      # - do we even want to use nvidia-shipped libssl?
+      "libcom_err.so.2"
+    ]
+    ++ lib.optionals (lib.versionOlder version "10.1") [
+      # For Cuda 10.0, nVidia also shipped a jre implementation which needed
+      # two old versions of ffmpeg which are not available in nixpkgs
+      "libavcodec.so.54"
+      "libavcodec.so.53"
+      "libavformat.so.54"
+      "libavformat.so.53"
+    ];
 
   preFixup =
     if (lib.versionAtLeast version "10.1" && lib.versionOlder version "11") then
@@ -282,7 +282,14 @@ backendStdenv.mkDerivation rec {
               for qtlib in $out/host-linux-x64/Plugins/*/libq*.so; do
                 qtdir=$(basename $(dirname $qtlib))
                 filename=$(basename $qtlib)
-                for qtpkgdir in ${lib.concatMapStringsSep " " (x: qt6Packages.${x}) ["qtbase" "qtimageformats" "qtsvg" "qtwayland"]}; do
+                for qtpkgdir in ${
+                  lib.concatMapStringsSep " " (x: qt6Packages.${x}) [
+                    "qtbase"
+                    "qtimageformats"
+                    "qtsvg"
+                    "qtwayland"
+                  ]
+                }; do
                   if [ -e $qtpkgdir/lib/qt-6/plugins/$qtdir/$filename ]; then
                     ln -snf $qtpkgdir/lib/qt-6/plugins/$qtdir/$filename $qtlib
                   fi
@@ -303,8 +310,9 @@ backendStdenv.mkDerivation rec {
       ''}
 
       # Remove some cruft.
-      ${lib.optionalString ((lib.versionAtLeast version "7.0") && (lib.versionOlder version "10.1"))
-        "rm $out/bin/uninstall*"}
+      ${lib.optionalString (
+        (lib.versionAtLeast version "7.0") && (lib.versionOlder version "10.1")
+      ) "rm $out/bin/uninstall*"}
 
       # Fixup path to samples (needed for cuda 6.5 or else nsight will not find them)
       if [ -d "$out"/cuda-samples ]; then
@@ -360,19 +368,18 @@ backendStdenv.mkDerivation rec {
       wrapProgram "$out/bin/$b" \
         --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
     done
-    ${
-      lib.optionalString (lib.versionAtLeast version "12")
-        # Check we don't have any lurking vendored qt libraries that weren't
-        # replaced during installPhase
-        ''
-          qtlibfiles=$(find $out -name "libq*.so" -type f)
-          if [ ! -z "$qtlibfiles" ]; then
-            echo "Found unexpected vendored Qt library files in $out" >&2
-            echo $qtlibfiles >&2
-            echo "These should be replaced with symlinks in installPhase" >&2
-            exit 1
-          fi
-        ''
+    ${lib.optionalString (lib.versionAtLeast version "12")
+      # Check we don't have any lurking vendored qt libraries that weren't
+      # replaced during installPhase
+      ''
+        qtlibfiles=$(find $out -name "libq*.so" -type f)
+        if [ ! -z "$qtlibfiles" ]; then
+          echo "Found unexpected vendored Qt library files in $out" >&2
+          echo $qtlibfiles >&2
+          echo "These should be replaced with symlinks in installPhase" >&2
+          exit 1
+        fi
+      ''
     }
   '';
 
@@ -405,7 +412,7 @@ backendStdenv.mkDerivation rec {
   meta = with lib; {
     description = "A compiler for NVIDIA GPUs, math libraries, and tools";
     homepage = "https://developer.nvidia.com/cuda-toolkit";
-    platforms = ["x86_64-linux"];
+    platforms = [ "x86_64-linux" ];
     license = licenses.nvidiaCuda;
     maintainers = teams.cuda.members;
   };

--- a/pkgs/development/cuda-modules/cudnn/fixup.nix
+++ b/pkgs/development/cuda-modules/cudnn/fixup.nix
@@ -17,7 +17,7 @@ let
     ;
 in
 finalAttrs: prevAttrs: {
-  src = fetchurl {inherit (package) url hash;};
+  src = fetchurl { inherit (package) url hash; };
 
   # Useful for inspecting why something went wrong.
   brokenConditions =
@@ -34,9 +34,9 @@ finalAttrs: prevAttrs: {
 
   buildInputs =
     prevAttrs.buildInputs
-    ++ [zlib]
-    ++ lists.optionals finalAttrs.passthru.useCudatoolkitRunfile [final.cudatoolkit]
-    ++ lists.optionals (!finalAttrs.passthru.useCudatoolkitRunfile) [final.libcublas.lib];
+    ++ [ zlib ]
+    ++ lists.optionals finalAttrs.passthru.useCudatoolkitRunfile [ final.cudatoolkit ]
+    ++ lists.optionals (!finalAttrs.passthru.useCudatoolkitRunfile) [ final.libcublas.lib ];
 
   # Tell autoPatchelf about runtime dependencies.
   # NOTE: Versions from CUDNN releases have four components.
@@ -51,13 +51,11 @@ finalAttrs: prevAttrs: {
     homepage = "https://developer.nvidia.com/cudnn";
     maintainers =
       prevAttrs.meta.maintainers
-      ++ (
-        with maintainers; [
-          mdaiter
-          samuela
-          connorbaker
-        ]
-      );
+      ++ (with maintainers; [
+        mdaiter
+        samuela
+        connorbaker
+      ]);
     license = {
       shortName = "cuDNN EULA";
       fullName = "NVIDIA cuDNN Software License Agreement (EULA)";

--- a/pkgs/development/cuda-modules/cudnn/releases.nix
+++ b/pkgs/development/cuda-modules/cudnn/releases.nix
@@ -13,7 +13,7 @@
       }
     ];
     # powerpc
-    linux-ppc64le = [];
+    linux-ppc64le = [ ];
     # server-grade arm
     linux-sbsa = [
       {

--- a/pkgs/development/cuda-modules/cutensor/extension.nix
+++ b/pkgs/development/cuda-modules/cutensor/extension.nix
@@ -65,12 +65,10 @@ let
       # Un-nest the manifests attribute set.
       releaseGrabber = evaluatedModules: evaluatedModules.config.cutensor.manifests;
     in
-    lists.map
-      (trivial.flip trivial.pipe [
-        configEvaluator
-        releaseGrabber
-      ])
-      cutensorVersions;
+    lists.map (trivial.flip trivial.pipe [
+      configEvaluator
+      releaseGrabber
+    ]) cutensorVersions;
 
   # Our cudaVersion tells us which version of CUDA we're building against.
   # The subdirectories in lib/ tell us which versions of CUDA are supported.
@@ -96,15 +94,11 @@ let
   redistArch = flags.getRedistArch hostPlatform.system;
   # platformIsSupported :: Manifests -> Boolean
   platformIsSupported =
-    {feature, ...}:
-    (attrsets.attrByPath
-      [
-        pname
-        redistArch
-      ]
-      null
-      feature
-    ) != null;
+    { feature, ... }:
+    (attrsets.attrByPath [
+      pname
+      redistArch
+    ] null feature) != null;
 
   # TODO(@connorbaker): With an auxilliary file keeping track of the CUDA versions each release supports,
   # we could filter out releases that don't support our CUDA version.
@@ -116,41 +110,39 @@ let
   # Compute versioned attribute name to be used in this package set
   # Patch version changes should not break the build, so we only use major and minor
   # computeName :: RedistribRelease -> String
-  computeName = {version, ...}: mkVersionedPackageName redistName version;
+  computeName = { version, ... }: mkVersionedPackageName redistName version;
 in
 final: _:
 let
   # buildCutensorPackage :: Manifests -> AttrSet Derivation
   buildCutensorPackage =
-    {redistrib, feature}:
+    { redistrib, feature }:
     let
       drv = final.callPackage ../generic-builders/manifest.nix {
         inherit pname redistName libPath;
         redistribRelease = redistrib.${pname};
         featureRelease = feature.${pname};
       };
-      fixedDrv = drv.overrideAttrs (
-        prevAttrs: {
-          buildInputs =
-            prevAttrs.buildInputs
-            ++ lists.optionals (strings.versionOlder cudaVersion "11.4") [final.cudatoolkit]
-            ++ lists.optionals (strings.versionAtLeast cudaVersion "11.4") (
-              [final.libcublas.lib]
-              # For some reason, the 1.4.x release of cuTENSOR requires the cudart library.
-              ++ lists.optionals (strings.hasPrefix "1.4" redistrib.${pname}.version) [final.cuda_cudart.lib]
-            );
-          meta = prevAttrs.meta // {
-            description = "cuTENSOR: A High-Performance CUDA Library For Tensor Primitives";
-            homepage = "https://developer.nvidia.com/cutensor";
-            maintainers = prevAttrs.meta.maintainers ++ [lib.maintainers.obsidian-systems-maintenance];
-            license = lib.licenses.unfreeRedistributable // {
-              shortName = "cuTENSOR EULA";
-              name = "cuTENSOR SUPPLEMENT TO SOFTWARE LICENSE AGREEMENT FOR NVIDIA SOFTWARE DEVELOPMENT KITS";
-              url = "https://docs.nvidia.com/cuda/cutensor/license.html";
-            };
+      fixedDrv = drv.overrideAttrs (prevAttrs: {
+        buildInputs =
+          prevAttrs.buildInputs
+          ++ lists.optionals (strings.versionOlder cudaVersion "11.4") [ final.cudatoolkit ]
+          ++ lists.optionals (strings.versionAtLeast cudaVersion "11.4") (
+            [ final.libcublas.lib ]
+            # For some reason, the 1.4.x release of cuTENSOR requires the cudart library.
+            ++ lists.optionals (strings.hasPrefix "1.4" redistrib.${pname}.version) [ final.cuda_cudart.lib ]
+          );
+        meta = prevAttrs.meta // {
+          description = "cuTENSOR: A High-Performance CUDA Library For Tensor Primitives";
+          homepage = "https://developer.nvidia.com/cutensor";
+          maintainers = prevAttrs.meta.maintainers ++ [ lib.maintainers.obsidian-systems-maintenance ];
+          license = lib.licenses.unfreeRedistributable // {
+            shortName = "cuTENSOR EULA";
+            name = "cuTENSOR SUPPLEMENT TO SOFTWARE LICENSE AGREEMENT FOR NVIDIA SOFTWARE DEVELOPMENT KITS";
+            url = "https://docs.nvidia.com/cuda/cutensor/license.html";
           };
-        }
-      );
+        };
+      });
     in
     attrsets.nameValuePair (computeName redistrib.${pname}) fixedDrv;
 
@@ -158,7 +150,7 @@ let
     let
       nameOfNewest = computeName (lists.last supportedManifests).redistrib.${pname};
       drvs = builtins.listToAttrs (lists.map buildCutensorPackage supportedManifests);
-      containsDefault = attrsets.optionalAttrs (drvs != {}) {cutensor = drvs.${nameOfNewest};};
+      containsDefault = attrsets.optionalAttrs (drvs != { }) { cutensor = drvs.${nameOfNewest}; };
     in
     drvs // containsDefault;
 in

--- a/pkgs/development/cuda-modules/generic-builders/manifest.nix
+++ b/pkgs/development/cuda-modules/generic-builders/manifest.nix
@@ -50,144 +50,139 @@ let
 
   sourceMatchesHost = flags.getNixSystem redistArch == stdenv.hostPlatform.system;
 in
-backendStdenv.mkDerivation (
-  finalAttrs: {
-    # NOTE: Even though there's no actual buildPhase going on here, the derivations of the
-    # redistributables are sensitive to the compiler flags provided to stdenv. The patchelf package
-    # is sensitive to the compiler flags provided to stdenv, and we depend on it. As such, we are
-    # also sensitive to the compiler flags provided to stdenv.
-    inherit pname;
-    inherit (redistribRelease) version;
+backendStdenv.mkDerivation (finalAttrs: {
+  # NOTE: Even though there's no actual buildPhase going on here, the derivations of the
+  # redistributables are sensitive to the compiler flags provided to stdenv. The patchelf package
+  # is sensitive to the compiler flags provided to stdenv, and we depend on it. As such, we are
+  # also sensitive to the compiler flags provided to stdenv.
+  inherit pname;
+  inherit (redistribRelease) version;
 
-    # Don't force serialization to string for structured attributes, like outputToPatterns
-    # and brokenConditions.
-    # Avoids "set cannot be coerced to string" errors.
-    __structuredAttrs = true;
+  # Don't force serialization to string for structured attributes, like outputToPatterns
+  # and brokenConditions.
+  # Avoids "set cannot be coerced to string" errors.
+  __structuredAttrs = true;
 
-    # Keep better track of dependencies.
-    strictDeps = true;
+  # Keep better track of dependencies.
+  strictDeps = true;
 
-    # NOTE: Outputs are evaluated jointly with meta, so in the case that this is an unsupported platform,
-    # we still need to provide a list of outputs.
-    outputs =
-      let
-        # Checks whether the redistributable provides an output.
-        hasOutput =
-          output:
-          attrsets.attrByPath
-            [
-              redistArch
-              "outputs"
-              output
-            ]
-            false
-            featureRelease;
-        # Order is important here so we use a list.
-        possibleOutputs = [
-          "bin"
-          "lib"
-          "static"
-          "dev"
-          "doc"
-          "sample"
-          "python"
-        ];
-        # Filter out outputs that don't exist in the redistributable.
-        # NOTE: In the case the redistributable isn't supported on the target platform,
-        # we will have `outputs = [ "out" ] ++ possibleOutputs`. This is of note because platforms which
-        # aren't supported would otherwise have evaluation errors when trying to access outputs other than `out`.
-        # The alternative would be to have `outputs = [ "out" ]` when`redistArch = "unsupported"`, but that would
-        # require adding guards throughout the entirety of the CUDA package set to ensure `cudaSupport` is true --
-        # recall that OfBorg will evaluate packages marked as broken and that `cudaPackages` will be evaluated with
-        # `cudaSupport = false`!
-        additionalOutputs =
-          if redistArch == "unsupported"
-          then possibleOutputs
-          else builtins.filter hasOutput possibleOutputs;
-        # The out output is special -- it's the default output and we always include it.
-        outputs = [ "out" ] ++ additionalOutputs;
-      in
-      outputs;
-
-    # Traversed in the order of the outputs speficied in outputs;
-    # entries are skipped if they don't exist in outputs.
-    outputToPatterns = {
-      bin = [ "bin" ];
-      dev = [
-        "share/pkgconfig"
-        "**/*.pc"
-        "**/*.cmake"
-      ];
-      lib = [
+  # NOTE: Outputs are evaluated jointly with meta, so in the case that this is an unsupported platform,
+  # we still need to provide a list of outputs.
+  outputs =
+    let
+      # Checks whether the redistributable provides an output.
+      hasOutput =
+        output:
+        attrsets.attrByPath [
+          redistArch
+          "outputs"
+          output
+        ] false featureRelease;
+      # Order is important here so we use a list.
+      possibleOutputs = [
+        "bin"
         "lib"
-        "lib64"
+        "static"
+        "dev"
+        "doc"
+        "sample"
+        "python"
       ];
-      static = ["**/*.a"];
-      sample = ["samples"];
-      python = ["**/*.whl"];
-    };
+      # Filter out outputs that don't exist in the redistributable.
+      # NOTE: In the case the redistributable isn't supported on the target platform,
+      # we will have `outputs = [ "out" ] ++ possibleOutputs`. This is of note because platforms which
+      # aren't supported would otherwise have evaluation errors when trying to access outputs other than `out`.
+      # The alternative would be to have `outputs = [ "out" ]` when`redistArch = "unsupported"`, but that would
+      # require adding guards throughout the entirety of the CUDA package set to ensure `cudaSupport` is true --
+      # recall that OfBorg will evaluate packages marked as broken and that `cudaPackages` will be evaluated with
+      # `cudaSupport = false`!
+      additionalOutputs =
+        if redistArch == "unsupported" then possibleOutputs else builtins.filter hasOutput possibleOutputs;
+      # The out output is special -- it's the default output and we always include it.
+      outputs = [ "out" ] ++ additionalOutputs;
+    in
+    outputs;
 
-    # Useful for introspecting why something went wrong. Maps descriptions of why the derivation would be marked as
-    # broken on have badPlatforms include the current platform.
-
-    # brokenConditions :: AttrSet Bool
-    # Sets `meta.broken = true` if any of the conditions are true.
-    # Example: Broken on a specific version of CUDA or when a dependency has a specific version.
-    brokenConditions = { };
-
-    # badPlatformsConditions :: AttrSet Bool
-    # Sets `meta.badPlatforms = meta.platforms` if any of the conditions are true.
-    # Example: Broken on a specific architecture when some condition is met (like targeting Jetson).
-    badPlatformsConditions = {
-      "No source" = !sourceMatchesHost;
-    };
-
-    # src :: Optional Derivation
-    src = trivial.pipe redistArch [
-      # If redistArch doesn't exist in redistribRelease, return null.
-      (redistArch: redistribRelease.${redistArch} or null)
-      # If the release is non-null, fetch the source; otherwise, return null.
-      (trivial.mapNullable (
-        { relative_path, sha256, ... }:
-        fetchurl {
-          url = "https://developer.download.nvidia.com/compute/${redistName}/redist/${relative_path}";
-          inherit sha256;
-        }
-      ))
+  # Traversed in the order of the outputs speficied in outputs;
+  # entries are skipped if they don't exist in outputs.
+  outputToPatterns = {
+    bin = [ "bin" ];
+    dev = [
+      "share/pkgconfig"
+      "**/*.pc"
+      "**/*.cmake"
     ];
+    lib = [
+      "lib"
+      "lib64"
+    ];
+    static = [ "**/*.a" ];
+    sample = [ "samples" ];
+    python = [ "**/*.whl" ];
+  };
 
-    # Handle the pkg-config files:
-    # 1. No FHS
-    # 2. Location expected by the pkg-config wrapper
-    # 3. Generate unversioned names too
-    postPatch = ''
-      for path in pkg-config pkgconfig ; do
-        [[ -d "$path" ]] || continue
-        mkdir -p share/pkgconfig
-        mv "$path"/* share/pkgconfig/
-        rmdir "$path"
-      done
+  # Useful for introspecting why something went wrong. Maps descriptions of why the derivation would be marked as
+  # broken on have badPlatforms include the current platform.
 
-      for pc in share/pkgconfig/*.pc ; do
-        sed -i \
-          -e "s|^cudaroot\s*=.*\$|cudaroot=''${!outputDev}|" \
-          -e "s|^libdir\s*=.*/lib\$|libdir=''${!outputLib}/lib|" \
-          -e "s|^includedir\s*=.*/include\$|includedir=''${!outputDev}/include|" \
-          "$pc"
-      done
+  # brokenConditions :: AttrSet Bool
+  # Sets `meta.broken = true` if any of the conditions are true.
+  # Example: Broken on a specific version of CUDA or when a dependency has a specific version.
+  brokenConditions = { };
 
-      # E.g. cuda-11.8.pc -> cuda.pc
-      for pc in share/pkgconfig/*-"$majorMinorVersion.pc" ; do
-        ln -s "$(basename "$pc")" "''${pc%-$majorMinorVersion.pc}".pc
-      done
-    '';
+  # badPlatformsConditions :: AttrSet Bool
+  # Sets `meta.badPlatforms = meta.platforms` if any of the conditions are true.
+  # Example: Broken on a specific architecture when some condition is met (like targeting Jetson).
+  badPlatformsConditions = {
+    "No source" = !sourceMatchesHost;
+  };
 
-    env.majorMinorVersion = cudaMajorMinorVersion;
+  # src :: Optional Derivation
+  src = trivial.pipe redistArch [
+    # If redistArch doesn't exist in redistribRelease, return null.
+    (redistArch: redistribRelease.${redistArch} or null)
+    # If the release is non-null, fetch the source; otherwise, return null.
+    (trivial.mapNullable (
+      { relative_path, sha256, ... }:
+      fetchurl {
+        url = "https://developer.download.nvidia.com/compute/${redistName}/redist/${relative_path}";
+        inherit sha256;
+      }
+    ))
+  ];
 
-    # We do need some other phases, like configurePhase, so the multiple-output setup hook works.
-    dontBuild = true;
+  # Handle the pkg-config files:
+  # 1. No FHS
+  # 2. Location expected by the pkg-config wrapper
+  # 3. Generate unversioned names too
+  postPatch = ''
+    for path in pkg-config pkgconfig ; do
+      [[ -d "$path" ]] || continue
+      mkdir -p share/pkgconfig
+      mv "$path"/* share/pkgconfig/
+      rmdir "$path"
+    done
 
-    nativeBuildInputs = [
+    for pc in share/pkgconfig/*.pc ; do
+      sed -i \
+        -e "s|^cudaroot\s*=.*\$|cudaroot=''${!outputDev}|" \
+        -e "s|^libdir\s*=.*/lib\$|libdir=''${!outputLib}/lib|" \
+        -e "s|^includedir\s*=.*/include\$|includedir=''${!outputDev}/include|" \
+        "$pc"
+    done
+
+    # E.g. cuda-11.8.pc -> cuda.pc
+    for pc in share/pkgconfig/*-"$majorMinorVersion.pc" ; do
+      ln -s "$(basename "$pc")" "''${pc%-$majorMinorVersion.pc}".pc
+    done
+  '';
+
+  env.majorMinorVersion = cudaMajorMinorVersion;
+
+  # We do need some other phases, like configurePhase, so the multiple-output setup hook works.
+  dontBuild = true;
+
+  nativeBuildInputs =
+    [
       autoPatchelfHook
       # This hook will make sure libcuda can be found
       # in typically /lib/opengl-driver by adding that
@@ -205,142 +200,140 @@ backendStdenv.mkDerivation (
       autoAddCudaCompatRunpath
     ];
 
-    buildInputs =
-      [
-        # autoPatchelfHook will search for a libstdc++ and we're giving it
-        # one that is compatible with the rest of nixpkgs, even when
-        # nvcc forces us to use an older gcc
-        # NB: We don't actually know if this is the right thing to do
-        stdenv.cc.cc.lib
-      ];
+  buildInputs = [
+    # autoPatchelfHook will search for a libstdc++ and we're giving it
+    # one that is compatible with the rest of nixpkgs, even when
+    # nvcc forces us to use an older gcc
+    # NB: We don't actually know if this is the right thing to do
+    stdenv.cc.cc.lib
+  ];
 
-    # Picked up by autoPatchelf
-    # Needed e.g. for libnvrtc to locate (dlopen) libnvrtc-builtins
-    appendRunpaths = ["$ORIGIN"];
+  # Picked up by autoPatchelf
+  # Needed e.g. for libnvrtc to locate (dlopen) libnvrtc-builtins
+  appendRunpaths = [ "$ORIGIN" ];
 
-    # NOTE: We don't need to check for dev or doc, because those outputs are handled by
-    # the multiple-outputs setup hook.
-    # NOTE: moveToOutput operates on all outputs:
-    # https://github.com/NixOS/nixpkgs/blob/2920b6fc16a9ed5d51429e94238b28306ceda79e/pkgs/build-support/setup-hooks/multiple-outputs.sh#L105-L107
-    installPhase =
-      let
-        mkMoveToOutputCommand =
-          output:
-          let
-            template = pattern: ''moveToOutput "${pattern}" "${"$" + output}"'';
-            patterns = finalAttrs.outputToPatterns.${output} or [];
-          in
-          strings.concatMapStringsSep "\n" template patterns;
-      in
-      # Pre-install hook
-      ''
-        runHook preInstall
-      ''
-      # Handle the existence of libPath, which requires us to re-arrange the lib directory
-      + strings.optionalString (libPath != null) ''
-        full_lib_path="lib/${libPath}"
-        if [[ ! -d "$full_lib_path" ]] ; then
-          echo "${finalAttrs.pname}: '$full_lib_path' does not exist, only found:" >&2
-          find lib/ -mindepth 1 -maxdepth 1 >&2
-          echo "This release might not support your CUDA version" >&2
-          exit 1
-        fi
-        echo "Making libPath '$full_lib_path' the root of lib" >&2
-        mv "$full_lib_path" lib_new
-        rm -r lib
-        mv lib_new lib
-      ''
-      # Create the primary output, out, and move the other outputs into it.
-      + ''
-        mkdir -p "$out"
-        mv * "$out"
-      ''
-      # Move the outputs into their respective outputs.
-      + strings.concatMapStringsSep "\n" mkMoveToOutputCommand (builtins.tail finalAttrs.outputs)
-      # Add a newline to the end of the installPhase, so that the post-install hook doesn't
-      # get concatenated with the last moveToOutput command.
-      + "\n"
-      # Post-install hook
-      + ''
-        runHook postInstall
-      '';
-
-    doInstallCheck = true;
-    allowFHSReferences = true; # TODO: Default to `false`
-    postInstallCheck = ''
-      echo "Executing postInstallCheck"
-
-      if [[ -z "''${allowFHSReferences-}" ]] ; then
-        mapfile -t outputPaths < <(for o in $(getAllOutputNames); do echo "''${!o}"; done)
-        if grep --max-count=5 --recursive --exclude=LICENSE /usr/ "''${outputPaths[@]}" ; then
-          echo "Detected references to /usr" >&2
-          exit 1
-        fi
-      fi
-    '';
-
-    # libcuda needs to be resolved during runtime
-    autoPatchelfIgnoreMissingDeps = [
-      "libcuda.so"
-      "libcuda.so.*"
-    ];
-
-    # The out output leverages the same functionality which backs the `symlinkJoin` function in
-    # Nixpkgs:
-    # https://github.com/NixOS/nixpkgs/blob/d8b2a92df48f9b08d68b0132ce7adfbdbc1fbfac/pkgs/build-support/trivial-builders/default.nix#L510
-    #
-    # That should allow us to emulate "fat" default outputs without having to actually create them.
-    #
-    # It is important that this run after the autoPatchelfHook, otherwise the symlinks in out will reference libraries in lib, creating a circular dependency.
-    postPhases = ["postPatchelf"];
-
-    # For each output, create a symlink to it in the out output.
-    # NOTE: We must recreate the out output here, because the setup hook will have deleted it if it was empty.
-    postPatchelf = ''
-      mkdir -p "$out"
-      for output in $(getAllOutputNames); do
-        if [[ "$output" != "out" ]]; then
-          ${meta.getExe lndir} "''${!output}" "$out"
-        fi
-      done
-    '';
-
-    # Make the CUDA-patched stdenv available
-    passthru.stdenv = backendStdenv;
-
-    # Setting propagatedBuildInputs to false will prevent outputs known to the multiple-outputs
-    # from depending on `out` by default.
-    # https://github.com/NixOS/nixpkgs/blob/2920b6fc16a9ed5d51429e94238b28306ceda79e/pkgs/build-support/setup-hooks/multiple-outputs.sh#L196
-    # Indeed, we want to do the opposite -- fat "out" outputs that contain all the other outputs.
-    propagatedBuildOutputs = false;
-
-    # By default, if the dev output exists it just uses that.
-    # However, because we disabled propagatedBuildOutputs, dev doesn't contain libraries or
-    # anything of the sort. To remedy this, we set outputSpecified to true, and use
-    # outputsToInstall, which tells Nix which outputs to use when the package name is used
-    # unqualified (that is, without an explicit output).
-    outputSpecified = true;
-
-    meta = {
-      description = "${redistribRelease.name}. By downloading and using the packages you accept the terms and conditions of the ${finalAttrs.meta.license.shortName}";
-      sourceProvenance = [sourceTypes.binaryNativeCode];
-      broken = lists.any trivial.id (attrsets.attrValues finalAttrs.brokenConditions);
-      platforms = trivial.pipe supportedRedistArchs [
-        # Map each redist arch to the equivalent nix system or null if there is no equivalent.
-        (builtins.map flags.getNixSystem)
-        # Filter out unsupported systems
-        (builtins.filter (nixSystem: !(strings.hasPrefix "unsupported-" nixSystem)))
-      ];
-      badPlatforms =
+  # NOTE: We don't need to check for dev or doc, because those outputs are handled by
+  # the multiple-outputs setup hook.
+  # NOTE: moveToOutput operates on all outputs:
+  # https://github.com/NixOS/nixpkgs/blob/2920b6fc16a9ed5d51429e94238b28306ceda79e/pkgs/build-support/setup-hooks/multiple-outputs.sh#L105-L107
+  installPhase =
+    let
+      mkMoveToOutputCommand =
+        output:
         let
-          isBadPlatform = lists.any trivial.id (attrsets.attrValues finalAttrs.badPlatformsConditions);
+          template = pattern: ''moveToOutput "${pattern}" "${"$" + output}"'';
+          patterns = finalAttrs.outputToPatterns.${output} or [ ];
         in
-        lists.optionals isBadPlatform finalAttrs.meta.platforms;
-      license = licenses.unfree;
-      maintainers = teams.cuda.members;
-      # Force the use of the default, fat output by default (even though `dev` exists, which
-      # causes Nix to prefer that output over the others if outputSpecified isn't set).
-      outputsToInstall = ["out"];
-    };
-  }
-)
+        strings.concatMapStringsSep "\n" template patterns;
+    in
+    # Pre-install hook
+    ''
+      runHook preInstall
+    ''
+    # Handle the existence of libPath, which requires us to re-arrange the lib directory
+    + strings.optionalString (libPath != null) ''
+      full_lib_path="lib/${libPath}"
+      if [[ ! -d "$full_lib_path" ]] ; then
+        echo "${finalAttrs.pname}: '$full_lib_path' does not exist, only found:" >&2
+        find lib/ -mindepth 1 -maxdepth 1 >&2
+        echo "This release might not support your CUDA version" >&2
+        exit 1
+      fi
+      echo "Making libPath '$full_lib_path' the root of lib" >&2
+      mv "$full_lib_path" lib_new
+      rm -r lib
+      mv lib_new lib
+    ''
+    # Create the primary output, out, and move the other outputs into it.
+    + ''
+      mkdir -p "$out"
+      mv * "$out"
+    ''
+    # Move the outputs into their respective outputs.
+    + strings.concatMapStringsSep "\n" mkMoveToOutputCommand (builtins.tail finalAttrs.outputs)
+    # Add a newline to the end of the installPhase, so that the post-install hook doesn't
+    # get concatenated with the last moveToOutput command.
+    + "\n"
+    # Post-install hook
+    + ''
+      runHook postInstall
+    '';
+
+  doInstallCheck = true;
+  allowFHSReferences = true; # TODO: Default to `false`
+  postInstallCheck = ''
+    echo "Executing postInstallCheck"
+
+    if [[ -z "''${allowFHSReferences-}" ]] ; then
+      mapfile -t outputPaths < <(for o in $(getAllOutputNames); do echo "''${!o}"; done)
+      if grep --max-count=5 --recursive --exclude=LICENSE /usr/ "''${outputPaths[@]}" ; then
+        echo "Detected references to /usr" >&2
+        exit 1
+      fi
+    fi
+  '';
+
+  # libcuda needs to be resolved during runtime
+  autoPatchelfIgnoreMissingDeps = [
+    "libcuda.so"
+    "libcuda.so.*"
+  ];
+
+  # The out output leverages the same functionality which backs the `symlinkJoin` function in
+  # Nixpkgs:
+  # https://github.com/NixOS/nixpkgs/blob/d8b2a92df48f9b08d68b0132ce7adfbdbc1fbfac/pkgs/build-support/trivial-builders/default.nix#L510
+  #
+  # That should allow us to emulate "fat" default outputs without having to actually create them.
+  #
+  # It is important that this run after the autoPatchelfHook, otherwise the symlinks in out will reference libraries in lib, creating a circular dependency.
+  postPhases = [ "postPatchelf" ];
+
+  # For each output, create a symlink to it in the out output.
+  # NOTE: We must recreate the out output here, because the setup hook will have deleted it if it was empty.
+  postPatchelf = ''
+    mkdir -p "$out"
+    for output in $(getAllOutputNames); do
+      if [[ "$output" != "out" ]]; then
+        ${meta.getExe lndir} "''${!output}" "$out"
+      fi
+    done
+  '';
+
+  # Make the CUDA-patched stdenv available
+  passthru.stdenv = backendStdenv;
+
+  # Setting propagatedBuildInputs to false will prevent outputs known to the multiple-outputs
+  # from depending on `out` by default.
+  # https://github.com/NixOS/nixpkgs/blob/2920b6fc16a9ed5d51429e94238b28306ceda79e/pkgs/build-support/setup-hooks/multiple-outputs.sh#L196
+  # Indeed, we want to do the opposite -- fat "out" outputs that contain all the other outputs.
+  propagatedBuildOutputs = false;
+
+  # By default, if the dev output exists it just uses that.
+  # However, because we disabled propagatedBuildOutputs, dev doesn't contain libraries or
+  # anything of the sort. To remedy this, we set outputSpecified to true, and use
+  # outputsToInstall, which tells Nix which outputs to use when the package name is used
+  # unqualified (that is, without an explicit output).
+  outputSpecified = true;
+
+  meta = {
+    description = "${redistribRelease.name}. By downloading and using the packages you accept the terms and conditions of the ${finalAttrs.meta.license.shortName}";
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    broken = lists.any trivial.id (attrsets.attrValues finalAttrs.brokenConditions);
+    platforms = trivial.pipe supportedRedistArchs [
+      # Map each redist arch to the equivalent nix system or null if there is no equivalent.
+      (builtins.map flags.getNixSystem)
+      # Filter out unsupported systems
+      (builtins.filter (nixSystem: !(strings.hasPrefix "unsupported-" nixSystem)))
+    ];
+    badPlatforms =
+      let
+        isBadPlatform = lists.any trivial.id (attrsets.attrValues finalAttrs.badPlatformsConditions);
+      in
+      lists.optionals isBadPlatform finalAttrs.meta.platforms;
+    license = licenses.unfree;
+    maintainers = teams.cuda.members;
+    # Force the use of the default, fat output by default (even though `dev` exists, which
+    # causes Nix to prefer that output over the others if outputSpecified isn't set).
+    outputsToInstall = [ "out" ];
+  };
+})

--- a/pkgs/development/cuda-modules/generic-builders/multiplex.nix
+++ b/pkgs/development/cuda-modules/generic-builders/multiplex.nix
@@ -52,7 +52,9 @@ let
   # - Package: ../modules/${pname}/releases/package.nix
 
   # FIXME: do this at the module system level
-  propagatePlatforms = lib.mapAttrs (redistArch: packages: map (p: { inherit redistArch; } // p) packages);
+  propagatePlatforms = lib.mapAttrs (
+    redistArch: packages: map (p: { inherit redistArch; } // p) packages
+  );
 
   # All releases across all platforms
   # See ../modules/${pname}/releases/releases.nix
@@ -61,7 +63,7 @@ let
   # Compute versioned attribute name to be used in this package set
   # Patch version changes should not break the build, so we only use major and minor
   # computeName :: Package -> String
-  computeName = {version, ...}: mkVersionedPackageName pname version;
+  computeName = { version, ... }: mkVersionedPackageName pname version;
 
   # Check whether a package supports our CUDA version and platform.
   # isSupported :: Package -> Bool
@@ -81,16 +83,15 @@ let
 
   # All the supported packages we can build for our platform.
   # perSystemReleases :: List Package
-  allReleases = lib.pipe releaseSets
-    [
-      (lib.attrValues)
-      (lists.flatten)
-      (lib.groupBy (p: lib.versions.majorMinor p.version))
-      (lib.mapAttrs (_: builtins.sort preferable))
-      (lib.mapAttrs (_: lib.take 1))
-      (lib.attrValues)
-      (lib.concatMap lib.trivial.id)
-    ];
+  allReleases = lib.pipe releaseSets [
+    (lib.attrValues)
+    (lists.flatten)
+    (lib.groupBy (p: lib.versions.majorMinor p.version))
+    (lib.mapAttrs (_: builtins.sort preferable))
+    (lib.mapAttrs (_: lib.take 1))
+    (lib.attrValues)
+    (lib.concatMap lib.trivial.id)
+  ];
 
   newest = builtins.head (builtins.sort preferable allReleases);
 
@@ -115,7 +116,10 @@ let
       buildPackage =
         package:
         let
-          shims = final.callPackage shimsFn {inherit package; inherit (package) redistArch; };
+          shims = final.callPackage shimsFn {
+            inherit package;
+            inherit (package) redistArch;
+          };
           name = computeName package;
           drv = final.callPackage ./manifest.nix {
             inherit pname;
@@ -129,7 +133,9 @@ let
       # versionedDerivations :: AttrSet Derivation
       versionedDerivations = builtins.listToAttrs (lists.map buildPackage allReleases);
 
-      defaultDerivation = { ${pname} = (buildPackage newest).value; };
+      defaultDerivation = {
+        ${pname} = (buildPackage newest).value;
+      };
     in
     versionedDerivations // defaultDerivation;
 in

--- a/pkgs/development/cuda-modules/modules/cuda/default.nix
+++ b/pkgs/development/cuda-modules/modules/cuda/default.nix
@@ -1,1 +1,4 @@
-{options, ...}: {options.cuda.manifests = options.generic.manifests;}
+{ options, ... }:
+{
+  options.cuda.manifests = options.generic.manifests;
+}

--- a/pkgs/development/cuda-modules/modules/cudnn/default.nix
+++ b/pkgs/development/cuda-modules/modules/cudnn/default.nix
@@ -1,4 +1,4 @@
-{options, ...}:
+{ options, ... }:
 {
   options.cudnn.releases = options.generic.releases;
   # TODO(@connorbaker): Figure out how to add additional options to the

--- a/pkgs/development/cuda-modules/modules/cutensor/default.nix
+++ b/pkgs/development/cuda-modules/modules/cutensor/default.nix
@@ -1,1 +1,4 @@
-{options, ...}: {options.cutensor.manifests = options.generic.manifests;}
+{ options, ... }:
+{
+  options.cutensor.manifests = options.generic.manifests;
+}

--- a/pkgs/development/cuda-modules/modules/generic/manifests/default.nix
+++ b/pkgs/development/cuda-modules/modules/generic/manifests/default.nix
@@ -1,7 +1,7 @@
-{lib, config, ...}:
+{ lib, config, ... }:
 {
   options.generic.manifests = {
-    feature = import ./feature/manifest.nix {inherit lib config;};
-    redistrib = import ./redistrib/manifest.nix {inherit lib;};
+    feature = import ./feature/manifest.nix { inherit lib config; };
+    redistrib = import ./redistrib/manifest.nix { inherit lib; };
   };
 }

--- a/pkgs/development/cuda-modules/modules/generic/manifests/feature/manifest.nix
+++ b/pkgs/development/cuda-modules/modules/generic/manifests/feature/manifest.nix
@@ -1,7 +1,7 @@
-{lib, config, ...}:
+{ lib, config, ... }:
 let
   inherit (lib) options trivial types;
-  Release = import ./release.nix {inherit lib config;};
+  Release = import ./release.nix { inherit lib config; };
 in
 options.mkOption {
   description = "A feature manifest is an attribute set which includes a mapping from package name to release";

--- a/pkgs/development/cuda-modules/modules/generic/manifests/feature/outputs.nix
+++ b/pkgs/development/cuda-modules/modules/generic/manifests/feature/outputs.nix
@@ -1,4 +1,4 @@
-{lib, ...}:
+{ lib, ... }:
 let
   inherit (lib) options types;
 in

--- a/pkgs/development/cuda-modules/modules/generic/manifests/feature/package.nix
+++ b/pkgs/development/cuda-modules/modules/generic/manifests/feature/package.nix
@@ -1,10 +1,10 @@
-{lib, ...}:
+{ lib, ... }:
 let
   inherit (lib) options types;
-  Outputs = import ./outputs.nix {inherit lib;};
+  Outputs = import ./outputs.nix { inherit lib; };
 in
 options.mkOption {
   description = "A package in the manifest";
-  example = (import ./release.nix {inherit lib;}).linux-x86_64;
-  type = types.submodule {options.outputs = Outputs;};
+  example = (import ./release.nix { inherit lib; }).linux-x86_64;
+  type = types.submodule { options.outputs = Outputs; };
 }

--- a/pkgs/development/cuda-modules/modules/generic/manifests/feature/release.nix
+++ b/pkgs/development/cuda-modules/modules/generic/manifests/feature/release.nix
@@ -1,10 +1,10 @@
-{lib, config, ...}:
+{ lib, config, ... }:
 let
   inherit (lib) options types;
-  Package = import ./package.nix {inherit lib config;};
+  Package = import ./package.nix { inherit lib config; };
 in
 options.mkOption {
   description = "A release is an attribute set which includes a mapping from platform to package";
-  example = (import ./manifest.nix {inherit lib;}).cuda_cccl;
+  example = (import ./manifest.nix { inherit lib; }).cuda_cccl;
   type = types.attrsOf Package.type;
 }

--- a/pkgs/development/cuda-modules/modules/generic/manifests/redistrib/manifest.nix
+++ b/pkgs/development/cuda-modules/modules/generic/manifests/redistrib/manifest.nix
@@ -1,7 +1,7 @@
-{lib, ...}:
+{ lib, ... }:
 let
   inherit (lib) options trivial types;
-  Release = import ./release.nix {inherit lib;};
+  Release = import ./release.nix { inherit lib; };
 in
 options.mkOption {
   description = "A redistributable manifest is an attribute set which includes a mapping from package name to release";

--- a/pkgs/development/cuda-modules/modules/generic/manifests/redistrib/package.nix
+++ b/pkgs/development/cuda-modules/modules/generic/manifests/redistrib/package.nix
@@ -1,10 +1,10 @@
-{lib, ...}:
+{ lib, ... }:
 let
   inherit (lib) options types;
 in
 options.mkOption {
   description = "A package in the manifest";
-  example = (import ./release.nix {inherit lib;}).linux-x86_64;
+  example = (import ./release.nix { inherit lib; }).linux-x86_64;
   type = types.submodule {
     options = {
       relative_path = options.mkOption {

--- a/pkgs/development/cuda-modules/modules/generic/manifests/redistrib/release.nix
+++ b/pkgs/development/cuda-modules/modules/generic/manifests/redistrib/release.nix
@@ -1,11 +1,11 @@
-{lib, ...}:
+{ lib, ... }:
 let
   inherit (lib) options types;
-  Package = import ./package.nix {inherit lib;};
+  Package = import ./package.nix { inherit lib; };
 in
 options.mkOption {
   description = "A release is an attribute set which includes a mapping from platform to package";
-  example = (import ./manifest.nix {inherit lib;}).cuda_cccl;
+  example = (import ./manifest.nix { inherit lib; }).cuda_cccl;
   type = types.submodule {
     # Allow any attribute name as these will be the platform names
     freeformType = types.attrsOf Package.type;

--- a/pkgs/development/cuda-modules/modules/generic/releases/default.nix
+++ b/pkgs/development/cuda-modules/modules/generic/releases/default.nix
@@ -1,4 +1,4 @@
-{lib, config, ...}:
+{ lib, config, ... }:
 let
   inherit (config.generic.types) majorMinorVersion majorMinorPatchBuildVersion;
   inherit (lib) options types;

--- a/pkgs/development/cuda-modules/modules/generic/types/default.nix
+++ b/pkgs/development/cuda-modules/modules/generic/types/default.nix
@@ -1,11 +1,11 @@
-{lib, ...}:
+{ lib, ... }:
 let
   inherit (lib) options types;
 in
 {
   options.generic.types = options.mkOption {
     type = types.attrsOf types.optionType;
-    default = {};
+    default = { };
     description = "A set of generic types.";
   };
   config.generic.types = {

--- a/pkgs/development/cuda-modules/modules/tensorrt/default.nix
+++ b/pkgs/development/cuda-modules/modules/tensorrt/default.nix
@@ -1,4 +1,4 @@
-{options, ...}:
+{ options, ... }:
 {
   options.tensorrt.releases = options.generic.releases;
   # TODO(@connorbaker): Figure out how to add additional options to the

--- a/pkgs/development/cuda-modules/nccl-tests/default.nix
+++ b/pkgs/development/cuda-modules/nccl-tests/default.nix
@@ -22,63 +22,61 @@ let
     nccl
     ;
 in
-backendStdenv.mkDerivation (
-  finalAttrs: {
+backendStdenv.mkDerivation (finalAttrs: {
 
-    pname = "nccl-tests";
-    version = "2.13.9";
+  pname = "nccl-tests";
+  version = "2.13.9";
 
-    src = fetchFromGitHub {
-      owner = "NVIDIA";
-      repo = finalAttrs.pname;
-      rev = "v${finalAttrs.version}";
-      hash = "sha256-QYuMBPhvHHVo2ku14jD1CVINLPW0cyiXJkXxb77IxbE=";
-    };
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-QYuMBPhvHHVo2ku14jD1CVINLPW0cyiXJkXxb77IxbE=";
+  };
 
-    strictDeps = true;
+  strictDeps = true;
 
-    nativeBuildInputs =
-      [which]
-      ++ lib.optionals (lib.versionOlder cudaVersion "11.4") [cudatoolkit]
-      ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [cuda_nvcc];
+  nativeBuildInputs =
+    [ which ]
+    ++ lib.optionals (lib.versionOlder cudaVersion "11.4") [ cudatoolkit ]
+    ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [ cuda_nvcc ];
 
-    buildInputs =
-      [nccl]
-      ++ lib.optionals (lib.versionOlder cudaVersion "11.4") [cudatoolkit]
-      ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [
-        cuda_nvcc.dev # crt/host_config.h
-        cuda_cudart
-      ]
-      ++ lib.optionals (lib.versionAtLeast cudaVersion "12.0") [
-        cuda_cccl.dev # <nv/target>
-      ]
-      ++ lib.optionals mpiSupport [mpi];
+  buildInputs =
+    [ nccl ]
+    ++ lib.optionals (lib.versionOlder cudaVersion "11.4") [ cudatoolkit ]
+    ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [
+      cuda_nvcc.dev # crt/host_config.h
+      cuda_cudart
+    ]
+    ++ lib.optionals (lib.versionAtLeast cudaVersion "12.0") [
+      cuda_cccl.dev # <nv/target>
+    ]
+    ++ lib.optionals mpiSupport [ mpi ];
 
-    makeFlags =
-      ["NCCL_HOME=${nccl}"]
-      ++ lib.optionals (lib.versionOlder cudaVersion "11.4") ["CUDA_HOME=${cudatoolkit}"]
-      ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") ["CUDA_HOME=${cuda_nvcc}"]
-      ++ lib.optionals mpiSupport ["MPI=1"];
+  makeFlags =
+    [ "NCCL_HOME=${nccl}" ]
+    ++ lib.optionals (lib.versionOlder cudaVersion "11.4") [ "CUDA_HOME=${cudatoolkit}" ]
+    ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [ "CUDA_HOME=${cuda_nvcc}" ]
+    ++ lib.optionals mpiSupport [ "MPI=1" ];
 
-    enableParallelBuilding = true;
+  enableParallelBuilding = true;
 
-    installPhase = ''
-      mkdir -p $out/bin
-      cp -r build/* $out/bin/
-    '';
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r build/* $out/bin/
+  '';
 
-    passthru.updateScript = gitUpdater {
-      inherit (finalAttrs) pname version;
-      rev-prefix = "v";
-    };
+  passthru.updateScript = gitUpdater {
+    inherit (finalAttrs) pname version;
+    rev-prefix = "v";
+  };
 
-    meta = with lib; {
-      description = "Tests to check both the performance and the correctness of NVIDIA NCCL operations";
-      homepage = "https://github.com/NVIDIA/nccl-tests";
-      platforms = platforms.linux;
-      license = licenses.bsd3;
-      broken = !config.cudaSupport || (mpiSupport && mpi == null);
-      maintainers = with maintainers; [jmillerpdt] ++ teams.cuda.members;
-    };
-  }
-)
+  meta = with lib; {
+    description = "Tests to check both the performance and the correctness of NVIDIA NCCL operations";
+    homepage = "https://github.com/NVIDIA/nccl-tests";
+    platforms = platforms.linux;
+    license = licenses.bsd3;
+    broken = !config.cudaSupport || (mpiSupport && mpi == null);
+    maintainers = with maintainers; [ jmillerpdt ] ++ teams.cuda.members;
+  };
+})

--- a/pkgs/development/cuda-modules/nccl/default.nix
+++ b/pkgs/development/cuda-modules/nccl/default.nix
@@ -22,94 +22,92 @@ let
     cudaVersion
     ;
 in
-backendStdenv.mkDerivation (
-  finalAttrs: {
-    pname = "nccl";
-    version = "2.20.5-1";
+backendStdenv.mkDerivation (finalAttrs: {
+  pname = "nccl";
+  version = "2.20.5-1";
 
-    src = fetchFromGitHub {
-      owner = "NVIDIA";
-      repo = finalAttrs.pname;
-      rev = "v${finalAttrs.version}";
-      hash = "sha256-ModIjD6RaRD/57a/PA1oTgYhZsAQPrrvhl5sNVXnO6c=";
-    };
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-ModIjD6RaRD/57a/PA1oTgYhZsAQPrrvhl5sNVXnO6c=";
+  };
 
-    strictDeps = true;
+  strictDeps = true;
 
-    outputs = [
-      "out"
-      "dev"
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs =
+    [
+      which
+      autoAddDriverRunpath
+      python3
+    ]
+    ++ lib.optionals (lib.versionOlder cudaVersion "11.4") [ cudatoolkit ]
+    ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [ cuda_nvcc ];
+
+  buildInputs =
+    lib.optionals (lib.versionOlder cudaVersion "11.4") [ cudatoolkit ]
+    ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [
+      cuda_nvcc.dev # crt/host_config.h
+      cuda_cudart
+    ]
+    # NOTE: CUDA versions in Nixpkgs only use a major and minor version. When we do comparisons
+    # against other version, like below, it's important that we use the same format. Otherwise,
+    # we'll get incorrect results.
+    # For example, lib.versionAtLeast "12.0" "12.0.0" == false.
+    ++ lib.optionals (lib.versionAtLeast cudaVersion "12.0") [ cuda_cccl ];
+
+  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-unused-function" ];
+
+  preConfigure = ''
+    patchShebangs ./src/device/generate.py
+    makeFlagsArray+=(
+      "NVCC_GENCODE=${lib.concatStringsSep " " cudaFlags.gencode}"
+    )
+  '';
+
+  makeFlags =
+    [ "PREFIX=$(out)" ]
+    ++ lib.optionals (lib.versionOlder cudaVersion "11.4") [
+      "CUDA_HOME=${cudatoolkit}"
+      "CUDA_LIB=${lib.getLib cudatoolkit}/lib"
+      "CUDA_INC=${lib.getDev cudatoolkit}/include"
+    ]
+    ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [
+      "CUDA_HOME=${cuda_nvcc}"
+      "CUDA_LIB=${lib.getLib cuda_cudart}/lib"
+      "CUDA_INC=${lib.getDev cuda_cudart}/include"
     ];
 
-    nativeBuildInputs =
+  enableParallelBuilding = true;
+
+  postFixup = ''
+    moveToOutput lib/libnccl_static.a $dev
+  '';
+
+  passthru.updateScript = gitUpdater {
+    inherit (finalAttrs) pname version;
+    rev-prefix = "v";
+  };
+
+  meta = with lib; {
+    description = "Multi-GPU and multi-node collective communication primitives for NVIDIA GPUs";
+    homepage = "https://developer.nvidia.com/nccl";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    # NCCL is not supported on Jetson, because it does not use NVLink or PCI-e for inter-GPU communication.
+    # https://forums.developer.nvidia.com/t/can-jetson-orin-support-nccl/232845/9
+    badPlatforms = lib.optionals cudaFlags.isJetsonBuild [ "aarch64-linux" ];
+    maintainers =
+      with maintainers;
       [
-        which
-        autoAddDriverRunpath
-        python3
+        mdaiter
+        orivej
       ]
-      ++ lib.optionals (lib.versionOlder cudaVersion "11.4") [cudatoolkit]
-      ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [cuda_nvcc];
-
-    buildInputs =
-      lib.optionals (lib.versionOlder cudaVersion "11.4") [cudatoolkit]
-      ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [
-        cuda_nvcc.dev # crt/host_config.h
-        cuda_cudart
-      ]
-      # NOTE: CUDA versions in Nixpkgs only use a major and minor version. When we do comparisons
-      # against other version, like below, it's important that we use the same format. Otherwise,
-      # we'll get incorrect results.
-      # For example, lib.versionAtLeast "12.0" "12.0.0" == false.
-      ++ lib.optionals (lib.versionAtLeast cudaVersion "12.0") [cuda_cccl];
-
-    env.NIX_CFLAGS_COMPILE = toString ["-Wno-unused-function"];
-
-    preConfigure = ''
-      patchShebangs ./src/device/generate.py
-      makeFlagsArray+=(
-        "NVCC_GENCODE=${lib.concatStringsSep " " cudaFlags.gencode}"
-      )
-    '';
-
-    makeFlags =
-      ["PREFIX=$(out)"]
-      ++ lib.optionals (lib.versionOlder cudaVersion "11.4") [
-        "CUDA_HOME=${cudatoolkit}"
-        "CUDA_LIB=${lib.getLib cudatoolkit}/lib"
-        "CUDA_INC=${lib.getDev cudatoolkit}/include"
-      ]
-      ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [
-        "CUDA_HOME=${cuda_nvcc}"
-        "CUDA_LIB=${lib.getLib cuda_cudart}/lib"
-        "CUDA_INC=${lib.getDev cuda_cudart}/include"
-      ];
-
-    enableParallelBuilding = true;
-
-    postFixup = ''
-      moveToOutput lib/libnccl_static.a $dev
-    '';
-
-    passthru.updateScript = gitUpdater {
-      inherit (finalAttrs) pname version;
-      rev-prefix = "v";
-    };
-
-    meta = with lib; {
-      description = "Multi-GPU and multi-node collective communication primitives for NVIDIA GPUs";
-      homepage = "https://developer.nvidia.com/nccl";
-      license = licenses.bsd3;
-      platforms = platforms.linux;
-      # NCCL is not supported on Jetson, because it does not use NVLink or PCI-e for inter-GPU communication.
-      # https://forums.developer.nvidia.com/t/can-jetson-orin-support-nccl/232845/9
-      badPlatforms = lib.optionals cudaFlags.isJetsonBuild [ "aarch64-linux" ];
-      maintainers =
-        with maintainers;
-        [
-          mdaiter
-          orivej
-        ]
-        ++ teams.cuda.members;
-    };
-  }
-)
+      ++ teams.cuda.members;
+  };
+})

--- a/pkgs/development/cuda-modules/saxpy/default.nix
+++ b/pkgs/development/cuda-modules/saxpy/default.nix
@@ -31,18 +31,18 @@ backendStdenv.mkDerivation {
       cmake
       autoAddDriverRunpath
     ]
-    ++ lib.optionals (lib.versionOlder cudaVersion "11.4") [cudatoolkit]
-    ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [cuda_nvcc];
+    ++ lib.optionals (lib.versionOlder cudaVersion "11.4") [ cudatoolkit ]
+    ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [ cuda_nvcc ];
 
   buildInputs =
-    lib.optionals (lib.versionOlder cudaVersion "11.4") [cudatoolkit]
+    lib.optionals (lib.versionOlder cudaVersion "11.4") [ cudatoolkit ]
     ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [
       (getDev libcublas)
       (getLib libcublas)
       (getOutput "static" libcublas)
       cuda_cudart
     ]
-    ++ lib.optionals (lib.versionAtLeast cudaVersion "12.0") [cuda_cccl];
+    ++ lib.optionals (lib.versionAtLeast cudaVersion "12.0") [ cuda_cccl ];
 
   cmakeFlags = [
     (lib.cmakeBool "CMAKE_VERBOSE_MAKEFILE" true)

--- a/pkgs/development/cuda-modules/setup-hooks/extension.nix
+++ b/pkgs/development/cuda-modules/setup-hooks/extension.nix
@@ -2,63 +2,50 @@ final: _: {
   # Helper hook used in both autoAddCudaCompatRunpath and
   # autoAddDriverRunpath that applies a generic patching action to all elf
   # files with a dynamic linking section.
-  autoFixElfFiles =
-    final.callPackage
-      (
-        {makeSetupHook}:
-         makeSetupHook
-          {
-            name = "auto-fix-elf-files";
-          }
-          ./auto-fix-elf-files.sh
-      )
-      {};
+  autoFixElfFiles = final.callPackage (
+    { makeSetupHook }: makeSetupHook { name = "auto-fix-elf-files"; } ./auto-fix-elf-files.sh
+  ) { };
 
   # Internal hook, used by cudatoolkit and cuda redist packages
   # to accommodate automatic CUDAToolkit_ROOT construction
-  markForCudatoolkitRootHook =
-    final.callPackage
-      (
-        {makeSetupHook}:
-        makeSetupHook {name = "mark-for-cudatoolkit-root-hook";} ./mark-for-cudatoolkit-root-hook.sh
-      )
-      {};
+  markForCudatoolkitRootHook = final.callPackage (
+    { makeSetupHook }:
+    makeSetupHook { name = "mark-for-cudatoolkit-root-hook"; } ./mark-for-cudatoolkit-root-hook.sh
+  ) { };
 
   # Currently propagated by cuda_nvcc or cudatoolkit, rather than used directly
-  setupCudaHook =
-    (final.callPackage
-      (
-        {makeSetupHook, backendStdenv}:
-        makeSetupHook
-          {
-            name = "setup-cuda-hook";
+  setupCudaHook = (
+    final.callPackage (
+      { makeSetupHook, backendStdenv }:
+      makeSetupHook {
+        name = "setup-cuda-hook";
 
-            substitutions.setupCudaHook = placeholder "out";
+        substitutions.setupCudaHook = placeholder "out";
 
-            # Point NVCC at a compatible compiler
-            substitutions.ccRoot = "${backendStdenv.cc}";
+        # Point NVCC at a compatible compiler
+        substitutions.ccRoot = "${backendStdenv.cc}";
 
-            # Required in addition to ccRoot as otherwise bin/gcc is looked up
-            # when building CMakeCUDACompilerId.cu
-            substitutions.ccFullPath = "${backendStdenv.cc}/bin/${backendStdenv.cc.targetPrefix}c++";
-          }
-          ./setup-cuda-hook.sh
-      )
-      {}
-    );
+        # Required in addition to ccRoot as otherwise bin/gcc is looked up
+        # when building CMakeCUDACompilerId.cu
+        substitutions.ccFullPath = "${backendStdenv.cc}/bin/${backendStdenv.cc.targetPrefix}c++";
+      } ./setup-cuda-hook.sh
+    ) { }
+  );
 
-  autoAddDriverRunpath =
-    final.callPackage
-      (
-        {addDriverRunpath, autoFixElfFiles, makeSetupHook}:
-        makeSetupHook
-          {
-            name = "auto-add-opengl-runpath-hook";
-            propagatedBuildInputs = [addDriverRunpath autoFixElfFiles];
-          }
-          ./auto-add-driver-runpath-hook.sh
-      )
-      {};
+  autoAddDriverRunpath = final.callPackage (
+    {
+      addDriverRunpath,
+      autoFixElfFiles,
+      makeSetupHook,
+    }:
+    makeSetupHook {
+      name = "auto-add-opengl-runpath-hook";
+      propagatedBuildInputs = [
+        addDriverRunpath
+        autoFixElfFiles
+      ];
+    } ./auto-add-driver-runpath-hook.sh
+  ) { };
 
   # Deprecated: an alias kept for compatibility. Consider removing after 24.11
   autoAddOpenGLRunpathHook = final.autoAddDriverRunpath;
@@ -68,27 +55,26 @@ final: _: {
   # patched elf files, but `cuda_compat` path must take precedence (otherwise,
   # it doesn't have any effect) and thus appear first. Meaning this hook must be
   # executed last.
-  autoAddCudaCompatRunpath =
-    final.callPackage
-      (
-        {makeSetupHook, autoFixElfFiles, cuda_compat ? null }:
-        makeSetupHook
-          {
-            name = "auto-add-cuda-compat-runpath-hook";
-            propagatedBuildInputs = [autoFixElfFiles];
+  autoAddCudaCompatRunpath = final.callPackage (
+    {
+      makeSetupHook,
+      autoFixElfFiles,
+      cuda_compat ? null,
+    }:
+    makeSetupHook {
+      name = "auto-add-cuda-compat-runpath-hook";
+      propagatedBuildInputs = [ autoFixElfFiles ];
 
-            substitutions = {
-              # Hotfix Ofborg evaluation
-              libcudaPath = if final.flags.isJetsonBuild then "${cuda_compat}/compat" else null;
-            };
+      substitutions = {
+        # Hotfix Ofborg evaluation
+        libcudaPath = if final.flags.isJetsonBuild then "${cuda_compat}/compat" else null;
+      };
 
-            meta.broken = !final.flags.isJetsonBuild;
+      meta.broken = !final.flags.isJetsonBuild;
 
-            # Pre-cuda_compat CUDA release:
-            meta.badPlatforms = final.lib.optionals (cuda_compat == null) final.lib.platforms.all;
-            meta.platforms = cuda_compat.meta.platforms or [ ];
-          }
-          ./auto-add-cuda-compat-runpath.sh
-      )
-      {};
+      # Pre-cuda_compat CUDA release:
+      meta.badPlatforms = final.lib.optionals (cuda_compat == null) final.lib.platforms.all;
+      meta.platforms = cuda_compat.meta.platforms or [ ];
+    } ./auto-add-cuda-compat-runpath.sh
+  ) { };
 }

--- a/pkgs/development/cuda-modules/tensorrt/fixup.nix
+++ b/pkgs/development/cuda-modules/tensorrt/fixup.nix
@@ -108,6 +108,6 @@ finalAttrs: prevAttrs: {
       prevAttrs.meta.badPlatforms or [ ]
       ++ lib.optionals (targetArch == "unsupported") [ hostPlatform.system ];
     homepage = "https://developer.nvidia.com/tensorrt";
-    maintainers = prevAttrs.meta.maintainers ++ [maintainers.aidalgol];
+    maintainers = prevAttrs.meta.maintainers ++ [ maintainers.aidalgol ];
   };
 }

--- a/pkgs/development/cuda-modules/tensorrt/releases.nix
+++ b/pkgs/development/cuda-modules/tensorrt/releases.nix
@@ -3,9 +3,9 @@
 {
   tensorrt.releases = {
     # jetson
-    linux-aarch64 = [];
+    linux-aarch64 = [ ];
     # powerpc
-    linux-ppc64le = [];
+    linux-ppc64le = [ ];
     # server-grade arm
     linux-sbsa = [
       {

--- a/pkgs/top-level/cuda-packages.nix
+++ b/pkgs/top-level/cuda-packages.nix
@@ -40,78 +40,75 @@ let
   # Backbone
   gpus = builtins.import ../development/cuda-modules/gpus.nix;
   nvccCompatibilities = builtins.import ../development/cuda-modules/nvcc-compatibilities.nix;
-  flags = callPackage ../development/cuda-modules/flags.nix {inherit cudaVersion gpus;};
-  passthruFunction =
-    final:
-    (
-      {
-        inherit cudaVersion lib pkgs;
-        inherit gpus nvccCompatibilities flags;
-        cudaMajorVersion = versions.major cudaVersion;
-        cudaMajorMinorVersion = versions.majorMinor cudaVersion;
-        cudaOlder = strings.versionOlder cudaVersion;
-        cudaAtLeast = strings.versionAtLeast cudaVersion;
+  flags = callPackage ../development/cuda-modules/flags.nix { inherit cudaVersion gpus; };
+  passthruFunction = final: ({
+    inherit cudaVersion lib pkgs;
+    inherit gpus nvccCompatibilities flags;
+    cudaMajorVersion = versions.major cudaVersion;
+    cudaMajorMinorVersion = versions.majorMinor cudaVersion;
+    cudaOlder = strings.versionOlder cudaVersion;
+    cudaAtLeast = strings.versionAtLeast cudaVersion;
 
-        # Maintain a reference to the final cudaPackages.
-        # Without this, if we use `final.callPackage` and a package accepts `cudaPackages` as an argument,
-        # it's provided with `cudaPackages` from the top-level scope, which is not what we want. We want to
-        # provide the `cudaPackages` from the final scope -- that is, the *current* scope.
-        cudaPackages = final;
+    # Maintain a reference to the final cudaPackages.
+    # Without this, if we use `final.callPackage` and a package accepts `cudaPackages` as an argument,
+    # it's provided with `cudaPackages` from the top-level scope, which is not what we want. We want to
+    # provide the `cudaPackages` from the final scope -- that is, the *current* scope.
+    cudaPackages = final;
 
-        # TODO(@connorbaker): `cudaFlags` is an alias for `flags` which should be removed in the future.
-        cudaFlags = flags;
+    # TODO(@connorbaker): `cudaFlags` is an alias for `flags` which should be removed in the future.
+    cudaFlags = flags;
 
-        # Exposed as cudaPackages.backendStdenv.
-        # This is what nvcc uses as a backend,
-        # and it has to be an officially supported one (e.g. gcc11 for cuda11).
-        #
-        # It, however, propagates current stdenv's libstdc++ to avoid "GLIBCXX_* not found errors"
-        # when linked with other C++ libraries.
-        # E.g. for cudaPackages_11_8 we use gcc11 with gcc12's libstdc++
-        # Cf. https://github.com/NixOS/nixpkgs/pull/218265 for context
-        backendStdenv = final.callPackage ../development/cuda-modules/backend-stdenv.nix {};
+    # Exposed as cudaPackages.backendStdenv.
+    # This is what nvcc uses as a backend,
+    # and it has to be an officially supported one (e.g. gcc11 for cuda11).
+    #
+    # It, however, propagates current stdenv's libstdc++ to avoid "GLIBCXX_* not found errors"
+    # when linked with other C++ libraries.
+    # E.g. for cudaPackages_11_8 we use gcc11 with gcc12's libstdc++
+    # Cf. https://github.com/NixOS/nixpkgs/pull/218265 for context
+    backendStdenv = final.callPackage ../development/cuda-modules/backend-stdenv.nix { };
 
-        # Loose packages
-        cudatoolkit = final.callPackage ../development/cuda-modules/cudatoolkit {};
-        saxpy = final.callPackage ../development/cuda-modules/saxpy {};
-        nccl = final.callPackage ../development/cuda-modules/nccl {};
-        nccl-tests = final.callPackage ../development/cuda-modules/nccl-tests {};
-      }
-    );
+    # Loose packages
+    cudatoolkit = final.callPackage ../development/cuda-modules/cudatoolkit { };
+    saxpy = final.callPackage ../development/cuda-modules/saxpy { };
+    nccl = final.callPackage ../development/cuda-modules/nccl { };
+    nccl-tests = final.callPackage ../development/cuda-modules/nccl-tests { };
+  });
 
   mkVersionedPackageName =
     name: version:
     strings.concatStringsSep "_" [
       name
-      (strings.replaceStrings ["."] ["_"] (versions.majorMinor version))
+      (strings.replaceStrings [ "." ] [ "_" ] (versions.majorMinor version))
     ];
 
-  composedExtension = fixedPoints.composeManyExtensions ([
-    (import ../development/cuda-modules/setup-hooks/extension.nix)
-    (callPackage ../development/cuda-modules/cuda/extension.nix {inherit cudaVersion;})
-    (callPackage ../development/cuda-modules/cuda/overrides.nix {inherit cudaVersion;})
-    (callPackage ../development/cuda-modules/generic-builders/multiplex.nix {
-      inherit cudaVersion flags mkVersionedPackageName;
-      pname = "cudnn";
-      releasesModule = ../development/cuda-modules/cudnn/releases.nix;
-      shimsFn = ../development/cuda-modules/cudnn/shims.nix;
-      fixupFn = ../development/cuda-modules/cudnn/fixup.nix;
-    })
-    (callPackage ../development/cuda-modules/cutensor/extension.nix {
-      inherit cudaVersion flags mkVersionedPackageName;
-    })
-    (callPackage ../development/cuda-modules/generic-builders/multiplex.nix {
-      inherit cudaVersion flags mkVersionedPackageName;
-      pname = "tensorrt";
-      releasesModule = ../development/cuda-modules/tensorrt/releases.nix;
-      shimsFn = ../development/cuda-modules/tensorrt/shims.nix;
-      fixupFn = ../development/cuda-modules/tensorrt/fixup.nix;
-    })
-    (callPackage ../development/cuda-modules/cuda-samples/extension.nix {inherit cudaVersion;})
-    (callPackage ../development/cuda-modules/cuda-library-samples/extension.nix {})
-  ] ++ lib.optionals config.allowAliases [
-    (import ../development/cuda-modules/aliases.nix)
-  ]);
+  composedExtension = fixedPoints.composeManyExtensions (
+    [
+      (import ../development/cuda-modules/setup-hooks/extension.nix)
+      (callPackage ../development/cuda-modules/cuda/extension.nix { inherit cudaVersion; })
+      (callPackage ../development/cuda-modules/cuda/overrides.nix { inherit cudaVersion; })
+      (callPackage ../development/cuda-modules/generic-builders/multiplex.nix {
+        inherit cudaVersion flags mkVersionedPackageName;
+        pname = "cudnn";
+        releasesModule = ../development/cuda-modules/cudnn/releases.nix;
+        shimsFn = ../development/cuda-modules/cudnn/shims.nix;
+        fixupFn = ../development/cuda-modules/cudnn/fixup.nix;
+      })
+      (callPackage ../development/cuda-modules/cutensor/extension.nix {
+        inherit cudaVersion flags mkVersionedPackageName;
+      })
+      (callPackage ../development/cuda-modules/generic-builders/multiplex.nix {
+        inherit cudaVersion flags mkVersionedPackageName;
+        pname = "tensorrt";
+        releasesModule = ../development/cuda-modules/tensorrt/releases.nix;
+        shimsFn = ../development/cuda-modules/tensorrt/shims.nix;
+        fixupFn = ../development/cuda-modules/tensorrt/fixup.nix;
+      })
+      (callPackage ../development/cuda-modules/cuda-samples/extension.nix { inherit cudaVersion; })
+      (callPackage ../development/cuda-modules/cuda-library-samples/extension.nix { })
+    ]
+    ++ lib.optionals config.allowAliases [ (import ../development/cuda-modules/aliases.nix) ]
+  );
 
   cudaPackages = customisation.makeScope newScope (
     fixedPoints.extends composedExtension passthruFunction


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Reformats the following paths with `nixfmt-rfc-style`:

- `pkgs/development/cuda-modules`
- `pkgs/test/cuda`
- `pkgs/top-level/cuda-packages.nix`

Additionally, adds the commit in which the reformatting happens to `.git-blame-ignore-revs`.

Ideally this will not cause any rebuilds, but it may if whitespace in raw text blocks change.

This PR also introduces a workflow to ensure that the changed files continue to stay formatted.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
