### PR TITLE
stdenv: add meta.repository attribute to fetchers

### DIFF
--- a/pkgs/build-support/fetch9front/default.nix
+++ b/pkgs/build-support/fetch9front/default.nix
@@ -29,7 +29,10 @@ lib.makeOverridable (
       passthru = {
         inherit gitRepoUrl;
       };
-    }) // passthruAttrs // { inherit name; };
+    })
+    // passthruAttrs
+    // { inherit name; }
+    // { meta.repository = [ gitRepoUrl ]; };
   in
 
   fetcher fetcherArgs // { inherit rev; }

--- a/pkgs/build-support/fetchbitbucket/default.nix
+++ b/pkgs/build-support/fetchbitbucket/default.nix
@@ -7,5 +7,6 @@ lib.makeOverridable (
   inherit name;
   url = "https://bitbucket.org/${owner}/${repo}/get/${rev}.tar.gz";
   meta.homepage = "https://bitbucket.org/${owner}/${repo}/";
+  meta.repository = [ "https://bitbucket.org/${owner}/${repo}/" ];
 } // removeAttrs args [ "owner" "repo" "rev" ]) // { inherit rev; }
 )

--- a/pkgs/build-support/fetchbzr/default.nix
+++ b/pkgs/build-support/fetchbzr/default.nix
@@ -12,4 +12,6 @@ stdenvNoCC.mkDerivation {
   outputHash = sha256;
 
   inherit url rev;
+
+  meta.repository = [ url ];
 }

--- a/pkgs/build-support/fetchcvs/default.nix
+++ b/pkgs/build-support/fetchcvs/default.nix
@@ -18,5 +18,7 @@ stdenvNoCC.mkDerivation {
   outputHash = sha256;
 
   inherit cvsRoot module sha256 tag date;
+
+  meta.repository = [ cvsRoot ];
 }
 )

--- a/pkgs/build-support/fetchdarcs/default.nix
+++ b/pkgs/build-support/fetchdarcs/default.nix
@@ -17,5 +17,7 @@ stdenvNoCC.mkDerivation {
   outputHash = sha256;
 
   inherit url rev context name;
+
+  meta.repository = [ url ];
 }
 )

--- a/pkgs/build-support/fetchfossil/default.nix
+++ b/pkgs/build-support/fetchfossil/default.nix
@@ -30,4 +30,6 @@ stdenv.mkDerivation {
 
   inherit url rev;
   preferLocalBuild = true;
+
+  meta.repository = [ url ];
 }

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -101,10 +101,14 @@ stdenvNoCC.mkDerivation {
   ];
 
 
-  inherit preferLocalBuild meta allowedRequisites;
+  inherit preferLocalBuild allowedRequisites;
 
   passthru = {
     gitRepoUrl = url;
   };
+
+  meta = {
+    repository = [ url ];
+  } // meta;
 }
 )

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -19,6 +19,7 @@ let
   baseUrl = "https://${githubBase}/${owner}/${repo}";
   newMeta = meta // {
     homepage = meta.homepage or baseUrl;
+    repository = meta.repository or [ baseUrl ];
   } // lib.optionalAttrs (position != null) {
     # to indicate where derivation originates, similar to make-derivation.nix's mkDerivation
     position = "${position.file}:${toString position.line}";

--- a/pkgs/build-support/fetchgitiles/default.nix
+++ b/pkgs/build-support/fetchgitiles/default.nix
@@ -8,5 +8,6 @@ fetchzip ({
   url = "${url}/+archive/${rev}.tar.gz";
   stripRoot = false;
   meta.homepage = url;
+  meta.repository = [ url ];
 } // removeAttrs args [ "url" "rev" ]) // { inherit rev; }
 )

--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -32,5 +32,8 @@ let
   }) // passthruAttrs // { inherit name; };
 in
 
