### PR TITLE
spectral-language-server: init at 1.0.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12980,6 +12980,15 @@
       fingerprint = "1248 D3E1 1D11 4A85 75C9  8934 6794 D45A 488C 2EDE";
     }];
   };
+  momeemt = {
+    name = "Mutsuha Asada";
+    email = "me@momee.mt";
+    github = "momeemt";
+    githubId = 43488453;
+    keys = [{
+      fingerprint = "D94F EA9F 5B08 F6A1 7B8F  EB8B ACB5 4F0C BC6A A7C6";
+    }];
+  };
   monaaraj = {
     name = "Mon Aaraj";
     email = "owo69uwu69@gmail.com";

--- a/pkgs/by-name/sp/spectral-language-server/package.json
+++ b/pkgs/by-name/sp/spectral-language-server/package.json
@@ -1,0 +1,159 @@
+{
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "author": "Stoplight <support@stoplight.io>",
+  "bugs": {
+    "url": "https://github.com/stoplightio/vscode-spectral/issues"
+  },
+  "categories": [
+    "Linters"
+  ],
+  "contributes": {
+    "configuration": {
+      "properties": {
+        "spectral.enable": {
+          "default": true,
+          "description": "Controls whether or not Spectral is enabled.",
+          "scope": "resource",
+          "type": "boolean"
+        },
+        "spectral.rulesetFile": {
+          "description": "Location of the ruleset file to use when validating. If omitted, the default is a .spectral.yml/.spectral.json in the same folder as the document being validated. Paths are relative to the workspace. This can also be a remote HTTP url.",
+          "scope": "resource",
+          "type": "string"
+        },
+        "spectral.run": {
+          "default": "onType",
+          "description": "Run the linter on save (onSave) or as you type (onType).",
+          "enum": [
+            "onSave",
+            "onType"
+          ],
+          "scope": "resource",
+          "type": "string"
+        },
+        "spectral.trace.server": {
+          "default": "off",
+          "description": "Traces the communication between VS Code and the language server.",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "scope": "window",
+          "type": "string"
+        },
+        "spectral.validateFiles": {
+          "description": "An array of file globs (e.g., `**/*.yaml`) in minimatch glob format which should be validated by Spectral. If language identifiers are also specified, the file must match both in order to be validated. You can also use negative file globs (e.g., `!**/package.json`) here to exclude files.",
+          "items": {
+            "type": "string"
+          },
+          "scope": "resource",
+          "type": "array"
+        },
+        "spectral.validateLanguages": {
+          "default": [
+            "json",
+            "yaml"
+          ],
+          "description": "An array of language IDs which should be validated by Spectral. If file globs are also specified, the file must match both in order to be validated.",
+          "items": {
+            "type": "string"
+          },
+          "scope": "resource",
+          "type": "array"
+        }
+      },
+      "title": "Spectral",
+      "type": "object"
+    },
+    "commands": [
+      {
+        "title": "Show Output Channel",
+        "category": "Spectral",
+        "command": "spectral.showOutputChannel"
+      }
+    ]
+  },
+  "description": "JSON/YAML linter with OpenAPI and custom ruleset support.",
+  "devDependencies": {
+    "@types/chai": "^4.3.1",
+    "@types/chai-jest-snapshot": "^1.3.6",
+    "@types/glob": "^7.2.0",
+    "@types/mocha": "^9.1.0",
+    "@types/node": "^18.11.18",
+    "@types/vscode": "^1.48.0",
+    "@typescript-eslint/eslint-plugin": "^4.33.0",
+    "@typescript-eslint/parser": "^4.1.0",
+    "chai": "^4.2.0",
+    "chai-jest-snapshot": "^2.0.0",
+    "copyfiles": "^2.4.1",
+    "cross-env": "^7.0.3",
+    "eslint": "^7.8.1",
+    "eslint-config-google": "^0.14.0",
+    "glob": "^8.0.3",
+    "http-test-servers": "^2.0.0",
+    "merge-options": "^3.0.0",
+    "mocha": "^8.1.3",
+    "rimraf": "^3.0.2",
+    "semver": "^7.3.2",
+    "shelljs": "^0.8.5",
+    "ts-loader": "^9.2.8",
+    "ts-node": "^8.10.2",
+    "typescript": "beta",
+    "vsce": "^1.103.1",
+    "vscode-test": "^1.5.0",
+    "webpack": "^5.72.0",
+    "webpack-cli": "^4.9.2"
+  },
+  "displayName": "Spectral",
+  "engines": {
+    "vscode": "^1.48.0",
+    "node": "^12.20 || >= 14.13"
+  },
+  "homepage": "https://github.com/stoplightio/vscode-spectral",
+  "icon": "icon.png",
+  "keywords": [
+    "linter",
+    "validator",
+    "OpenAPI",
+    "Swagger",
+    "API",
+    "style guide",
+    "API description",
+    "API specification",
+    "OAS",
+    "OAS2",
+    "OAS3",
+    "AsyncAPI",
+    "json",
+    "yaml"
+  ],
+  "license": "Apache-2.0",
+  "main": "./client/index.js",
+  "name": "spectral",
+  "private": true,
+  "publisher": "stoplight",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stoplightio/vscode-spectral"
+  },
+  "scripts": {
+    "clean": "rimraf dist && rimraf \"{server,client}/dist\"",
+    "lint": "eslint --ext .ts,.js .",
+    "test": "mocha -r ts-node/register \"./+(client|server)/__tests__/unit/**/*.test.ts\"",
+    "test:e2e": "cross-env CI=true CHAI_JEST_SNAPSHOT_UPDATE_ALL=false ts-node ./client/src/__tests__/e2e/index.ts"
+  },
+  "version": "1.1.2",
+  "workspaces": {
+    "packages": [
+      "client",
+      "server"
+    ],
+    "nohoist": [
+      "client/**",
+      "server/**"
+    ]
+  }
+}

