### PR TITLE
warp-terminal: enabled wayland support

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/package.nix
+++ b/pkgs/by-name/wa/warp-terminal/package.nix
@@ -10,9 +10,12 @@
 , libglvnd
 , libxkbcommon
 , vulkan-loader
+, wayland
 , xdg-utils
 , xorg
 , zlib
+, makeWrapper
+, waylandSupport ? false
 }:
 
 let
@@ -35,7 +38,7 @@ linux = stdenv.mkDerivation (finalAttrs:  {
       --replace-fail /opt/ $out/opt/
   '';
 
-  nativeBuildInputs = [ autoPatchelfHook zstd ];
+  nativeBuildInputs = [ autoPatchelfHook zstd makeWrapper ];
 
   buildInputs = [
     curl
@@ -54,7 +57,7 @@ linux = stdenv.mkDerivation (finalAttrs:  {
     xorg.libxcb
     xorg.libXcursor
     xorg.libXi
-  ];
+  ] ++ lib.optionals waylandSupport [wayland];
 
   installPhase = ''
     runHook preInstall
@@ -62,6 +65,9 @@ linux = stdenv.mkDerivation (finalAttrs:  {
     mkdir $out
     cp -r opt usr/* $out
 
+  '' ++ lib.optionalString waylandSupport ''
+    wrapProgram $out/bin/warp-terminal --set WARP_ENABLE_WAYLAND 1
+  '' ++ ''
     runHook postInstall
   '';
 });


### PR DESCRIPTION
## Description of changes
Enabled wayland support thanks to some help from @xiro-codes at https://github.com/NixOS/nixpkgs/issues/301902#issuecomment-2040742810. 

Tested using xeyes, and it is running in wayland mode in wayland and in x11 mode in xorg. 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
