### PR TITLE
jetbrains.jdk: add updateScript and a test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -481,6 +481,7 @@ in {
   jellyfin = handleTest ./jellyfin.nix {};
   jenkins = handleTest ./jenkins.nix {};
   jenkins-cli = handleTest ./jenkins-cli.nix {};
+  jetbrains-jdk = runTest ./jetbrains-jdk;
   jibri = handleTest ./jibri.nix {};
   jirafeau = handleTest ./jirafeau.nix {};
   jitsi-meet = handleTest ./jitsi-meet.nix {};

--- a/nixos/tests/jetbrains-jdk/BrowserTest.java
+++ b/nixos/tests/jetbrains-jdk/BrowserTest.java
@@ -1,0 +1,34 @@
+import com.jetbrains.cef.JCefAppConfig;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.swing.JFrame;
+import org.cef.CefApp;
+import org.cef.CefSettings;
+import org.cef.browser.CefRendering;
+
+public class BrowserTest {
+    private static void fail(String message) {
+        throw new RuntimeException(message);
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        var started = CefApp.startup(args);
+        var config = JCefAppConfig.getInstance();
+
+	var settings = config.getCefSettings();
+	var app = CefApp.getInstance(settings);
+        var latch = new CountDownLatch(1);
+        app.onInitialization(s -> latch.countDown());
+        latch.await(30, TimeUnit.SECONDS);
+        if (latch.getCount() > 0) {
+            fail("CEF initialization timed out");
+        }
+
+        var client = app.createClient();
+        var browser = client.createBrowser("chrome://system", CefRendering.DEFAULT, false);
+        var frame = new JFrame("browser test");
+        frame.add(browser.getUIComponent());
+        frame.setSize(640, 480);
+        frame.setVisible(true);
+    }
+}

--- a/nixos/tests/jetbrains-jdk/default.nix
+++ b/nixos/tests/jetbrains-jdk/default.nix
@@ -1,0 +1,25 @@
+# Tests if opening a JCEF window with chrome://about by building
+# and running a simple Java application using JBR.
+{ lib, ... }:
+{
+  name = "jetbrains-jdk-jcef";
+
+  meta.maintainers = with lib.maintainers; [ liff ];
+
+  enableOCR = true;
+
+  nodes.machine =
+    { lib, pkgs, ... }:
+    let
+      jbr-browser-test = pkgs.callPackage ./jbr-browser-test.nix { };
+    in
+    {
+      services.cage.program = lib.getExe jbr-browser-test;
+      imports = [ ../common/wayland-cage.nix ];
+    };
+
+  testScript = ''
+    machine.wait_for_unit('graphical.target')
+    machine.wait_for_text('CHROME VERSION', timeout=90)
+  '';
+}

--- a/nixos/tests/jetbrains-jdk/jbr-browser-test.nix
+++ b/nixos/tests/jetbrains-jdk/jbr-browser-test.nix
@@ -1,0 +1,30 @@
+{
+  stdenv,
+  lib,
+  makeWrapper,
+  jetbrains,
+}:
+
+stdenv.mkDerivation {
+  name = "jbr-browser-test";
+
+  src = ./BrowserTest.java;
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ jetbrains.jdk ];
+
+  buildPhase = ''
+    cp $src BrowserTest.java
+    javac BrowserTest.java
+  '';
+
+  installPhase = ''
+    mkdir --parents $out/{lib,bin}
+    cp *.class $out/lib/
+    makeWrapper ${lib.getBin jetbrains.jdk}/bin/java $out/bin/jbr-browser-test \
+      --append-flags "-cp $out/lib BrowserTest"
+  '';
+
+  meta.mainProgram = "jbr-browser-test";
+}

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -1,6 +1,8 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, testers
+, nixosTests
 , jetbrains
 , jdk
 , git
@@ -152,5 +154,13 @@ jdk.overrideAttrs (oldAttrs: rec {
 
   passthru = oldAttrs.passthru // {
     home = "${jetbrains.jdk}/lib/openjdk";
+    tests = {
+      version = testers.testVersion {
+        package = jetbrains.jdk;
+        command = "java --version";
+        version = javaVersion;
+      };
+      jcef = nixosTests.jetbrains-jdk;
+    };
   };
 })

