### PR TITLE
meson: fix extraframework dependencies on case-sensitive APFS

### DIFF
--- a/pkgs/by-name/me/meson/007-case-sensitive-fs.patch
+++ b/pkgs/by-name/me/meson/007-case-sensitive-fs.patch
@@ -1,0 +1,87 @@
+From a6fb2c165cda4bbf315424c96165ec9cc7052363 Mon Sep 17 00:00:00 2001
+From: Randy Eckenrode <randy@largeandhighquality.com>
+Date: Wed, 3 Apr 2024 17:35:56 -0400
+Subject: [PATCH] dependencies: find extraframeworks on case-sensitive
+ filesystems
+
+Fixes a test failure on case-sensitive filesystems when a CMake
+dependency is turned into an Apple framework.
+---
+ mesonbuild/dependencies/framework.py              | 9 +++++++--
+ test cases/osx/11 case sensitive apfs/meson.build | 5 +++++
+ test cases/osx/11 case sensitive apfs/prog.c      | 3 +++
+ test cases/osx/11 case sensitive apfs/test.json   | 5 +++++
+ 4 files changed, 20 insertions(+), 2 deletions(-)
+ create mode 100644 test cases/osx/11 case sensitive apfs/meson.build
+ create mode 100644 test cases/osx/11 case sensitive apfs/prog.c
+ create mode 100644 test cases/osx/11 case sensitive apfs/test.json
+
+diff --git a/mesonbuild/dependencies/framework.py b/mesonbuild/dependencies/framework.py
+index 3c880c7430af..1fbd628235ba 100644
+--- a/mesonbuild/dependencies/framework.py
++++ b/mesonbuild/dependencies/framework.py
+@@ -47,6 +47,7 @@ def detect(self, name: str, paths: T.List[str]) -> None:
+             framework_path = self._get_framework_path(p, name)
+             if framework_path is None:
+                 continue
++            framework_name = framework_path.stem
+             # We want to prefer the specified paths (in order) over the system
+             # paths since these are "extra" frameworks.
+             # For example, Python2's framework is in /System/Library/Frameworks and
+@@ -54,11 +55,15 @@ def detect(self, name: str, paths: T.List[str]) -> None:
+             # Python.framework. We need to know for sure that the framework was
+             # found in the path we expect.
+             allow_system = p in self.system_framework_paths
+-            args = self.clib_compiler.find_framework(name, self.env, [p], allow_system)
++            args = self.clib_compiler.find_framework(framework_name, self.env, [p], allow_system)
+             if args is None:
+                 continue
+             self.link_args = args
+             self.framework_path = framework_path.as_posix()
++            # The search is done case-insensitively, so the found name may differ
++            # from the one that was requested. Setting the name ensures the correct
++            # one is used when linking on case-sensitive filesystems.
++            self.name = framework_name
+             self.compile_args = ['-F' + self.framework_path]
+             # We need to also add -I includes to the framework because all
+             # cross-platform projects such as OpenGL, Python, Qt, GStreamer,
+@@ -74,7 +79,7 @@ def _get_framework_path(self, path: str, name: str) -> T.Optional[Path]:
+         p = Path(path)
+         lname = name.lower()
+         for d in p.glob('*.framework/'):
+-            if lname == d.name.rsplit('.', 1)[0].lower():
++            if lname == d.stem.lower():
+                 return d
+         return None
+ 
+diff --git a/test cases/osx/11 case sensitive apfs/meson.build b/test cases/osx/11 case sensitive apfs/meson.build
+new file mode 100644
+index 000000000000..dd566b185f28
+--- /dev/null
++++ b/test cases/osx/11 case sensitive apfs/meson.build	
+@@ -0,0 +1,5 @@
++project('case-sensitive APFS with extra frameworks test', 'c')
++
++dep = dependency('FoUnDaTiOn')
++
++exe = executable('prog', 'prog.c', install : true, dependencies: dep)
+diff --git a/test cases/osx/11 case sensitive apfs/prog.c b/test cases/osx/11 case sensitive apfs/prog.c
+new file mode 100644
+index 000000000000..9b6bdc2ec2f0
+--- /dev/null
++++ b/test cases/osx/11 case sensitive apfs/prog.c	
+@@ -0,0 +1,3 @@
++int main(void) {
++    return 0;
++}
+diff --git a/test cases/osx/11 case sensitive apfs/test.json b/test cases/osx/11 case sensitive apfs/test.json
+new file mode 100644
+index 000000000000..a883714eaa27
+--- /dev/null
++++ b/test cases/osx/11 case sensitive apfs/test.json	
+@@ -0,0 +1,5 @@
++{
++  "installed": [
++    {"type": "file", "file": "usr/bin/prog"}
++  ]
++}

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -83,6 +83,10 @@ python3.pkgs.buildPythonApplication rec {
       url = "https://github.com/mesonbuild/meson/pull/13411.patch";
       hash = "sha256-IHSV0Dfse0lzDtxh/+APc/dzGr/BUbR/WIOqDsm7/8Y=";
     })
+
+    # Fix extraframework lookup on case-sensitive APFS.
+    # https://github.com/mesonbuild/meson/pull/13038
+    ./007-case-sensitive-fs.patch
   ];
 
   buildInputs = lib.optionals (python3.pythonOlder "3.9") [


### PR DESCRIPTION
## Description of changes

I ran into this while working on https://github.com/NixOS/nixpkgs/pull/301354. I built did full bootstraps with this patch as part of my work on that PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
