### PR TITLE
arduino-create-agent: init at 1.6.1

### DIFF
--- a/pkgs/by-name/ar/arduino-create-agent/package.nix
+++ b/pkgs/by-name/ar/arduino-create-agent/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  go-task,
+}:
+
+buildGoModule rec {
+  pname = "arduino-create-agent";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "arduino";
+    repo = "arduino-create-agent";
+    rev = "${version}";
+    hash = "sha256-TWyjF/2F3ub+sGFOTWc3kv2w6SRrvDaBSztOki32oxc=";
+  };
+
+  patches = [
+    ./updater.patch
+  ];
+
+  vendorHash = "sha256-SV0Cw0MrAufBleloG1m4qNPme03cBj0UgQGL7jY1wY4=";
+
+  ldflags = [
+    "-X github.com/arduino/arduino-create-agent/version.versionString=${version}"
+    "-X github.com/arduino/arduino-create-agent/version.commit=unknown"
+  ];
+
+  doCheck = false; # require network connectivity
+
+  meta = {
+    description = "Agent to upload code to any USB connected Arduino board directly from the browser";
+    homepage = "https://github.com/arduino/arduino-create-agent";
+    changelog = "https://github.com/arduino/arduino-create-agent/releases/tag/${version}";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ kilimnik ];
+  };
+}

--- a/pkgs/by-name/ar/arduino-create-agent/updater.patch
+++ b/pkgs/by-name/ar/arduino-create-agent/updater.patch
@@ -1,0 +1,25 @@
+diff --git a/main.go b/main.go
+index 65b8219..8be36c6 100755
+--- a/main.go
++++ b/main.go
+@@ -399,7 +399,6 @@ func loop() {
+ 	r.Handle("WSS", "/socket.io/", socketHandler)
+ 	r.GET("/info", infoHandler)
+ 	r.POST("/pause", pauseHandler)
+-	r.POST("/update", updateHandler)
+ 
+ 	// Mount goa handlers
+ 	goa := v2.Server(config.GetDataDir().String(), Index)
+diff --git a/updater/updater.go b/updater/updater.go
+index db4e545..693431a 100644
+--- a/updater/updater.go
++++ b/updater/updater.go
+@@ -34,7 +34,7 @@ import (
+ // binary to be executed to perform the update. If no update has been downloaded
+ // it returns an empty string.
+ func Start(src string) string {
+-	return start(src)
++	return ""
+ }
+ 
+ // CheckForUpdates checks if there is a new version of the binary available and


### PR DESCRIPTION
## Description of changes

Packages the Arduino Create Agent, it is a software interfacing with their [cloud IDE](https://create.arduino.cc/) to upload sketches to Arduino Boards.
https://github.com/arduino/arduino-create-agent

I disabled the test cases, as they are downloading files.
I also patched the updater to disable it, as this does not work with nixpkgs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
