### PR TITLE
coqPackages: update interval, gappalib & vcfloat

### DIFF
--- a/pkgs/development/coq-modules/gappalib/default.nix
+++ b/pkgs/development/coq-modules/gappalib/default.nix
@@ -6,7 +6,8 @@ mkCoqDerivation {
   owner = "gappa";
   domain = "gitlab.inria.fr";
   inherit version;
-  defaultVersion = if lib.versions.range "8.8" "8.18" coq.coq-version then "1.5.4" else null;
+  defaultVersion = if lib.versions.range "8.8" "8.19" coq.coq-version then "1.5.5" else null;
+  release."1.5.5".sha256 = "sha256-qxi2Kg3N3o6+ncq7aPNEg98dBmQC5WCa86zROPJSDdo=";
   release."1.5.4".sha256 = "sha256-9PlkXqCu4rbFD7qnMF1GSpPCVmwJ3r593RfAvkJbbdA=";
   release."1.5.3".sha256 = "sha256-SuMopX5sm4jh2uBuE7zr6vhWhHYZYnab+epjqYJqg+s=";
   release."1.5.2".sha256 = "sha256-A021Bhqz5r2CZBayfjIiWrCIfUlejcQAfbTmOaf6QTM=";

--- a/pkgs/development/coq-modules/interval/default.nix
+++ b/pkgs/development/coq-modules/interval/default.nix
@@ -7,6 +7,7 @@ mkCoqDerivation rec {
   domain = "gitlab.inria.fr";
   inherit version;
   defaultVersion = with lib.versions; lib.switch coq.coq-version [
+    { case = range "8.12" "8.19"; out = "4.10.0"; }
     { case = range "8.12" "8.18"; out = "4.9.0"; }
     { case = range "8.12" "8.17"; out = "4.8.0"; }
     { case = range "8.12" "8.16"; out = "4.6.0"; }
@@ -15,6 +16,7 @@ mkCoqDerivation rec {
     { case = range "8.7" "8.11"; out = "3.4.2"; }
     { case = range "8.5" "8.6";  out = "3.3.0"; }
   ] null;
+  release."4.10.0".sha256 = "sha256-MZJVoKGLXjDabdv9BuUSK1L9z1cubzC9cqVuWevKIXQ=";
   release."4.9.0".sha256 = "sha256-+5NppyQahcc1idGu/U3B+EIWuZz2L3/oY7dIJR6pitE=";
   release."4.8.1".sha256 = "sha256-gknZ3bA90YY2AvwfFsP5iMhohwkQ8G96mH+4st2RPDc=";
   release."4.8.0".sha256 = "sha256-YPQ1tuUgGixAVdQUJ9a3lZUNVgm2pKK3RKvl3m+/8rY=";

--- a/pkgs/development/coq-modules/vcfloat/default.nix
+++ b/pkgs/development/coq-modules/vcfloat/default.nix
@@ -1,6 +1,6 @@
 { lib, mkCoqDerivation, coq, interval, compcert, flocq, bignums, version ? null }:
 
-let self = with lib; mkCoqDerivation {
+let self = mkCoqDerivation {
   pname = "vcfloat";
   owner = "VeriNum";
   inherit version;
@@ -8,9 +8,11 @@ let self = with lib; mkCoqDerivation {
   postPatch = ''
     coq_makefile -o Makefile -f _CoqProject *.v
   '';
-  defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.16" "8.17"; out = "2.1.1"; }
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
+    { case = isEq "8.19"; out = "2.2"; }
+    { case = range "8.16" "8.18"; out = "2.1.1"; }
   ] null;
+  release."2.2".sha256 = "sha256-PyMm84ZYh+dOnl8Kk2wlYsQ+S/d1Hsp6uv2twTedEPg=";
   release."2.1.1".sha256 = "sha256-bd/XSQhyFUAnSm2bhZEZBWB6l4/Ptlm9JrWu6w9BOpw=";
   releaseRev = v: "v${v}";
 
@@ -18,8 +20,8 @@ let self = with lib; mkCoqDerivation {
 
   meta = {
     description = "A tool for Coq proofs about floating-point round-off error";
-    maintainers = with maintainers; [ quinn-dougherty ];
-    license = licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ quinn-dougherty ];
+    license = lib.licenses.lgpl3Plus;
   };
 };
 in self

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -122,9 +122,10 @@ let
       tlc = callPackage ../development/coq-modules/tlc {};
       topology = callPackage ../development/coq-modules/topology {};
       trakt = callPackage ../development/coq-modules/trakt {};
-      vcfloat = callPackage ../development/coq-modules/vcfloat {
-        interval = self.interval.override { version = "4.9.0"; };
-      };
+      vcfloat = callPackage ../development/coq-modules/vcfloat (lib.optionalAttrs
+        (lib.versions.range "8.16" "8.18" self.coq.version) {
+          interval = self.interval.override { version = "4.9.0"; };
+        });
       Velisarios = callPackage ../development/coq-modules/Velisarios {};
       Verdi = callPackage ../development/coq-modules/Verdi {};
       Vpl = callPackage ../development/coq-modules/Vpl {};

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -122,7 +122,9 @@ let
       tlc = callPackage ../development/coq-modules/tlc {};
       topology = callPackage ../development/coq-modules/topology {};
       trakt = callPackage ../development/coq-modules/trakt {};
-      vcfloat = callPackage ../development/coq-modules/vcfloat {};
+      vcfloat = callPackage ../development/coq-modules/vcfloat {
+        interval = self.interval.override { version = "4.9.0"; };
+      };
       Velisarios = callPackage ../development/coq-modules/Velisarios {};
       Verdi = callPackage ../development/coq-modules/Verdi {};
       Vpl = callPackage ../development/coq-modules/Vpl {};


### PR DESCRIPTION
## Description of changes

https://gitlab.inria.fr/coqinterval/interval/-/raw/interval-4.10.0/NEWS.md
https://gitlab.inria.fr/gappa/coq/-/raw/gappalib-coq-1.5.5/NEWS.md

Tested there: coq-community/coq-nix-toolbox#208

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
