### PR TITLE
Revert #294347 (and #300177)

### DIFF
--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -47,10 +47,6 @@ Release branch. Used to specify that a package is not going to receive updates t
 
 The package’s homepage. Example: `https://www.gnu.org/software/hello/manual/`
 
-### `repository` {#var-meta-repository}
-
-A webpage where the package's source code can be viewed.  `https` links are preferred if available.  Automatically set to a default value if the package uses a `fetchFrom*` fetcher for its `src`. Example: `https://github.com/forthy42/gforth`
-
 ### `downloadPage` {#var-meta-downloadPage}
 
 The page where a link to the current version can be found. Example: `https://ftp.gnu.org/gnu/hello/`

--- a/pkgs/development/coq-modules/serapi/default.nix
+++ b/pkgs/development/coq-modules/serapi/default.nix
@@ -71,8 +71,7 @@ in
           if version == "8.11.0+0.11.1" then version
           else builtins.replaceStrings [ "+" ] [ "." ] version
         }.tbz";
-    # abort/syntax error will fail package set eval, but throw is "fine"
-    sha256 = release."${version}".sha256 or (throw "Unknown version '${version}'");
+    sha256 = release."${version}".sha256;
   };
 
   patches =

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -304,10 +304,6 @@ let
       str
     ];
     downloadPage = str;
-    repository = union [
-      (listOf str)
-      str
-    ];
     changelog = union [
       (listOf str)
       str
@@ -457,29 +453,7 @@ let
       outputs = attrs.outputs or [ "out" ];
       hasOutput = out: builtins.elem out outputs;
     in
-    optionalAttrs (attrs ? src.meta.homepage || attrs ? srcs && isList attrs.srcs && any (src: src ? meta.homepage) attrs.srcs) {
-      # should point to an http-browsable source tree, if available.
-      # fetchers like fetchFromGitHub set it automatically.
-      # this could be handled a lot easier if we nulled it instead
-      # of having it be undefined, but that wouldn't match the
-      # other attributes.
-      repository = let
-        getSrcs = attrs:
-          if attrs ? src
-          then
-            [ attrs.src ]
-          else
-            lib.filter (src: src ? meta.homepage) attrs.srcs;
-        getHomePages = srcs: map (src: src.meta.homepage) srcs;
-        unlist = list:
-          if lib.length list == 1
-          then
-            lib.elemAt list 0
-          else
-            list;
-      in
-        unlist (getHomePages (getSrcs attrs));
-    } // {
+    {
       # `name` derivation attribute includes cross-compilation cruft,
       # is under assert, and is sanitized.
       # Let's have a clean always accessible version here.

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -10,9 +10,7 @@ let
     concatMapStrings
     concatMapStringsSep
     concatStrings
-    filter
     findFirst
-    head
     isDerivation
     length
     concatMap
@@ -446,18 +444,6 @@ let
     # -----
     else { valid = "yes"; });
 
-  getRepository = let
-    getSrcs = attrs:
-      if attrs ? src
-      then
-        [ attrs.src ]
-      else
-        filter (src: src ? meta.homepage) attrs.srcs;
-    getHomePages = map (src: src.meta.homepage);
-    unlist = list:
-      if length list == 1 then head list
-      else list;
-    in attrs: unlist (getHomePages (getSrcs attrs));
 
   # The meta attribute is passed in the resulting attribute set,
   # but it's not part of the actual derivation, i.e., it's not
@@ -477,7 +463,22 @@ let
       # this could be handled a lot easier if we nulled it instead
       # of having it be undefined, but that wouldn't match the
       # other attributes.
-      repository = getRepository attrs;
+      repository = let
+        getSrcs = attrs:
+          if attrs ? src
+          then
+            [ attrs.src ]
+          else
+            lib.filter (src: src ? meta.homepage) attrs.srcs;
+        getHomePages = srcs: map (src: src.meta.homepage) srcs;
+        unlist = list:
+          if lib.length list == 1
+          then
+            lib.elemAt list 0
+          else
+            list;
+      in
+        unlist (getHomePages (getSrcs attrs));
     } // {
       # `name` derivation attribute includes cross-compilation cruft,
       # is under assert, and is sanitized.


### PR DESCRIPTION
## Description of changes

Broke eval, backing out.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
