### PR TITLE
rqbit: 5.5.3 -> 5.5.4

### DIFF
--- a/pkgs/by-name/rq/rqbit/Cargo.lock
+++ b/pkgs/by-name/rq/rqbit/Cargo.lock
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "librqbit"
-version = "5.5.3"
+version = "5.5.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "librqbit-bencode"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "anyhow",
  "librqbit-buffers",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "librqbit-buffers"
-version = "2.2.1"
+version = "3.0.0"
 dependencies = [
  "librqbit-clone-to-owned",
  "serde",
@@ -1341,7 +1341,7 @@ version = "2.2.1"
 
 [[package]]
 name = "librqbit-core"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "anyhow",
  "directories",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "librqbit-dht"
-version = "5.0.1"
+version = "5.0.2"
 dependencies = [
  "anyhow",
  "backoff",
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "librqbit-peer-protocol"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1403,16 +1403,14 @@ dependencies = [
 
 [[package]]
 name = "librqbit-sha1-wrapper"
-version = "2.2.1"
+version = "3.0.0"
 dependencies = [
  "crypto-hash",
- "openssl",
- "sha1",
 ]
 
 [[package]]
 name = "librqbit-tracker-comms"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2070,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "rqbit"
-version = "5.5.3"
+version = "5.5.4"
 dependencies = [
  "anyhow",
  "bytes",

--- a/pkgs/by-name/rq/rqbit/package.nix
+++ b/pkgs/by-name/rq/rqbit/package.nix
@@ -2,13 +2,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rqbit";
-  version = "5.5.3";
+  version = "5.5.4";
 
   src = fetchFromGitHub {
     owner = "ikatson";
     repo = "rqbit";
     rev = "v${version}";
-    hash = "sha256-r/ff/Z/nsmQEWCVvmS0hGKXRuzIoDGhzfIRAxC6EaZk=";
+    hash = "sha256-o+v/h51F9xXzMLSkRJfmXddKskMXTF2p5LEIcoXvh74=";
   };
 
   cargoLock = {


### PR DESCRIPTION
Diff: https://github.com/ikatson/rqbit/compare/v5.5.3...v5.5.4

Changelog: https://github.com/ikatson/rqbit/releases/tag/v5.5.4

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
