### PR TITLE
immersed-vr: version update to 10.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8297,12 +8297,6 @@
     githubId = 55025025;
     name = "Feather Lin";
   };
-  iggyZiggy = {
-    email = "iggy.ziggy@gmail.com";
-    github = "iggyZiggy";
-    githubId = 4414394;
-    name = "Iggy Ziggy";
-  };
   igsha = {
     email = "igor.sharonov@gmail.com";
     github = "igsha";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8297,6 +8297,12 @@
     githubId = 55025025;
     name = "Feather Lin";
   };
+  iggyZiggy = {
+    email = "iggy.ziggy@gmail.com";
+    github = "iggyZiggy";
+    githubId = 4414394;
+    name = "Iggy Ziggy";
+  };
   igsha = {
     email = "igor.sharonov@gmail.com";
     github = "igsha";

--- a/pkgs/by-name/im/immersed-vr/package.nix
+++ b/pkgs/by-name/im/immersed-vr/package.nix
@@ -6,16 +6,16 @@
 }:
 let
   pname = "immersed-vr";
-  version = "10.1.1";
+  version = "10.2.0";
 
   sources = rec {
     x86_64-linux = {
-      url = "https://web.archive.org/web/20240325135651/https://static.immersed.com/dl/Immersed-x86_64.AppImage";
-      hash = "sha256-NwO8nJqwLnr4wi+MSoXaJwsPi8zSlFQ8hNsIscdEcw8=";
+      url = "https://web.archive.org/web/20240411143649/https://static.immersed.com/dl/Immersed-x86_64.AppImage";
+      hash = "sha256-ZY9pwOryADkpbMLx1w5Lymx6iQ0BhIrFAAvy47wLnQ8=";
     };
     x86_64-darwin = {
-      url = "https://web.archive.org/web/20231227045127/https://static.immersed.com/dl/Immersed.dmg";
-      hash = "sha256-CR2KylovlS7zerZIEScnadm4+ENNhib5QnS6z5Ihv1Y=";
+      url = "https://web.archive.org/web/20240411144415/https://static.immersed.com/dl/Immersed.dmg";
+      hash = "sha256-MdRJAo85xAB8OEgdQf0BjfORwSLIwtpOVwJ5qWfpXJY=";
     };
     aarch64-darwin = x86_64-darwin;
   };

--- a/pkgs/by-name/im/immersed-vr/package.nix
+++ b/pkgs/by-name/im/immersed-vr/package.nix
@@ -6,15 +6,15 @@
 }:
 let
   pname = "immersed-vr";
-  version = "10.2.0";
+  version = "10.2.1";
 
   sources = rec {
     x86_64-linux = {
-      url = "https://web.archive.org/web/20240411143649/https://static.immersed.com/dl/Immersed-x86_64.AppImage";
-      hash = "sha256-ZY9pwOryADkpbMLx1w5Lymx6iQ0BhIrFAAvy47wLnQ8=";
+      url = "http://web.archive.org/web/20240415082836/https://static.immersed.com/dl/Immersed-x86_64.AppImage";
+      hash = "sha256-hKaF1XzZa0qAh7r1CtK0j2JFqE16hGNBGph7aOnYJCQ=";
     };
     x86_64-darwin = {
-      url = "https://web.archive.org/web/20240411144415/https://static.immersed.com/dl/Immersed.dmg";
+      url = "http://web.archive.org/web/20240415083533/https://static.immersed.com/dl/Immersed.dmg";
       hash = "sha256-MdRJAo85xAB8OEgdQf0BjfORwSLIwtpOVwJ5qWfpXJY=";
     };
     aarch64-darwin = x86_64-darwin;

--- a/pkgs/by-name/im/immersed-vr/package.nix
+++ b/pkgs/by-name/im/immersed-vr/package.nix
@@ -6,15 +6,15 @@
 }:
 let
   pname = "immersed-vr";
-  version = "9.10";
+  version = "10.1.1";
 
   sources = rec {
     x86_64-linux = {
-      url = "https://web.archive.org/web/20240210075929/https://static.immersed.com/dl/Immersed-x86_64.AppImage";
-      hash = "sha256-Mx8UnV4fZSebj9ah650ZqsL/EIJpM6jl8tYmXJZiJpA=";
+      url = "https://web.archive.org/web/20240325135651/https://static.immersed.com/dl/Immersed-x86_64.AppImage";
+      hash = "sha256-NwO8nJqwLnr4wi+MSoXaJwsPi8zSlFQ8hNsIscdEcw8=";
     };
     x86_64-darwin = {
-      url = "https://web.archive.org/web/20240210075929/https://static.immersed.com/dl/Immersed.dmg";
+      url = "https://web.archive.org/web/20231227045127/https://static.immersed.com/dl/Immersed.dmg";
       hash = "sha256-CR2KylovlS7zerZIEScnadm4+ENNhib5QnS6z5Ihv1Y=";
     };
     aarch64-darwin = x86_64-darwin;


### PR DESCRIPTION
## Description of changes

version bump up to 10.1.1, updated to new links on web archive and updated hashes

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
