### PR TITLE
ldproxy: init at 0.31.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21006,6 +21006,12 @@
     githubId = 357664;
     name = "Viktor Petersson";
   };
+  vpochapuis = {
+    email = "vincent.professional@chapuis.ovh";
+    github = "vpochapuis";
+    githubId = 75721408;
+    name = "Vincent Chapuis";
+  };
   vq = {
     email = "vq@erq.se";
     github = "vq";

--- a/pkgs/by-name/ld/ldproxy/package.nix
+++ b/pkgs/by-name/ld/ldproxy/package.nix
@@ -1,0 +1,29 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ldproxy";
+  version = "0.31.4";
+
+  # The source of this tools actually comes from the set of tools located in the `esp-rs:embuild` repository
+  # cf: https://github.com/esp-rs/embuild
+  src = fetchFromGitHub {
+    owner = "esp-rs";
+    repo = "embuild";
+    rev = "v${version}";
+    hash = "sha256-YH2CPb3uBlPncd+KkP25xhCVvDB7HDxJuSqWOJ1LT3k=";
+  };
+
+  cargoHash = "sha256-HobX/aBn10KPpUKRSLt2IvfFVW7YpOu5tX4zNSCz6tw=";
+
+  # However we are only interested in building the specific crate located at `/ldproxy`
+  # cf: https://github.com/esp-rs/embuild/tree/v0.31.4/ldproxy
+  buildAndTestSubdir = "ldproxy";
+
+  meta = with lib; {
+    description = "Linker Proxy: a simple tool to forward linker arguments to the actual linker executable";
+    homepage = "https://github.com/esp-rs/embuild";
+    changelog = "https://github.com/esp-rs/embuild/blob/v${version}/CHANGELOG.md";
+    license = with licenses; [ mit /* or */ asl20 ];
+    maintainers = with maintainers; [ vpochapuis ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adding the [`ldproxy`](https://github.com/esp-rs/embuild/tree/master/ldproxy) rust linker tool. (At the current lastest version as of the moment of writing this PR, hence `0.31.4`).
This tool is presented as a crate within a bigger workspace parent project called [`embuild`](https://github.com/esp-rs/embuild/tree/master).
However we are only building the inner crate containing `ldproxy` which is usually installed in rust using `cargo install ldproxy`.
This tool is used in the building of embedded platforms using `esp-rs` and the `std` crate, like for the `esp32c3`.

(This package introduction was previously attempted in #190267 by @matthiasbeyer and is mostly based on it).

## Call for help

This is my first contribution to the `nixpkgs`.
I would like first to thank all the maintainers of this project which lets us have the chance to aim for reproducible builds in our daily work and personal projects. 
I have been introduced very recently to `nix`, `nixpks` and `NixOs` in my quest to automate builds of my Rust packages as well as easily reproduce my desktop and server environments.
The learning curve is steep as it was for me for Rust, the learning materials are numerous however I have found it hard to find one place to easily learn from scratch all the various concepts while seeing tangible examples of common and relatable use cases. I wish in my learning journey I could have a better view of the project and maybe one day help new comers to be introduced to this amazing ecosystem. 
As this is my first attempt of contribution to this project after a [recommendation](https://github.com/NixOS/nixpkgs/pull/190267#issuecomment-2035260188) to do so (thank you @doronbehar), I tried to read the different resources available (official website then got redirected to the README.md and CONTRIBUTING.md), and I have to say it was the most complicated process I have encountered yet in my contribution adventure (I am quite new to open-source contributions but I would like to make this a more common occurrence as I would like to give back to the communities that have already given so much to everyone).
Hence I might have made some mistakes and I hope I could be helped in improving this PR and make it up to the standards of this community.

Thank you very much for your time and attention.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - [ ] Help needed: after running the command got `error: build log of '/nix/store/5dixzydh8bfsr68zbdimqmns4mz8sw00-ldproxy-0.31.4.drv^*' is not available`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
