### PR TITLE
apache_datasketches: update to 1.7.0

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
+++ b/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
@@ -1,22 +1,22 @@
 { stdenv, lib, fetchFromGitHub, postgresql, boost182, nixosTests }:
 
 let
-  version = "1.6.0";
+  version = "1.7.0";
 
   main_src = fetchFromGitHub {
     name   = "datasketches-postgresql";
     owner  = "apache";
     repo   = "datasketches-postgresql";
     rev    = "refs/tags/${version}";
-    hash   = "sha256-sz94fIe7nyWhjiw8FAm6ZzVpB0sAK5YxUrtbaZt/guA=";
+    hash   = "sha256-W41uAs3W4V7c9O/wBw3rut65bcmY8EdQS1/tPszMGqA=";
   };
 
   cpp_src = fetchFromGitHub {
     name   = "datasketches-cpp";
     owner  = "apache";
     repo   = "datasketches-cpp";
-    rev    = "refs/tags/4.1.0";
-    hash   = "sha256-vPoFzRxOXlEAiiHH9M5S6255ahzaKsGNYS0cdHwrRYw=";
+    rev    = "refs/tags/5.0.2";
+    hash   = "sha256-yGk1OckYipAgLTQK6w6p6EdHMxBIQSjPV/MMND3cDks=";
   };
 in
 
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     runHook preInstall
-    install -D -m 644 ./datasketches.so -t $out/lib/
+    install -D -m 644 ./datasketches${postgresql.dlSuffix} -t $out/lib/
     cat \
       sql/datasketches_cpc_sketch.sql \
       sql/datasketches_kll_float_sketch.sql \
@@ -56,6 +56,7 @@ stdenv.mkDerivation {
       ./sql/datasketches--1.3.0--1.4.0.sql \
       ./sql/datasketches--1.4.0--1.5.0.sql \
       ./sql/datasketches--1.5.0--1.6.0.sql \
+      ./sql/datasketches--1.6.0--1.7.0.sql \
       -t $out/share/postgresql/extension
     runHook postInstall
   '';


### PR DESCRIPTION
## Description of changes

Updated Apache datasketches-postgresql to version 1.7.0. See [release notes](https://github.com/apache/datasketches-postgresql/releases/tag/1.7.0) for updates

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
