### PR TITLE
gonic: 0.15.2 -> 0.16.4

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -215,6 +215,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
   release notes of [v19](https://github.com/systemd/mkosi/releases/tag/v19) and
   [v20](https://github.com/systemd/mkosi/releases/tag/v20) for a list of changes.
 
+- `gonic` has been updated to v0.16.4. Config now requires `playlists-path` to be set. See the rest of the [v0.16.0 release notes](https://github.com/sentriz/gonic/releases/tag/v0.16.0) for more details.
+
 - The `services.vikunja` systemd service now uses `vikunja` as dynamic user instead of `vikunja-api`. Database users might need to be changed.
 
 - The `services.vikunja.setupNginx` setting has been removed. Users now need to setup the webserver configuration on their own with a proxy pass to the vikunja service.

--- a/nixos/modules/services/audio/gonic.nix
+++ b/nixos/modules/services/audio/gonic.nix
@@ -55,6 +55,9 @@ in
         RuntimeDirectory = "gonic";
         RootDirectory = "/run/gonic";
         ReadWritePaths = "";
+        BindPaths = [
+          cfg.settings.playlists-path
+        ];
         BindReadOnlyPaths = [
           # gonic can access scrobbling services
           "-/etc/resolv.conf"

--- a/nixos/tests/gonic.nix
+++ b/nixos/tests/gonic.nix
@@ -2,11 +2,19 @@ import ./make-test-python.nix ({ pkgs, ... }: {
   name = "gonic";
 
   nodes.machine = { ... }: {
+    systemd.tmpfiles.settings = {
+      "10-gonic" = {
+        "/tmp/music"."d" = {};
+        "/tmp/podcast"."d" = {};
+        "/tmp/playlists"."d" = {};
+      };
+    };
     services.gonic = {
       enable = true;
       settings = {
-        music-path = [ "/tmp" ];
-        podcast-path = "/tmp";
+        music-path = [ "/tmp/music" ];
+        podcast-path = "/tmp/podcast";
+        playlists-path = "/tmp/playlists";
       };
     };
   };

--- a/pkgs/servers/gonic/default.nix
+++ b/pkgs/servers/gonic/default.nix
@@ -13,17 +13,17 @@
 
 buildGoModule rec {
   pname = "gonic";
-  version = "0.15.2";
+  version = "0.16.4";
   src = fetchFromGitHub {
     owner = "sentriz";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-lyKKD6Rxr4psFUxqGTtqQ3M/vQXoNPbcg0cTam9MkXk=";
+    sha256 = "sha256-+8rKODoADU2k1quKvbijjs/6S/hpkegHhG7Si0LSE0k=";
   };
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ taglib zlib ];
-  vendorHash = "sha256-+PUKPqW+ER7mmZXrDIc0cE4opoTxA3po3WXSeZO+Xwo=";
+  vendorHash = "sha256-6JkaiaAgtXYAZqVSRZJFObZvhEsHsbPaO9pwmKqIhYI=";
 
   # TODO(Profpatsch): write a test for transcoding support,
   # since it is prone to break
@@ -39,6 +39,11 @@ buildGoModule rec {
       --replace \
         '"mpv"' \
         '"${lib.getBin mpv}/bin/mpv"'
+  '' + ''
+    substituteInPlace server/ctrlsubsonic/testdata/test* \
+      --replace \
+        '"audio/flac"' \
+        '"audio/x-flac"'
   '';
 
   passthru = {

--- a/pkgs/servers/gonic/default.nix
+++ b/pkgs/servers/gonic/default.nix
@@ -54,7 +54,7 @@ buildGoModule rec {
     homepage = "https://github.com/sentriz/gonic";
     description = "Music streaming server / subsonic server API implementation";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ autrimpo ];
     platforms = lib.platforms.linux;
     mainProgram = "gonic";
   };


### PR DESCRIPTION
## Description of changes

Updates gonic to the latest version, with corresponding module/test fixes. Also adds myself as the maintainer since the package is currently without one.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
