### PR TITLE
forgejo: add missing internal version ldflags, nixosTests.forgejo: test /api/forgejo/v1/version

### DIFF
--- a/nixos/tests/forgejo.nix
+++ b/nixos/tests/forgejo.nix
@@ -108,6 +108,12 @@ let
 
         assert "BEGIN PGP PUBLIC KEY BLOCK" in server.succeed("curl http://localhost:3000/api/v1/signing-key.gpg")
 
+        api_version = json.loads(server.succeed("curl http://localhost:3000/api/forgejo/v1/version")).get("version")
+        assert "development" != api_version and "-gitea-" in api_version, (
+            "/api/forgejo/v1/version should not return 'development' "
+            + f"but should contain a gitea compatibility version string. Got '{api_version}' instead."
+        )
+
         server.succeed(
             "curl --fail http://localhost:3000/user/sign_up | grep 'Registration is disabled. "
             + "Please contact your site administrator.'"


### PR DESCRIPTION
## Description of changes

PR is a bug fix in our nixpkgs packaging, prepares us for the next major release and adds a version test.

---

Those two ldlfags provide the version string for the /api/forgejo/v1/version API endpoint and the forgejo_sem_ver database table.

Prio to this change, /api/forgejo/v1/version returned "development" and the database table "1.0.0".

The proper version string, which we are now providing, is a combination of a hardcoded version compatibility string (like "gitea-1.21.8") and the forgejo semver version.

The forgejo semver version in forgejo v1.21.8-0 is technically hardcoded in the Makefile, but will use git describe starting with the next major release (which will also be the release when forgejo makes this semver user facing).

So in summary, this commit is a bug fix in our nixpkgs packaging and prepares us for the next major release.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).