### PR TITLE
codechecker: init at 6.23.1

### DIFF
--- a/pkgs/by-name/co/codechecker/package.nix
+++ b/pkgs/by-name/co/codechecker/package.nix
@@ -1,0 +1,117 @@
+{
+  lib,
+  python3,
+  fetchPypi,
+  fetchFromGitHub,
+  makeWrapper,
+  cppcheck,
+  clang,
+  gcc,
+  clang-tools,
+}:
+let
+  python = python3.override {
+    packageOverrides = self: super: rec {
+      # codechecker is incompatible with SQLAlchemy greater than 1.3
+      sqlalchemy = super.sqlalchemy_1_4.overridePythonAttrs (oldAttrs: rec {
+        version = "1.3.23";
+        pname = oldAttrs.pname;
+        src = fetchFromGitHub {
+          owner = "sqlalchemy";
+          repo = "sqlalchemy";
+          rev = "rel_${lib.replaceStrings [ "." ] [ "_" ] version}";
+          hash = "sha256-hWA0/f7rQpEfYTg10i0rBK3qeJbw3p6HW7S59rLnD0Q=";
+        };
+        doCheck = false;
+        # That test does not exist in the 1.3 branch so we get an error for disabling it
+        disabledTestPaths = builtins.filter (
+          testPath: testPath != "test/ext/mypy"
+        ) oldAttrs.disabledTestPaths;
+      });
+      sqlalchemy_1_4 = sqlalchemy;
+
+      # The current alembic version is not compatible with SQLAlchemy 1.3 so we need to downgrade it
+      alembic = super.alembic.overridePythonAttrs (oldAttrs: rec {
+        pname = "alembic";
+        version = "1.5.5";
+        src = fetchPypi {
+          inherit pname version;
+          hash = "sha256-3wAowZJ1os/xN+OWF6Oc3NvRFzczuHtr+iV7fAhgITs=";
+        };
+        doCheck = false;
+        dependencies = oldAttrs.dependencies ++ [
+          super.python-dateutil
+          super.python-editor
+        ];
+      });
+    };
+  };
+  python3Packages = python.pkgs;
+in
+python3Packages.buildPythonApplication rec {
+  pname = "codechecker";
+  version = "6.23.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ylTEjyZChAl7XvZGXT0cNSpOVbWKyTkrkRWX9gOeNto=";
+  };
+
+  nativeBuildInputs = with python3Packages; [
+    setuptools
+    pythonRelaxDepsHook
+    makeWrapper
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    lxml
+    sqlalchemy
+    alembic
+    portalocker
+    psutil
+    multiprocess
+    thrift
+    gitpython
+    pyyaml
+    types-pyyaml
+    sarif-tools
+    pytest
+    pycodestyle
+    pylint
+    mkdocs
+    coverage
+  ];
+  pythonRelaxDeps = [
+    "thrift"
+    "portalocker"
+    "types-pyyaml"
+    "lxml"
+    "psutil"
+    "multiprocess"
+    "gitpython"
+    "sarif-tools"
+  ];
+
+  # CodeChecker needs to be able to find the analyzers at runtime
+  postInstall = ''
+    wrapProgram "$out/bin/CodeChecker" --prefix PATH : ${
+      lib.makeBinPath [
+        cppcheck
+        clang
+        gcc
+        clang-tools
+      ]
+    }
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/Ericsson/codechecker";
+    changelog = "https://github.com/Ericsson/codechecker/releases/tag/v${version}";
+    description = "Analyzer tooling, defect database and viewer extension for the Clang Static Analyzer and Clang Tidy";
+    license = licenses.asl20-llvm;
+    maintainers = with maintainers; [ zebreus ];
+    mainProgram = "CodeChecker";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

[Codechecker](https://github.com/Ericsson/codechecker) is an analyzer tooling, defect database and viewer extension for the Clang Static Analyzer and Clang Tidy.

I verified that `CodeChecker analyzers` finds all static analyzers and `CodeChecker server` starts the application and it appears to work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
