### PR TITLE
pkgs/top-level/release.nix: drop unused `dist` targets

### DIFF
--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -276,12 +276,6 @@ rec {
     };
   };
 
-  dist = runCommand "stdenv-bootstrap-tools" {} ''
-    mkdir -p $out/nix-support
-    echo "file tarball ${build}/on-server/*.tar.xz" >> $out/nix-support/hydra-build-products
-    echo "file unpack ${build}/on-server/unpack.* " >> $out/nix-support/hydra-build-products
-  '';
-
   bootstrapFiles = {
     bootstrapTools = "${build}/on-server/bootstrap-tools.tar.xz";
     unpack = runCommand "unpack" { allowedReferences = []; } ''

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -212,22 +212,6 @@ in with pkgs; rec {
       allowedReferences = [];
     };
 
-  dist = stdenv.mkDerivation {
-    name = "stdenv-bootstrap-tools";
-
-    meta = {
-      # Increase priority to unblock nixpkgs-unstable
-      # https://github.com/NixOS/nixpkgs/pull/104679#issuecomment-732267288
-      schedulingPriority = 200;
-    };
-
-    buildCommand = ''
-      mkdir -p $out/nix-support
-      echo "file tarball ${build}/on-server/bootstrap-tools.tar.xz" >> $out/nix-support/hydra-build-products
-      echo "file busybox ${build}/on-server/busybox" >> $out/nix-support/hydra-build-products
-    '';
-  };
-
   bootstrapFiles = {
     # Make them their own store paths to test that busybox still works when the binary is named /nix/store/HASH-busybox
     busybox = runCommand "busybox" {} "cp ${build}/on-server/busybox $out";

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -234,7 +234,7 @@ let
                 };
               };
             in {
-              inherit (bootstrap) build dist test;
+              inherit (bootstrap) build test;
             }
           else if hasSuffix "-darwin" config then
             let
@@ -243,7 +243,7 @@ let
               };
             in {
               # Lightweight distribution and test
-              inherit (bootstrap) build dist test;
+              inherit (bootstrap) build test;
               # Test a full stdenv bootstrap from the bootstrap tools definition
               # TODO: Re-enable once the new bootstrap-tools are in place.
               #inherit (bootstrap.test-pkgs) stdenv;


### PR DESCRIPTION
The PR https://github.com/NixOS/nixpkgs/pull/284090 exposed `build` target directly on hydra. We are using it now in
https://github.com/NixOS/nixpkgs/tree/master/maintainers/scripts/bootstrap-files to generate bootstrap tarballs on `linux` and `darwin`.

`dist` was not very useful as it was a bit hard to link back to hydra jobs that build it. Let's just drop it.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
