### PR TITLE
chipsec: use `elfutils` instead of abandoned `libelf`

### DIFF
--- a/pkgs/tools/security/chipsec/default.nix
+++ b/pkgs/tools/security/chipsec/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , kernel ? null
-, libelf
+, elfutils
 , nasm
 , python3
 , withDriver ? false
@@ -26,8 +26,9 @@ python3.pkgs.buildPythonApplication rec {
   KSRC = lib.optionalString withDriver "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
 
   nativeBuildInputs = [
-    libelf
     nasm
+  ] ++ lib.optionals (lib.meta.availableOn stdenv.buildPlatform elfutils) [
+    elfutils
   ] ++ lib.optionals withDriver kernel.moduleBuildDependencies;
 
   nativeCheckInputs = with python3.pkgs; [


### PR DESCRIPTION
## Description of changes

Switch from using unmaintained `libelf` to `elfutils` (https://github.com/NixOS/nixpkgs/issues/271473).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages marked as broken and skipped:</summary>
  <ul>
    <li>linuxKernel.packages.linux_4_19_hardened.chipsec</li>
    <li>linuxKernel.packages.linux_4_19_hardened.chipsec.dist</li>
  </ul>
</details>
<details>
  <summary>4 packages failed to build:</summary>
  <ul>
    <li>linuxKernel.packages.linux_5_4_hardened.chipsec</li>
    <li>linuxKernel.packages.linux_5_4_hardened.chipsec.dist</li>
    <li>linuxKernel.packages.linux_lqx.chipsec</li>
    <li>linuxKernel.packages.linux_lqx.chipsec.dist</li>
  </ul>
</details>
<details>
  <summary>38 packages built:</summary>
  <ul>
    <li>chipsec</li>
    <li>chipsec.dist</li>
    <li>linuxKernel.packages.linux_4_19.chipsec</li>
    <li>linuxKernel.packages.linux_4_19.chipsec.dist</li>
    <li>linuxKernel.packages.linux_5_10.chipsec</li>
    <li>linuxKernel.packages.linux_5_10.chipsec.dist</li>
    <li>linuxKernel.packages.linux_5_10_hardened.chipsec</li>
    <li>linuxKernel.packages.linux_5_10_hardened.chipsec.dist</li>
    <li>linuxKernel.packages.linux_5_15.chipsec</li>
    <li>linuxKernel.packages.linux_5_15.chipsec.dist</li>
    <li>linuxKernel.packages.linux_5_15_hardened.chipsec</li>
    <li>linuxKernel.packages.linux_5_15_hardened.chipsec.dist</li>
    <li>linuxKernel.packages.linux_5_4.chipsec</li>
    <li>linuxKernel.packages.linux_5_4.chipsec.dist</li>
    <li>linuxKernel.packages.linux_6_1.chipsec</li>
    <li>linuxKernel.packages.linux_6_1.chipsec.dist</li>
    <li>linuxKernel.packages.linux_6_1_hardened.chipsec</li>
    <li>linuxKernel.packages.linux_6_1_hardened.chipsec.dist</li>
    <li>linuxKernel.packages.linux_6_6.chipsec</li>
    <li>linuxKernel.packages.linux_6_6.chipsec.dist</li>
    <li>linuxKernel.packages.linux_hardened.chipsec (linuxKernel.packages.linux_6_6_hardened.chipsec)</li>
    <li>linuxKernel.packages.linux_hardened.chipsec.dist (linuxKernel.packages.linux_6_6_hardened.chipsec.dist)</li>
    <li>linuxKernel.packages.linux_6_7.chipsec</li>
    <li>linuxKernel.packages.linux_6_7.chipsec.dist</li>
    <li>linuxKernel.packages.linux_6_7_hardened.chipsec</li>
    <li>linuxKernel.packages.linux_6_7_hardened.chipsec.dist</li>
    <li>linuxKernel.packages.linux_6_8.chipsec</li>
    <li>linuxKernel.packages.linux_6_8.chipsec.dist</li>
    <li>linuxKernel.packages.linux_latest_libre.chipsec</li>
    <li>linuxKernel.packages.linux_latest_libre.chipsec.dist</li>
    <li>linuxKernel.packages.linux_libre.chipsec</li>
    <li>linuxKernel.packages.linux_libre.chipsec.dist</li>
    <li>linuxKernel.packages.linux_xanmod.chipsec</li>
    <li>linuxKernel.packages.linux_xanmod.chipsec.dist</li>
    <li>linuxKernel.packages.linux_xanmod_latest.chipsec (linuxKernel.packages.linux_xanmod_stable.chipsec)</li>
    <li>linuxKernel.packages.linux_xanmod_latest.chipsec.dist (linuxKernel.packages.linux_xanmod_stable.chipsec.dist)</li>
    <li>linuxKernel.packages.linux_zen.chipsec</li>
    <li>linuxKernel.packages.linux_zen.chipsec.dist</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
