### PR TITLE
parlatype: 4.0 -> 4.1

### DIFF
--- a/pkgs/applications/audio/parlatype/default.nix
+++ b/pkgs/applications/audio/parlatype/default.nix
@@ -10,6 +10,7 @@
 , hicolor-icon-theme
 , isocodes
 , itstool
+, libadwaita
 , libxml2
 , meson
 , ninja
@@ -20,13 +21,13 @@
 
 stdenv.mkDerivation rec {
   pname = "parlatype";
-  version = "4.0";
+  version = "4.1";
 
   src = fetchFromGitHub {
     owner = "gkarsay";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1iyjxss6sgc9gx6ij30zz97bl31qix8pxklzn4kknh1b0j7hhbwq";
+    sha256 = "0546rl5sm7xmgl54cqps3a7bhfs7xdvz98jgdcf4sgiz1k2vh9xq";
   };
 
   nativeBuildInputs = [
@@ -53,6 +54,7 @@ stdenv.mkDerivation rec {
     gtk4
     hicolor-icon-theme
     isocodes
+    libadwaita
   ];
 
   postPatch = ''
@@ -72,7 +74,8 @@ stdenv.mkDerivation rec {
       useful for journalists, students, scientists and whoever needs to
       transcribe audio files.
     '';
-    homepage = "https://www.parlatype.org/";
+    # maintainer lost control of parlatype.org
+    homepage = "https://github.com/gkarsay/parlatype";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ alexshpilkin melchips ];
     platforms = platforms.linux;


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/gkarsay/parlatype/releases/tag/v4.1

TL;DR: libadwaita port, some bugfixes, some translation updates

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
