### PR TITLE
nixos/rtkit: Add option for rtkit-daemon command-line args

### DIFF
--- a/nixos/modules/security/rtkit.nix
+++ b/nixos/modules/security/rtkit.nix
@@ -1,11 +1,15 @@
 # A module for ‘rtkit’, a DBus system service that hands out realtime
 # scheduling priority to processes that ask for it.
 
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, utils, ... }:
 
 with lib;
 
-{
+let
+  cfg = config.security.rtkit;
+  package = pkgs.rtkit;
+
+in {
 
   options = {
 
@@ -20,19 +24,38 @@ with lib;
       '';
     };
 
+    security.rtkit.args = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      description = ''
+        Command-line options for `rtkit-daemon`.
+      '';
+      example = [
+        "--our-realtime-priority=29"
+        "--max-realtime-priority=28"
+      ];
+    };
+
   };
 
 
-  config = mkIf config.security.rtkit.enable {
+  config = mkIf cfg.enable {
 
     security.polkit.enable = true;
 
     # To make polkit pickup rtkit policies
-    environment.systemPackages = [ pkgs.rtkit ];
+    environment.systemPackages = [ package ];
 
-    systemd.packages = [ pkgs.rtkit ];
+    services.dbus.packages = [ package ];
 
-    services.dbus.packages = [ pkgs.rtkit ];
+    systemd.packages = [ package ];
+
+    systemd.services.rtkit-daemon = {
+      serviceConfig.ExecStart = [
+        ""  # Resets command from upstream unit.
+        "${package}/libexec/rtkit-daemon ${utils.escapeSystemdExecArgs cfg.args}"
+      ];
+    };
 
     users.users.rtkit =
       {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -890,6 +890,7 @@ in {
   rstudio-server = handleTest ./rstudio-server.nix {};
   rsyncd = handleTest ./rsyncd.nix {};
   rsyslogd = handleTest ./rsyslogd.nix {};
+  rtkit = runTest ./rtkit.nix;
   rtorrent = handleTest ./rtorrent.nix {};
   rxe = handleTest ./rxe.nix {};
   sabnzbd = handleTest ./sabnzbd.nix {};

--- a/nixos/tests/rtkit.nix
+++ b/nixos/tests/rtkit.nix
@@ -1,0 +1,216 @@
+{ lib, ... }:
+
+{
+  name = "rtkit";
+
+  meta.maintainers = with lib.maintainers; [ rvl ];
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      assertions = [
+        {
+          assertion = config.security.polkit.enable;
+          message = "rtkit needs polkit to handle authorization";
+        }
+      ];
+
+      imports = [ ./common/user-account.nix ];
+      services.getty.autologinUser = "alice";
+
+      security.rtkit.enable = true;
+
+      # Modified configuration with higher maximum realtime priority.
+      specialisation.withHigherPrio.configuration = {
+        security.rtkit.args = [
+          "--max-realtime-priority=89"
+          "--our-realtime-priority=90"
+        ];
+      };
+
+      # Target process for testing - belongs to a logind session.
+      systemd.user.services.sleeper = {
+        description = "Guinea pig service";
+        serviceConfig = {
+          ExecStart = "@${pkgs.coreutils}/bin/sleep sleep inf";
+          # rtkit-daemon won't grant real-time to threads unless they have a rttime limit.
+          LimitRTTIME = 200000;
+        };
+        wantedBy = [ "default.target" ];
+      };
+
+      # Target process for testing - doesn't belong to a session.
+      systemd.services."sleeper@" = {
+        description = "Guinea pig system service for %I";
+        serviceConfig = {
+          ExecStart = "@${pkgs.coreutils}/bin/sleep sleep inf";
+          LimitRTTIME = 200000;
+          User = "%I";
+        };
+      };
+      systemd.targets.multi-user.wants = [ "sleeper@alice.service" ];
+
+      # Install chrt to check outcomes of rtkit calls
+      environment.systemPackages = [ pkgs.util-linux ];
+
+      # Provide a little logging of polkit checks - otherwise it's
+      # impossible to know what's going on.
+      security.polkit.debug = true;
+      security.polkit.extraConfig = ''
+        polkit.addRule(function(action, subject) {
+          const ns = "org.freedesktop.RealtimeKit1.";
+          const acquireHighPrio = ns + "acquire-high-priority";
+          const acquireRT = ns + "acquire-real-time";
+          if (action.id == acquireHighPrio || action.id == acquireRT) {
+            polkit.log("rtkit: Checking " + action.id + " for " + subject.user + "\n  " + subject);
+          }
+        });
+      '';
+    };
+
+  interactive.nodes.machine =
+    { pkgs, ... }:
+    {
+      security.rtkit.args = [ "--debug" ];
+      systemd.services.strace-rtkit =
+        let
+          target = "rtkit-daemon.service";
+        in
+        {
+          bindsTo = [ target ];
+          after = [ target ];
+          scriptArgs = target;
+          script = ''
+            pid=$(systemctl show -P MainPID $1)
+            strace -tt -s 100 -e trace=all -p $pid
+          '';
+          path = [ pkgs.strace ];
+        };
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      specialisations = "${nodes.machine.system.build.toplevel}/specialisation";
+      uid = toString nodes.machine.users.users.alice.uid;
+    in
+    ''
+      import json
+      import shlex
+      from collections import namedtuple
+      from typing import Any, Optional
+
+      Result = namedtuple("Result", ["command", "machine", "status", "out", "value"])
+      Value = namedtuple("Value", ["type", "data"])
+
+      def busctl(node: Machine, *args: Any, user: Optional[str] = None) -> Result:
+          command = f"busctl --json=short {shlex.join(map(str, args))}"
+          if user is not None:
+              command = f"su - {user} -c {shlex.quote(command)}"
+          (status, out) = node.execute(command)
+          out = out.strip()
+          value = json.loads(out, object_hook=lambda x: Value(**x)) if status == 0 and out else None
+          return Result(command, node, status, out, value)
+
+      def assert_result_success(result: Result):
+          if result.status != 0:
+              result.machine.log(f"output: {result.out}")
+              raise Exception(f"command `{result.command}` failed (exit code {result.status})")
+
+      def assert_result_fail(result: Result):
+          if result.status == 0:
+              raise Exception(f"command `{result.command}` unexpectedly succeeded")
+
+      def rtkit_make_process_realtime(node: Machine, pid: int, priority: int, user: Optional[str] = None) -> Result:
+          return busctl(node, "call", "org.freedesktop.RealtimeKit1", "/org/freedesktop/RealtimeKit1", "org.freedesktop.RealtimeKit1", "MakeThreadRealtimeWithPID", "ttu", pid, 0, priority, user=user)
+
+      def get_max_realtime_priority() -> int:
+          result = busctl(machine, "get-property", "org.freedesktop.RealtimeKit1", "/org/freedesktop/RealtimeKit1", "org.freedesktop.RealtimeKit1", "MaxRealtimePriority")
+          assert_result_success(result)
+          assert result.value.type == "i", f"""Unexpected MaxRealtimePriority property type ({result.value})"""
+          return int(result.value.data)
+
+      def parse_chrt(out: str, field: str) -> str:
+          return next(map(lambda l: l.split(": ")[1], filter(lambda l: field in l, out.splitlines())))
+
+      def get_pid(node: Machine, unit: str, user: Optional[str] = None) -> int:
+          node.wait_for_unit(unit, user=user)
+          (status, out) = node.systemctl(f"show -P MainPID {unit}", user=user)
+          if status == 0:
+              return int(out.strip())
+          else:
+              node.log(out)
+              raise Exception(f"unable to determine MainPID of {unit} (systemctl exit code {status})")
+
+      def assert_sched(node: Machine, pid: int, policy: Optional[str] = None, priority: Optional[int] = None):
+          out = node.succeed(f"chrt -p {pid}")
+          node.log(out)
+          if policy is not None:
+              thread_policy = parse_chrt(out, "policy")
+              assert policy in thread_policy, f"Expected {policy} scheduling policy, but got: {thread_policy}"
+          if priority is not None:
+              thread_priority = parse_chrt(out, "priority")
+              assert str(priority) == thread_priority, f"Expected scheduling priority {priority}, but got: {thread_priority}"
+
+      machine.wait_for_unit("basic.target")
+
+      rtprio = 20
+      higher_rtprio = 42
+      max_rtprio = get_max_realtime_priority()
+
+      with subtest("maximum sched_rr priority"):
+          assert max_rtprio >= rtprio, f"""MaxRealtimePriority ({max_rtprio}) too low"""
+          assert higher_rtprio > max_rtprio, f"""Test value higher_rtprio ({higher_rtprio}) insufficient compared to MaxRealtimePriority ({max_rtprio})"""
+
+      # wait for autologin and systemd user service manager
+      machine.wait_for_unit("multi-user.target")
+      machine.wait_for_unit("user@${uid}.service")
+
+      with subtest("polkit sanity check"):
+          pid = get_pid(machine, "sleeper.service", user="alice")
+          machine.succeed(f"pkcheck -p {pid} -a org.freedesktop.RealtimeKit1.acquire-real-time")
+
+      with subtest("chrt sanity check"):
+          print(machine.succeed("chrt --rr --max"))
+          pid = get_pid(machine, "sleeper.service", user="alice")
+          machine.succeed(f"chrt --rr --pid {rtprio} {pid}")
+          assert_sched(machine, pid, policy="SCHED_RR", priority=rtprio)
+          machine.stop_job("sleeper.service", user="alice")
+          machine.start_job("sleeper.service", user="alice")
+
+      # Permission granted by policy from rtkit package.
+      with subtest("local user process can acquire real-time scheduling"):
+          pid = get_pid(machine, "sleeper.service", user="alice")
+          result = rtkit_make_process_realtime(machine, pid, rtprio, user="alice")
+          assert_result_success(result)
+          assert_sched(machine, pid, policy="SCHED_RR", priority=rtprio)
+
+      # User must not get higher priority than the maximum
+      with subtest("real-time scheduling priority is limited"):
+          machine.stop_job("sleeper.service", user="alice")
+          machine.start_job("sleeper.service", user="alice")
+          pid = get_pid(machine, "sleeper.service", user="alice")
+          with machine.nested("rtkit call must fail"):
+              result = rtkit_make_process_realtime(machine, pid, max_rtprio + 1, user="alice")
+              assert_result_fail(result)
+          assert_sched(machine, pid, policy="SCHED_OTHER")
+
+      # This is a local shop for local people - we'll have no trouble here.
+      # In this test, the target process belongs to alice, but doesn't
+      # have a user session, so it's considered non-local.
+      with subtest("non-local user process cannot acquire real-time scheduling"):
+          pid = get_pid(machine, "sleeper@alice.service")
+          with machine.nested("rtkit call must fail"):
+              result = rtkit_make_process_realtime(machine, pid, rtprio, "alice")
+              assert_result_fail(result)
+          assert_sched(machine, pid, policy="SCHED_OTHER")
+
+      # Switch to alternate configuration then ask for higher priority.
+      with subtest("command-line arguments allow increasing maximum rtprio"):
+          machine.succeed("${specialisations}/withHigherPrio/bin/switch-to-configuration test")
+          pid = get_pid(machine, "sleeper.service", user="alice")
+          result = rtkit_make_process_realtime(machine, pid, higher_rtprio, user="alice")
+          assert_result_success(result)
+          assert_sched(machine, pid, policy="SCHED_RR", priority=higher_rtprio)
+    '';
+}


### PR DESCRIPTION
## Description of changes

When configuring rtkit for realtime audio with pipewire (following [FAQ: How to change rtkit rtprio](https://gitlab.freedesktop.org/pipewire/pipewire/-/wikis/FAQ#how-to-change-rtkit-rtprio)) , I found it necessary to adjust the command-line arguments of `rtkit-daemon`.

This option makes it easier to do.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
