### PR TITLE
oven-media-engine: 0.15.14 -> 0.16.5

### DIFF
--- a/pkgs/servers/misc/oven-media-engine/default.nix
+++ b/pkgs/servers/misc/oven-media-engine/default.nix
@@ -19,13 +19,13 @@
 
 stdenv.mkDerivation rec {
   pname = "oven-media-engine";
-  version = "0.15.14";
+  version = "0.16.5";
 
   src = fetchFromGitHub {
     owner = "AirenSoft";
     repo = "OvenMediaEngine";
     rev = "v${version}";
-    sha256 = "sha256-pLLnk0FXJ6gb0WSdWGEzJSEbKdOpjdWECIRzrHvi8HQ=";
+    sha256 = "sha256-hkLIJ3vGpnywcOw+bfEsQESGFe1FUcCVJlMlVgGsrNs=";
   };
 
   sourceRoot = "${src.name}/src";
@@ -40,10 +40,6 @@ stdenv.mkDerivation rec {
     patchShebangs core/colorgcc
     patchShebangs projects/main/update_git_info.sh
 
-    sed -i -e 's/const AVOutputFormat /AVOutputFormat /g' \
-      projects/modules/mpegts/mpegts_writer.cpp \
-      projects/modules/file/file_writer.cpp \
-      projects/modules/rtmp/rtmp_writer.cpp
     sed -i -e '/^CC =/d' -e '/^CXX =/d' -e '/^AR =/d' projects/third_party/pugixml-1.9/scripts/pugixml.make
   '';
 


### PR DESCRIPTION
## Description of changes

A large number of fixes & improvements

Added features:
- Added DRM (Widevine and FairPlay) features to LLHLS (Beta)
- Added support for multiple hardware acceleration
- Added mp3 codec decoder
- Added Netint VPU for H264/H265 (thanks to nums https://github.com/AirenSoft/OvenMediaEngine/pull/1473)
- Added SkipFrames option for Video/Image encoding
- Added keyframe interval by time
- Added Scheduled Channel feature (https://github.com/AirenSoft/OvenMediaEngine/discussions/1461)
- Added netint hardware encoder support
- Integrated with Pallycon DRM
- FairPlay DRM supported
- Added Automated Recording
- Added PRIV frame into HLS ID3 TimedMata
- Added SAMPLE-AES-CTR mode encryption to LLHLS DRM
- Added GET /v1/version API
- Added Multiplex Channel Provider

Changes:
- Due to performance issues, the logic that holds request sessions until WebRTC and LLHLS streams are ready has been removed.
- Changed the NVCC header library installation path.
- Deprecated HardwareAccelerator option in Server.xml and changed to HWAccels
- Changed Xilinx Video SDK version from 2.0 to 3.0
- Changed OpenH264 to 2.4.0
- Change the root of the relative path of Multiplex Provider and Scheduled Provider from the path where the existing binary was located to the path where Server.xml is located

Backwards compatibilty does not seem to have been affected

[Complete changelog](https://github.com/AirenSoft/OvenMediaEngine/releases)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
