### PR TITLE
xmlto: use docbook-xml-ns package XSD files (offline mode)

### DIFF
--- a/pkgs/tools/typesetting/xmlto/default.nix
+++ b/pkgs/tools/typesetting/xmlto/default.nix
@@ -1,13 +1,26 @@
-{ fetchurl, fetchpatch, lib, stdenv, libxml2, libxslt
-, docbook_xml_dtd_45, docbook_xsl, flex, w3m
-, bash, getopt, makeWrapper }:
+{
+  bash,
+  docbook_xml_dtd_45,
+  docbook_xsl,
+  fetchpatch,
+  fetchurl,
+  flex,
+  getopt,
+  lib,
+  libxml2,
+  libxslt,
+  makeWrapper,
+  stdenv,
+  w3m,
+}:
 
 stdenv.mkDerivation rec {
   pname = "xmlto";
   version = "0.0.28";
+
   src = fetchurl {
     url = "https://releases.pagure.org/${pname}/${pname}-${version}.tar.bz2";
-    sha256 = "0xhj8b2pwp4vhl9y16v3dpxpsakkflfamr191mprzsspg4xdyc0i";
+    hash = "sha256-ETDfOnlX659vDSnkqhx1cyp9+21jm+AThZtcfsVCEnY=";
   };
 
   # Note: These patches modify `xmlif/xmlif.l`, which requires `flex` to be rerun.
@@ -37,8 +50,18 @@ stdenv.mkDerivation rec {
 
   # `libxml2' provides `xmllint', needed at build-time and run-time.
   # `libxslt' provides `xsltproc', used by `xmlto' at run-time.
-  nativeBuildInputs = [ makeWrapper flex getopt ];
-  buildInputs = [ libxml2 libxslt docbook_xml_dtd_45 docbook_xsl ];
+  nativeBuildInputs = [
+    makeWrapper
+    flex
+    getopt
+  ];
+
+  buildInputs = [
+    docbook_xml_dtd_45
+    docbook_xsl
+    libxml2
+    libxslt
+  ];
 
   postInstall = ''
     # `w3m' is needed for HTML to text conversions.
@@ -47,17 +70,18 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
+    changelog = "https://pagure.io/xmlto/blob/master/f/ChangeLog";
     description = "Front-end to an XSL toolchain";
-
+    homepage = "https://pagure.io/xmlto/";
+    license = lib.licenses.gpl2Plus;
     longDescription = ''
       xmlto is a front-end to an XSL toolchain.  It chooses an
       appropriate stylesheet for the conversion you want and applies
       it using an external XSL-T processor.  It also performs any
       necessary post-processing.
     '';
-
-    license = lib.licenses.gpl2Plus;
-    homepage = "https://pagure.io/xmlto/";
+    mainProgram = "xmlto";
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/tools/typesetting/xmlto/default.nix
+++ b/pkgs/tools/typesetting/xmlto/default.nix
@@ -1,11 +1,16 @@
 {
   bash,
+  coreutils,
   docbook_xml_dtd_45,
   docbook_xsl,
+  docbook-xsl-ns,
   fetchpatch,
   fetchurl,
+  findutils,
   flex,
   getopt,
+  gnugrep,
+  gnused,
   lib,
   libxml2,
   libxslt,
@@ -41,11 +46,18 @@ stdenv.mkDerivation rec {
     patchShebangs xmlif/test/run-test
 
     substituteInPlace "xmlto.in" \
-      --replace "/bin/bash" "${bash}/bin/bash"
-    substituteInPlace "xmlto.in" \
-      --replace "/usr/bin/locale" "$(type -P locale)"
-    substituteInPlace "xmlto.in" \
-      --replace "mktemp" "$(type -P mktemp)"
+      --replace-fail "@BASH@" "${bash}/bin/bash" \
+      --replace-fail "@FIND@" "${findutils}/bin/find" \
+      --replace-fail "@GETOPT@" "${getopt}/bin/getopt" \
+      --replace-fail "@GREP@" "${gnugrep}/bin/grep" \
+      --replace-fail "@MKTEMP@" "$(type -P mktemp)" \
+      --replace-fail "@SED@" "${gnused}/bin/sed" \
+      --replace-fail "@TAIL@" "${coreutils}/bin/tail"
+
+    for f in format/docbook/* xmlto.in; do
+      substituteInPlace $f \
+        --replace-fail "http://docbook.sourceforge.net/release/xsl/current" "${docbook-xsl-ns}/xml/xsl/docbook"
+    done
   '';
 
   # `libxml2' provides `xmllint', needed at build-time and run-time.

--- a/pkgs/tools/typesetting/xmlto/default.nix
+++ b/pkgs/tools/typesetting/xmlto/default.nix
@@ -16,15 +16,16 @@
   libxslt,
   makeWrapper,
   stdenv,
+  testers,
   w3m,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xmlto";
   version = "0.0.28";
 
   src = fetchurl {
-    url = "https://releases.pagure.org/${pname}/${pname}-${version}.tar.bz2";
+    url = "https://releases.pagure.org/xmlto/xmlto-${finalAttrs.version}.tar.bz2";
     hash = "sha256-ETDfOnlX659vDSnkqhx1cyp9+21jm+AThZtcfsVCEnY=";
   };
 
@@ -81,6 +82,11 @@ stdenv.mkDerivation rec {
        --prefix PATH : "${lib.makeBinPath [ libxslt libxml2 getopt w3m ]}"
   '';
 
+  passthru.tests.version = testers.testVersion {
+    command = "${lib.getExe finalAttrs.finalPackage} --version";
+    package = finalAttrs.finalPackage;
+  };
+
   meta = {
     changelog = "https://pagure.io/xmlto/blob/master/f/ChangeLog";
     description = "Front-end to an XSL toolchain";
@@ -96,4 +102,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

* Substitute Docbook XSD URLs by docbook-xml-ns package XSD files
  * Required to build documentation of other nixpkgs package relying on gdbus-codegen or xmlto (like [realmd](https://github.com/NixOS/nixpkgs/pull/181145))
* Format with nixfmt-rfc-style
* Add passthru.tests.version

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
