### PR TITLE
nixos/binfmt: Add support for using statically-linked QEMU (continuation of #160802)

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -293,6 +293,10 @@ let
           then selectEmulator pkgs
           else throw "Don't know how to run ${final.config} executables.";
 
+        staticEmulator = pkgs:
+          if builtins.elem final.system pkgs.qemu-user-static.passthru.qemuUserPlatforms then
+            "${pkgs.qemu-user-static}/bin/qemu-${final.qemuArch}"
+          else null;
     }) // mapAttrs (n: v: v final.parsed) inspect.predicates
       // mapAttrs (n: v: v final.gcc.arch or "default") architectures.predicates
       // args // {

--- a/nixos/tests/systemd-binfmt.nix
+++ b/nixos/tests/systemd-binfmt.nix
@@ -87,4 +87,27 @@ in {
       ).lower()
     '';
   };
+
+  chroot = makeTest {
+    name = "systemd-binfmt-chroot";
+    nodes.machine = { pkgs, ... }: {
+      boot.binfmt.emulatedSystems = [
+        "aarch64-linux"
+      ];
+      boot.binfmt.preferStaticEmulators = true;
+
+      environment.systemPackages = [
+        (pkgs.writeShellScriptBin "test-chroot" ''
+          set -euo pipefail
+          mkdir -p /tmp/chroot
+          cp ${pkgs.pkgsCross.aarch64-multiplatform.pkgsStatic.busybox}/bin/busybox /tmp/chroot/busybox
+          chroot /tmp/chroot /busybox uname -m | grep aarch64
+        '')
+      ];
+    };
+    testScript = ''
+      machine.start()
+      machine.succeed("test-chroot")
+    '';
+  };
 }

--- a/pkgs/applications/virtualization/qemu/aio-find-static-library.patch
+++ b/pkgs/applications/virtualization/qemu/aio-find-static-library.patch
@@ -1,0 +1,14 @@
+diff --git a/meson.build b/meson.build
+index 96de1a6ef9..908d841f6a 100644
+--- a/meson.build
++++ b/meson.build
+@@ -420,8 +420,7 @@ zlib = dependency('zlib', required: true, kwargs: static_kwargs)
+ libaio = not_found
+ if not get_option('linux_aio').auto() or have_block
+   libaio = cc.find_library('aio', has_headers: ['libaio.h'],
+-                           required: get_option('linux_aio'),
+-                           kwargs: static_kwargs)
++                           required: get_option('linux_aio'))
+ endif
+ linux_io_uring = not_found
+ if not get_option('linux_io_uring').auto() or have_block

--- a/pkgs/applications/virtualization/qemu/aio-find-static-library.patch
+++ b/pkgs/applications/virtualization/qemu/aio-find-static-library.patch
@@ -1,14 +1,26 @@
 diff --git a/meson.build b/meson.build
-index 96de1a6ef9..908d841f6a 100644
+index c9c3217ba4..1a8de03f4e 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -420,8 +420,7 @@ zlib = dependency('zlib', required: true, kwargs: static_kwargs)
+@@ -986,7 +986,8 @@ zlib = dependency('zlib', required: true)
  libaio = not_found
  if not get_option('linux_aio').auto() or have_block
    libaio = cc.find_library('aio', has_headers: ['libaio.h'],
--                           required: get_option('linux_aio'),
--                           kwargs: static_kwargs)
-+                           required: get_option('linux_aio'))
+-                           required: get_option('linux_aio'))
++                           required: get_option('linux_aio'),
++                           dirs: [get_option('linux_aio_path')])
  endif
