### PR TITLE
cadzinho: 0.4.1 → 0.5.0

### DIFF
--- a/pkgs/by-name/ca/cadzinho/package.nix
+++ b/pkgs/by-name/ca/cadzinho/package.nix
@@ -1,28 +1,34 @@
-{ lib, stdenv, fetchFromGitHub, SDL2, glew, lua5_4, desktopToDarwinBundle }:
+{ lib, stdenv, fetchFromGitHub, SDL2, SDL2_net, glew, lua5_4, desktopToDarwinBundle }:
 
 stdenv.mkDerivation rec {
   pname = "cadzinho";
-  version = "0.4.1";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "zecruel";
     repo = "CadZinho";
     rev = version;
-    hash = "sha256-6/sBNxQb52FFO2fWLVs6YDOmJLEbSOA5mwdMdJDjEDM=";
+    hash = "sha256-s2+k1TcmY3xwxXccHP7au71e0l3Qrso5XxmGGVvyIo0=";
   };
 
   postPatch = ''
-    substituteInPlace src/gui_config.c --replace "/usr/share/cadzinho" "$out/share/cadzinho"
+    substituteInPlace src/gui_config.c --replace-fail "/usr/share/cadzinho" "$out/share/cadzinho"
+    substituteInPlace Makefile --replace-fail "-lGLEW" "-lGLEW -lSDL2_net"
   '';
 
   nativeBuildInputs = lib.optional stdenv.isDarwin desktopToDarwinBundle;
 
-  buildInputs = [ SDL2 glew lua5_4 ];
+  buildInputs = [ SDL2 SDL2_net glew lua5_4 ];
 
   makeFlags = [ "CC:=$(CC)" ];
 
-  # https://github.com/llvm/llvm-project/issues/62254
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-fno-builtin-strrchr";
+  env.NIX_CFLAGS_COMPILE = toString ([
+    "-I${SDL2.dev}/include/SDL2"
+    "-I${SDL2_net.dev}/include/SDL2"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # https://github.com/llvm/llvm-project/issues/62254
+    "-fno-builtin-strrchr"
+  ]);
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
## Description of changes
https://github.com/zecruel/CadZinho/releases/tag/0.5.0

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
