### PR TITLE
snippetexpander: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/by-name/sn/snippetexpander/package.nix
+++ b/pkgs/by-name/sn/snippetexpander/package.nix
@@ -1,9 +1,11 @@
 { lib
 , buildGoModule
 , fetchFromSourcehut
+, makeWrapper
 , scdoc
 , installShellFiles
 , snippetexpanderd
+, snippetexpanderx
 }:
 
 buildGoModule rec {
@@ -11,24 +13,27 @@ buildGoModule rec {
 
   pname = "snippetexpander";
 
-  vendorHash = "sha256-wSAho59yxcXTu1zQ5x783HT4gtfSM4GdsOEeC1wfHhE=";
+  vendorHash = "sha256-W9NkENdZRzqSAONI9QS2EI5aERK+AaPqwYwITKLwXQE=";
 
   proxyVendor = true;
 
   modRoot = "cmd/snippetexpander";
 
   nativeBuildInputs = [
+    makeWrapper
     scdoc
     installShellFiles
   ];
 
   buildInputs = [
     snippetexpanderd
+    snippetexpanderx
   ];
 
   ldflags = [
     "-s"
     "-w"
+    "-X 'main.version=${src.rev}'"
   ];
 
   postInstall = ''
@@ -36,12 +41,18 @@ buildGoModule rec {
     installManPage snippetexpander.1
   '';
 
-  meta = with lib; {
+  postFixup = ''
+    # Ensure snippetexpanderd and snippetexpanderx are available to start/stop.
+    wrapProgram $out/bin/snippetexpander \
+      --prefix PATH : ${lib.makeBinPath [ snippetexpanderd snippetexpanderx ]}
+  '';
+
+  meta = {
     description = "Your little expandable text snippet helper CLI";
     homepage = "https://snippetexpander.org";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ianmjones ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ ianmjones ];
+    platforms = lib.platforms.linux;
     mainProgram = "snippetexpander";
   };
 }

--- a/pkgs/by-name/sn/snippetexpanderd/package.nix
+++ b/pkgs/by-name/sn/snippetexpanderd/package.nix
@@ -2,44 +2,49 @@
 , stdenv
 , buildGoModule
 , fetchFromSourcehut
-, pkg-config
 , makeWrapper
 , scdoc
 , installShellFiles
-, xorg
-, gtk3
+, xclip
+, wl-clipboard
+, xdotool
+, wtype
 }:
 
 buildGoModule rec {
   pname = "snippetexpanderd";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromSourcehut {
     owner = "~ianmjones";
     repo = "snippetexpander";
     rev = "v${version}";
-    hash = "sha256-y3TJ+L3kXYfZFzAD1vmhvP6Yarctu5LHq/74005h8sI=";
+    hash = "sha256-iEoBri+NuFfLkARUBA+D/Fe9xk6PPV62N/YRqPv9C/A=";
   };
 
-  vendorHash = "sha256-QX8HI8I1ZJI6HJ1sl86OiJ4nxwFAjHH8h1zB9ASJaQs=";
+  vendorHash = "sha256-W9NkENdZRzqSAONI9QS2EI5aERK+AaPqwYwITKLwXQE=";
+
+  proxyVendor = true;
 
   modRoot = "cmd/snippetexpanderd";
 
   nativeBuildInputs = [
-    pkg-config
     makeWrapper
     scdoc
     installShellFiles
   ];
 
   buildInputs = [
-    xorg.libX11
-    gtk3
+    xclip
+    wl-clipboard
+    xdotool
+    wtype
   ];
 
   ldflags = [
     "-s"
     "-w"
+    "-X 'main.version=${src.rev}'"
   ];
 
   postInstall = ''
@@ -48,16 +53,17 @@ buildGoModule rec {
   '';
 
   postFixup = ''
+    # Ensure xclip/wcopy and xdotool/wtype are available for copy and paste duties.
     wrapProgram $out/bin/snippetexpanderd \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ xorg.libX11 ]}
+      --prefix PATH : ${lib.makeBinPath [ xclip wl-clipboard xdotool wtype ]}
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Your little expandable text snippet helper daemon";
     homepage = "https://snippetexpander.org";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ianmjones ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ ianmjones ];
+    platforms = lib.platforms.linux;
     mainProgram = "snippetexpanderd";
   };
 }

--- a/pkgs/by-name/sn/snippetexpandergui/package.nix
+++ b/pkgs/by-name/sn/snippetexpandergui/package.nix
@@ -1,7 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromSourcehut
-, makeWrapper
+, wrapGAppsHook
 , wails
 , scdoc
 , installShellFiles
@@ -10,6 +10,7 @@
 , webkitgtk
 , gsettings-desktop-schemas
 , snippetexpanderd
+, snippetexpanderx
 }:
 
 buildGoModule rec {
@@ -17,30 +18,31 @@ buildGoModule rec {
 
   pname = "snippetexpandergui";
 
-  vendorHash = "sha256-iZfZdT8KlfZMVLQcYmo6EooIdsSGrpO/ojwT9Ft1GQI=";
+  vendorHash = "sha256-W9NkENdZRzqSAONI9QS2EI5aERK+AaPqwYwITKLwXQE=";
 
   proxyVendor = true;
 
   modRoot = "cmd/snippetexpandergui";
 
   nativeBuildInputs = [
-    makeWrapper
     wails
     scdoc
     installShellFiles
+    wrapGAppsHook
   ];
 
   buildInputs = [
     xorg.libX11
     gtk3
     webkitgtk
-    gsettings-desktop-schemas
     snippetexpanderd
+    snippetexpanderx
   ];
 
   ldflags = [
     "-s"
     "-w"
+    "-X 'main.version=${src.rev}'"
   ];
 
   tags = [
@@ -54,17 +56,19 @@ buildGoModule rec {
     installManPage snippetexpandergui.1
   '';
 
-  postFixup = ''
-    wrapProgram $out/bin/snippetexpandergui \
-      --prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}
+  preFixup = ''
+    gappsWrapperArgs+=(
+      # Ensure snippetexpanderd and snippetexpanderx are available to start/stop.
+      --prefix PATH : ${lib.makeBinPath [ snippetexpanderd snippetexpanderx ]}
+    )
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Your little expandable text snippet helper GUI";
     homepage = "https://snippetexpander.org";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ianmjones ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ ianmjones ];
+    platforms = lib.platforms.linux;
     mainProgram = "snippetexpandergui";
   };
 }

--- a/pkgs/by-name/sn/snippetexpanderx/package.nix
+++ b/pkgs/by-name/sn/snippetexpanderx/package.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation rec {
     snippetexpanderd
   ];
 
+  makeFlags = [ "VERSION=${src.rev}" ];
+
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin
@@ -53,12 +55,12 @@ stdenv.mkDerivation rec {
   # There are no tests.
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Your little expandable text snippet helper auto expander daemon";
     homepage = "https://snippetexpander.org";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ianmjones ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ ianmjones ];
+    platforms = lib.platforms.linux;
     mainProgram = "snippetexpanderx";
   };
 }


### PR DESCRIPTION
## Description of changes

Update snippetexpander to v1.0.2

Changelog: https://git.sr.ht/~ianmjones/snippetexpander/refs/v1.0.2

Also:
 * Updates dependencies as they have changed for this version.
 * Fixes version displayed for each binary (they expect tag format).
 * Ensures required `snippetexpanderd` and `snippetexpanderx` daemons are available to start/stop by client apps if only clients are installed.
 * Updates meta section to remove `with lib;`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
