### PR TITLE
ascii-draw: init at 0.3.0

### DIFF
--- a/pkgs/by-name/as/ascii-draw/fix_palette_data_dir.patch
+++ b/pkgs/by-name/as/ascii-draw/fix_palette_data_dir.patch
@@ -1,0 +1,38 @@
+diff --git a/src/window.py b/src/window.py
+index adc6d6d..1cb6bec 100644
+--- a/src/window.py
++++ b/src/window.py
+@@ -34,6 +34,15 @@ import unicodedata
+ import emoji
+ import os
+ 
++def get_data_dir():
++    xdg_data_home = os.environ.get('XDG_DATA_HOME')
++    if xdg_data_home and xdg_data_home.strip():
++        data_dir = os.path.join(xdg_data_home, 'ascii-draw', 'data')
++    else:
++        home = os.path.expanduser("~")
++        data_dir = os.path.join(home, '.local', 'share', 'ascii-draw', 'data')
++    return data_dir
++
+ @Gtk.Template(resource_path='/io/github/nokse22/asciidraw/ui/window.ui')
+ class AsciiDrawWindow(Adw.ApplicationWindow):
+     __gtype_name__ = 'AsciiDrawWindow'
+@@ -266,7 +275,7 @@ class AsciiDrawWindow(Adw.ApplicationWindow):
+ 
+         self.palettes = []
+ 
+-        directory_path = "/var/data/palettes"
++        directory_path = f"{get_data_dir()}/palettes"
+         os.makedirs(directory_path, exist_ok=True)
+ 
+         for filename in os.listdir(directory_path):
+@@ -316,7 +325,7 @@ class AsciiDrawWindow(Adw.ApplicationWindow):
+             self.char_carousel_go_next.set_sensitive(True)
+ 
+     def save_new_palette(self, palette):
+-        with open(f"/var/data/palettes/{palette.name}.txt", 'w') as file:
++        with open(f"{get_data_dir()}/palettes/{palette.name}.txt", 'w') as file:
+             file.write(palette.chars)
+ 
+     @Gtk.Template.Callback("char_pages_go_back")

--- a/pkgs/by-name/as/ascii-draw/package.nix
+++ b/pkgs/by-name/as/ascii-draw/package.nix
@@ -1,0 +1,63 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, gobject-introspection
+, wrapGAppsHook4
+, desktop-file-utils
+, libadwaita
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "ascii-draw";
+  version = "0.3.0";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "Nokse22";
+    repo = "ascii-draw";
+    rev = "v${version}";
+    hash = "sha256-vI+j8OuQ3b6La0+7wWeoUtBal24dazlN/T0Bng5TgMo=";
+  };
+
+  # Temporary fix for autosaving to flatpak directory
+  # https://github.com/Nokse22/ascii-draw/issues/31
+  patches = [ ./fix_palette_data_dir.patch ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gobject-introspection
+    wrapGAppsHook4
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    libadwaita
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
+    pyfiglet
+    emoji
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  meta = {
+    description = "An app to draw diagrams or anything using only ASCII";
+    homepage = "https://github.com/Nokse22/ascii-draw";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "ascii-draw";
+    maintainers = with lib.maintainers; [ aleksana ];
+    # gnulib bindtextdomain is missing on various other unix platforms
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Not so bad

![image](https://github.com/NixOS/nixpkgs/assets/42209822/4992d188-9e67-4dad-892d-e0d4d3dfdc97)


```
    ┌╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶┐
    ╎                                  ╎
    ╎                                  ╎
    ╎    _      _ ___  _ ____  ____    ╎
    ╎   / \  /|/ \\  \///  _ \/ ___\   ╎
    ╎   | |\ ||| | \  / | / \||    \   ╎
    ╎   | | \||| | /  \ | \_/|\___ |   ╎
    ╎   \_/  \|\_//__/\\\____/\____/   ╎
    ╎                                  ╎
    ╎                                  ╎
    ╎                                  ╎
    └╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶┘
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
