### PR TITLE
cc-wrapper: add support for `spectrev2` hardening flag

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -32,7 +32,7 @@ if [[ -n "${hardeningEnableMap[fortify3]-}" ]]; then
 fi
 
 if (( "${NIX_DEBUG:-0}" >= 1 )); then
-  declare -a allHardeningFlags=(fortify fortify3 stackprotector pie pic strictoverflow format trivialautovarinit zerocallusedregs)
+  declare -a allHardeningFlags=(fortify fortify3 stackprotector pie pic spectrev2 strictoverflow format trivialautovarinit zerocallusedregs)
   declare -A hardeningDisableMap=()
 
   # Determine which flags were effectively disabled so we can report below.
@@ -91,6 +91,14 @@ for flag in "${!hardeningEnableMap[@]}"; do
     pic)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling pic >&2; fi
       hardeningCFlagsBefore+=('-fPIC')
+      ;;
+    spectrev2)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling spectrev2 >&2; fi
+      if (( @isClang@ )); then
+        hardeningCFlagsBefore+=('-mretpoline')
+      else
+        hardeningCFlagsBefore+=('-mindirect-branch=thunk' '-mfunction-return=thunk')
+      fi
       ;;
     strictoverflow)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling strictoverflow >&2; fi

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -424,7 +424,8 @@ pipe ((callFile ./common/builder.nix {}) ({
     hardeningUnsupportedFlags = optional is48 "stackprotector"
       ++ optional (!atLeast11) "zerocallusedregs"
       ++ optionals (!atLeast12) [ "fortify3" "trivialautovarinit" ]
-      ++ optionals (langFortran) [ "fortify" "format" ];
+      ++ optionals (langFortran) [ "fortify" "format" ]
+      ++ optional (!(targetPlatform.isx86_64 && atLeast8)) "spectrev2";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/llvm/12/clang/default.nix
+++ b/pkgs/development/compilers/llvm/12/clang/default.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  self = stdenv.mkDerivation ({
+  self = stdenv.mkDerivation (finalAttrs: {
     pname = "clang";
     inherit version;
 
@@ -90,6 +90,9 @@ let
       inherit libllvm;
       isClang = true;
       hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
+      hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
+        lib.optional (targetPlatform.isDarwin || !targetPlatform.isx86_64) "spectrev2"
+        ++ (finalAttrs.passthru.hardeningUnsupportedFlags or []);
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/13/clang/default.nix
+++ b/pkgs/development/compilers/llvm/13/clang/default.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  self = stdenv.mkDerivation ({
+  self = stdenv.mkDerivation (finalAttrs: {
     pname = "clang";
     inherit version;
 
@@ -84,6 +84,9 @@ let
       inherit libllvm;
       isClang = true;
       hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
+      hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
+        lib.optional (targetPlatform.isDarwin || !targetPlatform.isx86_64) "spectrev2"
+        ++ (finalAttrs.passthru.hardeningUnsupportedFlags or []);
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/14/clang/default.nix
+++ b/pkgs/development/compilers/llvm/14/clang/default.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  self = stdenv.mkDerivation (rec {
+  self = stdenv.mkDerivation (finalAttrs: rec {
     pname = "clang";
     inherit version;
 
@@ -87,6 +87,9 @@ let
       inherit libllvm;
       isClang = true;
       hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
+      hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
+        lib.optional (targetPlatform.isDarwin || !targetPlatform.isx86_64) "spectrev2"
+        ++ (finalAttrs.passthru.hardeningUnsupportedFlags or []);
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/15/clang/default.nix
+++ b/pkgs/development/compilers/llvm/15/clang/default.nix
@@ -102,6 +102,7 @@ let
       ];
       hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
         lib.optional (!(targetPlatform.isx86_64 || targetPlatform.isAarch64)) "zerocallusedregs"
+        ++ lib.optional (targetPlatform.isDarwin || !targetPlatform.isx86_64) "spectrev2"
         ++ (finalAttrs.passthru.hardeningUnsupportedFlags or []);
     };
 

--- a/pkgs/development/compilers/llvm/16/clang/default.nix
+++ b/pkgs/development/compilers/llvm/16/clang/default.nix
@@ -96,6 +96,7 @@ let
       ];
       hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
         lib.optional (!(targetPlatform.isx86_64 || targetPlatform.isAarch64)) "zerocallusedregs"
+        ++ lib.optional (targetPlatform.isDarwin || !targetPlatform.isx86_64) "spectrev2"
         ++ (finalAttrs.passthru.hardeningUnsupportedFlags or []);
     };
 

--- a/pkgs/development/compilers/llvm/17/clang/default.nix
+++ b/pkgs/development/compilers/llvm/17/clang/default.nix
@@ -100,6 +100,7 @@ let
       ];
       hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
         lib.optional (!(targetPlatform.isx86_64 || targetPlatform.isAarch64)) "zerocallusedregs"
+        ++ lib.optional (targetPlatform.isDarwin || !targetPlatform.isx86_64) "spectrev2"
         ++ (finalAttrs.passthru.hardeningUnsupportedFlags or []);
     };
 

--- a/pkgs/development/compilers/llvm/9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/9/clang/default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  self = stdenv.mkDerivation ({
+  self = stdenv.mkDerivation (finalAttrs: {
     pname = "clang";
     inherit version;
 
@@ -98,6 +98,9 @@ let
       inherit libllvm;
       isClang = true;
       hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
+      hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
+        lib.optional (targetPlatform.isDarwin || !targetPlatform.isx86_64) "spectrev2"
+        ++ (finalAttrs.passthru.hardeningUnsupportedFlags or []);
     };
 
     meta = llvm_meta // {

--- a/pkgs/development/compilers/llvm/git/clang/default.nix
+++ b/pkgs/development/compilers/llvm/git/clang/default.nix
@@ -98,6 +98,7 @@ let
       ];
       hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
         lib.optional (!(targetPlatform.isx86_64 || targetPlatform.isAarch64)) "zerocallusedregs"
+        ++ lib.optional (targetPlatform.isDarwin || !targetPlatform.isx86_64) "spectrev2"
         ++ (finalAttrs.passthru.hardeningUnsupportedFlags or []);
     };
 

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -48,7 +48,7 @@ in
     # The pie, stackprotector and fortify hardening flags are autodetected by
     # glibc and enabled by default if supported. Setting it for every gcc
     # invocation does not work.
-    hardeningDisable = [ "fortify" "pie" "stackprotector" ];
+    hardeningDisable = [ "fortify" "pie" "spectrev2" "stackprotector" ];
 
     env = (previousAttrs.env or { }) // {
       NIX_CFLAGS_COMPILE = (previousAttrs.env.NIX_CFLAGS_COMPILE or "") + lib.concatStringsSep " "

--- a/pkgs/os-specific/linux/kexec-tools/default.nix
+++ b/pkgs/os-specific/linux/kexec-tools/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  hardeningDisable = [ "format" "pic" "relro" "pie" ];
+  hardeningDisable = [ "format" "pic" "spectrev2" "relro" "pie" ];
 
   # Prevent kexec-tools from using uname to detect target, which is wrong in
   # cases like compiling for aarch32 on aarch64

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -328,7 +328,7 @@ in
               '';
               passthru = {
                 isFromBootstrapFiles = true;
-                hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" ];
+                hardeningUnsupportedFlags = [ "fortify3" "spectrev2" "zerocallusedregs" ];
               };
             };
             clang-unwrapped = selfTools.libclang;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -118,6 +118,7 @@ let
     "pic"
     "pie"
     "relro"
+    "spectrev2"
     "stackprotector"
     "strictoverflow"
     "trivialautovarinit"

--- a/pkgs/stdenv/linux/bootstrap-tools-musl/default.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools-musl/default.nix
@@ -15,5 +15,5 @@ derivation ({
   langC = true;
   langCC = true;
   isGNU = true;
-  hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" "trivialautovarinit" ];
+  hardeningUnsupportedFlags = [ "fortify3" "spectrev2" "zerocallusedregs" "trivialautovarinit" ];
 } // extraAttrs)

--- a/pkgs/stdenv/linux/bootstrap-tools/default.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools/default.nix
@@ -15,5 +15,5 @@ derivation ({
   langC = true;
   langCC = true;
   isGNU = true;
-  hardeningUnsupportedFlags = [ "fortify3" "zerocallusedregs" "trivialautovarinit" ];
+  hardeningUnsupportedFlags = [ "fortify3" "spectrev2" "zerocallusedregs" "trivialautovarinit" ];
 } // extraAttrs)


### PR DESCRIPTION
## Description of changes
This enables the "retpoline" protection on supported compilers for hardening against spectre v2 ("Branch Target Injection") attacks.

There are comparatively few packages that are likely to be vulnerable to this kind of attack, and packages like the kernel handle these flags themselves - so this flag is mostly for the paranoid or users of "hardened" systems (what's the difference har har). Though it is a good demonstrator of how to implement platform-specific hardening flags via `hardeningUnsupportedFlagsByTargetPlatform`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
