### PR TITLE
dolphin-emu-primehack: 1.0.6a -> 1.0.7a

### DIFF
--- a/pkgs/applications/emulators/dolphin-emu/primehack.nix
+++ b/pkgs/applications/emulators/dolphin-emu/primehack.nix
@@ -1,132 +1,20 @@
 { lib
-, stdenv
 , fetchFromGitHub
-, pkg-config
-, cmake
-, wrapQtAppsHook
-, qtbase
-, bluez
-, ffmpeg
-, libao
-, libGLU
-, libGL
-, pcre
-, gettext
-, libXrandr
-, libusb1
-, libpthreadstubs
-, libXext
-, libXxf86vm
-, libXinerama
-, libSM
-, libXdmcp
-, readline
-, openal
-, udev
-, libevdev
-, portaudio
-, curl
-, alsa-lib
-, miniupnpc
-, enet
-, mbedtls_2
-, soundtouch
-, sfml
-, fmt
-, xz
-, vulkan-loader
-, libpulseaudio
-
-# - Inputs used for Darwin
-, CoreBluetooth
-, ForceFeedback
-, IOKit
-, OpenGL
-, libpng
-, hidapi
+, dolphin-emu
+, stdenv
 }:
 
-stdenv.mkDerivation rec {
+dolphin-emu.overrideAttrs (oldAttrs: rec {
   pname = "dolphin-emu-primehack";
-  version = "1.0.6a";
+  version = "1.0.7a";
 
   src = fetchFromGitHub {
     owner = "shiiion";
     repo = "dolphin";
     rev = version;
-    sha256 = "sha256-gc4+ofoLKR+cvm+SaWEnGaKrSjWMKq7pF6pEIi75Rtk=";
+    sha256 = "sha256-vuTSXQHnR4HxAGGiPg5tUzfiXROU3+E9kyjH+T6zVmc=";
     fetchSubmodules = true;
   };
-
-  nativeBuildInputs = [
-    pkg-config
-    cmake
-  ] ++ lib.optional stdenv.isLinux wrapQtAppsHook;
-
-  buildInputs = [
-    curl
-    ffmpeg
-    libao
-    libGLU
-    libGL
-    pcre
-    gettext
-    libpthreadstubs
-    libpulseaudio
-    libXrandr
-    libXext
-    libXxf86vm
-    libXinerama
-    libSM
-    readline
-    openal
-    libXdmcp
-    portaudio
-    libusb1
-    libpng
-    hidapi
-    miniupnpc
-    enet
-    mbedtls_2
-    soundtouch
-    sfml
-    fmt
-    xz
-    qtbase
-  ] ++ lib.optionals stdenv.isLinux [
-    bluez
-    udev
-    libevdev
-    alsa-lib
-    vulkan-loader
-  ] ++ lib.optionals stdenv.isDarwin [
-    CoreBluetooth
-    OpenGL
-    ForceFeedback
-    IOKit
-  ];
-
-  cmakeFlags = [
-    "-DUSE_SHARED_ENET=ON"
-    "-DENABLE_LTO=ON"
-  ] ++ lib.optionals stdenv.isDarwin [
-    "-DOSX_USE_DEFAULT_SEARCH_PATH=True"
-  ];
-
-  qtWrapperArgs = lib.optionals stdenv.isLinux [
-    "--prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib"
-    # https://bugs.dolphin-emu.org/issues/11807
-    # The .desktop file should already set this, but Dolphin may be launched in other ways
-    "--set QT_QPA_PLATFORM xcb"
-  ];
-
-  # - Allow Dolphin to use nix-provided libraries instead of building them
-  postPatch = ''
-    substituteInPlace CMakeLists.txt --replace 'DISTRIBUTOR "None"' 'DISTRIBUTOR "NixOS"'
-  '' + lib.optionalString stdenv.isDarwin ''
-    substituteInPlace CMakeLists.txt --replace 'if(NOT APPLE)' 'if(true)'
-    substituteInPlace CMakeLists.txt --replace 'if(LIBUSB_FOUND AND NOT APPLE)' 'if(LIBUSB_FOUND)'
-  '';
 
   postInstall = ''
     mv $out/bin/dolphin-emu $out/bin/dolphin-emu-primehack
@@ -147,4 +35,4 @@ stdenv.mkDerivation rec {
     broken = stdenv.isDarwin;
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2863,10 +2863,7 @@ with pkgs;
       else stdenv;
   };
 
-  dolphin-emu-primehack = qt5.callPackage ../applications/emulators/dolphin-emu/primehack.nix {
-    inherit (darwin.apple_sdk.frameworks) CoreBluetooth ForceFeedback IOKit OpenGL;
-    fmt = fmt_8;
-  };
+  dolphin-emu-primehack = callPackage ../applications/emulators/dolphin-emu/primehack.nix { };
 
   ### APPLICATIONS/EMULATORS/RETROARCH
 


### PR DESCRIPTION
## Description of changes
Changelog: [https://github.com/shiiion/dolphin/releases/tag/1.0.7a](https://github.com/shiiion/dolphin/releases/tag/1.0.7a)
Replaces dolphin-emu-primehack package with an override for dolphin-emu
Updates dolphin-emu-primehack

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
