### PR TITLE
dmenu-extended: init at 1.2.1

### DIFF
--- a/pkgs/by-name/dm/dmenu-extended/package.nix
+++ b/pkgs/by-name/dm/dmenu-extended/package.nix
@@ -5,7 +5,7 @@
 , dmenu
 }:
 
-python3Packages.buildPythonApplication rec{
+python3Packages.buildPythonApplication rec {
 
   pname = "dmenu-extended";
   version = "1.2.1";

--- a/pkgs/by-name/dm/dmenu-extended/package.nix
+++ b/pkgs/by-name/dm/dmenu-extended/package.nix
@@ -30,7 +30,7 @@ python3Packages.buildPythonApplication rec{
   meta = with lib; {
     description = "An extension to dmenu for quickly opening files and folders";
     homepage = "https://github.com/MarkHedleyJones/dmenu-extended";
-    license = with licenses; [ mit ];
+    license = licenses.mit;
     maintainers = with maintainers; [ ByteSudoer ];
     mainProgram = "dmenu-extended";
     platforms = platforms.unix;

--- a/pkgs/by-name/dm/dmenu-extended/package.nix
+++ b/pkgs/by-name/dm/dmenu-extended/package.nix
@@ -1,8 +1,8 @@
 {
-  lib
-, fetchPypi
-, python3Packages
-, dmenu
+  lib,
+  fetchPypi,
+  python3Packages,
+  dmenu,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -35,5 +35,4 @@ python3Packages.buildPythonApplication rec {
     mainProgram = "dmenu-extended";
     platforms = platforms.unix;
   };
-
 }

--- a/pkgs/by-name/dm/dmenu-extended/package.nix
+++ b/pkgs/by-name/dm/dmenu-extended/package.nix
@@ -1,0 +1,39 @@
+{
+  lib
+, fetchPypi
+, python3Packages
+, dmenu
+}:
+
+python3Packages.buildPythonApplication rec{
+
+  pname = "dmenu-extended";
+  version = "1.2.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "dmenu_extended";
+    inherit version;
+    hash = "sha256-gO+HYs9I+naD4ZBLTnATWym4b7K0yWbFo4zOvvgYpjM=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    python3Packages.setuptools
+    dmenu
+  ];
+
+  meta = with lib; {
+    description = "An extension to dmenu for quickly opening files and folders";
+    homepage = "https://github.com/MarkHedleyJones/dmenu-extended";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ ByteSudoer ];
+    mainProgram = "dmenu-extended";
+    platforms = platforms.unix;
+  };
+
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
It's a python package that extends dmenu so it can find files on PC and more

Metadata
- homepage URL: https://github.com/MarkHedleyJones/dmenu-extended
- source URL: https://github.com/MarkHedleyJones/dmenu-extended
- license: MIT
- platforms: linux

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
