### PR TITLE
Add Hyper-V fixes, and Enhanced Guest support option

### DIFF
--- a/nixos/modules/services/networking/xrdp.nix
+++ b/nixos/modules/services/networking/xrdp.nix
@@ -40,8 +40,12 @@ let
 
     ${cfg.extraConfDirCommands}
   '';
-in
-{
+
+  portFlag = if cfg.transportMode == null then
+    "${toString cfg.port}"
+  else
+    "${cfg.transportMode}://${cfg.address}:${toString cfg.port}";
+in {
 
   ###### interface
 
@@ -56,6 +60,25 @@ in
       audio = {
         enable = mkEnableOption (lib.mdDoc "audio support for xrdp sessions. So far it only works with PulseAudio sessions on the server side. No PipeWire support yet");
         package = mkPackageOptionMD pkgs "pulseaudio-module-xrdp" {};
+      };
+
+      transportMode = mkOption {
+        type = types.enum [ null "unix" "tcp" "tcp6" "vsock" ];
+        default = null;
+        example = "tcp6";
+        description = lib.mdDoc ''
+          Specifies the transport mode on which the xrdp daemon listens. Null means all interfaces.
+        '';
+      };
+
+      address = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "192.168.1.1";
+        description = lib.mdDoc ''
+          Specifies the addresses on which the xrdp daemon listens. Null means all addresses.
+          Will be cid for vsock mode.
+        '';
       };
 
       port = mkOption {
@@ -139,6 +162,12 @@ in
     })
 
     (mkIf cfg.enable {
+      assertions = [{
+        assertion = cfg.transportMode == null -> cfg.address == null;
+        message = ''
+          address can't be set without transportMode
+        '';
+      }];
 
       networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
 
@@ -186,7 +215,7 @@ in
             User = "xrdp";
             Group = "xrdp";
             PermissionsStartOnly = true;
-            ExecStart = "${pkgs.xrdp}/bin/xrdp --nodaemon --port ${toString cfg.port} --config ${confDir}/xrdp.ini";
+            ExecStart = "${pkgs.xrdp}/bin/xrdp --nodaemon --port ${portFlag} --config ${confDir}/xrdp.ini";
           };
         };
 

