### PR TITLE
poke: 3.2 -> 4.0

### DIFF
--- a/pkgs/applications/editors/poke/default.nix
+++ b/pkgs/applications/editors/poke/default.nix
@@ -1,37 +1,35 @@
 { lib
 , stdenv
 , fetchurl
-, gettext
 , help2man
 , pkg-config
 , texinfo
 , boehmgc
 , readline
-, guiSupport ? false, makeWrapper, tcl, tcllib, tk
-, miSupport ? true, json_c
 , nbdSupport ? !stdenv.isDarwin, libnbd
-, textStylingSupport ? true
+, textStylingSupport ? true, gettext
 , dejagnu
 
-# update script only
+  # update script only
 , writeScript
 }:
 
 let
   isCross = stdenv.hostPlatform != stdenv.buildPlatform;
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "poke";
-  version = "3.2";
+  version = "4.0";
 
   src = fetchurl {
-    url = "mirror://gnu/${pname}/${pname}-${version}.tar.gz";
-    hash = "sha256-dY5VHdU6bM5U7JTY/CH6TWtSon0cJmcgbVmezcdPDZc=";
+    url = "mirror://gnu/poke/poke-${finalAttrs.version}.tar.gz";
+    hash = "sha256-ArqyLLH6YVOhtqknyLs81Y1QhUPBRIQqbX7nTxmXOnc=";
   };
 
   outputs = [ "out" "dev" "info" "lib" ]
-  # help2man can't cross compile because it runs `poke --help` to
-  # generate the man page
-  ++ lib.optional (!isCross) "man";
+    # help2man can't cross compile because it runs `poke --help` to
+    # generate the man page
+    ++ lib.optional (!isCross) "man";
 
   postPatch = ''
     patchShebangs .
@@ -40,51 +38,31 @@ in stdenv.mkDerivation rec {
   strictDeps = true;
 
   nativeBuildInputs = [
-    gettext
     pkg-config
     texinfo
   ] ++ lib.optionals (!isCross) [
     help2man
-  ] ++ lib.optionals guiSupport [
-    makeWrapper
-    tcl.tclPackageHook
   ];
 
   buildInputs = [ boehmgc readline ]
-  ++ lib.optionals guiSupport [ tcl tcllib tk ]
-  ++ lib.optional miSupport json_c
-  ++ lib.optional nbdSupport libnbd
-  ++ lib.optional textStylingSupport gettext
-  ++ lib.optional (!isCross) dejagnu;
+    ++ lib.optional nbdSupport libnbd
+    ++ lib.optional textStylingSupport gettext
+    ++ lib.optional finalAttrs.finalPackage.doCheck dejagnu;
 
   configureFlags = [
     # libpoke depends on $datadir/poke, so we specify the datadir in
     # $lib, and later move anything else it doesn't depend on to $out
     "--datadir=${placeholder "lib"}/share"
-  ] ++ lib.optionals guiSupport [
-    "--enable-gui"
-    "--with-tcl=${tcl}/lib"
-    "--with-tk=${tk}/lib"
-    "--with-tkinclude=${tk.dev}/include"
   ];
 
   enableParallelBuilding = true;
 
-  doCheck = !isCross;
-  nativeCheckInputs = lib.optionals (!isCross) [ dejagnu ];
+  doCheck = true;
+  nativeCheckInputs = [ dejagnu ];
 
   postInstall = ''
     moveToOutput share/emacs "$out"
     moveToOutput share/vim "$out"
-  '';
-
-  # Prevent tclPackageHook from auto-wrapping all binaries, we only
-  # need to wrap poke-gui
-  dontWrapTclBinaries = true;
-
-  postFixup = lib.optionalString guiSupport ''
-    wrapProgram "$out/bin/poke-gui" \
-      --prefix TCLLIBPATH ' ' "$TCLLIBPATH"
   '';
 
   passthru = {
@@ -97,18 +75,17 @@ in stdenv.mkDerivation rec {
       # Expect the text in format of '<a href="...">poke 2.0</a>'
       new_version="$(curl -s https://www.jemarch.net/poke |
           pcregrep -o1 '>poke ([0-9.]+)</a>')"
-      update-source-version ${pname} "$new_version"
+      update-source-version poke "$new_version"
     '';
   };
 
-  meta = with lib; {
+  meta = {
     description = "Interactive, extensible editor for binary data";
     homepage = "http://www.jemarch.net/poke";
-    changelog = "https://git.savannah.gnu.org/cgit/poke.git/plain/ChangeLog?h=releases/poke-${version}";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ AndersonTorres kira-bruneau ];
-    platforms = platforms.unix;
+    changelog = "https://git.savannah.gnu.org/cgit/poke.git/plain/ChangeLog?h=releases/poke-${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ AndersonTorres kira-bruneau ];
+    platforms = lib.platforms.unix;
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
-}
-
-# TODO: Enable guiSupport by default once it's more than just a stub
+})


### PR DESCRIPTION
## Description of changes

https://www.jemarch.net/poke-4.0-relnotes.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
