### PR TITLE
openapi-changes: init at v0.0.61

### DIFF
--- a/pkgs/by-name/op/openapi-changes/package.nix
+++ b/pkgs/by-name/op/openapi-changes/package.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, git
+, makeWrapper
+}:
+
+buildGoModule rec {
+  pname = "openapi-changes";
+  version = "0.0.61";
+
+  src = fetchFromGitHub {
+    owner = "pb33f";
+    repo = pname;
+    # github reports `the given path has multiple possibilities` for the tagged release
+    # rev = "v${version}";
+    rev = "f0bccc1fcf42ea6a97a81acc3283dbe14a3ebb51";
+    hash = "sha256-D0jUXCxlf1aF0uc/P9Lgu9Va4Es3CQcko9BzGg1pCq8=";
+  };
+
+  # this test requires the `.git` of the project to be present
+  patchPhase = ''
+    rm git/read_local_test.go
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/openapi-changes --prefix PATH : ${lib.makeBinPath [ git ]}
+  '';
+
+  vendorHash = "sha256-gaBVwrSaIwe1eh8voq928cxM/d0urVUF0OUwWZb2fR8=";
+
+  meta = with lib; {
+    description = "The world's sexiest OpenAPI breaking changes detector";
+    homepage = "https://pb33f.io/openapi-changes/";
+    changelog = "https://github.com/pb33f/openapi-changes/releases/tag/v${version}";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ mguentner ];
+  };
+}


### PR DESCRIPTION
## Description of changes

init [openapi-changes](https://pb33f.io/openapi-changes/) at version 0.0.61

tested the `html-report` and `report` feature

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
