### PR TITLE
openafs: avoid top-level `with` statement

### DIFF
--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -14,11 +14,9 @@
 , fetchpatch
 }:
 
-with (import ./srcs.nix {
-  inherit fetchurl;
-});
-
 let
+  inherit (import ./srcs.nix { inherit fetchurl; }) src version;
+
   modDestDir = "$out/lib/modules/${kernel.modDirVersion}/extra/openafs";
   kernelBuildDir = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
 


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is no functional change contained in this PR.

To find the symbols exported from `srcs.nix`, I ran the following command:

```
nix-instantiate --json --strict --eval --expr 'let srcs = import pkgs/servers/openafs/1.8/srcs.nix { fetchurl = pkgs.fetchurl; }; pkgs = import ./. { }; in builtins.attrNames srcs' | jq -r '.[]' 
```

When I ran `nixpkgs-review rev HEAD`, no packages need to be rebuilt.

## Things done

- [x] `nixpkgs-review rev HEAD`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).