### PR TITLE
hid-fanatecff: init module

### DIFF
--- a/nixos/modules/hardware/hid-fanatecff.md
+++ b/nixos/modules/hardware/hid-fanatecff.md
@@ -1,0 +1,21 @@
+# Fanatec Wheelbases {#module-hid-fanatecff}
+
+*Source:* {file}`modules/hardware/hid-fanatecff.nix`
+
+*Upstream documentation:* <https://github.com/gotzl/hid-fanatecff>
+
+`hid-fanatecff` is a kernel driver to support FANATEC input devices,
+in particular ForceFeedback of various wheel-bases.
+
+To enable `hid-fanatecff`, add the following to your
+{file}`configuration.nix`:
+```nix
+{
+  hardware.hid-fanatecff.enable = true;
+
+  # If you want to use Oversteer
+  users.YOUR_USERNAME.extraGroups = [ "games" ];
+  services.udev.packages = with pkgs; [ oversteer ];
+  environment.systemPackages = with pkgs; [ oversteer ];
+}
+```

--- a/nixos/modules/hardware/hid-fanatecff.nix
+++ b/nixos/modules/hardware/hid-fanatecff.nix
@@ -1,0 +1,23 @@
+{ lib, config, ... }:
+
+let
+  cfg = config.hardware.hid-fanatecff;
+  kernelPackages = config.boot.kernelPackages;
+in
+{
+  options.hardware.hid-fanatecff.enable = lib.mkEnableOption "the Linux kernel drivers for Fanatec wheel bases";
+
+  config = lib.mkIf cfg.enable {
+    boot = {
+      extraModulePackages = [ kernelPackages.hid-fanatecff ];
+      kernelModules = [ "hid-fanatecf" ];
+    };
+    services.udev.packages = [ kernelPackages.hid-fanatecff ];
+    users.groups.games = { };
+  };
+
+  meta = {
+    doc = ./hid-fanatecff.md;
+    maintainers = with lib.maintainers; [ theaninova ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -67,6 +67,7 @@
   ./hardware/glasgow.nix
   ./hardware/gpgsmartcards.nix
   ./hardware/hackrf.nix
+  ./hardware/hid-fanatecff.nix
   ./hardware/i2c.nix
   ./hardware/infiniband.nix
   ./hardware/keyboard/qmk.nix

--- a/pkgs/os-specific/linux/hid-fanatecff/default.nix
+++ b/pkgs/os-specific/linux/hid-fanatecff/default.nix
@@ -48,12 +48,12 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Driver to support FANATEC input devices, in particular ForceFeedback of various wheel-bases";
     homepage = "https://github.com/gotzl/hid-fanatecff";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ theaninova ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ theaninova ];
+    platforms = lib.platforms.linux;
     broken = stdenv.isAarch64;
   };
 }

--- a/pkgs/os-specific/linux/hid-fanatecff/default.nix
+++ b/pkgs/os-specific/linux/hid-fanatecff/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  kernel,
+  fetchFromGitHub,
+  linuxConsoleTools,
+  bash,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hid-fanatecff";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "gotzl";
+    repo = "hid-fanatecff";
+    rev = lib.versions.majorMinor version;
+    hash = "sha256-1Nm/34Er/qfel9LJp++IWd7cTh2Wi93Kgd28YLMVvWo=";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = kernel.makeFlags ++ [
+    "KVERSION=${kernel.modDirVersion}"
+    "KERNEL_SRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  patchPhase = ''
+    runHook prePatch
+
+    substituteInPlace fanatec.rules \
+      --replace-fail "/bin/sh" "${bash}/bin/sh"
+    substituteInPlace fanatec.rules \
+      --replace-fail "/usr/bin/evdev-joystick" "${linuxConsoleTools}/bin/evdev-joystick"
+
+    runHook postPatch
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/etc/udev/rules.d
+    cp ${src}/fanatec.rules $out/etc/udev/rules.d/99-fanatec.rules
+
+    mkdir -p $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/hid
+    cp hid-fanatec.ko $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/hid
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Driver to support FANATEC input devices, in particular ForceFeedback of various wheel-bases";
+    homepage = "https://github.com/gotzl/hid-fanatecff";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ theaninova ];
+    platforms = platforms.linux;
+    broken = stdenv.isAarch64;
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -348,6 +348,8 @@ in {
 
     gcadapter-oc-kmod = callPackage ../os-specific/linux/gcadapter-oc-kmod { };
 
+    hid-fanatecff = callPackage ../os-specific/linux/hid-fanatecff { };
+
     hyperv-daemons = callPackage ../os-specific/linux/hyperv-daemons { };
 
     e1000e = if lib.versionOlder kernel.version "4.10" then  callPackage ../os-specific/linux/e1000e {} else null;


### PR DESCRIPTION
## Description of changes

Add the [`hid-fanatecff`](https://github.com/gotzl/hid-fanatecff) kernel module.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
```
3 packages failed to build:
linuxKernel.packages.linux_4_19_hardened.hid-fanatecff linuxKernel.packages.linux_5_4_hardened.hid-fanatecff linuxKernel.packages.linux_lqx.hid-fanatecff
```
*I could not figure out how to deal with this*
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
