### PR TITLE
git-gr: 1.0.3 -> 1.2.1

### DIFF
--- a/pkgs/by-name/gi/git-gr/package.nix
+++ b/pkgs/by-name/gi/git-gr/package.nix
@@ -8,12 +8,14 @@
   libiconv,
   darwin,
   nix-update-script,
+  pkg-config,
+  openssl,
 }:
 let
   canRunGitGr = stdenv.hostPlatform.emulatorAvailable buildPackages;
   gitGr = "${stdenv.hostPlatform.emulator buildPackages} $out/bin/git-gr";
   pname = "git-gr";
-  version = "1.0.3";
+  version = "1.2.1";
 in
 rustPlatform.buildRustPackage {
   inherit pname version;
@@ -22,18 +24,25 @@ rustPlatform.buildRustPackage {
     owner = "9999years";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-hvK4reFR60q9mw3EdNLav9VMr4H6Zabv1N1D/5AAKuQ=";
+    hash = "sha256-5Pr1z+RmY92cfT7KtFnUKpzhniUN6RjDKBekWiYCCuU=";
   };
 
   buildFeatures = [ "clap_mangen" ];
 
-  cargoHash = "sha256-efoRiPWugz955MflIS81Nie7Oq5Y4u5CI+/el8fJVl0=";
+  cargoHash = "sha256-5JLTSBBTPGUbuqUql/cMJKBLlO2uzuU1EDhfScaeCUg=";
+
+  OPENSSL_NO_VENDOR = true;
 
   nativeBuildInputs =
-    [ installShellFiles ]
+    [installShellFiles]
+    ++ lib.optional stdenv.isLinux pkg-config;
+
+  buildInputs =
+    lib.optional stdenv.isLinux openssl
     ++ lib.optionals stdenv.isDarwin [
       libiconv
       darwin.apple_sdk.frameworks.CoreServices
+      darwin.apple_sdk.frameworks.SystemConfiguration
     ];
 
   postInstall = lib.optionalString canRunGitGr ''


### PR DESCRIPTION
## Description of changes

- https://github.com/9999years/git-gr/releases/tag/v1.2.0
  - Adds `git gr api` to access the HTTP REST API
  - Adds `git gr show-chain` to show the relation chain for the current change
  - Queries related changes when traversing relation chains to correctly resolve outdated changes
- https://github.com/9999years/git-gr/releases/tag/v1.2.1
  - Adds `git gr view` to view a change in a web browser

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
