### PR TITLE
google-cloud-sdk: fix gcloud storage sign-url error due to missing pyopenssl dependency

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -13,7 +13,7 @@ let
   pythonEnv = python.withPackages (p: with p; [
     cffi
     cryptography
-    openssl
+    pyopenssl
     crcmod
     numpy
   ] ++ lib.optional (with-gce) google-compute-engine);


### PR DESCRIPTION
#141773 changes the python dependencies to include `openssl` instead of `pyopenssl` which seems like a mistake due to `openssl` not existing inside `pythonPackages` (and the `with` binding picking up the top level dependency instead). The author referenced #135045 which was caused by pyopenssl crashing on aarch64-darwin (pyca/pyopenssl#873), due to cffi's behaviour. Since then, #187636 has fixed cffi and hence makes `pyopenssl` compatible with aarch64-darwin.

Despite the previous change, `pyopenssl` is still required to sign urls to Google Cloud Storage buckets when using a service account private key file. Attempting to do so with the current package results in:

```shell
❯ gcloud storage sign-url --private-key-file /path/to/file.json gs://bucket/file
ERROR: (gcloud.storage.sign-url) This command requires the pyOpenSSL library. Please install it and set the environment variable CLOUDSDK_PYTHON_SITEPACKAGES to 1 before re-running this command.
```

Changing the dependency back to `pyopenssl` fixes this issue, and the steps to reproduce #135045 still succeed on aarch64-darwin.

Unfortunately, `gsutil` will still show `pyopenssl` as missing because they rely on the presence of a now-deleted pyopenssl function and fall back to the same (confusing) error message (GoogleCloudPlatform/gsutil#1753).

(I have attempted to write a test for this, but gcloud absolutely want to be authenticated to google cloud in order to reach a point where the error would've been displayed)

## Description of changes
Fix the pyopenssl dependency by referencing the right package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

