### PR TITLE
[23.11] prismlauncher: 8.0 -> 8.3

### DIFF
--- a/pkgs/games/prismlauncher/default.nix
+++ b/pkgs/games/prismlauncher/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontWrapQtApps = true;
 
-  meta = with lib; {
+  meta = {
     mainProgram = "prismlauncher";
     homepage = "https://prismlauncher.org/";
     description = "A free, open source launcher for Minecraft";
@@ -78,9 +78,9 @@ stdenv.mkDerivation (finalAttrs: {
       their own mods, texture packs, saves, etc) and helps you manage them and
       their associated options with a simple interface.
     '';
-    platforms = with platforms; linux ++ darwin;
-    changelog = "https://github.com/PrismLauncher/PrismLauncher/releases/tag/${version}";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ minion3665 Scrumplex getchoo ];
+    platforms = with lib.platforms; linux ++ darwin;
+    changelog = "https://github.com/PrismLauncher/PrismLauncher/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ minion3665 Scrumplex getchoo ];
   };
 })

--- a/pkgs/games/prismlauncher/default.nix
+++ b/pkgs/games/prismlauncher/default.nix
@@ -31,13 +31,13 @@ assert lib.assertMsg (stdenv.isLinux || !gamemodeSupport) "gamemodeSupport is on
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "prismlauncher-unwrapped";
-  version = "8.0";
+  version = "8.2";
 
   src = fetchFromGitHub {
     owner = "PrismLauncher";
     repo = "PrismLauncher";
     rev = finalAttrs.version;
-    hash = "sha256-WBajtfj3qAMq8zd2S53CQyHiyqtvffLOHOjmOpdALAA=";
+    hash = "sha256-4VsoxZzi/EfEsnDvvwzg2xhj7j5B+k3gvaSqwJFDweE=";
   };
 
   nativeBuildInputs = [ extra-cmake-modules cmake jdk17 ninja canonicalize-jars-hook ];

--- a/pkgs/games/prismlauncher/default.nix
+++ b/pkgs/games/prismlauncher/default.nix
@@ -60,7 +60,11 @@ stdenv.mkDerivation (finalAttrs: {
     "-DLauncher_BUILD_PLATFORM=nixpkgs"
   ] ++ lib.optionals (msaClientID != null) [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ]
   ++ lib.optionals (lib.versionOlder qtbase.version "6") [ "-DLauncher_QT_VERSION_MAJOR=5" ]
-  ++ lib.optionals stdenv.isDarwin [ "-DINSTALL_BUNDLE=nodeps" "-DMACOSX_SPARKLE_UPDATE_FEED_URL=''" ];
+  ++ lib.optionals stdenv.isDarwin [
+    "-DINSTALL_BUNDLE=nodeps"
+    "-DMACOSX_SPARKLE_UPDATE_FEED_URL=''"
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}/Applications/"
+  ];
 
   postUnpack = ''
     rm -rf source/libraries/libnbtplusplus

--- a/pkgs/games/prismlauncher/default.nix
+++ b/pkgs/games/prismlauncher/default.nix
@@ -31,13 +31,13 @@ assert lib.assertMsg (stdenv.isLinux || !gamemodeSupport) "gamemodeSupport is on
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "prismlauncher-unwrapped";
-  version = "8.2";
+  version = "8.3";
 
   src = fetchFromGitHub {
     owner = "PrismLauncher";
     repo = "PrismLauncher";
     rev = finalAttrs.version;
-    hash = "sha256-4VsoxZzi/EfEsnDvvwzg2xhj7j5B+k3gvaSqwJFDweE=";
+    hash = "sha256-1YGzCgNdzscnOVeNlHMFJa0RbMo6C2qQjtBOeDxHakI=";
   };
 
   nativeBuildInputs = [ extra-cmake-modules cmake jdk17 ninja canonicalize-jars-hook ];

--- a/pkgs/games/prismlauncher/wrapper.nix
+++ b/pkgs/games/prismlauncher/wrapper.nix
@@ -72,7 +72,7 @@ symlinkJoin {
   ]
   ++ lib.optional (lib.versionAtLeast qtbase.version "6" && stdenv.isLinux) qtwayland;
 
-  waylandPreExec = ''
+  waylandPreExec = lib.optionalString withWaylandGLFW ''
     if [ -n "$WAYLAND_DISPLAY" ]; then
       export LD_LIBRARY_PATH=${lib.getLib glfw-wayland-minecraft}/lib:"$LD_LIBRARY_PATH"
     fi

--- a/pkgs/games/prismlauncher/wrapper.nix
+++ b/pkgs/games/prismlauncher/wrapper.nix
@@ -24,6 +24,7 @@
 , mesa-demos
 , pciutils
 , udev
+, vulkan-loader
 , libusb1
 
 , msaClientID ? null
