### PR TITLE
Libsystem: remove broken `postFetch` step in `darling.src`

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
@@ -10,24 +10,13 @@
 let
   darling.src = fetchzip {
     url = "https://github.com/darlinghq/darling/archive/d2cc5fa748003aaa70ad4180fff0a9a85dc65e9b.tar.gz";
-    sha256 = "11b51fw47nl505h63bgx5kqiyhf3glhp1q6jkpb6nqfislnzzkrf";
+    hash = "sha256-/YynrKJdi26Xj4lvp5wsN+TAhZjonOrNNHuk4L5tC7s=";
     postFetch = ''
-      # The archive contains both `src/opendirectory` and `src/OpenDirectory`,
-      # pre-create the directory to choose the canonical case on
-      # case-insensitive filesystems.
-      mkdir -p $out/src/OpenDirectory
-
-      cd $out
-      tar -xzf $downloadedFile --strip-components=1
-      rm -r $out/src/libm
-
-      # If `src/opendirectory` and `src/OpenDirectory` refer to different
-      # things, then combine them into `src/OpenDirectory` to match the result
-      # on case-insensitive filesystems.
-      if [ "$(stat -c %i src/opendirectory)" != "$(stat -c %i src/OpenDirectory)" ]; then
-        mv src/opendirectory/* src/OpenDirectory/
-        rmdir src/opendirectory
-      fi
+      # The archive contains both `src/opendirectory` and `src/OpenDirectory`.
+      # Since neither directory is used for anything, we just remove them to avoid
+      #  the potential issue where file systems with different case sensitivity produce
+      #  different hashes.
+      rm -rf $out/src/{OpenDirectory,opendirectory}
     '';
   };
 


### PR DESCRIPTION
## Description of changes

Fixes #297765

The `fetchzip` `postFetch` step in `darling.src` in `Libsystem` is broken because it references `$downloadedFile`, which does not exist because `fetchzip` moves `$downloadedFile` to `$renamed` before the `postFetch` step is executed.

The brokenness of this step did not become apparent until commit 5a6a31e54ddaf59aa8e1c5e7e9b02623d4881c34 was merged, since before this commit the `fetchzip` `postFetch` step wasn't executed at all.

Furthermore, the tarball referenced by `darling.src` no longer contains both `src/opendirectory` and `src/OpenDirectory`, so the `postFetch` step isn't needed anyway.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
  - [x] `sandbox = false`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
