### PR TITLE
 nixos: use `substitute` rather than `substituteAll` in installer modules

### DIFF
--- a/nixos/maintainers/scripts/lxd/lxd-container-image.nix
+++ b/nixos/maintainers/scripts/lxd/lxd-container-image.nix
@@ -14,9 +14,9 @@
 
   # copy the config for nixos-rebuild
   system.activationScripts.config = let
-    config = pkgs.substituteAll {
+    config = pkgs.substitute {
       src = ./lxd-container-image-inner.nix;
-      stateVersion = lib.trivial.release;
+      substitutions = [ "--subst-var-by" "stateVersion" lib.trivial.release ];
     };
   in ''
     if [ ! -e /etc/nixos/configuration.nix ]; then

--- a/nixos/maintainers/scripts/lxd/lxd-virtual-machine-image.nix
+++ b/nixos/maintainers/scripts/lxd/lxd-virtual-machine-image.nix
@@ -14,9 +14,9 @@
 
   # copy the config for nixos-rebuild
   system.activationScripts.config = let
-    config = pkgs.substituteAll {
+    config = pkgs.substitute {
       src = ./lxd-virtual-machine-image-inner.nix;
-      stateVersion = lib.trivial.release;
+      substitutions = [ "--subst-var-by" "stateVersion" lib.trivial.release ];
     };
   in ''
     if [ ! -e /etc/nixos/configuration.nix ]; then

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -828,10 +828,10 @@ in
         { source = config.isoImage.splashImage;
           target = "/isolinux/background.png";
         }
-        { source = pkgs.substituteAll  {
+        { source = pkgs.substitute {
             name = "isolinux.cfg";
             src = pkgs.writeText "isolinux.cfg-in" isolinuxCfg;
-            bootRoot = "/boot";
+            substitutions = [ "--subst-var-by" "bootRoot" "/boot" ];
           };
           target = "/isolinux/isolinux.cfg";
         }

--- a/nixos/modules/installer/tools/nixos-enter.sh
+++ b/nixos/modules/installer/tools/nixos-enter.sh
@@ -3,6 +3,8 @@
 
 set -e
 
+export PATH=@path@:$PATH
+
 # Re-exec ourselves in a private mount namespace so that our bind
 # mounts get cleaned up automatically.
 if [ -z "$NIXOS_ENTER_REEXEC" ]; then


### PR DESCRIPTION
## Description of changes

Rationale is here:

- https://github.com/NixOS/nixpkgs/issues/237216

There's mostly no change to the files. I did make two bug fixes:

1. In `nixos/modules/installer/tools/nixos-install.sh`, there is no `nix` replacement variable, but there is a path substitution, so I added `config.nix.package.out` to the path.
2. In `nixos/modules/installer/tools/nixos-enter.sh`, there was no `path` replacement variable; I added it.

These changes validate the logic that motivated opening https://github.com/NixOS/nixpkgs/issues/237216. It's too easy to write a bug!

Previously:
- https://github.com/NixOS/nixpkgs/pull/300308
- https://github.com/NixOS/nixpkgs/pull/300322

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).