### PR TITLE
home-assistant.custom-components.garmin_connect: init at unstable-2024-01-16

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -14,6 +14,8 @@
 
   frigate = callPackage ./frigate {};
 
+  garmin_connect = callPackage ./garmin_connect {};
+
   govee-lan = callPackage ./govee-lan {};
 
   gpio = callPackage ./gpio {};

--- a/pkgs/servers/home-assistant/custom-components/garmin_connect/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/garmin_connect/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, buildHomeAssistantComponent
+
+, garminconnect
+, tzlocal
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "cyberjunky";
+  domain = "garmin_connect";
+  version = "unstable-2024-04-06";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "home-assistant-garmin_connect";
+    rev = "d42edcabc67ba6a7f960e849c8aaec1aabef87c0";
+    sha256 = "sha256-KqbP6TpH9B0/AjtsW5TcWSNgUhND+w8rO6X8fHqtsDI=";
+  };
+
+  propagatedBuildInputs = [
+    garminconnect
+    tzlocal
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/cyberjunky/home-assistant-garmin_connect";
+    license = licenses.mit;
+    description = "Garmin Connect integration for Home Assistant";
+    maintainers = with maintainers; [ dmadisetti ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Added garmin_connect: https://github.com/cyberjunky/home-assistant-garmin_connect

I was happy to keep this in my own configs, but saw that @graham33 had the same component (https://github.com/graham33/nur-packages/blob/master/pkgs/garminconnect/default.nix), so figured I'd push upstream for others too

## Things done

Check that it works. Using unstable because the published package seems a lot behind

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