--- a/pkgs/development/compilers/jetbrains-jdk/update.py
+++ b/pkgs/development/compilers/jetbrains-jdk/update.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3
+#!nix-shell -p nix-prefetch-github
+#!nix-shell -p "python3.withPackages(p: with p; [ python-dotenv ])"
+#
+# Usage: ./update <idea-ultimate tarball> <idea version>
+#
+# The first argument is a path to an IntelliJ IDEA Ultimate tarball and the second argument is version, like 2023.3.1
+# of that tarball. You can get a path to one with `nix-build -A jetbrains.idea-ultimate.src`.
+#
+# The tarball contains a file with JBR version information at <prefix>/jbr/release. From that file we resolve the
+# Git tag and a few other bits of metadata of the JBR version used by that version of IDEA, and with that we can
+# pre-fetch the source and get the hash.
+#
+import json
+import os.path
+import re
+import subprocess
+import sys
+import tarfile
+from datetime import datetime
+from io import TextIOWrapper
+from json.decoder import JSONDecodeError
+from pathlib import PurePath
+
+import dotenv.parser
+
+# Size of the tarfile buffer
+BUFFER_SIZE = 4 * 1024 * 1024
+
+# Regular expression for extracting different components from an `IMPLEMENTOR_VERSION` line, like:
+#     JBR-17.0.10+1-1087.23-jcef
+#         └┬────┘ ╿ └┬────┘
+#          │      │  │
+#          │      │  │
+#          │      │  ┕ build
+#          │      ┕ javaBuild
+#          ┕ javaVersion
+#
+VERSION_LINE = re.compile(r"""JBR-(?P<javaVersion>[0-9.]+)\+(?P<javaBuild>\d+)-(?P<build>\d+\.\d+)(-\w+)?""")
+
+
+def extract_jbr_release(intellij_tarball: str) -> dict[str, str]:
+    """Extracts jbr/release from the source tarball and returns a dict with the contents of that file."""
+
+    with tarfile.open(name=intellij_tarball, mode="r", bufsize=BUFFER_SIZE) as src:
+        member = next(member for member in src if PurePath(member.name).match("*/jbr/release"))
+
+        with src.extractfile(member) as release:
+            return {b.key: b.value for b in dotenv.parser.parse_stream(TextIOWrapper(release))}
+
+
+def prefetch(rev: str) -> str:
+    argv = ["nix-prefetch-github", "--meta", "--rev", tag, "JetBrains", "JetBrainsRuntime"]
+    prefetched = json.loads(subprocess.check_output(argv).decode("utf-8"))
+    src = prefetched["src"]
+    meta = prefetched["meta"]
+    commit_timestamp = datetime.fromisoformat(f"{meta['commitDate']}T{meta['commitTimeOfDay']}Z")
+    return dict(
+        hash=src["hash"],
+        SOURCE_DATE_EPOCH=int(commit_timestamp.timestamp()),
+    )
+
+
+if __name__ == "__main__":
+    idea_tarball = sys.argv[1]
+    idea_version = sys.argv[2]
+    version_info_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "version-info.json")
+
+    try:
+        with open(version_info_file, mode="rb") as input:
+            version_info = json.load(input)
+    except (FileNotFoundError, JSONDecodeError):
+        version_info = dict()
+
+    if version_info.get("ideaVersion") == idea_version:
+        print(f"Up to date at {version_info['rev']} for IntelliJ IDEA {idea_version}.", file=sys.stderr)
+        sys.exit(0)
+
+    print(f"Updating JBR release to match IDEA {idea_version}…", file=sys.stderr)
+
+    release = extract_jbr_release(idea_tarball)
+
+    version_info = {"ideaVersion": idea_version}
+
+    version_info |= VERSION_LINE.fullmatch(release["IMPLEMENTOR_VERSION"]).groupdict()
+
+    java_version = version_info["javaVersion"]
+    java_build = version_info["javaBuild"]
+    build = version_info["build"]
+    tag = f"jb{java_version}-b{build}"
+
+    version_info["openjdkTag"] = f"jbr-{java_version}+{java_build}"
+
+    version_info["rev"] = tag
+    version_info |= prefetch(tag)
+
+    with open(version_info_file, "w") as out:
+        json.dump(version_info, out, indent=4)
+        out.write("\n")
+
+    print(f"JBR updated to {tag}", file=sys.stderr)

--- a/pkgs/development/compilers/jetbrains-jdk/version-info.json
+++ b/pkgs/development/compilers/jetbrains-jdk/version-info.json
@@ -1,0 +1,10 @@
+{
+    "ideaVersion": "2024.2.1",
+    "javaVersion": "21.0.3",
+    "javaBuild": "13",
+    "build": "509.11",
+    "openjdkTag": "jbr-21.0.3+13",
+    "rev": "jb21.0.3-b509.11",
+    "hash": "sha256-zTstmrH4KteR40BVDRfxOrl8aUQ26acE+ywscBd8sw8=",
+    "SOURCE_DATE_EPOCH": 1723453663
+}


### PR DESCRIPTION
The update script uses the `jbr/release` file in IDEA Ultimate’s current release tarball to resolve the latest JBR version JetBrains is currently using in their IDEs.

This only adds the update script, the package version remains the same.

I also added a NixOS test that attempts to verify that JCEF works.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
