### PR TITLE
 iscc: init at 6.2.2 

### DIFF
--- a/pkgs/by-name/is/iscc/package.nix
+++ b/pkgs/by-name/is/iscc/package.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, fetchurl
+, innoextract
+, runtimeShell
+, wineWow64Packages
+, lib
+}:
+
+let
+  version = "6.2.2";
+  majorVersion = builtins.substring 0 1 version;
+in
+stdenv.mkDerivation rec {
+  pname = "iscc";
+  inherit version;
+  src = fetchurl {
+    url = "https://files.jrsoftware.org/is/${majorVersion}/innosetup-${version}.exe";
+    hash = "sha256-gRfRDQCirTOhOQl46jhyhhwzDgh5FEEKY3eyLExbhWM=";
+  };
+  nativeBuildInputs = [
+    innoextract
+    wineWow64Packages.stable
+  ];
+  unpackPhase = ''
+    runHook preUnpack
+    innoextract $src
+    runHook postUnpack
+  '';
+  dontBuild = true;
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/bin"
+    cp -r ./app/* "$out/bin"
+
+    cat << 'EOF' > "$out/bin/${pname}"
+    #!${runtimeShell}
+    export PATH=${wineWow64Packages.stable}/bin:$PATH
+    export WINEDLLOVERRIDES="mscoree=" # disable mono
+
+    # Solves PermissionError: [Errno 13] Permission denied: '/homeless-shelter/.wine'
+    export HOME=$(mktemp -d)
+
+    wineInputFile=$(${wineWow64Packages.stable}/bin/wine winepath -w $1)
+    ${wineWow64Packages.stable}/bin/wine "$out/bin/ISCC.exe" "$wineInputFile"
+    EOF
+
+    substituteInPlace $out/bin/${pname} \
+      --replace "\$out" "$out"
+
+    chmod +x "$out/bin/${pname}"
+
+    runHook postInstall
+  '';
+
+
+  meta = with lib; {
+    description = "A compiler for Inno Setup, a tool for creating Windows installers";
+    homepage = "https://jrsoftware.org/isinfo.php";
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ ];
+    platforms = wineWow64Packages.stable.meta.platforms;
+  };
+}


### PR DESCRIPTION
## Description of changes
New package iscc used to create windows installers. See https://github.com/seanybaggins/qt-package-overalys/blob/main/nix/overlays/pkgs/qtapp-example/default.nix#L45-L125 for an example on how to use.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
