### PR TITLE
python3Packages.bidict: overwrite bundled pytest.ini

### DIFF
--- a/pkgs/development/python-modules/bidict/default.nix
+++ b/pkgs/development/python-modules/bidict/default.nix
@@ -36,12 +36,11 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  pytestFlagsArray = [
-    # Pass -c /dev/null so that pytest does not use the bundled pytest.ini, which adds
-    # options to run additional integration tests that are overkill for our purposes.
-    "-c"
-    "/dev/null"
-  ];
+  # Remove the bundled pytest.ini, which adds options to run additional integration
+  # tests that are overkill for our purposes.
+  preCheck = ''
+    rm pytest.ini
+  '';
 
   pythonImportsCheck = [ "bidict" ];
 


### PR DESCRIPTION
Overwrite the bundled pytest.ini instead of calling pytest with `-c /dev/null` to bypass it.

For some reason the latter suddenly started failing with a PermissionError on Darwin after working fine for the last 11 days.

Fixes #299933