### PR TITLE
pynvim-pp: unstable-2023-08-03 -> unstable-2024-03-11

### DIFF
--- a/pkgs/development/python-modules/pynvim-pp/default.nix
+++ b/pkgs/development/python-modules/pynvim-pp/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage {
   pname = "pynvim-pp";
-  version = "unstable-2023-08-03";
+  version = "unstable-2024-03-11";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ms-jpq";
     repo = "pynvim_pp";
-    rev = "40d0f6053ddbba61f53505eebb0290cfb661661b";
-    hash = "sha256-4jeYE9HL+PQZuJq5nyf9CgL4UrRWm3ifLL/vfygLOwc=";
+    rev = "34e3a027c595981886d7efd1c91071f3eaa4715d";
+    hash = "sha256-2+jDRJXlg9q4MN9vOhmeq4cWVJ0wp5r5xAh3G8lqgOg=";
   };
 
   nativeBuildInputs = [ setuptools ];


### PR DESCRIPTION
## Description of changes

Minor pynvim-pp update. pynvim-pp went through a [minor but breaking change](https://github.com/ms-jpq/pynvim_pp/commit/34e3a027c595981886d7efd1c91071f3eaa4715d) and NixOS updated to a version of CHADtree that depends on it in a118538862a91aed41873ebc1dd4c9b390aac128, which unfortunately means it is currently broken. This update should fix it. This probably also unbreaks nvim_coq, but I don't use it, so I'm not sure.

I tested this with my local nixvim config and it does unbreak CHADtree again.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
