### PR TITLE
python312Packages.flask-babelex: fix build for bukuserver

### DIFF
--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -82,6 +82,6 @@ with python3.pkgs; buildPythonApplication rec {
     homepage = "https://github.com/jarun/Buku";
     license = licenses.gpl3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ matthiasbeyer infinisil ];
+    maintainers = with maintainers; [ matthiasbeyer infinisil anthonyroussel ];
   };
 }

--- a/pkgs/development/python-modules/flask-admin/default.nix
+++ b/pkgs/development/python-modules/flask-admin/default.nix
@@ -7,7 +7,7 @@
 , email-validator
 , enum34
 , fetchpatch
-, fetchPypi
+, fetchFromGitHub
 , flask
 , flask-babelex
 , flask-mongoengine
@@ -34,10 +34,11 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.8";
 
-  src = fetchPypi {
-    pname = "Flask-Admin";
-    inherit version;
-    hash = "sha256-JMrir4MramEaAdfcNfQtJmwdbHWkJrhp2MskG3gjM2k=";
+  src = fetchFromGitHub {
+    owner = "flask-admin";
+    repo = "flask-admin";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-L8Q9uPpoen6ZvuF2bithCMSgc6X5khD1EqH2FJPspZc=";
   };
 
   patches = [
@@ -49,7 +50,7 @@ buildPythonPackage rec {
     })
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     flask
     wtforms
   ];
@@ -115,11 +116,11 @@ buildPythonPackage rec {
     "flask_admin"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Admin interface framework for Flask";
     homepage = "https://github.com/flask-admin/flask-admin/";
     changelog = "https://github.com/flask-admin/flask-admin/releases/tag/v${version}";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ anthonyroussel ];
   };
 }

--- a/pkgs/development/python-modules/flask-babelex/default.nix
+++ b/pkgs/development/python-modules/flask-babelex/default.nix
@@ -20,6 +20,10 @@ buildPythonPackage rec {
     sha256 = "09yfr8hlwvpgvq8kp1y7qbnnl0q28hi0348bv199ssiqx779r99r";
   };
 
