### PR TITLE
writeClosure: add `paths` pre-instantiation filtering and sorting

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -636,7 +636,13 @@ rec {
     {
       # Get the cleaner exportReferencesGraph interface
       __structuredAttrs = true;
-      exportReferencesGraph.graph = paths;
+      exportReferencesGraph.graph = lib.pipe paths [
+        # Reemove null
+        (lib.remove null)
+        # Sort paths to avoid unnecessary rebuild
+        (map (p: "${p}"))
+        (lib.sort lib.lessThan)
+      ];
       nativeBuildInputs = [ jq ];
     }
     ''


### PR DESCRIPTION
## Description of changes

Pre-process paths before feeding to `exportReferencesGraph`.
- Remove `null`.
    - Specifying a package as `null` is a common approach to "cancel" a dependency from the override interface. However, `exportReferencesGraph` doesn't handle `null` correctly (with or without `__structuredAttrs = true`), hence the removal.
- Manually string-interpolate for sorting.
    - See below.
- Sort alphabetically to reduce unnecessary rebuilds.
    - There were once discussion about sorting `buildInputs` and `nativeBuildInputs` automatically for similar purposes, but such proposal faced the challenge of a few packages' relying on the order of dependency package to determine the order of `PATH`s. The `paths` attribute of `writeClosure` doesn't have such issue, as the closure is, by definition, independent to the permutation of `paths`.

Regarding the [concern](https://github.com/NixOS/nixpkgs/pull/178717#discussion_r1527165574) about manual string interpolation, the paths will eventually go through string interpolation before being serialized into a [store derivation](https://nixos.org/manual/nix/stable/glossary#gloss-store-derivation) (`/nix/store/*.drv`) and form `$NIX_ATTRS_JSON_FILE` and `$NIX_ATTRS_SH_FILE`. Manual string interpolation doesn't change any of the `drvPath` or `outPath`, nor does it introduce extra dependencies or affects realization.

Proof:

The following Nix expression evaluates to `true`.

```nix
let
  pkgs = import <nixpkgs> { };
  dump = with pkgs; paths:
    runCommand "dump-exportReferencesGraph-attrs" {
      __structuredAttrs = true;
      exportReferencesGraph.graph = paths;
    } ''
      mkdir -p "$out"
      cp "$NIX_ATTRS_JSON_FILE" "$NIX_ATTRS_SH_FILE" "$out"
    '';
in
(dump [ pkgs.hello pkgs.cowsay ]) == (dump [ "${pkgs.hello}" "${pkgs.cowsay}" ])
```


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
