### PR TITLE
apparmor-utils: fix libapparmor.python cross-build

### DIFF
--- a/nixos/tests/apparmor.nix
+++ b/nixos/tests/apparmor.nix
@@ -71,14 +71,14 @@ import ./make-test-python.nix ({ pkgs, lib, ... } : {
                   r ${pkgs.glibc.libgcc}/share/**,
                   x ${pkgs.glibc.libgcc}/foo/**,
               ''} ${pkgs.runCommand "actual.rules" { preferLocalBuild = true; } ''
-                  ${pkgs.gnused}/bin/sed -e 's:^[^ ]* ${builtins.storeDir}/[^,/-]*-\([^/,]*\):\1 \0:' ${
+                  ${pkgs.buildPackages.gnused}/bin/sed -e 's:^[^ ]* ${builtins.storeDir}/[^,/-]*-\([^/,]*\):\1 \0:' ${
                       pkgs.apparmorRulesFromClosure {
                         name = "ping";
                         additionalRules = ["x $path/foo/**"];
                       } [ pkgs.libcap ]
                   } |
-                  ${pkgs.coreutils}/bin/sort -n -k1 |
-                  ${pkgs.gnused}/bin/sed -e 's:^[^ ]* ::' >$out
+                  ${pkgs.buildPackages.coreutils}/bin/sort -n -k1 |
+                  ${pkgs.buildPackages.gnused}/bin/sed -e 's:^[^ ]* ::' >$out
               ''}"
           )
     '';

--- a/pkgs/os-specific/linux/apparmor/default.nix
+++ b/pkgs/os-specific/linux/apparmor/default.nix
@@ -4,7 +4,7 @@
 , linuxHeaders ? stdenv.cc.libc.linuxHeaders
 , gawk
 , withPerl ? stdenv.hostPlatform == stdenv.buildPlatform && lib.meta.availableOn stdenv.hostPlatform perl, perl
-, withPython ? stdenv.hostPlatform == stdenv.buildPlatform && lib.meta.availableOn stdenv.hostPlatform python3, python3
+, withPython ? true, python3
 , swig
 , ncurses
 , pam
@@ -67,6 +67,7 @@ let
   ];
 
   python = python3.withPackages (ps: with ps; [ setuptools ]);
+  buildPython = buildPackages.python3.withPackages (ps: with ps; [ setuptools ]);
 
   # Set to `true` after the next FIXME gets fixed or this gets some
   # common derivation infra. Too much copy-paste to fix one by one.
@@ -94,7 +95,11 @@ let
       ncurses
       which
       perl
-    ] ++ lib.optional withPython python;
+    ] ++ lib.optional withPython buildPython;
+
+    # The python env uses a makeCWrapper python-config which breaks cross-builds,
+    # for the purposes of this build, the original shell script is sufficient.
+    PYTHON_CONFIG = "${stdenv.shell} ${python.python}/bin/python-config";
 
     buildInputs = [ libxcrypt ]
       ++ lib.optional withPerl perl
@@ -123,6 +128,12 @@ let
     postInstall = lib.optionalString withPython ''
       mkdir -p $python/lib
       mv $out/lib/python* $python/lib/
+    '' # setuptools incorrectly names shared library with buildPlatform architecture name.
+    + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+      pushd $python/lib/*/site-packages/LibAppArmor
+      OLD=$(ls _LibAppArmor.*.so)
+      mv $OLD ''${OLD/${stdenv.buildPlatform.qemuArch}/${stdenv.targetPlatform.qemuArch}}
+      popd
     '';
 
     inherit doCheck;
@@ -184,7 +195,7 @@ let
     inherit doCheck;
 
     meta = apparmor-meta "user-land utilities" // {
-      broken = !(withPython && withPerl);
+      broken = !(withPython);
     };
   };
 


### PR DESCRIPTION
The `libapparmor.python` output fails to cross-build due to the supplied python environment (just containing `setuptools`) breaking the normal splicing of buildInputs and nativeBuildInputs. Additionally `python-check` needs to provide values and paths for targetPlatform while executable on the hostPlatform; luckily this can be achieved by using the targetPlatfrom's `python-check` instead of the `makeCWrapped` binary.

I'm not sure why but the shared library built by `setuptools` retains the platform name of the buildPlatform despite being the correct output for the targetPlatform. I'm just doing a simple rename to fix this but please let me know if anyone knows a more correct solution.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  
  ## Testing
   - [x] legacyPackages.x86_64-linux.nixosTests.apparmor
   - [ ] legacyPackages.aarch64-linux.nixosTests.apparmor
   - [ ] legacyPackages.x86_64-linux.pkgsCross.aarch64-multiplatform.nixosTests.apparmor