### PR TITLE
tootik: init at 0.9.6

### DIFF
--- a/pkgs/by-name/to/tootik/package.nix
+++ b/pkgs/by-name/to/tootik/package.nix
@@ -1,0 +1,35 @@
+{ lib, stdenv, buildGoModule, fetchFromGitHub, openssl }:
+
+buildGoModule rec {
+  pname = "tootik";
+  version = "0.9.6";
+
+  src = fetchFromGitHub {
+    owner = "dimkr";
+    repo = "tootik";
+    rev = version;
+    hash = "sha256-RcuioFb0+mvZupwgaCN6qbcOy7gHp9KjJxRwaPI55yo=";
+  };
+
+  vendorHash = "sha256-/52VjfoecXaML1cDRIEe1EQPYU8xeP9lu4lY3cMV3VE=";
+
+  nativeBuildInputs = [ openssl ];
+
+  preBuild = ''
+    go generate ./migrations
+  '';
+
+  ldflags = [ "-X github.com/dimkr/tootik/buildinfo.Version=${version}" ];
+
+  tags = [ "fts5" ];
+
+  doCheck = !(stdenv.isDarwin && stdenv.isAarch64);
+
+  meta = {
+    description = "A federated nanoblogging service with a Gemini frontend";
+    homepage = "https://github.com/dimkr/tootik";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ sikmir ];
+    mainProgram = "tootik";
+  };
+}


### PR DESCRIPTION
## Description of changes
https://github.com/dimkr/tootik - federated nanoblogging service with a Gemini frontend

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
