### PR TITLE
rocmPackages_{5,6}.miopen: fix test builds by linking gtest

### DIFF
--- a/pkgs/development/rocm-modules/5/miopen/default.nix
+++ b/pkgs/development/rocm-modules/5/miopen/default.nix
@@ -156,6 +156,7 @@ in stdenv.mkDerivation (finalAttrs: {
     python3Packages.breathe
     python3Packages.myst-parser
   ] ++ lib.optionals buildTests [
+    gtest
     zlib
   ];
 
@@ -189,6 +190,9 @@ in stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace test/gtest/CMakeLists.txt \
       --replace "include(googletest)" ""
+
+    substituteInPlace test/gtest/CMakeLists.txt \
+      --replace-fail " gtest_main " " ${gtest}/lib/libgtest.so ${gtest}/lib/libgtest_main.so "
 
     ln -sf ${gfx900} src/kernels/gfx900.kdb
     ln -sf ${gfx906} src/kernels/gfx906.kdb

--- a/pkgs/development/rocm-modules/6/miopen/default.nix
+++ b/pkgs/development/rocm-modules/6/miopen/default.nix
@@ -155,6 +155,7 @@ in stdenv.mkDerivation (finalAttrs: {
     python3Packages.breathe
     python3Packages.myst-parser
   ] ++ lib.optionals buildTests [
+    gtest
     zlib
   ];
 
@@ -184,6 +185,9 @@ in stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace test/gtest/CMakeLists.txt \
       --replace "include(googletest)" ""
+
+    substituteInPlace test/gtest/CMakeLists.txt \
+      --replace-fail " gtest_main " " ${gtest}/lib/libgtest.so ${gtest}/lib/libgtest_main.so "
 
     ln -sf ${gfx900} src/kernels/gfx900.kdb
     ln -sf ${gfx906} src/kernels/gfx906.kdb


### PR DESCRIPTION
## Description of changes

At HEAD neither rocm 5.x or rocm 6.x versions of `miopen` succeed in building when `buildTests = true`, because gtest isn't included in `buildInputs` or correctly linked. Simply putting it in `buildInputs` isn't sufficient apparently, so this PR includes a patch to `CMakeLists.txt`.

It seems most of the tests for the rocm 5.x version pass, though overall the build fails due to non-passing tests (I am new in the rocm world so it's possible I'm holding it wrong). For rocm 6.x, there is an LLVM undefined symbol error (see #299156) that I think just means the derivation for that version of MIOpen is completely broken right now. I haven't managed to resolve it yet, and will leave #299156 open to track it, renaming as appropriate. 

Even if the tests don't pass I'd argue that having them buildable is strictly better than not. I also split it into two commits in the unlikely case there's desire to backport the 5.x fix to stable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
