### PR TITLE
keydb: init at 6.3.4

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -441,6 +441,7 @@ with lib.maintainers; {
     # Verify additions to this team with at least one already existing member of the team.
     members = [
       das_j
+      conni2461
     ];
     scope = "Group registration for packages maintained by Helsinki Systems";
     shortName = "Helsinki Systems employees";

--- a/nixos/modules/services/databases/redis.nix
+++ b/nixos/modules/services/databases/redis.nix
@@ -338,7 +338,7 @@ in {
       after = [ "network.target" ];
 
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/redis-server /var/lib/${redisName name}/redis.conf ${escapeShellArgs conf.extraParams}";
+        ExecStart = "${cfg.package}/bin/${cfg.package.serverBin or "redis-server"} /var/lib/${redisName name}/redis.conf ${escapeShellArgs conf.extraParams}";
         ExecStartPre = "+"+pkgs.writeShellScript "${redisName name}-prep-conf" (let
           redisConfVar = "/var/lib/${redisName name}/redis.conf";
           redisConfRun = "/run/${redisName name}/nixos.conf";
@@ -391,7 +391,8 @@ in {
         RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
         RestrictNamespaces = true;
         LockPersonality = true;
-        MemoryDenyWriteExecute = true;
+        # we need to disable MemoryDenyWriteExecute for keydb
+        MemoryDenyWriteExecute = cfg.package.pname != "keydb";
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
         PrivateMounts = true;

--- a/nixos/tests/redis.nix
+++ b/nixos/tests/redis.nix
@@ -1,44 +1,87 @@
-import ./make-test-python.nix ({ pkgs, lib, ... }:
 {
-  name = "redis";
-  meta.maintainers = with lib.maintainers; [ flokli ];
+  system ? builtins.currentSystem,
+  config ? { },
+  pkgs ? import ../../.. { inherit system config; },
 
-  nodes = {
-    machine =
-      { pkgs, lib, ... }:
-
-      {
-        services.redis.servers."".enable = true;
-        services.redis.servers."test".enable = true;
-
-        users.users = lib.listToAttrs (map (suffix: lib.nameValuePair "member${suffix}" {
-          createHome = false;
-          description = "A member of the redis${suffix} group";
-          isNormalUser = true;
-          extraGroups = [ "redis${suffix}" ];
-        }) ["" "-test"]);
-      };
+  lib ? pkgs.lib,
+}:
+let
+  makeTest = import ./make-test-python.nix;
+  mkTestName =
+    pkg: "${pkg.pname}_${builtins.replaceStrings [ "." ] [ "" ] (lib.versions.majorMinor pkg.version)}";
+  redisPackages = {
+    inherit (pkgs) redis keydb;
   };
+  makeRedisTest =
+    {
+      package,
+      name ? mkTestName package,
+    }:
+    makeTest {
+      inherit name;
+      meta.maintainers = [
+        lib.maintainers.flokli
+        lib.teams.helsinki-systems.members
+      ];
 
-  testScript = { nodes, ... }: let
-    inherit (nodes.machine.config.services) redis;
-    in ''
-    start_all()
-    machine.wait_for_unit("redis")
-    machine.wait_for_unit("redis-test")
+      nodes = {
+        machine =
+          { lib, ... }:
 
-    # The unnamed Redis server still opens a port for backward-compatibility
-    machine.wait_for_open_port(6379)
+          {
+            services = {
+              redis = {
+                inherit package;
+                servers."".enable = true;
+                servers."test".enable = true;
+              };
+            };
 
-    machine.wait_for_file("${redis.servers."".unixSocket}")
-    machine.wait_for_file("${redis.servers."test".unixSocket}")
+            users.users = lib.listToAttrs (
+              map
+                (
+                  suffix:
+                  lib.nameValuePair "member${suffix}" {
+                    createHome = false;
+                    description = "A member of the redis${suffix} group";
+                    isNormalUser = true;
+                    extraGroups = [ "redis${suffix}" ];
+                  }
+                )
+                [
+                  ""
+                  "-test"
+                ]
+            );
+          };
+      };
 
-    # The unix socket is accessible to the redis group
-    machine.succeed('su member -c "redis-cli ping | grep PONG"')
-    machine.succeed('su member-test -c "redis-cli ping | grep PONG"')
+      testScript =
+        { nodes, ... }:
+        let
+          inherit (nodes.machine.services) redis;
+        in
+        ''
+          start_all()
+          machine.wait_for_unit("redis")
+          machine.wait_for_unit("redis-test")
 
-    machine.succeed("redis-cli ping | grep PONG")
-    machine.succeed("redis-cli -s ${redis.servers."".unixSocket} ping | grep PONG")
-    machine.succeed("redis-cli -s ${redis.servers."test".unixSocket} ping | grep PONG")
-  '';
-})
+          # The unnamed Redis server still opens a port for backward-compatibility
+          machine.wait_for_open_port(6379)
+
+          machine.wait_for_file("${redis.servers."".unixSocket}")
+          machine.wait_for_file("${redis.servers."test".unixSocket}")
+
+          # The unix socket is accessible to the redis group
+          machine.succeed('su member -c "${pkgs.redis}/bin/redis-cli ping | grep PONG"')
+          machine.succeed('su member-test -c "${pkgs.redis}/bin/redis-cli ping | grep PONG"')
+
+          machine.succeed("${pkgs.redis}/bin/redis-cli ping | grep PONG")
+          machine.succeed("${pkgs.redis}/bin/redis-cli -s ${redis.servers."".unixSocket} ping | grep PONG")
+          machine.succeed("${pkgs.redis}/bin/redis-cli -s ${
+            redis.servers."test".unixSocket
+          } ping | grep PONG")
+        '';
+    };
+in
+lib.mapAttrs (_: package: makeRedisTest { inherit package; }) redisPackages

--- a/pkgs/by-name/ke/keydb/package.nix
+++ b/pkgs/by-name/ke/keydb/package.nix
@@ -1,0 +1,106 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  libuuid,
+  curl,
+  pkg-config,
+  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  systemd,
+  tlsSupport ? !stdenv.hostPlatform.isStatic,
+  openssl,
+  jemalloc,
+  which,
+  tcl,
+  tcltls,
+  ps,
+  getconf,
+  nixosTests,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "keydb";
+  version = "6.3.4";
+
+  src = fetchFromGitHub {
+    owner = "snapchat";
+    repo = "keydb";
+    rev = "v${version}";
+    hash = "sha256-j6qgK6P3Fv+b6k9jwKQ5zW7XLkKbXXcmHKBCQYvwEIU=";
+  };
+
+  postPatch = ''
+    substituteInPlace deps/lua/src/Makefile \
+      --replace-fail "ar rcu" "${stdenv.cc.targetPrefix}ar rcu"
+    substituteInPlace src/Makefile \
+      --replace-fail "as --64 -g" "${stdenv.cc.targetPrefix}as --64 -g"
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    jemalloc
+    curl
+    libuuid
+  ] ++ lib.optionals tlsSupport [ openssl ] ++ lib.optionals withSystemd [ systemd ];
+
+  makeFlags =
+    [
+      "PREFIX=${placeholder "out"}"
+      "AR=${stdenv.cc.targetPrefix}ar"
+      "RANLIB=${stdenv.cc.targetPrefix}ranlib"
+      "USEASM=${if stdenv.isx86_64 then "true" else "false"}"
+    ]
+    ++ lib.optionals (!tlsSupport) [ "BUILD_TLS=no" ]
+    ++ lib.optionals withSystemd [ "USE_SYSTEMD=yes" ]
+    ++ lib.optionals (!stdenv.isx86_64) [ "MALLOC=libc" ];
+
+  enableParallelBuilding = true;
+
+  hardeningEnable = lib.optionals (!stdenv.isDarwin) [ "pie" ];
+
+  # darwin currently lacks a pure `pgrep` which is extensively used here
+  doCheck = !stdenv.isDarwin;
+  nativeCheckInputs = [
+    which
+    tcl
+    ps
+  ] ++ lib.optionals stdenv.hostPlatform.isStatic [ getconf ] ++ lib.optionals tlsSupport [ tcltls ];
+  checkPhase = ''
+    runHook preCheck
+
+    # disable test "Connect multiple replicas at the same time": even
+    # upstream find this test too timing-sensitive
+    substituteInPlace tests/integration/replication.tcl \
+      --replace-fail 'foreach mdl {no yes}' 'foreach mdl {}'
+
+    substituteInPlace tests/support/server.tcl \
+      --replace-fail 'exec /usr/bin/env' 'exec env'
+
+    sed -i '/^proc wait_load_handlers_disconnected/{n ; s/wait_for_condition 50 100/wait_for_condition 50 500/; }' \
+      tests/support/util.tcl
+
+    patchShebangs ./utils/gen-test-certs.sh
+    ${if tlsSupport then "./utils/gen-test-certs.sh" else ""}
+
+    ./runtest \
+      --no-latency \
+      --timeout 2000 \
+      --clients $NIX_BUILD_CORES \
+      --tags -leaks ${if tlsSupport then "--tls" else ""}
+
+    runHook postCheck
+  '';
+
+  passthru.tests.redis = nixosTests.redis;
+  passthru.serverBin = "keydb-server";
+
+  meta = with lib; {
+    homepage = "https://keydb.dev";
+    description = "A Multithreaded Fork of Redis";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    changelog = "https://github.com/Snapchat/KeyDB/raw/v${version}/00-RELEASENOTES";
+    maintainers = teams.helsinki-systems.members;
+    mainProgram = "keydb-cli";
+  };
+}

--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -85,6 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru.tests.redis = nixosTests.redis;
+  passthru.serverBin = "redis-server";
 
   meta = with lib; {
     homepage = "https://redis.io";


### PR DESCRIPTION
## Description of changes

very similar to the already existing redis package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
