### PR TITLE
k3s_1_27: 1.27.11+k3s1 -> 1.27.12+k3s1

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_27/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_27/versions.nix
@@ -1,8 +1,8 @@
 {
-  k3sVersion = "1.27.11+k3s1";
-  k3sCommit = "06d6bc80b469a61e5e90438b1f2639cd136a89e7";
-  k3sRepoSha256 = "0qkm8yqs9p34kb5k2q0j5wiykj78qc12n65n0clas5by23jrqcqa";
-  k3sVendorHash = "sha256-+z8pr30+28puv7yjA7ZvW++I0ipNEmen2OhCxFMzYOY=";
+  k3sVersion = "1.27.12+k3s1";
+  k3sCommit = "78ad57567c9eb1fd1831986f5fd7b4024add1767";
+  k3sRepoSha256 = "1j6xb3af4ypqq5m6a8x2yc2515zvlgqzfsfindjm9cbmq5iisphq";
+  k3sVendorHash = "sha256-65cmpRwD9C+fcbBSv1YpeukO7bfGngsLv/rk6sM59gU=";
   chartVersions = import ./chart-versions.nix;
   k3sRootVersion = "0.12.2";
   k3sRootSha256 = "1gjynvr350qni5mskgm7pcc7alss4gms4jmkiv453vs8mmma9c9k";


### PR DESCRIPTION
k3s_1_27: 1.27.11+k3s1 -> 1.27.12+k3s1

Release: https://github.com/k3s-io/k3s/releases/tag/v1.27.12%2Bk3s1

Testing done:
> nix build .#k3s_1_27
> nix build .#k3s_1_27.passthru.tests.{single-node,multi-node,etcd}