### PR TITLE
[23.11] curl: apply patches for CVE-2024-2398 and CVE-2024-2004

### DIFF
--- a/pkgs/tools/networking/curl/0003-CVE-2024-2398.patch
+++ b/pkgs/tools/networking/curl/0003-CVE-2024-2398.patch
@@ -1,0 +1,94 @@
+From b1b7ab02e055249c02eac8c2a80295701f2530a2 Mon Sep 17 00:00:00 2001
+From: Stefan Eissing <stefan@eissing.org>
+Date: Wed, 6 Mar 2024 09:36:08 +0100
+Subject: [PATCH 3/4] http2: push headers better cleanup
+
+- provide common cleanup method for push headers
+
+Closes #13054
+
+(cherry picked from commit deca8039991886a559b67bcd6701db800a5cf764)
+---
+ lib/http2.c | 34 +++++++++++++++-------------------
+ 1 file changed, 15 insertions(+), 19 deletions(-)
+
+diff --git a/lib/http2.c b/lib/http2.c
+index c8b059498..8c422d156 100644
+--- a/lib/http2.c
++++ b/lib/http2.c
+@@ -271,6 +271,15 @@ static CURLcode http2_data_setup(struct Curl_cfilter *cf,
+   return CURLE_OK;
+ }
+ 
++static void free_push_headers(struct stream_ctx *stream)
++{
++  size_t i;
++  for(i = 0; i<stream->push_headers_used; i++)
++    free(stream->push_headers[i]);
++  Curl_safefree(stream->push_headers);
++  stream->push_headers_used = 0;
++}
++
+ static void http2_data_done(struct Curl_cfilter *cf,
+                             struct Curl_easy *data, bool premature)
+ {
+@@ -318,15 +327,7 @@ static void http2_data_done(struct Curl_cfilter *cf,
+   Curl_bufq_free(&stream->recvbuf);
+   Curl_h1_req_parse_free(&stream->h1);
+   Curl_dynhds_free(&stream->resp_trailers);
+-  if(stream->push_headers) {
+-    /* if they weren't used and then freed before */
+-    for(; stream->push_headers_used > 0; --stream->push_headers_used) {
+-      free(stream->push_headers[stream->push_headers_used - 1]);
+-    }
+-    free(stream->push_headers);
+-    stream->push_headers = NULL;
+-  }
+-
++  free_push_headers(stream);
+   free(stream);
+   H2_STREAM_LCTX(data) = NULL;
+ }
+@@ -865,7 +866,6 @@ static int push_promise(struct Curl_cfilter *cf,
+     struct curl_pushheaders heads;
+     CURLMcode rc;
+     CURLcode result;
+-    size_t i;
+     /* clone the parent */
+     struct Curl_easy *newhandle = h2_duphandle(cf, data);
+     if(!newhandle) {
+@@ -910,11 +910,7 @@ static int push_promise(struct Curl_cfilter *cf,
+     Curl_set_in_callback(data, false);
+ 
+     /* free the headers again */
+-    for(i = 0; i<stream->push_headers_used; i++)
+-      free(stream->push_headers[i]);
+-    free(stream->push_headers);
+-    stream->push_headers = NULL;
+-    stream->push_headers_used = 0;
++    free_push_headers(stream);
+ 
+     if(rv) {
+       DEBUGASSERT((rv > CURL_PUSH_OK) && (rv <= CURL_PUSH_ERROROUT));
+@@ -1455,14 +1451,14 @@ static int on_header(nghttp2_session *session, const nghttp2_frame *frame,
+       if(stream->push_headers_alloc > 1000) {
+         /* this is beyond crazy many headers, bail out */
+         failf(data_s, "Too many PUSH_PROMISE headers");
+-        Curl_safefree(stream->push_headers);
++        free_push_headers(stream);
+         return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
+       }
+       stream->push_headers_alloc *= 2;
+-      headp = Curl_saferealloc(stream->push_headers,
+-                               stream->push_headers_alloc * sizeof(char *));
++      headp = realloc(stream->push_headers,
++                      stream->push_headers_alloc * sizeof(char *));
+       if(!headp) {
+-        stream->push_headers = NULL;
++        free_push_headers(stream);
+         return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
+       }
+       stream->push_headers = headp;
+-- 
+2.44.0
+

--- a/pkgs/tools/networking/curl/0004-CVE-2024-2004.patch
+++ b/pkgs/tools/networking/curl/0004-CVE-2024-2004.patch
@@ -1,0 +1,137 @@
+From b091564d9fd187c6dc6410e3badf4621df8f4e0a Mon Sep 17 00:00:00 2001
+From: Daniel Gustafsson <daniel@yesql.se>
+Date: Tue, 27 Feb 2024 15:43:56 +0100
+Subject: [PATCH] setopt: Fix disabling all protocols
+
+When disabling all protocols without enabling any, the resulting
+set of allowed protocols remained the default set.  Clearing the
+allowed set before inspecting the passed value from --proto make
+the set empty even in the errorpath of no protocols enabled.
+
+Co-authored-by: Dan Fandrich <dan@telarity.com>
+Reported-by: Dan Fandrich <dan@telarity.com>
+Reviewed-by: Daniel Stenberg <daniel@haxx.se>
+Closes: #13004
+(cherry picked from commit 17d302e56221f5040092db77d4f85086e8a20e0e)
+---
+ lib/setopt.c            | 16 ++++++++--------
+ tests/data/Makefile.inc |  2 +-
+ tests/data/test1475     | 42 +++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 51 insertions(+), 9 deletions(-)
+ create mode 100644 tests/data/test1475
+
+diff --git a/lib/setopt.c b/lib/setopt.c
+index 0d399adfe..e022096f6 100644
+--- a/lib/setopt.c
++++ b/lib/setopt.c
+@@ -154,6 +154,12 @@ static CURLcode setstropt_userpwd(char *option, char **userp, char **passwdp)
+ 
+ static CURLcode protocol2num(const char *str, curl_prot_t *val)
+ {
++  /*
++   * We are asked to cherry-pick protocols, so play it safe and disallow all
++   * protocols to start with, and re-add the wanted ones back in.
++   */
++  *val = 0;
++
+   if(!str)
+     return CURLE_BAD_FUNCTION_ARGUMENT;
+ 
+@@ -162,8 +168,6 @@ static CURLcode protocol2num(const char *str, curl_prot_t *val)
+     return CURLE_OK;
+   }
+ 
+-  *val = 0;
+-
+   do {
+     const char *token = str;
+     size_t tlen;
+@@ -2690,22 +2694,18 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
+     break;
+ 
+   case CURLOPT_PROTOCOLS_STR: {
+-    curl_prot_t prot;
+     argptr = va_arg(param, char *);
+-    result = protocol2num(argptr, &prot);
++    result = protocol2num(argptr, &data->set.allowed_protocols);
+     if(result)
+       return result;
+-    data->set.allowed_protocols = prot;
+     break;
+   }
+ 
+   case CURLOPT_REDIR_PROTOCOLS_STR: {
+-    curl_prot_t prot;
+     argptr = va_arg(param, char *);
+-    result = protocol2num(argptr, &prot);
++    result = protocol2num(argptr, &data->set.redir_protocols);
+     if(result)
+       return result;
+-    data->set.redir_protocols = prot;
+     break;
+   }
+ 
+diff --git a/tests/data/Makefile.inc b/tests/data/Makefile.inc
+index 1472b1954..bdb2ef742 100644
+--- a/tests/data/Makefile.inc
++++ b/tests/data/Makefile.inc
+@@ -185,7 +185,7 @@ test1439 test1440 test1441 test1442 test1443 test1444 test1445 test1446 \
+ test1447 test1448 test1449 test1450 test1451 test1452 test1453 test1454 \
+ test1455 test1456 test1457 test1458 test1459 test1460 test1461 test1462 \
+ test1463 test1464 test1465 test1466 test1467 test1468 test1469 test1470 \
+-test1471 test1472 test1473 test1474 \
++test1471 test1472 test1473 test1474 test1475 \
+ \
+ test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
+ test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \
+diff --git a/tests/data/test1475 b/tests/data/test1475
+new file mode 100644
+index 000000000..c66fa2810
+--- /dev/null
++++ b/tests/data/test1475
+@@ -0,0 +1,42 @@
++<testcase>
++<info>
++<keywords>
++HTTP
++HTTP GET
++--proto
++</keywords>
++</info>
++
++#
++# Server-side
++<reply>
++<data>
++</data>
++</reply>
++
++#
++# Client-side
++<client>
++<server>
++none
++</server>
++<features>
++http
++</features>
++<name>
++--proto -all disables all protocols
++</name>
++<command>
++--proto -all http://%HOSTIP:%NOLISTENPORT/%TESTNUMBER
++</command>
++</client>
++
++#
++# Verify data after the test has been "shot"
++<verify>
++# 1 - Protocol "http" disabled
++<errorcode>
++1
++</errorcode>
++</verify>
++</testcase>
+-- 
+2.44.0
+

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -65,6 +65,10 @@ stdenv.mkDerivation (finalAttrs: {
     ./0001-CVE-2023-42619.patch
     # https://curl.se/docs/CVE-2023-46218.html
     ./0002-CVE-2023-42618.patch
+    # https://curl.se/docs/CVE-2024-2398.html
+    ./0003-CVE-2024-2398.patch
+    # https://curl.se/docs/CVE-2024-2004.html
+    ./0004-CVE-2024-2004.patch
   ];
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];


### PR DESCRIPTION
# Description of changes

https://curl.se/docs/CVE-2024-2398.html
https://curl.se/docs/CVE-2024-2004.html

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux up to `curlFull` and `curl.passthru.tests` (skipped curl.passthru.tests.nginx-http3)
  - [x] aarch64-linux up to `curlFull` and `curl.passthru.tests` (skipped curl.passthru.tests.nginx-http3)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
