### PR TITLE
swiftc: pass -Xcc before -march

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -53,10 +53,6 @@
 , gccForLibs ? if useCcForLibs then cc else null
 , fortify-headers ? null
 , includeFortifyHeaders ? null
-
-# https://github.com/NixOS/nixpkgs/issues/295322
-# should -march flag be used
-, disableMarch ? false
 }:
 
 assert nativeTools -> !propagateDoc && nativePrefix != "";
@@ -633,7 +629,7 @@ stdenv.mkDerivation {
 
     # TODO: aarch64-darwin has mcpu incompatible with gcc
     + optionalString ((targetPlatform ? gcc.arch) && !isClang && !(stdenv.isDarwin && stdenv.isAarch64) &&
-                      isGccArchSupported targetPlatform.gcc.arch && !disableMarch) ''
+                      isGccArchSupported targetPlatform.gcc.arch) ''
       echo "-march=${targetPlatform.gcc.arch}" >> $out/nix-support/cc-cflags-before
     ''
 
@@ -729,7 +725,7 @@ stdenv.mkDerivation {
     + optionalString isClang ''
       # Escape twice: once for this script, once for the one it gets substituted into.
       export march=${escapeShellArg
-        (optionalString (targetPlatform ? gcc.arch && !disableMarch)
+        (optionalString (targetPlatform ? gcc.arch)
           (escapeShellArg "-march=${targetPlatform.gcc.arch}"))}
       export defaultTarget=${targetPlatform.config}
       substituteAll ${./add-clang-cc-cflags-before.sh} $out/nix-support/add-local-cc-cflags-before.sh

--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -25,13 +25,9 @@ let
     #
     # The following selects the correct Clang version, matching the version
     # used in Swift, and applies the same libc overrides as `apple_sdk.stdenv`.
-    clang = let
-      # https://github.com/NixOS/nixpkgs/issues/295322
-      clangNoMarch = swiftLlvmPackages.clang.override { disableMarch = true; };
-    in
-    if pkgs.stdenv.isDarwin
+    clang = if pkgs.stdenv.isDarwin
       then
-        clangNoMarch.override rec {
+        swiftLlvmPackages.clang.override rec {
           libc = apple_sdk.Libsystem;
           bintools = pkgs.bintools.override { inherit libc; };
           # Ensure that Swift’s internal clang uses the same libc++ and libc++abi as the
@@ -41,7 +37,7 @@ let
           inherit (llvmPackages) libcxx;
         }
       else
-        clangNoMarch;
+        swiftLlvmPackages.clang;
 
     # Overrides that create a useful environment for swift packages, allowing
     # packaging with `swiftPackages.callPackage`. These are similar to

--- a/pkgs/development/compilers/swift/wrapper/wrapper.sh
+++ b/pkgs/development/compilers/swift/wrapper/wrapper.sh
@@ -242,17 +242,26 @@ if [[ -e $cc_wrapper/nix-support/add-local-cc-cflags-before.sh ]]; then
     source $cc_wrapper/nix-support/add-local-cc-cflags-before.sh
 fi
 
-# May need to transform the triple injected by the above.
-for ((i = 1; i < ${#extraBefore[@]}; i++)); do
-    if [[ "${extraBefore[i]}" = -target ]]; then
+for ((i=0; i < ${#extraBefore[@]}; i++));do
+    case "${extraBefore[i]}" in
+    -target)
         i=$((i + 1))
         # On Darwin only, need to change 'aarch64' to 'arm64'.
         extraBefore[i]="${extraBefore[i]/aarch64-apple-/arm64-apple-}"
         # On Darwin, Swift requires the triple to be annotated with a version.
         # TODO: Assumes macOS.
         extraBefore[i]="${extraBefore[i]/-apple-darwin/-apple-macosx${MACOSX_DEPLOYMENT_TARGET:-11.0}}"
-        break
-    fi
+        ;;
+    -march=*)
+        [[ i -gt 0 && ${extraBefore[i-1]} == -Xcc ]] && continue
+        extraBefore=(
+            "${extraBefore[@]:0:i}"
+            -Xcc
+            "${extraBefore[@]:i:${#extraBefore[@]}}"
+        )
+        i=$((i + 1))
+        ;;
+    esac
 done
 
 # As a very special hack, if the arguments are just `-v', then don't


### PR DESCRIPTION
## Description of changes

Adds the `-Xcc` flag before the `-march` flag passed to `swiftc`.

#291901 changed how clang got the `-march` flag, which caused swiftc to get that flag as well. However, swiftc needs `-Xcc` before `-march` because it's a clang flag, not a swift flag.

We could also simply prevent the `-march` flag from being passed to swiftc. I'm not familiar with exactly what this flag does, so I'm choosing to leave it in. However, note that #291901 seems to only have intended to add this flag to clang and accidentally added it to Swift, so maybe we do just want to remove it.

I know adding `-Xcc` made Swift able to build one of my Swift packages on aarch64-darwin, and I assume removing the flag will as well.

Closes #295322.
May supercede #296082.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
