### PR TITLE
mdadm: Fix hardcoded directory

### DIFF
--- a/pkgs/os-specific/linux/mdadm/default.nix
+++ b/pkgs/os-specific/linux/mdadm/default.nix
@@ -9,7 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-QWcnrh8QgOpuMJDOo23QdoJvw2kVHjarc2VXupIZb58=";
   };
 
-  patches = [ ./no-self-references.patch ];
+  patches = [
+    ./no-self-references.patch
+    ./fix-hardcoded-mapdir.patch
+  ];
 
   makeFlags = [
     "NIXOS=1" "INSTALL=install" "BINDIR=$(out)/sbin"

--- a/pkgs/os-specific/linux/mdadm/default.nix
+++ b/pkgs/os-specific/linux/mdadm/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Programs for managing RAID arrays under Linux";
-    homepage = "http://neil.brown.name/blog/mdadm";
+    homepage = "https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git";
     license = licenses.gpl2;
     mainProgram = "mdadm";
     maintainers = with maintainers; [ ekleog ];

--- a/pkgs/os-specific/linux/mdadm/fix-hardcoded-mapdir.patch
+++ b/pkgs/os-specific/linux/mdadm/fix-hardcoded-mapdir.patch
@@ -1,0 +1,13 @@
+diff --git a/udev.c b/udev.c
+index bc4722b0..aa2a1a24 100644
+--- a/udev.c
++++ b/udev.c
+@@ -167,7 +167,7 @@ enum udev_status udev_block(char *devnm)
+ 	int fd;
+ 	char *path = xcalloc(1, BUFSIZ);
+ 
+-	snprintf(path, BUFSIZ, "/run/mdadm/creating-%s", devnm);
++	snprintf(path, BUFSIZ, "%s/creating-%s", MAP_DIR, devnm);
+ 
+ 	fd = open(path, O_CREAT | O_RDWR, 0600);
+ 	if (!is_fd_valid(fd)) {


### PR DESCRIPTION
In [upstream change][1], handling of creating `/run/mdadm/creating-%s` file was changed to fail if it was unable to create the file. This revealed that the path itself incorrectly hardcodes `/run/mdadm` instead of using `MAP_DIR` or similar. Since nixpkgs sets `RUN_DIR=/run/.mdadm` at compile time, and `MAP_DIR=$(RUN_DIR)` in upstream, the `/run/mdadm` is never created. This remedies by fixing the hard-coded directory.

[1]: https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git/commit/?id=9f376da6439b07dc93ae084ab576e133b9d8d839

See also https://github.com/NixOS/nixpkgs/pull/301063 and discussion there.

Fixes the failure in https://hydra.nixos.org/build/254811279 introduced by https://github.com/NixOS/nixpkgs/commit/994232c0341269b4eda21707b781ad6a0e28af96

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

`nix-build -A nixosTests.installer.swraid`

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
