### PR TITLE
buildRubyGem: Include platform in suffix for non-Ruby platforms

### DIFF
--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -62,7 +62,7 @@ let
     if type == "gem" then
       fetchurl {
         urls = map (
-          remote: "${remote}/gems/${gemName}-${version}.gem"
+          remote: "${remote}/gems/${gemName}-${suffix}.gem"
         ) (attrs.source.remotes or [ "https://rubygems.org" ]);
         inherit (attrs.source) sha256;
       }
@@ -80,6 +80,8 @@ let
   suffix =
     if type == "git" then
       builtins.substring 0 12 attrs.source.rev
+    else if platform != "ruby" then
+      "${version}-${platform}"
     else
       version;
 


### PR DESCRIPTION
## Description of changes

This adheres to how Bundler handles such gems. We must also adjust the generated URL to use this full suffix.

## Things done

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review) (nothing built).

I have tested this with this by applying this patch and `nix-build -A rubyPackages.sorbet-static`. Before this change, building non-ruby-platform gems was not trivially possible.

```diff
diff --git a/pkgs/top-level/ruby-packages.nix b/pkgs/top-level/ruby-packages.nix
index 232c48c739b1..4ffe6db90665 100644
--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -10,6 +10,18 @@
     };
     version = "7.1.3.2";
   };
+  sorbet-static = {
+    dependencies = [ ];
+    groups = [ "default" ];
+    platform = "x86_64-linux";
+    platforms = [ ];
+    source = {
+      remotes = ["https://rubygems.org"];
+      type = "gem";
+      sha256 = "5f6aaa02f28ceed4bf43dd40fdbe9a47c8d3589ccb9917bb1f9da90ee546ee8d";
+    };
+    version = "0.5.11294";
+  };
   actionmailbox = {
     dependencies = ["actionpack" "activejob" "activerecord" "activestorage" "activesupport" "mail" "net-imap" "net-pop" "net-smtp"];
     groups = ["default"];
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