+  patches = [
+    ./flask-3.0-compat.patch
+  ];
+
   propagatedBuildInputs = [
     flask
     babel

--- a/pkgs/development/python-modules/flask-babelex/flask-3.0-compat.patch
+++ b/pkgs/development/python-modules/flask-babelex/flask-3.0-compat.patch
@@ -1,0 +1,114 @@
+diff --git a/flask_babelex/__init__.py b/flask_babelex/__init__.py
+index 74f8a63..21a533b 100644
+--- a/flask_babelex/__init__.py
++++ b/flask_babelex/__init__.py
+@@ -17,7 +17,8 @@ if os.environ.get('LC_CTYPE', '').lower() == 'utf-8':
+     os.environ['LC_CTYPE'] = 'en_US.utf-8'
+
+ from datetime import datetime
+-from flask import _request_ctx_stack
++from flask import current_app
++from flask.globals import request_ctx
+ from babel import dates, numbers, support, Locale
+ from babel.support import NullTranslations
+ from werkzeug.datastructures import ImmutableDict
+@@ -205,13 +206,13 @@ def get_locale():
+     a request. If flask-babel was not attached to the Flask application,
+     will return 'en' locale.
+     """
+-    ctx = _request_ctx_stack.top
+-    if ctx is None:
++    ctx = request_ctx
++    if not ctx:
+         return None
+
+     locale = getattr(ctx, 'babel_locale', None)
+     if locale is None:
+-        babel = ctx.app.extensions.get('babel')
++        babel = current_app.extensions.get('babel')
+
+         if babel is None:
+             locale = _DEFAULT_LOCALE
+@@ -236,11 +237,11 @@ def get_timezone():
+     a request. If flask-babel was not attached to application, will
+     return UTC timezone object.
+     """
+-    ctx = _request_ctx_stack.top
++    ctx = request_ctx
+     tzinfo = getattr(ctx, 'babel_tzinfo', None)
+
+     if tzinfo is None:
+-        babel = ctx.app.extensions.get('babel')
++        babel = current_app.extensions.get('babel')
+
+         if babel is None:
+             tzinfo = UTC
+@@ -275,7 +276,7 @@ def refresh():
+     Without that refresh, the :func:`~flask.flash` function would probably
+     return English text and a now German page.
+     """
+-    ctx = _request_ctx_stack.top
++    ctx = request_ctx
+     for key in 'babel_locale', 'babel_tzinfo':
+         if hasattr(ctx, key):
+             delattr(ctx, key)
+@@ -285,7 +286,7 @@ def _get_format(key, format):
+     """A small helper for the datetime formatting functions.  Looks up
+     format defaults for different kinds.
+     """
+-    babel = _request_ctx_stack.top.app.extensions.get('babel')
++    babel = current_app.extensions.get('babel')
+
+     if babel is not None:
+         formats = babel.date_formats
+@@ -481,8 +482,8 @@ class Domain(object):
+
+     def as_default(self):
+         """Set this domain as default for the current request"""
+-        ctx = _request_ctx_stack.top
+-        if ctx is None:
++        ctx = request_ctx
++        if not ctx:
+             raise RuntimeError("No request context")
+
+         ctx.babel_domain = self
+@@ -495,7 +496,7 @@ class Domain(object):
+         """Returns translations directory path. Override if you want
+         to implement custom behavior.
+         """
+-        return self.dirname or os.path.join(ctx.app.root_path, 'translations')
++        return self.dirname or os.path.join(current_app.root_path, 'translations')
+
+     def get_translations(self):
+         """Returns the correct gettext translations that should be used for
+@@ -503,8 +504,8 @@ class Domain(object):
+         object if used outside of the request or if a translation cannot be
+         found.
+         """
+-        ctx = _request_ctx_stack.top
+-        if ctx is None:
++        ctx = request_ctx
++        if not ctx:
+             return NullTranslations()
+
+         locale = get_locale()
+@@ -603,8 +604,8 @@ def get_domain():
+     This will return the default domain (e.g. "messages" in <approot>/translations")
+     if none is set for this request.
+     """
+-    ctx = _request_ctx_stack.top
+-    if ctx is None:
++    ctx = request_ctx
++    if not ctx:
+         return domain
+
+     try:
+@@ -612,7 +613,7 @@ def get_domain():
+     except AttributeError:
+         pass
+
+-    babel = ctx.app.extensions.get('babel')
++    babel = current_app.extensions.get('babel')
+     if babel is not None:
+         d = babel._default_domain
+     else:

--- a/pkgs/development/python-modules/flask-wtf/default.nix
+++ b/pkgs/development/python-modules/flask-wtf/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     description = "Simple integration of Flask and WTForms.";
     license = licenses.bsd3;
     maintainers = with maintainers; [ mic92 anthonyroussel ];
-    homepage = "https://github.com/lepture/flask-wtf/";
+    homepage = "https://github.com/wtforms/flask-wtf/";
     changelog = "https://github.com/wtforms/flask-wtf/releases/tag/v${version}";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6627,6 +6627,8 @@ with pkgs;
 
   buku = callPackage ../applications/misc/buku { };
 
+  buku-server = buku.override { withServer = true; };
+
   byzanz = callPackage ../applications/video/byzanz { };
 
   algolia-cli = callPackage ../development/tools/algolia-cli { };


### PR DESCRIPTION
## Description of changes

`bukuserver` does not work

It depends on `flask-admin`, which in turn depends on `flask-babelex`, an obsolete package that is no longer maintained upstream.

`flask-babelex` hasn't built since Flask 3+ and `flask-admin` still hasn't been updated to work with `flask-babel`.

As the simplest solution, we'll fix `flask-babelex` to work with Flask 3+.

To detect this type of error more easily in the future, we should activate the bukuserver build, which is not currently built on Hydra. To do this, I propose to add a `buku-server` package (override of buku with withServer attribute enabled) in addition to the buku package to separate the two.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
