### PR TITLE
python312Packages.msgraph-sdk: 1.1.0 -> 1.2.0, python312Packages.microsoft-kiota-serialization-multipart: init at 0.1.0, python312Packages.microsoft-kiota-serialization-form: init at 0.1.0

### DIFF
--- a/pkgs/development/python-modules/microsoft-kiota-abstractions/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-abstractions/default.nix
@@ -1,14 +1,15 @@
-{ lib
-, buildPythonPackage
-, fetchFromGitHub
-, flit-core
-, opentelemetry-api
-, opentelemetry-sdk
-, pytest-asyncio
-, pytest-mock
-, pytestCheckHook
-, pythonOlder
-, std-uritemplate
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  opentelemetry-api,
+  opentelemetry-sdk,
+  pytest-asyncio,
+  pytest-mock,
+  pytestCheckHook,
+  pythonOlder,
+  std-uritemplate,
 }:
 
 buildPythonPackage rec {
@@ -25,9 +26,7 @@ buildPythonPackage rec {
     hash = "sha256-n9Erm21slKm+zDblhSHA5Cwxkyrcyx0w09ua3bUc5XI=";
   };
 
-  build-system = [
-    flit-core
-  ];
+  build-system = [ flit-core ];
 
   dependencies = [
     opentelemetry-api
@@ -41,9 +40,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
-    "kiota_abstractions"
-  ];
+  pythonImportsCheck = [ "kiota_abstractions" ];
 
   meta = with lib; {
     description = "Abstractions library for Kiota generated Python clients";

--- a/pkgs/development/python-modules/microsoft-kiota-authentication-azure/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-authentication-azure/default.nix
@@ -1,16 +1,17 @@
-{ lib
-, aiohttp
-, azure-core
-, buildPythonPackage
-, fetchFromGitHub
-, flit-core
-, microsoft-kiota-abstractions
-, opentelemetry-api
-, opentelemetry-sdk
-, pytest-asyncio
-, pytest-mock
-, pytestCheckHook
-, pythonOlder
+{
+  lib,
+  aiohttp,
+  azure-core,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  microsoft-kiota-abstractions,
+  opentelemetry-api,
+  opentelemetry-sdk,
+  pytest-asyncio,
+  pytest-mock,
+  pytestCheckHook,
+  pythonOlder,
 }:
 
 buildPythonPackage rec {
@@ -27,9 +28,7 @@ buildPythonPackage rec {
     hash = "sha256-RA0BbIwDs3cXiH4tQsvCGUO1OAg+DWjEeWd7MEVIC8E=";
   };
 
-  nativeBuildInputs = [
-    flit-core
-  ];
+  nativeBuildInputs = [ flit-core ];
 
   propagatedBuildInputs = [
     aiohttp
@@ -45,9 +44,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
-    "kiota_authentication_azure"
-  ];
+  pythonImportsCheck = [ "kiota_authentication_azure" ];
 
   meta = with lib; {
     description = "Kiota Azure authentication provider";

--- a/pkgs/development/python-modules/microsoft-kiota-authentication-azure/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-authentication-azure/default.nix
@@ -28,9 +28,9 @@ buildPythonPackage rec {
     hash = "sha256-RA0BbIwDs3cXiH4tQsvCGUO1OAg+DWjEeWd7MEVIC8E=";
   };
 
-  nativeBuildInputs = [ flit-core ];
+  build-system = [ flit-core ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     aiohttp
     azure-core
     microsoft-kiota-abstractions

--- a/pkgs/development/python-modules/microsoft-kiota-http/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-http/default.nix
@@ -1,16 +1,17 @@
-{ lib
-, buildPythonPackage
-, fetchFromGitHub
-, flit-core
-, httpx
-, microsoft-kiota-abstractions
-, opentelemetry-api
-, opentelemetry-sdk
-, pytest-asyncio
-, pytest-mock
-, pytestCheckHook
-, pythonOlder
-, urllib3
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  httpx,
+  microsoft-kiota-abstractions,
+  opentelemetry-api,
+  opentelemetry-sdk,
+  pytest-asyncio,
+  pytest-mock,
+  pytestCheckHook,
+  pythonOlder,
+  urllib3,
 }:
 
 buildPythonPackage rec {
@@ -27,9 +28,7 @@ buildPythonPackage rec {
     hash = "sha256-I16WARk6YBr8KgE9MtHcA5VdsnLXBKcZOaqRL/eqwKE=";
   };
 
-  nativeBuildInputs = [
-    flit-core
-  ];
+  nativeBuildInputs = [ flit-core ];
 
   propagatedBuildInputs = [
     httpx
@@ -45,9 +44,7 @@ buildPythonPackage rec {
     urllib3
   ];
 
-  pythonImportsCheck = [
-    "kiota_http"
-  ];
+  pythonImportsCheck = [ "kiota_http" ];
 
   meta = with lib; {
     description = "HTTP request adapter implementation for Kiota clients for Python";

--- a/pkgs/development/python-modules/microsoft-kiota-http/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-http/default.nix
@@ -28,9 +28,9 @@ buildPythonPackage rec {
     hash = "sha256-I16WARk6YBr8KgE9MtHcA5VdsnLXBKcZOaqRL/eqwKE=";
   };
 
-  nativeBuildInputs = [ flit-core ];
+  build-system = [ flit-core ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     httpx
     microsoft-kiota-abstractions
     opentelemetry-api

--- a/pkgs/development/python-modules/microsoft-kiota-serialization-form/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-serialization-form/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  microsoft-kiota-abstractions,
+  pytest-asyncio,
+  pendulum,
+  pytest-mock,
+  pytestCheckHook,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "microsoft-kiota-serialization-form";
+  version = "0.1.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "kiota-serialization-form-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-ecFspbCaSkRoQTTeyZdqGpWSKiQJS6viDgBVNDHPo4g=";
+  };
+
+  build-system = [ flit-core ];
+
+  dependencies = [
+    microsoft-kiota-abstractions
+    pendulum
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "kiota_serialization_form" ];
+
+  meta = with lib; {
+    description = "Form serialization implementation for Kiota clients in Python";
+    homepage = "https://github.com/microsoft/kiota-serialization-form-python";
+    changelog = "https://github.com/microsoft/kiota-serialization-form-python/blob/${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/microsoft-kiota-serialization-json/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-serialization-json/default.nix
@@ -25,9 +25,9 @@ buildPythonPackage rec {
     hash = "sha256-igMqwoKArfQ37pzdjUICgXY795dfg/MX65iwTVe0sLM=";
   };
 
-  nativeBuildInputs = [ flit-core ];
+  build-system = [ flit-core ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     microsoft-kiota-abstractions
     pendulum
   ];

--- a/pkgs/development/python-modules/microsoft-kiota-serialization-json/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-serialization-json/default.nix
@@ -1,17 +1,18 @@
-{ lib
-, buildPythonPackage
-, fetchFromGitHub
-, flit-core
-, microsoft-kiota-abstractions
-, pendulum
-, pytest-asyncio
-, pytest-mock
-, pytestCheckHook
-, pythonOlder
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  microsoft-kiota-abstractions,
+  pendulum,
+  pytest-asyncio,
+  pytest-mock,
+  pytestCheckHook,
+  pythonOlder,
 }:
 
 buildPythonPackage rec {
-  pname = "kiota-serialization-json";
+  pname = "microsoft-kiota-serialization-json";
   version = "1.1.0";
   pyproject = true;
 
@@ -24,9 +25,7 @@ buildPythonPackage rec {
     hash = "sha256-igMqwoKArfQ37pzdjUICgXY795dfg/MX65iwTVe0sLM=";
   };
 
-  nativeBuildInputs = [
-    flit-core
-  ];
+  nativeBuildInputs = [ flit-core ];
 
   propagatedBuildInputs = [
     microsoft-kiota-abstractions
@@ -39,9 +38,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
-    "kiota_serialization_json"
-  ];
+  pythonImportsCheck = [ "kiota_serialization_json" ];
 
   disabledTests = [
     # Test compare an output format

--- a/pkgs/development/python-modules/microsoft-kiota-serialization-multipart/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-serialization-multipart/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  microsoft-kiota-abstractions,
+  microsoft-kiota-serialization-json,
+  pytest-asyncio,
+  pytest-mock,
+  pytestCheckHook,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "microsoft-kiota-serialization-multipart";
+  version = "0.1.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "kiota-serialization-multipart-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-OGX6vX02928F1uCP8bF/q1Z5aDrdj29iQNOITzF2LQI=";
+  };
+
+  build-system = [ flit-core ];
+
+  dependencies = [ microsoft-kiota-abstractions ];
+
+  nativeCheckInputs = [
+    microsoft-kiota-serialization-json
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "kiota_serialization_multipart" ];
+
+  meta = with lib; {
+    description = "Multipart serialization implementation for Kiota clients in Python";
+    homepage = "https://github.com/microsoft/kiota-serialization-multipart-python";
+    changelog = "https://github.com/microsoft/kiota-serialization-multipart-python/blob/${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/microsoft-kiota-serialization-text/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-serialization-text/default.nix
@@ -1,17 +1,18 @@
-{ lib
-, buildPythonPackage
-, fetchFromGitHub
-, flit-core
-, microsoft-kiota-abstractions
-, pytest-asyncio
-, pytest-mock
-, pytestCheckHook
-, python-dateutil
-, pythonOlder
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  microsoft-kiota-abstractions,
+  pytest-asyncio,
+  pytest-mock,
+  pytestCheckHook,
+  python-dateutil,
+  pythonOlder,
 }:
 
 buildPythonPackage rec {
-  pname = "kiota-serialization-text";
+  pname = "microsoft-kiota-serialization-text";
   version = "1.0.0";
   pyproject = true;
 
@@ -24,9 +25,7 @@ buildPythonPackage rec {
     hash = "sha256-jPuRfvqO4n5/PjSOS5NMCawaYRhXmrZtfg6LgYFCv7o=";
   };
 
-  nativeBuildInputs = [
-    flit-core
-  ];
+  nativeBuildInputs = [ flit-core ];
 
   propagatedBuildInputs = [
     microsoft-kiota-abstractions
@@ -39,9 +38,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
-    "kiota_serialization_text"
-  ];
+  pythonImportsCheck = [ "kiota_serialization_text" ];
 
   meta = with lib; {
     description = "Text serialization implementation for Kiota generated clients in Python";

--- a/pkgs/development/python-modules/microsoft-kiota-serialization-text/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-serialization-text/default.nix
@@ -25,9 +25,9 @@ buildPythonPackage rec {
     hash = "sha256-jPuRfvqO4n5/PjSOS5NMCawaYRhXmrZtfg6LgYFCv7o=";
   };
 
-  nativeBuildInputs = [ flit-core ];
+  build-system = [ flit-core ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     microsoft-kiota-abstractions
     python-dateutil
   ];

--- a/pkgs/development/python-modules/msgraph-sdk/default.nix
+++ b/pkgs/development/python-modules/msgraph-sdk/default.nix
@@ -6,7 +6,9 @@
   microsoft-kiota-abstractions,
   microsoft-kiota-authentication-azure,
   microsoft-kiota-http,
+  microsoft-kiota-serialization-form,
   microsoft-kiota-serialization-json,
+  microsoft-kiota-serialization-multipart,
   microsoft-kiota-serialization-text,
   msgraph-core,
   pythonOlder,
@@ -15,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "msgraph-sdk";
-  version = "1.1.0";
+  version = "1.2.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -24,7 +26,7 @@ buildPythonPackage rec {
     owner = "microsoftgraph";
     repo = "msgraph-sdk-python";
     rev = "refs/tags/v${version}";
-    hash = "sha256-fAchReqVhkVhT48UrTnBUQerHmgB7qxpey0xrgxIVDs=";
+    hash = "sha256-UaGdusPGWlF7gTzpCq9WrF/evdDSK5srrkH8/Vz9O8M=";
   };
 
   build-system = [ setuptools ];
@@ -34,7 +36,9 @@ buildPythonPackage rec {
     microsoft-kiota-abstractions
     microsoft-kiota-authentication-azure
     microsoft-kiota-http
+    microsoft-kiota-serialization-form
     microsoft-kiota-serialization-json
+    microsoft-kiota-serialization-multipart
     microsoft-kiota-serialization-text
     msgraph-core
   ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7317,6 +7317,8 @@ self: super: with self; {
 
   microsoft-kiota-serialization-json = callPackage ../development/python-modules/microsoft-kiota-serialization-json { };
 
+  microsoft-kiota-serialization-multipart = callPackage ../development/python-modules/microsoft-kiota-serialization-multipart { };
+
   microsoft-kiota-serialization-text = callPackage ../development/python-modules/microsoft-kiota-serialization-text { };
 
   midiutil = callPackage ../development/python-modules/midiutil { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7315,6 +7315,8 @@ self: super: with self; {
 
   microsoft-kiota-http = callPackage ../development/python-modules/microsoft-kiota-http { };
 
+  microsoft-kiota-serialization-form = callPackage ../development/python-modules/microsoft-kiota-serialization-form { };
+
   microsoft-kiota-serialization-json = callPackage ../development/python-modules/microsoft-kiota-serialization-json { };
 
   microsoft-kiota-serialization-multipart = callPackage ../development/python-modules/microsoft-kiota-serialization-multipart { };


### PR DESCRIPTION
Changelog: https://github.com/microsoftgraph/msgraph-sdk-python/releases/tag/v1.2.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
