### PR TITLE
mongodb: add avxSupport override

### DIFF
--- a/pkgs/servers/nosql/mongodb/5.0.nix
+++ b/pkgs/servers/nosql/mongodb/5.0.nix
@@ -1,4 +1,7 @@
-{ stdenv, callPackage, lib, sasl, boost, Security, CoreFoundation, cctools }:
+{ stdenv, callPackage, lib, sasl, boost
+, Security, CoreFoundation, cctools
+, avxSupport ? stdenv.hostPlatform.avxSupport
+}:
 
 let
   buildMongoDB = callPackage ./mongodb.nix {
@@ -18,6 +21,7 @@ let
     };
 in
 buildMongoDB {
+  inherit avxSupport;
   version = variants.version;
   sha256 = variants.sha256;
   patches = [

--- a/pkgs/servers/nosql/mongodb/6.0.nix
+++ b/pkgs/servers/nosql/mongodb/6.0.nix
@@ -1,4 +1,7 @@
-{ stdenv, callPackage, lib, fetchpatch, sasl, boost, Security, CoreFoundation, cctools }:
+{ stdenv, callPackage, lib, fetchpatch
+, sasl, boost, Security, CoreFoundation, cctools
+, avxSupport ? stdenv.hostPlatform.avxSupport
+}:
 
 let
   buildMongoDB = callPackage ./mongodb.nix {
@@ -6,6 +9,7 @@ let
   };
 in
 buildMongoDB {
+  inherit avxSupport;
   version = "6.0.15";
   sha256 = "sha256-DX1wbrDx1/JrEHbzNaXC4Hqq7MrLqz+JZgG98beyVds=";
   patches = [

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -29,6 +29,7 @@ with lib;
 
 { version, sha256, patches ? []
 , license ? lib.licenses.sspl
+, avxSupport ? stdenv.hostPlatform.avxSupport
 }:
 
 let
@@ -114,6 +115,9 @@ in stdenv.mkDerivation rec {
     # don't fail by default on i686
     substituteInPlace src/mongo/db/storage/storage_options.h \
       --replace 'engine("wiredTiger")' 'engine("mmapv1")'
+  '' + lib.optionalString (!avxSupport) ''
+    substituteInPlace SConstruct \
+      --replace-fail "default=['+sandybridge']," 'default=[],'
   '';
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang


### PR DESCRIPTION
https://www.mongodb.com/docs/v5.0/administration/production-notes/#platform-support-notes

"MongoDB 5.0 requires use of the AVX instruction set, available on select Intel and AMD processors."

While most recent CPUs support this, some lower end CPUs do not which produces an invalid opcode when run. mongodb compiled without the default "sandbridge" experimental-optimization flag runs on such machines. Allow the user to override this at his own risk.

Currently testing with unifi 8.1.113 with mongodb 6 on a Intel N5105.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
