### PR TITLE
python3Packages.rasterio: ignore tests failing on PytestRemovedIn8Warning

### DIFF
--- a/pkgs/development/python-modules/rasterio/default.nix
+++ b/pkgs/development/python-modules/rasterio/default.nix
@@ -104,6 +104,9 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [
     "-m 'not network'"
+
+    # pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
+    "-W ignore::pytest.PytestRemovedIn8Warning"
   ];
 
   disabledTests = [


### PR DESCRIPTION
## Description of changes

Fix package build.
Ignore test failing on `pytest.PytestRemovedIn8Warning: Passing None has been deprecated.`

```
FAILED tests/test_rio_shapes.py::test_shapes_band1_as_mask - pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
FAILED tests/test_rio_shapes.py::test_shapes_indent - pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
FAILED tests/test_rio_shapes.py::test_shapes_mask_sampling - pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
FAILED tests/test_rio_shapes.py::test_shapes_sequence - pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
FAILED tests/test_rio_shapes.py::test_shapes - pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
FAILED tests/test_rio_shapes.py::test_shapes_mask - pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
FAILED tests/test_rio_shapes.py::test_shapes_compact - pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
FAILED tests/test_warnings.py::test_no_notgeoref_warning[None-gcps1-None] - pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
FAILED tests/test_warnings.py::test_no_notgeoref_warning[transform0-None-None] - pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
FAILED tests/test_warnings.py::test_no_notgeoref_warning[None-None-rpcs2] - pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
= 10 failed, 2048 passed, 6 skipped, 16 deselected, 15 xfailed, 7 xpassed, 284 warnings in 170.36s (0:02:50) =
```

Following the same approach as many other other packages [do](https://github.com/search?q=repo%3ANixOS%2Fnixpkgs%20pytest.PytestRemovedIn8Warning&type=code).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
