### PR TITLE
sbcl.pkgs.cephes: fix build

### DIFF
--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -243,6 +243,14 @@ let
     '';
   };
 
+  cephes = build-with-compile-into-pwd {
+    inherit (super.cephes) pname version src lispLibs;
+    patches = [ ./patches/cephes-make.patch ];
+    postConfigure = ''
+      substituteAllInPlace cephes.asd
+    '';
+  };
+
   clx-truetype = build-asdf-system {
     pname = "clx-truetype";
     version = "20160825-git";

--- a/pkgs/development/lisp-modules/patches/cephes-make.patch
+++ b/pkgs/development/lisp-modules/patches/cephes-make.patch
@@ -1,0 +1,22 @@
+--- a/cephes.asd
++++ b/cephes.asd
+@@ -5,7 +5,7 @@
+ (defclass makefile (source-file) ((type :initform "m")))
+ (defmethod perform ((o load-op) (c makefile)) t)
+ (defmethod perform ((o compile-op) (c makefile))
+-  (let* ((lib-dir (system-relative-pathname "cephes" "scipy-cephes"))
++  (let* ((lib-dir #P"@out@/scipy-cephes")
+          (lib (make-pathname :directory `(:relative ,(namestring lib-dir))
+                              :name "libmd"
+                              :type #+darwin "dylib" #+(and unix (not darwin)) "so" #+(or windows win32) "dll"))
+@@ -14,7 +14,7 @@
+ 	(format *error-output* "Library ~S exists, skipping build" lib)
+ 	(format *error-output* "Building ~S~%" lib))
+     (unless built
+-      (chdir (native-namestring lib-dir))
++      (chdir "scipy-cephes")
+       (run-program "make" :output t))))
+ 
+ (defsystem "cephes"
+
+Diff finished.  Thu Mar 28 08:13:30 2024


### PR DESCRIPTION
## Description of changes

Fix build of sbcl.pkgs.cephes.

Cephes was required to build lisp-stat.

## Things done

The package could not be built because it was trying to write the DLL into $src. One way to fix that is to build the DLL beforehand. Perhaps "make" could be convinced to put its outputs elsewhere, then the build-with-compile-into-pwd could be swapped for just build-asdf-system. It would have to create $out during buildPhase.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
