### PR TITLE
coqPackages.vscoq-language-server: 2.0.3 → 2.1.2

### DIFF
--- a/pkgs/development/coq-modules/vscoq-language-server/default.nix
+++ b/pkgs/development/coq-modules/vscoq-language-server/default.nix
@@ -2,13 +2,16 @@
   version ? null }:
 
 let ocamlPackages = coq.ocamlPackages;
-    defaultVersion = lib.switch coq.coq-version [
-      { case = "8.18"; out = "2.0.3+coq8.18"; }
+    defaultVersion = with lib.versions; lib.switch coq.coq-version [
+      { case = range "8.18" "8.19"; out = "2.1.2"; }
+      { case = isEq "8.18"; out = "2.0.3+coq8.18"; }
     ] null;
     location = { domain = "github.com"; owner = "coq-community"; repo = "vscoq"; };
     fetch = metaFetch ({
       release."2.0.3+coq8.18".sha256 = "sha256-VXhHCP6Ni5/OcsgoI1EbJfYCpXzwkuR8kbbKrl6dfjU=";
       release."2.0.3+coq8.18".rev = "v2.0.3+coq8.18";
+      release."2.1.2".rev = "v2.1.2";
+      release."2.1.2".sha256 = "sha256-GloY68fLmIv3oiEGNWwmgKv1CMAReBuXzMTUsKOs328=";
       inherit location; });
     fetched = fetch (if version != null then version else defaultVersion);
 in
@@ -16,12 +19,13 @@ ocamlPackages.buildDunePackage {
   pname = "vscoq-language-server";
   inherit (fetched) version;
   src = "${fetched.src}/language-server";
+  nativeBuildInputs = [ coq ];
   buildInputs =
     [ coq glib gnome.adwaita-icon-theme wrapGAppsHook ] ++
     (with ocamlPackages; [ findlib
       lablgtk3-sourceview3 yojson zarith ppx_inline_test
       ppx_assert ppx_sexp_conv ppx_deriving ppx_import sexplib
-      ppx_yojson_conv lsp sel ]);
+      ppx_yojson_conv lsp sel ppx_optcomp ]);
 
   meta = with lib; {
     description = "Language server for the vscoq vscode/codium extension";


### PR DESCRIPTION
## Description of changes

Support for Coq 8.19

Build tested there: https://github.com/coq-community/coq-nix-toolbox/pull/209

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
