### PR TITLE
wlr-layout-ui: init at 1.4.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2693,6 +2693,12 @@
     github = "bmwalters";
     githubId = 4380777;
   };
+  bnlrnz = {
+    github = "bnlrnz";
+    githubId = 11310385;
+    name = "Ben Lorenz";
+    email = "bnlrnz@gmail.com";
+  };
   bobakker = {
     email = "bobakk3r@gmail.com";
     github = "bobakker";

--- a/pkgs/by-name/wl/wlr-layout-ui/package.nix
+++ b/pkgs/by-name/wl/wlr-layout-ui/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "wlr-layout-ui";
+  version = "1.4.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "fdev31";
+    repo = "wlr-layout-ui";
+    rev = "${version}";
+    hash = "sha256-3NV02/Lk43h3r17jwmSAqx7wofaHFJKDh+vaWwU17Gw=";
+  };
+
+  postPatch = ''
+    # The hyprland default.nix patches the version.h of hyprland so that the
+    # version info moves to the commit key.
+    substituteInPlace src/wlr_layout_ui/screens.py \
+      --replace 'json.loads(subprocess.getoutput("hyprctl -j version"))["tag"]'\
+                'json.loads(subprocess.getoutput("hyprctl -j version"))["commit"]'
+  '';
+
+  nativeBuildInputs = [
+    python3.pkgs.poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pyglet
+    tomli
+    tomli-w
+  ];
+
+  postInstall = ''
+    install -Dm644 files/wlr-layout-ui.desktop $out/share/applications/wlr-layout-ui.desktop
+  '';
+
+  meta = with lib; {
+    description = "A simple GUI to setup the screens layout on wlroots based systems";
+    homepage = "https://github.com/fdev31/wlr-layout-ui/";
+    maintainers = with maintainers; [ bnlrnz ];
+    license = licenses.mit;
+    mainProgram = "wlrlui";
+    platforms = subtractLists platforms.darwin platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adding a Python-based package that provides a UI to configure monitor layouts for wlr based systems.
[Link to the original Repo](https://github.com/fdev31/wlr-layout-ui/)

This PR is related to Issue https://github.com/NixOS/nixpkgs/issues/298342

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
