### PR TITLE
add systemd-resolved when `boot.initrd.systemd.network` is enabled

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -2976,6 +2976,7 @@ let
         "systemd-networkd.service"
         "systemd-networkd.socket"
         "systemd-network-generator.service"
+        "systemd-resolved.service"
         "network-online.target"
         "network-pre.target"
         "network.target"
@@ -2985,7 +2986,9 @@ let
         "remote-fs.target"
       ];
       systemd.users.systemd-network = {};
+      systemd.users.systemd-resolve = {};
       systemd.groups.systemd-network = {};
+      systemd.groups.systemd-resolve = {};
 
       systemd.contents."/etc/systemd/networkd.conf" = renderConfig cfg.config;
 
@@ -2995,6 +2998,10 @@ let
       systemd.sockets.systemd-networkd = {
         wantedBy = [ "initrd.target" ];
       };
+      systemd.services.systemd-resolved = {
+        wantedBy = ["initrd.target"];
+        serviceConfig.ExecStartPre = "-+/bin/ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf";
+      };
 
       systemd.services.systemd-network-generator.wantedBy = [ "sysinit.target" ];
 
@@ -3002,6 +3009,7 @@ let
         "${config.boot.initrd.systemd.package}/lib/systemd/systemd-networkd"
         "${config.boot.initrd.systemd.package}/lib/systemd/systemd-networkd-wait-online"
         "${config.boot.initrd.systemd.package}/lib/systemd/systemd-network-generator"
+        "${config.boot.initrd.systemd.package}/lib/systemd/systemd-resolved"
       ];
       kernelModules = [ "af_packet" ];
 


### PR DESCRIPTION
## Description of changes

Upstream systemd-resolved  part  in https://github.com/ElvishJerricco/stage1-tpm-tailscale.
@ElvishJerricco

#301333

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
