### PR TITLE
ubootRaspberryPi: embiggen, again

### DIFF
--- a/pkgs/misc/uboot/0001-configs-rpi-allow-for-bigger-kernels.patch
+++ b/pkgs/misc/uboot/0001-configs-rpi-allow-for-bigger-kernels.patch
@@ -2,22 +2,6 @@ diff --git a/board/raspberrypi/rpi/rpi.env b/board/raspberrypi/rpi/rpi.env
 index 30228285ed..0327ef74fa 100644
 --- a/board/raspberrypi/rpi/rpi.env
 +++ b/board/raspberrypi/rpi/rpi.env
-@@ -55,11 +55,11 @@ dfu_alt_info+=zImage fat 0 1
-  * more than ~700M away from the start of the kernel image but this number can
-  * be larger OR smaller depending on e.g. the 'vmalloc=xxxM' command line
-  * parameter given to the kernel. So reserving memory from low to high
-- * satisfies this constraint again. Reserving 1M at 0x02600000-0x02700000 for
-- * the DTB leaves rest of the free RAM to the initrd starting at 0x02700000.
-+ * satisfies this constraint again. Reserving 1M at 0x04700000-0x04800000 for
-+ * the DTB leaves rest of the free RAM to the initrd starting at 0x04800000.
-  * Even with the smallest possible CPU-GPU memory split of the CPU getting
-- * only 64M, the remaining 25M starting at 0x02700000 should allow quite
-- * large initrds before they start colliding with U-Boot.
-+ * only 64M, the remaining 8M starting at 0x04800000 should allow reasonably
-+ * sized initrds before they start colliding with U-Boot.
-  */
- #ifdef CONFIG_ARM64
- fdt_high=ffffffffffffffff
 @@ -69,9 +69,9 @@ fdt_high=ffffffff
  initrd_high=ffffffff
  #endif
@@ -26,10 +10,10 @@ index 30228285ed..0327ef74fa 100644
 -pxefile_addr_r=0x02500000
 -fdt_addr_r=0x02600000
 -ramdisk_addr_r=0x02700000
-+scriptaddr=0x04500000
-+pxefile_addr_r=0x04600000
-+fdt_addr_r=0x04700000
-+ramdisk_addr_r=0x04800000
++scriptaddr=0x05500000
++pxefile_addr_r=0x05600000
++fdt_addr_r=0x05700000
++ramdisk_addr_r=0x05800000
  
  boot_targets=mmc usb pxe dhcp
 


### PR DESCRIPTION
Our kernels are bigger than 64M now, so give it another 16M. Also, stop updating the comment, it's not worth it.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
