### PR TITLE
Avoid top-level `with ...;` in `nixos/doc/`

### DIFF
--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -9,12 +9,20 @@
 , prefix ? ../../..
 }:
 
-with pkgs;
-
 let
-  inherit (lib) hasPrefix removePrefix;
+  inherit (pkgs) buildPackages runCommand docbook_xsl_ns;
 
-  lib = pkgs.lib;
+  inherit (pkgs.lib)
+    hasPrefix
+    removePrefix
+    flip
+    foldr
+    types
+    mkOption
+    escapeShellArg
+    concatMapStringsSep
+    sourceFilesBySuffices
+    ;
 
   common = import ./common.nix;
 
@@ -27,7 +35,7 @@ let
   # E.g. if some `options` came from modules in ${pkgs.customModules}/nix,
   # you'd need to include `extraSources = [ pkgs.customModules ]`
   prefixesToStrip = map (p: "${toString p}/") ([ prefix ] ++ extraSources);
-  stripAnyPrefixes = lib.flip (lib.foldr lib.removePrefix) prefixesToStrip;
+  stripAnyPrefixes = flip (foldr removePrefix) prefixesToStrip;
 
   optionsDoc = buildPackages.nixosOptionsDoc {
     inherit options revision baseOptionsJSON warningsAreErrors;
@@ -42,8 +50,8 @@ let
   testOptionsDoc = let
       eval = nixos-lib.evalTest {
         # Avoid evaluating a NixOS config prototype.
-        config.node.type = lib.types.deferredModule;
-        options._module.args = lib.mkOption { internal = true; };
+        config.node.type = types.deferredModule;
+        options._module.args = mkOption { internal = true; };
       };
     in buildPackages.nixosOptionsDoc {
       inherit (eval) options;
@@ -76,7 +84,7 @@ let
     substituteInPlace ./configuration/configuration.md \
       --replace \
           '@MODULE_CHAPTERS@' \
-          ${lib.escapeShellArg (lib.concatMapStringsSep "\n" (p: "${p.value}") config.meta.doc)}
+          ${escapeShellArg (concatMapStringsSep "\n" (p: "${p.value}") config.meta.doc)}
     substituteInPlace ./nixos-options.md \
       --replace \
         '@NIXOS_OPTIONS_JSON@' \
@@ -95,7 +103,7 @@ in rec {
   # Generate the NixOS manual.
   manualHTML = runCommand "nixos-manual-html"
     { nativeBuildInputs = [ buildPackages.nixos-render-docs ];
-      inputs = lib.sourceFilesBySuffices ./. [ ".md" ];
+      inputs = sourceFilesBySuffices ./. [ ".md" ];
       meta.description = "The NixOS manual in HTML format";
       allowedReferences = ["out"];
     }
@@ -114,8 +122,8 @@ in rec {
 
       nixos-render-docs -j $NIX_BUILD_CORES manual html \
         --manpage-urls ${manpageUrls} \
-        --revision ${lib.escapeShellArg revision} \
-        --generator "nixos-render-docs ${lib.version}" \
+        --revision ${escapeShellArg revision} \
+        --generator "nixos-render-docs ${pkgs.lib.version}" \
         --stylesheet style.css \
         --stylesheet highlightjs/mono-blue.css \
         --script ./highlightjs/highlight.pack.js \
@@ -147,7 +155,7 @@ in rec {
               xml:id="book-nixos-manual">
           <info>
             <title>NixOS Manual</title>
-            <subtitle>Version ${lib.version}</subtitle>
+            <subtitle>Version ${pkgs.lib.version}</subtitle>
           </info>
           <chapter>
             <title>Temporarily unavailable</title>
@@ -199,7 +207,7 @@ in rec {
       # Generate manpages.
       mkdir -p $out/share/man/man5
       nixos-render-docs -j $NIX_BUILD_CORES options manpage \
-        --revision ${lib.escapeShellArg revision} \
+        --revision ${escapeShellArg revision} \
         ${optionsJSON}/${common.outputPath}/options.json \
         $out/share/man/man5/configuration.nix.5
     '';


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is no functional change contained in this PR.

Spot the bug with `drvPath = guard drvPath;` though. Never evaled, and under a global `with`, it's not an error.

I used the refactor strategy that looks for the uses of names [coming from `lib`](https://gist.github.com/philiptaron/04326000d5ff20cb72c2805efd09701c). 

Following advice, I also preferred to inherit names from `lib` instead of `builtins` where there was a choice. I also preferred to inherit from `lib` in one place, rather than to have a mixture of `with lib;`, `lib.thing` and `inherit (lib) thing`. **I can drop those changes if reviewers desire.**

There are no rebuilds when I run `nixpkgs-review rev HEAD`, so I've targeted master with this PR.

## Things done

- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev HEAD`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).