### PR TITLE
ocamlPackages.ocaml-lua: init at 1.8

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-lua/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lua/default.nix
@@ -1,0 +1,37 @@
+{ lib, fetchFromGitHub, buildDunePackage, lua5_1, pkg-config }:
+
+buildDunePackage {
+  pname = "ocaml-lua";
+  version = "1.8";
+
+  minimalOCamlVersion = "4.08";
+
+  src = fetchFromGitHub {
+    owner = "pdonadeo";
+    repo = "ocaml-lua";
+    # Take the latest commit, as some warnings have been fixed/suppressed
+    rev = "f44ad50c88bf999f48a13af663051493c89d7d02";
+    hash = "sha256-AXtKrty8JdI+yc+Y9EiufBbySlr49OyXW6wKwmDb0xo=";
+  };
+
+  # ocaml-lua vendors and builds Lua: replace that with the one from nixpkgs
+  postPatch = ''
+    rm -r src/lua_c
+    substituteInPlace src/dune \
+      --replace "-Ilua_c/lua515/src" "" \
+      --replace "(libraries unix threads lua_c)" \
+                "(libraries unix threads) (c_library_flags -llua)"
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ lua5_1 ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Lua bindings for OCaml";
+    homepage = "https://pdonadeo.github.io/ocaml-lua";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.kenran ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1233,6 +1233,8 @@ let
 
     ocaml-lsp = callPackage ../development/ocaml-modules/ocaml-lsp { };
 
+    ocaml-lua = callPackage ../development/ocaml-modules/ocaml-lua { };
+
     ocaml_lwt = lwt;
 
     ocaml-migrate-parsetree = ocaml-migrate-parsetree-1-8;


### PR DESCRIPTION
## Description of changes

Add the [ocaml-lua](https://github.com/pdonadeo/ocaml-lua) package to `ocamlPackages`. In order to do so the vendored Lua version has been replaced by the one in `nixpkgs`.

I've also tested the package against my personal OCaml project that uses `ocaml-lua`.

NOTE: I'm not sure whether `postPatch` is the right place to put my "patching" code.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
