### PR TITLE
kwin & plasma-mobile: 6.0.3 -> 6.0.3.1

### DIFF
--- a/pkgs/kde/generated/sources/plasma.json
+++ b/pkgs/kde/generated/sources/plasma.json
@@ -125,9 +125,9 @@
     "hash": "sha256-2dz0Ncoy1J8kG5EWyzWa2TrQ8KsgZ/bkG5VaeDTY4bo="
   },
   "kwin": {
-    "version": "6.0.3",
-    "url": "mirror://kde/stable/plasma/6.0.3/kwin-6.0.3.tar.xz",
-    "hash": "sha256-D0bnds1Qg3TFUsClpVpFvyj5zMyIcAiQCYVKETTXKnk="
+    "version": "6.0.3.1",
+    "url": "mirror://kde/stable/plasma/6.0.3/kwin-6.0.3.1.tar.xz",
+    "hash": "sha256-8VEIqZMga5YqPFg1uYigtJIsCpvJq4D69rNqM00yGzM="
   },
   "kwrited": {
     "version": "6.0.3",
@@ -215,9 +215,9 @@
     "hash": "sha256-W+t3hNEk2eoQjwCAQ6k8g3wHVz9byK/PkhbutGRK/Yo="
   },
   "plasma-mobile": {
-    "version": "6.0.3",
-    "url": "mirror://kde/stable/plasma/6.0.3/plasma-mobile-6.0.3.tar.xz",
-    "hash": "sha256-oHgh272xMZYdoTidGyR2xsdASVTU50mAw9+nUyF5+Xo="
+    "version": "6.0.3.1",
+    "url": "mirror://kde/stable/plasma/6.0.3/plasma-mobile-6.0.3.1.tar.xz",
+    "hash": "sha256-pIkzv+U5s3JOxKP4JwW54SF4MwhgNA1nd4riCmU224M="
   },
   "plasma-nano": {
     "version": "6.0.3",


### PR DESCRIPTION
## Description of changes

There has been an update to Plasma 6.0.3

plasma-mobile now has plasma-mobile-6.0.3.1 tar available to download
for packaging
sha256sum: a48933bfe539b3724ec4a3f82705b9e12178330860340d67778ae20a6536db83
Git commit: 900200d57cda48b5702ffa262b2615280b4d4932

kwin now has kwin-6.0.3.1 tar available to download for packaging
sha256sum: f15108a993206b962a3c5835b988a0b4922c0a9bc9ab80faf6b36a334d321b33
Git commit: 166988cef75e6142b72f9bc3f9d58a8cfce1e26e

https://kde.org/info/plasma-6.0.3/


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
  
Cc: @K900

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
