### PR TITLE
kdePackages.kservice: don't overresolve symlinks when generating sycoca

### DIFF
--- a/pkgs/kde/frameworks/kservice/default.nix
+++ b/pkgs/kde/frameworks/kservice/default.nix
@@ -4,8 +4,10 @@ mkKdeDerivation {
 
   patches = [
     # follow symlinks when generating sycoca
-    # FIXME(later): upstream
     ./qdiriterator-follow-symlinks.patch
+    # but not too much
+    ./dont-overresolve-symlinks.patch
+    # FIXME(later): upstream?
   ];
   meta.mainProgram = "kbuildsycoca6";
 }

--- a/pkgs/kde/frameworks/kservice/dont-overresolve-symlinks.patch
+++ b/pkgs/kde/frameworks/kservice/dont-overresolve-symlinks.patch
@@ -1,0 +1,14 @@
+diff --git a/src/sycoca/vfolder_menu.cpp b/src/sycoca/vfolder_menu.cpp
+index 12313911..b364e44a 100644
+--- a/src/sycoca/vfolder_menu.cpp
++++ b/src/sycoca/vfolder_menu.cpp
+@@ -399,7 +399,8 @@ QString VFolderMenu::absoluteDir(const QString &_dir, const QString &baseDir, bo
+     }
+ 
+     if (!relative) {
+-        QString resolved = QDir(dir).canonicalPath();
++        // Nixpkgs: don't resolve symlinks here, or things get confused when the targets move around
++        QString resolved = QDir(dir).absolutePath();
+         if (!resolved.isEmpty()) {
+             dir = resolved;
+         }


### PR DESCRIPTION
This revives the patch we were applying to KF5, but slightly cleaner.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
