### PR TITLE
python312Packages.referencing: 0.33.0 -> 0.34.0

### DIFF
--- a/pkgs/development/python-modules/referencing/default.nix
+++ b/pkgs/development/python-modules/referencing/default.nix
@@ -11,14 +11,13 @@
 , rpds-py
 }:
 
-
 let
   self = buildPythonPackage rec {
     pname = "referencing";
     version = "0.34.0";
-    format = "pyproject";
+    pyproject = true;
 
-    disabled = pythonOlder "3.7";
+    disabled = pythonOlder "3.8";
 
     src = fetchFromGitHub {
       owner = "python-jsonschema";
@@ -28,12 +27,12 @@ let
       hash = "sha256-Vx+WVgt09I04Z/sIYsLLtPCwuo5wW0Z2o2OTH2V17UY=";
     };
 
-    nativeBuildInputs = [
+    build-system = [
       hatch-vcs
       hatchling
     ];
 
-    propagatedBuildInputs = [
+    dependencies = [
       attrs
       rpds-py
     ];
@@ -44,7 +43,7 @@ let
       pytestCheckHook
     ];
 
-    # avoid infinite recursion with jsonschema
+    # Avoid infinite recursion with jsonschema
     doCheck = false;
 
     passthru.tests.referencing = self.overridePythonAttrs { doCheck = true; };
@@ -56,7 +55,7 @@ let
     meta = with lib; {
       description = "Cross-specification JSON referencing";
       homepage = "https://github.com/python-jsonschema/referencing";
-      changelog = "https://github.com/python-jsonschema/referencing/blob/${version}/CHANGELOG.rst";
+      changelog = "https://github.com/python-jsonschema/referencing/releases/tag/v${version}";
       license = licenses.mit;
       maintainers = with maintainers; [ fab ];
     };

--- a/pkgs/development/python-modules/referencing/default.nix
+++ b/pkgs/development/python-modules/referencing/default.nix
@@ -1,14 +1,15 @@
-{ lib
-, attrs
-, buildPythonPackage
-, fetchFromGitHub
-, hatch-vcs
-, hatchling
-, jsonschema
-, pytest-subtests
-, pytestCheckHook
-, pythonOlder
-, rpds-py
+{
+  lib,
+  attrs,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatch-vcs,
+  hatchling,
+  jsonschema,
+  pytest-subtests,
+  pytestCheckHook,
+  pythonOlder,
+  rpds-py,
 }:
 
 let
@@ -48,9 +49,7 @@ let
 
     passthru.tests.referencing = self.overridePythonAttrs { doCheck = true; };
 
-    pythonImportsCheck = [
-      "referencing"
-    ];
+    pythonImportsCheck = [ "referencing" ];
 
     meta = with lib; {
       description = "Cross-specification JSON referencing";
@@ -61,4 +60,4 @@ let
     };
   };
 in
-  self
+self

--- a/pkgs/development/python-modules/referencing/default.nix
+++ b/pkgs/development/python-modules/referencing/default.nix
@@ -15,7 +15,7 @@
 let
   self = buildPythonPackage rec {
     pname = "referencing";
-    version = "0.33.0";
+    version = "0.34.0";
     format = "pyproject";
 
     disabled = pythonOlder "3.7";
@@ -25,7 +25,7 @@ let
       repo = "referencing";
       rev = "refs/tags/v${version}";
       fetchSubmodules = true;
-      hash = "sha256-QP/F6UNiKHGNMhGphDJgEFZnpGU5izExcI/A9WJjA5Q=";
+      hash = "sha256-Vx+WVgt09I04Z/sIYsLLtPCwuo5wW0Z2o2OTH2V17UY=";
     };
 
     nativeBuildInputs = [


### PR DESCRIPTION
Diff: https://github.com/python-jsonschema/referencing/compare/refs/tags/v0.33.0...v0.34.0

Changelog: https://github.com/python-jsonschema/referencing/blob/0.34.0/CHANGELOG.rst

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
