### PR TITLE
vscode-extensions.ms-vsliveshare.vsliveshare: 1.0.5900 -> 1.0.5918

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-vsliveshare.vsliveshare/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-vsliveshare.vsliveshare/default.nix
@@ -1,54 +1,23 @@
-# Based on previous attempts:
-#  -  <https://github.com/msteen/nixos-vsliveshare/blob/master/pkgs/vsliveshare/default.nix>
-#  -  <https://github.com/NixOS/nixpkgs/issues/41189>
-{ lib, gccStdenv, vscode-utils
-, autoPatchelfHook, bash, makeWrapper
-, curl, gcc, libsecret, libunwind, libX11, lttng-ust, util-linux
-, desktop-file-utils, xsel
-}:
+{ lib, vscode-utils, xsel }:
 
-let
-  # https://docs.microsoft.com/en-us/visualstudio/liveshare/reference/linux#install-prerequisites-manually
-  libs = [
-    # Credential Storage
-    libsecret
-
-    # NodeJS
-    libX11
-
-    # https://github.com/flathub/com.visualstudio.code.oss/issues/11#issuecomment-392709170
-    libunwind
-    lttng-ust
-    curl
-
-    # General
-    gcc.cc.lib
-    util-linux # libuuid
-  ];
-
-in ((vscode-utils.override { stdenv = gccStdenv; }).buildVscodeMarketplaceExtension {
+vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "vsliveshare";
     publisher = "ms-vsliveshare";
-    version = "1.0.5900";
-    hash = "sha256-syVW/aS2ppJjg4OZaenzGM3lczt+sLy7prwsYFTDl9s=";
+    version = "1.0.5918";
+    hash = "sha256-Tk0mKydUF8M7l7NC9wEA7t2rzJWy/mq4/HvIHI2/ldQ=";
   };
-}).overrideAttrs({ buildInputs ? [], ... }: {
-  buildInputs = buildInputs ++ libs;
 
-  # Using a patch file won't work, because the file changes too often, causing the patch to fail on most updates.
-  # Rather than patching the calls to functions, we modify the functions to return what we want,
-  # which is less likely to break in the future.
   postPatch = ''
     substituteInPlace extension.js \
-      --replace "'xsel'" "'${xsel}/bin/xsel'"
+      --replace-fail '"xsel"' '"${xsel}/bin/xsel"'
   '';
 
   meta = {
-    description = "Live Share lets you achieve greater confidence at speed by streamlining collaborative editing, debugging, and more in real-time during development";
+    description = "Real-time collaborative development for VS Code";
     homepage = "https://aka.ms/vsls-docs";
+    changelog = "https://marketplace.visualstudio.com/items/MS-vsliveshare.vsliveshare/changelog";
     license = lib.licenses.unfree;
-    maintainers = [ lib.maintainers.jraygauthier lib.maintainers.V ];
-    platforms = [ "x86_64-linux" ];
+    maintainers = builtins.attrValues { inherit (lib.maintainers) jraygauthier V; };
   };
-})
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

In addition, this cleans up the package, and enables it on platforms other than x86_64-linux (which had been supported for a while).

Fixes #163202.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
