### PR TITLE
linux: set various common hardening config

### DIFF
--- a/nixos/tests/kernel-generic.nix
+++ b/nixos/tests/kernel-generic.nix
@@ -47,6 +47,9 @@ in mapAttrs (_: lP: testsForLinuxPackages lP) kernels // {
   passthru = {
     inherit testsForLinuxPackages;
 
+    # Useful for development testing of all Kernel configs without building full Kernel
+    configfiles = mapAttrs (_: lP: lP.kernel.configfile) kernels;
+
     testsForKernel = kernel: testsForLinuxPackages (pkgs.linuxPackagesFor kernel);
   };
 }

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -723,6 +723,8 @@ let
       # Randomize page allocator when page_alloc.shuffle=1
       SHUFFLE_PAGE_ALLOCATOR = whenAtLeast "5.2" yes;
 
+      INIT_ON_ALLOC_DEFAULT_ON = whenAtLeast "5.3" yes;
+
       # Enable stack smashing protections in schedule()
       # See: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v4.8&id=0d9e26329b0c9263d4d9e0422d80a0e73268c52f
       SCHED_STACK_END_CHECK            = yes;

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -674,6 +674,8 @@ let
 
       HARDENED_USERCOPY                = yes;
       RANDOMIZE_BASE                   = option yes;
+      STRICT_KERNEL_RWX                = yes;
+      STRICT_MODULE_RWX                = yes;
       STRICT_DEVMEM                    = mkDefault yes; # Filter access to /dev/mem
       IO_STRICT_DEVMEM                 = mkDefault yes;
       SECURITY_SELINUX_BOOTPARAM_VALUE = whenOlder "5.1" (freeform "0"); # Disable SELinux by default

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -671,16 +671,19 @@ let
 
       # https://googleprojectzero.blogspot.com/2019/11/bad-binder-android-in-wild-exploit.html
       DEBUG_LIST                       = yes;
+
       HARDENED_USERCOPY                = yes;
       RANDOMIZE_BASE                   = option yes;
       STRICT_DEVMEM                    = mkDefault yes; # Filter access to /dev/mem
       IO_STRICT_DEVMEM                 = mkDefault yes;
       SECURITY_SELINUX_BOOTPARAM_VALUE = whenOlder "5.1" (freeform "0"); # Disable SELinux by default
+
       # Prevent processes from ptracing non-children processes
       SECURITY_YAMA                    = option yes;
       # The goal of Landlock is to enable to restrict ambient rights (e.g. global filesystem access) for a set of processes.
       # This does not have any effect if a program does not support it
       SECURITY_LANDLOCK                = whenAtLeast "5.13" yes;
