### PR TITLE
st: remove andsild as maintainer

### DIFF
--- a/pkgs/applications/terminal-emulators/st/default.nix
+++ b/pkgs/applications/terminal-emulators/st/default.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://st.suckless.org/";
     description = "Simple Terminal for X from Suckless.org Community";
     license = licenses.mit;
-    maintainers = with maintainers; [ andsild qusic ];
+    maintainers = with maintainers; [ qusic ];
     platforms = platforms.unix;
     mainProgram = "st";
   };


### PR DESCRIPTION
## Description of changes
Removing myself from maintainers list of st package, since I am no longer active

## Things done

- [ :heavy_check_mark: ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).