### PR TITLE
ida-free: init at `8.4.240320`

### DIFF
--- a/pkgs/by-name/id/ida-free/package.nix
+++ b/pkgs/by-name/id/ida-free/package.nix
@@ -1,0 +1,133 @@
+{ autoPatchelfHook
+, cairo
+, copyDesktopItems
+, dbus
+, fetchurl
+, fontconfig
+, freetype
+, glib
+, gtk3
+, lib
+, libdrm
+, libGL
+, libkrb5
+, libsecret
+, libsForQt5
+, libunwind
+, libxkbcommon
+, makeDesktopItem
+, makeWrapper
+, openssl
+, stdenv
+, xorg
+, zlib
+}:
+
+let
+  srcs = builtins.fromJSON (builtins.readFile ./srcs.json);
+in
+stdenv.mkDerivation rec {
+  pname = "ida-free";
+  version = "8.4.240320";
+
+  src = fetchurl {
+    inherit (srcs.${stdenv.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}")) urls sha256;
+  };
+
+  icon = fetchurl {
+    urls = [
+      "https://www.hex-rays.com/products/ida/news/8_1/images/icon_free.png"
+      "https://web.archive.org/web/20221105181231if_/https://hex-rays.com/products/ida/news/8_1/images/icon_free.png"
+    ];
+    sha256 = "sha256-widkv2VGh+eOauUK/6Sz/e2auCNFAsc8n9z0fdrSnW0=";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "ida-free";
+    exec = "ida64";
+    icon = icon;
+    comment = meta.description;
+    desktopName = "IDA Free";
+    genericName = "Interactive Disassembler";
+    categories = [ "Development" ];
+  };
+
+  nativeBuildInputs = [ makeWrapper copyDesktopItems autoPatchelfHook libsForQt5.wrapQtAppsHook ];
+
+  # We just get a runfile in $src, so no need to unpack it.
+  dontUnpack = true;
+
+  # Add everything to the RPATH, in case IDA decides to dlopen things.
+  runtimeDependencies = [
+    cairo
+    dbus
+    fontconfig
+    freetype
+    glib
+    gtk3
+    libdrm
+    libGL
+    libkrb5
+    libsecret
+    libsForQt5.qtbase
+    libunwind
+    libxkbcommon
+    openssl
+    stdenv.cc.cc
+    xorg.libICE
+    xorg.libSM
+    xorg.libX11
+    xorg.libXau
+    xorg.libxcb
+    xorg.libXext
+    xorg.libXi
+    xorg.libXrender
+    xorg.xcbutilimage
+    xorg.xcbutilkeysyms
+    xorg.xcbutilrenderutil
+    xorg.xcbutilwm
+    zlib
+  ];
+  buildInputs = runtimeDependencies;
+
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib $out/opt
+
+    # IDA depends on quite some things extracted by the runfile, so first extract everything
+    # into $out/opt, then remove the unnecessary files and directories.
+    IDADIR=$out/opt
+
+    # Invoke the installer with the dynamic loader directly, avoiding the need
+    # to copy it to fix permissions and patch the executable.
+    $(cat $NIX_CC/nix-support/dynamic-linker) $src \
+      --mode unattended --prefix $IDADIR --installpassword ""
+
+    # Copy the exported libraries to the output.
+    cp $IDADIR/libida64.so $out/lib
+
+    # Some libraries come with the installer.
+    addAutoPatchelfSearchPath $IDADIR
+
+    for bb in ida64 assistant; do
+      wrapProgram $IDADIR/$bb \
+        --prefix QT_PLUGIN_PATH : $IDADIR/plugins/platforms
+      ln -s $IDADIR/$bb $out/bin/$bb
+    done
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Freeware version of the world's smartest and most feature-full disassembler";
+    homepage = "https://hex-rays.com/ida-free/";
+    license = licenses.unfree;
+    mainProgram = "ida64";
+    maintainers = with maintainers; [ msanft ];
+    platforms = [ "x86_64-linux" ]; # Right now, the installation script only supports Linux.
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/id/ida-free/srcs.json
+++ b/pkgs/by-name/id/ida-free/srcs.json
@@ -1,0 +1,20 @@
+{
+    "x86_64-linux": {
+        "urls": [
+            "https://web.archive.org/web/20240330140328/https://out7.hex-rays.com/files/idafree84_linux.run"
+        ],
+        "sha256": "1wg60afkhjj7my2la4x4qf6gdxzl2aqdbvd6zfnwf8n3bl7ckn2a"
+    },
+    "x86_64-darwin": {
+        "urls": [
+            "https://web.archive.org/web/20240330140623/https://out7.hex-rays.com/files/idafree84_mac.app.zip"
+        ],
+        "sha256": "0a97xb0ah6rcq69whs5xvkar43ci8r5nan9wa29ad19w8k25ryym"
+    },
+    "aarch64-darwin": {
+        "urls": [
+            "https://web.archive.org/web/20240330140634/https://out7.hex-rays.com/files/arm_idafree84_mac.app.zip"
+        ],
+        "sha256": "10wwq7ia1z1kxfigj4i7xr037bzv1cg3pyvrl27jdq9v7bghdf3m"
+    }
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Takes up the work done in #217753. I decided to drop the automatic update script, as Hex-Rays doesn't seem to offer a stable API for version information. Scraping their website would be possible, but very error-prone, as it doesn't have a stable format we could rely on to get the newest versions. I think in this case, it might be better to manually perform the updates. Other than that, the feedback from the referenced PR should be incorporated.

Supersedes #217753.

Closes #253024.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
