### PR TITLE
python312Packages.sse-starlette: 2.1.0 -> 2.1.0 

### DIFF
--- a/pkgs/development/python-modules/sse-starlette/default.nix
+++ b/pkgs/development/python-modules/sse-starlette/default.nix
@@ -1,18 +1,19 @@
-{ lib
-, anyio
-, asgi-lifespan
-, buildPythonPackage
-, fastapi
-, fetchFromGitHub
-, httpx
-, pdm-backend
-, psutil
-, pytest-asyncio
-, pytestCheckHook
-, pythonOlder
-, requests
-, starlette
-, uvicorn
+{
+  lib,
+  anyio,
+  asgi-lifespan,
+  buildPythonPackage,
+  fastapi,
+  fetchFromGitHub,
+  httpx,
+  pdm-backend,
+  psutil,
+  pytest-asyncio,
+  pytestCheckHook,
+  pythonOlder,
+  requests,
+  starlette,
+  uvicorn,
 }:
 
 buildPythonPackage rec {
@@ -29,9 +30,7 @@ buildPythonPackage rec {
     hash = "sha256-gBkEs1jSKIOme2rbLf+pM3jFDgJkxyU92q+GsUsp8Eo=";
   };
 
-  build-system = [
-    pdm-backend
-  ];
+  build-system = [ pdm-backend ];
 
   dependencies = [
     anyio
@@ -49,9 +48,7 @@ buildPythonPackage rec {
     requests
   ];
 
-  pythonImportsCheck = [
-    "sse_starlette"
-  ];
+  pythonImportsCheck = [ "sse_starlette" ];
 
   disabledTests = [
     # AssertionError

--- a/pkgs/development/python-modules/sse-starlette/default.nix
+++ b/pkgs/development/python-modules/sse-starlette/default.nix
@@ -10,13 +10,14 @@
 , pytest-asyncio
 , pytestCheckHook
 , pythonOlder
+, requests
 , starlette
 , uvicorn
 }:
 
 buildPythonPackage rec {
   pname = "sse-starlette";
-  version = "2.0.0";
+  version = "2.1.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -25,7 +26,7 @@ buildPythonPackage rec {
     owner = "sysid";
     repo = "sse-starlette";
     rev = "refs/tags/v${version}";
-    hash = "sha256-kDcSG/3foP7fMZKYrkKx6FHvT9c9rSzxyv2EHjQ2WSA=";
+    hash = "sha256-gBkEs1jSKIOme2rbLf+pM3jFDgJkxyU92q+GsUsp8Eo=";
   };
 
   build-system = [
@@ -45,6 +46,7 @@ buildPythonPackage rec {
     psutil
     pytest-asyncio
     pytestCheckHook
+    requests
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
Diff: https://github.com/sysid/sse-starlette/compare/refs/tags/v2.1.0...v2.1.0

Changelog: https://github.com/sysid/sse-starlette/blob/2.1.0/CHANGELOG.md

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
