### PR TITLE
cargo-c: 0.9.29 -> 0.9.31

### DIFF
--- a/pkgs/development/tools/rust/cargo-c/default.nix
+++ b/pkgs/development/tools/rust/cargo-c/default.nix
@@ -13,16 +13,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-c";
-  version = "0.9.29";
+  version = "0.9.31";
 
   src = fetchCrate {
     inherit pname;
     # this version may need to be updated along with package version
-    version = "${version}+cargo-0.76.0";
-    hash = "sha256-Uy5Bm8WwN3jQO2btnV/ayxTlIJAe5q2FUvhxCCrn9U8=";
+    version = "${version}+cargo-0.78.0";
+    hash = "sha256-RqwUV3e02GykYH/pWHjoent+gix+CD+t3yAQxqUmo54=";
   };
 
-  cargoHash = "sha256-fkekUCZReiexdtiQcWx+Hqz4XDDbRGa4fGheBCNZ3Qw=";
+  cargoHash = "sha256-SfKDlcN+PW1twJu3YbmMsQOtFh6JHncAhdrVg+tweAE=";
 
   nativeBuildInputs = [ pkg-config (lib.getDev curl) ];
   buildInputs = [ openssl curl ] ++ lib.optionals stdenv.isDarwin [
@@ -55,6 +55,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/lu-zero/cargo-c";
     changelog = "https://github.com/lu-zero/cargo-c/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ cpu ];
   };
 }


### PR DESCRIPTION
## Description of changes

This commit:

* Updates cargo-c from v0.9.29 to [v0.9.31](https://github.com/lu-zero/cargo-c/releases/tag/v0.9.31).
* Adds myself as a maintainer, since the prev. maintainer stepped down (https://github.com/NixOS/nixpkgs/commit/fe29880472b296ff472f9c20772786e371533bce) and I have an interest in keeping cargo-c usable for my work downstream in [rustls-ffi](https://github.com/rustls/rustls-ffi).

Changelog:

  https://github.com/lu-zero/cargo-c/compare/v0.9.29...v0.9.31

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