-fetcher fetcherArgs // { meta.homepage = "${protocol}://${domain}/${slug}/"; inherit rev owner repo; }
-)
+fetcher fetcherArgs // {
+  meta.homepage = "${protocol}://${domain}/${slug}/";
+  meta.repository = [ gitRepoUrl ];
+  inherit rev owner repo;
+})

--- a/pkgs/build-support/fetchhg/default.nix
+++ b/pkgs/build-support/fetchhg/default.nix
@@ -31,4 +31,6 @@ stdenvNoCC.mkDerivation {
 
   inherit url rev;
   inherit preferLocalBuild;
+
+  meta.repository = [ url ];
 }

--- a/pkgs/build-support/fetchpijul/default.nix
+++ b/pkgs/build-support/fetchpijul/default.nix
@@ -55,5 +55,7 @@ else
     inherit url change state channel;
 
     impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+
+    meta.repository = [ url ];
   }
 )

--- a/pkgs/build-support/fetchrepoorcz/default.nix
+++ b/pkgs/build-support/fetchrepoorcz/default.nix
@@ -7,4 +7,5 @@
   inherit name;
   url = "https://repo.or.cz/${repo}.git/snapshot/${rev}.tar.gz";
   meta.homepage = "https://repo.or.cz/${repo}.git/";
+  meta.repository = [ "https://repo.or.cz/${repo}.git/" ];
 } // removeAttrs args [ "repo" "rev" ]) // { inherit rev; }

--- a/pkgs/build-support/fetchsavannah/default.nix
+++ b/pkgs/build-support/fetchsavannah/default.nix
@@ -8,5 +8,6 @@ lib.makeOverridable (
   inherit name;
   url = "https://git.savannah.gnu.org/cgit/${repo}.git/snapshot/${repo}-${rev}.tar.gz";
   meta.homepage = "https://git.savannah.gnu.org/cgit/${repo}.git/";
+  meta.repository = [ "https://git.savannah.gnu.org/cgit/${repo}.git/" ];
 } // removeAttrs args [ "repo" "rev" ]) // { inherit rev; }
 )

--- a/pkgs/build-support/fetchsourcehut/default.nix
+++ b/pkgs/build-support/fetchsourcehut/default.nix
@@ -58,5 +58,6 @@ let
 in cases.${fetcher}.fetch cases.${fetcher}.arguments // {
   inherit rev;
   meta.homepage = "${baseUrl}";
+  meta.repository = [ "${baseUrl}" ];
 }
 )

--- a/pkgs/build-support/fetchsvn/default.nix
+++ b/pkgs/build-support/fetchsvn/default.nix
@@ -56,4 +56,6 @@ stdenvNoCC.mkDerivation {
 
   impureEnvVars = lib.fetchers.proxyImpureEnvVars;
   inherit preferLocalBuild;
+
+  meta.repository = [ url ];
 }

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -318,6 +318,10 @@ let
       (listOf licenseType)
       licenseType
     ];
+    repository = union [
+      (listOf str)
+      str
+    ];
     sourceProvenance = listOf attrs;
     maintainers = listOf (attrsOf any); # TODO use the maintainer type from lib/tests/maintainer-module.nix
     priority = int;

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -465,6 +465,10 @@ let
       # Let's have a clean always accessible version here.
       name = attrs.name or "${attrs.pname}-${attrs.version}";
 
+      # `repository` shall default to an empty list
+
+      repository = attrs.repository or [];
+
       # If the packager hasn't specified `outputsToInstall`, choose a default,
       # which is the name of `p.bin or p.out or p` along with `p.man` when
       # present.


### PR DESCRIPTION
Restarting the feature request from lolbinarycat at https://github.com/NixOS/nixpkgs/issues/293838.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Following the hints from 
- https://github.com/NixOS/nixpkgs/pull/294347#discussion_r1544933853 
- https://github.com/NixOS/nixpkgs/pull/294347#discussion_r1544615000

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
