### PR TITLE
[23.11] podman: add patch for CVE-2024-1753

### DIFF
--- a/pkgs/applications/virtualization/podman/buildah-CVE-2024-1753.patch
+++ b/pkgs/applications/virtualization/podman/buildah-CVE-2024-1753.patch
@@ -1,0 +1,27 @@
+Based on patch listed @
+https://github.com/containers/podman/security/advisories/GHSA-874v-pj72-92f3
+with necessary path adjustments
+
+--- a/vendor/github.com/containers/buildah/internal/volumes/volumes.go
++++ b/vendor/github.com/containers/buildah/internal/volumes/volumes.go
+@@ -11,6 +11,7 @@ import (
+ 
+ 	"errors"
+ 
++	"github.com/containers/buildah/copier"
+ 	"github.com/containers/buildah/define"
+ 	"github.com/containers/buildah/internal"
+ 	internalParse "github.com/containers/buildah/internal/parse"
+@@ -189,7 +190,11 @@ func GetBindMount(ctx *types.SystemContext, args []string, contextDir string, st
+ 	// buildkit parity: support absolute path for sources from current build context
+ 	if contextDir != "" {
+ 		// path should be /contextDir/specified path
+-		newMount.Source = filepath.Join(contextDir, filepath.Clean(string(filepath.Separator)+newMount.Source))
++		evaluated, err := copier.Eval(contextDir, newMount.Source, copier.EvalOptions{})
++		if err != nil {
++			return newMount, "", err
++		}
++		newMount.Source = evaluated
+ 	} else {
+ 		// looks like its coming from `build run --mount=type=bind` allow using absolute path
+ 		// error out if no source is set

--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -74,6 +74,7 @@ buildGoModule rec {
   patches = [
     # we intentionally don't build and install the helper so we shouldn't display messages to users about it
     ./rm-podman-mac-helper-msg.patch
+    ./buildah-CVE-2024-1753.patch
   ];
 
   vendorHash = null;


### PR DESCRIPTION
## Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2024-1753

A little ugly - patching a vendored dependency - but no dependency-bumped 4.7.x release has been made.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
