### PR TITLE
sportstracker: init at 8.0.1

### DIFF
--- a/pkgs/by-name/sp/sportstracker/fix-maven-plugin-versions.patch
+++ b/pkgs/by-name/sp/sportstracker/fix-maven-plugin-versions.patch
@@ -1,0 +1,77 @@
+diff --git a/leafletmap/pom.xml b/leafletmap/pom.xml
+index f1c0089..2fccca4 100644
+--- a/leafletmap/pom.xml
++++ b/leafletmap/pom.xml
+@@ -10,6 +10,12 @@
+     <packaging>jar</packaging>
+     <version>1.0.9</version>
+ 
++    <parent>
++        <groupId>de.saring</groupId>
++        <artifactId>st-parent</artifactId>
++        <version>1.0.0</version>
++    </parent>
++
+     <organization>
+         <name>Saring</name>
+         <url>https://www.saring.de</url>
+diff --git a/pom.xml b/pom.xml
+index 9446306..0c14ddc 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -181,6 +182,55 @@
+                 <artifactId>maven-failsafe-plugin</artifactId>
+                 <version>3.2.5</version>
+             </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-enforcer-plugin</artifactId>
++                <version>3.5.0</version>
++                <executions>
++                    <execution>
++                        <id>require-all-plugin-versions-to-be-set</id>
++                        <phase>validate</phase>
++                        <goals>
++                            <goal>enforce</goal>
++                        </goals>
++                        <configuration>
++                            <rules>
++                                <requirePluginVersions />
++                            </rules>
++                        </configuration>
++                    </execution>
++                </executions>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-clean-plugin</artifactId>
++                <version>3.4.0</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-install-plugin</artifactId>
++                <version>3.1.3</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-site-plugin</artifactId>
++                <version>3.20.0</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-deploy-plugin</artifactId>
++                <version>3.1.3</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-jar-plugin</artifactId>
++                <version>3.4.2</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-resources-plugin</artifactId>
++                <version>3.3.1</version>
++            </plugin>
+         </plugins>
+     </build>
+ 

--- a/pkgs/by-name/sp/sportstracker/package.nix
+++ b/pkgs/by-name/sp/sportstracker/package.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  jdk21,
+  openjfx21,
+  maven,
+  fetchFromGitHub,
+  makeDesktopItem,
+  copyDesktopItems,
+  wrapGAppsHook3,
+  gtk3,
+}:
+
+let
+  jdkWithJFX = jdk21.override {
+    enableJavaFX = true;
+    openjfx21 = openjfx21.override { withWebKit = true; };
+  };
+in
+maven.buildMavenPackage rec {
+  pname = "sportstracker";
+  version = "8.0.1";
+
+  src = fetchFromGitHub {
+    owner = "ssaring";
+    repo = "sportstracker";
+    rev = "SportsTracker-${version}";
+    hash = "sha256-5TRTZmBwu33CJieYyt4OtlzVjlfY1FLef9WwKl9iUIw=";
+  };
+
+  patches = [
+    # We use nixpkgs's JavaFX instead of the one originally fetched by Maven,
+    # so we don't even need to fetch it. This avoids having platform-dependent hashes.
+    ./remove-pom-jfx.patch
+    ./fix-maven-plugin-versions.patch
+  ];
+
+  mvnJdk = jdkWithJFX;
+  mvnHash = "sha256-dAANjxM9cEEw+y3tOLHykxjdlVQh8I7pd/9k3lbkgzY=";
+
+  mvnParameters = toString [
+    "-Dproject.build.outputTimestamp=1980-01-01T00:00:02Z" # set fixed build timestamp for deterministic jar
+    "-Dtest=!BindingUtilsToggleGroupTest" # uses DISPLAY
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [ gtk3 ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 sportstracker/target/sportstracker-*.jar $out/share/sportstracker/sportstracker.jar
+    install -Dm644 sportstracker/target/lib/*.jar -t $out/share/sportstracker/lib
+    install -Dm644 sportstracker/docs/* -t $out/share/doc/sportstracker
+    install -Dm644 st-packager/icons/linux/SportsTracker.png -t $out/share/pixmaps
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "sportstracker";
+      exec = "SportsTracker";
+      icon = "SportsTracker";
+      desktopName = "SportsTracker";
+      comment = meta.description;
+      terminal = false;
+      categories = [
+        "Sports"
+        "Utility"
+      ];
+    })
+  ];
+
+  # don't double-wrap
+  dontWrapGApps = true;
+
+  postFixup = ''
+    makeWrapper ${jdkWithJFX}/bin/java $out/bin/SportsTracker \
+        --add-flags "-Djava.awt.headless=true" \
+        --add-flags "-jar $out/share/sportstracker/sportstracker.jar" \
+        "''${gappsWrapperArgs[@]}"
+  '';
+
+  meta = {
+    changelog = "https://www.saring.de/sportstracker/CHANGES.txt";
+    description = "Desktop application for people who want to record and analyze their sporting activities";
+    homepage = "https://www.saring.de/sportstracker";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "SportsTracker";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = jdkWithJFX.meta.platforms;
+  };
+}

--- a/pkgs/by-name/sp/sportstracker/remove-pom-jfx.patch
+++ b/pkgs/by-name/sp/sportstracker/remove-pom-jfx.patch
@@ -1,0 +1,37 @@
+diff --git a/leafletmap/pom.xml b/leafletmap/pom.xml
+index f1c0089..e13d634 100644
+--- a/leafletmap/pom.xml
++++ b/leafletmap/pom.xml
+@@ -23,16 +23,6 @@
+     </properties>
+     
+     <dependencies>
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-fxml</artifactId>
+-            <version>${javafx.version}</version>
+-        </dependency>
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-web</artifactId>
+-            <version>${javafx.version}</version>
+-        </dependency>
+         <dependency>
+             <groupId>org.jetbrains.kotlin</groupId>
+             <artifactId>kotlin-stdlib</artifactId>
+diff --git a/pom.xml b/pom.xml
+index 9446306..d2cb9ec 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -44,11 +43,6 @@
+             <artifactId>kotlin-stdlib</artifactId>
+             <version>${kotlin.version}</version>
+         </dependency>
+-        <dependency>
+-            <groupId>org.openjfx</groupId>
+-            <artifactId>javafx-fxml</artifactId>
+-            <version>${javafx.version}</version>
+-        </dependency>
+         <dependency>
+             <groupId>jakarta.inject</groupId>
+             <artifactId>jakarta.inject-api</artifactId>


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/298184

This PR adds 1 package: `sportstracker`
I went with a capitalized executable name, because the releases also capitalize them.

This is a JavaFX application. The package wants to fetch `javafx` for itself, however we can provide `javafx` through nixpkgs by overriding the `jdk`. This way we won't have to patch any `.so` files inside the fetched files and there will be no platform-dependent `mvnHash` differences.

Unfortunately, currently there isn't a cached jdk21 with webkit enabled, so you'll have to wait out the long build time (~1 hour).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
