### PR TITLE
nixos-rebuild: use `substitute` rather than `substituteAll`

### DIFF
--- a/pkgs/os-specific/linux/nixos-rebuild/default.nix
+++ b/pkgs/os-specific/linux/nixos-rebuild/default.nix
@@ -1,5 +1,5 @@
 { callPackage
-, substituteAll
+, substitute
 , runtimeShell
 , coreutils
 , gnused
@@ -14,19 +14,25 @@
 let
   fallback = import ./../../../../nixos/modules/installer/tools/nix-fallback-paths.nix;
 in
-substituteAll {
+substitute {
   name = "nixos-rebuild";
   src = ./nixos-rebuild.sh;
   dir = "bin";
   isExecutable = true;
-  inherit runtimeShell nix;
-  nix_x86_64_linux = fallback.x86_64-linux;
-  nix_i686_linux = fallback.i686-linux;
-  nix_aarch64_linux = fallback.aarch64-linux;
-  path = lib.makeBinPath [ coreutils gnused gnugrep jq util-linux ];
+
+  substitutions = [
+    "--subst-var-by" "runtimeShell" runtimeShell
+    "--subst-var-by" "nix" nix
+    "--subst-var-by" "nix_x86_64_linux" fallback.x86_64-linux
+    "--subst-var-by" "nix_i686_linux" fallback.i686-linux
+    "--subst-var-by" "nix_aarch64_linux" fallback.aarch64-linux
+    "--subst-var-by" "path" (lib.makeBinPath [ coreutils gnused gnugrep jq util-linux ])
+  ];
+
   nativeBuildInputs = [
     installShellFiles
   ];
+
   postInstall = ''
     installManPage ${./nixos-rebuild.8}
 


### PR DESCRIPTION
## Description of changes

There's no change in produced output, though this does rebuild the script. Rationale is here:

- https://github.com/NixOS/nixpkgs/issues/237216

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).