### PR TITLE
 python3Packages.flake8-builtins: init at 2.3.0 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5366,6 +5366,13 @@
     githubId = 277927;
     name = "Dylan Taylor";
   };
+  dyniec = {
+    email = "pawel+nixpkgs@dybiec.info";
+    matrix = "@dyniec:matrix.org";
+    github = "dyniec";
+    githubId = 7108963;
+    name = "Paweł Dybiec";
+  };
   dysinger = {
     email = "tim@dysinger.net";
     github = "dysinger";

--- a/pkgs/development/python-modules/flake8-builtins/default.nix
+++ b/pkgs/development/python-modules/flake8-builtins/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flake8
+, hatchling
+, pytest
+, pythonOlder
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "flake8-builtins";
+  version = "2.3.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "gforcada";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-0xDUwMqhuLQ6HVSbY2TnPn479V/8K8xFjQCaQQ51Cgs=";
+  };
+
+  nativeBuildInputs = [
+    hatchling
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    flake8
+  ];
+
+  nativeCheckInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    pytest run_tests.py
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "Check for python builtins being used as variables or parameters";
+    homepage = "https://github.com/gforcada/flake8-builtins";
+    changelog = "https://github.com/gforcada/flake8-builtins/blob/${version}/HISTORY.rst";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ dyniec ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4177,6 +4177,8 @@ self: super: with self; {
 
   flake8-blind-except = callPackage ../development/python-modules/flake8-blind-except { };
 
+  flake8-builtins = callPackage ../development/python-modules/flake8-builtins { };
+
   flake8-bugbear = callPackage ../development/python-modules/flake8-bugbear { };
 
   flake8 = callPackage ../development/python-modules/flake8 { };


### PR DESCRIPTION
## Description of changes
Add [flake8-builtins](https://pypi.org/project/flake8-builtins/#description) to nixpkgs. It's a plugin to flake8.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) - tested behavior of flake8 when flake8-builtins is present with `nix-shell -I nixpkgs=$(pwd) -p  'python39.withPackages(ps : with ps; [ flake8-builtins flake8])'`
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
