### PR TITLE
doc: in overlays, pull functions from `self`, not `super`

### DIFF
--- a/doc/using/overlays.chapter.md
+++ b/doc/using/overlays.chapter.md
@@ -51,15 +51,15 @@ self: super:
   boost = super.boost.override {
     python = self.python3;
   };
-  rr = super.callPackage ./pkgs/rr {
+  rr = self.callPackage ./pkgs/rr {
     stdenv = self.stdenv_32bit;
   };
 }
 ```
 
-The first argument (`self`) corresponds to the final package set. You should use this set for the dependencies of all packages specified in your overlay. For example, all the dependencies of `rr` in the example above come from `self`, as well as the overridden dependencies used in the `boost` override.
+The first argument (`self`) corresponds to the final package set. You should use this set for the dependencies of all packages specified in your overlay, including any nixpkgs functions. In the example above, `self` provides all the overridden dependencies of `boost` and `rr`, as well as the `callPackage` function.
 
-The second argument (`super`) corresponds to the result of the evaluation of the previous stages of Nixpkgs. It does not contain any of the packages added by the current overlay, nor any of the following overlays. This set should be used either to refer to packages you wish to override, or to access functions defined in Nixpkgs. For example, the original recipe of `boost` in the above example, comes from `super`, as well as the `callPackage` function.
+The second argument (`super`) corresponds to the result of the evaluation of the previous stages of Nixpkgs. It does not contain any of the packages added by the current overlay, nor any of the following overlays. This set should be used to refer to packages you wish to override (where using `self` would result in infinite recursion). In the example above, the original recipe of `boost` comes from `super`.
 
 The value returned by this function should be a set similar to `pkgs/top-level/all-packages.nix`, containing overridden and/or new packages.
 


### PR DESCRIPTION
## Description of changes

The motivation for this change is to correct a longstanding error in the docs, suggesting that functions should come from `super`.
In fact, functions should come from `self` precisely because you want to use the final version of said function.
Moreover, when these functions are builders, you want your overlays to actually take effect!

As an example, this overlay results in infrec, because `xz` is part of `stdenv`, which is used by `fetchurl`:

```nix
final: prev: {
  xz = prev.xz.overrideAttrs (finalAttrs: prevAttrs: {
    version = "5.4.6";

    src = prev.fetchurl {
      url = "mirror://sourceforge/lzmautils/xz-${finalAttrs.version}.tar.bz2";
      hash = "sha256-kThRsnTo4dMXgeyUnxwj6NvPDs9uc6JDbcIXad0+b0k=";
    };
  });
}
```

While this one works as expected (the only change being to pull `fetchurl` from `self` aka `final`, rather than `super` aka `prev`):

```nix
final: prev: {
  xz = prev.xz.overrideAttrs (finalAttrs: prevAttrs: {
    version = "5.4.6";

    src = final.fetchurl {
      url = "mirror://sourceforge/lzmautils/xz-${finalAttrs.version}.tar.bz2";
      hash = "sha256-kThRsnTo4dMXgeyUnxwj6NvPDs9uc6JDbcIXad0+b0k=";
    };
  });
}
```

The original reason for the suggestion to use functions from `super` came from a 2017 talk on the topic, but with no explanation provided. Further investigation reveals this suggestion was related to a feature known as "automatic grafting" (currently nonexistent in nixpkgs). Given that functions should in fact come from `self`, it's likely the feature itself had some design flaws, and as it was never merged, we can safely correct this documentation.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
