### PR TITLE
WIP: paddlepaddle: 2.5.0 -> 2.6.1, build from source

### DIFF
--- a/pkgs/development/python-modules/paddlepaddle/default.nix
+++ b/pkgs/development/python-modules/paddlepaddle/default.nix
@@ -6,12 +6,11 @@
 , python
 , pythonOlder
 , pythonAtLeast
-, openssl_1_1
 , zlib
 , setuptools
 , cudaSupport ? config.cudaSupport or false
 , cudaPackages_11 ? {}
-, addOpenGLRunpath
+# , addOpenGLRunpath
 # runtime dependencies
 , httpx
 , numpy
@@ -21,60 +20,117 @@
 , astor
 , paddle-bfloat
 , opt-einsum
+, cmake
+, fetchFromGitHub
+, pip
+, wheel
+, pyyaml
+, jinja2
+, liblapack
+, openblas
+, perl
+, symlinkJoin
+, writeScriptBin
+
+, ccacheStdenv
 }:
 
 let
-  pname = "paddlepaddle" + lib.optionalString cudaSupport "-gpu";
-  version = "2.5.0";
-  format = "wheel";
-  pyShortVersion = "cp${builtins.replaceStrings ["."] [""] python.pythonVersion}";
-  allHashAndPlatform = import ./binary-hashes.nix;
-  hash = allHashAndPlatform."${stdenv.system}"."${if cudaSupport then "gpu" else "cpu"}"."${pyShortVersion}";
-  platform = allHashAndPlatform."${stdenv.system}".platform;
-  src = fetchPypi ({
-    inherit version format hash platform;
-    pname = builtins.replaceStrings [ "-" ] [ "_" ] pname;
-    dist = pyShortVersion;
-    python = pyShortVersion;
-    abi = pyShortVersion;
+  version = "2.6.1";
+  src = fetchFromGitHub ({
+    owner = "PaddlePaddle";
+    repo = "Paddle";
+    rev = "v${version}";
+    hash = "sha256-En+cGjExAbTrEJupOuyfPlEZq7MXTYJli6oKQqCBkfo=";
+    # leaveDotGit = true;
+    fetchSubmodules = true;
   });
-in
-buildPythonPackage {
-  inherit pname version format src;
 
-  disabled = pythonOlder "3.9" || pythonAtLeast "3.11";
-
-  libraryPath = lib.makeLibraryPath (
-    # TODO: remove openssl_1_1 and zlib, maybe by building paddlepaddle from
-    # source as suggested in the following comment:
-    # https://github.com/NixOS/nixpkgs/pull/243583#issuecomment-1641450848
-    [ openssl_1_1 zlib ] ++ lib.optionals cudaSupport (with cudaPackages_11; [
-      cudatoolkit.lib
-      cudatoolkit.out
-      cudnn
-    ])
-  );
-
-  postFixup = lib.optionalString stdenv.isLinux ''
-    function fixRunPath {
-      p=$(patchelf --print-rpath $1)
-      patchelf --set-rpath "$p:$libraryPath" $1
-      ${lib.optionalString cudaSupport ''
-        addOpenGLRunpath $1
-      ''}
-    }
-    fixRunPath $out/${python.sitePackages}/paddle/fluid/libpaddle.so
+  # The Paddle build process uses git to checkout in the submodules, which doesn't work.
+  # However, the submodules already have the right commits so we just use a dummy git command.
+  fakeGit = writeScriptBin "git" ''
+    echo fakegit "$@"
+    if [ "$1" = "rev-parse" ]; then
+        exit 1
+    fi
   '';
 
+  # We build the C++ part in a separate derivation. This is so that when packaging we can iterate on CMake and Python
+  # separately, because the C++ part takes a long time. Also, this way we get the Nix CMake settings automatically.
+  paddlePaddleCmake = stdenv.mkDerivation {
+    name = "paddlepaddle-cmake";
+    inherit src;
+
+    patches = [
+      # Paddle wants to download and use precompiled lapack. This is unneccessary because
+      # OpenBLAS provides LAPACK.
+      ./no-extern-lapack.patch
+    ];
+
+    buildInputs = [ openblas ];
+    nativeBuildInputs = [
+      cmake
+      pip
+      wheel
+      pyyaml
+      jinja2
+      perl
+
+      numpy
+      protobuf
+
+      pip # pip won't actually work but configuration fails without it.
+
+      fakeGit
+    ];
+
+    # Use OpenBLAS from nixpkgs. cblas.cmake expects /include and /lib to be in the same directory.
+    OPENBLAS_ROOT = symlinkJoin {
+      name = "openblas-merged";
+      paths = [ openblas.out openblas.dev ];
+    };
+
+    cmakeFlags = [
+      "-DWITH_MKL=OFF" # MKL support currently wants to download more sources, so disable for now.
+      "-DWITH_SETUP_INSTALL=ON" # run as if called by setup.py, we'll call it ourselves after
+    ];
+
+
+    hardeningDisable = [ "fortify" ];
+    enableParallelBuilding = true;
+
+    # We just want the CMake build directory.
+    installPhase = ''
+      mkdir $out
+      cp -r . $out/build
+    '';
+
+    # # Nix doesn't like rpaths to the build directory in the output, but we want to just copy it to another build, so turn this check off.
+    noAuditTmpdir = true;
+
+    # dontFixup = true;
+    dontStrip = true;
+  };
+in
+buildPythonPackage {
+  pname = "paddlepaddle" + lib.optionalString cudaSupport "-gpu";
+  format = "setuptools";
+  inherit version src;
+
+  PY_VERSION = python.pythonVersion;
+
+  dontUseCmakeConfigure = true; # setup.py will call cmake itself.
+
   nativeBuildInputs = [
-    addOpenGLRunpath
+    cmake
+    pip
+    pyyaml
   ];
 
   propagatedBuildInputs = [
-    setuptools
-    httpx
     numpy
     protobuf
+    httpx
     pillow
     decorator
     astor
@@ -82,11 +138,16 @@ buildPythonPackage {
     opt-einsum
   ];
 
-  pythonImportsCheck = [ "paddle" ];
+  patches = [
+    ./no-python-cmake.patch
+ ];
 
-  # no tests
-  doCheck = false;
-
+  # Copy the pre-built CMake directory.
+  preBuild = ''
+    echo Copying ${paddlePaddleCmake}
+    cp -r --no-preserve=mode,ownership ${paddlePaddleCmake}/build .
+  '';
+#
   meta = with lib; {
     description = "PArallel Distributed Deep LEarning: Machine Learning Framework from Industrial Practice （『飞桨』核心框架，深度学习&机器学习高性能单机、分布式训练和跨平台部署";
     homepage = "https://github.com/PaddlePaddle/Paddle";

--- a/pkgs/development/python-modules/paddlepaddle/no-extern-lapack.patch
+++ b/pkgs/development/python-modules/paddlepaddle/no-extern-lapack.patch
@@ -1,0 +1,34 @@
+diff --git a/cmake/third_party.cmake b/cmake/third_party.cmake
+index 7c086f780a..f6c7aded8b 100755
+--- a/cmake/third_party.cmake
++++ b/cmake/third_party.cmake
+@@ -339,7 +339,6 @@ list(
+   extern_warprnnt
+   extern_threadpool
+   extern_utf8proc)
+-include(external/lapack) # download, build, install lapack
+ 
+ list(APPEND third_party_deps extern_eigen3 extern_gflags extern_glog
+      extern_xxhash)
+@@ -350,8 +349,7 @@ list(
+   extern_dlpack
+   extern_warpctc
+   extern_warprnnt
+-  extern_threadpool
+-  extern_lapack)
++  extern_threadpool)
+ 
+ include(cblas) # find first, then download, build, install openblas
+ 
+diff --git a/paddle/phi/CMakeLists.txt b/paddle/phi/CMakeLists.txt
+index 64c18b2b60..8d80171606 100644
+--- a/paddle/phi/CMakeLists.txt
++++ b/paddle/phi/CMakeLists.txt
+@@ -193,7 +193,6 @@ if(MKL_FOUND AND WITH_ONEMKL)
+   target_include_directories(phi PRIVATE ${MKL_INCLUDE})
+ endif()
+ 
+-add_dependencies(phi extern_lapack)
+ if(WITH_CUTLASS)
+   add_dependencies(phi cutlass_codegen)
+   add_definitions("-DPADDLE_WITH_MEMORY_EFFICIENT_ATTENTION"

--- a/pkgs/development/python-modules/paddlepaddle/no-python-cmake.patch
+++ b/pkgs/development/python-modules/paddlepaddle/no-python-cmake.patch
@@ -1,0 +1,38 @@
+diff --git a/setup.py b/setup.py
+index 87fd3c65f4..f37ad98cda 100644
+--- a/setup.py
++++ b/setup.py
+@@ -301,21 +301,7 @@ class InstallLib(install_lib):
+ 
+ 
+ def git_commit():
+-    try:
+-        cmd = ['git', 'rev-parse', 'HEAD']
+-        git_commit = (
+-            subprocess.Popen(
+-                cmd,
+-                stdout=subprocess.PIPE,
+-                cwd=env_dict.get("PADDLE_SOURCE_DIR"),
+-            )
+-            .communicate()[0]
+-            .strip()
+-        )
+-    except:
+-        git_commit = 'Unknown'
+-    git_commit = git_commit.decode('utf-8')
+-    return str(git_commit)
++    return "Unknown"
+ 
+ 
+ def _get_version_detail(idx):
+@@ -1667,10 +1653,6 @@ def main():
+ 
+     # check build dependency
+     check_build_dependency()
+-    check_submodules()
+-    # Execute the build process,cmake and make
+-    if cmake_and_build:
+-        build_steps()
+ 
+     if os.getenv("WITH_PYTHON") == "OFF":
+         print("only compile, not package")


### PR DESCRIPTION
## Description of changes

I took a crack at building `paddlepaddle` from source, avoiding the binary blob and the openssl-1.1 dependency. I've got as far as building the C++ part successfully, but the python packaging doesn't work yet. I split them into two separate derivations to make iteration faster.

I since found [frotms/PaddleOCR2Pytorch](https://github.com/frotms/PaddleOCR2Pytorch) which might work better for me so I'm not sure if I have time to finish this.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
