### PR TITLE
deltachat-rpc-server: init at 1.136.3

### DIFF
--- a/pkgs/by-name/de/deltachat-rpc-server/package.nix
+++ b/pkgs/by-name/de/deltachat-rpc-server/package.nix
@@ -1,0 +1,26 @@
+{ lib
+, rustPlatform
+, libdeltachat
+, perl
+, pkg-config
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "deltachat-rpc-server";
+
+  inherit (libdeltachat) version src cargoLock buildInputs;
+
+  nativeBuildInputs = [
+    perl
+    pkg-config
+  ];
+
+  cargoBuildFlags = [ "--package" "deltachat-rpc-server" ];
+
+  doCheck = false;
+
+  meta = libdeltachat.meta // {
+    description = "Delta Chat RPC server exposing JSON-RPC core API over standard I/O";
+    mainProgram = "deltachat-rpc-server";
+  };
+}

--- a/pkgs/development/libraries/libdeltachat/default.nix
+++ b/pkgs/development/libraries/libdeltachat/default.nix
@@ -5,6 +5,7 @@
 , cmake
 , deltachat-desktop
 , deltachat-repl
+, deltachat-rpc-server
 , openssl
 , perl
 , pkg-config
@@ -81,7 +82,7 @@ in stdenv.mkDerivation rec {
   passthru = {
     inherit cargoLock;
     tests = {
-      inherit deltachat-desktop deltachat-repl;
+      inherit deltachat-desktop deltachat-repl deltachat-rpc-server;
       python = python3.pkgs.deltachat;
     };
   };


### PR DESCRIPTION
## Description of changes

Adds deltachat-rpc-server package similar to deltachat-repl.
It is another binary provided by deltachat useful for bots that are built on top of RPC client.
Delta Chat Desktop also plans to use deltachat-rpc-server in the future
instead of building Delta Chat core as a nodejs module.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
