### PR TITLE
tetrio-desktop: use nixpkgs electron

### DIFF
--- a/pkgs/by-name/te/tetrio-desktop/package.nix
+++ b/pkgs/by-name/te/tetrio-desktop/package.nix
@@ -2,19 +2,9 @@
 , lib
 , fetchurl
 , dpkg
-, autoPatchelfHook
-, wrapGAppsHook
-, alsa-lib
-, cups
-, libGL
-, libX11
-, libXScrnSaver
-, libXtst
-, mesa
-, nss
-, gtk3
-, libpulseaudio
-, systemd
+, makeWrapper
+, addOpenGLRunpath
+, electron
 , withTetrioPlus ? false # For backwards compatibility. At the time of writing, the latest released tetrio plus version is not compatible with tetrio desktop.
 , tetrio-plus ? false # For backwards compatibility. At the time of writing, the latest released tetrio plus version is not compatible with tetrio desktop.
 }:
@@ -22,13 +12,6 @@
 lib.warnIf (withTetrioPlus != false) "withTetrioPlus: Currently unsupported with tetrio-desktop 9.0.0. Please remove this attribute."
 lib.warnIf (tetrio-plus != false) "tetrio-plus: Currently unsupported with tetrio-desktop 9.0.0. Please remove this attribute."
 
-(let
-  libPath = lib.makeLibraryPath [
-    libGL
-    libpulseaudio
-    systemd
-  ];
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "tetrio-desktop";
   version = "9.0.0";
@@ -40,31 +23,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     dpkg
-    autoPatchelfHook
-    wrapGAppsHook
+    makeWrapper
   ];
-
-  dontWrapGApps = true;
-
-  buildInputs = [
-    alsa-lib
-    cups
-    libX11
-    libXScrnSaver
-    libXtst
-    mesa
-    nss
-    gtk3
-  ];
-
-  unpackCmd = "dpkg -x $curSrc src";
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin
-    cp -r opt/ usr/share/ $out
-    ln -s $out/opt/TETR.IO/TETR.IO $out/bin/tetrio
+    mkdir -p $out
+    cp -r usr/share/ $out
+
+    mkdir -p $out/share/TETR.IO/
+    cp opt/TETR.IO/resources/app.asar $out/share/TETR.IO/app.asar
 
     substituteInPlace $out/share/applications/TETR.IO.desktop \
       --replace-fail "Exec=/opt/TETR.IO/TETR.IO" "Exec=$out/bin/tetrio"
@@ -73,12 +42,14 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postFixup = ''
-    wrapProgram $out/opt/TETR.IO/TETR.IO \
-      --prefix LD_LIBRARY_PATH : ${libPath}:$out/opt/TETR.IO \
-      ''${gappsWrapperArgs[@]}
+    makeShellWrapper '${lib.getExe electron}' $out/bin/tetrio \
+      --prefix LD_LIBRARY_PATH : ${addOpenGLRunpath.driverLink}/lib \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --add-flags $out/share/TETR.IO/app.asar
   '';
 
   meta = {
+    changelog = "https://tetr.io/about/desktop/history/";
     description = "TETR.IO desktop client";
     downloadPage = "https://tetr.io/about/desktop/";
     homepage = "https://tetr.io";
@@ -88,7 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
       Play against friends and foes all over the world, or claim a spot on the leaderboards - the stacker future is yours!
     '';
     mainProgram = "tetrio";
-    maintainers = with lib.maintainers; [ wackbyte ];
+    maintainers = with lib.maintainers; [ wackbyte huantian ];
     platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
   };
-}))
+})


### PR DESCRIPTION
## Description of changes
@wackbyte 

I'll make this a bit better, but wanted to get this out quickly to have some eyes on it. Now that upstream is using a modern version of electron, we can wrap it with our electron instead of using the provided binary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
