### PR TITLE
linux-scripts: init at ${linuxHeaders.version}

### DIFF
--- a/pkgs/by-name/li/linux-scripts/package.nix
+++ b/pkgs/by-name/li/linux-scripts/package.nix
@@ -1,0 +1,64 @@
+{ lib
+, linuxHeaders # Linux source tree
+, makeWrapper
+, stdenvNoCC
+
+, binutils
+, coreutils
+, gnugrep
+
+  # decompressors for possible kernel image formats
+, bzip2
+, gzip
+, lz4
+, lzop
+, xz
+, zstd
+}:
+
+let
+  commonDeps = [
+    binutils
+    coreutils
+    gnugrep
+    gzip
+    xz
+    bzip2
+    lzop
+    lz4
+    zstd
+  ];
+
+  toWrapScriptLines = scriptName: ''
+    install -Dm 0755 scripts/${scriptName} $out/bin/${scriptName}
+    wrapProgram $out/bin/${scriptName} --prefix PATH : ${lib.makeBinPath commonDeps}
+  '';
+in
+stdenvNoCC.mkDerivation
+{
+  inherit (linuxHeaders) version;
+  pname = "linux-scripts";
+
+  # These scripts will rarely change and are usually not bound to a specific
+  # version of Linux. So it is okay to just use whatever Linux version comes
+  # from `linuxHeaders.
+  src = linuxHeaders.src;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    ${toWrapScriptLines "extract-ikconfig"}
+    ${toWrapScriptLines "extract-vmlinux"}
+  '';
+
+  meta = with lib; {
+    description = "Standalone scripts from <linux>/scripts";
+    homepage = "https://www.kernel.org/";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.phip1611 ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
Linux helper scripts live in the scripts/ directory of the Linux source tree. Only few of them are useful outside it, but extract-vmlinux  and extract-ikconfig are among them. They are independent of the Linux tree and are helpful for OS-space developers.

## Description of changes

Init `linux-scripts` (unversioned / transitively versioned by `linuxHeaders.version`).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
