### PR TITLE
sst: init at 0.0.246

### DIFF
--- a/pkgs/by-name/ss/sst/package.nix
+++ b/pkgs/by-name/ss/sst/package.nix
@@ -1,0 +1,32 @@
+{ pkgs
+, lib
+, fetchFromGitHub
+, buildGoModule
+,
+}:
+buildGoModule rec {
+  pname = "sst";
+  version = "0.0.246";
+
+  src = fetchFromGitHub {
+    owner = "sst";
+    repo = "ion";
+    rev = "v${version}";
+    hash = "sha256-tCAi2v/W5UF+YIkOkzTkIFsmhsI0KR0MNaumHBZ6TaE=";
+  };
+
+  vendorHash = "sha256-F/6VawWgBjpNcjRT2rbf/01Dc5Xzd6KrUD3kFPVUVCQ=";
+
+  ldflags = [ "-s" "-w" "-X main.version=${version}" ];
+
+  CGO_ENABLED = 0;
+
+  meta = with lib; {
+    homepage = "https://github.com/sst/ion";
+    description = "Ion is a new engine for deploying SST apps. It uses Pulumi and Terraform, as opposed to CDK and CloudFormation..";
+    mainProgram = "sst";
+    maintainers = with maintainers; [ averagebit ];
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
## Description of changes

sst - Ion is a new engine for deploying SST apps. It uses Pulumi and Terraform, as opposed to CDK and CloudFormation.

See: 
https://github.com/sst/ion/
https://repology.org/project/sst/information

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).