### PR TITLE
corewars: init at 0.9.13

### DIFF
--- a/pkgs/by-name/co/corewars/package.nix
+++ b/pkgs/by-name/co/corewars/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  gtk2,
+}:
+
+let
+  gtk2-support-patch = fetchurl {
+    url = "https://sourceforge.net/p/corewars/patches/_discuss/thread/947a192c/b4cd/attachment/corewars-gtk2.patch.gz";
+    hash = "sha256-nSaXUjRO+ckT5X8EycXUf3iMWFdV2+MFCrq1DQVzizA=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "corewars";
+  version = "0.9.13";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/corewars/corewars-${finalAttrs.version}.tar.gz";
+    hash = "sha256-I5V+Yg47vuJlw+uHh1LK9dQYZCjjYa95ozc6aYAQ9uI=";
+  };
+
+  postPatch = ''
+    zcat ${gtk2-support-patch} | patch -Np1
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ gtk2 ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-fcommon" # for GCC 10 and above
+    "-lm" # fix: error adding symbols: DSO missing from command line
+    "-Wno-deprecated-declarations"
+  ];
+
+  meta = {
+    description = "A simulation game where programs try to crash each other";
+    homepage = "http://corewars.org";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "corewars";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

This PR adds 1 package: `corewars`
Homepage: http://corewars.org/

This is a very old program, still written for GTK1. There is a patch uploaded to sourceforge, which adds `gtk2` support. Because it is a `.gz` file, I had to manually call `patch` after extracting patch contents with `zcat`.

I am not sure who will want to run this package nowadays. I got it to compile so I'm putting it here for discoverability, even if this doesn't get merged.  

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
