### PR TITLE
treewide: rename `lib.licenses.apsl{10,20}` -> `lib.licenses.apple-psl{10,20}`

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -93,12 +93,12 @@ in mkLicense lset) ({
     url = "https://aomedia.org/license/patent-license/";
   };
 
-  apsl10 = {
+  apple-psl10 = {
     spdxId = "APSL-1.0";
     fullName = "Apple Public Source License 1.0";
   };
 
-  apsl20 = {
+  apple-psl20 = {
     spdxId = "APSL-2.0";
     fullName = "Apple Public Source License 2.0";
   };
@@ -1272,6 +1272,18 @@ in mkLicense lset) ({
   };
 } // {
   # TODO: remove legacy aliases
+  apsl10 = {
+    # deprecated for consistency with `apple-psl20`; use `apple-psl10`
+    spdxId = "APSL-1.0";
+    fullName = "Apple Public Source License 1.0";
+    deprecated = true;
+  };
+  apsl20 = {
+    # deprecated due to confusion with Apache-2.0; use `apple-psl20`
+    spdxId = "APSL-2.0";
+    fullName = "Apple Public Source License 2.0";
+    deprecated = true;
+  };
   gpl2 = {
     spdxId = "GPL-2.0";
     fullName = "GNU General Public License v2.0";

--- a/pkgs/by-name/ce/cert-viewer/package.nix
+++ b/pkgs/by-name/ce/cert-viewer/package.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
   meta = {
     description = "Admin tool to view and inspect multiple x509 Certificates";
     homepage = "https://github.com/mgit-at/cert-viewer";
-    license = lib.licenses.apsl20;
+    license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.mkg20001 ];
     mainProgram = "cert-viewer";
   };

--- a/pkgs/by-name/ma/maa-assistant-arknights/fastdeploy-ppocr.nix
+++ b/pkgs/by-name/ma/maa-assistant-arknights/fastdeploy-ppocr.nix
@@ -68,7 +68,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     description = "MaaAssistantArknights stripped-down version of FastDeploy";
     homepage = "https://github.com/MaaAssistantArknights/FastDeploy";
     platforms = platforms.linux;
-    license = licenses.apsl20;
+    license = licenses.asl20;
     broken = cudaSupport && stdenv.hostPlatform.system != "x86_64-linux";
   };
 })

--- a/pkgs/by-name/op/opencflite/package.nix
+++ b/pkgs/by-name/op/opencflite/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Cross platform port of the macOS CoreFoundation";
     homepage = "https://github.com/gerickson/opencflite";
-    license = lib.licenses.apsl20;
+    license = lib.licenses.apple-psl20;
     maintainers = with lib.maintainers; [ wegank ];
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/development/python-modules/dazl/default.nix
+++ b/pkgs/development/python-modules/dazl/default.nix
@@ -69,6 +69,6 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "High-level Ledger API client for Daml ledgers";
-    license = licenses.apsl20;
+    license = licenses.asl20;
   };
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/CarbonHeaders/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/CarbonHeaders/default.nix
@@ -15,6 +15,6 @@ appleDerivation' stdenvNoCC {
   meta = with lib; {
     maintainers = with maintainers; [ copumpkin ];
     platforms   = platforms.darwin;
-    license     = licenses.apsl20;
+    license     = licenses.apple-psl20;
   };
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/CommonCrypto/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/CommonCrypto/default.nix
@@ -37,6 +37,6 @@ appleDerivation' stdenvNoCC {
   meta = with lib; {
     maintainers = with maintainers; [ copumpkin ];
     platforms   = platforms.darwin;
-    license     = licenses.apsl20;
+    license     = licenses.apple-psl20;
   };
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/Csu/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Csu/default.nix
@@ -24,6 +24,6 @@ appleDerivation' stdenv {
     description = "Apple's common startup stubs for darwin";
     maintainers = with maintainers; [ copumpkin ];
     platforms   = platforms.darwin;
