### PR TITLE
zitadel-bin: init at 2.49.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1025,6 +1025,7 @@ in {
   zeronet-conservancy = handleTest ./zeronet-conservancy.nix {};
   zfs = handleTest ./zfs.nix {};
   zigbee2mqtt = handleTest ./zigbee2mqtt.nix {};
+  zitadel = handleTest ./web-apps/zitadel.nix {};
   zoneminder = handleTest ./zoneminder.nix {};
   zookeeper = handleTest ./zookeeper.nix {};
   zram-generator = handleTest ./zram-generator.nix {};

--- a/nixos/tests/web-apps/zitadel.nix
+++ b/nixos/tests/web-apps/zitadel.nix
@@ -1,0 +1,92 @@
+import ../make-test-python.nix (
+  { lib, pkgs, ... }:
+  {
+    name = "zitadel";
+
+    meta.maintainers = with lib.maintainers; [ bhankas ];
+
+    nodes.machine =
+      { config, ... }:
+      {
+        virtualisation.memorySize = 2048;
+
+        environment.etc."zitadel/zitadel.env".text = ''
+          foobar
+        '';
+
+        services = {
+          postgresql = {
+            enable = true;
+            ensureUsers = [
+              {
+                name = "postgres";
+                ensureClauses = {
+                  login = true;
+                  superuser = true;
+                  createrole = true;
+                  createdb = true;
+                };
+              }
+              {
+                name = "zitadel";
+                ensureClauses = {
+                  login = true;
+                  createrole = true;
+                  createdb = true;
+                };
+              }
+            ];
+          };
+
+          zitadel = {
+            enable = true;
+            package = pkgs.zitadel-bin;
+            openFirewall = false;
+            tlsMode = "disabled";
+            masterKeyFile = "/etc/zitadel/zitadel.env";
+            settings = {
+              Port = 8080;
+              ExternalDomain = "https://foo.bar.com";
+            };
+            steps = {
+              bhankas = {
+                InstanceName = "testinstance";
+                Org.Human = {
+                  UserName = "userName";
+                  FirstName = "fName";
+                  LastName = "lName";
+                };
+              };
+            };
+          };
+        };
+
+        systemd.services.zitadel.environment = {
+          ZITADEL_DATABASE_POSTGRES_HOST = "localhost";
+          ZITADEL_DATABASE_POSTGRES_PORT = "5432";
+          ZITADEL_DATABASE_POSTGRES_DATABASE = "zitadel";
+          ZITADEL_DATABASE_POSTGRES_USER_USERNAME = "zitadel";
+          ZITADEL_DATABASE_POSTGRES_USER_PASSWORD = "zitadel";
+          ZITADEL_DATABASE_POSTGRES_USER_SSL_MODE = "disable";
+          ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME = "postgres";
+          ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE = "postgres";
+        };
+      };
+
+    testScript = ''
+      start_all()
+      machine.wait_for_unit("zitadel.service")
+      machine.wait_for_open_port(8080)
+      machine.sleep(5)
+
+      with subtest("zitadel bin works"):
+          machine.succeed("${lib.getExe pkgs.zitadel-bin} ready")
+
+      with subtest("zitadel service starts"):
+          machine.wait_until_succeeds(
+              "curl -sSfL http://localhost:8080/ > /dev/null",
+              timeout=30
+          )
+    '';
+  }
+)

--- a/pkgs/by-name/zi/zitadel-bin/package.nix
+++ b/pkgs/by-name/zi/zitadel-bin/package.nix
@@ -1,0 +1,50 @@
+{
+  fetchurl,
+  lib,
+  stdenv,
+  autoPatchelfHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zitadel-bin";
+  version = "2.49.0";
+  system =
+    if stdenv.isLinux && stdenv.isx86_64 then
+      "linux-amd64"
+    else if stdenv.isLinux && stdenv.isAarch64 then
+      "linux-arm64"
+    else
+      "";
+
+  src = fetchurl {
+    url = "https://github.com/zitadel/zitadel/releases/download/v${finalAttrs.version}/zitadel-${finalAttrs.system}.tar.gz";
+
+    hash =
+      if stdenv.isLinux && stdenv.isAarch64 then
+        "sha256-JPOLtXnmA+LW2X8ZCRSjZLdsYJCUof8dcV0pZX0lXNY="
+      else if stdenv.isLinux && stdenv.isx86_64 then
+        "sha256-PuDSXmvqHEUzqKbJ11PZ7W9Q8snhmawPUT8QfDm0TcA="
+      else
+        builtins.throw "Unsupported platform, please contact Nixpkgs maintainers for zitadel package";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  installPhase = ''
+    tar -xf $src
+    runHook preInstall
+    install -D zitadel-${finalAttrs.system}/zitadel $out/bin/zitadel
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Identity and access management platform";
+    homepage = "https://zitadel.com/";
+    downloadPage = "https://github.com/zitadel/zitadel/releases";
+    platforms = platforms.linux;
+    license = licenses.asl20;
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    maintainers = with maintainers; [ bhankas ];
+    mainProgram = "zitadel";
+  };
+})


### PR DESCRIPTION
## Description of changes

zitadel source build has issues with protocol hash mismatch in nixpkgs (see #298208).

One of the suggested solutions is to package binary release until upstream gets a chance to fix.

This PR adds a new package `zitadel-bin` to address that. Also added is a nixos module test for `services.zitadel` using binary package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
