### PR TITLE
kavita: restore db migrations

### DIFF
--- a/pkgs/servers/web-apps/kavita/default.nix
+++ b/pkgs/servers/web-apps/kavita/default.nix
@@ -26,6 +26,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     patches = [
       # The webroot is hardcoded as ./wwwroot
       ./change-webroot.diff
+      # Upstream removes database migrations between versions
+      # Restore them to avoid breaking on updates
+      # Info: Restores migrations for versions between v0.7.1.4 and v0.7.9
+      # On update: check if more migrations need to be restored!
+      # Migrations should at least allow updates from previous NixOS versions
+      ./restore-migrations.diff
     ];
     postPatch = ''
       substituteInPlace API/Services/DirectoryService.cs --subst-var out

--- a/pkgs/servers/web-apps/kavita/restore-migrations.diff
+++ b/pkgs/servers/web-apps/kavita/restore-migrations.diff
@@ -1,0 +1,147 @@
+diff --git a/API/Data/ManualMigrations/MigrateDisableScrobblingOnComicLibraries.cs b/API/Data/ManualMigrations/MigrateDisableScrobblingOnComicLibraries.cs
+new file mode 100644
+index 00000000..0de7bf5d
+--- /dev/null
++++ b/API/Data/ManualMigrations/MigrateDisableScrobblingOnComicLibraries.cs
+@@ -0,0 +1,38 @@
++using System.Linq;
++using System.Threading.Tasks;
++using API.Entities.Enums;
++using Microsoft.EntityFrameworkCore;
++using Microsoft.Extensions.Logging;
++
++namespace API.Data.ManualMigrations;
++
++/// <summary>
++/// v0.7.4 introduced Scrobbling with Kavita+. By default, it is on, but Comic libraries have no scrobble providers, so disable
++/// </summary>
++public static class MigrateDisableScrobblingOnComicLibraries
++{
++    public static async Task Migrate(IUnitOfWork unitOfWork, DataContext dataContext, ILogger<Program> logger)
++    {
++        if (!await dataContext.Library.Where(s => s.Type == LibraryType.Comic).Where(l => l.AllowScrobbling).AnyAsync())
++        {
++            return;
++        }
++        logger.LogInformation("Running MigrateDisableScrobblingOnComicLibraries migration. Please be patient, this may take some time");
++
++
++        foreach (var lib in await dataContext.Library.Where(s => s.Type == LibraryType.Comic).Where(l => l.AllowScrobbling).ToListAsync())
++        {
++            lib.AllowScrobbling = false;
++            unitOfWork.LibraryRepository.Update(lib);
++        }
++
++        if (unitOfWork.HasChanges())
++        {
++            await unitOfWork.CommitAsync();
++        }
++
++        logger.LogInformation("MigrateDisableScrobblingOnComicLibraries migration finished");
++
++    }
++
++}
+diff --git a/API/Data/ManualMigrations/MigrateLoginRoles.cs b/API/Data/ManualMigrations/MigrateLoginRoles.cs
+new file mode 100644
+index 00000000..f649908a
+--- /dev/null
++++ b/API/Data/ManualMigrations/MigrateLoginRoles.cs
+@@ -0,0 +1,36 @@
++using System.Threading.Tasks;
++using API.Constants;
++using API.Entities;
++using Microsoft.AspNetCore.Identity;
++using Microsoft.Extensions.Logging;
++
++namespace API.Data.ManualMigrations;
++
++/// <summary>
++/// Added in v0.7.1.18
++/// </summary>
++public static class MigrateLoginRoles
++{
++    /// <summary>
++    /// Will not run if any users have the <see cref="PolicyConstants.LoginRole"/> role already
++    /// </summary>
++    /// <param name="unitOfWork"></param>
++    /// <param name="userManager"></param>
++    /// <param name="logger"></param>
++    public static async Task Migrate(IUnitOfWork unitOfWork, UserManager<AppUser> userManager, ILogger<Program> logger)
++    {
++        var usersWithRole = await userManager.GetUsersInRoleAsync(PolicyConstants.LoginRole);
++        if (usersWithRole.Count != 0) return;
++
++        logger.LogCritical("Running MigrateLoginRoles migration");
++
++        var allUsers = await unitOfWork.UserRepository.GetAllUsersAsync();
++        foreach (var user in allUsers)
++        {
++            await userManager.RemoveFromRoleAsync(user, PolicyConstants.LoginRole);
++            await userManager.AddToRoleAsync(user, PolicyConstants.LoginRole);
++        }
++
++        logger.LogInformation("MigrateLoginRoles migration complete");
++    }
++}
+diff --git a/API/Data/ManualMigrations/MigrateRemoveWebPSettingRows.cs b/API/Data/ManualMigrations/MigrateRemoveWebPSettingRows.cs
+new file mode 100644
+index 00000000..07e98ef6
+--- /dev/null
++++ b/API/Data/ManualMigrations/MigrateRemoveWebPSettingRows.cs
+@@ -0,0 +1,31 @@
++using System.Threading.Tasks;
++using API.Entities.Enums;
++using Microsoft.Extensions.Logging;
++
++namespace API.Data.ManualMigrations;
++
++/// <summary>
++/// Added in v0.7.2.7/v0.7.3 in which the ConvertXToWebP Setting keys were removed. This migration will remove them.
++/// </summary>
++public static class MigrateRemoveWebPSettingRows
++{
++    public static async Task Migrate(IUnitOfWork unitOfWork, ILogger<Program> logger)
++    {
++        logger.LogCritical("Running MigrateRemoveWebPSettingRows migration - Please be patient, this may take some time. This is not an error");
++
++        var key = await unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.ConvertBookmarkToWebP);
++        var key2 = await unitOfWork.SettingsRepository.GetSettingAsync(ServerSettingKey.ConvertCoverToWebP);
++        if (key == null && key2 == null)
++        {
++            logger.LogCritical("Running MigrateRemoveWebPSettingRows migration - complete. Nothing to do");
++            return;
++        }
++
++        unitOfWork.SettingsRepository.Remove(key);
++        unitOfWork.SettingsRepository.Remove(key2);
++
++        await unitOfWork.CommitAsync();
++
++        logger.LogCritical("Running MigrateRemoveWebPSettingRows migration - Completed. This is not an error");
++    }
++}
+diff --git a/API/Startup.cs b/API/Startup.cs
+index 21c4fa45..04f4a077 100644
+--- a/API/Startup.cs
++++ b/API/Startup.cs
+@@ -232,11 +232,19 @@ public class Startup
+             Task.Run(async () =>
+                 {
+                     // Apply all migrations on startup
++                    var userManager = serviceProvider.GetRequiredService<UserManager<AppUser>>();
+                     var dataContext = serviceProvider.GetRequiredService<DataContext>();
+ 
+ 
+                     logger.LogInformation("Running Migrations");
+ 
++                    // v0.7.2
++                    await MigrateLoginRoles.Migrate(unitOfWork, userManager, logger);
++                    // v0.7.3
++                    await MigrateRemoveWebPSettingRows.Migrate(unitOfWork, logger);
++                    // v0.7.4
++                    await MigrateDisableScrobblingOnComicLibraries.Migrate(unitOfWork, dataContext, logger);
++
+                     // v0.7.9
+                     await MigrateUserLibrarySideNavStream.Migrate(unitOfWork, dataContext, logger);
+ 


### PR DESCRIPTION
## Description of changes

The last kavita bump (https://github.com/NixOS/nixpkgs/pull/281236), didn't include db migrations necessary to facilitate a clean upgrade because upstream removed them. This PR restores these migrations. Going further back with restoring migrations would seem to require work beyond restoring and enabling the migrations.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Closes #299964
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Built the changes with an override and confirmed the software still runs after the upgrade as expected.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
