### PR TITLE
python311Packages.{batchgenerators,evaluate,monai-deploy,ome-zarr,pillow-jpls,templateflow,tensorly}: remove unused inputs

### DIFF
--- a/pkgs/development/python-modules/batchgenerators/default.nix
+++ b/pkgs/development/python-modules/batchgenerators/default.nix
@@ -6,7 +6,6 @@
 , future
 , numpy
 , pillow
-, fetchpatch
 , scipy
 , scikit-learn
 , scikit-image

--- a/pkgs/development/python-modules/evaluate/default.nix
+++ b/pkgs/development/python-modules/evaluate/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , pythonOlder
 , pythonRelaxDepsHook
-, pytestCheckHook
 , cookiecutter
 , datasets
 , dill

--- a/pkgs/development/python-modules/monai-deploy/default.nix
+++ b/pkgs/development/python-modules/monai-deploy/default.nix
@@ -4,7 +4,6 @@
 , fetchFromGitHub
 , networkx
 , numpy
-, pydicom
 , pytest-lazy-fixture
 , pytestCheckHook
 , pythonOlder
@@ -61,7 +60,7 @@ buildPythonPackage rec {
     "monai.deploy.core"
     # "monai.deploy.operators" should be imported as well but
     # requires some "optional" dependencies
-    # like highdicom (which is not packaged yet) and pydicom
+    # like highdicom and pydicom
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/ome-zarr/default.nix
+++ b/pkgs/development/python-modules/ome-zarr/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
-, fetchpatch
 , pytestCheckHook
 , aiohttp
 , dask

--- a/pkgs/development/python-modules/pillow-jpls/default.nix
+++ b/pkgs/development/python-modules/pillow-jpls/default.nix
@@ -1,8 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchPypi
-, fetchpatch
 , pythonOlder
 , pytestCheckHook
 , cmake

--- a/pkgs/development/python-modules/pyorthanc/default.nix
+++ b/pkgs/development/python-modules/pyorthanc/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
-, pytestCheckHook
 , pythonRelaxDepsHook
 , poetry-core
 , httpx

--- a/pkgs/development/python-modules/templateflow/default.nix
+++ b/pkgs/development/python-modules/templateflow/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
-, pytestCheckHook
 , setuptools-scm
 , nipreps-versions
 , pybids

--- a/pkgs/development/python-modules/tensorly/default.nix
+++ b/pkgs/development/python-modules/tensorly/default.nix
@@ -1,5 +1,4 @@
-{ stdenv
-, lib
+{ lib
 , buildPythonPackage
 , fetchFromGitHub
 , numpy


### PR DESCRIPTION
## Description of changes

Ran `deadnix` on the Python packages I'm maintainer of. Should be a no-op.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
