### PR TITLE
[Backport release 23.11] searxng 2023-10-31 -> 2024-03-08; uwsgi 2.0.23 -> 2.0.24

### DIFF
--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -218,7 +218,7 @@ in
       serviceConfig = {
         User  = "searx";
         Group = "searx";
-        ExecStart = "${cfg.package}/bin/searx-run";
+        ExecStart = lib.getExe cfg.package;
       } // optionalAttrs (cfg.environmentFile != null)
         { EnvironmentFile = builtins.toPath cfg.environmentFile; };
       environment = {

--- a/nixos/tests/searx.nix
+++ b/nixos/tests/searx.nix
@@ -36,7 +36,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
   };
 
   # fancy setup: run in uWSGI and use nginx as proxy
-  nodes.fancy = { ... }: {
+  nodes.fancy = { config, ... }: {
     imports = [ ../modules/profiles/minimal.nix ];
 
     services.searx = {
@@ -65,7 +65,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
           include ${pkgs.nginx}/conf/uwsgi_params;
           uwsgi_pass unix:/run/searx/uwsgi.sock;
         '';
-      locations."/searx/static/".alias = "${pkgs.searx}/share/static/";
+      locations."/searx/static/".alias = "${config.services.searx.package}/share/static/";
     };
 
     # allow nginx access to the searx socket
@@ -108,7 +108,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
               "${pkgs.curl}/bin/curl --fail http://localhost/searx >&2"
           )
           fancy.succeed(
-              "${pkgs.curl}/bin/curl --fail http://localhost/searx/static/themes/oscar/js/bootstrap.min.js >&2"
+              "${pkgs.curl}/bin/curl --fail http://localhost/searx/static/themes/simple/js/leaflet.js >&2"
           )
     '';
 })

--- a/pkgs/by-name/se/searxng/package.nix
+++ b/pkgs/by-name/se/searxng/package.nix
@@ -5,13 +5,13 @@
 
 python3.pkgs.toPythonModule (python3.pkgs.buildPythonApplication rec {
   pname = "searxng";
-  version = "0-unstable-2024-02-24";
+  version = "0-unstable-2024-03-08";
 
   src = fetchFromGitHub {
     owner = "searxng";
     repo = "searxng";
-    rev = "d72fa99bd0a4d702a55188b07919ce5a764b1d6c";
-    hash = "sha256-1A7dyWrF63fSSvWP+2HrCS6H8o/4CUlqiP0KANVZHUA=";
+    rev = "9c08a0cdddae7ceafbe5e00ce94cf7f1d36c97e0";
+    hash = "sha256-0qlOpJqpOmseIeIafd0NLd2lF5whu18QxmwOua8dKzg=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/se/searxng/package.nix
+++ b/pkgs/by-name/se/searxng/package.nix
@@ -73,6 +73,7 @@ python3.pkgs.toPythonModule (python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/searxng/searxng";
     description = "A fork of Searx, a privacy-respecting, hackable metasearch engine";
     license = licenses.agpl3Plus;
+    mainProgram = "searxng-run";
     maintainers = with maintainers; [ SuperSandro2000 _999eagle ];
   };
 })

--- a/pkgs/by-name/se/searxng/package.nix
+++ b/pkgs/by-name/se/searxng/package.nix
@@ -5,13 +5,13 @@
 
 python3.pkgs.toPythonModule (python3.pkgs.buildPythonApplication rec {
   pname = "searxng";
-  version = "unstable-2023-10-31";
+  version = "0-unstable-2024-02-24";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
-    rev = "b05a15540e1dc2dfb8e4e25aa537b2a68e713844";
-    hash = "sha256-x0PyS+A4KjbBnTpca17Wx3BQjtOHvVuWpusPPc1ULnU=";
+    owner = "searxng";
+    repo = "searxng";
+    rev = "d72fa99bd0a4d702a55188b07919ce5a764b1d6c";
+    hash = "sha256-1A7dyWrF63fSSvWP+2HrCS6H8o/4CUlqiP0KANVZHUA=";
   };
 
   postPatch = ''
@@ -20,7 +20,7 @@ python3.pkgs.toPythonModule (python3.pkgs.buildPythonApplication rec {
 
   preBuild =
     let
-      versionString = lib.concatStringsSep "." (builtins.tail (lib.splitString "-" version));
+      versionString = lib.concatStringsSep "." (builtins.tail (lib.splitString "-" (lib.removePrefix "0-" version)));
       commitAbbrev = builtins.substring 0 8 src.rev;
     in
     ''
@@ -66,7 +66,7 @@ python3.pkgs.toPythonModule (python3.pkgs.buildPythonApplication rec {
     ln -s ../${python3.sitePackages}/searx/static $out/share/
 
     # copy config schema for the limiter
-    cp searx/botdetection/limiter.toml $out/${python3.sitePackages}/searx/botdetection/limiter.toml
+    cp searx/limiter.toml $out/${python3.sitePackages}/searx/limiter.toml
   '';
 
   meta = with lib; {

--- a/pkgs/servers/uwsgi/default.nix
+++ b/pkgs/servers/uwsgi/default.nix
@@ -71,13 +71,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "uwsgi";
-  version = "2.0.23";
+  version = "2.0.24";
 
   src = fetchFromGitHub {
     owner = "unbit";
     repo = "uwsgi";
     rev = finalAttrs.version;
-    hash = "sha256-gyYsgPF6eGa3D7bjmhhVER+uM0yPLfZiwSUzZ2mGcHg=";
+    hash = "sha256-KVzIp2rKCpF6aXhhu+6nw7q8Pnx/0+HD23mmYmVFPSA=";
   };
 
   patches = [


### PR DESCRIPTION
## Description of changes
Backport
searxng: 2023-10-31 -> 2024-03-08
uwsgi: 2.0.23 -> 2.0.24

Backport needed due to [upstream bug](https://github.com/searxng/searxng/issues/3227)
Closes #301912 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
