### PR TITLE
jfrog-cli: 2.52.10 -> 2.55.0

### DIFF
--- a/pkgs/tools/misc/jfrog-cli/default.nix
+++ b/pkgs/tools/misc/jfrog-cli/default.nix
@@ -59,6 +59,6 @@ buildGoModule rec {
     changelog = "https://github.com/jfrog/jfrog-cli/releases/tag/v${version}";
     license = licenses.asl20;
     mainProgram = "jf";
-    maintainers = with maintainers; [ detegr ];
+    maintainers = with maintainers; [ detegr aidalgol ];
   };
 }

--- a/pkgs/tools/misc/jfrog-cli/default.nix
+++ b/pkgs/tools/misc/jfrog-cli/default.nix
@@ -1,21 +1,45 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
+, nodejs
 , nix-update-script
 }:
 
 buildGoModule rec {
   pname = "jfrog-cli";
-  version = "2.52.10";
+  version = "2.56.0";
 
   src = fetchFromGitHub {
     owner = "jfrog";
     repo = "jfrog-cli";
     rev = "refs/tags/v${version}";
-    hash = "sha256-sqKlYHOpjIxNff1QK540Xxqr7w+WZ+pZXgfAKjRbMuM=";
+    hash = "sha256-a7zCPyKV9kZ34XxVBYotcMvXUVrieunFpKGBK1Jhvo4=";
   };
 
-  vendorHash = "sha256-Cm6Wu2U2i6WZfps1WLAjYuVZZ1y7J4WXFLmX2bkevd4=";
+  vendorHash = "sha256-q0PXbLTS5Po3xTK+CkU7BtZ6tk1PfH3zVAVK1IbmitY=";
+
+  # Upgrade the Go version during the vendoring FOD build because it fails otherwise.
+  overrideModAttrs = _: {
+    preBuild = ''
+      substituteInPlace go.mod --replace-fail 'go 1.20' 'go 1.21'
+    '';
+    postInstall = ''
+      cp go.mod "$out/go.mod"
+    '';
+  };
+
+  # Copy the modified go.mod we got from the vendoring process.
+  preBuild = ''
+    cp vendor/go.mod go.mod
+  '';
+
+  postPatch = ''
+    # Patch out broken test cleanup.
+    substituteInPlace artifactory_test.go \
+      --replace-fail \
+      'deleteReceivedReleaseBundle(t, "cli-tests", "2")' \
+      '// deleteReceivedReleaseBundle(t, "cli-tests", "2")'
+  '';
 
   postInstall = ''
     # Name the output the same way as the original build script does
@@ -24,6 +48,8 @@ buildGoModule rec {
 
   # Some of the tests require a writable $HOME
   preCheck = "export HOME=$TMPDIR";
+
+  nativeCheckInputs = [ nodejs ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/tools/misc/jfrog-cli/default.nix
+++ b/pkgs/tools/misc/jfrog-cli/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
+, nix-update-script
 }:
 
 buildGoModule rec {
@@ -23,6 +24,8 @@ buildGoModule rec {
 
   # Some of the tests require a writable $HOME
   preCheck = "export HOME=$TMPDIR";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/jfrog/jfrog-cli";


### PR DESCRIPTION
## Description of changes
* Set update script.
* Update to latest release.
* Add myself as maintainer.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
