### PR TITLE
mricron: init at 1.0.20190902

### DIFF
--- a/pkgs/by-name/mr/mricron/package.nix
+++ b/pkgs/by-name/mr/mricron/package.nix
@@ -1,0 +1,89 @@
+{
+  atk,
+  autoPatchelfHook,
+  cairo,
+  copyDesktopItems,
+  freetype,
+  fontconfig,
+  lib,
+  stdenv,
+  fetchurl,
+  gtk2,
+  glib,
+  gdk-pixbuf,
+  makeWrapper,
+  makeDesktopItem,
+  pango,
+  unzip,
+  xorg,
+  zlib,
+}:
+stdenv.mkDerivation rec {
+
+  pname = "mricron";
+  version = "1.0.20190902";
+  src = fetchurl {
+    url = "https://github.com/neurolabusc/MRIcron/releases/download/v${version}/MRIcron_linux.zip";
+    hash = "sha256-C155u9dvYEyWRfTv3KNQFI6aMWIAjgvdSIqMuYVIOQA=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    makeWrapper
+    unzip
+  ];
+
+  buildInputs = [
+    atk
+    cairo
+    freetype
+    fontconfig
+    gtk2
+    glib
+    gdk-pixbuf
+    pango
+    xorg.libX11
+    zlib
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/icons/hicolor/256x256/apps
+
+    install -Dm777 ./MRIcron $out/bin/mricron
+    install -Dm444 -t $out/share/icons/hicolor/scalable/apps/ ./Resources/mricron.svg
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      name = "mricron";
+      desktopName = "MRIcron";
+      comment = "Application to display NIfTI medical imaging data";
+      exec = "mricron %U";
+      icon = "mricron";
+      categories = [
+        "Graphics"
+        "MedicalSoftware"
+        "Science"
+      ];
+      terminal = false;
+      keywords = [
+        "medical"
+        "imaging"
+        "nifti"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "Application to display NIfTI medical imaging data";
+    homepage = "https://people.cas.sc.edu/rorden/mricron/index.HTML";
+    license = lib.licenses.bsd1;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ adriangl ];
+    mainProgram = "mricron";
+  };
+}


### PR DESCRIPTION
## Description of changes

I tried to package mricron
can be found on https://github.com/neurolabusc/MRIcron or https://www.nitrc.org/projects/mricron
(github was used as upstream)

description from website:

  MRIcron is a cross-platform NIfTI format image viewer. It can load multiple layers of images, generate volume renderings and draw volumes of interest. It also provides dcm2nii for converting DICOM images to NIfTI format and NPM for statistics. MRIcron is a mature and useful tool, however you may want to consider the more recent MRIcroGL as an alternative. 

Currently only mricron is packaged because i found the package [dcm2niix](https://search.nixos.org/packages?query=dcm2nii)  and i dont think it would be nessesary to add the bundeled one.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
