### PR TITLE
blastem: init at 0.6.2-unstable-2024-03-31

### DIFF
--- a/pkgs/by-name/bl/blastem/package.nix
+++ b/pkgs/by-name/bl/blastem/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  fetchhg,
+  pkg-config,
+  makeWrapper,
+  SDL2,
+  glew,
+  gtk3,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "blastem";
+  version = "0.6.2-unstable-2024-03-31";
+
+  src = fetchhg {
+    url = "https://www.retrodev.com/repos/blastem";
+    rev = "48ab1e3e5df5";
+    hash = "sha256-UZl5fIE7LJqxwS8kFJ3xr8BJyHF60dnRNeA5k7lAuxg=";
+  };
+
+  # will probably be fixed in https://github.com/NixOS/nixpkgs/pull/302481
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace Makefile \
+        --replace-fail "-flto" ""
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    gtk3
+    SDL2
+    glew
+  ];
+
+  # Note: menu.bin cannot be generated yet, because it would
+  # need the `vasmm68k_mot` executable (part of vbcc for amigaos68k
+  # Luckily, menu.bin doesn't need to be present for the emulator to function
+
+  makeFlags = [ "HOST_ZLIB=1" ];
+
+  env.NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL2}/include/SDL2";
+
+  installPhase = ''
+    runHook preInstall
+
+    # not sure if any executable other than blastem is really needed here
+    install -Dm755 blastem dis zdis termhelper -t $out/share/blastem
+    install -Dm644 gamecontrollerdb.txt default.cfg rom.db -t $out/share/blastem
+    cp -r shaders $out/share/blastem/shaders
+
+    # wrapping instead of sym-linking makes sure argv0 stays at the original location
+    makeWrapper $out/share/blastem/blastem $out/bin/blastem
+
+    runHook postInstall
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "blastem -v";
+    version = "0.6.3-pre"; # remove line when moving to a stable version
+  };
+
+  meta = {
+    description = "The fast and accurate Genesis emulator";
+    homepage = "https://www.retrodev.com/blastem/";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "blastem";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+      "x86_64-darwin"
+    ];
+  };
+})

--- a/pkgs/by-name/bl/blastem/package.nix
+++ b/pkgs/by-name/bl/blastem/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchhg,
   pkg-config,
-  makeWrapper,
+  makeBinaryWrapper,
   SDL2,
   glew,
   gtk3,
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
-    makeWrapper
+    makeBinaryWrapper
   ];
 
   buildInputs = [


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/301134
@keenanweaver

---
This PR adds 1 package: `blastem`
`libretro.blastem` already exists, this is the original.

I put `blastem`, `dis`, `zdis` and `termhelper` into `$out/share/blastem`, but only `blastem` seem to do anything other than segfaulting or crashing. (I have no idea what they're supposed to do). Because of this I only made a wrapper for `blastem` in `$out/bin`.

I can't really test this ATM.

There was also a `menu.bin` file in the binary distribution of the package. I couldn't get it to build, because it would need `vasmm68k_mot`, which is not package in nixpkgs. Not sure if it's something important.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
