### PR TITLE
curl-impersonate: 0.5.4 -> 0.6.1

### DIFF
--- a/pkgs/tools/networking/curl-impersonate/default.nix
+++ b/pkgs/tools/networking/curl-impersonate/default.nix
@@ -28,13 +28,13 @@
 let
   makeCurlImpersonate = { name, target }: stdenv.mkDerivation rec {
     pname = "curl-impersonate-${name}";
-    version = "0.5.4";
+    version = "0.6.1";
 
     src = fetchFromGitHub {
       owner = "lwthiker";
       repo = "curl-impersonate";
       rev = "v${version}";
-      hash = "sha256-LBGWFal2szqgURIBCLB84kHWpdpt5quvBBZu6buGj2A=";
+      hash = "sha256-ExmEhjJC8FPzx08RuKOhRxKgJ4Dh+ElEl+OUHzRCzZc=";
     };
 
     patches = [
@@ -145,7 +145,7 @@ let
         inherit (passthru.deps."boringssl.zip") name;
 
         src = passthru.deps."boringssl.zip";
-        vendorHash = "sha256-ISmRdumckvSu7hBXrjvs5ZApShDiGLdD3T5B0fJ1x2Q=";
+        vendorHash = "sha256-SNUsBiKOGWmkRdTVABVrlbLAVMfu0Q9IgDe+kFC5vXs=";
 
         nativeBuildInputs = [ unzip ];
 

--- a/pkgs/tools/networking/curl-impersonate/deps.nix
+++ b/pkgs/tools/networking/curl-impersonate/deps.nix
@@ -2,9 +2,9 @@
 { fetchurl }:
 
 {
-  "curl-7.84.0.tar.xz" = fetchurl {
-    url = "https://curl.se/download/curl-7.84.0.tar.xz";
-    hash = "sha256-LRGLQ/VHv+W66AbY1HtOWW6lslpsHwgK70n7zYF8Xbg=";
+  "curl-8.1.1.tar.xz" = fetchurl {
+    url = "https://curl.se/download/curl-8.1.1.tar.xz";
+    hash = "sha256-CKlI4GGSlkVZfB73GU4HswiyIIT/A/p0ALRl5sBRSeU=";
   };
 
   "brotli-1.0.9.tar.gz" = fetchurl {
@@ -12,18 +12,18 @@
     hash = "sha256-+ejYHQQFumbRgVKa9CozVPg4yTkJX/mZMNpqqc32/kY=";
   };
 
-  "nss-3.87.tar.gz" = fetchurl {
-    url = "https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_87_RTM/src/nss-3.87-with-nspr-4.35.tar.gz";
-    hash = "sha256-63DqC1jc5pqkkOnp/s0TKn1kTh2j1jHhYzdqDcwRoCI=";
+  "nss-3.92.tar.gz" = fetchurl {
+    url = "https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_92_RTM/src/nss-3.92-with-nspr-4.35.tar.gz";
+    hash = "sha256-IcF2v/+27IQLX5hcf48BRoL0ovtVsGkkc0Fy1cBIbcU=";
   };
 
   "boringssl.zip" = fetchurl {
-    url = "https://github.com/google/boringssl/archive/3a667d10e94186fd503966f5638e134fe9fb4080.zip";
-    hash = "sha256-HsDIkd1x5IH49fUF07dJaabMIMsQygW+NI7GneULpA8=";
+    url = "https://github.com/google/boringssl/archive/1b7fdbd9101dedc3e0aa3fcf4ff74eacddb34ecc.zip";
+    hash = "sha256-daVVQvpxkuEL/8/+QtLOJkdO+ECYZE3P4qJmDjV1GM0=";
   };
 
-  "nghttp2-1.46.0.tar.bz2" = fetchurl {
-    url = "https://github.com/nghttp2/nghttp2/releases/download/v1.46.0/nghttp2-1.46.0.tar.bz2";
-    hash = "sha256-moKXjIcAcbdp8n0riBkct3/clFpRwdaFx/YafhP8Ryk=";
+  "nghttp2-1.56.0.tar.bz2" = fetchurl {
+    url = "https://github.com/nghttp2/nghttp2/releases/download/v1.56.0/nghttp2-1.56.0.tar.bz2";
+    hash = "sha256-L13Nv1d6LfUTokZGRUhMw10uTQczZT1jGTrlHbQd70E=";
   };
 }


### PR DESCRIPTION
## Description of changes

Update curl-impersonate: 0.5.4 -> 0.6.1

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


## Note
Normally the build fails with 
```
       Known issues:
        - CVE-2023-38545
        - CVE-2023-32001
        - CVE-2022-43551
        - CVE-2022-42916
```
But with `NIXPKGS_ALLOW_INSECURE=1` can be built successfully.

Should close https://github.com/NixOS/nixpkgs/issues/289010

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
