### PR TITLE
luneta: init at 0.7.4

### DIFF
--- a/pkgs/by-name/lu/luneta/dub-lock.json
+++ b/pkgs/by-name/lu/luneta/dub-lock.json
@@ -1,0 +1,24 @@
+{
+  "dependencies": {
+    "arsd-official": {
+      "version": "7.2.0",
+      "sha256": "1m546r6l0pkk80y5f3ff8im08hp59nwzjb5ikjhfiswvdizpwjlh"
+    },
+    "fuzzyd": {
+      "version": "2.2.0-beta",
+      "sha256": "0wzih4yrlrrj12ls9hd27gnxrj4j4c0ha9xprdfc7azszlv16j6g"
+    },
+    "ncurses": {
+      "version": "1.0.0",
+      "sha256": "0ivl88vp2dy9rpv6x3f9jlyqa7aps2x1kkyx80w2d4vcs31pzmb2"
+    },
+    "riverd-loader": {
+      "version": "1.0.2",
+      "sha256": "0c94551bscnia7vpixaq4xd2anprkd7pkf0q0anyadv5kqa8xgip"
+    },
+    "riverd-ncurses": {
+      "version": "1.0.5",
+      "sha256": "1wgdschv6hpdjykf5bblxphnhnpy2kvw8hq8h5iaygi9zr7jf286"
+    }
+  }
+}

--- a/pkgs/by-name/lu/luneta/package.nix
+++ b/pkgs/by-name/lu/luneta/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildDubPackage,
+  fetchFromGitHub,
+  ncurses,
+}:
+
+buildDubPackage rec {
+  pname = "luneta";
+  version = "0.7.4";
+
+  src = fetchFromGitHub {
+    owner = "fbeline";
+    repo = "luneta";
+    rev = "v${version}";
+    hash = "sha256-pYE8hccXT87JIMh71PtXzVQBegTzU7bdpVEaV2VkaEk=";
+  };
+
+  # not sure why, but this alias does not resolve
+  postPatch = ''
+    substituteInPlace source/luneta/keyboard.d \
+        --replace-fail "wint_t" "dchar"
+  '';
+
+  # ncurses dub package version is locked to 1.0.0 instead of using ~master
+  dubLock = ./dub-lock.json;
+
+  buildInputs = [ ncurses ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 luneta -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/fbeline/luneta/releases/tag/${src.rev}";
+    description = "An interactive filter and fuzzy finder for the command-line";
+    homepage = "https://github.com/fbeline/luneta";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "luneta";
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This PR adds 1 package: `luneta`

Homepage: https://github.com/fbeline/luneta

Now that https://github.com/NixOS/nixpkgs/pull/299618 is merged, I was looking around for other D programs to package and `luneta` seemed cool.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
