### PR TITLE
thcrap-steam-proton-wrapper: init at 0-unstable-2024-04-03

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1758,6 +1758,16 @@
     githubId = 11037075;
     name = "Ashley Hooper";
   };
+  ashuramaruzxc = {
+    email = "ashuramaru@tenjin-dk.com";
+    matrix = "@tenjin:mozilla.org";
+    github = "ashuramaruzxc";
+    githubId = 72100551;
+    name = "Mariia Holovata";
+    keys = [{
+      fingerprint = "409D 201E 9450 8732 A49E  D0FC 6BDA F874 0068 08DF";
+    }];
+  };
   ashvith-shetty = {
     github = "Ashvith10";
     githubId = 113123021;

--- a/pkgs/by-name/th/thcrap-steam-proton-wrapper/package.nix
+++ b/pkgs/by-name/th/thcrap-steam-proton-wrapper/package.nix
@@ -1,0 +1,56 @@
+{
+  lib
+  , stdenv
+  , fetchFromGitHub
+  , makeWrapper
+  , bash
+  , subversion
+  , gnome
+}:
+stdenv.mkDerivation {
+  pname = "thcrap-proton";
+  version = "0-unstable-2024-04-03";
+
+  src = fetchFromGitHub {
+    owner = "tactikauan";
+    repo = "thcrap-steam-proton-wrapper";
+    rev = "2b636c3f5f1ce1b9b41f731aa9397aa68d2ce66b";
+    sha256 = "sha256-J2O8F75NMdsxSaNVr8zLf+vLEJE6CHqWQIIscuuJZ3o=";
+  };
+
+  buildInputs = [ subversion ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp thcrap_proton $out/bin/thcrap_proton
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/thcrap_proton \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          bash
+          subversion
+          gnome.zenity
+        ]
+      }
+  '';
+
+  meta = {
+    description = "A wrapper script for launching the official Touhou games on Steam with patches through Proton on GNU/Linux";
+    homepage = "https://github.com/tactikauan/thcrap-steam-proton-wrapper";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ ashuramaruzxc ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "thcrap_proton";
+  };
+}


### PR DESCRIPTION
## Description of changes
Add package with a [wrapper script](https://github.com/tactikauan/thcrap-steam-proton-wrapper) for running Touhou games under steam proton with: 
[thcrap patch](https://github.com/thpatch/thcrap) (English localization, QOL and etc),
[thprac](https://github.com/touhouworldcup/thprac) (Practice tool), 
vsync patch.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
```
1 package built:
thcrap-steam-proton-wrapper
```
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
