### PR TITLE
ndiswrapper: use `elfutils` instead of abandoned `libelf`

### DIFF
--- a/pkgs/os-specific/linux/ndiswrapper/default.nix
+++ b/pkgs/os-specific/linux/ndiswrapper/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, kernel, perl, kmod, libelf }:
+{ lib, stdenv, fetchurl, kernel, perl, kmod, elfutils }:
 let
   version = "1.63";
 in
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
     sha256 = "1v6b66jhisl110jfl00hm43lmnrav32vs39d85gcbxrjqnmcx08g";
   };
 
-  buildInputs = [ perl libelf ];
+  buildInputs = [ perl elfutils ];
 
   meta = {
     description = "Ndis driver wrapper for the Linux kernel";


### PR DESCRIPTION
## Description of changes

Switch from using unmaintained `libelf` to `elfutils` (https://github.com/NixOS/nixpkgs/issues/271473).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>19 packages marked as broken and skipped:</summary>
  <ul>
    <li>linuxKernel.packages.linux_5_10.ndiswrapper</li>
    <li>linuxKernel.packages.linux_5_10_hardened.ndiswrapper</li>
    <li>linuxKernel.packages.linux_5_15.ndiswrapper</li>
    <li>linuxKernel.packages.linux_5_15_hardened.ndiswrapper</li>
    <li>linuxKernel.packages.linux_6_1.ndiswrapper</li>
    <li>linuxKernel.packages.linux_6_1_hardened.ndiswrapper</li>
    <li>linuxKernel.packages.linux_6_6.ndiswrapper</li>
    <li>linuxKernel.packages.linux_6_6_hardened.ndiswrapper</li>
    <li>linuxKernel.packages.linux_6_7.ndiswrapper</li>
    <li>linuxKernel.packages.linux_6_7_hardened.ndiswrapper</li>
    <li>linuxKernel.packages.linux_6_8.ndiswrapper</li>
    <li>linuxKernel.packages.linux_hardened.ndiswrapper</li>
    <li>linuxKernel.packages.linux_latest_libre.ndiswrapper</li>
    <li>linuxKernel.packages.linux_libre.ndiswrapper</li>
    <li>linuxKernel.packages.linux_lqx.ndiswrapper</li>
    <li>linuxKernel.packages.linux_xanmod.ndiswrapper</li>
    <li>linuxKernel.packages.linux_xanmod_latest.ndiswrapper</li>
    <li>linuxKernel.packages.linux_xanmod_stable.ndiswrapper</li>
    <li>linuxKernel.packages.linux_zen.ndiswrapper</li>
  </ul>
</details>
<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>linuxKernel.packages.linux_4_19_hardened.ndiswrapper</li>
    <li>linuxKernel.packages.linux_5_4_hardened.ndiswrapper</li>
  </ul>
</details>
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>linuxKernel.packages.linux_4_19.ndiswrapper</li>
    <li>linuxKernel.packages.linux_5_4.ndiswrapper</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
