### PR TITLE
tbb: 2021.8.0 -> 2021.11.0

### DIFF
--- a/pkgs/applications/misc/bambu-studio/default.nix
+++ b/pkgs/applications/misc/bambu-studio/default.nix
@@ -38,7 +38,7 @@
 , pcre
 , qhull
 , systemd
-, tbb_2021_8
+, tbb_2021_11
 , webkitgtk
 , wxGTK31
 , xorg
@@ -53,7 +53,7 @@ let
     ];
   });
   openvdb_tbb_2021_8 = openvdb.overrideAttrs (old: rec {
-    buildInputs = [ openexr boost179 tbb_2021_8 jemalloc c-blosc ilmbase ];
+    buildInputs = [ openexr boost179 tbb_2021_11 jemalloc c-blosc ilmbase ];
   });
 in
 stdenv.mkDerivation rec {
@@ -102,7 +102,7 @@ stdenv.mkDerivation rec {
     opencascade-occt
     openvdb_tbb_2021_8
     pcre
-    tbb_2021_8
+    tbb_2021_11
     webkitgtk
     wxGTK31'
     xorg.libX11

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -27,7 +27,7 @@
 , openvdb
 , pcre
 , qhull
-, tbb_2021_8
+, tbb_2021_11
 , wxGTK32
 , xorg
 , libbgcode
@@ -61,7 +61,7 @@ let
       hash = "sha256-WNdAYu66ggpSYJ8Kt57yEA4mSTv+Rvzj9Rm1q765HpY=";
     };
   });
-  openvdb_tbb_2021_8 = openvdb.override { tbb = tbb_2021_8; };
+  openvdb_tbb_2021_8 = openvdb.override { tbb = tbb_2021_11; };
   wxGTK-override' = if wxGTK-override == null then wxGTK-prusa else wxGTK-override;
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -104,7 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
     openvdb_tbb_2021_8
     pcre
     qhull
-    tbb_2021_8
+    tbb_2021_11
     wxGTK-override'
     xorg.libX11
     libbgcode

--- a/pkgs/by-name/op/openscad-unstable/package.nix
+++ b/pkgs/by-name/op/openscad-unstable/package.nix
@@ -31,7 +31,7 @@
 , mesa
 , mpfr
 , python3
-, tbb_2021_8
+, tbb_2021_11
 , wayland
 , wayland-protocols
 , wrapGAppsHook
@@ -51,7 +51,7 @@ let
       hash = "sha256-f11CNfa8jF9VbzvOoX1vT8zGIJL9cZ/VBpiklUn0YdU=";
     };
     nativeBuildInputs = [ cmake pkg-config ];
-    buildInputs = [ tbb_2021_8 ];
+    buildInputs = [ tbb_2021_11 ];
     cmakeFlags = [
       # only enable what we need
       "-DCCCL_ENABLE_CUB=OFF"
@@ -105,7 +105,7 @@ clangStdenv.mkDerivation rec {
     # manifold dependencies
     clipper2
     glm
-    tbb_2021_8
+    tbb_2021_11
     nvidia-cccl
 
     boost

--- a/pkgs/by-name/pd/pdf4qt/package.nix
+++ b/pkgs/by-name/pd/pdf4qt/package.nix
@@ -7,7 +7,7 @@
 , pkg-config
 , qt6
 , openjpeg
-, tbb_2021_8
+, tbb_2021_11
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.qtspeech
     lcms
     openjpeg
-    tbb_2021_8
+    tbb_2021_11
   ];
 
   cmakeFlags = [

--- a/pkgs/by-name/sa/salmon/package.nix
+++ b/pkgs/by-name/sa/salmon/package.nix
@@ -13,7 +13,7 @@
 , libiconv
 , libstaden-read
 , pkg-config
-, tbb_2021_8
+, tbb_2021_11
 , xz
 , zlib
 }:
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     jemalloc
     libgff
     libstaden-read
-    tbb_2021_8
+    tbb_2021_11
     xz
     zlib
   ] ++ lib.optionals stdenv.isDarwin [ libiconv ];

--- a/pkgs/by-name/ue/ueberzugpp/package.nix
+++ b/pkgs/by-name/ue/ueberzugpp/package.nix
@@ -6,7 +6,7 @@
 , openssl
 , zeromq
 , cppzmq
-, tbb_2021_8
+, tbb_2021_11
 , spdlog
 , libsodium
 , fmt
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     openssl
     zeromq
     cppzmq