--- a/pkgs/by-name/sp/spectral-language-server/package.nix
+++ b/pkgs/by-name/sp/spectral-language-server/package.nix
@@ -1,0 +1,109 @@
+{ lib
+, buildNpmPackage
+, mkYarnPackage
+, fetchYarnDeps
+, fetchFromGitHub
+, typescript
+, jq
+, fetchpatch
+}:
+let
+  # Instead of the build script that spectral-language-server provides (ref: https://github.com/luizcorreia/spectral-language-server/blob/master/script/vscode-spectral-build.sh), we build vscode-spectral manually.
+  # This is because the script must go through the network and will not work under the Nix sandbox environment.
+  vscodeSpectral = mkYarnPackage rec {
+    pname = "vscode-spectral";
+    version = "1.1.2";
+
+    src = fetchFromGitHub {
+      owner = "stoplightio";
+      repo = "vscode-spectral";
+      rev = "v${version}";
+      hash = "sha256-TWy+bC6qhTKDY874ORTBbvCIH8ycpmBiU8GLYxBIiAs=";
+    };
+
+    packageJSON = ./package.json;
+
+    offlineCache = fetchYarnDeps {
+      yarnLock = src + "/yarn.lock";
+      hash = "sha256-am27A9VyFoXuOlgG9mnvNqV3Q7Bi7GJzDqqVFGDVWIA=";
+    };
+
+    nativeBuildInputs = [ typescript jq ];
+
+    postPatch = ''
+      cp server/tsconfig.json server/tsconfig.json.bak
+      jq '.compilerOptions += {"module": "NodeNext", "moduleResolution": "NodeNext"}' server/tsconfig.json.bak > server/tsconfig.json
+    '';
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+      # FIXME: vscode-spactral depends on @rollup/pluginutils, but it may have a bug that doesn't provide the type definitions for NodeNext module resolution. (ref: https://github.com/rollup/plugins/issues/1192)
+      # tsc detects some type errors in the code. However we ignore this because it's not a problem for the final build if server/dist is generated.
+      tsc -p server || true
+      test -d server/dist
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -R server/dist $out
+      runHook postInstall
+    '';
+
+    doDist = false;
+
+    meta = with lib; {
+      homepage = "https://github.com/stoplightio/vscode-spectral";
+      description = "VS Code extension bringing the awesome Spectral JSON/YAML linter with OpenAPI/AsyncAPI support";
+      license = licenses.asl20;
+    };
+  };
+in
+buildNpmPackage rec {
+  pname = "spectral-language-server";
+  version = "1.0.8-unstable-2023-06-06";
+
+  src = fetchFromGitHub {
+    owner = "luizcorreia";
+    repo = "spectral-language-server";
+    rev = "c9a7752b08e6bba937ef4f5435902afd41b6957f";
+    hash = "sha256-VD2aAzlCnJ6mxPUSbNRfMOlslM8kLPqrAI2ah6sX9cU=";
+  };
+
+  npmDepsHash = "sha256-ixAXy/rRkyWL3jdAkrXJh1qhWcKIkr5nH/Bhu2JV6k8=";
+
+  patches = [
+    # https://github.com/luizcorreia/spectral-language-server/pull/15
+    (fetchpatch {
+      name = "fix-package-lock.patch";
+      url = "https://github.com/luizcorreia/spectral-language-server/commit/909704850dd10e7b328fc7d15f8b07cdef88899d.patch";
+      hash = "sha256-+mN93xP4HCll4dTcnh2W/m9k3XovvgnB6AOmuJpZUZ0=";
+    })
+  ];
+
+  dontNpmBuild = true;
+
+  npmFlags = [ "--ignore-scripts" ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    mkdir -p $out/node_modules
+    mkdir -p $out/dist/spectral-language-server
+    cp -R ${vscodeSpectral}/dist/* $out/dist/spectral-language-server/
+    cp ./bin/* $out/bin
+    cp -R ./node_modules/* $out/node_modules
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/luizcorreia/spectral-language-server";
+    description = "Awesome Spectral JSON/YAML linter with OpenAPI/AsyncAPI support";
+    maintainers = with maintainers; [ momeemt ];
+    license = licenses.mit;
+    mainProgram = "spectral-language-server";
+  };
+}


### PR DESCRIPTION
close #283363 

## Description of changes

spectral-language-server is a language server that includes Spectral, a flexible object linter with out-of-the-box support for OpenAPI v2 and v3, JSON Schema, and AsyncAPI.
I defined a derivation because #283363 requests this package.

https://github.com/luizcorreia/spectral-language-server

As this is my first time writing code on nixpkgs, I would be grateful if you could tell me if there are any bugs.
In particular, I'm wondering if my workaround for @rollup/pluginutils not providing type definitions for NodeNext is the right one.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
