### PR TITLE
bluespec: 2023.01 -> 2024.01

### DIFF
--- a/pkgs/development/compilers/bluespec/default.nix
+++ b/pkgs/development/compilers/bluespec/default.nix
@@ -13,7 +13,7 @@
 , tcl
 , tk
 , xorg
-, yices
+, yices # bsc uses a patched version of yices
 , zlib
 , ghc
 , gmp-static
@@ -28,13 +28,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "bluespec";
-  version = "2023.01";
+  version = "2024.01";
 
   src = fetchFromGitHub {
     owner = "B-Lang-org";
     repo = "bsc";
     rev = version;
-    sha256 = "sha256-kFHQtRaQmZiHo+IQ+mwbW23i3kbdAh/XH0OE7P/ibd0=";
+    sha256 = "sha256-yqmtydv94p7qhps0t4EdPaSZNh/9XCuUwOzLqz0gjxE=";
   };
 
   yices-src = fetchurl {
@@ -46,7 +46,8 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "out" "doc" ];
 
-  # https://github.com/B-Lang-org/bsc/pull/278
+  # https://github.com/B-Lang-org/bsc/pull/278 is still applicable, but will probably not be applied as such
+  # there is work ongoing: https://github.com/B-Lang-org/bsc/issues/595 https://github.com/B-Lang-org/bsc/pull/600
   patches = [ ./libstp_stub_makefile.patch ];
 
   postUnpack = ''
@@ -67,6 +68,10 @@ in stdenv.mkDerivation rec {
 
     # allow running bsc to bootstrap
     export LD_LIBRARY_PATH=$PWD/inst/lib/SAT
+
+    # use more cores for GHC building, 44 causes heap overflows in ghc, and
+    # there is not much speedup after 8..
+    if [[ $NIX_BUILD_CORES -gt 8 ]] ; then export GHCJOBS=8; else export GHCJOBS=$NIX_BUILD_CORES; fi
   '';
 
   buildInputs = yices.buildInputs ++ [
@@ -96,7 +101,7 @@ in stdenv.mkDerivation rec {
     "NO_DEPS_CHECKS=1" # skip the subrepo check (this deriviation uses yices-src instead of the subrepo)
     "NOGIT=1" # https://github.com/B-Lang-org/bsc/issues/12
     "LDCONFIG=ldconfig" # https://github.com/B-Lang-org/bsc/pull/43
-    "STP_STUB=1"
+    "STP_STUB=1" # uses yices as a SMT solver and stub out STP
   ];
 
   doCheck = true;
@@ -106,7 +111,7 @@ in stdenv.mkDerivation rec {
     verilog
   ];
 
-  checkTarget = "check-smoke";
+  checkTarget = "check-smoke"; # this is the shortest check but "check-suite" tests much more
 
   installPhase = ''
     mkdir -p $out


### PR DESCRIPTION
## Description of changes

Update to [release 2024.01](https://github.com/B-Lang-org/bsc/blob/2024.01/release/ReleaseNotes.adoc) of the Bluespec HDL. 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
