### PR TITLE
airbuddy: 2.7.1 -> 2.7.2

### DIFF
--- a/pkgs/os-specific/darwin/airbuddy/default.nix
+++ b/pkgs/os-specific/darwin/airbuddy/default.nix
@@ -6,12 +6,12 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "airbuddy";
-  version = "2.7.1";
+  version = "2.7.2";
 
   src = fetchurl {
     name = "AirBuddy.dmg";
     url = "https://download.airbuddy.app/WebDownload/AirBuddy_v${finalAttrs.version}.dmg";
-    hash = "sha256-z8iy3kIBO+1HDgmWxXmFHArLdw85CLNSMvMFZfEJAp0=";
+    hash = "sha256-bsxVfWthmetF0gfMgsZRAfdNzhplU+NpK+Xtk5NFaeg=";
   };
 
   dontPatch = true;


### PR DESCRIPTION
## Description of changes

What's new in AirBuddy 2.7.2

- Improved AirPods connection reliability in macOS Ventura and later
- Improved reliability of Spatial Audio control, especially for apps that don’t show up in now playing
- Improved support for AirPods Pro (2nd generation) USB-C charging case (macOS Ventura and later)
- In macOS Ventura and later, charged battery alerts will now work for AirPods Pro (2nd generation) even when they're charging inside the case with the lid closed
- In macOS Sonoma, the AirBuddy volume indicator will no longer show up for volume changes caused by the Personalized Volume feature on AirPods Pro (2nd generation)
- Addresses an issue that could cause repeated low battery alerts for some AirPods models
- Addresses an issue where a battery indicator could be partially hidden in the small status window when using increased font size
- Addresses an issue that could cause AirBuddy to display incorrect charging case battery information when only a single AirPod was inside the charging case

## Things done

As there is new version of AirBuddy binary I've updated it. 

Remark: Download URL for AirBuddy returns newest version regardless of the version requested in file name, so it breaks "building" every time version changes.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
