### PR TITLE
parquet-tools: support Moto 5.x

### DIFF
--- a/pkgs/tools/misc/parquet-tools/default.nix
+++ b/pkgs/tools/misc/parquet-tools/default.nix
@@ -18,6 +18,12 @@ buildPythonApplication rec {
     hash = "sha256-2jIwDsxB+g37zV9hLc2VNC5YuZXTpTmr2aQ72AeHYJo=";
   };
 
+  patches = [
+    # support Moto 5.x
+    # https://github.com/ktrueda/parquet-tools/pull/55
+    ./moto5.patch
+  ];
+
   postPatch = ''
     substituteInPlace tests/test_inspect.py \
       --replace "parquet-cpp-arrow version 5.0.0" "parquet-cpp-arrow version ${pyarrow.version}" \

--- a/pkgs/tools/misc/parquet-tools/moto5.patch
+++ b/pkgs/tools/misc/parquet-tools/moto5.patch
@@ -1,0 +1,28 @@
+diff --git a/tests/fixtures/aws.py b/tests/fixtures/aws.py
+index 7eea4bd..9fb3345 100644
+--- a/tests/fixtures/aws.py
++++ b/tests/fixtures/aws.py
+@@ -1,15 +1,17 @@
+ import boto3
+-from moto import mock_s3
+ import pytest
+ 
++try:
++    # Moto 4.x
++    from moto import mock_s3
++except ImportError:
++    # Moto 5.x
++    from moto import mock_aws as mock_s3
+ 
+ @pytest.fixture
+ def aws_session():
+-    mock_s3_server = mock_s3()
+-    mock_s3_server.start()
+-    yield boto3.Session()
+-    mock_s3_server.stop()
+-
++    with mock_s3():
++        yield boto3.Session()
+ 
+ @pytest.fixture
+ def aws_s3_bucket(aws_session):


### PR DESCRIPTION
## Description of changes

This makes the test fixtures compatible with the new Moto API.

Supersedes #301032

Upstream issue: https://github.com/ktrueda/parquet-tools/issues/54
Upstream PR: https://github.com/ktrueda/parquet-tools/pull/55

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
