### PR TITLE
lib/strings: add parseLinuxConfig, linuxManualConfig: refactor readConfig

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -35,6 +35,7 @@ rec {
     substring
     tail
     toJSON
+    tryEval
     typeOf
     unsafeDiscardStringContext
     ;
@@ -1148,6 +1149,68 @@ rec {
         absolutePaths = map (path: rootPath + "/${path}") relativePaths;
       in
         absolutePaths);
+
+  /*
+    Parse Linux Kernel Config text to an attribute set.
+    With `relaxed = true`, ill-formed lines will be skipped.
+
+    Example:
+      parseLinuxConfig {
+        configText = ''
+          # Kernel config
+          #
+
+          CONFIG_A=y
+          CONFIG_B=m
+          CONFIG_C="text"
+          CONFIG_D is not set
+        '';
+        relaxed = true;
+      }
+      => {
+        CONFIG_A = "y";
+        CONFIG_B = "m";
+        CONFIG_C = "text";
+      }
+  */
+  parseLinuxConfig = {
+    configText,
+    # skip ill-formed lines
+    relaxed ? false,
+  }:
+
+  let
+    inherit (lib) assertMsg nameValuePair listToAttrs;
+    rawLines = splitString "\n" configText;
+    nonEmptyLines = filter (line: line != "") rawLines;
+    configLines = filter (line: !(hasPrefix "#" line)) nonEmptyLines;
+    parseConfigLine =
+      line:
+      let
+        parsed = parseConfigLineUnquoted line;
+      in
+      parsed // { value = removeQuote parsed.value; };
+    parseConfigLineUnquoted =
+      line:
+      let
+        parsed = match "(CONFIG_[^=]+)=(.*)$" line;
+      in
+      assert assertMsg (parsed != null) "failed to parse kernel config line '${line}'";
+      nameValuePair (elemAt parsed 0) (elemAt parsed 1);
+    removeQuote =
+      value:
+      let
+        quoteMatch = match ''"(.*)"'' value;
+      in
+      if quoteMatch == null then value else elemAt quoteMatch 0;
+    tryParseConfigLine = line: tryEval (parseConfigLine line);
+  in
+  if relaxed then
+    listToAttrs (
+      map (result: result.value) (filter (result: result.success) (map tryParseConfigLine configLines))
+    )
+  else
+    listToAttrs (map parseConfigLine configLines);
 
   /* Read the contents of a file removing the trailing \n
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -595,6 +595,32 @@ runTests {
     ( builtins.tryEval (toIntBase10 " foo00123 ") == { success = false; value = false; } )
   ];
 
+  testParseLinuxConfig = {
+    expr = strings.parseLinuxConfig {
+      configText = ''
+        # Kernel config
+        #
+
+        CONFIG_A=y
+        CONFIG_B=m
+        CONFIG_C="some text"
+        CONFIG_LONG_NAME=n
+        CONFIG_D is not set
+        KONFIG_E=y
+        # CONFIG_F=y
+        CONFIG_G=""
+      '';
+      relaxed = true;
+    };
+    expected = {
+      CONFIG_A = "y";
+      CONFIG_B = "m";
+      CONFIG_C = "some text";
+      CONFIG_LONG_NAME = "n";
+      CONFIG_G = "";
+    };
+  };
+
 # LISTS
 
   testFilter = {


### PR DESCRIPTION
## Description of changes

With this PR, when `bulitins.readFile configfile` is not IFD (import from derivation), kernel packages using `linuxManualConfig` can be evaluated without IFD. For example, when `configfile = ./config`.

This PR:
1. Add a new function `parseLinuxConfig` to `lib.strings`.
2. Refactor `readConfig` in `linuxManualConfig` with the newly added function.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
