### PR TITLE
ki: init at 0-unstable-2023-11-08

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5821,6 +5821,15 @@
     githubId = 4576666;
     name = "Eliza Velasquez";
   };
+  eljamm = {
+    name = "Fedi Jamoussi";
+    email = "fedi.jamoussi@protonmail.ch";
+    github = "eljamm";
+    githubId = 83901271;
+    keys = [{
+      fingerprint = "FF59 E027 4EE2 E792 512B  BDC8 7630 FDF7 C8FB 1F3F";
+    }];
+  };
   elkowar = {
     email = "thereal.elkowar@gmail.com";
     github = "elkowar";

--- a/pkgs/by-name/ki/ki/package.nix
+++ b/pkgs/by-name/ki/ki/package.nix
@@ -1,0 +1,69 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+, cmake
+, anki
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "ki";
+  version = "0-unstable-2023-11-08";
+
+  pyproject = true;
+
+  disabled = python3Packages.pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "langfield";
+    repo = pname;
+    rev = "eb32fbd3229dc1a60bcc76a937ad63f3eb869f65";
+    sha256 = "sha256-5mQhJhvJQC9835goL3t3DRbD+c4P3KxnOflxvqmxL58=";
+  };
+
+  patches = [
+    ./update-to-newer-anki-versions.patch
+    ./replace-deprecated-distutils-with-setuptools.patch
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  propagatedBuildInputs = with python3Packages; [
+    beartype
+    click
+    colorama
+    git-filter-repo
+    gitpython
+    lark
+    tqdm
+    whatthepatch
+  ] ++ [
+    anki
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    bitstring
+    checksumdir
+    gitpython
+    loguru
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # requires git to not be in path, but git is needed for other tests
+    "test_clone_cleans_up_on_error"
+    "test_clone_clean_up_preserves_directories_that_exist_a_priori"
+  ];
+
+  dontCheckRuntimeDeps = true;
+
+  # CMake needs to be run by pyproject rather than by its hook
+  dontConfigure = true;
+
+  meta = with lib; {
+    description = "Version control for Anki collections";
+    homepage = "https://github.com/langfield/ki";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ eljamm ];
+  };
+}

--- a/pkgs/by-name/ki/ki/replace-deprecated-distutils-with-setuptools.patch
+++ b/pkgs/by-name/ki/ki/replace-deprecated-distutils-with-setuptools.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/test_integration.py b/tests/test_integration.py
+index 93d3661..ef24fca 100644
+--- a/tests/test_integration.py
++++ b/tests/test_integration.py
+@@ -7,7 +7,7 @@ import sqlite3
+ import tempfile
+ import subprocess
+ from pathlib import Path
+-from distutils.dir_util import copy_tree
++from setuptools._distutils.dir_util import copy_tree
+ from importlib.metadata import version
+ 
+ import git

