### PR TITLE
docpars: init 0.3.0

### DIFF
--- a/pkgs/by-name/do/docpars/package.nix
+++ b/pkgs/by-name/do/docpars/package.nix
@@ -1,0 +1,27 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "docpars";
+  version = "v0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "denisidoro";
+    repo = "docpars";
+    rev = version;
+    hash = "sha256-gp1fOSTlDyOZ007jvsq4LgGRumn1946rmWqzU7qEDjo=";
+  };
+
+
+  cargoHash = "sha256-q/1AL4Q6WIRi1hnWOxmi7w6N7r4hLRUeOifritY24a0=";
+
+  meta = with lib; {
+    description = "An ultra-fast parser for declarative command-line options for your shell scripts";
+    homepage = "https://github.com/denisidoro/docpars";
+    maintainers = with maintainers; [ sentientmonkey ];
+    license = licenses.asl20;
+    mainProgram = "docpars";
+  };
+}


### PR DESCRIPTION
## Description of changes

Adding [docpars](https://github.com/denisidoro/docpars), an ultra-fast parser for declarative command-line options for your shell scripts.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
