### PR TITLE
ebpf-exporter: init at 2.4.2 and add module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -228,6 +228,10 @@
 
 - [CookCLI](https://cooklang.org/cli/) Server, a web UI for cooklang recipes.
 
+- [Prometheus eBPF Exporter](https://github.com/cloudflare/ebpf_exporter),
+  Prometheus exporter for custom eBPF metrics. Available as
+  [services.prometheus.exporters.ebpf](#opt-services.prometheus.exporters.ebpf.enable).
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-25.05-incompatibilities}

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -65,6 +65,7 @@ let
         "dnssec"
         "domain"
         "dovecot"
+        "ebpf"
         "fastly"
         "flow"
         "fritz"

--- a/nixos/modules/services/monitoring/prometheus/exporters/ebpf.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/ebpf.nix
@@ -1,0 +1,49 @@
+{
+  config,
+  lib,
+  pkgs,
+  options,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.ebpf;
+  inherit (lib)
+    mkOption
+    types
+    concatStringsSep
+    ;
+in
+{
+  port = 9435;
+  extraOpts = {
+    names = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "timers" ];
+      description = ''
+        List of eBPF programs to load
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      AmbientCapabilities = [
+        "CAP_BPF"
+        "CAP_DAC_READ_SEARCH"
+        "CAP_PERFMON"
+      ];
+      CapabilityBoundingSet = [
+        "CAP_BPF"
+        "CAP_DAC_READ_SEARCH"
+        "CAP_PERFMON"
+      ];
+      ExecStart = ''
+        ${pkgs.prometheus-ebpf-exporter}/bin/ebpf_exporter \
+        --config.dir=${pkgs.prometheus-ebpf-exporter}/examples \
+        --config.names=${concatStringsSep "," cfg.names} \
+        --web.listen-address ${cfg.listenAddress}:${toString cfg.port}
+      '';
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -407,6 +407,20 @@ let
         '';
       };
 
+    ebpf = {
+      exporterConfig = {
+        enable = true;
+        names = [ "timers" ];
+      };
+      exporterTest = ''
+        wait_for_unit("prometheus-ebpf-exporter.service")
+        wait_for_open_port(9435)
+        succeed(
+            "curl -sSf http://localhost:9435/metrics | grep 'ebpf_exporter_enabled_configs{name=\"timers\"} 1'"
+        )
+      '';
+    };
+
     fastly = {
       exporterConfig = {
         enable = true;

--- a/pkgs/by-name/pr/prometheus-ebpf-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-ebpf-exporter/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nixosTests,
+  pkgs,
+  libbpf,
+  libelf,
+  libsystemtap,
+  libz,
+}:
+
+let
+  version = "2.4.2";
+  tag = "v${version}";
+in
+buildGoModule.override
+  {
+    stdenv = pkgs.clangStdenv;
+  }
+  {
+    name = "ebpf_exporter";
+
+    src = fetchFromGitHub {
+      inherit tag;
+      owner = "cloudflare";
+      repo = "ebpf_exporter";
+      hash = "sha256-gXzaMx9Z6LzrlDaQnagQIi183uKhJvdYiolYb8P+MIs=";
+    };
+
+    vendorHash = "sha256-GhQvPp8baw2l91OUOg+/lrG27P/D4Uzng8XevJf8Pj4=";
+
+    postPatch = ''
+      substituteInPlace examples/Makefile \
+        --replace-fail "-Wall -Werror" ""
+    '';
+
+    buildInputs = [
+      libbpf
+      libelf
+      libsystemtap
+      libz
+    ];
+
+    CGO_LDFLAGS = "-l bpf";
+
+    hardeningDisable = [ "zerocallusedregs" ];
+
+    # Tests fail on trying to access cgroups.
+    doCheck = false;
+
+    ldflags = [
+      "-s"
+      "-w"
+      "-X github.com/prometheus/common/version.Version=${version}"
+      "-X github.com/prometheus/common/version.Revision=${tag}"
+      "-X github.com/prometheus/common/version.Branch=unknown"
+      "-X github.com/prometheus/common/version.BuildUser=nix@nixpkgs"
+      "-X github.com/prometheus/common/version.BuildDate=unknown"
+    ];
+
+    postBuild = ''
+      BUILD_LIBBPF=0 make examples
+    '';
+
+    postInstall = ''
+      mkdir -p $out/examples
+      mv examples/*.o examples/*.yaml $out/examples
+    '';
+
+    passthru.tests = { inherit (nixosTests.prometheus-exporters) ebpf; };
+
+    meta = {
+      description = "Prometheus exporter for custom eBPF metrics";
+      mainProgram = "ebpf_exporter";
+      homepage = "https://github.com/cloudflare/ebpf_exporter";
+      changelog = "https://github.com/cloudflare/ebpf_exporter/releases/tag/v${tag}";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ jpds ];
+      platforms = lib.platforms.linux;
+    };
+  }


### PR DESCRIPTION
## Description of changes

Adds https://github.com/cloudflare/ebpf_exporter at 2.4.1, tested with biolatency eBPF program from upstream.

Also adds a module for the exporter.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
