### PR TITLE
hujsonfmt: init at 0-unstable-2022-12-23

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4348,6 +4348,13 @@
       fingerprint = "4779 D1D5 3C97 2EAE 34A5  ED3D D8AF C4BF 0567 0F9D";
     }];
   };
+  dan-theriault = {
+    email = "nix@theriault.codes";
+    github = "Dan-Theriault";
+    githubId = 13945563;
+    matrix = "@dan:matrix.org";
+    name = "Daniel Theriault";
+  };
   dariof4 = {
     name = "dariof4";
     email = "dazedtank@gmail.com";

--- a/pkgs/by-name/hu/hujsonfmt/package.nix
+++ b/pkgs/by-name/hu/hujsonfmt/package.nix
@@ -1,0 +1,29 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+let
+  inherit (lib) licenses maintainers;
+in
+buildGoModule {
+  pname = "hujsonfmt";
+  version = "0-unstable-2022-12-23";
+
+  src = fetchFromGitHub {
+    owner = "tailscale";
+    repo = "hujson";
+    rev = "20486734a56a3455c47994bf4942974d6f9969a0";
+    hash = "sha256-j2HRs5zZ0jTIqWIRhHheO9eaGzMMkNuKXuhboq9KpB4=";
+  };
+
+  proxyVendor = true;
+  vendorHash = "sha256-cvoj85BNnm/ZX1UnXKU2HjvjQkRZ9uN3U0BnD3DmiTE=";
+
+  subPackages = [ "cmd/hujsonfmt" ];
+
+  meta = {
+    homepage = "https://tailscale.com";
+    description = "Automatic formatter for HuJSON / JSON With Comments and trailing Commas (JWCC)";
+    license = licenses.bsd3;
+    mainProgram = "hujsonfmt";
+    maintainers = with maintainers; [ dan-theriault ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Package Tailscale's formatter for HuJSON / JSON With Comments and trailing Commas (JWCC). Tailscale uses this format for its ACL configurations. This formatter is useful if you are managing such configurations via GitOps (rather than the web interface). It also provides a transformation from JWCC to plain JSON, which may be more broadly useful.

JWCC is described at https://nigeltao.github.io/blog/2021/json-with-commas-comments.html

No releases of this utility have been cut, but it's been stable for over a year in its current form. Open to discussion as to whether this belongs in nixpkgs, but I have the package definition & am willing to maintain it. I am not aware of an alternative JWCC formatter.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
