### PR TITLE
rofi-games: init at 1.10.2

### DIFF
--- a/pkgs/by-name/ro/rofi-games/fix-justfile.patch
+++ b/pkgs/by-name/ro/rofi-games/fix-justfile.patch
@@ -1,0 +1,26 @@
+diff --git a/justfile b/justfile
+index cd111a1..b6f3827 100644
+--- a/justfile
++++ b/justfile
+@@ -13,9 +13,9 @@ PKGNAME := env("PKGNAME", "rofi-games")
+ PKGDIR := env("PKGDIR", "")
+ LIB_NAME := "librofi_games.so"
+ PLUGIN_NAME := "games.so"
+-THEMES_DIR := "/usr/share/rofi/themes"
+-LICENSES_DIR := "/usr/share/licenses/" + PKGNAME
+-PLUGINS_DIR := `pkg-config --variable pluginsdir rofi || if test -d "/usr/lib64"; then echo "/usr/lib64/rofi"; else echo "/usr/lib/rofi"; fi`
++THEMES_DIR := "/share/rofi/themes"
++LICENSES_DIR := "/share/licenses/" + PKGNAME
++PLUGINS_DIR := "/lib/rofi"
+ PLUGIN_PATH := join(PLUGINS_DIR, PLUGIN_NAME)
+ 
+ # Set rust flags if running a version of `rofi` with changes newer than the base `1.7.5`
+@@ -32,7 +32,7 @@ RUSTFLAGS := if `rofi -version` =~ '^Version: 1\.7\.5(?:\+wayland2)?$' { "" } el
+ 
+ # List commands
+ default:
+-    just --list
++    just build
+ 
+ # Build
+ build:

--- a/pkgs/by-name/ro/rofi-games/package.nix
+++ b/pkgs/by-name/ro/rofi-games/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  cargo,
+  just,
+  rofi,
+  pkg-config,
+  glib,
+  cairo,
+  pango,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rofi-games";
+  version = "1.10.2";
+
+  src = fetchFromGitHub {
+    owner = "Rolv-Apneseth";
+    repo = "rofi-games";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-4L3gk/RG9g5QnUW1AJkZIl0VkBiO/L0HUBC3pibN/qo=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-cU7gp/c1yx3ZLaZuGs1bvOV4AKgLusraILVJ2EhH1iA=";
+  };
+
+  patches = [
+    # fix the install locations of files and set default just task
+    ./fix-justfile.patch
+  ];
+
+  env.PKGDIR = placeholder "out";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    cargo
+    just
+    rofi
+    pkg-config
+  ];
+
+  buildInputs = [
+    glib
+    cairo
+    pango
+  ];
+
+  meta = {
+    changelog = "https://github.com/Rolv-Apneseth/rofi-games/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    description = "Rofi plugin which adds a mode that will list available games for launch along with their box art";
+    homepage = "https://github.com/Rolv-Apneseth/rofi-games";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Closes: https://github.com/NixOS/nixpkgs/issues/301374
Related: https://github.com/Rolv-Apneseth/rofi-games/issues/19

This PR adds 1 package: `rofi-games`
- the package builds a rofi plugin: (the .so file)
- and it also includes the recommended rofi themes


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
