### PR TITLE
stdenv/check-meta: Fix performance regressions introduced in #294347

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -31,6 +31,14 @@ let
     toList
     isList
     elem
+    ;
+
+  inherit (lib.meta)
+    availableOn
+  ;
+
+  inherit (lib.generators)
+    toPretty
   ;
 
   # If we're in hydra, we can dispense with the more verbose error
@@ -86,7 +94,7 @@ let
     # was `licenses: lib.lists.any (l: !l.free or true) licenses;`
     # which always evaluates to `!true` for strings.
     else if isString licenses then false
-    else lib.lists.any (l: !l.free or true) licenses;
+    else any (l: !l.free or true) licenses;
 
   hasUnfreeLicense = attrs: hasLicense attrs && isUnfree attrs.meta.license;
 
@@ -96,7 +104,7 @@ let
   isMarkedBroken = attrs: attrs.meta.broken or false;
 
   hasUnsupportedPlatform =
-    pkg: !(lib.meta.availableOn hostPlatform pkg);
+    pkg: !(availableOn hostPlatform pkg);
 
   isMarkedInsecure = attrs: (attrs.meta.knownVulnerabilities or []) != [];
 
@@ -366,7 +374,7 @@ let
         [ ]
       else
         [ "key 'meta.${k}' has invalid value; expected ${metaTypes.${k}.name}, got\n    ${
-          lib.generators.toPretty { indent = "    "; } v
+          toPretty { indent = "    "; } v
         }" ]
     else
       [ "key 'meta.${k}' is unrecognized; expected one of: \n  [${concatMapStringsSep ", " (x: "'${x}'") (attrNames metaTypes)}]" ];
@@ -416,7 +424,7 @@ let
     else if !allowBroken && attrs.meta.broken or false then
       { valid = "no"; reason = "broken"; errormsg = "is marked as broken"; }
     else if !allowUnsupportedSystem && hasUnsupportedPlatform attrs then
-      let toPretty = lib.generators.toPretty {
+      let toPretty = toPretty {
             allowPrettyValues = true;
             indent = "  ";
           };

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -10,7 +10,9 @@ let
     concatMapStrings
     concatMapStringsSep
     concatStrings
+    filter
     findFirst
+    head
     isDerivation
     length
     concatMap
@@ -436,6 +438,18 @@ let
     # -----
     else { valid = "yes"; });
 
+  getRepository = let
+    getSrcs = attrs:
+      if attrs ? src
+      then
+        [ attrs.src ]
+      else
+        filter (src: src ? meta.homepage) attrs.srcs;
+    getHomePages = map (src: src.meta.homepage);
+    unlist = list:
+      if length list == 1 then head list
+      else list;
+    in attrs: unlist (getHomePages (getSrcs attrs));
 
   # The meta attribute is passed in the resulting attribute set,
   # but it's not part of the actual derivation, i.e., it's not
@@ -454,22 +468,7 @@ let
       # this could be handled a lot easier if we nulled it instead
       # of having it be undefined, but that wouldn't match the
       # other attributes.
-      repository = let
-        getSrcs = attrs:
-          if attrs ? src
-          then
-            [ attrs.src ]
-          else
-            lib.filter (src: src ? meta.homepage) attrs.srcs;
-        getHomePages = srcs: map (src: src.meta.homepage) srcs;
-        unlist = list:
-          if lib.length list == 1
-          then
-            lib.elemAt list 0
-          else
-            list;
-      in
-        unlist (getHomePages (getSrcs attrs));
+      repository = getRepository attrs;
     } // {
       # `name` derivation attribute includes cross-compilation cruft,
       # is under assert, and is sanitized.


### PR DESCRIPTION
## Description of changes

This fixes a few performance related regressions added in https://github.com/NixOS/nixpkgs/pull/294347

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
