### PR TITLE
gitg: 41 -> 44

### DIFF
--- a/pkgs/desktops/gnome/misc/gitg/default.nix
+++ b/pkgs/desktops/gnome/misc/gitg/default.nix
@@ -1,12 +1,11 @@
 { lib
 , stdenv
 , fetchurl
-, fetchpatch
 , vala
-, gettext
 , pkg-config
 , gtk3
 , glib
+, gpgme
 , json-glib
 , wrapGAppsHook
 , libpeas
@@ -14,12 +13,13 @@
 , gobject-introspection
 , gtksourceview4
 , gsettings-desktop-schemas
-, adwaita-icon-theme
 , gnome
 , gspell
+, gvfs
 , shared-mime-info
 , libgee
 , libgit2-glib
+, libhandy
 , libsecret
 , libxml2
 , meson
@@ -30,25 +30,15 @@
 
 stdenv.mkDerivation rec {
   pname = "gitg";
-  version = "41";
+  version = "44";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "f7Ybn7EPuqVI0j1wZbq9cq1j5iHeVYQMBlzm45hsRik=";
+    hash = "sha256-NCoxaE2rlnHNNBvT485mWtzuBGDCoIHdxJPNvAMTJTA=";
   };
-
-  patches = [
-    # Fix build with meson 0.61
-    # data/meson.build:8:5: ERROR: Function does not take positional arguments.
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gitg/-/commit/1978973b12848741b08695ec2020bac98584d636.patch";
-      sha256 = "sha256-RzaGPGGiKMgjy0waFqt48rV2yWBGZgC3kHehhVhxktk=";
-    })
-  ];
 
   nativeBuildInputs = [
     gobject-introspection
-    gettext
     meson
     ninja
     pkg-config
@@ -58,28 +48,29 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    adwaita-icon-theme
     glib
+    gpgme
     gsettings-desktop-schemas
     gtk3
     gtksourceview4
     gspell
+    gvfs
     json-glib
     libdazzle
     libgee
     libgit2-glib
+    libhandy
     libpeas
     libsecret
     libxml2
   ];
 
-  doCheck = false; # FAIL: tests-gitg gtk_style_context_add_provider_for_screen: assertion 'GDK_IS_SCREEN (screen)' failed
+  doCheck = true;
 
   postPatch = ''
-    chmod +x meson_post_install.py
     patchShebangs meson_post_install.py
 
-    substituteInPlace tests/libgitg/test-commit.vala --replace "/bin/bash" "${bash}/bin/bash"
+    substituteInPlace tests/libgitg/test-commit.vala --replace-fail "/bin/bash" "${bash}/bin/bash"
   '';
 
   preFixup = ''
@@ -95,11 +86,13 @@ stdenv.mkDerivation rec {
     };
   };
 
+  strictDeps = true;
+
   meta = with lib; {
     homepage = "https://wiki.gnome.org/Apps/Gitg";
     description = "GNOME GUI client to view git repositories";
     mainProgram = "gitg";
-    maintainers = with maintainers; [ domenkozar ];
+    maintainers = with maintainers; [ domenkozar Luflosi ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
## Description of changes
https://download.gnome.org/sources/gitg/44/gitg-44.news

Also:
- Add myself as a maintainer
- Enable `strictDeps`
- Run the tests again since they now work
- Use `--replace-fail` instead of `--replace` for `substituteInPlace`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
