### PR TITLE
nixos/xserver: respect module order

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -111,7 +111,7 @@ let
     }
       ''
         echo 'Section "Files"' >> $out
-        echo $fontpath >> $out
+        echo "$fontpath" >> $out
 
         for i in ${toString fontsForXServer}; do
           if test "''${i:0:''${#NIX_STORE}}" == "$NIX_STORE"; then
@@ -121,11 +121,9 @@ let
           fi
         done
 
-        for i in $(find ${toString cfg.modules} -type d | sort); do
-          if test $(echo $i/*.so* | wc -w) -ne 0; then
-            echo "  ModulePath \"$i\"" >> $out
-          fi
-        done
+        ${concatMapStrings (m: ''
+        echo "  ModulePath \"${m}/lib/xorg/modules\"" >> "$out"
+        '') cfg.modules}
 
         echo '${cfg.filesSection}' >> $out
         echo 'EndSection' >> $out


### PR DESCRIPTION
Reimplement the `ModulePath` generation logic by only adding the `/lib/xorg/modules` subpath for each module, in the [specified](https://github.com/NixOS/nixpkgs/blob/8f72bd17eae0d1a7fcb63e3f1a3baa7dadebef68/nixos/modules/services/x11/xserver.nix#L802-L806) order.

In particular, hardware-specific drivers are listed *before* `xorgserver`, which fixes https://github.com/NixOS/nixpkgs/issues/299684.

This also keeps the list reproducible, as wanted by https://github.com/NixOS/nixpkgs/pull/230186.

I have confirmed that X is able to find `.so` files recursively within the `ModulePath`, so that there is no need to include subdirectories of `/lib/xorg/modules`. Furthermore, I don't expect there to be a need to include directories *outside* of `/lib/xorg/modules`, as the default `ModulePath` on standard distributions is `/usr/lib/xorg/modules`. (see https://www.x.org/releases/current/doc/man/man5/xorg.conf.5.xhtml#heading4)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