+
       DEVKMEM                          = whenOlder "5.13" no; # Disable /dev/kmem
 
       USER_NS                          = yes; # Support for user namespaces

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -669,6 +669,7 @@ let
     security = {
       # Report BUG() conditions and kill the offending process.
       BUG = yes;
+      BUG_ON_DATA_CORRUPTION = yes;
 
       FORTIFY_SOURCE                   = option yes;
 

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -752,6 +752,10 @@ let
       # Mitigate straight line speculation at the cost of some file size
       SLS = whenBetween "5.17" "6.9" yes;
       MITIGATION_SLS = whenAtLeast "6.9" yes;
+
+      DEFAULT_MMAP_MIN_ADDR = freeform "65536";
+    } // optionalAttrs stdenv.hostPlatform.isAarch64 {
+      DEFAULT_MMAP_MIN_ADDR = freeform "32768";
     };
 
     microcode = {

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -667,6 +667,9 @@ let
     };
 
     security = {
+      # Report BUG() conditions and kill the offending process.
+      BUG = yes;
+
       FORTIFY_SOURCE                   = option yes;
 
       # https://googleprojectzero.blogspot.com/2019/11/bad-binder-android-in-wild-exploit.html

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -720,6 +720,8 @@ let
 
       # Enable support for page poisoning. Still needs to be enabled on the command line to actually work.
       PAGE_POISONING                   = yes;
+      # Randomize page allocator when page_alloc.shuffle=1
+      SHUFFLE_PAGE_ALLOCATOR = whenAtLeast "5.2" yes;
 
       # Enable stack smashing protections in schedule()
       # See: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v4.8&id=0d9e26329b0c9263d4d9e0422d80a0e73268c52f

--- a/pkgs/os-specific/linux/kernel/hardened/config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened/config.nix
@@ -49,9 +49,6 @@ assert (versionAtLeast version "4.9");
   # restricts loading of line disciplines via TIOCSETD ioctl to CAP_SYS_MODULE
   CONFIG_LDISC_AUTOLOAD = option no;
 
-  # Randomize page allocator when page_alloc.shuffle=1
-  SHUFFLE_PAGE_ALLOCATOR = whenAtLeast "5.2" yes;
-
   # Wipe higher-level memory allocations on free() with page_poison=1
   PAGE_POISONING_NO_SANITY = whenOlder "5.11" yes;
   PAGE_POISONING_ZERO      = whenOlder "5.11" yes;

--- a/pkgs/os-specific/linux/kernel/hardened/config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened/config.nix
@@ -53,8 +53,7 @@ assert (versionAtLeast version "4.9");
   PAGE_POISONING_NO_SANITY = whenOlder "5.11" yes;
   PAGE_POISONING_ZERO      = whenOlder "5.11" yes;
 
-  # Enable init_on_alloc and init_on_free by default
-  INIT_ON_ALLOC_DEFAULT_ON = whenAtLeast "5.3" yes;
+  # Enable init_on_free by default
   INIT_ON_FREE_DEFAULT_ON  = whenAtLeast "5.3" yes;
 
   # Wipe all caller-used registers on exit from a function

--- a/pkgs/os-specific/linux/kernel/hardened/config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened/config.nix
@@ -17,9 +17,6 @@ with (lib.kernel.whenHelpers version);
 assert (versionAtLeast version "4.9");
 
 {
-  # Report BUG() conditions and kill the offending process.
-  BUG = yes;
-
   # Mark LSM hooks read-only after init.  SECURITY_WRITABLE_HOOKS n
   # conflicts with SECURITY_SELINUX_DISABLE y; disabling the latter
   # implicitly marks LSM hooks read-only after init.

--- a/pkgs/os-specific/linux/kernel/hardened/config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened/config.nix
@@ -55,7 +55,6 @@ assert (versionAtLeast version "4.9");
   SHUFFLE_PAGE_ALLOCATOR = whenAtLeast "5.2" yes;
 
   # Wipe higher-level memory allocations on free() with page_poison=1
-  PAGE_POISONING           = yes;
   PAGE_POISONING_NO_SANITY = whenOlder "5.11" yes;
   PAGE_POISONING_ZERO      = whenOlder "5.11" yes;
 
@@ -113,9 +112,6 @@ assert (versionAtLeast version "4.9");
   CC_STACKPROTECTOR_REGULAR = lib.mkForce (whenOlder "4.18" no);
   CC_STACKPROTECTOR_STRONG  = whenOlder "4.18" yes;
 
-  # Detect out-of-bound reads/writes and use-after-free
-  KFENCE = whenAtLeast "5.12" yes;
-
   # CONFIG_DEVMEM=n causes these to not exist anymore.
   STRICT_DEVMEM    = option no;
   IO_STRICT_DEVMEM = option no;
@@ -126,8 +122,4 @@ assert (versionAtLeast version "4.9");
 
   # not needed for less than a decade old glibc versions
   LEGACY_VSYSCALL_NONE = yes;
-
-  # Straight-Line-Speculation
-  # https://lwn.net/Articles/877845/
-  SLS = option yes;
 }

--- a/pkgs/os-specific/linux/kernel/hardened/config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened/config.nix
@@ -31,8 +31,6 @@ assert (versionAtLeast version "4.9");
   SECURITY_SELINUX_DISABLE = whenOlder "6.4" no; # On 6.4: error: unused option: SECURITY_SELINUX_DISABLE
   SECURITY_WRITABLE_HOOKS  = option no;
 
-  STRICT_KERNEL_RWX = yes;
-
   # Perform additional validation of commonly targeted structures.
   DEBUG_CREDENTIALS     = whenOlder "6.6" yes;
   DEBUG_NOTIFIERS       = yes;


### PR DESCRIPTION
## Description of changes

See commits.

## Things done

I have been running with these changes on several x86_64 machines with different platforms since ~2 weeks prior to opening this PR.

Tested building all configs; plus (based off nixos-unstable) tests for default, oldest, and newest Kernels.

```
echo '{ allowAliases = false; }' > config.nix
NIXPKGS_CONFIG="$(pwd)/config.nix" nix-build -A nixosTests.kernel-generic.passthru.configfiles

nix-build -A linux.passthru.tests -A linux_4_19.passthru.tests -A linux_6_8.passthru.tests
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
