### PR TITLE
labelImg: 1.8.3 -> 1.8.6, re-format with `nixfmt-rfc-style`

### DIFF
--- a/pkgs/applications/science/machine-learning/labelimg/default.nix
+++ b/pkgs/applications/science/machine-learning/labelimg/default.nix
@@ -1,21 +1,33 @@
-{ lib, python3Packages, fetchFromGitHub, qt5 }:
+{ lib
+, python3Packages
+, fetchFromGitHub
+, fetchpatch
+, qt5
+}:
   python3Packages.buildPythonApplication rec {
     pname = "labelImg";
-    version = "1.8.3";
+    version = "1.8.6";
     src = fetchFromGitHub {
       owner = "tzutalin";
       repo = "labelImg";
       rev = "v${version}";
-      sha256 = "07v106fzlmxrbag4xm06m4mx9m0gckb27vpwsn7sap1bbgc1pap5";
+      hash = "sha256-RJxCtiDOePajlrjy9cpKETSKsWlH/Dlu1iFMj2aO4XU=";
     };
     nativeBuildInputs = with python3Packages; [
       pyqt5
       qt5.wrapQtAppsHook
     ];
+    patches = [
+      # fixes https://github.com/heartexlabs/labelImg/issues/838
+      # can be removed after next upstream version bump
+      (fetchpatch {
+        url = "https://github.com/heartexlabs/labelImg/commit/5c38b6bcddce895d646e944e3cddcb5b43bf8b8b.patch";
+        hash = "sha256-BmbnJS95RBfoNQT0E6JDJ/IZfBa+tv1C69+RVOSFdRA=";
+      })
+    ];
     propagatedBuildInputs = with python3Packages; [
       pyqt5
       lxml
-      sip4
     ];
     preBuild = ''
       make qt5py3

--- a/pkgs/applications/science/machine-learning/labelimg/default.nix
+++ b/pkgs/applications/science/machine-learning/labelimg/default.nix
@@ -1,50 +1,51 @@
-{ lib
-, python3Packages
-, fetchFromGitHub
-, fetchpatch
-, qt5
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  fetchpatch,
+  qt5,
 }:
-  python3Packages.buildPythonApplication rec {
-    pname = "labelImg";
-    version = "1.8.6";
-    src = fetchFromGitHub {
-      owner = "tzutalin";
-      repo = "labelImg";
-      rev = "v${version}";
-      hash = "sha256-RJxCtiDOePajlrjy9cpKETSKsWlH/Dlu1iFMj2aO4XU=";
-    };
-    nativeBuildInputs = with python3Packages; [
-      pyqt5
-      qt5.wrapQtAppsHook
-    ];
-    patches = [
-      # fixes https://github.com/heartexlabs/labelImg/issues/838
-      # can be removed after next upstream version bump
-      (fetchpatch {
-        url = "https://github.com/heartexlabs/labelImg/commit/5c38b6bcddce895d646e944e3cddcb5b43bf8b8b.patch";
-        hash = "sha256-BmbnJS95RBfoNQT0E6JDJ/IZfBa+tv1C69+RVOSFdRA=";
-      })
-    ];
-    propagatedBuildInputs = with python3Packages; [
-      pyqt5
-      lxml
-    ];
-    preBuild = ''
-      make qt5py3
-    '';
-    postInstall = ''
-      cp libs/resources.py $out/${python3Packages.python.sitePackages}/libs
-    '';
-    dontWrapQtApps = true;
-    preFixup = ''
-      makeWrapperArgs+=("''${qtWrapperArgs[@]}")
-    '';
-    meta = with lib; {
-      description = "A graphical image annotation tool and label object bounding boxes in images";
-      mainProgram = "labelImg";
-      homepage = "https://github.com/tzutalin/labelImg";
-      license = licenses.mit;
-      platforms = platforms.linux;
-      maintainers = [ maintainers.cmcdragonkai ];
-    };
-  }
+python3Packages.buildPythonApplication rec {
+  pname = "labelImg";
+  version = "1.8.6";
+  src = fetchFromGitHub {
+    owner = "tzutalin";
+    repo = "labelImg";
+    rev = "v${version}";
+    hash = "sha256-RJxCtiDOePajlrjy9cpKETSKsWlH/Dlu1iFMj2aO4XU=";
+  };
+  nativeBuildInputs = with python3Packages; [
+    pyqt5
+    qt5.wrapQtAppsHook
+  ];
+  patches = [
+    # fixes https://github.com/heartexlabs/labelImg/issues/838
+    # can be removed after next upstream version bump
+    (fetchpatch {
+      url = "https://github.com/heartexlabs/labelImg/commit/5c38b6bcddce895d646e944e3cddcb5b43bf8b8b.patch";
+      hash = "sha256-BmbnJS95RBfoNQT0E6JDJ/IZfBa+tv1C69+RVOSFdRA=";
+    })
+  ];
+  propagatedBuildInputs = with python3Packages; [
+    pyqt5
+    lxml
+  ];
+  preBuild = ''
+    make qt5py3
+  '';
+  postInstall = ''
+    cp libs/resources.py $out/${python3Packages.python.sitePackages}/libs
+  '';
+  dontWrapQtApps = true;
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
+  meta = with lib; {
+    description = "A graphical image annotation tool and label object bounding boxes in images";
+    mainProgram = "labelImg";
+    homepage = "https://github.com/tzutalin/labelImg";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.cmcdragonkai ];
+  };
+}


### PR DESCRIPTION
## Description of changes

- This PR closes #228562 

  Its author @TheDelus  has disappeared for 3 months, and it needs to rebase based on the HEAD of master due to conflict.
  
  It's also fixed an upstream crash issue https://github.com/HumanSignal/labelImg/issues/838 , so I think it's need to be merged soon.
  
  The origin PR branch has another problem: https://github.com/NixOS/nixpkgs/pull/228562#issuecomment-1869618450 , but could be fixed by rebased on the HEAD of master.
  
  Already added @TheDelus as the co-author.

- Re-format with `nixfmt-rfc-style` to remove weird indents

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
