### PR TITLE
lexical: init at 0.5.2

### DIFF
--- a/pkgs/by-name/le/lexical/package.nix
+++ b/pkgs/by-name/le/lexical/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  beamPackages,
+  fetchFromGitHub,
+  writeScript,
+  elixir,
+}:
+
+beamPackages.mixRelease rec {
+  pname = "lexical";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "lexical-lsp";
+    repo = "lexical";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-HWqwJ7PAz80bm6YeDG84hLWPE11n06K98GOyeDQWZWU=";
+  };
+
+  mixFodDeps = beamPackages.fetchMixDeps {
+    inherit pname version src;
+
+    hash = "sha256-G0mT+rvXZWLJIMfrhxq3TXt26wDImayu44wGEYJ+3CE=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mix do compile --no-deps-check, package --path "$out"
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    substituteInPlace "$out/bin/start_lexical.sh" --replace 'elixir_command=' 'elixir_command="${elixir}/bin/"'
+    mv "$out/bin" "$out/libexec"
+    makeWrapper "$out/libexec/start_lexical.sh" "$out/bin/lexical" --set RELEASE_COOKIE lexical
+  '';
+
+  meta = with lib; {
+    description = "Lexical is a next-generation elixir language server";
+    homepage = "https://github.com/lexical-lsp/lexical";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ GaetanLepage ];
+    mainProgram = "lexical";
+    platforms = beamPackages.erlang.meta.platforms;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add the [lexical](https://github.com/lexical-lsp/lexical) Elixir language server.

Note: I have no experience in packaging things for this language.
I use the [project's own flake](https://github.com/lexical-lsp/lexical/blob/main/nix/lexical.nix) as a starting point.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
