### PR TITLE
Initial Prometheus DNSSEC Exporter package, module and test

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19082,6 +19082,12 @@
     github = "sweenu";
     githubId = 7051978;
   };
+  swendel = {
+    name = "Sebastian Wendel";
+    email = "nix24@srx.digital";
+    github = "SebastianWendel";
+    githubId = 919570;
+  };
   swesterfeld = {
     email = "stefan@space.twc.de";
     github = "swesterfeld";

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -142,6 +142,10 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [Uni-Sync](https://github.com/EightB1ts/uni-sync), a synchronization tool for Lian Li Uni Controllers. Available as [hardware.uni-sync](#opt-hardware.uni-sync.enable)
 
+- [Prometheus DNSSEC Exporter](https://github.com/chrj/prometheus-dnssec-exporter), check for validity and expiration in DNSSEC signatures and expose metrics for Prometheus. Available as [services.prometheus.exporters.dnssec](#opt-services.prometheus.exporters.dnssec.enable).
+
+- [Prometheus DNSSEC Exporter](https://github.com/chrj/prometheus-dnssec-exporter), check for validity and expiration in DNSSEC signatures and expose metrics for Prometheus. Available as [services.prometheus.exporters.dnssec](#opt-services.prometheus.exporters.dnssec.enable).
+
 ## Backward Incompatibilities {#sec-release-24.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -31,6 +31,7 @@ let
     "collectd"
     "dmarc"
     "dnsmasq"
+    "dnssec"
     "domain"
     "dovecot"
     "fastly"

--- a/nixos/modules/services/monitoring/prometheus/exporters/dnssec.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/dnssec.nix
@@ -1,0 +1,97 @@
+{ config, lib, pkgs, options, ... }:
+let
+  cfg = config.services.prometheus.exporters.dnssec;
+  configFormat = pkgs.formats.toml { };
+  configFile = configFormat.generate "dnssec-checks.toml" cfg.configuration;
+in
+{
+  port = 9204;
+  extraOpts = {
+    configuration = lib.mkOption {
+      type = lib.types.nullOr lib.types.attrs;
+      default = null;
+      description = lib.mdDoc ''
+        dnssec exporter configuration as nix attribute set.
+
+        See <https://github.com/chrj/prometheus-dnssec-exporter/blob/master/README.md>
+        for the description of the configuration file format.
+      '';
+      example = lib.literalExpression ''
+        {
+          records = [
+            {
+              zone = "ietf.org";
+              record = "@";
+              type = "SOA";
+            }
+            {
+              zone = "verisigninc.com";
+              record = "@";
+              type = "SOA";
+            }
+          ];
+        }
+      '';
+    };
+
+    listenAddress = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = lib.mdDoc ''
+        Listen address as host IP and port definition.
+      '';
+      example = ":9204";
+    };
+
+    resolvers = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = lib.mdDoc ''
+        DNSSEC capable resolver to be used for the check.
+      '';
+      example = [ "0.0.0.0:53" ];
+    };
+
+    timeout = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = lib.mdDoc ''
+        DNS request timeout duration.
+      '';
+      example = "10s";
+    };
+
+    extraFlags = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = lib.mdDoc ''
+        Extra commandline options when launching Prometheus.
+      '';
+    };
+  };
+
+  serviceOpts = {
+    serviceConfig =
+      let
+        startScript = pkgs.writeShellScriptBin "prometheus-dnssec-exporter-start" "${lib.concatStringsSep " " ([
+      "${pkgs.prometheus-dnssec-exporter}/bin/prometheus-dnssec-exporter"
+    ]
+      ++ lib.optionals (cfg.configuration != null) [
+      "-config ${configFile}"
+    ]
+      ++ lib.optionals (cfg.listenAddress != null) [
+      "-listen-address ${lib.escapeShellArg cfg.listenAddress}"
+    ]
+      ++ lib.optionals (cfg.resolvers != [ ]) [
+      "-resolvers ${lib.escapeShellArg (lib.concatStringsSep "," cfg.resolvers)}"
+    ]
+      ++ lib.optionals (cfg.timeout != null) [
+      "-timeout ${lib.escapeShellArg cfg.timeout}"
+    ]
+      ++ cfg.extraFlags)}";
+      in
+      {
+        ExecStart = lib.getExe startScript;
+      };
+  };
+}

--- a/pkgs/by-name/pr/prometheus-dnssec-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-dnssec-exporter/package.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "prometheus-dnssec-exporter";
+  version = "0-unstable-2023-03-05";
+
+  src = fetchFromGitHub {
+    owner = "chrj";
+    repo = "prometheus-dnssec-exporter";
+    rev = version;
+    hash = "sha256-SGoQKSgTRfSyA65xEZ9P7Z956sLMhB88h3HaXmFywiQ=";
+  };
+
+  vendorHash = "sha256-u7X8v7h1aL8B1el4jFzGRKHvnaK+Rz0OCitaC6xgyjw=";
+
+  doCheck = false;
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    description = "DNSSEC Exporter for Prometheus";
+    license = licenses.mit;
+    maintainers = with maintainers; [ swendel ];
+  };
+}


### PR DESCRIPTION
Prometheus DNSSEC Exporter package, module and test

## Description of changes

This PR introduces the `prometheus-dnssec-exporter` package and its accompanying NixOS module `services.prometheus.exporters.dnssec` to the Nixpkgs collection. The [prometheus-dnssec-exporter](https://github.com/chrj/prometheus-dnssec-exporter) is a tool designed to check the validity and expiration of DNSSEC signatures and expose these metrics for Prometheus, making it a valuable asset for monitoring the health and security of DNS infrastructure.

## Things done

- Added `prometheus-dnssec-exporter` package, allowing users to easily deploy this tool in a Nix environment.
- Created a NixOS module `services.prometheus.exporters.dnssec`, facilitating simple configuration and deployment of the service within NixOS systems.
- Implemented a NixOS test for the `services.prometheus.exporters.dnssec` module to ensure its correct operation and integration within the NixOS ecosystem.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
