### PR TITLE
wiremock: add passthru.tests.version, use stdenvNoCC

### DIFF
--- a/pkgs/by-name/wi/wiremock/package.nix
+++ b/pkgs/by-name/wi/wiremock/package.nix
@@ -4,11 +4,11 @@
   jre,
   lib,
   makeWrapper,
-  stdenv,
+  stdenvNoCC,
   testers,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "wiremock";
   version = "3.5.2";
 

--- a/pkgs/by-name/wi/wiremock/package.nix
+++ b/pkgs/by-name/wi/wiremock/package.nix
@@ -1,11 +1,19 @@
-{ lib, stdenv, fetchurl, jre, makeWrapper, gitUpdater }:
+{
+  fetchurl,
+  gitUpdater,
+  jre,
+  lib,
+  makeWrapper,
+  stdenv,
+  testers,
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "wiremock";
   version = "3.5.2";
 
   src = fetchurl {
-    url = "mirror://maven/org/wiremock/wiremock-standalone/${version}/wiremock-standalone-${version}.jar";
+    url = "mirror://maven/org/wiremock/wiremock-standalone/${finalAttrs.version}/wiremock-standalone-${finalAttrs.version}.jar";
     hash = "sha256-27DIcfP5R1Qiwl2fhvUQjFsE8pTHTv5MuFqHGa+whVY=";
   };
 
@@ -15,25 +23,31 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p "$out"/{share/wiremock,bin}
-    cp ${src} "$out/share/wiremock/wiremock.jar"
+    cp ${finalAttrs.src} "$out/share/wiremock/wiremock.jar"
 
-    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+    makeWrapper ${jre}/bin/java $out/bin/${finalAttrs.meta.mainProgram} \
       --add-flags "-jar $out/share/wiremock/wiremock.jar"
   '';
 
-  passthru.updateScript = gitUpdater {
-    url = "https://github.com/wiremock/wiremock.git";
-    ignoredVersions = "(alpha|beta|rc).*";
+  passthru = {
+    tests.version = testers.testVersion {
+      command = "${lib.getExe finalAttrs.finalPackage} --version";
+      package = finalAttrs.finalPackage;
+    };
+    updateScript = gitUpdater {
+      url = "https://github.com/wiremock/wiremock.git";
+      ignoredVersions = "(alpha|beta|rc).*";
+    };
   };
 
   meta = {
     description = "A flexible tool for building mock APIs";
     homepage = "https://wiremock.org/";
-    changelog = "https://github.com/wiremock/wiremock/releases/tag/${version}";
+    changelog = "https://github.com/wiremock/wiremock/releases/tag/${finalAttrs.version}";
     maintainers = with lib.maintainers; [ bobvanderlinden anthonyroussel ];
     mainProgram = "wiremock";
     platforms = jre.meta.platforms;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

`wiremock --version` is available since [v3.4.0](https://github.com/wiremock/wiremock/releases/tag/3.4.0)

We can now add wiremock.tests.version
Also use stdenvNoCC to use minimal stdenv (smaller closure size), and reduce chances of rebuilding wiremock when compiler toolchain changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
