### PR TITLE
mysql-backup init at 1.0.0-rc3

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -99,6 +99,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [transfer-sh](https://github.com/dutchcoders/transfer.sh), a tool that supports easy and fast file sharing from the command-line. Available as [services.transfer-sh](#opt-services.transfer-sh.enable).
 
+- [mysql-backup](https://github.com/databacker/mysql-backup/), a tool for creating and managing backups of MySQL databases. Available as [services.databacker-mysql-backup](#opt-services.databacker-mysql-backup.enable).
+
 - [Suwayomi Server](https://github.com/Suwayomi/Suwayomi-Server), a free and open source manga reader server that runs extensions built for [Tachiyomi](https://tachiyomi.org). Available as [services.suwayomi-server](#opt-services.suwayomi-server.enable).
 
 - [ping_exporter](https://github.com/czerwonk/ping_exporter), a Prometheus exporter for ICMP echo requests. Available as [services.prometheus.exporters.ping](#opt-services.prometheus.exporters.ping.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -370,6 +370,7 @@
   ./services/backup/borgbackup.nix
   ./services/backup/borgmatic.nix
   ./services/backup/btrbk.nix
+  ./services/backup/databacker-mysql-backup.nix
   ./services/backup/duplicati.nix
   ./services/backup/duplicity.nix
   ./services/backup/mysql-backup.nix

--- a/nixos/modules/services/backup/databacker-mysql-backup.md
+++ b/nixos/modules/services/backup/databacker-mysql-backup.md
@@ -1,0 +1,53 @@
+# Databacker's MySQL Backup {#module-databacker-mysql-backup}
+
+*Source:* {file}`modules/services/backup/databacker-mysql-backup.nix`
+
+*Upstream documentation:* <https://github.com/databacker/mysql-backup/blob/master/README.md>
+
+
+[mysql-backup](https://github.com/databacker/mysql-backup) is a simple way to do
+MySQL database backups and restores, as well as manage your backups.
+
+It has the following features:
+
+* dump and restore
+* dump to local filesystem or to SMB server
+* select database user and password
+* connect to any container running on the same system
+* select how often to run a dump
+* select when to start the first dump, whether time of day or relative to container start time
+* prune backups older than a specific time period or quantity
+
+
+The NixOS module allows you to easily configure a systemd service that will
+backup your MySQL databases (remotely or locally) and store the dumps on a local
+disk, remote samba fs, or AWS S3 compatible service.
+
+If configured with retention settings, the service will automatically prune old backups.
+
+## Configuring {#module-services-backup-databacker-mysql-backup-configuring}
+
+A complete list of options for the MySQL Backup module may be found
+[here](#opt-services.databacker-mysql-backup).
+
+## Basic usage for a local backup {#opt-services-backup-databacker-mysql-backup-local-directory}
+
+A very basic configuration for backing up to a locally accessible directory is:
+
+```
+{
+    services.mysql = {
+      enable = true;
+      package = pkgs.mariadb;
+    }
+
+    services.databacker-mysql-backup = {
+      enable = true;
+      cron = "15 1 * * *"
+    };
+}
+```
+
+This will backup *all* schemas in the local mysql instance at 1:15 everyday. The
+backups will be stored in `/var/backup/mysql`, and will *NOT* be pruned by
+default.

--- a/nixos/modules/services/backup/databacker-mysql-backup.nix
+++ b/nixos/modules/services/backup/databacker-mysql-backup.nix
@@ -1,0 +1,406 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.databacker-mysql-backup;
+
+  defaultUser = "mysqlbackup";
+
+  dumpTargetIsLocalDir =
+    lib.isPath cfg.dumpTarget
+    || lib.isString cfg.dumpTarget && builtins.substring 0 1 cfg.dumpTarget == "/";
+
+  mysqlBackupEnvVars = lib.generators.toKeyValue {
+    mkKeyValue = lib.flip lib.generators.mkKeyValueDefault "=" {
+      mkValueString =
+        v:
+        if builtins.isInt v then
+          toString v
+        else if lib.isString v then
+          "\"${v}\""
+        else if true == v then
+          "true"
+        else if false == v then
+          "false"
+        else if null == v then
+          ""
+        else
+          throw "unsupported type ${builtins.typeOf v}: ${(lib.generators.toPretty { }) v}";
+    };
+  };
+  filteredConfig = lib.converge (lib.filterAttrsRecursive (
+    _: v:
+    !lib.elem v [
+      { }
+      null
+    ]
+  )) cfg.config;
+  mysqlBackupEnv = pkgs.writeText "mysqlBackup.env" (mysqlBackupEnvVars filteredConfig);
+in
+{
+  options = {
+    services.databacker-mysql-backup = {
+      enable = lib.mkEnableOption (lib.mdDoc "MySQL backups with databacker's mysql-backup");
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = defaultUser;
+        description = lib.mdDoc ''
+          User to be used to perform backup.
+        '';
+      };
+
+      package = lib.mkPackageOption pkgs "mysql-backup" { };
+
+      dumpTarget = lib.mkOption {
+        type = lib.types.either lib.types.path lib.types.str;
+        default = "/var/backup/mysql";
+        example = ''
+          /var/backup/mysql
+          smb://hostname/share/path/
+          s3://bucketname.fqdn.com/path
+        '';
+        description = lib.mdDoc ''
+          Where to put the dump files. If a path or a string starting with /, then it will be treated as a local directory. Otherwise mysql-backup will treat it as a url (for example smb:// or s3://)
+        '';
+      };
+
+      retention = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "3d";
+        description = lib.mdDoc ''
+          How long to keep the dumps. If null (the default), no pruning is done and all backups are kept.
+          Refer to the [documentation](https://github.com/databacker/mysql-backup/blob/master/docs/prune.md) for the format.
+        '';
+      };
+
+      databases = lib.mkOption {
+        default = null;
+        type = lib.types.nullOr (lib.types.listOf lib.types.str);
+        description = lib.mdDoc ''
+          List of database names to dump, or null to dump all databases (the default).
+        '';
+      };
+
+      frequency = lib.mkOption {
+        type = lib.types.nullOr lib.types.int;
+        default = null;
+        example = "60";
+        description = lib.mdDoc ''
+          How often to do a dump, in minutes.  Mutually exclusive with
+          `services.databacker-mysql-backup.cron`.
+        '';
+      };
+
+      begin = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "+10";
+        description = lib.mdDoc ''
+          What time to do the first dump. Must be in one of two formats: Absolute: HHMM,
+          e.g. 2330 or `0415`; or Relative: +MM, i.e. how many minutes after starting the
+          container, e.g. `+0` (immediate), `+10` (in 10 minutes), or `+90` in an hour and
+          a half (default "+0") Mutually exclusive with
+          `services.databacker-mysql-backup.cron`.
+
+        '';
+      };
+
+      cron = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "15 1 * * *";
+        description = lib.mdDoc ''
+          Cron schedule for dumps and prunes.  Mutually exclusive with
+          `services.databacker-mysql-backup.frequency` and `.begin`.
+        '';
+      };
+
+      useLocalMySQL = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = lib.mdDoc ''
+          Automatically connect to and use the local MySQL (managed by
+          `services.mysql`). If set to false, you must provide connection and
+          credentials.
+        '';
+      };
+
+      localUserPrivs = lib.mkOption {
+        type = lib.types.str;
+        default = "SELECT, SHOW VIEW, TRIGGER, LOCK TABLES";
+        description = lib.mdDoc ''
+          Privileges to grant to the local MySQL user. Only relevant when
+          `services.databacker-mysql-backup.useLocalMySQL` is set to `true`.
+          Note that if `databases` is null (so all dbs should be backed up),
+          then `SHOW DATABASES` will be automatically added to this list.
+        '';
+      };
+
+      mysql = {
+        host = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "mysql.example.com";
+          description = lib.mdDoc ''
+            MySQL server to connect to.
+            Only required when `services.databacker-mysql-backup.useLocalMySQL` is set to `false`.
+          '';
+        };
+
+        port = lib.mkOption {
+          type = lib.types.nullOr lib.types.port;
+          default = 3306;
+          description = lib.mdDoc ''
+            MySQL server port to connect to.
+            Only required when `services.databacker-mysql-backup.useLocalMySQL` is set to `false`.
+          '';
+        };
+
+        user = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "root";
+          description = lib.mdDoc ''
+            MySQL user to connect as.
+            Only required when `services.databacker-mysql-backup.useLocalMySQL` is set to `false`.
+          '';
+        };
+
+        passwordFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          example = "/run/secrets/mysql-backup-password";
+          description = lib.mdDoc ''
+            Path to a file containing the MySQL user's password.
+            Only required when `services.databacker-mysql-backup.useLocalMySQL` is set to `false`.
+          '';
+        };
+      };
+
+      extraConfigFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/etc/mysql-backup/extra.yaml";
+        description = lib.mdDoc ''
+          Path to an extra configuration file for mysql-backup. This file will be included in the final configuration file alongside the other options.
+        '';
+      };
+
+      configFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/etc/mysql-backup/config.yaml";
+        description = lib.mdDoc ''
+          Path to the configuration file for mysql-backup. Use this for complete control over the configuration. If set, all other options affecting the configuration will be ignored.
+        '';
+      };
+      config = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.nullOr (
+            lib.types.oneOf [
+              lib.types.bool
+              lib.types.int
+              lib.types.port
+              lib.types.path
+              lib.types.str
+            ]
+          )
+        );
+        default = { };
+        example = ''
+          {
+            DB_DUMP_COMPRESSION = "bzip2";
+            DB_DUMP_DEBUG = true;
+            DB_DUMP_NICE = 10;
+          }
+        '';
+        description = lib.mdDoc ''
+          Extra configuration for the mysql-backup service. Use the environment variable
+          format described in the [mysql-backup
+          documentation](https://github.com/databacker/mysql-backup/blob/master/docs/configuration.md)
+
+          **WARNING**: This config will be writtten to the globally-readable nix store, so
+          do not include secrets in it. Instead use
+          `services.databacker-mysql-backup.extraConfigFile`.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions =
+      let
+        keyMatches = key: (builtins.match ".*access_key.*|.*secret.*|.*pass.*" (lib.toLower key)) != null;
+        matchingKeys = lib.filter keyMatches (lib.attrNames cfg.config);
+      in
+      [
+        {
+          assertion = builtins.length matchingKeys == 0;
+          message = "You have keys in `services.databacker-mysql-backup.config` that look like they might be secrets. Please use `services.databacker-mysql-backup.extraConfigFile` instead.";
+        }
+        {
+          assertion = (cfg.frequency != null) -> cfg.frequency >= 1;
+          message = "The `services.databacker-mysql-backup.frequency` must be 1 or greater";
+        }
+        {
+          assertion = cfg.configFile == null -> (cfg.cron != null) != (cfg.frequency != null);
+          message = "You must set one of `services.databacker-mysql-backup.cron` or both `.frequency` and `begin`.";
+        }
+        {
+          assertion = (cfg.cron != null) -> cfg.frequency == null && cfg.begin == null;
+          message = "You cannot set both `services.databacker-mysql-backup.cron` and `frequency`/`begin`";
+        }
+        {
+          assertion = (cfg.frequency != null) -> cfg.begin != null;
+          message = "If you set `services.databacker-mysql-backup.frequency` you also need to set `.begin`";
+        }
+        {
+          assertion = (cfg.begin != null) -> cfg.frequency != null;
+          message = "If you set `services.databacker-mysql-backup.begin` you also need to set `.frequency`";
+        }
+        {
+          assertion = !(cfg.configFile != null && cfg.extraConfigFile != null);
+          messsage = "You cannot set both `services.databacker-mysql-backup.configFile` and `services.databacker-mysql-backup.extraConfigFile` at the same time.";
+        }
+        {
+          assertion =
+            cfg.useLocalMySQL
+            -> (cfg.mysql.host == null && cfg.mysql.user == null && cfg.mysql.passwordFile == null);
+          message = "If `services.databacker-mysql-backup.useLocalMySQL` is set to `true`, you must not set an options under `services.databacker-mysql-backup.mysql.*`.";
+        }
+        {
+          assertion =
+            !cfg.useLocalMySQL
+            -> (cfg.mysql.host != null && cfg.mysql.user != null && cfg.mysql.passwordFile != null);
+          message = "If `services.databacker-mysql-backup.useLocalMySQL` is set to `true`, you must not set an options under `services.databacker-mysql-backup.mysql.*`.";
+        }
+      ];
+
+    users.users = lib.optionalAttrs (cfg.user == defaultUser) {
+      ${defaultUser} = {
+        isSystemUser = true;
+        createHome = false;
+        group = "nogroup";
+      };
+    };
+
+    services.mysql = lib.mkIf cfg.useLocalMySQL {
+      ensureUsers = [
+        {
+          name = cfg.user;
+          ensurePermissions =
+            let
+              grant = db: lib.nameValuePair "${db}.*" cfg.localUserPrivs;
+            in
+            if cfg.databases == null then
+              { "*.*" = cfg.localUserPrivs + ", SHOW DATABASES"; }
+            else
+              lib.listToAttrs (map grant cfg.databases);
+        }
+      ];
+    };
+
+    services.databacker-mysql-backup.config =
+      lib.optionalAttrs (cfg.configFile == null) {
+        DB_DUMP_TARGET = cfg.dumpTarget;
+        DB_NAMES = if cfg.databases == null then "" else lib.concatStringsSep "," cfg.databases;
+      }
+      // lib.optionalAttrs (cfg.cron != null) { DB_DUMP_CRON = cfg.cron; }
+      // lib.optionalAttrs (cfg.frequency != null) {
+        DB_DUMP_FREQ = cfg.frequency;
+        DB_DUMP_BEGIN = cfg.begin;
+      }
+      // lib.optionalAttrs (cfg.retention != null) { RETENTION = cfg.retention; }
+      // (
+        if cfg.useLocalMySQL then
+          {
+            DB_SERVER = "/run/mysqld/mysqld.sock";
+            DB_USER = cfg.user;
+          }
+        else
+          {
+            DB_SERVER = cfg.mysql.host;
+            DB_PORT = toString cfg.mysql.port;
+            DB_USER = cfg.mysql.user;
+          }
+      );
+
+    systemd.services.databacker-mysql-backup = {
+      description = "MySQL Backup Service from databacker";
+      enable = true;
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ] ++ lib.optional cfg.useLocalMySQL "mysql.service";
+      requires = lib.optional cfg.useLocalMySQL "mysql.service";
+      serviceConfig = {
+        EnvironmentFile = mysqlBackupEnv;
+        User = cfg.user;
+        Restart = "on-failure";
+        RestartSec = "5s";
+        ReadWritePaths = lib.optional dumpTargetIsLocalDir cfg.dumpTarget;
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectHostname = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        PrivateMounts = true;
+        SystemCallArchitectures = "native";
+        LoadCredential =
+          [ ]
+          ++ lib.optionals (cfg.mysql.passwordFile != null) [ "DB_PASS:${cfg.mysql.passwordFile}" ];
+      };
+      script =
+        let
+          # is there a better way to get the first non-null value?
+          activeConfigFile = lib.foldr (x: y: if x != null then x else y) null [
+            cfg.configFile
+            cfg.extraConfigFile
+          ];
+          args = lib.optionalString (activeConfigFile != null) (
+            lib.escapeShellArgs [
+              "--config-file"
+              activeConfigFile
+            ]
+          );
+        in
+        ''
+          if [ -d "$CREDENTIALS_DIRECTORY" ]; then
+            for file in "$CREDENTIALS_DIRECTORY"/*; do
+                if [ ! -f "$file" ]; then
+                    continue
+                fi
+                filename=$(basename -- "$file")
+                content=$(cat "$file")
+                # Export an environment variable with the name of the file and content as its value
+                declare "$filename=$content"
+                export "$filename"
+            done
+          fi
+          env
+          ${lib.getExe cfg.package} dump ${args}
+        '';
+    };
+    systemd.tmpfiles = lib.mkIf dumpTargetIsLocalDir {
+      rules = [ "d ${cfg.dumpTarget} 0700 ${cfg.user} - - -" ];
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -233,6 +233,7 @@ in {
   croc = handleTest ./croc.nix {};
   darling = handleTest ./darling.nix {};
   dae = handleTest ./dae.nix {};
+  databacker-mysql-backup = handleTest ./databacker-mysql-backup.nix { };
   dconf = handleTest ./dconf.nix {};
   deconz = handleTest ./deconz.nix {};
   deepin = handleTest ./deepin.nix {};

--- a/nixos/tests/databacker-mysql-backup.nix
+++ b/nixos/tests/databacker-mysql-backup.nix
@@ -1,0 +1,187 @@
+{
+  system ? builtins.currentSystem,
+  config ? { },
+  pkgs ? import ../.. { inherit system config; },
+}:
+
+with import ../lib/testing-python.nix { inherit system pkgs; };
+let
+  lib = pkgs.lib;
+  mysqlBackupTest =
+    {
+      mysqlBackupConfig,
+      withNoDbName ? false,
+      withRemoteUser ? false,
+    }:
+    makeTest {
+      name = "databacker-mysql-backup";
+      meta.maintainers = with lib.maintainers; [ ramblurr ];
+      nodes.machine =
+        { config, pkgs, ... }:
+        lib.mkMerge [
+          mysqlBackupConfig
+          {
+            environment.systemPackages = with pkgs; [ mysql-backup ];
+            services.mysql = {
+              package = pkgs.mariadb;
+              enable = true;
+              initialScript = pkgs.writeText "mysql-init.sql" ''
+                create user if not exists 'mysql-backup-remote'@'localhost' identified with mysql_native_password;
+                alter user 'mysql-backup-remote'@'localhost' identified by 'hunter2';
+                grant all privileges on *.* to 'mysql-backup-remote'@'localhost';
+                create database test_db default character set utf8mb4;
+                use test_db;
+                create table t1
+                  (id int, name varchar(20), d date, t time, dt datetime, ts timestamp);
+                  insert into t1 (id,name,d,t,dt,ts)
+                  values
+                  (1, "John", "2012-11-01", "00:15:00", "2012-11-01 00:15:00", "2012-11-01 00:15:00"),
+                  (2, "Jill", "2012-11-02", "00:16:00", "2012-11-02 00:16:00", "2012-11-02 00:16:00"),
+                  (3, "Sam", "2012-11-03", "00:17:00", "2012-11-03 00:17:00", "2012-11-03 00:17:00"),
+                  (4, "Sarah", "2012-11-04", "00:18:00", "2012-11-04 00:18:00", "2012-11-04 00:18:00");
+              '';
+
+              settings = {
+                mysqld = {
+                  character-set-server = "utf8mb4";
+                  collation-server = "utf8mb4_unicode_ci";
+                  log_warnings = 1;
+                };
+              };
+            };
+          }
+        ];
+
+      testScript =
+        ''
+          start_all()
+          machine.wait_for_unit("mysql")
+          machine.wait_for_unit("databacker-mysql-backup")
+        ''
+        + (
+          if withRemoteUser then
+            ''
+              machine.fail("mysql -e 'SHOW GRANTS FOR 'mysqlbackup'@'localhost';' | grep -E 'GRANT SELECT.*LOCK.*SHOW VIEW.*TRIGGER.*mysqlbackup' ")
+            ''
+          else
+            ''
+              machine.succeed("mysql -e 'SHOW GRANTS FOR 'mysqlbackup'@'localhost';' | grep -E 'GRANT SELECT.*LOCK.*SHOW VIEW.*TRIGGER.*mysqlbackup' ")
+            ''
+        )
+        + ''
+          machine.sleep(5)
+          machine.succeed("[ -d /var/backup/mysql ]")
+          print(machine.succeed("find /var/backup/mysql -type f -name 'db_backup*.tgz' -exec tar -xzvf {} -C /var/backup/mysql \;"))
+          print(machine.succeed("ls -al /var/backup/mysql"))
+          machine.succeed("find /var/backup/mysql -type f -name 'test_db*.sql' -exec cat {} \; | grep Jill")
+          print(machine.succeed("find /var/backup/mysql -type f -name 'test_db*.sql' -exec cat {} \;"))
+
+        ''
+        + (
+          if withNoDbName then
+            ''
+              machine.fail("find /var/backup/mysql -type f -name 'test_db*.sql' -exec cat {} \; | grep 'USE `test_db`'")
+            ''
+          else
+            ''
+              machine.succeed("find /var/backup/mysql -type f -name 'test_db*.sql' -exec cat {} \; | grep 'USE `test_db`'")
+            ''
+        )
+        + ''
+          machine.fail("find /var/backup/mysql -type f -name 'test_db*.sql' -exec cat {} \; | grep DOES_NOT_EXIST")
+        '';
+    }
+    // { };
+in
+{
+  # Most simple configuration
+  test1 = mysqlBackupTest {
+    mysqlBackupConfig = {
+      services.databacker-mysql-backup = {
+        enable = true;
+        frequency = 60;
+        begin = "+0";
+      };
+    };
+  };
+  # Test that applying a config works
+  test2 = mysqlBackupTest {
+    withNoDbName = true;
+    mysqlBackupConfig = {
+      services.databacker-mysql-backup = {
+        enable = true;
+        frequency = 60;
+        begin = "+0";
+        databases = [ "test_db" ];
+        config = {
+          DB_DUMP_NO_DATABASE_NAME = true;
+        };
+      };
+    };
+  };
+  # Test MySQL over TCP
+  test3 = mysqlBackupTest {
+    withRemoteUser = true;
+    mysqlBackupConfig = {
+      systemd.services.databacker-mysql-backup.after = [ "mysql.service" ];
+      systemd.services.databacker-mysql-backup.requires = [ "mysql.service" ];
+      services.databacker-mysql-backup = {
+        enable = true;
+        frequency = 60;
+        begin = "+0";
+        useLocalMySQL = false;
+        mysql = {
+          host = "127.0.0.1";
+          user = "mysql-backup-remote";
+          passwordFile = "${pkgs.writeText "mysql-backup-pass" "hunter2"}";
+        };
+      };
+    };
+  };
+  # Test external config file
+  test4 = mysqlBackupTest {
+    mysqlBackupConfig = {
+      services.databacker-mysql-backup = {
+        enable = true;
+        configFile = pkgs.writeText "mysql-backup-conf.yaml" ''
+          ---
+          type: config.databack.io
+          version: 1
+          logging: info
+          dump:
+            schedule:
+              frequency: 1
+              begin: +0
+            targets:
+              - local
+          database:
+            server: /run/mysqld/mysqld.sock
+          targets:
+            local:
+              type: file
+              url: file:///var/backup/mysql
+
+        '';
+      };
+    };
+  };
+  # Test extraConfig
+  test5 = mysqlBackupTest {
+    withNoDbName = true;
+    mysqlBackupConfig = {
+      services.databacker-mysql-backup = {
+        enable = true;
+        frequency = 60;
+        begin = "+0";
+        databases = [ "test_db" ];
+        extraConfigFile = pkgs.writeText "mysql-backup-extra-conf.yaml" ''
+          ---
+          type: config.databack.io
+          version: 1
+          dump:
+            no-database-name: true
+        '';
+      };
+    };
+  };
+}

--- a/pkgs/by-name/my/mysql-backup/package.nix
+++ b/pkgs/by-name/my/mysql-backup/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+}:
+
+buildGoModule rec {
+  name = "mysql-backup";
+  version = "1.0.0-rc3";
+
+  src = fetchFromGitHub {
+    owner = "ramblurr";
+    repo = "mysql-backup";
+    rev = "da43226cce801e488efcf037529084f6da13df44";
+    hash = "sha256-gAJ05sWeo4MqG6rJXfArOypU1M8FHIzp5lLM560EsTo=";
+  };
+
+  vendorHash = "sha256-2pa9DKnkAhyF/XyDpPCcXJZbSaWQWoSsk3uTUEJAxPc=";
+
+  meta = {
+    description = "A simple way to manage MySQL backups and restores";
+    changelog = "https://github.com/databacker/mysql-backup/releases/tag/v${version}";
+    homepage = "https://github.com/databacker/mysql-backup";
+    license = lib.licenses.mit;
+    mainProgram = "mysql-backup";
+    maintainers = with lib.maintainers; [ ramblurr ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This PR introduces a new package [`mysql-backup`](https://github.com/databacker/mysql-backup) and a nixos module `services.databacker-mysql-backup` to configure it.

### A few notes:

1. This PR is in draft mode until [an upstream PR](https://github.com/databacker/mysql-backup/pull/286) is  merged that patches `mysql-backup` to enable it to connect over the local unix domain socket.
2. I am submitting the PR now in hopes to start a review of the NixOS module.
3. Once that PR is merged and a new release is made I will update the package  (the module does not need updating) to point to upstream (not my fork)
4. I've included extensive tests for the module

### Module name conflict

There already exists a [`services.mysqlBackup`](https://search.nixos.org/options?channel=23.11&from=0&size=50&sort=relevance&type=packages&query=services.mysqlBackup) module that is a small collection of bash scripts. This PR does not have anything to do with that module. 

**But then why add this module if `services.mysqlBackup` already exists?**

I think this comparison table speaks for itself:

| Feature                                                    | `services.mysqlBackup` | `services.databacker-mysql-backup` (this PR) |
|------------------------------------------------------------|------------------------|----------------------------------------------|
| Backup local databases by name                             | x                      | x                                            |
| Backup to a local directory                                | x                      | x                                            |
| Prune and rotate backups according to a retention schedule |                        | x                                            |
| Backup all local databases without enumeration             |                        | x                                            |
| Backup remote databases                                    |                        | x                                            |
| Backup to S3-compat endpoint                               |                        | x                                            |
| Backup to Samba share                                      |                        | x                                            |


Also, I am not happy with the name `services.databacker-mysql-backup` but I thought that `services.mysql-backup`, while available was too close to the existing `services.mysqlBackup`. I'm open to better name suggestions, but please no bike shedding.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
