### PR TITLE
proto: init at 0.32.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14348,6 +14348,12 @@
     githubId = 42322511;
     name = "Patryk Kwiatek";
   };
+  nokazn = {
+    email = "me@nokazn.me";
+    github = "nokazn";
+    githubId = 41154684;
+    name = "nokazn";
+  };
   nomeata = {
     email = "mail@joachim-breitner.de";
     github = "nomeata";

--- a/pkgs/by-name/pr/proto/package.nix
+++ b/pkgs/by-name/pr/proto/package.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, darwin
+, libiconv
+, makeBinaryWrapper
+, pkg-config
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "proto";
+  version = "0.32.2";
+
+  src = fetchFromGitHub {
+    owner = "moonrepo";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-QxaVXggVfr3O26RwSuUx4qpabhWE9+ZFLKRin/ya2e4=";
+  };
+
+  cargoHash = "sha256-j5wXmlauhrUnUVTj/KyqDrf1y9bq3ZInREZXIUQImVE=";
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.SystemConfiguration
+    libiconv
+  ];
+  nativeBuildInputs = [ makeBinaryWrapper pkg-config ];
+
+  # Tests requires network access
+  doCheck = false;
+  cargoBuildFlags = [ "--bin proto" "--bin proto-shim" ];
+
+  postInstall = ''
+    # proto looks up a proto-shim executable file in $PROTO_LOOKUP_DIR
+    wrapProgram $out/bin/${pname} \
+      --set PROTO_LOOKUP_DIR $out/bin
+  '';
+
+  meta = {
+    description = "A pluggable multi-language version manager";
+    longDescription = ''
+      proto is a pluggable next-generation version manager for multiple programming languages. A unified toolchain.
+    '';
+    homepage = "https://moonrepo.dev/proto";
+    changelog = "https://github.com/moonrepo/proto/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nokazn ];
+    mainProgram = "proto";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add [moonrepo/proto](https://github.com/moonrepo/proto) newly.
Proto is a pluggable multi-language version manager.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
