### PR TITLE
photini: init at 2024.2.1

### DIFF
--- a/pkgs/by-name/ph/photini/package.nix
+++ b/pkgs/by-name/ph/photini/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  gitUpdater,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "photini";
+  version = "2024.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jim-easterbrook";
+    repo = "Photini";
+    rev = "refs/tags/${version}";
+    hash = "sha256-iTaFyQpC585QPInLvFzgk65+Znvb1kTTsrzEQvy1quY=";
+  };
+
+  build-system = with python3Packages; [ setuptools-scm ];
+  dependencies = with python3Packages; [
+    pyqt6
+    pyqt6-webengine
+    cachetools
+    appdirs
+    chardet
+    exiv2
+    filetype
+    requests
+    requests-oauthlib
+    requests-toolbelt
+    pyenchant
+    gpxpy
+    keyring
+    pillow
+  ];
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    homepage = "https://github.com/jim-easterbrook/Photini";
+    changelog = "https://photini.readthedocs.io/en/release-${version}/misc/changelog.html";
+    description = "An easy to use digital photograph metadata (Exif, IPTC, XMP) editing application";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ zebreus ];
+    mainProgram = "photini";
+  };
+}

--- a/pkgs/development/python-modules/exiv2/default.nix
+++ b/pkgs/development/python-modules/exiv2/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  pkg-config,
+  exiv2,
+  python3Packages,
+  fetchFromGitHub,
+  gitUpdater,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "exiv2";
+  version = "0.16.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jim-easterbrook";
+    repo = "python-exiv2";
+    rev = "refs/tags/${version}";
+    hash = "sha256-DX0pg80fOSkWqrIvcye0btZGglnizzM9ZEuVEpnEJKQ=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    toml
+  ];
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ exiv2 ];
+
+  pythonImportsCheck = [ "exiv2" ];
+  nativeCheckInputs = with python3Packages; [ unittestCheckHook ];
+  unittestFlagsArray = [
+    "-s"
+    "tests"
+    "-v"
+  ];
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "Low level Python interface to the Exiv2 C++ library";
+    homepage = "https://github.com/jim-easterbrook/python-exiv2";
+    changelog = "https://python-exiv2.readthedocs.io/en/release-${version}/misc/changelog.html";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ zebreus ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3992,6 +3992,10 @@ self: super: with self; {
 
   exifread = callPackage ../development/python-modules/exifread { };
 
+  exiv2 = callPackage ../development/python-modules/exiv2 {
+    inherit (pkgs) exiv2;
+  };
+
   expandvars = callPackage ../development/python-modules/expandvars { };
 
   expects = callPackage ../development/python-modules/expects { };
@@ -10600,7 +10604,9 @@ self: super: with self; {
 
   py3buddy = toPythonModule (callPackage ../development/python-modules/py3buddy { });
 
-  py3exiv2 = callPackage ../development/python-modules/py3exiv2 { };
+  py3exiv2 = callPackage ../development/python-modules/py3exiv2 {
+    inherit (pkgs) exiv2;
+  };
 
   py3langid = callPackage ../development/python-modules/py3langid { };
 


### PR DESCRIPTION
## Description of changes

[Photini](https://github.com/jim-easterbrook/Photini) is a graphical image metadata (Exif, IPTC, XMP) editor for Linux and MacOS.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
