### PR TITLE
ex_doc: init at 0.31.2

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -83,6 +83,8 @@ let
       # Remove old versions of elixir, when the supports fades out:
       # https://hexdocs.pm/elixir/compatibility-and-deprecations.html
 
+      ex_doc = callPackage ./ex_doc { inherit elixir fetchMixDeps mixRelease; };
+
       elixir-ls = callPackage ./elixir-ls { inherit elixir fetchMixDeps mixRelease; };
 
       lfe = lfe_2_1;

--- a/pkgs/development/beam-modules/ex_doc/default.nix
+++ b/pkgs/development/beam-modules/ex_doc/default.nix
@@ -1,0 +1,55 @@
+{ lib, elixir, fetchFromGitHub, fetchMixDeps, mixRelease, nix-update-script }:
+# Based on ../elixir-ls/default.nix
+
+let
+  pname = "ex_doc";
+  version = "0.31.2";
+  src = fetchFromGitHub {
+    owner = "elixir-lang";
+    repo = "${pname}";
+    rev = "v${version}";
+    hash = "sha256-qUiXZ1KHD9sS1xG7QNYyrZVzPqerwCRdkN8URrlQ45g=";
+  };
+in
+mixRelease {
+  inherit pname version src elixir;
+
+  stripDebug = true;
+
+  mixFodDeps = fetchMixDeps {
+    pname = "mix-deps-${pname}";
+    inherit src version elixir;
+    hash = "sha256-ZNHhWCZ3n2Y/XCsXVjbu4wbx/J95JdFP/2raACciAUU=";
+  };
+
+  configurePhase = ''
+    runHook preConfigure
+    mix deps.compile --no-deps-check
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    mix do escript.build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp -v ex_doc $out/bin
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/elixir-lang/ex_doc";
+    description = ''
+      ExDoc produces HTML and EPUB documentation for Elixir projects
+    '';
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    mainProgram = "ex_doc";
+    maintainers = with maintainers; [chiroptical];
+  };
+  passthru.updateScript = nix-update-script { };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17397,7 +17397,7 @@ with pkgs;
   erlang_nox = beam_nox.interpreters.erlang;
 
   inherit (beam.packages.erlang)
-    erlang-ls erlfmt elvis-erlang
+    ex_doc erlang-ls erlfmt elvis-erlang
     rebar rebar3 rebar3WithPlugins
     fetchHex
     lfe lfe_2_1;


### PR DESCRIPTION
## Description of changes

I am adding ex_doc (https://github.com/elixir-lang/ex_doc, initialized at v0.31.2) as it is a new dependency for erlang 27.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

```
➤ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
$ git worktree add /home/barry/.cache/nixpkgs-review/rev-18a33c45bab0a05eed5f17c66aa0df56a7fa865b/nixpkgs dcd67b74f14a823a61b90ac6678218c08075f39b
Preparing worktree (detached HEAD dcd67b74f14a)
Updating files: 100% (40733/40733), done.
HEAD is now at dcd67b74f14a Merge pull request #299899 from thefossguy/uboot-nanopc-t6-init
$ nix-env --option system x86_64-linux -f /home/barry/.cache/nixpkgs-review/rev-18a33c45bab0a05eed5f17c66aa0df56a7fa865b/nixpkgs -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
$ git merge --no-commit --no-ff 18a33c45bab0a05eed5f17c66aa0df56a7fa865b
Auto-merging pkgs/top-level/all-packages.nix
Automatic merge went well; stopped before committing as requested
$ nix-env --option system x86_64-linux -f /home/barry/.cache/nixpkgs-review/rev-18a33c45bab0a05eed5f17c66aa0df56a7fa865b/nixpkgs -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
1 package added:
ex_doc (init at 0.31.2)

$ nix --experimental-features nix-command build --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed -f /home/barry/.cache/nixpkgs-review/rev-18a33c45bab0a05eed5f17c66aa0df56a7fa865b/build.nix
1 package built:
ex_doc

$ /nix/store/68h49rgalrx6g3vrxwhaz1m2rchjn471-nix-2.12.0/bin/nix-shell /home/barry/.cache/nixpkgs-review/rev-18a33c45bab0a05eed5f17c66aa0df56a7fa865b/shell.nix

[nix-shell:~/.cache/nixpkgs-review/rev-18a33c45bab0a05eed5f17c66aa0df56a7fa865b]$ ex_doc help
Too few arguments.

Usage:
  ex_doc PROJECT VERSION BEAMS [OPTIONS]

Examples:
  ex_doc "Ecto" "0.8.0" "_build/dev/lib/ecto/ebin" -u "https://github.com/elixir-ecto/ecto"
  ex_doc "Project" "1.0.0" "_build/dev/lib/project/ebin" -c "docs.exs"

Options:
  PROJECT             Project name
  VERSION             Version number
  BEAMS               Path to compiled beam files
      --canonical     Indicate the preferred URL with rel="canonical" link element
  -c, --config        Give configuration through a file instead of a command line.
                      See "Custom config" section below for more information.
  -f, --formatter     Docs formatter to use (html or epub), default: html and epub
      --homepage-url  URL to link to for the site name
      --language      Identify the primary language of the documents, its value must be
                      a valid [BCP 47](https://tools.ietf.org/html/bcp47) language tag, default: "en"
  -l, --logo          Path to a logo image for the project. Must be PNG, JPEG or SVG. The image will
                      be placed in the output "assets" directory.
  -m, --main          The entry-point page in docs, default: "api-reference"
  -o, --output        Path to output docs, default: "doc"
      --package       Hex package name
      --paths         Prepends the given path to Erlang code path. The path might contain a glob
                      pattern but in that case, remember to quote it: --paths "_build/dev/lib/*/ebin".
                      This option can be given multiple times
      --proglang      The project's programming language, default: "elixir"
  -q, --quiet         Only output warnings and errors
      --source-ref    Branch/commit/tag used for source link inference, default: "master"
  -u, --source-url    URL to the source code
  -v, --version       Print ExDoc version

## Custom config

A custom config can be given with the `--config` option.

The file must either have ".exs" or ".config" extension.

The file with the ".exs" extension must be an Elixir script that returns a keyword list with
the same options declares in `Mix.Tasks.Docs`. Here is an example:

    [
      extras: Path.wildcard("lib/elixir/pages/*.md"),
      groups_for_docs: [
        Guards: & &1[:guard] == true
      ],
      skip_undefined_reference_warnings_on: ["compatibility-and-deprecations"],
      groups_for_modules: [
        ...
      ]
    ]

The file with the ".config" extension must contain Erlang terms separated by ".".
See `:file.consult/1` for more information. Here is an example:

    {extras, [<<"README.md">>, <<"CHANGELOG.md">>]}.
    {main, <<"readme">>}.
    {proglang, erlang}.

## Source linking

ExDoc by default provides links to the source code implementation as
long as `--source-url` or `--source-url-pattern` is provided. If you
provide `--source-url`, ExDoc will inflect the url pattern automatically
for GitHub, GitLab, and Bitbucket URLs. For example:

    --source-url "https://github.com/elixir-ecto/ecto"

Will be inflected as:

    https://github.com/elixir-ecto/ecto/blob/master/%{path}#L%{line}

To specify a particular branch or commit, use the `--source-ref` option:

    --source-url "https://github.com/elixir-ecto/ecto" --source-ref "v1.0"

will result in the following URL pattern:

    https://github.com/elixir-ecto/ecto/blob/v1.0/%{path}#L%{line}
```

I was also able to test on my M2 laptop. Both appear to work.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
