### PR TITLE
voidmap: init at 1.1.5-unstable-2023-09-13

### DIFF
--- a/pkgs/by-name/vo/voidmap/package.nix
+++ b/pkgs/by-name/vo/voidmap/package.nix
@@ -1,0 +1,29 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "voidmap";
+  version = "1.1.5-unstable-2023-09-13";
+
+  src = fetchFromGitHub {
+    owner = "void-rs";
+    repo = "void";
+    rev = "ab32290632fa9477a7e59b884bdfa69fb4b91906";
+    hash = "sha256-+P83psu+BYzgC/I/Ul7vrbZ99KIybd410/ycsIY1pGI=";
+  };
+
+  cargoHash = "sha256-+UhqGl7w2jtGBFgX4u/g8tGO0NJTkDAJdNfwe8RobPQ=";
+
+  checkFlags = [
+    # The test utilizes a redirect stdout to file with dup2 and breaks sandbox assumptions
+    "--skip=screen::qc_input_events_dont_crash_void"
+  ];
+
+  meta = {
+    description = "A terminal-based personal organizer";
+    homepage = "https://github.com/void-rs/void";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "void";
+    maintainers = with lib.maintainers; [ poptart ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds the command line mind mapping tool [void(map)](https://github.com/void-rs/void). This package is a binary tool for managing task and workflow diagrams.

Unfortunately depends on merging #283654 to get the following maintainer commit in order to not create a conflict: https://github.com/NixOS/nixpkgs/pull/283654/commits/70093e0f2c7cb6baead81f0cb24a3c981ad4789d 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
