### PR TITLE
{nixos-container,lsb-release}: use `substitute` rather than `substituteAll`, fix cross-compilation

### DIFF
--- a/pkgs/os-specific/linux/lsb-release/default.nix
+++ b/pkgs/os-specific/linux/lsb-release/default.nix
@@ -1,8 +1,11 @@
-{ substituteAll, lib
-, coreutils, getopt
+{ lib
+, substitute
+, coreutils
+, getopt
+, runtimeShell
 }:
 
-substituteAll {
+substitute {
   name = "lsb_release";
 
   src = ./lsb_release.sh;
@@ -10,7 +13,11 @@ substituteAll {
   dir = "bin";
   isExecutable = true;
 
-  inherit coreutils getopt;
+  substitutions = [
+    "--subst-var-by" "coreutils" coreutils
+    "--subst-var-by" "getopt" getopt
+    "--subst-var-by" "shell" runtimeShell
+  ];
 
   meta = with lib; {
     description = "Prints certain LSB (Linux Standard Base) and Distribution information";


### PR DESCRIPTION
## Description of changes

This change fixes cross-compilation of the `lsb-release` and `nixos-container` scripts, all of which used the `stdenv` environment variable `shell` instead of `runtimeShell` string as the shebang... leading to a cross-compilation mess.

There's no other change in produced output. Rationale for using `substitute` instead of `substituteAll` is here:

- https://github.com/NixOS/nixpkgs/issues/237216

Previously:
- https://github.com/NixOS/nixpkgs/pull/300308

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).