### PR TITLE
feat: add additional kargs to the hardening profile

### DIFF
--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -52,17 +52,17 @@ with lib;
     "debugfs=off"
 
     # Disable vsyscall as it is both obsolete and enables an ROP attack vector
-    vsyscall=none
+    "vsyscall=none"
 
     # Enable kernel stack offset randomization
-    randomize_kstack_offset=on
+    "randomize_kstack_offset=on"
 
     # enable iommu
-    iommu=force
-    intel_iommu=on
-    amd_iommu=force_isolation
-    iommu.passthrough=0
-    iommu.strict=1
+    "iommu=force"
+    "intel_iommu=on"
+    "amd_iommu=force_isolation"
+    "iommu.passthrough=0"
+    "iommu.strict=1"
   ];
 
   boot.blacklistedKernelModules = [

--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -39,7 +39,7 @@ with lib;
   security.apparmor.killUnconfinedConfinables = mkDefault true;
 
   boot.kernelParams = [
-    # Don't merge slabs
+    # Don't merge slabs, increasing difficulty of heap exploitation
     "slab_nomerge"
 
     # Overwrite free'd pages
@@ -50,6 +50,19 @@ with lib;
 
     # Disable debugfs
     "debugfs=off"
+
+    # Disable vsyscall as it is both obsolete and enables an ROP attack vector
+    vsyscall=none
+
+    # Enable kernel stack offset randomization
+    randomize_kstack_offset=on
+
+    # enable iommu
+    iommu=force
+    intel_iommu=on
+    amd_iommu=force_isolation
+    iommu.passthrough=0
+    iommu.strict=1
   ];
 
   boot.blacklistedKernelModules = [


### PR DESCRIPTION
## Description of changes

Adds additional kargs to the hardening profile

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
