### PR TITLE
Revert "python311Packages.pathlib-abc: 0.1.1 -> 0.2.0"

### DIFF
--- a/pkgs/development/python-modules/pathlib-abc/default.nix
+++ b/pkgs/development/python-modules/pathlib-abc/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "pathlib-abc";
-  version = "0.2.0";
+  version = "0.1.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "pathlib_abc";
     inherit version;
-    hash = "sha256-ua9rOf1RMhSFZ47DgD0KEeAqIuhp6AUsrLbo9l3nuGI=";
+    hash = "sha256-CE573ZGbD3d0kUqeZM2GobOYYPgfeB3XJCWGMfKRWr4=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/pathtools/default.nix
+++ b/pkgs/development/python-modules/pathtools/default.nix
@@ -1,12 +1,16 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonAtLeast
 }:
 
 buildPythonPackage rec {
   pname = "pathtools";
   version = "0.1.2";
   format = "setuptools";
+
+  # imp and distuils usage, last commit in 2016
+  disabled = pythonAtLeast "3.12";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -51,6 +51,7 @@ buildPythonPackage rec {
   };
 
   pythonRelaxDeps = [
+    "smart-open"
     "typer"
   ];
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#299290

Regresses pathy, it's only reverse dependency, which in turn blocks spacy, textuals and others.