### PR TITLE
zombietrackergps: 1.10 -> 1.15

### DIFF
--- a/pkgs/applications/gis/zombietrackergps/default.nix
+++ b/pkgs/applications/gis/zombietrackergps/default.nix
@@ -1,67 +1,61 @@
-{ mkDerivation
-, lib
-, fetchFromGitLab
-, qmake
-, qtcharts
-, qtsvg
-, marble
-, qtwebengine
-, ldutils
+{
+  mkDerivation,
+  lib,
+  fetchFromGitLab,
+  gitUpdater,
+  wrapQtAppsHook,
+  cmake,
+  marble,
+  libsForQt5,
 }:
-
 mkDerivation rec {
   pname = "zombietrackergps";
-  version = "1.10";
+  version = "1.15";
 
   src = fetchFromGitLab {
     owner = "ldutils-projects";
     repo = pname;
-    rev = "v_${version}";
-    sha256 = "sha256-qRhCAOVWyDLD3WDptPRQVq+VwyFu83XQNaL5TMsGs4Y=";
+    # latest revision is not tagged upstream, use commit sha in the meantime
+    #rev = "v_${version}";
+    rev = "cc75d5744965cc6973323f5bb77f00b0b0153dce";
+    sha256 = "sha256-z/LFNRFdQQFxEWyAjcuGezRbTsv8z6Q6fK8NLjP4HNM=";
   };
 
-  buildInputs = [
-    ldutils
-    qtcharts
-    qtsvg
-    marble.dev
-    qtwebengine
-  ];
+  buildInputs =
+    [
+      marble.dev
+    ]
+    ++ (with libsForQt5; [
+      qtbase
+      qtcharts
+      qtsvg
+      qtwebengine
+      ldutils
+    ]);
 
   nativeBuildInputs = [
-    qmake
+    cmake
+    wrapQtAppsHook
   ];
-
-  prePatch = ''
-    substituteInPlace ztgps.pro --replace "../libldutils" "libldutils"
-    substituteInPlace tests.pro --replace "../libldutils" "libldutils"
-
-    ln -s ${ldutils} libldutils
-  '';
 
   preConfigure = ''
     export LANG=en_US.UTF-8
-    export INSTALL_ROOT=$out
   '';
 
-  preInstall = ''
-    substituteInPlace Makefile.ztgps --replace '$(INSTALL_ROOT)' ""
-    substituteInPlace Makefile.art --replace '$(INSTALL_ROOT)' ""
-  '';
+  cmakeFlags = [
+    "-DLDUTILS_ROOT=${libsForQt5.ldutils}"
+  ];
 
-  postInstall = ''
-    install -Dm644 build/rcc/*.rcc -t $out/share/zombietrackergps
-  '';
-
-  qmakeFlags = [ "ZombieTrackerGPS.pro" ];
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v_";
+  };
 
   meta = with lib; {
     description = "GPS track manager for Qt using KDE Marble maps";
     homepage = "https://www.zombietrackergps.net/ztgps/";
     changelog = "https://www.zombietrackergps.net/ztgps/history.html";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ sohalt ];
+    maintainers = with maintainers; [sohalt];
     platforms = platforms.linux;
-    broken = true;  # doesn't build with latest Marble
   };
 }

--- a/pkgs/development/libraries/ldutils/default.nix
+++ b/pkgs/development/libraries/ldutils/default.nix
@@ -1,41 +1,41 @@
-{ mkDerivation
-, lib
-, fetchFromGitLab
-, qtcharts
-, qtsvg
-, qmake
+{
+  mkDerivation,
+  lib,
+  fetchFromGitLab,
+  libsForQt5,
+  cmake,
 }:
-
 mkDerivation rec {
   pname = "ldutils";
-  version = "1.10";
+  version = "1.15";
 
   src = fetchFromGitLab {
     owner = "ldutils-projects";
     repo = pname;
-    rev = "v_${version}";
-    sha256 = "sha256-fP+tZY+ayaeuxPvywO/639sNE+IwrxaEJ245q9HTOCU=";
+    rev = "4fc416f694ce888c5bd4c4432a7730bb6260475c";
+    #rev = "v_${version}";
+    sha256 = "sha256-UMDayvz9RlcR4HVJNn7tN4FKbiKAFRSPaK0osA6OGTI=";
   };
 
-  buildInputs = [
+  buildInputs = with libsForQt5.qt5; [
     qtcharts
     qtsvg
   ];
 
   nativeBuildInputs = [
-    qmake
+    cmake
   ];
 
-  qmakeFlags = [ "ldutils.pro" ];
+  qmakeFlags = ["ldutils.pro"];
 
-  LDUTILS_LIB=placeholder "out";
-  LDUTILS_INCLUDE=placeholder "out";
+  LDUTILS_LIB = placeholder "out";
+  LDUTILS_INCLUDE = placeholder "out";
 
   meta = with lib; {
     description = "Headers and link library for other ldutils projects";
     homepage = "https://gitlab.com/ldutils-projects/ldutils";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ sohalt ];
+    maintainers = with maintainers; [sohalt];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
## Description of changes

closes https://github.com/NixOS/nixpkgs/issues/300214

Update ldutils and zombietrackergps from 1.10 -> 1.15.
Change from qmake to cmake.
No other derviation depends on ldutils.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
