### PR TITLE
pdm: 2.12.4 -> 2.13.2; python311Packages.unearth: 0.14.0 -> 0.15.1; python311Packages.pbs-installer: init at 2024.4.1

### DIFF
--- a/pkgs/development/python-modules/pbs-installer/default.nix
+++ b/pkgs/development/python-modules/pbs-installer/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pdm-backend
+, httpx
+, zstandard
+}:
+
+buildPythonPackage rec {
+  pname = "pbs-installer";
+  version = "2024.4.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "frostming";
+    repo = "pbs-installer";
+    rev = version;
+    hash = "sha256-0LuajPD/sM0LoyRoCkGJ9medUcWNEPqvY76GgK2rIac=";
+  };
+
+  build-system = [
+    pdm-backend
+  ];
+
+  optional-dependencies = {
+    all = optional-dependencies.install ++ optional-dependencies.download;
+    download = [
+      httpx
+    ];
+    install = [
+      zstandard
+    ];
+  };
+
+  pythonImportsCheck = [ "pbs_installer" ];
+
+  # upstream has no test
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Installer for Python Build Standalone";
+    homepage = "https://github.com/frostming/pbs-installer";
+    changelog = "https://github.com/frostming/pbs-installer/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/unearth/default.nix
+++ b/pkgs/development/python-modules/unearth/default.nix
@@ -2,12 +2,12 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
-, cached-property
 , packaging
 , pdm-backend
-, requests
+, httpx
 , flask
 , pytest-httpserver
+, pytest-mock
 , pytestCheckHook
 , requests-wsgi-adapter
 , trustme
@@ -15,23 +15,23 @@
 
 buildPythonPackage rec {
   pname = "unearth";
-  version = "0.14.0";
-  format = "pyproject";
+  version = "0.15.1";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-883fuUrA+GX7z5ZCMVVu9xgwEDecALASBVF6UMeKGG0=";
+    hash = "sha256-hj3rMznA1lpb4NCtLGfUbV9XSnmOdO8FUr8R0pijCrs=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     pdm-backend
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     packaging
-    requests
+    httpx
   ];
 
   __darwinAllowLocalNetworking = true;
@@ -39,6 +39,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     flask
     pytest-httpserver
+    pytest-mock
     pytestCheckHook
     requests-wsgi-adapter
     trustme

--- a/pkgs/tools/package-management/pdm/default.nix
+++ b/pkgs/tools/package-management/pdm/default.nix
@@ -1,8 +1,6 @@
 { lib
-, stdenv
 , python3
 , fetchFromGitHub
-, fetchpatch
 , fetchPypi
 , nix-update-script
 , runtimeShell
@@ -35,41 +33,46 @@ in
 with python.pkgs;
 buildPythonApplication rec {
   pname = "pdm";
-  version = "2.12.4";
+  version = "2.13.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-0Eh3Ni+Vz5/8HSw4uFH2k3BuSSiEDkiYauV22tV0FJY=";
+    hash = "sha256-4oK/HK8KCD/A+16JrW9518V5/1LHu1juhYfqPVu54Uo=";
   };
 
   nativeBuildInputs = [
-    pdm-backend
     installShellFiles
   ];
 
-  propagatedBuildInputs = [
+  build-system = [
+    pdm-backend
+  ];
+
+  dependencies = [
     blinker
-    certifi
-    cachecontrol
     dep-logic
+    filelock
     findpython
+    hishel
+    httpx
     installer
+    msgpack
     packaging
+    pbs-installer
     platformdirs
     pyproject-hooks
     python-dotenv
-    requests-toolbelt
     resolvelib
     rich
     shellingham
     tomlkit
     unearth
     virtualenv
-  ]
-  ++ cachecontrol.optional-dependencies.filecache
+  ] ++ httpx.optional-dependencies.socks
+  ++ pbs-installer.optional-dependencies.install
   ++ lib.optionals (pythonOlder "3.11") [
     tomli
   ]
@@ -100,7 +103,6 @@ buildPythonApplication rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-mock
-    pytest-rerunfailures
     pytest-xdist
     pytest-httpserver
   ] ++ lib.optional stdenv.isLinux first;
@@ -120,7 +122,9 @@ buildPythonApplication rec {
     "test_convert_setup_py_project"
     # pythonfinder isn't aware of nix's python infrastructure
     "test_use_wrapper_python"
-    "test_use_invalid_wrapper_python"
+
+    # touches the network
+    "test_find_candidates_from_find_links"
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/tools/package-management/pdm/default.nix
+++ b/pkgs/tools/package-management/pdm/default.nix
@@ -138,7 +138,7 @@ buildPythonApplication rec {
   meta = with lib; {
     homepage = "https://pdm-project.org";
     changelog = "https://github.com/pdm-project/pdm/releases/tag/${version}";
-    description = "A modern Python package manager with PEP 582 support";
+    description = "A modern Python package and dependency manager supporting the latest PEP standards";
     license = licenses.mit;
     maintainers = with maintainers; [ cpcloud ];
     mainProgram = "pdm";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9398,6 +9398,8 @@ self: super: with self; {
 
   pbr = callPackage ../development/python-modules/pbr { };
 
+  pbs-installer = callPackage ../development/python-modules/pbs-installer { };
+
   pc-ble-driver-py = toPythonModule (callPackage ../development/python-modules/pc-ble-driver-py { });
 
   pcapy-ng = callPackage ../development/python-modules/pcapy-ng {


### PR DESCRIPTION
## Description of changes

pdm: 2.12.4 -> 2.13.2
Changelog: https://github.com/pdm-project/pdm/releases/tag/2.13.2

python311Packages.unearth: 0.14.0 -> 0.15.1
Changelog: https://github.com/frostming/unearth/releases/tag/0.15.1

python311Packages.pbs-installer: init at 2024.4.1

closes https://github.com/NixOS/nixpkgs/issues/300116

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