-    license     = licenses.apsl20;
+    license     = licenses.apple-psl20;
   };
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/IOKit/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/IOKit/default.nix
@@ -183,6 +183,6 @@ appleDerivation' stdenv {
   meta = with lib; {
     maintainers = with maintainers; [ copumpkin ];
     platforms   = platforms.darwin;
-    license     = licenses.apsl20;
+    license     = licenses.apple-psl20;
   };
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/Librpcsvc/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Librpcsvc/default.nix
@@ -17,6 +17,6 @@ appleDerivation {
   meta = with lib; {
     maintainers = with maintainers; [ matthewbauer ];
     platforms   = platforms.darwin;
-    license     = licenses.apsl20;
+    license     = licenses.apple-psl20;
   };
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
@@ -181,6 +181,6 @@ appleDerivation' stdenv {
     description = "The Mac OS libc/libSystem (tapi library with pure headers)";
     maintainers = with maintainers; [ copumpkin gridaphobe ];
     platforms   = platforms.darwin;
-    license     = licenses.apsl20;
+    license     = licenses.apple-psl20;
   };
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/architecture/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/architecture/default.nix
@@ -34,6 +34,6 @@ appleDerivation' stdenvNoCC {
   meta = with lib; {
     maintainers = with maintainers; [ copumpkin ];
     platforms   = platforms.darwin;
-    license     = licenses.apsl20;
+    license     = licenses.apple-psl20;
   };
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -187,7 +187,7 @@ let
   } // (if builtins.isFunction attrs then attrs finalAttrs else attrs) // {
     meta = (with lib; {
       platforms = platforms.darwin;
-      license = licenses.apsl20;
+      license = licenses.apple-psl20;
     }) // (attrs.meta or {});
   });
 

--- a/pkgs/os-specific/darwin/apple-source-releases/dyld/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/dyld/default.nix
@@ -11,6 +11,6 @@ appleDerivation' stdenvNoCC {
     description = "Impure primitive symlinks to the Mac OS native dyld, along with headers";
     maintainers = with maintainers; [ copumpkin ];
     platforms   = platforms.darwin;
-    license     = licenses.apsl20;
+    license     = licenses.apple-psl20;
   };
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/libunwind/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libunwind/default.nix
@@ -12,6 +12,6 @@ appleDerivation {
   meta = with lib; {
     maintainers = with maintainers; [ copumpkin lnl7 ];
     platforms   = platforms.darwin;
-    license     = licenses.apsl20;
+    license     = licenses.apple-psl20;
   };
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/libutil/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libutil/default.nix
@@ -38,6 +38,6 @@ appleDerivation' (if headersOnly then stdenvNoCC else stdenv) {
   meta = with lib; {
     maintainers = with maintainers; [ copumpkin ];
     platforms   = platforms.darwin;
-    license     = licenses.apsl20;
+    license     = licenses.apple-psl20;
   };
 }

--- a/pkgs/os-specific/darwin/cctools/apple.nix
+++ b/pkgs/os-specific/darwin/cctools/apple.nix
@@ -116,7 +116,7 @@ symlinkJoin rec {
   meta = with lib; {
     description = "MacOS Compiler Tools";
     homepage = "http://www.opensource.apple.com/source/cctools/";
-    license = licenses.apsl20;
+    license = licenses.apple-psl20;
     platforms = platforms.darwin;
   };
 }

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -186,7 +186,7 @@ stdenv.mkDerivation {
     broken = !stdenv.targetPlatform.isDarwin; # Only supports darwin targets
     homepage = "http://www.opensource.apple.com/source/cctools/";
     description = "MacOS Compiler Tools (cross-platform port)";
-    license = lib.licenses.apsl20;
+    license = lib.licenses.apple-psl20;
     maintainers = with lib.maintainers; [ matthewbauer ];
   };
 }

--- a/pkgs/servers/x11/quartz-wm/default.nix
+++ b/pkgs/servers/x11/quartz-wm/default.nix
@@ -24,7 +24,7 @@ in stdenv.mkDerivation {
     AppKit Xplugin Foundation
   ];
   meta = with lib; {
-    license = licenses.apsl20;
+    license = licenses.apple-psl20;
     platforms = platforms.darwin;
     maintainers = with maintainers; [ matthewbauer ];
   };

--- a/pkgs/tools/filesystems/hfsprogs/default.nix
+++ b/pkgs/tools/filesystems/hfsprogs/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "HFS/HFS+ user space utils";
-    license = lib.licenses.apsl20;
+    license = lib.licenses.apple-psl20;
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/tools/system/pdisk/default.nix
+++ b/pkgs/tools/system/pdisk/default.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/apple-oss-distributions/pdisk";
     license = with licenses; [
       hpnd # original license statements seems to match this (in files that are shared with mac-fdisk)
-      apsl10 # new files
+      apple-psl10 # new files
     ];
     maintainers = with maintainers; [ OPNA2608 ];
     platforms = platforms.unix;


### PR DESCRIPTION
## Description of changes

The easy half of #301908. (The harder second half will probably be in several days.)

This renames the two versions of the Apple Public Source License seen in nixpkgs; `apsl20` was often confused as being for the widely-used Apache License 2.0. `apsl10` is renamed for consistency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