--- a/nixos/modules/virtualisation/hyperv-guest.nix
+++ b/nixos/modules/virtualisation/hyperv-guest.nix
@@ -10,6 +10,9 @@ in {
     virtualisation.hypervGuest = {
       enable = mkEnableOption (lib.mdDoc "Hyper-V Guest Support");
 
+      enhancedSession =
+        mkEnableOption (lib.mdDoc "Hyper-V Enhanced Session Support");
+
       videoMode = mkOption {
         type = types.str;
         default = "1152x864";
@@ -25,40 +28,69 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
-    boot = {
-      initrd.kernelModules = [
-        "hv_balloon" "hv_netvsc" "hv_storvsc" "hv_utils" "hv_vmbus"
-      ];
+  config = mkIf cfg.enable (mkMerge [
+    {
+      boot = {
+        initrd.kernelModules = [
+          "hv_balloon" "hv_netvsc" "hv_storvsc" "hv_utils" "hv_vmbus"
+        ];
 
-      initrd.availableKernelModules = [ "hyperv_keyboard" ];
+        initrd.availableKernelModules = [ "hyperv_keyboard" ];
 
-      kernelParams = [
-        "video=hyperv_fb:${cfg.videoMode}" "elevator=noop"
-      ];
-    };
-
-    environment.systemPackages = [ config.boot.kernelPackages.hyperv-daemons.bin ];
-
-    # enable hotadding cpu/memory
-    services.udev.packages = lib.singleton (pkgs.writeTextFile {
-      name = "hyperv-cpu-and-memory-hotadd-udev-rules";
-      destination = "/etc/udev/rules.d/99-hyperv-cpu-and-memory-hotadd.rules";
-      text = ''
-        # Memory hotadd
-        SUBSYSTEM=="memory", ACTION=="add", DEVPATH=="/devices/system/memory/memory[0-9]*", TEST=="state", ATTR{state}="online"
-
-        # CPU hotadd
-        SUBSYSTEM=="cpu", ACTION=="add", DEVPATH=="/devices/system/cpu/cpu[0-9]*", TEST=="online", ATTR{online}="1"
-      '';
-    });
-
-    systemd = {
-      packages = [ config.boot.kernelPackages.hyperv-daemons.lib ];
-
-      targets.hyperv-daemons = {
-        wantedBy = [ "multi-user.target" ];
+        kernelParams = [
+          "video=hyperv_fb:${cfg.videoMode}" "elevator=noop"
+        ];
+        blacklistedKernelModules = [ "hyperv_fb" ]; # workaround to use hyperv_drm
       };
-    };
-  };
+
+      environment.systemPackages = [ config.boot.kernelPackages.hyperv-daemons.bin ];
+
+      # enable hotadding cpu/memory
+      services.udev.packages = lib.singleton (pkgs.writeTextFile {
+        name = "hyperv-cpu-and-memory-hotadd-udev-rules";
+        destination = "/etc/udev/rules.d/99-hyperv-cpu-and-memory-hotadd.rules";
+        text = ''
+          # Memory hotadd
+          SUBSYSTEM=="memory", ACTION=="add", DEVPATH=="/devices/system/memory/memory[0-9]*", TEST=="state", ATTR{state}="online"
+
+          # CPU hotadd
+          SUBSYSTEM=="cpu", ACTION=="add", DEVPATH=="/devices/system/cpu/cpu[0-9]*", TEST=="online", ATTR{online}="1"
+        '';
+      });
+
+      systemd = {
+        packages = [ config.boot.kernelPackages.hyperv-daemons.lib ];
+
+        targets.hyperv-daemons = {
+          wantedBy = [ "multi-user.target" ];
+        };
+      };
+    }
+    (mkIf cfg.enable {
+      assertions = [{
+        assertion = config.hardware.pulseaudio.enable;
+        message = ''
+          Audio support for Hyper-V (xrdp) currently only supports pulseaudio
+        '';
+      }];
+      services.xrdp = {
+        enable = true;
+        openFirewall = true;
+        transportMode = "vsock";
+        address = "-1";
+        audio.enable = true;
+        extraConfDirCommands = ''
+          substituteInPlace $out/xrdp.ini \
+            --replace-fail security_layer=negotiate security_layer=rdp \
+            --replace-fail crypt_level=high crypt_level=none \
+            --replace-fail bitmap_compression=true bitmap_compression=false
+
+          substituteInPlace $out/sesman.ini \
+            --replace-fail FuseMountName=thinclient_drives FuseMountName=shared-drives
+        '';
+      };
+      boot.kernelModules = [ "hv_sock" ];
+
+    })
+  ]);
 }


### PR DESCRIPTION
## Description of changes

This change makes various changes supporting NixOS usage as a Hyper-V guest.

**Hyper-V Guest changes:**

NixOS on Hyper-V didn't work "out of the box" for me with any WM. With some digging I found https://github.com/NixOS/nixpkgs/issues/57290#issuecomment-1956812230. I found that adding `blacklistedKernelModules = [ "hyperv_fb" ];` to use hyperv_drm instead was the only thing that was needed to solve this issue.

I then added support for Hyper-V's Enhanced Guest sessions, which is needed for audio/clipboard/etc. These are hidden behind the `enhancedSession` option.

**xrdp changes:**

Since Hyper-V uses RDP for its Enhanced Guest sessions, changes were made to the xrdp.nix package to support this.
Primarily, the `--port=3389` flag needed to be set to `--port=vsock://-1:3389`. The current implementation just supplies the `--port` flag, which also overrides the config file's option. Thus a code change here was needed.
See [the xrdp.ini comments](https://github.com/neutrinolabs/xrdp/blob/e73f26c7c1ce817c57c0999cf724c34c318967c3/xrdp/xrdp.ini.in#L22) for more information about possible ways to set this flag.
A `transportMode` and `address` option was added to be able to set these values, as well as support other xrdp setups. If they are set to `null`, then it follows the previous behaviour. The `transportMode` values were taken from the possible options that [xrdp_listen_pp](https://github.com/Belinsky-L-V/xrdp/blob/0b17739da06de8f9e84438ac638753fb80e5780b/xrdp/xrdp_listen.c#L558) handles.
See also https://github.com/neutrinolabs/xrdp/pull/1441 for information about `vsock://-1:3389`.

Nix's xrdp package currently only supports pulseaudio (using [pulseaudio-module-xrdp](https://github.com/neutrinolabs/pulseaudio-module-xrdp)). So an assertion was added with enhancedSession to ensure it's enabled. However there's a [pipewire-module-xrdp](https://github.com/neutrinolabs/pipewire-module-xrdp) that doesn't have a nix package yet? So a future change could add that pipewire support with xrdp by default.

**Previous work that I've referenced:**

https://github.com/NixOS/nixpkgs/pull/75581
https://github.com/NixOS/nixpkgs/issues/57290#issuecomment-1956812230
https://github.com/NixOS/nixos-hardware/pull/252

I'm not very experienced in the Nix ecosystem, I just really wanted to get it working with Hyper-V. It currently didn't work at all "out of the box". Please let me know about any issues or best practices I've missed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
