### PR TITLE
xiasl: init at 1.1.67

### DIFF
--- a/pkgs/by-name/xi/xiasl/package.nix
+++ b/pkgs/by-name/xi/xiasl/package.nix
@@ -4,7 +4,6 @@
 , makeDesktopItem
 , copyDesktopItems
 , libsForQt5
-, imagemagick
 , acpica-tools
 }:
 

--- a/pkgs/by-name/xi/xiasl/package.nix
+++ b/pkgs/by-name/xi/xiasl/package.nix
@@ -1,0 +1,76 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeDesktopItem
+, copyDesktopItems
+, libsForQt5
+, imagemagick
+, acpica-tools
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xiasl";
+  version = "1.1.67";
+
+  src = fetchFromGitHub {
+    owner = "ic005k";
+    repo = "Xiasl";
+    rev = finalAttrs.version;
+    hash = "sha256-6RJeNLgeFchCjYLcwKgGtV0dLyHO7gYpIpo/3BBh/wM=";
+  };
+
+  buildInputs = [
+    libsForQt5.qtbase
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    libsForQt5.wrapQtAppsHook
+    libsForQt5.qmake
+  ];
+
+  postPatch = ''
+    rm libqscintilla2_qt5.so
+    ln -s '${lib.getLib libsForQt5.qscintilla}/lib/libqscintilla2_qt5.so' .
+
+    substituteInPlace Xiasl.pro \
+      --replace-warn '/opt/$''${TARGET}' "$out"
+
+    substituteInPlace *.cpp \
+      --replace-quiet 'appInfo.filePath() + "/iasl"' '"${acpica-tools}/bin/iasl"' \
+      --replace-quiet 'appInfo.filePath() + "/acpidump"' '"${acpica-tools}/bin/acpidump"' \
+  '';
+
+  postInstall = ''
+    install -Dm644 icon.png "$out/share/pixmaps/xiasl.png"
+  '';
+
+  preFixup = ''
+    patchelf --add-rpath '${lib.makeLibraryPath [ libsForQt5.qscintilla ]}' "$out/bin/Xiasl"
+  '';
+
+  dontStrip = true; # https://github.com/NixOS/patchelf/issues/99#issuecomment-355536880
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "xiasl";
+      exec = "Xiasl";
+      icon = "xiasl";
+      desktopName = "Xiasl";
+      comment = "Cross-platform DSDT & SSDT IDE";
+      categories = [ "Development" "IDE" ];
+    })
+  ];
+
+  meta = {
+    description = "A cross-platform DSDT & SSDT IDE";
+    homepage = "https://github.com/ic005k/Xiasl";
+    downloadPage = "${finalAttrs.meta.homepage}/releases";
+    changelog = "${finalAttrs.meta.downloadPage}/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hacker1024 ];
+    mainProgram = "Xiasl";
+    platforms = with lib.platforms; linux ++ darwin;
+    broken = stdenv.hostPlatform.isDarwin; # Additional patching is required for Darwin.
+  };
+})


### PR DESCRIPTION
## Description of changes

[Xiasl](https://github.com/ic005k/Xiasl) is a cross-platform DSDT & SSDT IDE.

Only Linux is supported by this derivation for now - additional patches to the build process and runtime executable searching are required for macOS. I recommend [MaciASL](https://github.com/acidanthera/MaciASL) on macOS for the time being.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ x Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
