### PR TITLE
telegram-desktop: 4.15.2 -> 4.16.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/default.nix
@@ -30,7 +30,6 @@
 , range-v3
 , tl-expected
 , hunspell
-, glibmm_2_68
 , webkitgtk_6_0
 , jemalloc
 , rnnoise
@@ -64,14 +63,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "telegram-desktop";
-  version = "4.15.2";
+  version = "4.16.0";
 
   src = fetchFromGitHub {
     owner = "telegramdesktop";
     repo = "tdesktop";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-gzwDezOmIvSF4fPHAslf8DyBAgCYkD5ySX+MKKMXhSg=";
+    hash = "sha256-llrHN/XCMKwAvbyUZ/92OUjAEOPJKPbDfldVChLZo5k=";
   };
 
   patches = [
@@ -144,7 +143,6 @@ stdenv.mkDerivation rec {
     libpulseaudio
     pipewire
     hunspell
-    glibmm_2_68
     webkitgtk_6_0
     jemalloc
   ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk_11_0.frameworks; [

--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/macos.patch
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/macos.patch
@@ -49,6 +49,70 @@ index 7ce90d3..dac3c2c 100644
  	const auto state = DetectBatteryState();
  	if (!state.has || !state.draining) {
  		return false;
+Submodule Telegram/lib_webrtc contains modified content
+diff --git a/Telegram/lib_webrtc/webrtc/platform/mac/webrtc_environment_mac.mm b/Telegram/lib_webrtc/webrtc/platform/mac/webrtc_environment_mac.mm
+index 7521c08..5e22da2 100644
+--- a/Telegram/lib_webrtc/webrtc/platform/mac/webrtc_environment_mac.mm
++++ b/Telegram/lib_webrtc/webrtc/platform/mac/webrtc_environment_mac.mm
+@@ -364,6 +364,7 @@ EnvironmentMac::EnvironmentMac(not_null<EnvironmentDelegate*> delegate)
+ 	DefaultCaptureDeviceChangedMonitor.registerEnvironment(this);
+ 	AudioDeviceListChangedMonitor.registerEnvironment(this);
+ 
++#if 0
+ 	if (@available(macOS 14.0, *)) {
+ 		const auto weak = base::make_weak(this);
+ 		id block = [^(BOOL shouldBeMuted){
+@@ -387,6 +388,7 @@ EnvironmentMac::EnvironmentMac(not_null<EnvironmentDelegate*> delegate)
+ 			setInputMuteStateChangeHandler:block
+ 			error:nil];
+ 	}
++#endif
+ }
+ 
+ EnvironmentMac::~EnvironmentMac() {
+@@ -537,15 +539,18 @@ void EnvironmentMac::devicesRequested(DeviceType type) {
+ }
+ 
+ void EnvironmentMac::setCaptureMuted(bool muted) {
++#if 0
+ 	if (@available(macOS 14.0, *)) {
+ 		if (!_captureMuteNotification) {
+ 			const auto value = muted ? YES : NO;
+ 			[[AVAudioApplication sharedInstance] setInputMuted:value error:nil];
+ 		}
+ 	}
++#endif
+ }
+ 
+ void EnvironmentMac::captureMuteSubscribe() {
++#if 0
+ 	if (@available(macOS 14.0, *)) {
+ 		id observer = [[InputMuteObserver alloc] init];
+ 		[[[NSWorkspace sharedWorkspace] notificationCenter]
+@@ -578,6 +583,7 @@ void EnvironmentMac::captureMuteSubscribe() {
+ 			[observer release];
+ 		});
+ 	}
++#endif
+ }
+ 
+ void EnvironmentMac::captureMuteUnsubscribe() {
+@@ -595,6 +601,7 @@ void EnvironmentMac::captureMuteRestartAdm() {
+ void EnvironmentMac::setCaptureMuteTracker(
+ 		not_null<CaptureMuteTracker*> tracker,
+ 		bool track) {
++#if 0
+ 	if (@available(macOS 14.0, *)) {
+ 		if (track) {
+ 			if (!_captureMuteTracker) {
+@@ -619,6 +626,7 @@ void EnvironmentMac::setCaptureMuteTracker(
+ 			}
+ 		}
+ 	}
++#endif
+ }
+ 
+ std::unique_ptr<Environment> CreateEnvironment(
 Submodule Telegram/lib_webview contains modified content
 diff --git a/Telegram/lib_webview/webview/platform/mac/webview_mac.mm b/Telegram/lib_webview/webview/platform/mac/webview_mac.mm
 index 738e574..80ff5f0 100644


### PR DESCRIPTION
Diff: https://github.com/telegramdesktop/tdesktop/compare/v4.15.2...v4.16.0

Changelog: https://github.com/telegramdesktop/tdesktop/releases/tag/v4.16.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
