### PR TITLE
dovecot_fts_xapian: fix build failure; cleanup

### DIFF
--- a/pkgs/servers/mail/dovecot/plugins/fts_xapian/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/fts_xapian/default.nix
@@ -1,13 +1,24 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, sqlite, pkg-config, dovecot, libtool, xapian, icu64 }:
-stdenv.mkDerivation rec {
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoconf
+, automake
+, sqlite
+, pkg-config
+, dovecot
+, libtool
+, xapian
+, icu64
+}:
+stdenv.mkDerivation (finalAttrs: {
   pname = "dovecot-fts-xapian";
   version = "1.7.10";
 
   src = fetchFromGitHub {
     owner = "grosjo";
     repo = "fts-xapian";
-    rev = version;
-    sha256 = "sha256-Gzr0365lY9wAvmXeVungD2z44WHC+AI0a1xLWy3mCK4=";
+    rev = "refs/tags/${finalAttrs.version}";
+    sha256 = "sha256-Yd14kla33qAx4Hy0ZdE08javvki3t+hCEc3OTO6YfkQ=";
   };
 
   buildInputs = [ dovecot xapian icu64 sqlite ];
@@ -24,13 +35,13 @@ stdenv.mkDerivation rec {
     "--with-moduledir=$(out)/lib/dovecot"
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/grosjo/fts-xapian";
     description = "Dovecot FTS plugin based on Xapian";
     changelog = "https://github.com/grosjo/fts-xapian/releases";
-    license = licenses.lgpl21Only;
-    maintainers = with maintainers; [ julm symphorien ];
-    platforms = platforms.unix;
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ julm notashelf symphorien ];
+    platforms = lib.platforms.unix;
     broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/dovecot_fts_xapian.x86_64-darwin
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Fixed the build failure for `dovecot_fts_xapian`, cleaned up derivation and added myself to maintainers. For those wondering, building
`dovecot_fts_xapian` on the latest commit (e.g. `nix build github:nixos/nixpkgs#dovecot_fts_xapian`) will produce a hash mismatch
error:

```bash
error: hash mismatch in fixed-output derivation '/nix/store/b9ybjz9sz4j1ykdhy4knmasj9hchkdxi-source.drv':
         specified: sha256-Gzr0365lY9wAvmXeVungD2z44WHC+AI0a1xLWy3mCK4=
         got:       sha256-Yd14kla33qAx4Hy0ZdE08javvki3t+hCEc3OTO6YfkQ=
```

This PR fixes that (potentially unblocking rebuilds on systems with simple-nixos-mailserver), and gets rid of the discouraged `with lib;`
in meta.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
