### PR TITLE
Avoid top-level `with ...;` in `nixos/lib/systemd*`

### DIFF
--- a/nixos/lib/systemd-network-units.nix
+++ b/nixos/lib/systemd-network-units.nix
@@ -1,8 +1,13 @@
 { lib, systemdUtils }:
 
-with lib;
-
 let
+  inherit (lib)
+    concatMapStrings
+    concatStringsSep
+    flip
+    optionalString
+    ;
+
   attrsToSection = systemdUtils.lib.attrsToSection;
   commonMatchText = def:
     optionalString (def.matchConfig != { }) ''

--- a/nixos/lib/systemd-types.nix
+++ b/nixos/lib/systemd-types.nix
@@ -1,47 +1,91 @@
 { lib, systemdUtils, pkgs }:
 
-with systemdUtils.lib;
-with systemdUtils.unitOptions;
-with lib;
+let
+  inherit (systemdUtils.lib)
+    automountConfig
+    makeUnit
+    mountConfig
+    stage1ServiceConfig
+    stage2ServiceConfig
+    unitConfig
+    ;
+
+  inherit (systemdUtils.unitOptions)
+    concreteUnitOptions
+    stage1AutomountOptions
+    stage1CommonUnitOptions
+    stage1MountOptions
+    stage1PathOptions
+    stage1ServiceOptions
+    stage1SliceOptions
+    stage1SocketOptions
+    stage1TimerOptions
+    stage2AutomountOptions
+    stage2CommonUnitOptions
+    stage2MountOptions
+    stage2PathOptions
+    stage2ServiceOptions
+    stage2SliceOptions
+    stage2SocketOptions
+    stage2TimerOptions
+    ;
+
+  inherit (lib)
+    mdDoc
+    mkDefault
+    mkDerivedConfig
+    mkEnableOption
+    mkIf
+    mkOption
+    ;
+
+  inherit (lib.types)
+    attrsOf
+    lines
+    listOf
+    nullOr
+    path
+    submodule
+    ;
+in
 
 rec {
-  units = with types;
-    attrsOf (submodule ({ name, config, ... }: {
-      options = concreteUnitOptions;
-      config = { unit = mkDefault (systemdUtils.lib.makeUnit name config); };
-    }));
+  units = attrsOf (submodule ({ name, config, ... }: {
+    options = concreteUnitOptions;
+    config = { unit = mkDefault (makeUnit name config); };
+  }));
 
-  services = with types; attrsOf (submodule [ stage2ServiceOptions unitConfig stage2ServiceConfig ]);
-  initrdServices = with types; attrsOf (submodule [ stage1ServiceOptions unitConfig stage1ServiceConfig ]);
+  services = attrsOf (submodule [ stage2ServiceOptions unitConfig stage2ServiceConfig ]);
+  initrdServices = attrsOf (submodule [ stage1ServiceOptions unitConfig stage1ServiceConfig ]);
 
-  targets = with types; attrsOf (submodule [ stage2CommonUnitOptions unitConfig ]);
-  initrdTargets = with types; attrsOf (submodule [ stage1CommonUnitOptions unitConfig ]);
+  targets = attrsOf (submodule [ stage2CommonUnitOptions unitConfig ]);
+  initrdTargets = attrsOf (submodule [ stage1CommonUnitOptions unitConfig ]);
 
-  sockets = with types; attrsOf (submodule [ stage2SocketOptions unitConfig ]);
-  initrdSockets = with types; attrsOf (submodule [ stage1SocketOptions unitConfig ]);
+  sockets = attrsOf (submodule [ stage2SocketOptions unitConfig ]);
+  initrdSockets = attrsOf (submodule [ stage1SocketOptions unitConfig ]);
 
-  timers = with types; attrsOf (submodule [ stage2TimerOptions unitConfig ]);
-  initrdTimers = with types; attrsOf (submodule [ stage1TimerOptions unitConfig ]);
+  timers = attrsOf (submodule [ stage2TimerOptions unitConfig ]);
+  initrdTimers = attrsOf (submodule [ stage1TimerOptions unitConfig ]);
 
-  paths = with types; attrsOf (submodule [ stage2PathOptions unitConfig ]);
-  initrdPaths = with types; attrsOf (submodule [ stage1PathOptions unitConfig ]);
+  paths = attrsOf (submodule [ stage2PathOptions unitConfig ]);
+  initrdPaths = attrsOf (submodule [ stage1PathOptions unitConfig ]);
 
-  slices = with types; attrsOf (submodule [ stage2SliceOptions unitConfig ]);
-  initrdSlices = with types; attrsOf (submodule [ stage1SliceOptions unitConfig ]);
+  slices = attrsOf (submodule [ stage2SliceOptions unitConfig ]);
+  initrdSlices = attrsOf (submodule [ stage1SliceOptions unitConfig ]);
 
-  mounts = with types; listOf (submodule [ stage2MountOptions unitConfig mountConfig ]);
-  initrdMounts = with types; listOf (submodule [ stage1MountOptions unitConfig mountConfig ]);
+  mounts = listOf (submodule [ stage2MountOptions unitConfig mountConfig ]);
+  initrdMounts = listOf (submodule [ stage1MountOptions unitConfig mountConfig ]);
 
-  automounts = with types; listOf (submodule [ stage2AutomountOptions unitConfig automountConfig ]);
-  initrdAutomounts = with types; attrsOf (submodule [ stage1AutomountOptions unitConfig automountConfig ]);
+  automounts = listOf (submodule [ stage2AutomountOptions unitConfig automountConfig ]);
+  initrdAutomounts = attrsOf (submodule [ stage1AutomountOptions unitConfig automountConfig ]);
 
-  initrdContents = types.attrsOf (types.submodule ({ config, options, name, ... }: {
+  initrdContents = attrsOf (submodule ({ config, options, name, ... }: {
     options = {
-      enable = mkEnableOption (lib.mdDoc "copying of this file and symlinking it") // { default = true; };
+      enable = mkEnableOption (mdDoc "copying of this file and symlinking it") // { default = true; };
 
       target = mkOption {
-        type = types.path;
-        description = lib.mdDoc ''
+        type = path;
+        description = mdDoc ''
           Path of the symlink.
         '';
         default = name;
@@ -49,13 +93,13 @@ rec {
 
       text = mkOption {
         default = null;
-        type = types.nullOr types.lines;
-        description = lib.mdDoc "Text of the file.";
+        type = nullOr lines;
+        description = mdDoc "Text of the file.";
       };
 
       source = mkOption {
-        type = types.path;
-        description = lib.mdDoc "Path of the source file.";
+        type = path;
+        description = mdDoc "Path of the source file.";
       };
     };
 

--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -1,9 +1,44 @@
-{ lib, config, pkgs }: with lib;
+{ lib, config, pkgs }:
+
+let
+  inherit (lib)
+    any
+    attrNames
+    concatMapStringsSep
+    concatStringsSep
+    elem
+    escapeShellArg
+    filter
+    flatten
+    getName
+    hasPrefix
+    hasSuffix
+    imap0
+    imap1
+    isAttrs
+    isDerivation
+    isFloat
+    isInt
+    isList
+    isPath
+    isString
+    listToAttrs
+    nameValuePair
+    optionalString
+    removePrefix
+    removeSuffix
+    replaceStrings
+    stringToCharacters
+    types
+    ;
+
+  inherit (lib.strings) toJSON normalizePath escapeC;
+in
 
 rec {
 
   # Copy configuration files to avoid having the entire sources in the system closure
-  copyFile = filePath: pkgs.runCommand (builtins.unsafeDiscardStringContext (builtins.baseNameOf filePath)) {} ''
+  copyFile = filePath: pkgs.runCommand (builtins.unsafeDiscardStringContext (baseNameOf filePath)) {} ''
     cp ${filePath} $out
   '';
 
@@ -46,11 +81,11 @@ rec {
   escapeSystemdPath = s: let
     replacePrefix = p: r: s: (if (hasPrefix p s) then r + (removePrefix p s) else s);
     trim = s: removeSuffix "/" (removePrefix "/" s);
-    normalizedPath = strings.normalizePath s;
+    normalizedPath = normalizePath s;
   in
     replaceStrings ["/"] ["-"]
-    (replacePrefix "." (strings.escapeC ["."] ".")
-    (strings.escapeC (stringToCharacters " !\"#$%&'()*+,;<=>=@[\\]^`{|}~-")
+    (replacePrefix "." (escapeC ["."] ".")
+    (escapeC (stringToCharacters " !\"#$%&'()*+,;<=>=@[\\]^`{|}~-")
     (if normalizedPath == "/" then normalizedPath else trim normalizedPath)));
 
   # Quotes an argument for use in Exec* service lines.
@@ -62,12 +97,12 @@ rec {
   # substitution for the directive.
   escapeSystemdExecArg = arg:
     let
-      s = if builtins.isPath arg then "${arg}"
-        else if builtins.isString arg then arg
-        else if builtins.isInt arg || builtins.isFloat arg || lib.isDerivation arg then toString arg
+      s = if isPath arg then "${arg}"
+        else if isString arg then arg
+        else if isInt arg || isFloat arg || isDerivation arg then toString arg
         else throw "escapeSystemdExecArg only allows strings, paths, numbers and derivations";
     in
-      replaceStrings [ "%" "$" ] [ "%%" "$$" ] (builtins.toJSON s);
+      replaceStrings [ "%" "$" ] [ "%%" "$$" ] (toJSON s);
 
   # Quotes a list of arguments into a single string for use in a Exec*
   # line.
@@ -197,7 +232,7 @@ rec {
                (attrNames secrets))
     + "\n"
     + "${pkgs.jq}/bin/jq >'${output}' "
-    + lib.escapeShellArg (stringOrDefault
+    + escapeShellArg (stringOrDefault
           (concatStringsSep
             " | "
             (imap1 (index: name: ''${name} = $ENV.secret${toString index}'')
@@ -205,7 +240,7 @@ rec {
           ".")
     + ''
        <<'EOF'
-      ${builtins.toJSON set}
+      ${toJSON set}
       EOF
       (( ! $inherit_errexit_enabled )) && shopt -u inherit_errexit
     '';
@@ -222,9 +257,9 @@ rec {
   */
   removePackagesByName = packages: packagesToRemove:
     let
-      namesToRemove = map lib.getName packagesToRemove;
+      namesToRemove = map getName packagesToRemove;
     in
-      lib.filter (x: !(builtins.elem (lib.getName x) namesToRemove)) packages;
+      filter (x: !(elem (getName x) namesToRemove)) packages;
 
   systemdUtils = {
     lib = import ./systemd-lib.nix { inherit lib config pkgs; };


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is no functional change contained in this PR.

I used the refactor strategy that looks for the uses of names [coming from `lib`](https://gist.github.com/philiptaron/04326000d5ff20cb72c2805efd09701c) and others to verify no regressions. 

Following advice, I also preferred to inherit names from `lib` instead of `builtins` where there was a choice. I also preferred to inherit from `lib` in one place, rather than to have a mixture of `lib.thing` and `inherit (lib) thing`. 

There are no rebuilds when I run `nixpkgs-review rev HEAD`, so I've targeted master with this PR.

## Things done

- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev HEAD`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).