### PR TITLE
`pipx`: add shell completions

### DIFF
--- a/pkgs/development/python-modules/pipx/default.nix
+++ b/pkgs/development/python-modules/pipx/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , hatchling
 , hatch-vcs
+, installShellFiles
 , packaging
 , platformdirs
 , pytestCheckHook
@@ -39,6 +40,10 @@ buildPythonPackage rec {
     userpath
   ] ++ lib.optionals (pythonOlder "3.11") [
     tomli
+  ];
+
+  nativeBuildInputs = [
+      installShellFiles
   ];
 
   nativeCheckInputs = [
@@ -78,6 +83,13 @@ buildPythonPackage rec {
     "test_list_short"
     "test_skip_maintenance"
   ];
+
+  postInstall =  ''
+    installShellCompletion --cmd pipx \
+      --bash <(${argcomplete}/bin/register-python-argcomplete pipx --shell bash) \
+      --zsh <(${argcomplete}/bin/register-python-argcomplete pipx --shell zsh) \
+      --fish <(${argcomplete}/bin/register-python-argcomplete pipx --shell fish)
+  '';
 
   meta = with lib; {
     description = "Install and run Python applications in isolated environments";


### PR DESCRIPTION
## Description of changes

Install shell completions with `pipx` for `bash`, `zsh` and `fish`.

Apart from convenience, this reduces confusion. `pipx completions` is
not quite accurate when `pipx` is installed with Nix, since you need to
do  `nix shell nixpkgs#python311Packages.argcomplete
register-python-argcomplete`. It is possible to also put it in the path,
as suggested in
https://discourse.nixos.org/t/python-how-to-expose-a-dependencys-bin/283,
but that would be a separate PR.

Fixes https://github.com/NixOS/nixpkgs/issues/299845

Cc: @natsukium, @mweinelt, @yshym (same people I Cc-ed in the issue)

## Things done

This is my first nixpkgs PR, let me know if I did something wrong. On my local machine, I checked that `fish` completions work if I install `pipx` from `nixpkgs` with this patch.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [?] Tested, as applicable: 
      (I checked that the fish completions seem to work on my machine. I'm counting on the CI for running the tests)
- [?] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
      
    (I ran this; there were no errors, but then a shell opened, and I wasn't sure what to do there).
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
