### PR TITLE
lua.tests.checkSetupHook: test lua setup hook for http package

### DIFF
--- a/pkgs/development/interpreters/lua-5/hooks/setup-hook.sh
+++ b/pkgs/development/interpreters/lua-5/hooks/setup-hook.sh
@@ -25,8 +25,8 @@ addToLuaSearchPathWithCustomDelimiter() {
   # export only if the folder contains lua files
   shopt -s globstar
 
-
-  for _file in ${absPattern/\?/\*\*}; do
+  local adjustedPattern="${absPattern/\?/\*\*\/\*}"
+  for _file in $adjustedPattern; do
     export "${varName}=${!varName:+${!varName};}${absPattern}"
     shopt -u globstar
     return;

--- a/pkgs/development/interpreters/lua-5/hooks/setup-hook.sh
+++ b/pkgs/development/interpreters/lua-5/hooks/setup-hook.sh
@@ -25,6 +25,7 @@ addToLuaSearchPathWithCustomDelimiter() {
   # export only if the folder contains lua files
   shopt -s globstar
 
+
   for _file in ${absPattern/\?/\*\*}; do
     export "${varName}=${!varName:+${!varName};}${absPattern}"
     shopt -u globstar

--- a/pkgs/development/interpreters/lua-5/tests/default.nix
+++ b/pkgs/development/interpreters/lua-5/tests/default.nix
@@ -66,6 +66,21 @@ in
       touch $out
     '');
 
+  # checks that lua's setup-hook adds dependencies to LUA_PATH
+  # Prevents the following regressions
+  # $ env NIX_PATH=nixpkgs=. nix-shell --pure -Q -p luajitPackages.lua luajitPackages.http
+  # nix-shell$ luajit
+  # > require('http.request')
+  # stdin:1: module 'http.request' not found:
+  checkSetupHook = pkgs.runCommandLocal "test-${lua.name}-setup-hook" ({
+      nativeBuildInputs = [lua];
+      buildInputs = [ lua.pkgs.http ];
+      meta.platforms = lua.meta.platforms;
+    }) (''
+      ${lua}/bin/lua -e "require'http.request'"
+      touch $out
+    '');
+
   checkRelativeImports = pkgs.runCommandLocal "test-${lua.name}-relative-imports" ({
     }) (''
       source ${./assert.sh}


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/pull/286822#issuecomment-2029454092

the 'http' package is an interesting one to test because all its lua
files are in a 'http' subfolder, ie., there is no share/lua/5.1/*.lua,
only share/lua/5.1/http/*.lua files unlike most packages. This tests we
can match those subfolders.


Will retarget against staging before merge

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
