### PR TITLE
python312Packages.appthreat-vulnerability-db: 5.6.4 -> 5.6.6,  dep-scan: 5.2.12 -> 5.2.14 

### DIFF
--- a/pkgs/by-name/de/dep-scan/package.nix
+++ b/pkgs/by-name/de/dep-scan/package.nix
@@ -5,26 +5,29 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "dep-scan";
-  version = "5.2.12";
+  version = "5.2.14";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "owasp-dep-scan";
     repo = "dep-scan";
     rev = "refs/tags/v${version}";
-    hash = "sha256-UoppQAokiWBcgTcSmwfoqrDKt/QHYd2NBR3CpNOqI4k=";
+    hash = "sha256-G8i/tGEDgjPnIP04nrbx4HseiaU6N1GJGSg78yhaqII=";
   };
 
   postPatch = ''
     substituteInPlace pytest.ini \
-      --replace " --cov-append --cov-report term --cov depscan" ""
+      --replace-fail " --cov-append --cov-report term --cov depscan" ""
+    # Already fixed by upstream
+    substituteInPlace pyproject.toml \
+      --replace-fail "==5.6.4" ">=5.6.4"
   '';
 
-  nativeBuildInputs = with python3.pkgs; [
+  build-system = with python3.pkgs; [
     setuptools
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3.pkgs; [
     appthreat-vulnerability-db
     cvss
     defusedxml

--- a/pkgs/development/python-modules/appthreat-vulnerability-db/default.nix
+++ b/pkgs/development/python-modules/appthreat-vulnerability-db/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-warn " --cov-report=term-missing --no-cov-on-fail --cov vdb" ""
+      --replace-fail " --cov-report=term-missing --no-cov-on-fail --cov vdb" ""
   '';
 
   pythonRelaxDeps = [
@@ -39,12 +39,15 @@ buildPythonPackage rec {
     "semver"
   ];
 
-  nativeBuildInputs = [
-    pythonRelaxDepsHook
+  build-system = [
     setuptools
   ];
 
-  propagatedBuildInputs = [
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
+  dependencies = [
     appdirs
     cvss
     httpx
@@ -75,10 +78,10 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Vulnerability database and package search for sources such as OSV, NVD, GitHub and npm";
-    mainProgram = "vdb";
     homepage = "https://github.com/appthreat/vulnerability-db";
     changelog = "https://github.com/AppThreat/vulnerability-db/releases/tag/v${version}";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
+    mainProgram = "vdb";
   };
 }

--- a/pkgs/development/python-modules/appthreat-vulnerability-db/default.nix
+++ b/pkgs/development/python-modules/appthreat-vulnerability-db/default.nix
@@ -17,16 +17,16 @@
 
 buildPythonPackage rec {
   pname = "appthreat-vulnerability-db";
-  version = "5.6.4";
+  version = "5.6.6";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.10";
 
   src = fetchFromGitHub {
     owner = "AppThreat";
     repo = "vulnerability-db";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Uq0DXrNQRVhQaPXXGNjbnPhOYoPpa8H3WuDdotCKS8c=";
+    hash = "sha256-wVl2C1AG9LbSh/p95fstJyJr6JnhZFIhNvq8mhpg13Q=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Diff: https://github.com/AppThreat/vulnerability-db/compare/refs/tags/v5.6.4...v5.6.6

Changelog: https://github.com/AppThreat/vulnerability-db/releases/tag/v5.6.6

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
