### PR TITLE
treewide: fix typos around "compatible" and "compatibility"

### DIFF
--- a/lib/fileset/default.nix
+++ b/lib/fileset/default.nix
@@ -1,5 +1,5 @@
 /*
-  <!-- This anchor is here for backwards compatibity -->
+  <!-- This anchor is here for backwards compatibility -->
   []{#sec-fileset}
 
   The [`lib.fileset`](#sec-functions-library-fileset) library allows you to work with _file sets_.

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -179,7 +179,7 @@ stdenv.mkDerivation rec {
       --prefix PATH : ${lib.makeBinPath [ coreutils glib.dev pciutils procps util-linux ]} \
       --prefix LD_LIBRARY_PATH ":" ${libs}
 
-    # Backwards compatiblity: we used to call it zoom-us
+    # Backwards compatibility: we used to call it zoom-us
     ln -s $out/bin/{zoom,zoom-us}
   '';
 

--- a/pkgs/by-name/ez/eza/package.nix
+++ b/pkgs/by-name/ez/eza/package.nix
@@ -10,7 +10,7 @@
 , darwin
 , libiconv
 , installShellFiles
-  # once eza upstream gets support for setting up a compatibilty symlink for exa, we should change
+  # once eza upstream gets support for setting up a compatibility symlink for exa, we should change
   # the handling here from postInstall to passing the required argument to the builder.
 , exaAlias ? true
 }:

--- a/pkgs/os-specific/darwin/apple-source-releases/libdispatch/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libdispatch/default.nix
@@ -13,7 +13,7 @@ appleDerivation' stdenvNoCC {
     cp -r dispatch/*.h $out/include/dispatch
     cp -r os/object*.h  $out/include/os
 
-    # gcc compatability. Source: https://stackoverflow.com/a/28014302/3714556
+    # gcc compatibility. Source: https://stackoverflow.com/a/28014302/3714556
     substituteInPlace $out/include/dispatch/object.h \
       --replace 'typedef void (^dispatch_block_t)(void);' \
                 '#ifdef __clang__

--- a/pkgs/pkgs-lib/formats/hocon/default.nix
+++ b/pkgs/pkgs-lib/formats/hocon/default.nix
@@ -107,7 +107,7 @@ in
     generate = name: value:
       let
         # TODO: remove in 24.11
-        # Backwards compatability for generators in the following locations:
+        # Backwards compatibility for generators in the following locations:
         #  - nixos/modules/services/networking/jibri/default.nix (__hocon_envvar)
         #  - nixos/modules/services/networking/jicofo.nix (__hocon_envvar, __hocon_unquoted_string)
         #  - nixos/modules/services/networking/jitsi-videobridge.nix (__hocon_envvar)

--- a/pkgs/servers/sql/postgresql/ext/citus.nix
+++ b/pkgs/servers/sql/postgresql/ext/citus.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    # "Our soft policy for Postgres version compatibilty is to support Citus'
+    # "Our soft policy for Postgres version compatibility is to support Citus'
     # latest release with Postgres' 3 latest releases."
     # https://www.citusdata.com/updates/v12-0/#deprecated_features
     broken = versionOlder postgresql.version "14";

--- a/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    # Fix compatiblity with PostgreSQL 16. Remove with the next release.
+    # Fix compatibility with PostgreSQL 16. Remove with the next release.
     (fetchpatch {
       url = "https://github.com/pgbigm/pg_bigm/commit/2a9d783c52a1d7a2eb414da6f091f6035da76edf.patch";
       hash = "sha256-LuMpSUPnT8cPChQfA9sJEKP4aGpsbN5crfTKLnDzMN8=";

--- a/pkgs/tools/bootloaders/refind/default.nix
+++ b/pkgs/tools/bootloaders/refind/default.nix
@@ -128,7 +128,7 @@ stdenv.mkDerivation rec {
       computers, such as all Intel-based Macs and recent (most 2011
       and later) PCs. rEFInd presents a boot menu showing all the EFI
       boot loaders on the EFI-accessible partitions, and optionally
-      BIOS-bootable partitions on Macs. EFI-compatbile OSes, including
+      BIOS-bootable partitions on Macs. EFI-compatible OSes, including
       Linux, provide boot loaders that rEFInd can detect and
       launch. rEFInd can launch Linux EFI boot loaders such as ELILO,
       GRUB Legacy, GRUB 2, and 3.3.0 and later kernels with EFI stub

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -76,7 +76,7 @@ let
         Whether to expose old attribute names for compatibility.
 
         The recommended setting is to enable this, as it
-        improves backward compatibity, easing updates.
+        improves backward compatibility, easing updates.
 
         The only reason to disable aliases is for continuous
         integration purposes. For instance, Nixpkgs should


### PR DESCRIPTION
## Description of changes

Perhaps the lowest-priority PR ever. Concocted by reading `lib` code, seeing a typo, and guessing that there were more out there.

## Things done

- [x] `nixpkgs-review rev HEAD` (no rebuilds)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).