### PR TITLE
kid3: build with qt6 and KDE support

### DIFF
--- a/pkgs/applications/audio/kid3/default.nix
+++ b/pkgs/applications/audio/kid3/default.nix
@@ -1,5 +1,4 @@
-{
-  chromaprint
+{ chromaprint
 , cmake
 , docbook_xml_dtd_45
 , docbook_xsl
@@ -7,25 +6,43 @@
 , ffmpeg
 , flac
 , id3lib
+, kdePackages
 , lib
 , libogg
 , libvorbis
 , libxslt
 , mp4v2
-, phonon
 , pkg-config
 , python3
 , qtbase
+, qtdeclarative
 , qtmultimedia
-, qtquickcontrols
 , qttools
 , readline
 , stdenv
 , taglib
 , wrapQtAppsHook
 , zlib
+, withCLI ? true
+, withKDE ? true
+, withQt ? false
 }:
 
+let
+  inherit (lib) optionals;
+
+  apps = lib.concatStringsSep ";" (
+    optionals withCLI [ "CLI" ]
+    ++ optionals withKDE [ "KDE" ]
+    ++ optionals withQt [ "Qt" ]
+  );
+
+  mainProgram =
+    if withQt then "kid3-qt"
+    else if withKDE then "kid3"
+    else "kid3-cli";
+
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "kid3";
   version = "3.9.5";
@@ -41,6 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     docbook_xsl
     pkg-config
     python3
+    qttools
     wrapQtAppsHook
   ];
 
@@ -53,25 +71,32 @@ stdenv.mkDerivation (finalAttrs: {
     libvorbis
     libxslt
     mp4v2
-    phonon
     qtbase
+    qtdeclarative
     qtmultimedia
-    qtquickcontrols
-    qttools
     readline
     taglib
     zlib
-  ];
+  ] ++ lib.optionals withKDE (with kdePackages; [
+    kconfig
+    kconfigwidgets
+    kcoreaddons
+    kio
+    kxmlgui
+    phonon
+  ]);
 
-  cmakeFlags = [ "-DWITH_APPS=Qt;CLI" ];
-  NIX_LDFLAGS = "-lm -lpthread";
+  cmakeFlags = [ (lib.cmakeFeature "WITH_APPS" apps) ];
 
-  preConfigure = ''
-    export DOCBOOKDIR="${docbook_xsl}/xml/xsl/docbook/"
-  '';
+  env = {
+    DOCBOOKDIR = "${docbook_xsl}/xml/xsl/docbook/";
+    LANG = "C.UTF-8";
+    NIX_LDFLAGS = "-lm -lpthread";
+  };
 
   meta = {
     description = "A simple and powerful audio tag editor";
+    inherit mainProgram;
     homepage = "https://kid3.kde.org/";
     license = lib.licenses.lgpl2Plus;
     longDescription = ''
@@ -103,7 +128,7 @@ stdenv.mkDerivation (finalAttrs: {
       - Edit synchronized lyrics and event timing codes, import and export
         LRC files.
     '';
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = with lib.maintainers; [ AndersonTorres ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32484,7 +32484,10 @@ with pkgs;
 
   khard = callPackage ../applications/misc/khard { };
 
-  kid3 = libsForQt5.callPackage ../applications/audio/kid3 { };
+  kid3-cli = qt6Packages.callPackage ../applications/audio/kid3 { withCLI = true; withKDE = false; withQt = false; };
+  kid3-kde = qt6Packages.callPackage ../applications/audio/kid3 { withCLI = true; withKDE = true; withQt = false; };
+  kid3-qt = qt6Packages.callPackage ../applications/audio/kid3 { withCLI = true; withKDE = false; withQt = true; };
+  kid3 = kid3-kde;
 
   kile = libsForQt5.callPackage ../applications/editors/kile { };
 


### PR DESCRIPTION
## Description of changes

Build with Qt6 instead of Qt5.

Additionally, kid3 can be built with and without KDE support but as our default DE is KDE, it makes sense to build that configuration by default.

The non-KDE version has been added as `kid3-qt`.

Cc: @AndersenTorres

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
  
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
