### PR TITLE
pgmodeler: add darwin build

### DIFF
--- a/pkgs/applications/misc/pgmodeler/default.nix
+++ b/pkgs/applications/misc/pgmodeler/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  dontWrapQtApps = lib.optional stdenv.isDarwin true;
+  dontWrapQtApps = stdenv.isDarwin;
 
   meta = with lib; {
     description = "A database modeling tool for PostgreSQL";

--- a/pkgs/applications/misc/pgmodeler/default.nix
+++ b/pkgs/applications/misc/pgmodeler/default.nix
@@ -7,6 +7,8 @@
 , qtwayland
 , qtsvg
 , postgresql
+, cups
+, libxml2
 }:
 
 stdenv.mkDerivation rec {
@@ -21,16 +23,22 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config qmake wrapQtAppsHook ];
-  qmakeFlags = [ "pgmodeler.pro" "CONFIG+=release" ];
+  qmakeFlags = [ "pgmodeler.pro" "CONFIG+=release" ] ++ lib.optionals stdenv.isDarwin [
+    "PGSQL_INC=${postgresql}/include"
+    "PGSQL_LIB=${postgresql.lib}/lib/libpq.dylib"
+    "XML_INC=${libxml2.dev}/include/libxml2"
+  ];
 
   # todo: libpq would suffice here. Unfortunately this won't work, if one uses only postgresql.lib here.
-  buildInputs = [ postgresql qtsvg qtwayland ];
+  buildInputs = [ postgresql qtsvg ]
+    ++ lib.optionals stdenv.isLinux [ qtwayland ]
+    ++ lib.optionals stdenv.isDarwin [ cups libxml2 ];
 
   meta = with lib; {
     description = "A database modeling tool for PostgreSQL";
     homepage = "https://pgmodeler.io/";
     license = licenses.gpl3;
     maintainers = [ maintainers.esclear ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/misc/pgmodeler/default.nix
+++ b/pkgs/applications/misc/pgmodeler/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     "PGSQL_INC=${postgresql}/include"
     "PGSQL_LIB=${postgresql.lib}/lib/libpq.dylib"
     "XML_INC=${libxml2.dev}/include/libxml2"
+    "XML_LIB=${libxml2.out}/lib/libxml2.dylib"
   ];
 
   # todo: libpq would suffice here. Unfortunately this won't work, if one uses only postgresql.lib here.

--- a/pkgs/applications/misc/pgmodeler/default.nix
+++ b/pkgs/applications/misc/pgmodeler/default.nix
@@ -28,12 +28,23 @@ stdenv.mkDerivation rec {
     "PGSQL_LIB=${postgresql.lib}/lib/libpq.dylib"
     "XML_INC=${libxml2.dev}/include/libxml2"
     "XML_LIB=${libxml2.out}/lib/libxml2.dylib"
+    "PREFIX=${placeholder "out"}/Applications/pgModeler.app/Contents"
   ];
 
   # todo: libpq would suffice here. Unfortunately this won't work, if one uses only postgresql.lib here.
   buildInputs = [ postgresql qtsvg ]
     ++ lib.optionals stdenv.isLinux [ qtwayland ]
     ++ lib.optionals stdenv.isDarwin [ cups libxml2 ];
+
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/bin
+    for item in pgmodeler pgmodeler-{cli,se,ch}
+    do
+      ln -s $out/Applications/pgModeler.app/Contents/MacOS/$item $out/bin
+    done
+  '';
+
+  dontWrapQtApps = lib.optional stdenv.isDarwin true;
 
   meta = with lib; {
     description = "A database modeling tool for PostgreSQL";


### PR DESCRIPTION
## Description of changes

Add darwin build for pgmodeler.

CC @esclear 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
