### PR TITLE
erigon: 2.55.1 -> 2.59.2

### DIFF
--- a/pkgs/applications/blockchains/erigon/default.nix
+++ b/pkgs/applications/blockchains/erigon/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "erigon";
-  version = "2.55.1";
+  version = "2.59.2";
 in
 buildGoModule {
   inherit pname version;
@@ -11,11 +11,11 @@ buildGoModule {
     owner = "ledgerwatch";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-ttBJIx2QR3H5JFyquoGwZpWwT10r7X7GnGE4uEzuRZA=";
+    hash = "sha256-gSoaPoyPyryC1yzYaafnPXKpMNzI9fw9Yd0nKzziAKw=";
     fetchSubmodules = true;
   };
 
-  vendorHash = "sha256-QLuWxec1gwMnVo0Zw8z4Ef8vzxc4xFpLL/TT986Sljo=";
+  vendorHash = "sha256-B3xbCI0szSAo9ULHDiqoTTR8tvgZUry7spDGuldu0lU=";
   proxyVendor = true;
 
   # Build errors in mdbx when format hardening is enabled:
@@ -33,6 +33,14 @@ buildGoModule {
     "cmd/rpcdaemon"
     "cmd/rlpdump"
   ];
+
+  # Matches the tags to upstream's release build configuration
+  # https://github.com/ledgerwatch/erigon/blob/0c0dbe5f3a81cf8f16da8e4838312ab80ebe5302/.goreleaser.yml
+  #
+  # Enabling silkworm also breaks the build as it requires dynamically linked libraries.
+  # If we need it in the future, we should consider packaging silkworm and silkworm-go
+  # as depenedencies explicitly.
+  tags = "-tags=nosqlite,noboltdb,nosilkworm";
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
## Description of changes

Bumps erigon to 2.59.2.

This is required to sync with the current mainnet, 2.55 is pre-Dencun and can't proceed past March 13th.

This also matches the go tags to what upstream does in their releases - the addition of silkworm recently broke the build for auto-updates - they should work again after this.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
