### PR TITLE
forgejo-runner: rename from forgejo-actions-runner, fix `meta.changelog`, 3.3.0 -> 3.4.1

### DIFF
--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -7,17 +7,17 @@
 
 buildGoModule rec {
   pname = "forgejo-runner";
-  version = "3.3.0";
+  version = "3.4.1";
 
   src = fetchFromGitea {
     domain = "code.forgejo.org";
     owner = "forgejo";
     repo = "runner";
     rev = "v${version}";
-    hash = "sha256-ZpsHytsIp+ZW4DI7X9MmI7nZRnXVHvx905YdZGS6WMY=";
+    hash = "sha256-c8heIHt+EJ6LnZT4/6TTWd7v85VRHjH72bdje12un4M=";
   };
 
-  vendorHash = "sha256-5GnGXpMy1D7KpVAVroX07Vw5QKYYtwdIhQsk23WCLgc=";
+  vendorHash = "sha256-FCCQZdAYRtJR3DGQIEvUzv+1kqvxVTGkwJwZSohq28s=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -37,7 +37,7 @@ buildGoModule rec {
     homepage = "https://code.forgejo.org/forgejo/runner";
     changelog = "https://gitea.com/gitea/act_runner/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ kranzes ];
+    maintainers = with maintainers; [ kranzes emilylange ];
     mainProgram = "act_runner";
   };
 }

--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -35,7 +35,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "A runner for Forgejo based on act";
     homepage = "https://code.forgejo.org/forgejo/runner";
-    changelog = "https://gitea.com/gitea/act_runner/releases/tag/${src.rev}";
+    changelog = "https://code.forgejo.org/forgejo/runner/src/tag/${src.rev}/RELEASE-NOTES.md";
     license = licenses.mit;
     maintainers = with maintainers; [ kranzes emilylange ];
     mainProgram = "act_runner";

--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -2,11 +2,11 @@
 , buildGoModule
 , fetchFromGitea
 , testers
-, forgejo-actions-runner
+, forgejo-runner
 }:
 
 buildGoModule rec {
-  pname = "forgejo-actions-runner";
+  pname = "forgejo-runner";
   version = "3.3.0";
 
   src = fetchFromGitea {
@@ -28,7 +28,7 @@ buildGoModule rec {
   doCheck = false; # Test try to lookup code.forgejo.org.
 
   passthru.tests.version = testers.testVersion {
-    package = forgejo-actions-runner;
+    package = forgejo-runner;
     version = src.rev;
   };
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -355,6 +355,7 @@ mapAliases ({
   flutter2 = throw "flutter2 has been removed because it isn't updated anymore, and no packages in nixpkgs use it. If you still need it, use flutter.mkFlutter to get a custom version"; # Added 2023-07-03
   flutter37 = throw "flutter37 has been removed because it isn't updated anymore, and no packages in nixpkgs use it. If you still need it, use flutter.mkFlutter to get a custom version"; # Added 2023-07-03
   foldingathome = fahclient; # Added 2020-09-03
+  forgejo-actions-runner = forgejo-runner; # Added 2024-04-04
 
   foundationdb51 = throw "foundationdb51 is no longer maintained, use foundationdb71 instead"; # added 2023-06-06
   foundationdb52 = throw "foundationdb52 is no longer maintained, use foundationdb71 instead"; # added 2023-06-06

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8484,8 +8484,6 @@ with pkgs;
 
   forgejo = callPackage ../applications/version-management/forgejo { };
 
-  forgejo-actions-runner = callPackage ../development/tools/continuous-integration/forgejo-actions-runner { };
-
   gokart = callPackage ../development/tools/gokart { };
 
   gl2ps = callPackage ../development/libraries/gl2ps { };


### PR DESCRIPTION
## Description of changes

This is to match the name upstream and other repositories use.

See https://code.forgejo.org/forgejo/runner and https://repology.org/project/forgejo-runner/versions

Furthermore, upstream calls the resulting binary `forgejo-runner` instead of `act_runner`.

https://code.forgejo.org/forgejo/runner/src/tag/v3.3.0/Makefile#L2

We should probably copy this.

Also adds me as maintainer, fixes the `meta.changelog` to something actually useful and bumps the package from 3.3.0 to 3.4.1.

https://code.forgejo.org/forgejo/runner/releases/tag/v3.4.0
https://code.forgejo.org/forgejo/runner/releases/tag/v3.4.1
changelog: https://code.forgejo.org/forgejo/runner/src/tag/v3.4.1/RELEASE-NOTES.md
diff: https://code.forgejo.org/forgejo/runner/compare/v3.3.0...v3.4.0
diff: https://code.forgejo.org/forgejo/runner/compare/v3.4.0...v3.4.1

Given the package name now matches the one other package repositories use, nixpkgs-update is likely able to catch outdated versions for once.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
