### PR TITLE
ut1999: add x86_64-darwin, aarch64-linux, i686-linux support, innoextract: enable on darwin

### DIFF
--- a/pkgs/by-name/ut/ut1999/package.nix
+++ b/pkgs/by-name/ut/ut1999/package.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, requireFile, autoPatchelfHook, fetchurl, makeDesktopItem, copyDesktopItems, imagemagick
+{ lib, stdenv, requireFile, autoPatchelfHook, undmg, fetchurl, makeDesktopItem, copyDesktopItems, imagemagick
 , runCommand, libgcc, wxGTK32, innoextract, libGL, SDL2, openal, libmpg123, libxmp }:
 
 let
@@ -11,6 +11,10 @@ let
     i686-linux = fetchurl {
       url = "https://github.com/OldUnreal/UnrealTournamentPatches/releases/download/v${version}/OldUnreal-UTPatch${version}-Linux-x86.tar.bz2";
       hash = "sha256-1JsFKuAAj/LtYvOUPFu0Hn+zvY3riW0YlJbLd4UnaKU=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://github.com/OldUnreal/UnrealTournamentPatches/releases/download/v${version}/OldUnreal-UTPatch${version}-macOS-Sonoma.dmg";
+      hash = "sha256-TbhJbOH4E5WOb6XR9dmqLkXziK3/CzhNjd1ypBkkmvw=";
     };
   };
   unpackGog = runCommand "ut1999-gog" {
@@ -35,6 +39,7 @@ let
   systemDir = {
     x86_64-linux = "System64";
     i686-linux = "System";
+    x86_64-darwin = "System";
   }.${stdenv.hostPlatform.system} or (throw "unsupported system: ${stdenv.hostPlatform.system}");
 in stdenv.mkDerivation {
   name = "ut1999";
@@ -53,38 +58,42 @@ in stdenv.mkDerivation {
     stdenv.cc.cc
   ];
 
-  nativeBuildInputs = [
+  nativeBuildInputs = lib.optionals stdenv.isLinux [
     copyDesktopItems
     autoPatchelfHook
     imagemagick
+  ] ++ lib.optionals stdenv.isDarwin [
+    undmg
   ];
 
-  installPhase = ''
+  installPhase = let
+    outPrefix = if stdenv.isDarwin then "$out/UnrealTournament.app/Contents/MacOS" else "$out";
+  in ''
     runHook preInstall
 
     mkdir -p $out/bin
-    cp -r ./* $out
-
-    # Remove bundled libraries to use native versions instead
-    rm $out/${systemDir}/libmpg123.so* \
-      $out/${systemDir}/libopenal.so* \
-      $out/${systemDir}/libSDL2* \
-      $out/${systemDir}/libxmp.so*
-
+    cp -r ${if stdenv.isDarwin then "UnrealTournament.app" else "./*"} $out
     chmod -R 755 $out
+    cd ${outPrefix}
 
-    ln -s ${unpackGog}/Music $out
-    ln -s ${unpackGog}/Sounds $out
-    cp -n ${unpackGog}/Textures/* $out/Textures || true
-    ln -s ${unpackGog}/Maps $out
-    cp -n ${unpackGog}/System/*.{u,int} $out/System || true
+    rm -rf ./{Music,Sounds,Maps}
+    ln -s ${unpackGog}/{Music,Sounds,Maps} .
 
+    cp -n ${unpackGog}/Textures/* ./Textures || true
+    cp -n ${unpackGog}/System/*.{u,int} ./System || true
+  '' + lib.optionalString (stdenv.isLinux) ''
     ln -s "$out/${systemDir}/ut-bin" "$out/bin/ut1999"
     ln -s "$out/${systemDir}/ucc-bin" "$out/bin/ut1999-ucc"
 
     convert "${unpackGog}/gfw_high.ico" "ut1999.png"
     install -D ut1999-5.png "$out/share/icons/hicolor/256x256/apps/ut1999.png"
 
+    # Remove bundled libraries to use native versions instead
+    rm $out/${systemDir}/libmpg123.so* \
+      $out/${systemDir}/libopenal.so* \
+      $out/${systemDir}/libSDL2* \
+      $out/${systemDir}/libxmp.so*
+  '' + ''
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ut/ut1999/package.nix
+++ b/pkgs/by-name/ut/ut1999/package.nix
@@ -8,6 +8,10 @@ let
       url = "https://github.com/OldUnreal/UnrealTournamentPatches/releases/download/v${version}/OldUnreal-UTPatch${version}-Linux-amd64.tar.bz2";
       hash = "sha256-aoGzWuakwN/OL4+xUq8WEpd2c1rrNN/DkffI2vDVGjs=";
     };
+    aarch64-linux = fetchurl {
+      url = "https://github.com/OldUnreal/UnrealTournamentPatches/releases/download/v${version}/OldUnreal-UTPatch${version}-Linux-arm64.tar.bz2";
+      hash = "sha256-2e9lHB12jLTR8UYofLWL7gg0qb2IqFk6eND3T5VqAx0=";
+    };
     i686-linux = fetchurl {
       url = "https://github.com/OldUnreal/UnrealTournamentPatches/releases/download/v${version}/OldUnreal-UTPatch${version}-Linux-x86.tar.bz2";
       hash = "sha256-1JsFKuAAj/LtYvOUPFu0Hn+zvY3riW0YlJbLd4UnaKU=";
@@ -30,7 +34,7 @@ let
       '';
     };
 
-    buildInputs = [ innoextract ];
+    nativeBuildInputs = [ innoextract ];
   } ''
     innoextract --extract --exclude-temp "$src"
     mkdir $out
@@ -38,8 +42,9 @@ let
   '';
   systemDir = {
     x86_64-linux = "System64";
-    i686-linux = "System";
+    aarch64-linux = "SystemARM64";
     x86_64-darwin = "System";
+    i686-linux = "System";
   }.${stdenv.hostPlatform.system} or (throw "unsupported system: ${stdenv.hostPlatform.system}");
 in stdenv.mkDerivation {
   name = "ut1999";
@@ -96,6 +101,11 @@ in stdenv.mkDerivation {
   '' + ''
     runHook postInstall
   '';
+
+  # .so files in the SystemARM64 directory are not loaded properly on aarch64-linux
+  appendRunpaths = lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
+    "${placeholder "out"}/${systemDir}"
+  ];
 
   desktopItems = [
     (makeDesktopItem {

--- a/pkgs/tools/archivers/innoextract/default.nix
+++ b/pkgs/tools/archivers/innoextract/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     homepage = "https://constexpr.org/innoextract/";
     license = licenses.zlib;
     maintainers = with maintainers; [ abbradar ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     mainProgram = "innoextract";
   };
 }


### PR DESCRIPTION
## Description of changes

- Added support for `x86_64-darwin` for `ut1999`
- Added support for `i686-linux` for `ut1999`
- Added support for `aarch64-linux` for `ut1999`
  - Did not test audio as my setup had some issues with PulseAudio dumping core. I can see from the logs `ALAudio: Failed to Initialize Open AL device (alcOpenDevice)`.
- Added support for darwin for `innoextract` (needed by `ut1999`).

For `aarch64-linux` it was a bit of a challenge as I run into some `.so` files from its `System` directory that were not being loaded dynamically. This led me to raise https://github.com/OldUnreal/UnrealTournamentPatches/issues/1557, but I had to close it since I cannot confirm if it's a NixOS-specific issue or something wrong upstream.

Here's a photo of it running on a PinePhone, on NixOS Mobile:

![image](https://github.com/NixOS/nixpkgs/assets/21236836/aea87e9a-7fa8-4288-bbc8-899c6e87c28e)


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] i686-linux (on a rebase on `nixos-23.11` due to too many builds to make otherwise)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
