### PR TITLE
simple64: init at 2024.09.1; simple64-netplay-server: init at 2024.06.1

### DIFF
--- a/pkgs/by-name/si/simple64-netplay-server/package.nix
+++ b/pkgs/by-name/si/simple64-netplay-server/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "simple64-netplay-server";
+  version = "2024.06.1";
+
+  src = fetchFromGitHub {
+    owner = "simple64";
+    repo = "simple64-netplay-server";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-WTEtTzRkXuIusfK6Nbj1aLwXcXyaXQi+j3SsDrvtLKo=";
+  };
+
+  vendorHash = "sha256-zfLSti368rBHj17HKDZKtOQQrhVGVa2CaieaDGHcZOk=";
+
+  meta = {
+    description = "Dedicated server for simple64 netplay";
+    homepage = "https://github.com/simple64/simple64-netplay-server";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "simple64-netplay-server";
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}

--- a/pkgs/by-name/si/simple64/add-official-server-error-message.patch
+++ b/pkgs/by-name/si/simple64/add-official-server-error-message.patch
@@ -1,0 +1,15 @@
+diff --git a/simple64-gui/netplay/joinroom.cpp b/simple64-gui/netplay/joinroom.cpp
+index 3b5c34e..68b46f2 100644
+--- a/simple64-gui/netplay/joinroom.cpp
++++ b/simple64-gui/netplay/joinroom.cpp
+@@ -308,7 +308,9 @@ void JoinRoom::processTextMessage(QString message)
+         }
+         else
+         {
+-            msgBox.setText(json.value("message").toString());
++            QString msg = json.value("message").toString();
++            if(msg == "Bad authentication code") msg += "<br>Note: using the official netplay servers is not allowed on unofficial builds.<br>You can host your own server with `simple64-netplay-server`";
++            msgBox.setText(msg);
+             msgBox.exec();
+         }
+     }

--- a/pkgs/by-name/si/simple64/dont-use-vosk-and-discord.patch
+++ b/pkgs/by-name/si/simple64/dont-use-vosk-and-discord.patch
@@ -1,0 +1,37 @@
+diff --git a/build.sh b/build.sh
+index 254a90d..e2d26cf 100644
+--- a/build.sh
++++ b/build.sh
+@@ -77,7 +77,7 @@ cmake -G Ninja -DCMAKE_BUILD_TYPE="${RELEASE_TYPE}" ..
+ cmake --build .
+ cp simple64-video-parallel.* "${install_dir}"
+ 
+-if [[ ! -d "${base_dir}/discord" ]]; then
++if false; then
+   echo "Downloading Discord SDK"
+   mkdir -p "${base_dir}/discord"
+   cd "${base_dir}/discord"
+@@ -86,7 +86,7 @@ if [[ ! -d "${base_dir}/discord" ]]; then
+   rm discord_game_sdk.zip
+ fi
+ 
+-if [[ ! -d "${base_dir}/vosk" ]]; then
++if false; then
+   mkdir -p "${base_dir}/vosk"
+   cd "${base_dir}/vosk"
+   if [[ ${UNAME} == *"MINGW64"* ]]; then
+@@ -156,14 +156,6 @@ if [[ ${UNAME} == *"MINGW64"* ]]; then
+   cp -v "${base_dir}/7z/x64/7za.exe" "${install_dir}"
+   cp -v "${base_dir}/discord/lib/x86_64/discord_game_sdk.dll" "${install_dir}"
+   cp -v "${base_dir}/vosk/libvosk.dll" "${install_dir}/vosk.dll"
+-else
+-  cp "${base_dir}/vosk/libvosk.so" "${install_dir}"
+-  if [[ "${PLATFORM}" == "aarch64" ]]; then
+-    my_os=linux_aarch64
+-  else
+-    my_os=linux_x86_64
+-    cp "${base_dir}/discord/lib/x86_64/discord_game_sdk.so" "${install_dir}/libdiscord_game_sdk.so"
+-  fi
+ fi
+ 
+ if [[ "$1" == "zip" ]]; then

--- a/pkgs/by-name/si/simple64/package.nix
+++ b/pkgs/by-name/si/simple64/package.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  writeShellScriptBin,
+  cmake,
+  ninja,
+  pkg-config,
+  makeWrapper,
+  zlib,
+  libpng,
+  SDL2,
+  SDL2_net,
+  hidapi,
+  qt6,
+  vulkan-loader,
+}:
+
+let
+  cheats-json = fetchurl {
+    url = "https://raw.githubusercontent.com/simple64/cheat-parser/87963b7aca06e0d4632b66bc5ffe7d6b34060f4f/cheats.json";
+    hash = "sha256-rS/4Mdi+18C2ywtM5nW2XaJkC1YnKZPc4YdQ3mCfESU=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "simple64";
+  version = "2024.09.1";
+
+  src = fetchFromGitHub {
+    owner = "simple64";
+    repo = "simple64";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-t3V7mvHlCP8cOvizR3N9DiCofnSvSHI6U0iXXkaMb34=";
+  };
+
+  patches = [
+    ./dont-use-vosk-and-discord.patch
+    ./add-official-server-error-message.patch
+  ];
+
+  postPatch = ''
+    cp ${cheats-json} cheats.json
+  '';
+
+  stictDeps = true;
+
+  nativeBuildInputs = [
+    qt6.wrapQtAppsHook
+    cmake
+    ninja
+    pkg-config
+    makeWrapper
+    # fake git command for version info generator
+    (writeShellScriptBin "git" "echo ${finalAttrs.src.rev}")
+  ];
+
+  buildInputs = [
+    zlib
+    libpng
+    SDL2
+    SDL2_net
+    hidapi
+    qt6.qtbase
+    qt6.qtwebsockets
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  dontWrapQtApps = true;
+
+  buildPhase = ''
+    runHook preInstall
+
+    sh build.sh
+
+    runHook postInstall
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/simple64 $out/bin
+    cp -r simple64/* $out/share/simple64
+
+    makeWrapper $out/share/simple64/simple64-gui $out/bin/simple64-gui \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]} \
+        "''${qtWrapperArgs[@]}"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Easy to use N64 emulator";
+    homepage = "https://simple64.github.io";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "simple64-gui";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/si/simple64/package.nix
+++ b/pkgs/by-name/si/simple64/package.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     hidapi
     qt6.qtbase
     qt6.qtwebsockets
+    qt6.qtwayland
   ];
 
   dontUseCmakeConfigure = true;


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/301143
@keenanweaver

---

This PR adds 2 packages: `simple64` and `simple64-netplay-server`.

`simple64`:
The repo provides a custom `build.sh` script for building everything, I used that instead of the default `cmake` behaviour.
I needed to remove the fetching of the discord SDK and `vosk`, hopefully they are not hard-dependencies.

An interesting thing I found was that this uses the same config directory as `mupen64plus`, which had a `/nix/store` path pointing to my no longer existing installation of `mupen64plus`...

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