@@ -100,6 +101,7 @@ symlinkJoin {
         glfw
         openal
         stdenv.cc.cc.lib
+        vulkan-loader # VulkanMod's lwjgl
 
         # oshi
         udev

--- a/pkgs/games/prismlauncher/wrapper.nix
+++ b/pkgs/games/prismlauncher/wrapper.nix
@@ -18,6 +18,7 @@
 , openal
 , jdk8
 , jdk17
+, jdk21
 , gamemode
 , flite
 , mesa-demos
@@ -39,7 +40,7 @@
   # itself can take slightly longer to start
 , withWaylandGLFW ? false
 
-, jdks ? [ jdk17 jdk8 ]
+, jdks ? [ jdk21 jdk17 jdk8 ]
 , additionalLibs ? [ ]
 , additionalPrograms ? [ ]
 }:

--- a/pkgs/games/prismlauncher/wrapper.nix
+++ b/pkgs/games/prismlauncher/wrapper.nix
@@ -1,9 +1,12 @@
 { lib
 , stdenv
 , symlinkJoin
-, prismlauncher-unwrapped
+, makeWrapper
 , wrapQtAppsHook
 , addOpenGLRunpath
+
+, prismlauncher-unwrapped
+
 , qtbase  # needed for wrapQtAppsHook
 , qtsvg
 , qtwayland
@@ -11,6 +14,7 @@
 , libpulseaudio
 , libGL
 , glfw
+, glfw-wayland-minecraft
 , openal
 , jdk8
 , jdk17
@@ -25,23 +29,43 @@
 , gamemodeSupport ? stdenv.isLinux
 , textToSpeechSupport ? stdenv.isLinux
 , controllerSupport ? stdenv.isLinux
+
+# The flag `withWaylandGLFW` enables runtime-checking of `WAYLAND_DISPLAY`;
+# if the option is enabled, a patched version of GLFW will be added to
+# `LD_LIBRARY_PATH` so that the launcher can use the correct one
+# depending on the desktop environment used.
+, withWaylandGLFW ? false
+
 , jdks ? [ jdk17 jdk8 ]
 , additionalLibs ? [ ]
 , additionalPrograms ? [ ]
 }:
+
+assert lib.assertMsg (withWaylandGLFW -> stdenv.isLinux) "withWaylandGLFW is only available on Linux";
+
 let
-  prismlauncherFinal = prismlauncher-unwrapped.override {
+  # By default, this package uses a binary wrapper for `wrapQtAppsHook`.
+  # Enabling `shellWrapper` will add `makeWrapper` to `nativeBuildInputs`,
+  # causing `wrapQtAppsHook` to output a shell wrapper instead.
+  # This is needed for checking environment variables at runtime
+  # and modifying others if necessary (see above option for example).
+  # Warning: This can make the program start slower, by about four milliseconds.
+  shellWrapper = withWaylandGLFW;
+
+  prismlauncher' = prismlauncher-unwrapped.override {
     inherit msaClientID gamemodeSupport;
   };
 in
-symlinkJoin {
-  name = "prismlauncher-${prismlauncherFinal.version}";
 
-  paths = [ prismlauncherFinal ];
+symlinkJoin {
+  name = "prismlauncher-${prismlauncher'.version}";
+
+  paths = [ prismlauncher' ];
 
   nativeBuildInputs = [
     wrapQtAppsHook
-  ];
+  ]
+  ++ lib.optional shellWrapper makeWrapper;
 
   buildInputs = [
     qtbase
@@ -49,20 +73,29 @@ symlinkJoin {
   ]
   ++ lib.optional (lib.versionAtLeast qtbase.version "6" && stdenv.isLinux) qtwayland;
 
+  waylandPreExec = ''
+    if [ -n "$WAYLAND_DISPLAY" ]; then
+      export LD_LIBRARY_PATH=${lib.getLib glfw-wayland-minecraft}/lib:"$LD_LIBRARY_PATH"
+    fi
+  '';
+
   postBuild = ''
+    ${lib.optionalString withWaylandGLFW ''
+      qtWrapperArgs+=(--run "$waylandPreExec")
+    ''}
+
     wrapQtAppsHook
   '';
 
   qtWrapperArgs =
     let
-      runtimeLibs = (with xorg; [
-        libX11
-        libXext
-        libXcursor
-        libXrandr
-        libXxf86vm
-      ])
-      ++ [
+      runtimeLibs = [
+        xorg.libX11
+        xorg.libXext
+        xorg.libXcursor
+        xorg.libXrandr
+        xorg.libXxf86vm
+
         # lwjgl
         libpulseaudio
         libGL
@@ -93,5 +126,5 @@ symlinkJoin {
       "--prefix PATH : ${lib.makeBinPath runtimePrograms}"
     ];
 
-  inherit (prismlauncherFinal) meta;
+  inherit (prismlauncher') meta;
 }


### PR DESCRIPTION
## Description of changes

This backports all Prism Launcher commits

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
