### PR TITLE
guitarix: 0.44.1 -> 0.46.0

### DIFF
--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchurl
+, fetchFromGitHub
 , avahi
 , bluez
 , boost
@@ -45,10 +45,15 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "guitarix";
   version = "0.46.0";
 
-  src = fetchurl {
-    url = "https://github.com/brummer10/guitarix/releases/download/V${finalAttrs.version}/guitarix2-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-xmC+s/Fs3EVdmebwdM1uorHxDB38SA6EIQRhY33JjEQ=";
+  src = fetchFromGitHub {
+    owner = "brummer10";
+    repo = "guitarix";
+    rev = "V${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-AftC6fQEDzG/3C/83YbK/++bRgP7vPD0E2X6KEWpowc=";
   };
+
+  sourceRoot = "${finalAttrs.src.name}/trunk";
 
   nativeBuildInputs = [
     gettext

--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -131,7 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/brummer10/guitarix";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ astsmtl goibhniu ];
+    maintainers = with maintainers; [ astsmtl goibhniu lord-valen ];
     platforms = platforms.linux;
   };
 })

--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchurl
-, fetchpatch
 , avahi
 , bluez
 , boost
@@ -44,27 +43,12 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "guitarix";
-  version = "0.44.1";
+  version = "0.46.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/guitarix/guitarix2-${finalAttrs.version}.tar.xz";
-    sha256 = "d+g9dU9RrDjFQj847rVd5bPiYSjmC1EbAtLe/PNubBg=";
+    url = "https://github.com/brummer10/guitarix/releases/download/V${finalAttrs.version}/guitarix2-${finalAttrs.version}.tar.xz";
+    sha256 = "sha256-xmC+s/Fs3EVdmebwdM1uorHxDB38SA6EIQRhY33JjEQ=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "gcc13-fixes.patch";
-      url = "https://github.com/brummer10/guitarix/commit/b52736180b6966f24398f8a5ad179a58173473ec.patch";
-      hash = "sha256-+jilgLujy/B6ijUb8NHzt3+4IKCt17X8LmuMLdmsvGw=";
-      relative = "trunk";
-    })
-  ];
-
-  # doesnt apply cleanly, so doing with substituteInPlace
-  # https://github.com/brummer10/guitarix/commit/39d7c21c4173eb0f121b1bbff439d9cf43331a00.patch
-  postPatch = ''
-    substituteInPlace wscript --replace "open(src_fname, 'rU')" "open(src_fname, 'r')"
-  '';
 
   nativeBuildInputs = [
     gettext
@@ -140,7 +124,7 @@ stdenv.mkDerivation (finalAttrs: {
       clean-sounds, nice overdrive, fat distortion and a diversity of
       crazy sounds never heard before.
     '';
-    homepage = "http://guitarix.sourceforge.net/";
+    homepage = "https://github.com/brummer10/guitarix";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ astsmtl goibhniu ];
     platforms = platforms.linux;

--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -42,12 +42,12 @@ let
   inherit (lib) optional;
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "guitarix";
   version = "0.44.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/guitarix/guitarix2-${version}.tar.xz";
+    url = "mirror://sourceforge/guitarix/guitarix2-${finalAttrs.version}.tar.xz";
     sha256 = "d+g9dU9RrDjFQj847rVd5bPiYSjmC1EbAtLe/PNubBg=";
   };
 
@@ -145,4 +145,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ astsmtl goibhniu ];
     platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
## Description of changes
Guitarix is now entirely on GitHub.
 
The patch formerly applied is included in 0.45.0, so I removed it.

Changes:
https://github.com/brummer10/guitarix/releases/tag/V0.45.0
https://github.com/brummer10/guitarix/releases/tag/V0.46.0

Notably now includes Neural Amp Modeler and RTNeural.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