- linux_io_uring = not_found
- if not get_option('linux_io_uring').auto() or have_block
+ 
+ linux_io_uring_test = '''
+diff --git a/meson_options.txt b/meson_options.txt
+index 0a99a059ec..84d2449de9 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -186,6 +186,7 @@ option('libusb', type : 'feature', value : 'auto',
+        description: 'libusb support for USB passthrough')
+ option('linux_aio', type : 'feature', value : 'auto',
+        description: 'Linux AIO support')
++option('linux_aio_path', type: 'string', value: '', description: 'Path for libaio.a')
+ option('linux_io_uring', type : 'feature', value : 'auto',
+        description: 'Linux io_uring support')
+ option('lzfse', type : 'feature', value : 'auto',

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -33,6 +33,7 @@
 , capstoneSupport ? !toolsOnly, capstone
 , pluginsSupport ? !stdenv.hostPlatform.isStatic
 , enableDocs ? true
+, enableTools ? true
 , hostCpuOnly ? false
 , hostCpuTargets ? (if toolsOnly
                     then [ ]
@@ -162,7 +163,7 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [
     "--disable-strip" # We'll strip ourselves after separating debug info.
     (lib.enableFeature enableDocs "docs")
-    "--enable-tools"
+    (lib.enableFeature enableTools "tools")
     "--localstatedir=/var"
     "--sysconfdir=/etc"
     "--cross-prefix=${stdenv.cc.targetPrefix}"

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -112,6 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals capstoneSupport [ capstone ];
 
   dontUseMesonConfigure = true; # meson's configurePhase isn't compatible with qemu build
+  dontAddStaticConfigureFlags = true;
 
   outputs = [ "out" ] ++ lib.optional guestAgentSupport "ga";
   # On aarch64-linux we would shoot over the Hydra's 2G output limit.
@@ -140,7 +141,10 @@ stdenv.mkDerivation (finalAttrs: {
       revert = true;
     })
   ]
-  ++ lib.optional nixosTestRunner ./force-uid0-on-9p.patch;
+  ++ lib.optional nixosTestRunner ./force-uid0-on-9p.patch
+
+  # Remove for QEMU 8.1
+  ++ lib.optional stdenv.hostPlatform.isStatic ./aio-find-static-library.patch;
 
   postPatch = ''
     # Otherwise tries to ensure /var/run exists.
@@ -190,7 +194,10 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional canokeySupport "--enable-canokey"
     ++ lib.optional capstoneSupport "--enable-capstone"
     ++ lib.optional (!pluginsSupport) "--disable-plugins"
-    ++ lib.optional (!enableBlobs) "--disable-install-blobs";
+    ++ lib.optional (!enableBlobs) "--disable-install-blobs"
+
+    # FIXME: "multiple definition of `strtoll'" with libnbcompat
+    ++ lib.optional stdenv.hostPlatform.isStatic "--static --extra-ldflags=-Wl,--allow-multiple-definition";
 
   dontWrapGApps = true;
 

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -254,7 +254,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Add a ‘qemu-kvm’ wrapper for compatibility/convenience.
   postInstall = lib.optionalString (!toolsOnly) ''
-    ln -s $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} $out/bin/qemu-kvm
+    if [ -f $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} ]; then
+      ln -s $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} $out/bin/qemu-kvm
+    fi
   '';
 
   passthru = {

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -31,6 +31,7 @@
 , uringSupport ? stdenv.isLinux, liburing
 , canokeySupport ? false, canokey-qemu
 , capstoneSupport ? !toolsOnly, capstone
+, pluginsSupport ? !stdenv.hostPlatform.isStatic
 , enableDocs ? true
 , hostCpuOnly ? false
 , hostCpuTargets ? (if toolsOnly
@@ -185,7 +186,8 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional smbdSupport "--smbd=${samba}/bin/smbd"
     ++ lib.optional uringSupport "--enable-linux-io-uring"
     ++ lib.optional canokeySupport "--enable-canokey"
-    ++ lib.optional capstoneSupport "--enable-capstone";
+    ++ lib.optional capstoneSupport "--enable-capstone"
+    ++ lib.optional (!pluginsSupport) "--disable-plugins";
 
   dontWrapGApps = true;
 

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -34,6 +34,7 @@
 , pluginsSupport ? !stdenv.hostPlatform.isStatic
 , enableDocs ? true
 , enableTools ? true
+, enableBlobs ? true
 , hostCpuOnly ? false
 , hostCpuTargets ? (if toolsOnly
                     then [ ]
@@ -188,7 +189,8 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional uringSupport "--enable-linux-io-uring"
     ++ lib.optional canokeySupport "--enable-canokey"
     ++ lib.optional capstoneSupport "--enable-capstone"
-    ++ lib.optional (!pluginsSupport) "--disable-plugins";
+    ++ lib.optional (!pluginsSupport) "--disable-plugins"
+    ++ lib.optional (!enableBlobs) "--disable-install-blobs";
 
   dontWrapGApps = true;
 

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -70,8 +70,9 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config flex bison dtc meson ninja
 
     # Don't change this to python3 and python3.pkgs.*, breaks cross-compilation
-    python3Packages.python python3Packages.sphinx python3Packages.sphinx-rtd-theme
+    python3Packages.python
   ]
+    ++ lib.optionals enableDocs [ python3Packages.sphinx python3Packages.sphinx-rtd-theme ]
     ++ lib.optionals gtkSupport [ wrapGAppsHook ]
     ++ lib.optionals hexagonSupport [ glib ]
     ++ lib.optionals stdenv.isDarwin [ sigtool ];

--- a/pkgs/applications/virtualization/qemu/user-static.nix
+++ b/pkgs/applications/virtualization/qemu/user-static.nix
@@ -23,6 +23,7 @@ let
     pulseSupport = false;
     sdlSupport = false;
     jackSupport = false;
+    pipewireSupport = false;
     gtkSupport = false;
     vncSupport = false;
     smartcardSupport = false;

--- a/pkgs/applications/virtualization/qemu/user-static.nix
+++ b/pkgs/applications/virtualization/qemu/user-static.nix
@@ -1,0 +1,52 @@
+{ lib, pkgsStatic }:
+
+let
+  qemuUserPlatforms = [
+    "aarch64-linux"
+    "armv7l-linux"
+    "i386-linux"
+    "powerpc-linux"
+    "powerpc64-linux"
+    "powerpc64le-linux"
+    "riscv32-linux"
+    "riscv64-linux"
+    "x86_64-linux"
+  ];
+
+  qemuTargets = map (system: (lib.systems.elaborate { inherit system; }).qemuArch + "-linux-user") qemuUserPlatforms;
+
+  static = (pkgsStatic.qemu.override {
+    guestAgentSupport = false;
+    numaSupport = false;
+    seccompSupport = false;
+    alsaSupport = false;
+    pulseSupport = false;
+    sdlSupport = false;
+    jackSupport = false;
+    gtkSupport = false;
+    vncSupport = false;
+    smartcardSupport = false;
+    spiceSupport = false;
+    ncursesSupport = false;
+    libiscsiSupport = false;
+    smbdSupport = false;
+    tpmSupport = false;
+    uringSupport = false;
+    capstoneSupport = false;
+    enableDocs = false;
+    enableTools = false;
+    enableBlobs = false;
+    hostCpuTargets = qemuTargets;
+  }).overrideAttrs (old: {
+    # HACK: Otherwise the result will have the entire buildinput closure
+    # injected by the pkgsStatic stdenv
+    # <https://github.com/NixOS/nixpkgs/issues/83667>
+    postFixup = (old.postFixup or "") + ''
+      rm -f $out/nix-support/propagated-build-inputs
+    '';
+  });
+in static // {
+  passthru = (static.passthru or {}) // {
+    inherit qemuUserPlatforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34246,6 +34246,8 @@ with pkgs;
     toolsOnly = true;
   };
 
+  qemu-user-static = callPackage ../applications/virtualization/qemu/user-static.nix { };
+
   canokey-qemu = callPackage ../applications/virtualization/qemu/canokey-qemu.nix { };
 
   wrapQemuBinfmtP = callPackage ../applications/virtualization/qemu/binfmt-p-wrapper.nix { };


### PR DESCRIPTION
(I'm not familiar with the etiquette on updating the PR of others, and I did not find the right git commands to keep #160802 authorship during the merge. I'd like to thank @zhaofengli for the original PR and I'll investigate how to keep the authorship intact meanwhile)

## Description of changes
Built on top of https://github.com/NixOS/nixpkgs/pull/160802, this commit
addresses necessary updates to bring it up to parity with `nixpkgs-unstable`:

- Introduce `pipewireSupport: false` as a new override option
- Remove 8.1.1 patch as qemu is 8.2.2 in nixpkgs-unstable
- Introduce new patch to expose libaio static due to upstream meson.build changes

In order to compile, the `perl` dependency must also be fixed
(https://github.com/NixOS/nixpkgs/pull/299623) on the `pkgsStatic` environment.
With this additional changeset, `nix-shell -p qemu-user-static` compiles.

**Tested on**:
- `x86_64-linux`
- `aarch64-linux`

**Depends on:**
- [ ] https://github.com/NixOS/nixpkgs/pull/299623

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
