### PR TITLE
protonup-rs: init 0.8.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11326,6 +11326,12 @@
     githubId = 591860;
     name = "Lionello Lunesu";
   };
+  liperium = {
+    email = "mattysgervais@gmail.com";
+    github = "liperium";
+    githubId = 48138387;
+    name = "Mattys Gervais";
+  };
   litchipi = {
     email = "litchi.pi@proton.me";
     github = "litchipi";

--- a/pkgs/by-name/pr/protonup-rs/package.nix
+++ b/pkgs/by-name/pr/protonup-rs/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "protonup-rs";
+  version = "0.8.2";
+  mainProgram = "protonup-rs";
+
+  src = fetchFromGitHub {
+    owner = "auyer";
+    repo = "Protonup-rs";
+    rev = "v${version}";
+    hash = "sha256-nBSrY4DAHRphzJ3VfausBAJcLKNxSVR0VNSzWreCs8E=";
+  };
+
+  cargoHash = "sha256-nzwWYHMY3IMi3S+x1IqHpaZks9Tv5saFJTWect62elg=";
+
+  # Can't seem to pass these tests? Network access?
+  # github::tests::test_get_release, github::tests::test_list_releases
+  checkFlags = [ "--skip={github::tests::test_get_release, github::tests::test_list_releases}" ];
+
+  meta = with lib; {
+    description = "Lib, CLI and GUI(wip) program to automate the installation and update of Proton-GE";
+    homepage = "https://github.com/auyer/Protonup-rs/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ liperium ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Lib, CLI and GUI(wip) program to automate the installation and update of Proton-GE
[Github Homepage](https://github.com/auyer/Protonup-rs)

I wasn't able to let tests enabled because of this error: `github::tests::test_fetch_data_from_tag` from the **libprotonup** library.

Old PR (messed with my branches) : https://github.com/NixOS/nixpkgs/pull/259262
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
