### PR TITLE
deb-s3: init at 0.11.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8011,6 +8011,11 @@
     githubId = 6074754;
     name = "Hlodver Sigurdsson";
   };
+  hmac = {
+    github = "hmac";
+    githubId = 237543;
+    name = "Harry Maclean";
+  };
   hmajid2301 = {
     name = "Haseeb Majid";
     email = "hello@haseebmajid.dev";

--- a/pkgs/by-name/de/deb-s3/Gemfile
+++ b/pkgs/by-name/de/deb-s3/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+gem "deb-s3"
+gem "ox"

--- a/pkgs/by-name/de/deb-s3/Gemfile.lock
+++ b/pkgs/by-name/de/deb-s3/Gemfile.lock
@@ -1,0 +1,36 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    aws-eventstream (1.3.0)
+    aws-partitions (1.907.0)
+    aws-sdk-core (3.191.6)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.78.0)
+      aws-sdk-core (~> 3, >= 3.191.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.146.1)
+      aws-sdk-core (~> 3, >= 3.191.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.8)
+    aws-sigv4 (1.8.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+    deb-s3 (0.11.8)
+      aws-sdk-s3 (~> 1)
+      thor (~> 1)
+    jmespath (1.6.2)
+    ox (2.14.18)
+    thor (1.3.1)
+
+PLATFORMS
+  arm64-darwin-23
+  ruby
+
+DEPENDENCIES
+  deb-s3
+  ox
+
+BUNDLED WITH
+   2.5.6

--- a/pkgs/by-name/de/deb-s3/gemset.nix
+++ b/pkgs/by-name/de/deb-s3/gemset.nix
@@ -1,0 +1,107 @@
+{
+  aws-eventstream = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0gvdg4yx4p9av2glmp7vsxhs0n8fj1ga9kq2xdb8f95j7b04qhzi";
+      type = "gem";
+    };
+    version = "1.3.0";
+  };
+  aws-partitions = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "099rd4l96c9wprn4z3623p81jah9xi2fm9vx9k070wjx9s0jj3rd";
+      type = "gem";
+    };
+    version = "1.907.0";
+  };
+  aws-sdk-core = {
+    dependencies = ["aws-eventstream" "aws-partitions" "aws-sigv4" "jmespath"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08h9apxdn2aflkg751j4i56ks4750znfbj56w4zlxf4jk7jxkbyk";
+      type = "gem";
+    };
+    version = "3.191.6";
+  };
+  aws-sdk-kms = {
+    dependencies = ["aws-sdk-core" "aws-sigv4"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0fbp2vw5qnyiya63hlmwiqkbh30lipyqplancmhm84ad7i98ambb";
+      type = "gem";
+    };
+    version = "1.78.0";
+  };
+  aws-sdk-s3 = {
+    dependencies = ["aws-sdk-core" "aws-sdk-kms" "aws-sigv4"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1al80phz4x9wwfnr07q1l8h5f0qxgfrrycbg8jvznhxm3zhrakrq";
+      type = "gem";
+    };
+    version = "1.146.1";
+  };
+  aws-sigv4 = {
+    dependencies = ["aws-eventstream"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1g3w27wzjy4si6kp49w10as6ml6g6zl3xrfqs5ikpfciidv9kpc4";
+      type = "gem";
+    };
+    version = "1.8.0";
+  };
+  deb-s3 = {
+    dependencies = ["aws-sdk-s3" "thor"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0p9ar4q7mhnh1ra5c0w4m10hm1pd7j92l9kq145cwf97fxjlklv8";
+      type = "gem";
+    };
+    version = "0.11.8";
+  };
+  jmespath = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1cdw9vw2qly7q7r41s7phnac264rbsdqgj4l0h4nqgbjb157g393";
+      type = "gem";
+    };
+    version = "1.6.2";
+  };
+  ox = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0w9gavjrvciip497hpdjpcs2c18vf6cgmlj696ynpaqv96804glr";
+      type = "gem";
+    };
+    version = "2.14.18";
+  };
+  thor = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vq1fjp45az9hfp6fxljhdrkv75cvbab1jfrwcw738pnsiqk8zps";
+      type = "gem";
+    };
+    version = "1.3.1";
+  };
+}

--- a/pkgs/by-name/de/deb-s3/package.nix
+++ b/pkgs/by-name/de/deb-s3/package.nix
@@ -1,0 +1,36 @@
+{ lib, bundlerApp }:
+
+bundlerApp {
+  pname = "deb-s3";
+  exes = [ "deb-s3" ];
+  gemdir = ./.;
+
+  meta = with lib; {
+    description = "A simple utility to make creating and managing APT repositories on S3";
+    longDescription = ''
+      Most existing guides on using S3 to host an APT repository have you using
+      something like reprepro to generate the repository file structure, and
+      then s3cmd to sync the files to S3.
+
+      The annoying thing about this process is it requires you to maintain a
+      local copy of the file tree for regenerating and syncing the next time.
+      Personally, my process is to use one-off virtual machines with Vagrant,
+      script out the build process, and then would prefer to just upload the
+      final .deb from my Mac.
+
+      With deb-s3, there is no need for this. deb-s3 features:
+
+      - Downloads the existing package manifest and parses it.
+      - Updates it with the new package, replacing the existing entry if already
+        there or adding a new one if not.
+      - Uploads the package itself, the Packages manifest, and the Packages.gz
+        manifest. It will skip the uploading if the package is already there.
+      - Updates the Release file with the new hashes and file sizes.
+    '';
+    homepage = "https://github.com/deb-s3/deb-s3";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hmac ];
+    platforms = platforms.unix;
+    mainProgram = "deb-s3";
+  };
+}


### PR DESCRIPTION
## Description of changes

[deb-s3](https://github.com/deb-s3/deb-s3) is a tool for managing APT repositories hosted on Amazon S3.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux (via [`darwin.linux-builder`](https://ryantm.github.io/nixpkgs/builders/special/darwin-builder/))
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
