### PR TITLE
factorio: use requireFile with better error msg and split off API docs to devdoc

### DIFF
--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -263,8 +263,15 @@ let
     };
     alpha = demo // {
 
+      outputs = [ "out" "devdoc" ];
       installPhase = demo.installPhase + ''
-        cp -a doc-html $out/share/factorio
+        mkdir -p $devdoc/share/doc
+        cp -a doc-html $devdoc/share/doc/factorio
+      '';
+
+      postFixup = ''
+        # postInstall itself is insufficient _multioutDocs hook in preFixup moves this to $doc output instead.
+        moveToOutput "share/doc" "$devdoc"
       '';
     };
   };

--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -37,7 +37,7 @@ let
 
   mods = args.mods or [ ];
 
-  helpMsg = ''
+  helpMsg = version: ''
 
     ===FETCH FAILED===
     Please ensure you have set the username and token with config.nix, or
@@ -62,8 +62,8 @@ let
     download the release through https://factorio.com/download , then add it to
     the store using e.g.:
 
-      releaseType=alpha
-      version=0.17.74
+      releaseType=${releaseType}
+      version=${version}
       nix-prefetch-url file://\''$HOME/Downloads/factorio_\''${releaseType}_x64_\''${version}.tar.xz --name factorio_\''${releaseType}_x64-\''${version}.tar.xz
 
     Note the ultimate "_" is replaced with "-" in the --name arg!
@@ -129,7 +129,7 @@ let
               '';
             failureHook = ''
               cat <<EOF
-              ${helpMsg}
+              ${helpMsg version}
               EOF
             '';
           }));


### PR DESCRIPTION
Specifically display the *actual* `releaseType` and `version` that they have to fetch manually instead of expecting them to derive this information from the full path of the derivation that just failed to build.

On top of that this splits the *developer*/*API* documentation to a separate `devdoc` output. Allowing most users to save on the ~100 MiB that this occupies. (Note this is basically an offline copy of https://lua-api.factorio.com/latest/ )

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
