### PR TITLE
tree-sitter: embed path to `emcc` so that `build --wasm` works

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -9,6 +9,7 @@
 , Security
 , callPackage
 , linkFarm
+, substitute
 , CoreServices
 , enableShared ? !stdenv.hostPlatform.isStatic
 , enableStatic ? stdenv.hostPlatform.isStatic
@@ -116,6 +117,13 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs =
     [ which ]
     ++ lib.optionals webUISupport [ emscripten ];
+
+  patches = lib.optionals webUISupport [
+    (substitute {
+      src = ./fix-paths.patch;
+      substitutions = [ "--subst-var-by" "emcc" "${emscripten}/bin/emcc" ];
+    })
+  ];
 
   postPatch = lib.optionalString (!webUISupport) ''
     # remove web interface

--- a/pkgs/development/tools/parsing/tree-sitter/fix-paths.patch
+++ b/pkgs/development/tools/parsing/tree-sitter/fix-paths.patch
@@ -1,0 +1,13 @@
+diff --git a/cli/loader/src/lib.rs b/cli/loader/src/lib.rs
+index 9c1d8dfc..a5cfc74c 100644
+--- a/cli/loader/src/lib.rs
++++ b/cli/loader/src/lib.rs
+@@ -747,7 +747,7 @@ impl Loader {
+             Podman,
+         }
+ 
+-        let emcc_name = if cfg!(windows) { "emcc.bat" } else { "emcc" };
++        let emcc_name = if cfg!(windows) { "emcc.bat" } else { "@emcc@" };
+ 
+         // Order of preference: emscripten > docker > podman > error
+         let source = if !force_docker && Command::new(emcc_name).output().is_ok() {


### PR DESCRIPTION
## Description of changes

I tried to run `tree-sitter playground` on the `master` branch and ran into the issue that @ErinvanderVeen described in https://github.com/NixOS/nixpkgs/issues/241304#issuecomment-1985336634.

On staging, which contains an upgrade to 0.22.2, the issue is changed, since the underlying symbol that caused the error has been [removed from the exports file](https://github.com/tree-sitter/tree-sitter/commit/8ab14a0ee5128a49648e0904b122ecb7e6aa2d3f).

This PR makes `tree-sitter build --wasm` always work, since it patches in the full path to the `emcc` binary in the Nix store.

With this change, I'm able to make a playground for https://github.com/nix-community/tree-sitter-nix ... and can continue work trying to make [`sg`](https://ast-grep.github.io) work for Nix.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
