### PR TITLE
darwin.libiconv: revert switch to libiconvReal

### DIFF
--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -11,7 +11,6 @@
 , perl
 , luajit
 , darwin
-, libiconv
 , python3
 }:
 
@@ -128,7 +127,7 @@ stdenv.mkDerivation {
       --replace " -L${stdenv.cc.libc}/lib" "" \
       --replace " -L${darwin.libobjc}/lib" "" \
       --replace " -L${darwin.libunwind}/lib" "" \
-      --replace " -L${libiconv}/lib" ""
+      --replace " -L${darwin.libiconv}/lib" ""
 
     # All the libraries we stripped have -osx- in their name as of this time.
     # Assert now that this pattern no longer appears in config.mk.

--- a/pkgs/by-name/fr/frankenphp/package.nix
+++ b/pkgs/by-name/fr/frankenphp/package.nix
@@ -7,7 +7,6 @@
 , testers
 , frankenphp
 , darwin
-, libiconv
 , pkg-config
 , makeBinaryWrapper
 , runCommand
@@ -65,7 +64,7 @@ in buildGoModule rec {
   '' + lib.optionalString stdenv.isDarwin ''
     # replace hard-code homebrew path
     substituteInPlace ../frankenphp.go \
-      --replace "-L/opt/homebrew/opt/libiconv/lib" "-L${libiconv}/lib"
+      --replace "-L/opt/homebrew/opt/libiconv/lib" "-L${darwin.libiconv}/lib"
   '';
 
   preFixup = ''

--- a/pkgs/development/python-modules/json-stream-rs-tokenizer/default.nix
+++ b/pkgs/development/python-modules/json-stream-rs-tokenizer/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , buildPythonPackage
 , cargo
-, libiconv
+, darwin
 , fetchFromGitHub
 , json-stream
 , json-stream-rs-tokenizer
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   ];
 
   buildInputs = lib.optionals stdenv.isDarwin [
-    libiconv
+    darwin.libiconv
   ];
 
   # Tests depend on json-stream, which depends on this package.

--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -11,6 +11,7 @@ let
     };
     "osx-10.12.6" = {
       xnu           = "3789.70.16";
+      libiconv      = "50";
       Libnotify     = "165.20.1";
       objc4         = "709.1";
       dyld          = "433.5";
@@ -37,6 +38,7 @@ let
       dtrace        = "168";
       xnu           = "3248.60.10";
       libpthread    = "138.10.4";
+      libiconv      = "44";
       Libnotify     = "150.40.1";
       objc4         = "680";
       eap8021x      = "222.40.1";
@@ -270,6 +272,7 @@ developerToolsPackages_11_3_1 // macosPackages_11_0_1 // {
     };
     libclosure      = applePackage "libclosure"        "osx-10.11.6"     "sha256-L5rQ+UBpf3B+W1U+gZKk7fXulslHsc8lxnCsplV+nr0=" {};
     libdispatch     = applePackage "libdispatch"       "osx-10.10.5"     "sha256-jfAEk0OLrJa9AIZVikIoHomd+l+4rCfc320Xh50qK5M=" {};
+    libiconv        = applePackage "libiconv"          "osx-10.12.6"     "sha256-ZzPFkchK3EU95UQUVVrR0t8iilhi/VnIkjjtP6KT2oI=" {};
     Libinfo         = applePackage "Libinfo"           "osx-10.11.6"     "sha256-6F7wiwerv4nz/xXHtp1qCHSaFzZgzcRN+jbmXA5oWOQ=" {};
     Libm            = applePackage "Libm"              "osx-10.7.4"      "sha256-KjMETfT4qJm0m0Ux/F6Rq8bI4Q4UVnFx6IKbKxXd+Es=" {};
     Libnotify       = applePackage "Libnotify"         "osx-10.12.6"     "sha256-6wvMBxAUfiYcQtmlfYCj1d3kFmFM/jdboTd7hRvi3e4=" {};

--- a/pkgs/os-specific/darwin/apple-source-releases/libiconv/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libiconv/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, appleDerivation, lib
+, enableStatic ? stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.hostPlatform.isStatic
+}:
+
+appleDerivation {
+  postUnpack = "sourceRoot=$sourceRoot/libiconv";
+
+  preConfigure = lib.optionalString stdenv.hostPlatform.isiOS ''
+    sed -i 's/darwin\*/ios\*/g' configure libcharset/configure
+  '';
+
+  configureFlags = [
+    (lib.enableFeature enableStatic "static")
+    (lib.enableFeature enableShared "shared")
+  ];
+
+  postInstall = lib.optionalString enableShared ''
+    mv $out/lib/libiconv.dylib $out/lib/libiconv-nocharset.dylib
+    ${stdenv.cc.bintools.targetPrefix}install_name_tool -id $out/lib/libiconv-nocharset.dylib $out/lib/libiconv-nocharset.dylib
+
+    # re-export one useless symbol; ld will reject a dylib that only reexports other dylibs
+    echo 'void dont_use_this(){}' | ${stdenv.cc.bintools.targetPrefix}clang -dynamiclib -x c - -current_version 2.4.0 \
+      -compatibility_version 7.0.0 -current_version 7.0.0 -o $out/lib/libiconv.dylib \
+      -Wl,-reexport_library -Wl,$out/lib/libiconv-nocharset.dylib \
+      -Wl,-reexport_library -Wl,$out/lib/libcharset.dylib
+  '';
+
+  setupHooks = [
+    ../../../../build-support/setup-hooks/role.bash
+    ../../../../development/libraries/libiconv/setup-hook.sh
+  ];
+
+  meta = {
+    mainProgram = "iconv";
+    platforms = lib.platforms.darwin;
+  };
+}

