### PR TITLE
mueval,diagrams-builder: fix GHC libdir

### DIFF
--- a/pkgs/development/tools/haskell/mueval/default.nix
+++ b/pkgs/development/tools/haskell/mueval/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, haskellPackages, packages ? (pkgs: [])
+{ lib, stdenv, makeWrapper, haskellPackages, packages ? (pkgs: [])
 }:
 
 let defaultPkgs = pkgs: [ pkgs.show
@@ -8,7 +8,6 @@ let defaultPkgs = pkgs: [ pkgs.show
                         ];
     env = haskellPackages.ghcWithPackages
            (pkgs: defaultPkgs pkgs ++ packages pkgs);
-    libDir = "${env}/lib/ghc-${env.version}";
 
 in stdenv.mkDerivation {
   name = "mueval-env";
@@ -17,11 +16,23 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildCommand = ''
+  dontUnpack = true;
+
+  buildPhase = ''
+    runHook preBuild
+
     mkdir -p $out/bin
 
     makeWrapper $mueval/bin/mueval $out/bin/mueval \
-      --set "NIX_GHC_LIBDIR" "${libDir}"
+      --set "NIX_GHC_LIBDIR" "$(${lib.getExe' env "ghc"} --print-libdir)"
+
+    runHook postBuild
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    [[ $($out/bin/mueval -e 42) == 42 ]]
   '';
 
   passthru = { inherit defaultPkgs; };

--- a/pkgs/tools/graphics/diagrams-builder/default.nix
+++ b/pkgs/tools/graphics/diagrams-builder/default.nix
@@ -17,13 +17,13 @@ let
   # Used same technique as for the yiCustom package.
   wrappedGhc = ghcWithPackages
     (self: [ diagrams-builder ] ++ extraPackages self);
-  ghcVersion = wrappedGhc.version;
+  ghc = lib.getExe' wrappedGhc "ghc";
 
   exeWrapper = backend : ''
     makeWrapper \
     "${diagrams-builder}/bin/diagrams-builder-${backend}" "$out/bin/diagrams-builder-${backend}" \
-      --set NIX_GHC ${wrappedGhc}/bin/ghc \
-      --set NIX_GHC_LIBDIR ${wrappedGhc}/lib/ghc-${ghcVersion}
+      --set NIX_GHC ${ghc} \
+      --set NIX_GHC_LIBDIR "$(${ghc} --print-libdir)"
   '';
 
   backends = ["svg" "cairo" "ps"];


### PR DESCRIPTION
Rather than hardcoding the path to GHC's libdir which may change, use `ghc --print-libdir` in wrappers.

Another option would be to expose mkGhcLibdir from generic-builder.nix.

Also add a test for mueval.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
