### PR TITLE
rabbitmq-c: 0.13.0 -> 0.14.0

### DIFF
--- a/pkgs/development/libraries/rabbitmq-c/default.nix
+++ b/pkgs/development/libraries/rabbitmq-c/default.nix
@@ -2,24 +2,17 @@
 
 stdenv.mkDerivation rec {
   pname = "rabbitmq-c";
-  version = "0.13.0";
+  version = "0.14.0";
 
   src = fetchFromGitHub {
     owner = "alanxz";
     repo = "rabbitmq-c";
     rev = "v${version}";
-    sha256 = "sha256-4tSZ+eaLZAkSmFsGnIrRXNvn3xA/4sTKyYZ3hPUMcd0=";
+    hash = "sha256-ffdnLEgUg+4G12JntjFag3ZXMvEL42hsrY6VT58ccJ0=";
   };
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ openssl popt xmlto ];
-
-  # https://github.com/alanxz/rabbitmq-c/issues/733
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace '\$'{exec_prefix}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR} \
-      --replace '\$'{prefix}/'$'{CMAKE_INSTALL_INCLUDEDIR} '$'{CMAKE_INSTALL_FULL_INCLUDEDIR}
-  '';
 
   meta = with lib; {
     description = "RabbitMQ C AMQP client library";


### PR DESCRIPTION
## Description of changes

Include the "fix" for CVE-2023-35789

Changelog:
https://github.com/alanxz/rabbitmq-c/releases/tag/v0.14.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


No new failures.  
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>syslogng</li>
    <li>syslogng.man</li>
  </ul>
</details>
<details>
  <summary>21 packages built:</summary>
  <ul>
    <li>ceph</li>
    <li>ceph-client</li>
    <li>ceph-csi</li>
    <li>ceph.dev</li>
    <li>ceph.doc</li>
    <li>libceph (ceph.lib ,libceph.dev ,libceph.doc ,libceph.lib ,libceph.man)</li>
    <li>ceph.man</li>
    <li>collectd</li>
    <li>php81Extensions.amqp</li>
    <li>php82Extensions.amqp</li>
    <li>php83Extensions.amqp</li>
    <li>qemu_full</li>
    <li>qemu_full.debug</li>
    <li>qemu_full.ga</li>
    <li>rabbitmq-c</li>
    <li>rsyslog</li>
    <li>samba4Full</li>
    <li>samba4Full.dev</li>
    <li>samba4Full.man</li>
    <li>sbclPackages.cl-rabbit</li>
    <li>sbclPackages.cl-rabbit-tests</li>
  </ul>
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
