### PR TITLE
forgejo: fix applying of our `STATIC_ROOT_PATH` patch

### DIFF
--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -59,11 +59,11 @@ buildGoModule rec {
   buildInputs = lib.optional pamSupport pam;
 
   patches = [
-    ./../gitea/static-root-path.patch
+    ./static-root-path.patch
   ];
 
   postPatch = ''
-    substituteInPlace modules/setting/setting.go --subst-var data
+    substituteInPlace modules/setting/server.go --subst-var data
   '';
 
   tags = lib.optional pamSupport "pam"

--- a/pkgs/applications/version-management/forgejo/static-root-path.patch
+++ b/pkgs/applications/version-management/forgejo/static-root-path.patch
@@ -1,0 +1,13 @@
+diff --git a/modules/setting/server.go b/modules/setting/server.go
+index 183906268..fa02e8915 100644
+--- a/modules/setting/server.go
++++ b/modules/setting/server.go
+@@ -319,7 +319,7 @@ func loadServerFrom(rootCfg ConfigProvider) {
+ 	OfflineMode = sec.Key("OFFLINE_MODE").MustBool()
+ 	Log.DisableRouterLog = sec.Key("DISABLE_ROUTER_LOG").MustBool()
+ 	if len(StaticRootPath) == 0 {
+-		StaticRootPath = AppWorkPath
++		StaticRootPath = "@data@"
+ 	}
+ 	StaticRootPath = sec.Key("STATIC_ROOT_PATH").MustString(StaticRootPath)
+ 	StaticCacheTime = sec.Key("STATIC_CACHE_TIME").MustDuration(6 * time.Hour)


### PR DESCRIPTION
## Description of changes

This fixes an issue where running the forgejo package standalone, without the use of our nixos/forgejo module, would try to use a directory named `@data@` for its `STATIC_ROOT_PATH` assets.

This went unnoticed until now, because most users use the nixos/forgejo module in which we explicitly set this option/setting/path to `cfg.package.data` by default (`pkgs.forgejo.data`).

Also, this commit hard-copies the patch in question from gitea to our nixpkgs derivation directory.

We decided a long time ago to part ways, and forgejo inheriting the patch from gitea's drv directory puts strain on gitea.

So we don't do that anymore and instead maintain that patch ourselves
from now on.

Unfortunately, `substituteInPlace --subst-var` does not error, when the
substitution fails.

This would have prevented this issue from going unnoticed.

Fixes #299802 (cc @LunarLambda)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
