### PR TITLE
Revert compromised xz version

### DIFF
--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xz";
-  version = "5.6.1";
+  version = "5.4.6";
 
   src = fetchurl {
     url = with finalAttrs; "https://github.com/tukaani-project/xz/releases/download/v${version}/xz-${version}.tar.bz2";
-    hash = "sha256-0wBCJkmgEksRIWML5VnIkM7t8yZn1wZLgSiTMWbCF8g=";
+    hash = "sha256-kThRsnTo4dMXgeyUnxwj6NvPDs9uc6JDbcIXad0+b0k=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
## Description of changes

Revert to `5.4.6`, last version before known compromised `5.6.0` and `5.6.1` releases.

See also: https://openwall.com/lists/oss-security/2024/03/29/4

## Things done

This PR has not been tested, but reverted to known good version/hash prior to upgrade to `5.6.0`: https://github.com/NixOS/nixpkgs/commit/5c7c19cc7ef416b2f4a154263c6d04a50bbac86c