### PR TITLE
cozette: add .psf

### DIFF
--- a/pkgs/data/fonts/cozette/default.nix
+++ b/pkgs/data/fonts/cozette/default.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation rec {
     install -Dm644 *.woff2 -t $out/share/fonts/woff2
 
     for f in *.fnt; do fnt2psf $f $(basename -- $f .fnt).psf; done
-    install -Dm644 *.psf -t $out/share/fonts/misc
+    install -Dm644 *.psf -t $out/share/consolefonts
 
     runHook postInstall
   '';

--- a/pkgs/data/fonts/cozette/default.nix
+++ b/pkgs/data/fonts/cozette/default.nix
@@ -16,6 +16,7 @@ stdenvNoCC.mkDerivation rec {
     install -Dm644 *.otf -t $out/share/fonts/opentype
     install -Dm644 *.bdf -t $out/share/fonts/misc
     install -Dm644 *.otb -t $out/share/fonts/misc
+    install -Dm644 *.psf -t $out/share/fonts/misc
     install -Dm644 *.woff -t $out/share/fonts/woff
     install -Dm644 *.woff2 -t $out/share/fonts/woff2
 

--- a/pkgs/data/fonts/cozette/default.nix
+++ b/pkgs/data/fonts/cozette/default.nix
@@ -16,7 +16,7 @@ stdenvNoCC.mkDerivation rec {
     install -Dm644 *.otf -t $out/share/fonts/opentype
     install -Dm644 *.bdf -t $out/share/fonts/misc
     install -Dm644 *.otb -t $out/share/fonts/misc
-    install -Dm644 *.psf -t $out/share/fonts/misc
+    install -Dm644 *.fnt -t $out/share/fonts/misc
     install -Dm644 *.woff -t $out/share/fonts/woff
     install -Dm644 *.woff2 -t $out/share/fonts/woff2
 

--- a/pkgs/data/fonts/cozette/default.nix
+++ b/pkgs/data/fonts/cozette/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, fetchzip }:
+{ lib, stdenvNoCC, fetchzip, psftools }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "cozette";
@@ -8,6 +8,8 @@ stdenvNoCC.mkDerivation rec {
     url = "https://github.com/slavfox/Cozette/releases/download/v.${version}/CozetteFonts-v-${builtins.replaceStrings ["."] ["-"] version}.zip";
     hash = "sha256-v1UWrVx1PnNPiFtMMy4kOkIe//iHxx0LOA4nHo95Zws=";
   };
+
+  buildInputs = [ psftools ];
 
   installPhase = ''
     runHook preInstall
@@ -19,6 +21,9 @@ stdenvNoCC.mkDerivation rec {
     install -Dm644 *.fnt -t $out/share/fonts/misc
     install -Dm644 *.woff -t $out/share/fonts/woff
     install -Dm644 *.woff2 -t $out/share/fonts/woff2
+
+    for f in *.fnt; do fnt2psf $f $(basename -- $f .fnt).psf; done
+    install -Dm644 *.psf -t $out/share/fonts/misc
 
     runHook postInstall
   '';


### PR DESCRIPTION
This should make it easier to use cozette as a `console.font`.