--- a/pkgs/by-name/ki/ki/update-to-newer-anki-versions.patch
+++ b/pkgs/by-name/ki/ki/update-to-newer-anki-versions.patch
@@ -1,0 +1,141 @@
+diff --git a/ki/__init__.py b/ki/__init__.py
+index 3f29c1a..f4ad950 100644
+--- a/ki/__init__.py
++++ b/ki/__init__.py
+@@ -1321,7 +1321,7 @@ def _clone1(collection: str, directory: str = "") -> git.Repo:
+     try:
+         col = M.collection(col_file)
+         _, _ = _clone2(col, targetdir, msg="Initial commit", silent=False)
+-        col.close(save=False)
++        col.close()
+         kirepo: KiRepo = M.kirepo(targetdir)
+         kirepo.repo.create_tag(LCA)
+         kirepo.repo.close()
+@@ -1404,11 +1404,11 @@ def _pull1() -> None:
+     hashes = list(filter(lambda l: l != "", hashes))
+     if md5sum in hashes[-1]:
+         echo("ki pull: up to date.")
+-        col.close(save=False)
++        col.close()
+         return
+ 
+     col = _pull2(kirepo, col)
+-    col.close(save=False)
++    col.close()
+ 
+ 
+ @beartype
+@@ -1545,7 +1545,7 @@ def _push() -> PushResult:
+     # If there are no changes, quit.
+     if len(set(deltas)) == 0:
+         echo("ki push: up to date.")
+-        col.close(save=False)
++        col.close()
+         return PushResult.UP_TO_DATE
+ 
+     echo(f"Pushing to '{kirepo.col_file}'")
+@@ -1603,7 +1603,7 @@ def write_collection(
+     do(warn, F.cat(map(push_note(tempcol, timestamp_ns, guids, new_nids), decknotes)))
+ 
+     # It is always safe to save changes to the DB, since the DB is a copy.
+-    tempcol.close(save=True)
++    tempcol.close()
+ 
+     # Backup collection file and overwrite collection.
+     backup(kirepo)
+@@ -1621,7 +1621,7 @@ def write_collection(
+     renames = filter(lambda a: a.file.name != a.new_name, map(addmedia(col), mbytes))
+     warnings = map(lambda r: RenamedMediaFileWarning(r.file.name, r.new_name), renames)
+     do(warn, warnings)
+-    col.close(save=True)
++    col.close()
+ 
+     # Append and commit collection checksum to hashes file.
+     append_md5sum(kirepo.ki, kirepo.col_file.name, F.md5(kirepo.col_file))
+diff --git a/tests/test_integration.py b/tests/test_integration.py
+index e046b8c..93d3661 100644
+--- a/tests/test_integration.py
++++ b/tests/test_integration.py
+@@ -320,7 +320,7 @@ def test_clone_generates_deck_tree_correctly():
+     # Create empty decks.
+     col = opencol(a)
+     do(col.decks.id, [":a:::b:", "blank::blank", "blank::Hello"])
+-    col.close(save=True)
++    col.close()
+ 
+     os.chdir(F.mkdtemp())
+     clone(a)
+@@ -401,7 +401,7 @@ def test_clone_writes_media_files():
+     a: File = mkcol([("Basic", ["Default"], 1, ["a", "b[sound:1sec.mp3]"])])
+     col = opencol(a)
+     col.media.add_file(DATA / "media/1sec.mp3")
+-    col.close(save=True)
++    col.close()
+     clone(a)
+     assert (Path(MEDIA) / "1sec.mp3").is_file()
+ 
+@@ -883,7 +883,7 @@ def test_push_writes_media():
+     write_basic("Default", ("air", '<img src="bullhorn-lg.png">'))
+     col = opencol(a)
+     col.media.add_file(DATA / "media/bullhorn-lg.png")
+-    col.close(save=True)
++    col.close()
+     F.commitall(repo, ".")
+     repo.close()
+     out = push()
+@@ -987,7 +987,7 @@ def test_push_doesnt_unnecessarily_deduplicate_notetypes():
+ 
+     col = opencol(a)
+     models = col.models.all_names_and_ids()
+-    col.close(save=False)
++    col.close()
+ 
+     # Remove a note.
+     assert os.path.isfile("Default/a.md")
+@@ -1012,7 +1012,7 @@ def test_push_doesnt_unnecessarily_deduplicate_notetypes():
+ 
+     col = opencol(a)
+     assert len(models) == len(col.models.all_names_and_ids())
+-    col.close(save=False)
++    col.close()
+ 
+ 
+ def test_push_is_nontrivial_when_pushed_changes_are_reverted_in_repository():
+diff --git a/tests/test_ki.py b/tests/test_ki.py
+index 5270b56..e5f3297 100644
+--- a/tests/test_ki.py
++++ b/tests/test_ki.py
+@@ -482,7 +482,7 @@ def mkcol(ns: List[NoteSpec]) -> File:
+     file = F.touch(F.mkdtemp(), "a.anki2")
+     col = opencol(file)
+     do(addnote(col), ns)
+-    col.close(save=True)
++    col.close()
+     return F.chk(file)
+ 
+ 
+@@ -491,7 +491,7 @@ def rm(f: File, nid: int) -> File:
+     """Remove note with given `nid`."""
+     col = opencol(f)
+     col.remove_notes([nid])
+-    col.close(save=True)
++    col.close()
+     return f
+ 
+ 
+@@ -514,7 +514,7 @@ def edit(f: File, spec: NoteSpec) -> File:
+     """Edit a note with specified nid."""
+     col = opencol(f)
+     editnote(col, spec)
+-    col.close(save=True)
++    col.close()
+     return f
+ 
+ 
+@@ -531,7 +531,7 @@ def editcol(
+     do(addnote(col), adds)
+     do(editnote(col), edits)
+     col.remove_notes(deletes)
+-    col.close(save=True)
++    col.close()
+     return f


### PR DESCRIPTION
## Description of changes

Adds Ki, a command-line tool for converting Anki collections and decks into git repositories.

https://github.com/langfield/ki

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