--- a/pkgs/os-specific/darwin/apple-source-releases/macos-11.0.1.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/macos-11.0.1.nix
@@ -27,6 +27,7 @@ file_cmds = applePackage' "file_cmds" "321.40.3" "macos-11.0.1" "0p077lnbcy8266m
 hfs = applePackage' "hfs" "556.41.1" "macos-11.0.1" "0a0s6b12b0q07wslfifna0bj51dml9v098i4crr2m1vivnx4xj75" {};
 libclosure = applePackage' "libclosure" "78" "macos-11.0.1" "0vf9n0k3m8dbprv1bf45zqg0g43bidy2i5z1v9a826bsf8lv7am7" {};
 libdispatch = applePackage' "libdispatch" "1271.40.12" "macos-11.0.1" "1ck5srcjapg18vqb8wl08gacs7ndc6xr067qjn3ngx39q1jdcywz" {};
+libiconv = applePackage' "libiconv" "59" "macos-11.0.1" "0lwa4brdwm4lvrdnxylzsn1yph4m7csgri2zkc4xb4xiisz32pwp" {};
 libmalloc = applePackage' "libmalloc" "317.40.8" "macos-11.0.1" "sha256-Tdhb0mq3w4Hwvp3xHB79Vr22hCOQK6h28HCsd7jvITI=" {};
 libplatform = applePackage' "libplatform" "254.40.4" "macos-11.0.1" "1qf3ri0yd8b1xjln1j1gyx7ks6k3a2jhd63blyvfby75y9s7flky" {};
 libpthread = applePackage' "libpthread" "454.40.3" "macos-11.0.1" "0zljbw8mpb80n1if65hhi9lkgwbgjr8vc9wvf7q1nl3mzyl35f8p" {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22737,7 +22737,7 @@ with pkgs;
 
   # GNU libc provides libiconv so systems with glibc don't need to
   # build libiconv separately. Additionally, Apple forked/repackaged
-  # libiconv, so build and use the upstream one with a compatible ABI,
+  # libiconv so we use that instead of the vanilla version on that OS,
   # and BSDs include libiconv in libc.
   #
   # We also provide `libiconvReal`, which will always be a standalone libiconv,
@@ -22748,7 +22748,7 @@ with pkgs;
         then libcCross
         else stdenv.cc.libc)
     else if stdenv.hostPlatform.isDarwin
-      then libiconvReal.override { enableDarwinABICompat = true; }
+      then darwin.libiconv
     else libiconvReal;
 
   libcIconv = libc: let
@@ -22765,7 +22765,7 @@ with pkgs;
     if lib.elem stdenv.hostPlatform.libc [ "glibc" "musl" ] then
       lib.getBin stdenv.cc.libc
     else if stdenv.hostPlatform.isDarwin then
-      lib.getBin libiconv
+      lib.getBin darwin.libiconv
     else
       lib.getBin libiconvReal;
 

--- a/pkgs/top-level/darwin-aliases.nix
+++ b/pkgs/top-level/darwin-aliases.nix
@@ -50,8 +50,4 @@ mapAliases ({
   ### B ###
 
   builder = throw "'darwin.builder' has been changed and renamed to 'darwin.linux-builder'. The default ssh port is now 31022. Please update your configuration or override the port back to 22. See https://nixos.org/manual/nixpkgs/unstable/#sec-darwin-builder"; # added 2023-07-06
-
-  ### L ###
-
-  libiconv = pkgs.libiconv; # 2024-03-27
 })

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2517,6 +2517,7 @@ self: super: with self; {
   cryptodatahub = callPackage ../development/python-modules/cryptodatahub { };
 
   cryptography = callPackage ../development/python-modules/cryptography {
+    inherit (pkgs.darwin) libiconv;
     inherit (pkgs.darwin.apple_sdk.frameworks) Security;
   };
 
@@ -2541,6 +2542,7 @@ self: super: with self; {
   css-html-js-minify = callPackage ../development/python-modules/css-html-js-minify { };
 
   css-inline = callPackage ../development/python-modules/css-inline {
+    inherit (pkgs.darwin) libiconv;
     inherit (pkgs.darwin.apple_sdk.frameworks) Security SystemConfiguration;
   };
 
@@ -11477,7 +11479,9 @@ self: super: with self; {
 
   pyreaderwriterlock = callPackage ../development/python-modules/pyreaderwriterlock { };
 
-  pyreadstat = callPackage ../development/python-modules/pyreadstat { };
+  pyreadstat = callPackage ../development/python-modules/pyreadstat {
+    inherit (pkgs.darwin) libiconv;
+  };
 
   pyrealsense2 = toPythonModule (pkgs.librealsense.override {
     enablePython = true;


### PR DESCRIPTION
## Description of changes

I found an issue building libgit2. While the replacement is binary compatible, git enables `core.precomposeunicode` by default on Darwin and relies on converting from a Darwin-specific encoding (utf-8-mac) for compatibility. This codec is only available in Apple’s libiconv, so tests in libgit2 fail when it can’t find this codec.

Apple has recently released updated source for their libiconv, which I am working on packaging. It switches the implementation from an old version of GNU libiconv to the one from FreeBSD. The upstream build doesn’t work very well with xcbuild, so I’m having to replace the build system like I did with system_cmds.

It is not ready yet, but to avoid any issues in the next staging-next cycle, I am reverting https://github.com/NixOS/nixpkgs/pull/299613 to avoid causing breakage in the next staging-next cycle (except for the commit that switched to `--replace-failed`).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
