### PR TITLE
tpm2-openssl: init at 1.2.0

### DIFF
--- a/pkgs/by-name/tp/tpm2-openssl/package.nix
+++ b/pkgs/by-name/tp/tpm2-openssl/package.nix
@@ -1,0 +1,46 @@
+{
+  stdenv,
+  lib,
+  autoreconfHook,
+  fetchFromGitHub,
+  autoconf-archive,
+  pkg-config,
+  openssl,
+  tpm2-tss,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tpm2-openssl";
+  version = "1.2.0";
+  src = fetchFromGitHub {
+    owner = "tpm2-software";
+    repo = "tpm2-openssl";
+    rev = finalAttrs.version;
+    hash = "sha256-mZ4Z/GxJFwwfyFd1SAiVlQqOjkFSzsZePeuEZtq8Mcg=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    autoconf-archive
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    tpm2-tss
+  ];
+
+  configureFlags = [ "--with-modulesdir=$$out/lib/ossl-modules" ];
+
+  postPatch = ''
+    echo ${finalAttrs.version} > VERSION
+  '';
+
+  meta = with lib; {
+    description = "OpenSSL Provider for TPM2 integration";
+    homepage = "https://github.com/tpm2-software/tpm2-openssl";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ stv0g ];
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

This PR packages [tpm2-openssl](https://github.com/tpm2-software/tpm2-openssl) an OpenSSL Provider for TPM2 integration.

Tested with:

```shell
nix build github:stv0g/nixpkgs/add-tpm2-openssl\#tpm2-openssl
nix run   github:stv0g/nixpkgs/add-tpm2-openssl\#openssl -- rand \
   -provider-path ./result/lib/ossl-modules \
   -provider tpm2 \
   16
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
