### PR TITLE
python3Packages.asn1crypto: use `let .. in` instead of top-level `with`

### DIFF
--- a/pkgs/development/python-modules/asn1crypto/default.nix
+++ b/pkgs/development/python-modules/asn1crypto/default.nix
@@ -13,8 +13,8 @@
 # Switch version based on python version, as the situation isn't easy:
 #   https://github.com/wbond/asn1crypto/issues/269
 #   https://github.com/MatthiasValvekens/certomancer/issues/12
-with (
-  if lib.versionOlder python.version "3.12" then rec {
+let
+  provenance = if lib.versionOlder python.version "3.12" then rec {
     version = "1.5.1";
     rev = version;
     hash = "sha256-M8vASxhaJPgkiTrAckxz7gk/QHkrFlNz7fFbnLEBT+M=";
@@ -22,19 +22,19 @@ with (
     version = "1.5.1-unstable-2023-11-03";
     rev = "b763a757bb2bef2ab63620611ddd8006d5e9e4a2";
     hash = "sha256-11WajEDtisiJsKQjZMSd5sDog3DuuBzf1PcgSY+uuXY=";
-  }
-);
+  };
+in
 
 buildPythonPackage rec {
   pname = "asn1crypto";
   pyproject = true;
-  inherit version;
+  inherit (provenance) version;
 
   # Pulling from Github to run tests
   src = fetchFromGitHub {
     owner = "wbond";
     repo = "asn1crypto";
-    inherit rev hash;
+    inherit (provenance) rev hash;
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is no functional change contained in this PR.

I pulled this commit out of the now-draft PR https://github.com/NixOS/nixpkgs/pull/299022.

## Things done

- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev HEAD`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).