### PR TITLE
bauh: init at 0.10.7

### DIFF
--- a/pkgs/by-name/ba/bauh/package.nix
+++ b/pkgs/by-name/ba/bauh/package.nix
@@ -1,0 +1,39 @@
+{ lib
+, fetchPypi
+, python3Packages
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "bauh";
+  version = "0.10.7";
+  pyproject = true;
+
+  src= fetchPypi{
+    inherit pname version;
+    hash = "sha256-N6zvEbx0Y2GGB9f5emmhNcWN6z0oPK0qoazKq0gIRC0=";
+  };
+
+  build-system = with python3Packages; [
+    build
+    installer
+    setuptools
+    wheel
+  ];
+
+  dependencies = with python3Packages; [
+    colorama
+    dateutil
+    pyaml
+    pyqt5
+    requests
+  ];
+
+  meta = with lib; {
+    description = "GUI for managing your Linux applications. Supports AppImage, Debian, Arch, Flatpak, Snap and Web apps";
+    homepage = "https://github.com/vinifmor/bauh";
+    license = licenses.zlib;
+    maintainers = with maintainers; [ ByteSudoer ];
+    mainProgram = "bauh";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes
bauh (baoo), formerly known as [fpakman](https://github.com/vinifmor/fpakman), is a graphical interface for managing your Linux software (packages/applications). It currently supports the following formats: AppImage, Debian and Arch Linux packages (including AUR), Flatpak, Snap and Web applications.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Metadata
- homepage URL: https://github.com/vinifmor/bauh
- source URL: https://github.com/vinifmor/bauh
- license: mit, bsd, gpl2+ , ...
- platforms: unix, linux, darwin, ...
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
