### PR TITLE
bagage: init at unstable-2024-03-26

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1299,6 +1299,7 @@
   ./services/web-apps/atlassian/crowd.nix
   ./services/web-apps/atlassian/jira.nix
   ./services/web-apps/audiobookshelf.nix
+  ./services/web-apps/bagage.nix
   ./services/web-apps/bookstack.nix
   ./services/web-apps/c2fmzq-server.nix
   ./services/web-apps/calibre-web.nix

--- a/nixos/modules/services/web-apps/bagage.nix
+++ b/nixos/modules/services/web-apps/bagage.nix
@@ -1,0 +1,149 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib) types;
+  cfg = config.services.bagage;
+  defaultUser = "bagage";
+  defaultGroup = defaultUser;
+in
+{
+  options = {
+    services.bagage = {
+      enable = lib.mkEnableOption "bagage, a webdav bridge to S3";
+
+      package = lib.mkPackageOption pkgs "bagage" { };
+
+      environmentFile = lib.mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        example = "/run/keys/bagage.env";
+        description = lib.mdDoc ''
+          An environment file as defined in {manpage}`systemd.exec(5)`.
+        '';
+      };
+
+      user = lib.mkOption {
+        type = types.str;
+        default = defaultUser;
+        example = "yourUser";
+        description = lib.mdDoc ''
+          The user to run bagage as.
+          By default, a user named `${defaultUser}` will be created whose home
+          directory is [stateDir](#opt-services.bagage.stateDir).
+        '';
+      };
+
+      group = lib.mkOption {
+        type = types.str;
+        default = defaultGroup;
+        example = "yourGroup";
+        description = lib.mdDoc ''
+          The group to run bagage under.
+          By default, a group named `${defaultGroup}` will be created.
+        '';
+      };
+
+      address = lib.mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = "Web interface address.";
+      };
+
+      port = lib.mkOption {
+        type = types.port;
+        default = 8080;
+        description = "Web interface port.";
+      };
+
+      url = lib.mkOption {
+        type = types.str;
+        default = "https://localhost:8080";
+        example = "https://some-hostname-or-ip:34567";
+        description = "Web interface address.";
+      };
+
+      stateDir = lib.mkOption {
+        default = "/var/lib/bagage";
+        type = types.str;
+        description = "bagage data directory.";
+      };
+
+      environment = lib.mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        description = lib.mdDoc ''
+          Extra config options.
+        '';
+        example = { };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.${defaultUser} = lib.mkIf (cfg.user == defaultUser) {
+      group = cfg.group;
+      home = cfg.stateDir;
+      isSystemUser = true;
+      createHome = true;
+      description = "bagage daemon user";
+    };
+
+    users.groups = lib.mkIf (cfg.group == defaultGroup) { ${defaultGroup} = { }; };
+
+    systemd = {
+      services.bagage = {
+        description = "bagage";
+        wantedBy = [ "multi-user.target" ];
+        environment = {
+          BAGAGE_HTTP_LISTEN = "0.0.0.0:7947";
+          BAGAGE_WEBDAV_PREFIX = "/webdav";
+          BAGAGE_LDAP_ENDPOINT = "https://ldap.bhankas.org";
+          BAGAGE_LDAP_USER_BASE_DN = "dc=bhankas,dc=org";
+          BAGAGE_LDAP_USERNAME_ATTR = "cn";
+          BAGAGE_S3_ENDPOINT = "garage.deuxfleurs.fr";
+          BAGAGE_S3_SSL = "true";
+          BAGAGE_S3_CACHE = "./s3_cache";
+          BAGAGE_SSH_KEY = "id_rsa";
+        } // cfg.environment;
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${lib.getExe cfg.package} server";
+          WorkingDirectory = cfg.stateDir;
+          User = cfg.user;
+          Group = cfg.group;
+          Restart = "always";
+          EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+          ReadWritePaths = [ cfg.stateDir ];
+          MemoryDenyWriteExecute = true;
+          NoNewPrivileges = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          ProtectControlGroups = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectKernelLogs = true;
+          RestrictAddressFamilies = [
+            "AF_UNIX"
+            "AF_INET"
+            "AF_INET6"
+            "AF_NETLINK"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          LockPersonality = true;
+          SystemCallArchitectures = "native";
+        };
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ bhankas ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -140,6 +140,7 @@ in {
   avahi-with-resolved = handleTest ./avahi.nix { networkd = true; };
   ayatana-indicators = handleTest ./ayatana-indicators.nix {};
   babeld = handleTest ./babeld.nix {};
+  bagage = handleTest ./bagage.nix {};
   bazarr = handleTest ./bazarr.nix {};
   bcachefs = handleTestOn ["x86_64-linux" "aarch64-linux"] ./bcachefs.nix {};
   beanstalkd = handleTest ./beanstalkd.nix {};

--- a/nixos/tests/bagage.nix
+++ b/nixos/tests/bagage.nix
@@ -1,0 +1,33 @@
+import ./make-test-python.nix (
+  { lib, pkgs, ... }:
+  {
+    name = "bagage";
+
+    meta.maintainers = with lib.maintainers; [ bhankas ];
+
+    nodes.machine =
+      { config, ... }:
+      {
+        virtualisation.memorySize = 2048;
+
+        # if you do this in production, dont put secrets in this file because it will be written to the world readable nix store
+        # environment.etc."ocis/ocis.env".text = '''';
+
+        services.bagage = {
+          enable = true;
+          environment = { };
+        };
+      };
+
+    testScript = ''
+      start_all()
+      machine.wait_for_unit("bagage.service")
+      machine.wait_for_open_port(7947)
+      # wait for bagage to fully come up
+      machine.sleep(5)
+
+      with subtest("garage works"):
+          machine.succeed("${lib.getExe pkgs.garage} version")
+    '';
+  }
+)

--- a/pkgs/by-name/ba/bagage/package.nix
+++ b/pkgs/by-name/ba/bagage/package.nix
@@ -1,0 +1,35 @@
+{
+  buildGoModule,
+  lib,
+  fetchFromGitea,
+}:
+
+buildGoModule {
+  pname = "bagage";
+  version = "unstable-2024-03-26";
+
+  src = fetchFromGitea {
+    domain = "git.deuxfleurs.fr";
+    owner = "Deuxfleurs";
+    repo = "bagage";
+    rev = "75b27becf26516a65549a00378155437e4acce4e";
+    hash = "sha256-SfCxMqIfNzjV7qqWe3tBzD/1Yz0EGIJg1/J1yk/bT80=";
+  };
+
+  vendorHash = "sha256-imy3MHj8BI8jxuLBzsaSxkAPtsAuh9/L1uVGWtRN8lk=";
+
+  subPackages = [ "." ];
+
+  meta = {
+    description = ''
+      Bagage is the bridge between our users and garage, it enables them to synchronize files that matter for them from their computer to garage through WebDAV.
+
+      Bagage will be a service to access your documents everywhere. Currently, it is only a WebDAV to S3 proxy. Later, it may propose a web interface and support synchronization with the Nextcloud client.
+    '';
+    homepage = "https://git.deuxfleurs.fr/Deuxfleurs/bagage";
+    changelog = "https://git.deuxfleurs.fr/Deuxfleurs/bagage/commits/branch/main";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ bhankas ];
+    mainProgram = "bagage";
+  };
+}


### PR DESCRIPTION
Bagage is an experimental web-app to build file-sharing facilities on top of [garage](https://garagehq.deuxfleurs.fr/).

This PR is left intentionally opened as draft until I'm confident in working of the app and module myself, although feel free if anyone actually wants to work on it. 

A nixos module and module test is also included.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
