### PR TITLE
scalafix: 0.10.0 -> 0.12.0

### DIFF
--- a/pkgs/development/tools/scalafix/default.nix
+++ b/pkgs/development/tools/scalafix/default.nix
@@ -6,6 +6,7 @@
   makeWrapper,
   installShellFiles,
   setJavaClassPath,
+  testers,
 }:
 stdenv.mkDerivation (
   finalAttrs: {
@@ -37,9 +38,12 @@ stdenv.mkDerivation (
         --zsh  <($out/bin/${finalAttrs.pname} --zsh)
     '';
 
-    installCheckPhase = ''
-      $out/bin/${finalAttrs.pname} --version | grep -q "${finalAttrs.version}"
-    '';
+    passthru.tests = {
+      testVersion = testers.testVersion {
+        program = "${finalAttrs.pname}";
+        version = "${finalAttrs.version}";
+      };
+    };
 
     meta = with lib; {
       description = "Refactoring and linting tool for Scala";

--- a/pkgs/development/tools/scalafix/default.nix
+++ b/pkgs/development/tools/scalafix/default.nix
@@ -7,43 +7,46 @@
   installShellFiles,
   setJavaClassPath,
 }:
-stdenv.mkDerivation rec {
-  pname = "scalafix";
-  version = "0.12.0";
-  deps = stdenv.mkDerivation {
-    name = "${pname}-deps-${version}";
-    buildCommand = ''
-      export COURSIER_CACHE=$(pwd)
-      ${coursier}/bin/cs fetch ch.epfl.scala:scalafix-cli_2.13.13:${version} > deps
-      mkdir -p $out/share/java
-      cp $(< deps) $out/share/java/
+stdenv.mkDerivation (
+  finalAttrs: {
+    pname = "scalafix";
+    version = "0.12.0";
+    deps = stdenv.mkDerivation {
+      name = "${finalAttrs.pname}-deps-${finalAttrs.version}";
+      buildCommand = ''
+        export COURSIER_CACHE=$(pwd)
+        ${coursier}/bin/cs fetch ch.epfl.scala:scalafix-cli_2.13.13:${finalAttrs.version} > deps
+        mkdir -p $out/share/java
+        cp $(< deps) $out/share/java/
+      '';
+      outputHashMode = "recursive";
+      outputHash = "sha256-HMTnr3awTIAgLSl4eF36U1kv162ajJxC5MreSk2TfUE=";
+    };
+
+    nativeBuildInputs = [makeWrapper installShellFiles setJavaClassPath];
+    buildInputs = [finalAttrs.deps];
+
+    dontUnpack = true;
+
+    installPhase = ''
+      makeWrapper ${jre}/bin/java $out/bin/${finalAttrs.pname} \
+        --add-flags "-cp $CLASSPATH scalafix.cli.Cli"
+
+      installShellCompletion --cmd ${finalAttrs.pname} \
+        --bash <($out/bin/${finalAttrs.pname} --bash) \
+        --zsh  <($out/bin/${finalAttrs.pname} --zsh)
     '';
-    outputHashMode = "recursive";
-    outputHash = "sha256-HMTnr3awTIAgLSl4eF36U1kv162ajJxC5MreSk2TfUE=";
-  };
 
-  nativeBuildInputs = [makeWrapper installShellFiles setJavaClassPath];
-  buildInputs = [deps];
+    installCheckPhase = ''
+      $out/bin/${finalAttrs.pname} --version | grep -q "${finalAttrs.version}"
+    '';
 
-  dontUnpack = true;
-
-  installPhase = ''
-    makeWrapper ${jre}/bin/java $out/bin/${pname} \
-      --add-flags "-cp $CLASSPATH scalafix.cli.Cli"
-
-    installShellCompletion --cmd ${pname} \
-      --bash <($out/bin/${pname} --bash) \
-      --zsh  <($out/bin/${pname} --zsh)
-  '';
-
-  installCheckPhase = ''
-    $out/bin/${pname} --version | grep -q "${version}"
-  '';
-
-  meta = with lib; {
-    description = "Refactoring and linting tool for Scala";
-    homepage = "https://scalacenter.github.io/scalafix/";
-    license = licenses.bsd3;
-    maintainers = [maintainers.tomahna];
-  };
-}
+    meta = with lib; {
+      description = "Refactoring and linting tool for Scala";
+      mainProgram = "scalafix";
+      homepage = "https://scalacenter.github.io/scalafix/";
+      license = licenses.bsd3;
+      maintainers = [maintainers.tomahna];
+    };
+  }
+)

--- a/pkgs/development/tools/scalafix/default.nix
+++ b/pkgs/development/tools/scalafix/default.nix
@@ -1,47 +1,49 @@
-{ lib, stdenv, jre, coursier, makeWrapper, installShellFiles, setJavaClassPath }:
-
-let
-  baseName = "scalafix";
-  version = "0.10.0";
+{
+  lib,
+  stdenv,
+  jre,
+  coursier,
+  makeWrapper,
+  installShellFiles,
+  setJavaClassPath,
+}:
+stdenv.mkDerivation rec {
+  pname = "scalafix";
+  version = "0.12.0";
   deps = stdenv.mkDerivation {
-    name = "${baseName}-deps-${version}";
+    name = "${pname}-deps-${version}";
     buildCommand = ''
       export COURSIER_CACHE=$(pwd)
-      ${coursier}/bin/cs fetch ch.epfl.scala:scalafix-cli_2.13.8:${version} > deps
+      ${coursier}/bin/cs fetch ch.epfl.scala:scalafix-cli_2.13.13:${version} > deps
       mkdir -p $out/share/java
       cp $(< deps) $out/share/java/
     '';
     outputHashMode = "recursive";
-    outputHash     = "sha256-lDeg90L484MggtQ2a9OyHv4UcfLPjzG3OJZCaWW2AC8=";
+    outputHash = "sha256-HMTnr3awTIAgLSl4eF36U1kv162ajJxC5MreSk2TfUE=";
   };
-in
-stdenv.mkDerivation {
-  pname = baseName;
-  inherit version;
 
-  nativeBuildInputs = [ makeWrapper installShellFiles setJavaClassPath ];
-  buildInputs = [ deps ];
+  nativeBuildInputs = [makeWrapper installShellFiles setJavaClassPath];
+  buildInputs = [deps];
 
   dontUnpack = true;
 
   installPhase = ''
-    makeWrapper ${jre}/bin/java $out/bin/${baseName} \
+    makeWrapper ${jre}/bin/java $out/bin/${pname} \
       --add-flags "-cp $CLASSPATH scalafix.cli.Cli"
 
-    installShellCompletion --cmd ${baseName} \
-      --bash <($out/bin/${baseName} --bash) \
-      --zsh  <($out/bin/${baseName} --zsh)
+    installShellCompletion --cmd ${pname} \
+      --bash <($out/bin/${pname} --bash) \
+      --zsh  <($out/bin/${pname} --zsh)
   '';
 
   installCheckPhase = ''
-    $out/bin/${baseName} --version | grep -q "${version}"
+    $out/bin/${pname} --version | grep -q "${version}"
   '';
 
   meta = with lib; {
     description = "Refactoring and linting tool for Scala";
-    mainProgram = "scalafix";
     homepage = "https://scalacenter.github.io/scalafix/";
     license = licenses.bsd3;
-    maintainers = [ maintainers.tomahna ];
+    maintainers = [maintainers.tomahna];
   };
 }

--- a/pkgs/development/tools/scalafix/default.nix
+++ b/pkgs/development/tools/scalafix/default.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation (
       homepage = "https://scalacenter.github.io/scalafix/";
       license = licenses.bsd3;
       maintainers = [maintainers.tomahna];
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
     };
   }
 )


### PR DESCRIPTION
## Description of changes
Bumps scalafix. Supersedes #275815

It also changes the `let ... in ...` syntax.
Nixpkgs often falls behind due to sheer number of PRs and limited number of maintainers. I frequently override src and hash to workaround the issue temporarly. It's not possible to override the variables defined in `let ... in ...`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
