### PR TITLE
box2d: multiple changes

### DIFF
--- a/pkgs/development/libraries/box2d/default.nix
+++ b/pkgs/development/libraries/box2d/default.nix
@@ -1,37 +1,72 @@
-{ lib, stdenv, fetchFromGitHub, cmake, libGLU, libGL, freeglut, libX11, xorgproto
-, libXi, pkg-config }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, libGLU
+, libGL
+, freeglut
+, libX11
+, libXcursor
+, libXinerama
+, libXrandr
+, xorgproto
+, libXi
+, pkg-config
+, Carbon
+, Cocoa
+, Kernel
+, OpenGL
+, settingsFile ? "include/box2d/b2_settings.h"
+}:
 
-stdenv.mkDerivation rec {
+let
+  inherit (lib) cmakeBool optionals;
+
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "box2d";
-  version = "2.3.1";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "erincatto";
     repo = "box2d";
-    rev = "v${version}";
-    sha256 = "sha256-Z2J17YMzQNZqABIa5eyJDT7BWfXveymzs+DWsrklPIs=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-cL8L+WSTcswj+Bwy8kSOwuEqLyWEM6xa/j/94aBiSck=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ libGLU libGL freeglut libX11 xorgproto libXi ];
+
+  buildInputs = [
+    libGLU
+    libGL
+    freeglut
+    libX11
+    libXcursor
+    libXinerama
+    libXrandr
+    xorgproto
+    libXi
+  ] ++ optionals stdenv.isDarwin [
+    Carbon Cocoa Kernel OpenGL
+  ];
 
   cmakeFlags = [
-    "-DBOX2D_INSTALL=ON"
-    "-DBOX2D_BUILD_SHARED=ON"
-    "-DBOX2D_BUILD_EXAMPLES=OFF"
+    (cmakeBool "BOX2D_BUILD_UNIT_TESTS" finalAttrs.doCheck)
   ];
 
   prePatch = ''
-    cd Box2D
-    substituteInPlace Box2D/Common/b2Settings.h \
-      --replace 'b2_maxPolygonVertices	8' 'b2_maxPolygonVertices	15'
+    substituteInPlace ${settingsFile}  \
+      --replace-fail 'b2_maxPolygonVertices	8' 'b2_maxPolygonVertices	15'
   '';
+
+  # tests are broken on 2.4.1 and 2.3.x doesn't have tests: https://github.com/erincatto/box2d/issues/677
+  doCheck = lib.versionAtLeast finalAttrs.version "2.4.2";
 
   meta = with lib; {
     description = "2D physics engine";
     homepage = "https://box2d.org/";
-    maintainers = [ maintainers.raskin ];
+    maintainers = with maintainers; [ raskin ];
     platforms = platforms.unix;
     license = licenses.zlib;
   };
-}
+})

--- a/pkgs/development/libraries/qmlbox2d/default.nix
+++ b/pkgs/development/libraries/qmlbox2d/default.nix
@@ -1,31 +1,51 @@
-{lib, stdenv, qtdeclarative, fetchFromGitHub, qmake }:
+{ lib, stdenv, qtbase, qtdeclarative, fetchFromGitHub, cmake, pkg-config, box2d }:
+
+let
+  inherit (lib) cmakeBool;
+
+  # 2.3.1 is the only supported version
+  box2d' = (box2d.override { settingsFile = "Box2D/Common/b2Settings.h"; }).overrideAttrs (old: rec {
+    version = "2.3.1";
+    src = fetchFromGitHub {
+      owner = "erincatto";
+      repo = "box2d";
+      rev = "v${version}";
+      hash = "sha256-Z2J17YMzQNZqABIa5eyJDT7BWfXveymzs+DWsrklPIs=";
+    };
+    sourceRoot = "source/Box2D";
+    cmakeFlags = old.cmakeFlags or [ ] ++ [
+      (cmakeBool "BOX2D_INSTALL" true)
+      (cmakeBool "BOX2D_BUILD_SHARED" true)
+      (cmakeBool "BOX2D_BUILD_EXAMPLES" false)
+    ];
+  });
+
+in
 stdenv.mkDerivation {
   pname = "qml-box2d";
-  version = "unstable-2018-04-06";
+  version = "unstable-2022-08-25";
+
   src = fetchFromGitHub {
     owner = "qml-box2d";
     repo = "qml-box2d";
-    sha256 = "0gb8limy6ck23z3k0k2j7c4c4s95p40f6lbzk4szq7fjnnw22kb7";
-    rev = "b7212d5640701f93f0cd88fbd3a32c619030ae62";
+    rev = "0bb88a6f871eef72b3b9ded9329c15f1da1f4fd7";
+    hash = "sha256-sfSVetpHIAIujpgjvRScAkJRlQQYjQ/yQrkWvp7Yu0s=";
   };
 
   dontWrapQtApps = true;
-  nativeBuildInputs = [ qmake ];
 
-  buildInputs = [ qtdeclarative ];
+  nativeBuildInputs = [ cmake pkg-config ];
 
-  patchPhase = ''
-    substituteInPlace box2d.pro \
-      --replace '$$[QT_INSTALL_QML]' "/$qtQmlPrefix/"
-    qmakeFlags="$qmakeFlags PREFIXSHORTCUT=$out"
-    '';
+  buildInputs = [ box2d' qtbase qtdeclarative ];
 
-  installFlags = [ "INSTALL_ROOT=$(out)" ];
+  cmakeFlags = [
+    (cmakeBool "USE_SYSTEM_BOX2D" true)
+  ];
 
   meta = with lib; {
     description = "A QML plugin for Box2D engine";
     homepage = "https://github.com/qml-box2d/qml-box2d";
-    maintainers = [ maintainers.guibou ];
+    maintainers = with maintainers; [ guibou ];
     platforms = platforms.linux;
     license = licenses.zlib;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20408,7 +20408,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
   };
 
-  box2d = callPackage ../development/libraries/box2d { };
+  box2d = callPackage ../development/libraries/box2d {
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa Kernel OpenGL;
+  };
 
   boxfort = callPackage ../development/libraries/boxfort { };
 

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -65,6 +65,7 @@ makeScopeWithSplicing' {
   };
   qcoro = callPackage ../development/libraries/qcoro { };
   qgpgme = callPackage ../development/libraries/gpgme { };
+  qmlbox2d = callPackage ../development/libraries/qmlbox2d { };
   packagekit-qt = callPackage ../tools/package-management/packagekit/qt.nix { };
 
   qt6ct = callPackage ../tools/misc/qt6ct { };


### PR DESCRIPTION
## Description of changes

- **box2d: 2.3.1 -> 2.4.1**
- **libsForQt5.qmlbox2d: 2018-04-06 -> 2022-08-025**
- **qt6Packages.qmlbox2d: init at unstable-2022-08-25**
  
I haven't tried building libreoffice but everything else is OK.  

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
