### PR TITLE
cmake: add __structuredAttrs support to setup hooks

### DIFF
--- a/pkgs/by-name/cm/cmake/check-pc-files-hook.sh
+++ b/pkgs/by-name/cm/cmake/check-pc-files-hook.sh
@@ -1,3 +1,6 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2016,SC2154
+
 cmakePcfileCheckPhase() {
     while IFS= read -rd $'\0' file; do
         grepout=$(grep --line-number '}//nix/store' "$file" || true)

--- a/pkgs/by-name/cm/cmake/setup-hook.sh
+++ b/pkgs/by-name/cm/cmake/setup-hook.sh
@@ -38,10 +38,10 @@ cmakeConfigurePhase() {
     declare -ga cmakeFlagsArray
 
     if [[ -n "${__structuredAttrs-}" ]]; then
-      cmakeFlagsArray=("${cmakeFlags[@]}" "${cmakeFlagsArray[@]}")
+        cmakeFlagsArray=("${cmakeFlags[@]}" "${cmakeFlagsArray[@]}")
     else
-      # shellcheck disable=SC2206
-      cmakeFlagsArray=($cmakeFlags "${cmakeFlagsArray[@]}")
+        # shellcheck disable=SC2206
+        cmakeFlagsArray=($cmakeFlags "${cmakeFlagsArray[@]}")
     fi
 
     if [ -z "${dontAddPrefix-}" ]; then
@@ -159,37 +159,37 @@ fi
 addEnvHooks "$targetOffset" addCMakeParams
 
 makeCmakeFindLibs(){
-  isystem_seen=
-  iframework_seen=
-  for flag in ${NIX_CFLAGS_COMPILE-} ${NIX_LDFLAGS-}; do
-    if test -n "$isystem_seen" && test -d "$flag"; then
-      isystem_seen=
-      export CMAKE_INCLUDE_PATH="${CMAKE_INCLUDE_PATH-}${CMAKE_INCLUDE_PATH:+:}${flag}"
-    elif test -n "$iframework_seen" && test -d "$flag"; then
-      iframework_seen=
-      export CMAKE_FRAMEWORK_PATH="${CMAKE_FRAMEWORK_PATH-}${CMAKE_FRAMEWORK_PATH:+:}${flag}"
-    else
-      isystem_seen=
-      iframework_seen=
-      case $flag in
-        -I*)
-          export CMAKE_INCLUDE_PATH="${CMAKE_INCLUDE_PATH-}${CMAKE_INCLUDE_PATH:+:}${flag:2}"
-          ;;
-        -L*)
-          export CMAKE_LIBRARY_PATH="${CMAKE_LIBRARY_PATH-}${CMAKE_LIBRARY_PATH:+:}${flag:2}"
-          ;;
-        -F*)
-          export CMAKE_FRAMEWORK_PATH="${CMAKE_FRAMEWORK_PATH-}${CMAKE_FRAMEWORK_PATH:+:}${flag:2}"
-          ;;
-        -isystem)
-          isystem_seen=1
-          ;;
-        -iframework)
-          iframework_seen=1
-          ;;
-      esac
-    fi
-  done
+    isystem_seen=
+    iframework_seen=
+    for flag in ${NIX_CFLAGS_COMPILE-} ${NIX_LDFLAGS-}; do
+        if test -n "$isystem_seen" && test -d "$flag"; then
+            isystem_seen=
+            export CMAKE_INCLUDE_PATH="${CMAKE_INCLUDE_PATH-}${CMAKE_INCLUDE_PATH:+:}${flag}"
+        elif test -n "$iframework_seen" && test -d "$flag"; then
+            iframework_seen=
+            export CMAKE_FRAMEWORK_PATH="${CMAKE_FRAMEWORK_PATH-}${CMAKE_FRAMEWORK_PATH:+:}${flag}"
+        else
+            isystem_seen=
+            iframework_seen=
+            case $flag in
+            -I*)
+                export CMAKE_INCLUDE_PATH="${CMAKE_INCLUDE_PATH-}${CMAKE_INCLUDE_PATH:+:}${flag:2}"
+                ;;
+            -L*)
+                export CMAKE_LIBRARY_PATH="${CMAKE_LIBRARY_PATH-}${CMAKE_LIBRARY_PATH:+:}${flag:2}"
+                ;;
+            -F*)
+                export CMAKE_FRAMEWORK_PATH="${CMAKE_FRAMEWORK_PATH-}${CMAKE_FRAMEWORK_PATH:+:}${flag:2}"
+                ;;
+            -isystem)
+                isystem_seen=1
+                ;;
+            -iframework)
+                iframework_seen=1
+                ;;
+            esac
+        fi
+    done
 }
 
 # not using setupHook, because it could be a setupHook adding additional


### PR DESCRIPTION
## Description of changes

### Summary

Provide structural attributes support to the setup hooks of CMake and lint them with ShelllCheck.

Fix #289037.

~### New interface~

~Provide interface to structurally specify CMake `-D` flags, i.e. `cmakeDFlagAttrs` and `cmakeDFlagEvalAttrs`. Not only can it be specified by phases/hooks run before `cmakeConfigurePhase`, but also as Nix Language attributes when `__structuralAttrs = true`.~

Update: The interface change is hold back here, and will be discussed in a subsequent PR.

### ~Questions~

- ~Naming.~
    - ~Any suggestions to the new names `cmakeDFlagAttrs` and `cmakeDFlagEvalAttrs`?~
- ~Boolean and non-string type management.~
    - ~Should we allow boolean and other non-string type when `cmakeDFlagAttrs` is used inside the Nix Language expression? That would be quite convenient in Nix expression level, but require an extra layer of conversion. This PR currently doesn't provide such support.~

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
