### PR TITLE
stdenv: re-add meta.repository (resurrected)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,5 @@ scripts, NixOS modules, etc.). It also might not apply to patches
 included in Nixpkgs, which may be derivative works of the packages to
 which they apply. The aforementioned artifacts are all covered by the
 licenses of the respective packages.
+
+<!-- re-trigger CI, this change will be removed before merging -->

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -47,6 +47,10 @@ Release branch. Used to specify that a package is not going to receive updates t
 
 The package’s homepage. Example: `https://www.gnu.org/software/hello/manual/`
 
+### `repository` {#var-meta-repository}
+
+A webpage (or list of webpages) where the package's source code can be viewed.  `https` links are preferred if available.  Automatically set to a default value if the package uses a `fetchFrom*` fetcher for its `src`. Example: `https://gitlab.freedesktop.org/libfprint/fprintd/`
+
 ### `downloadPage` {#var-meta-downloadPage}
 
 The page where a link to the current version can be found. Example: `https://ftp.gnu.org/gnu/hello/`

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -10,7 +10,9 @@ let
     concatMapStrings
     concatMapStringsSep
     concatStrings
+    filter
     findFirst
+    head
     isDerivation
     length
     concatMap
@@ -303,6 +305,10 @@ let
       (listOf str)
       str
     ];
+    repository = union [
+      (listOf str)
+      str
+    ];
     downloadPage = str;
     changelog = union [
       (listOf str)
@@ -440,6 +446,15 @@ let
     # -----
     else { valid = "yes"; });
 
+  unlist = list:
+    if length list == 1
+    then head list
+    else list;
+
+  valOrEmpty = res:
+   if res.success
+   then res.value
+   else [];
 
   # The meta attribute is passed in the resulting attribute set,
   # but it's not part of the actual derivation, i.e., it's not
@@ -454,6 +469,17 @@ let
       hasOutput = out: builtins.elem out outputs;
     in
     {
+      # get the default value for the meta.repository field.
+      # the fetchFrom* fetchers set src.meta.homepage
+      # tryEval will catch any throw-class errors, abort-class errors during
+      # evaluation are bugs and should be fixed.
+      repository =
+        valOrEmpty (builtins.tryEval (
+          if attrs ? src.meta.homepage
+          then attrs.src.meta.homepage
+          else if attrs ? srcs && isList attrs.srcs
+          then unlist (map (src: src.meta.homepage) (filter (src: src ? meta.homepage) attrs.srcs))
+          else []));
       # `name` derivation attribute includes cross-compilation cruft,
       # is under assert, and is sanitized.
       # Let's have a clean always accessible version here.


### PR DESCRIPTION
## Description of changes
previous PR (#300313) got messed up due to me trying to do too many fancy git things at once (mainly using shallow pulls and amending commits)

i've updated the documentation to match the new behavior, and have added a different example

@a-n-n-a-l-e-e @AndersonTorres @nyabinary for participating in the previous PR
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
