### PR TITLE
poetryPlugins.poeblix: renamed from poetryPlugins.poetry-plugin-poeblix

### DIFF
--- a/pkgs/tools/package-management/poetry/default.nix
+++ b/pkgs/tools/package-management/poetry/default.nix
@@ -27,10 +27,10 @@ let
   });
 
   plugins = ps: with ps; {
+    poeblix = callPackage ./plugins/poeblix.nix { };
     poetry-audit-plugin = callPackage ./plugins/poetry-audit-plugin.nix { };
     poetry-plugin-export = callPackage ./plugins/poetry-plugin-export.nix { };
     poetry-plugin-up = callPackage ./plugins/poetry-plugin-up.nix { };
-    poetry-plugin-poeblix = callPackage ./plugins/poetry-plugin-poeblix.nix { };
   };
 
   # selector is a function mapping pythonPackages to a list of plugins

--- a/pkgs/tools/package-management/poetry/plugins/poeblix.nix
+++ b/pkgs/tools/package-management/poetry/plugins/poeblix.nix
@@ -2,10 +2,11 @@
 , buildPythonPackage
 , fetchFromGitHub
 , poetry-core
+, poetry
 }:
 
 buildPythonPackage rec {
-  pname = "poetry-plugin-poeblix";
+  pname = "poeblix";
   version = "0.10.0";
   pyproject = true;
 
@@ -16,20 +17,22 @@ buildPythonPackage rec {
     hash = "sha256-TKadEOk9kM3ZYsQmE2ftzjHNGNKI17p0biMr+Nskigs=";
   };
 
-  postPatch = ''
-    sed -i '/poetry =/d' pyproject.toml
-  '';
-
-  nativeBuildInputs = [
+  build-system = [
     poetry-core
   ];
 
-  doCheck = false;
+  buildInputs = [
+    poetry
+  ];
+
   pythonImportsCheck = ["poeblix"];
+
+  # poeblix tests currently fail with Python 3.11: https://github.com/spoorn/poeblix/issues/22
+  doCheck = false;
 
   meta = with lib; {
     changelog = "https://github.com/spoorn/poeblix/releases/tag/${src.rev}";
-    description = "Poetry Plugin that adds various features that extend the poetry command such as building wheel files with locked dependencies, and validations of wheel/docker containers";
+    description = "Poetry plugin for building wheel files with locked dependencies and validating wheel/docker containers";
     license = licenses.mit;
     homepage = "https://github.com/spoorn/poeblix";
     maintainers = with maintainers; [ hennk ];


### PR DESCRIPTION
## Description of changes

Incorporate packaging changes requested after merging of https://github.com/NixOS/nixpkgs/pull/295651

## Things done

* Renamed from poetryPlugins.poetry-plugin-poeblix to poetryPlugins.poeblix to reflect the real package name on PyPi
* Added comment why checks are disabled
* Avoid patch by providing more build inputs

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
