### PR TITLE
pkcs11-provider: init at 0.3

### DIFF
--- a/pkgs/by-name/pk/pkcs11-provider/package.nix
+++ b/pkgs/by-name/pk/pkcs11-provider/package.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, fetchFromGitHub
+, openssl, nss, p11-kit
+, opensc, gnutls, expect
+, autoreconfHook, autoconf-archive, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pkcs11-provider";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "latchset";
+    repo = "pkcs11-provider";
+    rev = "v${version}";
+    hash = "sha256-jEQYsINRZ7bi2UqOXUUmGpm+1h+1qBNe18KvfAw2JzU=";
+  };
+
+  buildInputs = [ openssl nss p11-kit ];
+  nativeBuildInputs = [ autoreconfHook pkg-config autoconf-archive ];
+
+  # don't add SoftHSM to here: https://github.com/openssl/openssl/issues/22508
+  nativeCheckInputs = [ p11-kit.bin opensc nss.tools gnutls openssl.bin expect ];
+
+  postPatch = ''
+    patchShebangs --build .
+
+    # Makefile redirects to logfiles; make sure we can catch them.
+    for name in softokn softhsm; do
+      ln -s /dev/stderr tests/setup-$name.log
+    done
+  '';
+
+  enableParallelBuilding = true;
+
+  # Frequently fails due to a race condition.
+  enableParallelInstalling = false;
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/latchset/pkcs11-provider";
+    description = "An OpenSSL 3.x provider to access hardware or software tokens using the PKCS#11 Cryptographic Token Interface";
+    maintainers = with maintainers; [ numinit ];
+    license = licenses.asl20;
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Init pkcs-provider at 0.3. This is a PKCS#11 provider for OpenSSL 3.

Currently this is packaged in https://github.com/numinit/nixpkcs, pushing upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
