### PR TITLE
docfd: 3.0.0 -> 4.0.0

### DIFF
--- a/pkgs/by-name/do/docfd/package.nix
+++ b/pkgs/by-name/do/docfd/package.nix
@@ -1,5 +1,7 @@
 { lib
 , ocamlPackages
+, stdenv
+, overrideSDK
 , fetchFromGitHub
 , python3
 , dune_3
@@ -10,7 +12,13 @@
 , docfd
 }:
 
-ocamlPackages.buildDunePackage rec {
+let
+  # Needed for x86_64-darwin
+  buildDunePackage' = ocamlPackages.buildDunePackage.override {
+    stdenv = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
+  };
+in
+buildDunePackage' rec {
   pname = "docfd";
   version = "4.0.0";
 

--- a/pkgs/by-name/do/docfd/package.nix
+++ b/pkgs/by-name/do/docfd/package.nix
@@ -3,6 +3,8 @@
 , fetchFromGitHub
 , python3
 , dune_3
+, testers
+, docfd
 }:
 
 ocamlPackages.buildDunePackage rec {
@@ -34,6 +36,10 @@ ocamlPackages.buildDunePackage rec {
     timedesc
     yojson
   ];
+
+  passthru.tests.version = testers.testVersion {
+    package = docfd;
+  };
 
   meta = with lib; {
     description = "TUI multiline fuzzy document finder";

--- a/pkgs/by-name/do/docfd/package.nix
+++ b/pkgs/by-name/do/docfd/package.nix
@@ -3,13 +3,16 @@
 , fetchFromGitHub
 , python3
 , dune_3
+, makeWrapper
+, pandoc
+, poppler_utils
 , testers
 , docfd
 }:
 
 ocamlPackages.buildDunePackage rec {
   pname = "docfd";
-  version = "3.0.0";
+  version = "4.0.0";
 
   minimalOCamlVersion = "5.1";
 
@@ -17,10 +20,10 @@ ocamlPackages.buildDunePackage rec {
     owner = "darrenldl";
     repo = "docfd";
     rev = version;
-    hash = "sha256-pJ5LlOfC+9NRfY7ng9LAxEnjr+mtJmhRNTo9Im6Lkbo=";
+    hash = "sha256-fgwUXRZ6k5i3XLxXpjbrl0TJZMT+NkGXf7KNwRgi+q8=";
   };
 
-  nativeBuildInputs = [ python3 dune_3 ];
+  nativeBuildInputs = [ python3 dune_3 makeWrapper ];
   buildInputs = with ocamlPackages; [
     cmdliner
     containers-data
@@ -37,6 +40,10 @@ ocamlPackages.buildDunePackage rec {
     yojson
   ];
 
+  postInstall = ''
+    wrapProgram $out/bin/docfd --prefix PATH : "${lib.makeBinPath [ pandoc poppler_utils ]}"
+  '';
+
   passthru.tests.version = testers.testVersion {
     package = docfd;
   };
@@ -44,14 +51,10 @@ ocamlPackages.buildDunePackage rec {
   meta = with lib; {
     description = "TUI multiline fuzzy document finder";
     longDescription = ''
-      Think interactive grep for both text and other document files, but
-      word/token based instead of regex and line based, so you can search
-      across lines easily. Aims to provide good UX via integration with
-      common text editors and other file viewers.
-      Optional dependencies:
-        fzf - for fuzzy file picker with "docfd ?".
-        poppler_utils - for pdf search.
-        pandoc - for .epub, .odt, .docx, .fb2, .ipynb, .html, & .htm files.
+      Think interactive grep for text and other document files.
+      Word/token based instead of regex and line based, so you
+      can search across lines easily. Aims to provide good UX via
+      integration with common text editors and other file viewers.
     '';
     homepage = "https://github.com/darrenldl/docfd";
     license = licenses.mit;

--- a/pkgs/development/ocaml-modules/eio/posix.nix
+++ b/pkgs/development/ocaml-modules/eio/posix.nix
@@ -1,4 +1,6 @@
 { buildDunePackage
+, lib
+, stdenv
 , dune-configurator
 , eio
 , fmt
@@ -13,6 +15,10 @@ buildDunePackage {
   minimalOCamlVersion = "5.0";
 
   dontStrip = true;
+
+  env = lib.optionalAttrs stdenv.isDarwin {
+    NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration";
+  };
 
   buildInputs = [
     dune-configurator


### PR DESCRIPTION
## Description of changes
- `docfd` - added a basic (version) passthru test

- `docfd` - updated 3.0.0 -> 4.0.0
https://github.com/darrenldl/docfd/releases/tag/4.0.0
I added `pandoc` and  `poppler_utils` as default dependencies since `docfd` now throws an error without them. 

- `ocamlPackages.eio_posix` - modified to allow it to build on x86_64-darwin. 
Closes https://github.com/NixOS/nixpkgs/issues/301174

- `docfd` - added a fix to help package build on x86_64-darwin (previous builds failed).
Closes https://github.com/NixOS/nixpkgs/issues/300987

Thanks to the darwin-maintainers for providing guidance on fixing the build.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
