### PR TITLE
treewide: replace wrapGAppsHook with wrapGAppsHook4 for gtk4 apps

### DIFF
--- a/pkgs/applications/audio/parlatype/default.nix
+++ b/pkgs/applications/audio/parlatype/default.nix
@@ -15,7 +15,7 @@
 , ninja
 , pkg-config
 , python3
-, wrapGAppsHook
+, wrapGAppsHook4
 }:
 
 stdenv.mkDerivation rec {
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [
@@ -56,6 +56,8 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
+    substituteInPlace data/meson_post_install.py \
+      --replace-fail 'gtk-update-icon-cache' 'gtk4-update-icon-cache'
     patchShebangs data/meson_post_install.py
     patchShebangs libparlatype/tests/data/generate_config_data
   '';

--- a/pkgs/applications/audio/zrythm/default.nix
+++ b/pkgs/applications/audio/zrythm/default.nix
@@ -64,7 +64,7 @@
 , sratom
 , texi2html
 , vamp-plugin-sdk
-, wrapGAppsHook
+, wrapGAppsHook4
 , xdg-utils
 , xxHash
 , zix
@@ -112,7 +112,7 @@ stdenv.mkDerivation rec {
     python3.pkgs.sphinx
     sassc
     texi2html
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [

--- a/pkgs/applications/display-managers/greetd/regreet.nix
+++ b/pkgs/applications/display-managers/greetd/regreet.nix
@@ -2,7 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , pkg-config
-, wrapGAppsHook
+, wrapGAppsHook4
 , glib
 , gtk4
 , pango
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
 
   buildFeatures = [ "gtk4_8" ];
 
-  nativeBuildInputs = [ pkg-config wrapGAppsHook];
+  nativeBuildInputs = [ pkg-config wrapGAppsHook4 ];
   buildInputs = [ glib gtk4 pango librsvg ];
 
   meta = with lib; {

--- a/pkgs/applications/graphics/conjure/default.nix
+++ b/pkgs/applications/graphics/conjure/default.nix
@@ -3,7 +3,7 @@
 , lib
 , libadwaita
 , python3Packages
-, wrapGAppsHook
+, wrapGAppsHook4
 , meson
 , ninja
 , desktop-file-utils
@@ -26,7 +26,7 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [
     gobject-introspection
-    wrapGAppsHook
+    wrapGAppsHook4
     desktop-file-utils
     appstream-glib
     meson

--- a/pkgs/applications/graphics/curtail/default.nix
+++ b/pkgs/applications/graphics/curtail/default.nix
@@ -1,7 +1,7 @@
 { lib
 , python3
 , fetchFromGitHub
-, wrapGAppsHook
+, wrapGAppsHook4
 , appstream-glib
 , desktop-file-utils
 , gettext
@@ -31,7 +31,7 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   nativeBuildInputs = [
-    wrapGAppsHook
+    wrapGAppsHook4
     appstream-glib
     desktop-file-utils
     gettext

--- a/pkgs/applications/misc/confy/default.nix
+++ b/pkgs/applications/misc/confy/default.nix
@@ -11,7 +11,7 @@
 , pkg-config
 , python3
 , stdenv
-, wrapGAppsHook
+, wrapGAppsHook4
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [
@@ -46,6 +46,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
+    substituteInPlace build-aux/meson/postinstall.py \
+      --replace-fail 'gtk-update-icon-cache' 'gtk4-update-icon-cache'
     patchShebangs build-aux/meson/postinstall.py
   '';
 

--- a/pkgs/applications/misc/gnome-solanum/default.nix
+++ b/pkgs/applications/misc/gnome-solanum/default.nix
@@ -10,7 +10,7 @@
 , ninja
 , pkg-config
 , rustc
-, wrapGAppsHook
+, wrapGAppsHook4
 , python3
 , git
 , glib
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    wrapGAppsHook
+    wrapGAppsHook4
     python3
     git
     desktop-file-utils

--- a/pkgs/applications/misc/gpu-viewer/default.nix
+++ b/pkgs/applications/misc/gpu-viewer/default.nix
@@ -9,7 +9,7 @@
 , gobject-introspection
 , vulkan-tools
 , python3
-, wrapGAppsHook
+, wrapGAppsHook4
 , gdk-pixbuf
 , lsb-release
 , glxinfo
@@ -35,7 +35,7 @@ python3.pkgs.buildPythonApplication rec {
     meson
     ninja
     gobject-introspection
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/plots/default.nix
+++ b/pkgs/applications/misc/plots/default.nix
@@ -3,7 +3,7 @@
 , python3Packages
 , gobject-introspection
 , libadwaita
-, wrapGAppsHook
+, wrapGAppsHook4
 , lmmath
 }:
 
@@ -18,7 +18,7 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-GjNpaorxkkhZsqrKq4kO5nqF5+4I4tmSc023AZpY8Sw=";
   };
 
-  nativeBuildInputs = [ gobject-introspection wrapGAppsHook ];
+  nativeBuildInputs = [ gobject-introspection wrapGAppsHook4 ];
   buildInputs = [ libadwaita ];
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/applications/networking/gnome-network-displays/default.nix
+++ b/pkgs/applications/networking/gnome-network-displays/default.nix
@@ -8,7 +8,7 @@
 , gettext
 , desktop-file-utils
 , appstream-glib
-, wrapGAppsHook
+, wrapGAppsHook4
 , python3
 # Not native
 , gst_all_1
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     gettext
     desktop-file-utils
     appstream-glib
-    wrapGAppsHook
+    wrapGAppsHook4
     python3
   ];
 

--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub
 , buildPackages
-, vala, cmake, ninja, wrapGAppsHook, pkg-config, gettext
+, vala, cmake, ninja, wrapGAppsHook4, pkg-config, gettext
 , gobject-introspection, glib, gdk-pixbuf, gtk4, glib-networking
 , libadwaita
 , libnotify, libsoup, libgee
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     cmake
     ninja # https://github.com/dino/dino/issues/230
     pkg-config
-    wrapGAppsHook
+    wrapGAppsHook4
     gettext
     gobject-introspection
   ];

--- a/pkgs/applications/networking/instant-messengers/tangram/default.nix
+++ b/pkgs/applications/networking/instant-messengers/tangram/default.nix
@@ -20,7 +20,7 @@
 , python3
 , webkitgtk_6_0
 , blueprint-compiler
-, wrapGAppsHook
+, wrapGAppsHook4
 }:
 
 stdenv.mkDerivation rec {
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     blueprint-compiler
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [

--- a/pkgs/applications/terminal-emulators/blackbox-terminal/default.nix
+++ b/pkgs/applications/terminal-emulators/blackbox-terminal/default.nix
@@ -18,9 +18,8 @@
 , libgee
 , callPackage
 , python3
-, gtk3
 , desktop-file-utils
-, wrapGAppsHook
+, wrapGAppsHook4
 , sixelSupport ? false
 }:
 
@@ -48,6 +47,8 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
+    substituteInPlace build-aux/meson/postinstall.py \
+      --replace-fail 'gtk-update-icon-cache' 'gtk4-update-icon-cache'
     patchShebangs build-aux/meson/postinstall.py
   '';
 
@@ -57,9 +58,8 @@ stdenv.mkDerivation rec {
     pkg-config
     vala
     sassc
-    wrapGAppsHook
+    wrapGAppsHook4
     python3
-    gtk3 # For gtk-update-icon-cache
     desktop-file-utils # For update-desktop-database
   ];
   buildInputs = [

--- a/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
+++ b/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
@@ -5,7 +5,7 @@
 , meson
 , ninja
 , pkg-config
-, wrapGAppsHook
+, wrapGAppsHook4
 , desktop-file-utils
 , feedbackd
 , gtk4
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     ninja
     phosh
     pkg-config
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [

--- a/pkgs/by-name/au/audio-sharing/package.nix
+++ b/pkgs/by-name/au/audio-sharing/package.nix
@@ -1,5 +1,6 @@
 { appstream-glib
 , cargo
+, dbus
 , desktop-file-utils
 , fetchFromGitLab
 , git
@@ -16,7 +17,7 @@
 , rustPlatform
 , rustc
 , stdenv
-, wrapGAppsHook
+, wrapGAppsHook4
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "audio-sharing";
@@ -46,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     python3
     rustc
-    wrapGAppsHook
+    wrapGAppsHook4
   ] ++ (with rustPlatform; [
     cargoSetupHook
   ]);
@@ -59,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gstreamer
     gtk4
     libadwaita
+    dbus
   ];
 
   passthru = {

--- a/pkgs/by-name/er/errands/package.nix
+++ b/pkgs/by-name/er/errands/package.nix
@@ -3,7 +3,7 @@
 , python3Packages
 , gobject-introspection
 , libadwaita
-, wrapGAppsHook
+, wrapGAppsHook4
 , meson
 , ninja
 , desktop-file-utils
@@ -29,7 +29,7 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [
     gobject-introspection
-    wrapGAppsHook
+    wrapGAppsHook4
     desktop-file-utils
     meson
     ninja

--- a/pkgs/by-name/go/goldwarden/package.nix
+++ b/pkgs/by-name/go/goldwarden/package.nix
@@ -8,7 +8,7 @@
 , libfido2
 , libnotify
 , python3
-, wrapGAppsHook
+, wrapGAppsHook4
 }:
 
 buildGoModule rec {
@@ -55,7 +55,7 @@ buildGoModule rec {
   nativeBuildInputs = [
     gobject-introspection
     python3.pkgs.wrapPython
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome/apps/gnome-sound-recorder/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-sound-recorder/default.nix
@@ -4,7 +4,7 @@
 , pkg-config
 , gettext
 , gobject-introspection
-, wrapGAppsHook
+, wrapGAppsHook4
 , gjs
 , glib
 , gtk4
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     gobject-introspection
-    wrapGAppsHook
+    wrapGAppsHook4
     python3
     desktop-file-utils
   ];
@@ -53,6 +53,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     chmod +x build-aux/meson_post_install.py
+    substituteInPlace build-aux/meson_post_install.py \
+      --replace-fail 'gtk-update-icon-cache' 'gtk4-update-icon-cache'
     patchShebangs build-aux/meson_post_install.py
   '';
 

--- a/pkgs/desktops/gnome/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-control-center/default.nix
@@ -62,7 +62,7 @@
 , libepoxy
 , gnome-user-share
 , gnome-remote-desktop
-, wrapGAppsHook
+, wrapGAppsHook4
 , xvfb-run
 }:
 
@@ -93,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     python3
     shared-mime-info
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [

--- a/pkgs/tools/misc/szyszka/default.nix
+++ b/pkgs/tools/misc/szyszka/default.nix
@@ -8,7 +8,7 @@
 , atk
 , gdk-pixbuf
 , gtk4
-, wrapGAppsHook
+, wrapGAppsHook4
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     pkg-config
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [

--- a/pkgs/tools/networking/lxi-tools/default.nix
+++ b/pkgs/tools/networking/lxi-tools/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub
 , meson, ninja, cmake, pkg-config
 , liblxi, readline, lua, bash-completion
-, wrapGAppsHook
+, wrapGAppsHook4
 , glib, gtk4, gtksourceview5, libadwaita, json-glib
 , desktop-file-utils, appstream-glib
 , gsettings-desktop-schemas
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     meson ninja cmake pkg-config
-  ] ++ lib.optional withGui wrapGAppsHook;
+  ] ++ lib.optional withGui wrapGAppsHook4;
 
   buildInputs = [
     liblxi readline lua bash-completion

--- a/pkgs/tools/system/lact/default.nix
+++ b/pkgs/tools/system/lact/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , blueprint-compiler
 , pkg-config
-, wrapGAppsHook
+, wrapGAppsHook4
 , gdk-pixbuf
 , gtk4
 , libdrm
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     blueprint-compiler
     pkg-config
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [


### PR DESCRIPTION
## Description of changes

This is checked with 
```shell
grep -rl 'gtk4' ./pkgs | xargs grep -l 'wrapGAppsHook' | xargs grep -L 'wrapGAppsHook4'
```

With some exceptions:
 
- ./pkgs/applications/misc/almanah/default.nix
Still uses gtk3
- ./pkgs/applications/networking/browsers/brave/default.nix
- ./pkgs/applications/networking/browsers/opera/default.nix
- ./pkgs/desktops/gnome/core/evolution-data-server/default.nix
- ./pkgs/desktops/gnome/core/gnome-terminal/default.nix
- ./pkgs/desktops/gnome/extensions/gsconnect/default.nix
- ./pkgs/desktops/gnome/extensions/extensionOverrides.nix
- ./pkgs/desktops/gnome/misc/gpaste/default.nix
Still uses gtk3
- ./pkgs/development/libraries/gtk/4.x.nix
- ./pkgs/development/lisp-modules/packages.nix
- ./pkgs/development/tools/cambalache/default.nix
- ./pkgs/development/tools/electron/wrapper.nix
- ./pkgs/tools/inputmethods/ibus/default.nix
- ./pkgs/by-name/pa/paper-plane/package.nix`


Also checked top-level reference, didn't see any of these using `wrapGAppsHook = wrapGAppsHook4`.

Since using `wrapGAppsHook` should be considered a mistake in such packages, I didn't consider issues like keeping overriding interface.

Please comment here as soon as possible if you think there is a good reason to use `wrapGAppsHook` in any of these packages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
