### PR TITLE
dlang dstep: init at 1.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8470,6 +8470,12 @@
       fingerprint = "F5B2 BE1B 9AAD 98FE 2916  5597 3665 FFF7 9D38 7BAA";
     }];
   };
+  imrying = {
+    email = "philiprying@gmail.com";
+    github = "imrying";
+    githubId = 36996706;
+    name = "Philip Rying";
+  };
   imuli = {
     email = "i@imu.li";
     github = "imuli";

--- a/pkgs/by-name/ds/dstep/dub-lock.json
+++ b/pkgs/by-name/ds/dstep/dub-lock.json
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/pkgs/by-name/ds/dstep/package.nix
+++ b/pkgs/by-name/ds/dstep/package.nix
@@ -1,0 +1,34 @@
+{ lib, buildDubPackage, fetchFromGitHub, clang, ldc, which }:
+buildDubPackage rec {
+  pname = "dstep";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "jacob-carlborg";
+    repo = "dstep";
+    rev = "v${version}";
+    hash = "sha256-ZFz2+GtBk3StqXo/9x47xrDFdz5XujHR62hj0p3AjcY=";
+  };
+
+  dubLock = ./dub-lock.json;
+
+  nativeBuildInputs = [ ldc which clang ];
+
+  preConfigure = ''
+    ./configure --llvm-path ${lib.getLib clang.cc}
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 bin/dstep -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A tool for converting C and Objective-C headers to D modules";
+    homepage = "https://github.com/jacob-carlborg/dstep";
+    license = licenses.boost;
+    mainProgram = "dstep";
+    maintainers = with maintainers; [ imrying ];
+  };
+}


### PR DESCRIPTION
## Description of changes
From github: DStep is a tool for automatically generating D bindings for C and Objective-C libraries. This is implemented by processing C or Objective-C header files and output D modules. DStep uses the Clang compiler as a library (libclang) to process the header files.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
I packaged the binary from releases since they are statically linked, and the configuration flow does not allow for easily updating to nix-style due to linker flags have to being set. If possible I think we could generate the `linker_flags.txt` manually and use this. Let me know if it is okay to package the binaries directly :-).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
