### PR TITLE
python311Packages.distrax: fix type errors

### DIFF
--- a/pkgs/development/python-modules/distrax/default.nix
+++ b/pkgs/development/python-modules/distrax/default.nix
@@ -74,6 +74,20 @@ buildPythonPackage rec {
     "distrax/_src/distributions/transformed_test.py"
     "distrax/_src/distributions/uniform_test.py"
     "distrax/_src/utils/transformations_test.py"
+    # https://github.com/google-deepmind/distrax/pull/270
+    "distrax/_src/distributions/deterministic_test.py"
+    "distrax/_src/distributions/epsilon_greedy_test.py"
+    "distrax/_src/distributions/gamma_test.py"
+    "distrax/_src/distributions/greedy_test.py"
+    "distrax/_src/distributions/gumbel_test.py"
+    "distrax/_src/distributions/logistic_test.py"
+    "distrax/_src/distributions/log_stddev_normal_test.py"
+    "distrax/_src/distributions/mvn_diag_test.py"
+    "distrax/_src/distributions/mvn_full_covariance_test.py"
+    "distrax/_src/distributions/mvn_tri_test.py"
+    "distrax/_src/distributions/one_hot_categorical_test.py"
+    "distrax/_src/distributions/softmax_test.py"
+    "distrax/_src/utils/hmm_test.py"
   ];
 
   meta = with lib; {
@@ -81,8 +95,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/deepmind/distrax";
     license = licenses.asl20;
     maintainers = with maintainers; [ onny ];
-    # Several tests fail with:
-    # AssertionError: [Chex] Assertion assert_type failed: Error in type compatibility check
-    broken = true;
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

As mentioned in https://github.com/NixOS/nixpkgs/pull/297146#issuecomment-2008582227, an update to `chex` breaks some of `distrax`'s tests. 

This PR is a stopgap measure to fix the build until this [PR](https://github.com/google-deepmind/distrax/pull/270) to distrax lands.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
