### PR TITLE
python3Packages.pytest-order: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/development/python-modules/pytest-order/default.nix
+++ b/pkgs/development/python-modules/pytest-order/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "pytest-order";
-  version = "1.2.0";
+  version = "1.2.1";
   format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-lE+GttRBqnsdqA+AHGq2W4S766Ry0KehLrQ7omZQEBo=";
+    hash = "sha256-RFG9iCG6T6IQlFWi/MiCr2DvjlPgnSRNZ2dL4I9W6sM=";
   };
 
   buildInputs = [ pytest ];

--- a/pkgs/development/python-modules/pytest-order/default.nix
+++ b/pkgs/development/python-modules/pytest-order/default.nix
@@ -27,10 +27,10 @@ buildPythonPackage rec {
     pytest-mock
   ];
 
-  meta = {
+  meta = with lib; {
     description = "Pytest plugin that allows you to customize the order in which your tests are run";
     homepage = "https://github.com/pytest-dev/pytest-order";
-    license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.jacg ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ jacg Luflosi ];
   };
 }

--- a/pkgs/development/python-modules/pytest-order/default.nix
+++ b/pkgs/development/python-modules/pytest-order/default.nix
@@ -27,6 +27,8 @@ buildPythonPackage rec {
     pytest-mock
   ];
 
+  strictDeps = true;
+
   meta = with lib; {
     description = "Pytest plugin that allows you to customize the order in which your tests are run";
     homepage = "https://github.com/pytest-dev/pytest-order";


### PR DESCRIPTION
## Description of changes
https://github.com/pytest-dev/pytest-order/releases/tag/v1.2.1

Also add myself as a maintainer and enable `strictDeps`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
