### PR TITLE
ptouch-print: 1.4.3 -> 1.5-unstable-2024-02-11

### DIFF
--- a/pkgs/misc/ptouch-print/default.nix
+++ b/pkgs/misc/ptouch-print/default.nix
@@ -1,35 +1,57 @@
-{ lib, stdenv
+{ cmake
 , fetchgit
-, autoreconfHook
 , gd
+, gettext
+, git
+, lib
+, libjpeg
+, libpng
 , libusb1
+, pkg-config
+, stdenv
+, zlib
 }:
 
 stdenv.mkDerivation rec {
   pname = "ptouch-print";
-  version = "1.4.3";
+  version = "1.5-unstable-2024-02-11";
 
   src = fetchgit {
-    url = "https://mockmoon-cybernetics.ch/cgi/cgit/linux/ptouch-print.git";
-    rev = "v${version}";
-    sha256 = "0i57asg2hj1nfwy5lcb0vhrpvb9dqfhf81vh4i929h1kiqhlw2hx";
+    url = "https://git.familie-radermacher.ch/linux/ptouch-print.git";
+    rev = "8aaeecd84b619587dc3885dd4fea4b7310c82fd4";
+    hash = "sha256-IIq3SmMfsgwSYbgG1w/wrBnFtb6xdFK2lkK27Qqk6mw=";
   };
 
   nativeBuildInputs = [
-    autoreconfHook
+    cmake
+    git
+    pkg-config
   ];
 
   buildInputs = [
     gd
+    gettext
+    libjpeg
+    libpng
+    zlib
     libusb1
   ];
 
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mv ptouch-print $out/bin
+
+    runHook postInstall
+  '';
+
   meta = with lib; {
     description = "Command line tool to print labels on Brother P-Touch printers on Linux";
+    homepage = "https://dominic.familie-radermacher.ch/projekte/ptouch-print/";
     license = licenses.gpl3Plus;
-    homepage = "https://mockmoon-cybernetics.ch/computer/p-touch2430pc/";
+    mainProgram = "ptouch-print";
     maintainers = with maintainers; [ shamilton ];
     platforms = platforms.linux;
-    mainProgram = "ptouch-print";
   };
 }


### PR DESCRIPTION
## Description of changes

Commit message:
```
The old upstream homepage and repo are dead; this moves them to the new home.

The latest release version is 1.5, but that does not contain several
important commits, including support for Brother's latest "standard"
label makers, so this moves to the latest commit.  Log here:
https://git.familie-radermacher.ch/linux/ptouch-print.git/log/

See original effort to update to 1.5 here; most of the changes are
from this original PR:
https://github.com/NixOS/nixpkgs/pull/197981
```

I have one of the devices that the new version of this software supports, so I was able to test it on real hardware with no issues.  I took over from https://github.com/NixOS/nixpkgs/pull/197981 because of that; most of the original work was done there by @justinas.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
  - *Tested on real hardware; see above.*
- [] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - *I couldn't get this to work, but nothing depends on this package.*
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
