### PR TITLE
python311Packages.arxiv-latex-cleaner: init at 1.0.5

### DIFF
--- a/pkgs/development/python-modules/arxiv-latex-cleaner/default.nix
+++ b/pkgs/development/python-modules/arxiv-latex-cleaner/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, setuptools-scm
+, pythonOlder
+, pythonRelaxDepsHook
+, fetchFromGitHub
+, pytestCheckHook
+, absl-py
+, pillow
+, pyyaml
+, regex
+}:
+
+buildPythonPackage rec {
+  pname = "arxiv-latex-cleaner";
+  version = "1.0.5";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "google-research";
+    repo = "arxiv-latex-cleaner";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Yxp8XtlISVZfEjCEJ/EXsIGMCHDPOwPcjkJxECeXvYk=";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+    pythonRelaxDepsHook
+  ];
+
+  propagatedBuildInputs = [
+    absl-py
+    pillow
+    pyyaml
+    regex
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonRelaxDeps = [ "absl_py" ];
+
+  pythonImportsCheck = [ "arxiv_latex_cleaner" ];
+
+  meta = {
+    description = "This tool allows you to easily clean the LaTeX code of your paper to submit to arXiv.";
+    homepage = "https://github.com/google-research/arxiv-latex-cleaner";
+    downloadPage = "https://github.com/google-research/arxiv-latex-cleaner/releases";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ chrispattison ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1,3 +1,4 @@
+
 # This file contains the Python packages set.
 # Each attribute is a Python library or a helper function.
 # Expressions for Python libraries are supposed to be in `pkgs/development/python-modules/<name>/default.nix`.
@@ -764,6 +765,8 @@ self: super: with self; {
   art = callPackage ../development/python-modules/art { };
 
   arviz = callPackage ../development/python-modules/arviz { };
+
+  arxiv-latex-cleaner = callPackage ../development/python-modules/arxiv-latex-cleaner { };
 
   arxiv2bib = callPackage ../development/python-modules/arxiv2bib { };
 


### PR DESCRIPTION
## Description of changes

python311Packages.arxiv-latex-cleaner: init at 1.0.5

[arxiv-latex-cleaner
](https://github.com/google-research/arxiv-latex-cleaner) is a tool for sanitizing latex sources before posting to arxiv
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
