### PR TITLE
otel-cli: 0.4.4 -> 0.4.5

### DIFF
--- a/pkgs/tools/misc/otel-cli/default.nix
+++ b/pkgs/tools/misc/otel-cli/default.nix
@@ -2,23 +2,25 @@
 
 buildGoModule rec {
   pname = "otel-cli";
-  version = "0.4.4";
+  version = "0.4.5";
 
   src = fetchFromGitHub {
     owner = "equinix-labs";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-XVhnDtt2FhYgfGWDPFkneZTboeHGaIbiF5YdHoqB8N8=";
+    hash = "sha256-JYi9CbP4mUhX0zNjhi6QlBzLKcj2zdPwlyBSIYKp6vk=";
   };
 
-  vendorHash = "sha256-HwbEqWtOqiTe5Z/MtMAs63Lzvll/vgmbCpMTREXgtXA=";
+  vendorHash = "sha256-fWQz7ZrU8gulhpOHSN8Prn4EMC0KXy942FZD/PMsLxc=";
 
   preCheck = ''
     ln -s $GOPATH/bin/otel-cli .
   '' + lib.optionalString (!stdenv.isDarwin) ''
     substituteInPlace main_test.go \
-      --replace 'const minimumPath = `/bin:/usr/bin`' 'const minimumPath = `${lib.makeBinPath [ getent coreutils ]}`'
+      --replace-fail 'const minimumPath = `/bin:/usr/bin`' 'const minimumPath = `${lib.makeBinPath [ getent coreutils ]}`'
   '';
+
+  patches = [ ./patches/bin-echo-patch.patch ];
 
   passthru.updateScript = nix-update-script {};
 

--- a/pkgs/tools/misc/otel-cli/patches/bin-echo-patch.patch
+++ b/pkgs/tools/misc/otel-cli/patches/bin-echo-patch.patch
@@ -1,0 +1,21 @@
+diff --git a/data_for_test.go b/data_for_test.go
+index c0b8980..691e270 100644
+--- a/data_for_test.go
++++ b/data_for_test.go
+@@ -555,14 +555,14 @@ var suites = []FixtureSuite{
+ 					"--endpoint", "{{endpoint}}",
+ 					"--verbose", "--fail",
+ 					"--attrs", "zy=ab", // ensure CLI args still propagate
+-					"--", "/bin/echo", "a", "z",
++					"--", "echo", "a", "z",
+ 				},
+ 			},
+ 			Expect: Results{
+ 				SpanCount: 1,
+ 				CliOutput: "a z\n",
+ 				SpanData: map[string]string{
+-					"attributes": "/^process.command=/bin/echo,process.command_args=/bin/echo,a,z,process.owner=\\w+,process.parent_pid=\\d+,process.pid=\\d+,zy=ab/",
++					"attributes": "/^process.command=echo,process.command_args=echo,a,z,process.owner=\\w+,process.parent_pid=\\d+,process.pid=\\d+,zy=ab/",
+ 				},
+ 			},
+ 		},


### PR DESCRIPTION
## Description of changes

see [Release Notes](https://github.com/equinix-labs/otel-cli/releases/tag/v0.4.5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