-    tbb_2021_8
+    tbb_2021_11
     spdlog
     libsodium
     fmt

--- a/pkgs/development/libraries/tbb/default.nix
+++ b/pkgs/development/libraries/tbb/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   pname = "tbb";
-  version = "2021.8.0";
+  version = "2021.11.0";
 
   outputs = [ "out" "dev" ];
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     owner = "oneapi-src";
     repo = "oneTBB";
     rev = "v${version}";
-    hash = "sha256-7MjUdPB1GsPt7ZkYj7DCisq20X8psljsVCjDpCSTYT4=";
+    hash = "sha256-zGZHMtAUVzBKFbCshpepm3ce3tW6wQ+F30kYYXAQ/TE=";
   };
 
   nativeBuildInputs = [
@@ -28,27 +28,11 @@ stdenv.mkDerivation rec {
       url = "https://patch-diff.githubusercontent.com/raw/oneapi-src/oneTBB/pull/899.patch";
       hash = "sha256-kU6RRX+sde0NrQMKlNtW3jXav6J4QiVIUmD50asmBPU=";
     })
-
-    # Fix/suppress warnings on gcc12.1 from https://github.com/oneapi-src/oneTBB/pull/866
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/oneapi-src/oneTBB/pull/866.patch";
-      hash = "sha256-e44Yv84Hfl5xoxWWTnLJLSGeNA1RBbah4/L43gPLS+c=";
-    })
-
-    # Fix build with GCC 13
-    (fetchpatch {
-      url = "https://github.com/oneapi-src/oneTBB/commit/154cc73ca4d359621202399cc0c3c91058e56e79.patch";
-      hash = "sha256-BVQQXgBg8T19DGw2gmFkm3KKOuzzJJNOTf/iNIcnHag=";
-    })
-    (fetchpatch {
-      url = "https://github.com/oneapi-src/oneTBB/commit/e131071769ee3df51b56b053ba6bfa06ae9eff25.patch";
-      hash = "sha256-IfV/DDb0luxE1l6TofAbQIeJEVxCxZfZqcONGwQEndY=";
-    })
   ];
 
   # Fix build with modern gcc
   # In member function 'void std::__atomic_base<_IntTp>::store(__int_type, std::memory_order) [with _ITp = bool]',
-  NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isGNU [ "-Wno-error=stringop-overflow" ] ++
+  NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isGNU [ "-Wno-error=array-bounds" "-Wno-error=stringop-overflow" ] ++
     # error: variable 'val' set but not used
     lib.optionals stdenv.cc.isClang [ "-Wno-error=unused-but-set-variable" ] ++
     # Workaround for gcc-12 ICE when using -O3

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17093,7 +17093,7 @@ with pkgs;
   swiPrologWithGui = swiProlog.override { withGui = true; };
 
   tbb_2020_3 = callPackage ../development/libraries/tbb/2020_3.nix { };
-  tbb_2021_8 = callPackage ../development/libraries/tbb { };
+  tbb_2021_11 = callPackage ../development/libraries/tbb { };
   # many packages still fail with latest version
   tbb = tbb_2020_3;
 
@@ -19085,7 +19085,7 @@ with pkgs;
 
   ikos = callPackage ../development/tools/analysis/ikos {
     inherit (llvmPackages_14) stdenv clang llvm;
-    tbb = tbb_2021_8;
+    tbb = tbb_2021_11;
   };
 
   img = callPackage ../development/tools/img { };
@@ -19331,7 +19331,7 @@ with pkgs;
 
   mold = callPackage ../development/tools/mold {
     stdenv = if stdenv.isDarwin then overrideLibcxx darwin.apple_sdk_11_0.llvmPackages_16.stdenv else stdenv;
-    tbb = tbb_2021_8;
+    tbb = tbb_2021_11;
   };
 
   mold-wrapped = wrapBintoolsWith {
@@ -20479,7 +20479,7 @@ with pkgs;
   ccrtp = callPackage ../development/libraries/ccrtp { };
 
   cctag = callPackage ../development/libraries/cctag {
-    tbb = tbb_2021_8;
+    tbb = tbb_2021_11;
   };
 
   cctz = callPackage ../development/libraries/cctz {


### PR DESCRIPTION
Fixes #301390

## Description of changes

Updates `tbb` to `2021.11.0`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@thoughtpolice @hesiod 