### PR TITLE
Fix haskellPackages.sqlcipher compilation problems.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3043,6 +3043,11 @@ self: super: {
     hash = "sha256-rCyY4rB/wLspeAbLw1jji5BykYFLnmTjLiUyNkiEXmw";
   }) (super.smtp-mail.override { connection = self.crypton-connection; });
 
+  # Currently the Haskell Sqlcipher bindings repository seems locked abandoned,
+  # https://github.com/figome/haskell-sqlcipher
+  # The patch provides enough fixes to make this compile again.
+  sqlcipher = appendPatch ./patches/sqlcipher-compilation-fixes.patch super.sqlcipher;
+
   # Use recent git version as the hackage version is outdated and not building on recent GHC versions
   haskell-to-elm = overrideSrc {
     version = "unstable-2023-12-02";

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5592,7 +5592,6 @@ broken-packages:
   - spy # failure in job https://hydra.nixos.org/build/233208095 at 2023-09-02
   - sqel # failure in job https://hydra.nixos.org/build/233256622 at 2023-09-02
   - sqids # failure in job https://hydra.nixos.org/build/233213849 at 2023-09-02
-  - sqlcipher # failure in job https://hydra.nixos.org/build/233259217 at 2023-09-02
   - sqlcli # failure in job https://hydra.nixos.org/build/252719841 at 2024-03-16
   - sqlite-easy # failure in job https://hydra.nixos.org/build/252728831 at 2024-03-16
   - sqlite # failure in job https://hydra.nixos.org/build/233215839 at 2023-09-02

--- a/pkgs/development/haskell-modules/patches/sqlcipher-compilation-fixes.patch
+++ b/pkgs/development/haskell-modules/patches/sqlcipher-compilation-fixes.patch
@@ -1,0 +1,82 @@
+diff --git a/Database/SQL/Types.hs b/Database/SQL/Types.hs
+index aaf92e9..3efad72 100644
+--- a/Database/SQL/Types.hs
++++ b/Database/SQL/Types.hs
+@@ -479,7 +479,7 @@ ppSQLExpr e =
+       BinSQLExpr op e1 e2 -> ppSQLExpr e1 <+> text op <+> ppSQLExpr e2
+       PrefixSQLExpr op e1 -> text op <+> ppSQLExpr e1
+       PostfixSQLExpr op e1-> ppSQLExpr e1 <+> text op
+-      FunSQLExpr f es     -> text f <> parens (commaH ppSQLExpr es)
++      FunSQLExpr f es     -> text f Text.PrettyPrint.HughesPJ.<> parens (commaH ppSQLExpr es)
+       ConstSQLExpr c      -> text c
+       CaseSQLExpr cs el   -> text "CASE" <+> vcat (map ppWhen cs)
+                              <+> text "ELSE" <+> ppSQLExpr el <+> text "END"
+diff --git a/Setup.hs b/Setup.hs
+index aea4278..d2915bd 100644
+--- a/Setup.hs
++++ b/Setup.hs
+@@ -13,7 +13,10 @@ type PreSDistHook = (Args -> SDistFlags -> IO HookedBuildInfo)
+ 
+ 
+ updatePreSDistHook :: (PreSDistHook -> PreSDistHook) -> UserHooks -> UserHooks
+-updatePreSDistHook update hooks@UserHooks{ preSDist = old }  = hooks { preSDist = update old }
++updatePreSDistHook update hooks = hooks
++
++-- updatePreSDistHook :: (PreSDistHook -> PreSDistHook) -> UserHooks -> UserHooks
++-- updatePreSDistHook update hooks@UserHooks{ preSDist = old }  = hooks { preSDist = update old }
+ 
+ 
+ configureSQLCipher :: PreSDistHook -> PreSDistHook
+diff --git a/sqlcipher.cabal b/sqlcipher.cabal
+index 6689bab..4ab1464 100644
+--- a/sqlcipher.cabal
++++ b/sqlcipher.cabal
+@@ -1,12 +1,13 @@
++cabal-version:   3.6
+ Name:            sqlcipher
+-Version:         1.0.1.2
++Version:         1.0.1.3
+ Synopsis:        Haskell binding to sqlcipher
+ Description:
+     Haskell binding to sqlcipher <https://www.zetetic.net/sqlcipher/>.
+ 
+     This was forked from sqlite3 library from Galois, Inc. since sqlcipher share most of its API.
+     .
+-License:         BSD3
++License:         BSD-3-Clause
+ License-file:    LICENSE
+ Author:          figo GmbH
+ Maintainer:      figo GmbH <package+haskell@figo.io>
+@@ -15,7 +16,6 @@ Copyright:
+   Copyright (c) 2016, figo GmbH
+ Homepage:        http://github.com/figome/haskell-sqlcipher
+ Category:        Database
+-cabal-version: >= 1.23
+ build-type:      Custom
+ 
+ -- Cheating here, including the tests/ .cabal +
+@@ -56,7 +57,7 @@ library
+     Database.SQLCipher,
+     Database.SQLCipher.Base,
+     Database.SQLCipher.Types,
+-    Database.SQL
++    Database.SQL,
+     Database.SQL.Types
+ 
+ 
+diff --git a/sqlcipher/sqlite3.c b/sqlcipher/sqlite3.c
+index 3aee1fb..77a6e95 100644
+--- a/sqlcipher/sqlite3.c
++++ b/sqlcipher/sqlite3.c
+@@ -20448,7 +20448,11 @@ static const char* sqlcipher_openssl_get_cipher(void *ctx) {
+ }
+ 
+ static int sqlcipher_openssl_get_key_sz(void *ctx) {
++#if OPENSSL_VERSION_NUMBER < 0x20000000
+   return EVP_CIPHER_key_length(((openssl_ctx *)ctx)->evp_cipher);
++#else
++  return EVP_CIPHER_get_key_length(((openssl_ctx *)ctx)->evp_cipher);
++#endif
+ }
+ 
+ static int sqlcipher_openssl_get_iv_sz(void *ctx) {


### PR DESCRIPTION
The bindings repository seems locked and abandoned, so I can't submit a PR against it - fixing it in Nix then.

This works at least on Darwin - I do not have a Linux system to test this with. Tests still fail, but not due to library problems: apparently some extra patches would need to be applied to they would run properly. I did not follow the `HACKING.md` procedures because they failed on my laptop even before I got to the changes in this PR, but I hope that this PR, if not "correct", at least gives enough information for somebody with a Linux system to follow the appropriate steps.

I have been using this patch on my own projects, and the bindings work fine in that respect.

Thanks!

## Description of changes

Applies a patch to the Sqlcipher bindings so they compile (and work, as I am using this library in my own projects).

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
