### PR TITLE
nixos/partition-manager: use qt6 when plasma6 is activated

### DIFF
--- a/nixos/modules/programs/partition-manager.nix
+++ b/nixos/modules/programs/partition-manager.nix
@@ -1,15 +1,21 @@
 { config, lib, pkgs, ... }:
 
-{
+let
+  cfg = config.programs.partition-manager;
+in {
   meta.maintainers = [ lib.maintainers.oxalica ];
 
   options = {
-    programs.partition-manager.enable = lib.mkEnableOption (lib.mdDoc "KDE Partition Manager");
+    programs.partition-manager = {
+      enable = lib.mkEnableOption (lib.mdDoc "KDE Partition Manager");
+
+      package = lib.mkPackageOption pkgs [ "libsForQt5" "partitionmanager" ] { };
+    };
   };
 
   config = lib.mkIf config.programs.partition-manager.enable {
-    services.dbus.packages = [ pkgs.libsForQt5.kpmcore ];
+    services.dbus.packages = [ cfg.package.kpmcore ];
     # `kpmcore` need to be installed to pull in polkit actions.
-    environment.systemPackages = [ pkgs.libsForQt5.kpmcore pkgs.libsForQt5.partitionmanager ];
+    environment.systemPackages = [ cfg.package.kpmcore cfg.package ];
   };
 }

--- a/nixos/modules/programs/partition-manager.nix
+++ b/nixos/modules/programs/partition-manager.nix
@@ -1,17 +1,13 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 {
-  meta.maintainers = [ maintainers.oxalica ];
+  meta.maintainers = [ lib.maintainers.oxalica ];
 
-  ###### interface
   options = {
-    programs.partition-manager.enable = mkEnableOption (lib.mdDoc "KDE Partition Manager");
+    programs.partition-manager.enable = lib.mkEnableOption (lib.mdDoc "KDE Partition Manager");
   };
 
-  ###### implementation
-  config = mkIf config.programs.partition-manager.enable {
+  config = lib.mkIf config.programs.partition-manager.enable {
     services.dbus.packages = [ pkgs.libsForQt5.kpmcore ];
     # `kpmcore` need to be installed to pull in polkit actions.
     environment.systemPackages = [ pkgs.libsForQt5.kpmcore pkgs.libsForQt5.partitionmanager ];

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -286,6 +286,7 @@ in {
     };
 
     programs.kdeconnect.package = kdePackages.kdeconnect-kde;
+    programs.partition-manager.package = kdePackages.partitionmanager;
 
     # FIXME: ugly hack. See #292632 for details.
     system.userActivationScripts.rebuildSycoca = activationScript;

--- a/pkgs/applications/kde/partitionmanager/default.nix
+++ b/pkgs/applications/kde/partitionmanager/default.nix
@@ -1,5 +1,4 @@
 { mkDerivation
-, fetchurl
 , lib
 , extra-cmake-modules
 , kdoctools
@@ -79,6 +78,10 @@ mkDerivation {
       --prefix PATH : "${runtimeDeps}"
     )
   '';
+
+  passthru = {
+    inherit kpmcore;
+  };
 
   meta = with lib; {
     description = "KDE Partition Manager";

--- a/pkgs/kde/gear/partitionmanager/default.nix
+++ b/pkgs/kde/gear/partitionmanager/default.nix
@@ -6,5 +6,10 @@ mkKdeDerivation {
   pname = "partitionmanager";
 
   propagatedUserEnvPkgs = [kpmcore];
+
+  passthru = {
+    inherit kpmcore;
+  };
+
   meta.mainProgram = "partitionmanager";
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
