### PR TITLE
libftdi1: Fix doc parallelism

### DIFF
--- a/pkgs/development/libraries/libftdi/0001-libftdi1-Fix-doc-parallelism.patch
+++ b/pkgs/development/libraries/libftdi/0001-libftdi1-Fix-doc-parallelism.patch
@@ -1,0 +1,44 @@
+From 83907314b1b6a6d314976f6217cc9c53667973e2 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Wed, 3 Apr 2024 01:00:07 +0200
+Subject: [PATCH] libftdi: Fix doc parallelism
+
+---
+ python/CMakeLists.txt | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index 5b6f420..b89f96a 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -25,7 +25,7 @@ link_directories ( ${CMAKE_CURRENT_BINARY_DIR}/../src )
+ if ( DOCUMENTATION )
+   set(CMAKE_SWIG_FLAGS -DDOXYGEN=${DOXYGEN_FOUND})
+   # manually add dependency for new cmake / swig versions
+-  set_property(SOURCE ftdi1.i PROPERTY DEPENDS ftdi1_doc.i)
++  set_property(SOURCE ftdi1.i PROPERTY DEPENDS doc_i)
+ endif()
+ if(NOT CMAKE_VERSION VERSION_LESS 3.8.0)
+   swig_add_library ( ftdi1 LANGUAGE python SOURCES ftdi1.i )
+@@ -62,15 +62,16 @@ if ( DOCUMENTATION )
+         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+         DEPENDS ${c_headers};${c_sources};${cpp_sources};${cpp_headers}
+     )
++    add_custom_target ( generated-ftdi_8c-xml DEPENDS ${CMAKE_BINARY_DIR}/doc/xml/ftdi_8c.xml)
+ 
+     # generate .i from doxygen .xml
+     add_custom_command ( OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/ftdi1_doc.i
+         COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/doxy2swig.py -n
+             ${CMAKE_BINARY_DIR}/doc/xml/ftdi_8c.xml
+             ${CMAKE_CURRENT_BINARY_DIR}/ftdi1_doc.i
+-        DEPENDS ${CMAKE_BINARY_DIR}/doc/xml/ftdi_8c.xml
++        DEPENDS generated-ftdi_8c-xml
+     )
+-    add_custom_target ( doc_i DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/ftdi1_doc.i )
++    add_custom_target ( doc_i DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/ftdi1_doc.i generated-ftdi_8c-xml)
+     add_dependencies( ${SWIG_MODULE_ftdi1_REAL_NAME} doc_i )
+ 
+ endif ()
+-- 
+2.42.0
+

--- a/pkgs/development/libraries/libftdi/1.x.nix
+++ b/pkgs/development/libraries/libftdi/1.x.nix
@@ -29,6 +29,11 @@ stdenv.mkDerivation rec {
     sha256 = "0vipg3y0kbbzjhxky6hfyxy42mpqhvwn1r010zr5givcfp8ghq26";
   };
 
+  patches = [
+    # Fix spurious build failures from bad target parallelisation
+    ./0001-libftdi1-Fix-doc-parallelism.patch
+  ];
+
   strictDeps = true;
 
   nativeBuildInputs = [ cmake pkg-config ]


### PR DESCRIPTION
## Description of changes

Spotted a random build failure while reviewing something unrelated.

```
[  8%] Generating ../doc/xml/ftdi_8c.xml
[...]
[ 12%] Generating ../doc/xml/ftdi_8c.xml
[...]
[ 14%] Generating ftdi1_doc.i
[...]
Traceback (most recent call last):
  File "/build/libftdi/python/doxy2swig.py", line 457, in <module>
    main()
  File "/build/libftdi/python/doxy2swig.py", line 453, in main
    convert(args[0], args[1], not options.func_def, options.quiet)
  File "/build/libftdi/python/doxy2swig.py", line 430, in convert
    p = Doxy2SWIG(input, include_function_definition, quiet)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/build/libftdi/python/doxy2swig.py", line 74, in __init__
    self.xmldoc = minidom.parse(f).documentElement
                  ^^^^^^^^^^^^^^^^
  File "/nix/store/gd3shnza1i50zn8zs04fa729ribr88m9-python3-3.11.8/lib/python3.11/xml/dom/minidom.py", line 1990, in parse
    return expatbuilder.parse(file)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/gd3shnza1i50zn8zs04fa729ribr88m9-python3-3.11.8/lib/python3.11/xml/dom/expatbuilder.py", line 913, in parse
    result = builder.parseFile(file)
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/gd3shnza1i50zn8zs04fa729ribr88m9-python3-3.11.8/lib/python3.11/xml/dom/expatbuilder.py", line 211, in parseFile
    parser.Parse(b"", True)
xml.parsers.expat.ExpatError: no element found: line 1, column 0
make[2]: *** [python/CMakeFiles/doc_i.dir/build.make:73: python/ftdi1_doc.i] Error 1
```

`add_custom_command` `OUTPUT` generation requires a separate `add_custom_target` to ensure parallelism-safety, and `DEPENDS` should use those targets instead of the `OUTPUT`ted files. Otherwise, multiple tasks will each invoke the `add_custom_command` for their own `DEPENDS` and overwrite each other's results, leading to issues like this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
