### PR TITLE
tangerine: init at 2024-04-05

### DIFF
--- a/pkgs/by-name/ta/tangerine/package.nix
+++ b/pkgs/by-name/ta/tangerine/package.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, ncurses
+, SDL2
+}:
+
+stdenv.mkDerivation {
+  pname = "tangerine";
+  version = "unstable-2024-04-05";
+
+  src = fetchFromGitHub {
+    owner = "Aeva";
+    repo = "tangerine";
+    rev = "a628e95d181d396246214df5194ac6b18698d811";
+    hash = "sha256-vn4/eH5o0UhTNfN2UB4r0eKNn90PbH3UPfarHsnQPIk=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "no-install-during-build.patch";
+      url = "https://github.com/Aeva/tangerine/pull/12/commits/2d7d1ae1e21e8fe52df2c4a33e947b2ff6b07812.patch";
+      hash = "sha256-zLAx5FOvtUsUZM/nUCFW8Z1Xe3+oV95Nv1s3GaNcV/c=";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ ncurses SDL2 ];
+
+  meta = with lib; {
+    description = "A system for creating 3D models procedurally from a set of Signed Distance Function (SDF) primitive shapes and combining operators";
+    homepage = "https://github.com/Aeva/tangerine";
+    license = licenses.asl20;
+    maintainers = [ maintainers.viraptor ];
+    broken = stdenv.isDarwin; # third_party/naive-surface-nets doesn't find std::execution
+  };
+}
+


### PR DESCRIPTION
## Description of changes


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
