### PR TITLE
firefly-iii: init at 6.1.13, nixos/firefly-iii: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -151,6 +151,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [davis](https://github.com/tchapi/davis), a simple CardDav and CalDav server inspired by Baïkal. Available as [services.davis]($opt-services-davis.enable).
 
+- [Firefly-iii](https://www.firefly-iii.org), a free and open source personal finance manager. Available as [services.firefly-iii](#opt-services.firefly-iii.enable)
+
 - [systemd-lock-handler](https://git.sr.ht/~whynothugo/systemd-lock-handler/), a bridge between logind D-Bus events and systemd targets. Available as [services.systemd-lock-handler.enable](#opt-services.systemd-lock-handler.enable).
 
 - [wastebin](https://github.com/matze/wastebin), a pastebin server written in rust. Available as [services.wastebin](#opt-services.wastebin.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1320,6 +1320,7 @@
   ./services/web-apps/dolibarr.nix
   ./services/web-apps/engelsystem.nix
   ./services/web-apps/ethercalc.nix
+  ./services/web-apps/firefly-iii.nix
   ./services/web-apps/fluidd.nix
   ./services/web-apps/freshrss.nix
   ./services/web-apps/galene.nix

--- a/nixos/modules/services/web-apps/firefly-iii.nix
+++ b/nixos/modules/services/web-apps/firefly-iii.nix
@@ -1,0 +1,367 @@
+{ pkgs, config, lib, ... }:
+
+let
+  inherit (lib) optionalString mkDefault mkIf mkOption mkEnableOption literalExpression;
+  inherit (lib.types) nullOr attrsOf oneOf str int bool path package enum submodule;
+  inherit (lib.strings) concatMapStringsSep removePrefix toShellVars removeSuffix hasSuffix;
+  inherit (lib.attrsets) attrValues genAttrs filterAttrs mapAttrs' nameValuePair;
+  inherit (builtins) isInt isString toString typeOf;
+
+  cfg = config.services.firefly-iii;
+
+  user = cfg.user;
+  group = cfg.group;
+
+  defaultUser = "firefly-iii";
+  defaultGroup = "firefly-iii";
+
+  artisan = "${cfg.package}/artisan";
+
+  env-file-values = mapAttrs' (n: v: nameValuePair (removeSuffix "_FILE" n) v)
+    (filterAttrs (n: v: hasSuffix "_FILE" n) cfg.settings);
+  env-nonfile-values = filterAttrs (n: v: ! hasSuffix "_FILE" n) cfg.settings;
+
+  envfile = pkgs.writeText "firefly-iii-env" ''
+    ${toShellVars env-file-values}
+    ${toShellVars env-nonfile-values}
+  '';
+
+  fileenv-func = ''
+    cp --no-preserve=mode ${envfile} /tmp/firefly-iii-env
+    ${concatMapStringsSep "\n"
+      (n: "${pkgs.replace-secret}/bin/replace-secret ${n} ${n} /tmp/firefly-iii-env")
+      (attrValues env-file-values)}
+    set -a
+    . /tmp/firefly-iii-env
+    set +a
+  '';
+
+  firefly-iii-maintenance = pkgs.writeShellScript "firefly-iii-maintenance.sh" ''
+    ${fileenv-func}
+
+    ${optionalString (cfg.settings.DB_CONNECTION == "sqlite")
+      "touch ${cfg.dataDir}/storage/database/database.sqlite"}
+    ${artisan} migrate --seed --no-interaction --force
+    ${artisan} firefly-iii:decrypt-all
+    ${artisan} firefly-iii:upgrade-database
+    ${artisan} firefly-iii:correct-database
+    ${artisan} firefly-iii:report-integrity
+    ${artisan} firefly-iii:laravel-passport-keys
+    ${artisan} cache:clear
+
+    mv /tmp/firefly-iii-env /run/phpfpm/firefly-iii-env
+  '';
+
+  commonServiceConfig = {
+    Type = "oneshot";
+    User = user;
+    Group = group;
+    StateDirectory = "${removePrefix "/var/lib/" cfg.dataDir}";
+    WorkingDirectory = cfg.package;
+    PrivateTmp = true;
+    PrivateDevices = true;
+    CapabilityBoundingSet = "";
+    AmbientCapabilities = "";
+    ProtectSystem = "strict";
+    ProtectKernelTunables = true;
+    ProtectKernelModules = true;
+    ProtectControlGroups = true;
+    ProtectClock = true;
+    ProtectHostname = true;
+    ProtectHome = "tmpfs";
+    ProtectKernelLogs = true;
+    ProtectProc = "invisible";
+    ProcSubset = "pid";
+    PrivateNetwork = false;
+    RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX";
+    SystemCallArchitectures = "native";
+    SystemCallFilter = [
+      "@system-service @resources"
+      "~@obsolete @privileged"
+    ];
+    RestrictSUIDSGID = true;
+    RemoveIPC = true;
+    NoNewPrivileges = true;
+    RestrictRealtime = true;
+    RestrictNamespaces = true;
+    LockPersonality = true;
+    PrivateUsers = true;
+  };
+
+in {
+
+  options.services.firefly-iii = {
+
+    enable = mkEnableOption "Firefly III: A free and open source personal finance manager";
+
+    user = mkOption {
+      type = str;
+      default = defaultUser;
+      description = "User account under which firefly-iii runs.";
+    };
+
+    group = mkOption {
+      type = str;
+      default = if cfg.enableNginx then "nginx" else defaultGroup;
+      defaultText = "If `services.firefly-iii.enableNginx` is true then `nginx` else ${defaultGroup}";
+      description = ''
+        Group under which firefly-iii runs. It is best to set this to the group
+        of whatever webserver is being used as the frontend.
+      '';
+    };
+
+    dataDir = mkOption {
+      type = path;
+      default = "/var/lib/firefly-iii";
+      description = ''
+        The place where firefly-iii stores its state.
+      '';
+    };
+
+    package = mkOption {
+      type = package;
+      default = pkgs.firefly-iii;
+      defaultText = literalExpression "pkgs.firefly-iii";
+      description = ''
+        The firefly-iii package served by php-fpm and the webserver of choice.
+        This option can be used to point the webserver to the correct root. It
+        may also be used to set the package to a different version, say a
+        development version.
+      '';
+      apply = firefly-iii : firefly-iii.override (prev: {
+        dataDir = cfg.dataDir;
+      });
+    };
+
+    enableNginx = mkOption {
+      type = bool;
+      default = false;
+      description = ''
+        Whether to enable nginx or not. If enabled, an nginx virtual host will
+        be created for access to firefly-iii. If not enabled, then you may use
+        `''${config.services.firefly-iii.package}` as your document root in
+        whichever webserver you wish to setup.
+      '';
+    };
+
+    virtualHost = mkOption {
+      type = str;
+      description = ''
+        The hostname at which you wish firefly-iii to be served. If you have
+        enabled nginx using `services.firefly-iii.enableNginx` then this will
+        be used.
+      '';
+    };
+
+    poolConfig = mkOption {
+      type = attrsOf (oneOf [ str int bool ]);
+      default = {
+        "pm" = "dynamic";
+        "pm.max_children" = 32;
+        "pm.start_servers" = 2;
+        "pm.min_spare_servers" = 2;
+        "pm.max_spare_servers" = 4;
+        "pm.max_requests" = 500;
+      };
+      description = ''
+        Options for the Firefly III PHP pool. See the documentation on <literal>php-fpm.conf</literal>
+        for details on configuration directives.
+      '';
+    };
+
+    settings = mkOption {
+      description = ''
+        Options for firefly-iii configuration. Refer to
+        <https://github.com/firefly-iii/firefly-iii/blob/main/.env.example> for
+        details on supported values. All <option>_FILE values supported by
+        upstream are supported here.
+
+        APP_URL will be set by `services.firefly-iii.virtualHost`, do not
+        redefine it here.
+      '';
+      example = literalExpression ''
+        {
+          APP_ENV = "production";
+          APP_KEY_FILE = "/var/secrets/firefly-iii-app-key.txt";
+          SITE_OWNER = "mail@example.com";
+          DB_CONNECTION = "mysql";
+          DB_HOST = "db";
+          DB_PORT = 3306;
+          DB_DATABASE = "firefly";
+          DB_USERNAME = "firefly";
+          DB_PASSWORD_FILE = "/var/secrets/firefly-iii-mysql-password.txt;
+        }
+      '';
+      default = {};
+      type = submodule {
+        freeformType = attrsOf (oneOf [str int bool]);
+        options = {
+          DB_CONNECTION = mkOption {
+            type = enum [ "sqlite" "pgsql" "mysql" ];
+            default = "sqlite";
+            example = "pgsql";
+            description = ''
+              The type of database you wish to use. Can be one of "sqlite",
+              "mysql" or "pgsql".
+            '';
+          };
+          APP_ENV = mkOption {
+            type = enum [ "local" "production" "testing" ];
+            default = "local";
+            example = "production";
+            description = ''
+              The app environment. It is recommended to keep this at "local".
+              Possible values are "local", "production" and "testing"
+            '';
+          };
+          DB_PORT = mkOption {
+            type = nullOr int;
+            default = if cfg.settings.DB_CONNECTION == "sqlite" then null
+                      else if cfg.settings.DB_CONNECTION == "mysql" then 3306
+                      else 5432;
+            defaultText = ''
+              `null` if DB_CONNECTION is "sqlite", `3306` if "mysql", `5432` if "pgsql"
+            '';
+            description = ''
+              The port your database is listening at. sqlite does not require
+              this value to be filled.
+            '';
+          };
+          APP_KEY_FILE = mkOption {
+            type = path;
+            description = ''
+              The path to your appkey. The file should contain a 32 character
+              random app key. This may be set using `echo "base64:$(head -c 32
+              /dev/urandom | base64)" > /path/to/key-file`.
+            '';
+          };
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    services.firefly-iii = {
+      settings = {
+        APP_URL = cfg.virtualHost;
+      };
+    };
+
+    services.phpfpm.pools.firefly-iii = {
+      inherit user group;
+      phpPackage = cfg.package.phpPackage;
+      phpOptions = ''
+        log_errors = on
+      '';
+      settings = {
+        "listen.mode" = "0660";
+        "listen.owner" = user;
+        "listen.group" = group;
+        "clear_env" = "no";
+      } // cfg.poolConfig;
+    };
+
+    systemd.services.phpfpm-firefly-iii.serviceConfig = {
+      EnvironmentFile = "/run/phpfpm/firefly-iii-env";
+      ExecStartPost = "${pkgs.coreutils}/bin/rm /run/phpfpm/firefly-iii-env";
+    };
+
+    systemd.services.firefly-iii-setup = {
+      requiredBy = [ "phpfpm-firefly-iii.service" ];
+      before = [ "phpfpm-firefly-iii.service" ];
+      serviceConfig = {
+        ExecStart = firefly-iii-maintenance;
+        RuntimeDirectory = "phpfpm";
+        RuntimeDirectoryPreserve = true;
+      } // commonServiceConfig;
+      unitConfig.JoinsNamespaceOf = "phpfpm-firefly-iii.service";
+    };
+
+    systemd.services.firefly-iii-cron = {
+      description = "Daily Firefly III cron job";
+      script = ''
+        ${fileenv-func}
+        ${artisan} firefly-iii:cron
+      '';
+      serviceConfig = commonServiceConfig;
+    };
+
+    systemd.timers.firefly-iii-cron = {
+      description = "Trigger Firefly Cron";
+      timerConfig = {
+        OnCalendar = "Daily";
+        RandomizedDelaySec = "1800s";
+        Persistent = true;
+      };
+      wantedBy = [ "timers.target" ];
+    };
+
+    services.nginx = mkIf cfg.enableNginx {
+      enable = true;
+      recommendedTlsSettings = mkDefault true;
+      recommendedOptimisation = mkDefault true;
+      recommendedGzipSettings = mkDefault true;
+      virtualHosts.${cfg.virtualHost} = {
+        root = "${cfg.package}/public";
+        locations = {
+          "/" = {
+            tryFiles = "$uri $uri/ /index.php?$query_string";
+            index = "index.php";
+            extraConfig = ''
+              sendfile off;
+            '';
+          };
+          "~ \.php$" = {
+            extraConfig = ''
+              include ${config.services.nginx.package}/conf/fastcgi_params ;
+              fastcgi_param SCRIPT_FILENAME $request_filename;
+              fastcgi_param modHeadersAvailable true; #Avoid sending the security headers twice
+              fastcgi_pass unix:${config.services.phpfpm.pools.firefly-iii.socket};
+            '';
+          };
+        };
+      };
+    };
+
+    systemd.tmpfiles.settings."10-firefly-iii" = genAttrs [
+      "${cfg.dataDir}/storage"
+      "${cfg.dataDir}/storage/app"
+      "${cfg.dataDir}/storage/database"
+      "${cfg.dataDir}/storage/export"
+      "${cfg.dataDir}/storage/framework"
+      "${cfg.dataDir}/storage/framework/cache"
+      "${cfg.dataDir}/storage/framework/sessions"
+      "${cfg.dataDir}/storage/framework/views"
+      "${cfg.dataDir}/storage/logs"
+      "${cfg.dataDir}/storage/upload"
+      "${cfg.dataDir}/cache"
+    ] (n: {
+      d = {
+        group = group;
+        mode = "0700";
+        user = user;
+      };
+    }) // {
+      "${cfg.dataDir}".d = {
+        group = group;
+        mode = "0710";
+        user = user;
+      };
+    };
+
+    users = {
+      users = mkIf (user == defaultUser) {
+        ${defaultUser} = {
+          description = "Firefly-iii service user";
+          inherit group;
+          isSystemUser = true;
+          home = cfg.dataDir;
+        };
+      };
+      groups = mkIf (group == defaultGroup) {
+        ${defaultGroup} = {};
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -305,6 +305,7 @@ in {
   ferm = handleTest ./ferm.nix {};
   ferretdb = handleTest ./ferretdb.nix {};
   filesystems-overlayfs = runTest ./filesystems-overlayfs.nix;
+  firefly-iii = handleTest ./firefly-iii.nix {};
   firefox = handleTest ./firefox.nix { firefoxPackage = pkgs.firefox; };
   firefox-beta = handleTest ./firefox.nix { firefoxPackage = pkgs.firefox-beta; };
   firefox-devedition = handleTest ./firefox.nix { firefoxPackage = pkgs.firefox-devedition; };

--- a/nixos/tests/firefly-iii.nix
+++ b/nixos/tests/firefly-iii.nix
@@ -1,0 +1,26 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }: {
+  name = "firefly-iii";
+  meta.maintainers = [ lib.maintainers.savyajha ];
+
+  nodes.machine = { config, ... }: {
+    environment.etc = {
+      "firefly-iii-appkey".text = "TestTestTestTestTestTestTestTest";
+    };
+    services.firefly-iii = {
+      enable = true;
+      virtualHost = "http://localhost";
+      enableNginx = true;
+      settings = {
+        APP_KEY_FILE = "/etc/firefly-iii-appkey";
+        LOG_CHANNEL = "stdout";
+        SITE_OWNER = "mail@example.com";
+      };
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("phpfpm-firefly-iii.service")
+    machine.wait_for_unit("nginx.service")
+    machine.succeed("curl -fvvv -Ls http://localhost/ | grep 'Firefly III'")
+  '';
+})

--- a/pkgs/by-name/fi/firefly-iii/package.nix
+++ b/pkgs/by-name/fi/firefly-iii/package.nix
@@ -1,0 +1,60 @@
+{ lib
+, fetchFromGitHub
+, buildNpmPackage
+, php83
+, nixosTests
+, dataDir ? "/var/lib/firefly-iii"
+}:
+
+let
+  pname = "firefly-iii";
+  version = "6.1.13";
+  phpPackage = php83;
+
+  src = fetchFromGitHub {
+    owner = "firefly-iii";
+    repo = "firefly-iii";
+    rev = "v${version}";
+    hash = "sha256-85zI8uCyyoCflzxDkvba6FWa9B3kh179DJfQ2Um6MGM=";
+  };
+
+  assets = buildNpmPackage {
+    pname = "${pname}-assets";
+    inherit version src;
+    npmDepsHash = "sha256-wuPUE6XuzzgKjpxZVgwh2wGut15M61WSBFG+YIZwOFM=";
+    dontNpmBuild = true;
+    installPhase = ''
+      runHook preInstall
+      npm run build
+      cp -r ./public $out/
+      runHook postInstall
+    '';
+  };
+in
+
+phpPackage.buildComposerProject (finalAttrs: {
+  inherit pname src version;
+
+  vendorHash = "sha256-CVGKyyLp5hjjpEulDNEYfljU4OgPBaFcYQQAUf6GeGs=";
+
+  passthru = {
+    inherit phpPackage;
+    tests = nixosTests.firefly-iii;
+  };
+
+  postInstall = ''
+    mv $out/share/php/${pname}/* $out/
+    rm -R $out/share $out/storage $out/bootstrap/cache $out/public
+    cp -a ${assets} $out/public
+    ln -s ${dataDir}/storage $out/storage
+    ln -s ${dataDir}/cache $out/bootstrap/cache
+  '';
+
+  meta = {
+    changelog = "https://github.com/firefly-iii/firefly-iii/releases/tag/v${version}";
+    description = "Firefly III: a personal finances manager";
+    homepage = "https://github.com/firefly-iii/firefly-iii";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.savyajha ];
+  };
+})


### PR DESCRIPTION
## Description of changes

We already have a PR for firefly-iii which has not been merged in #184362. This is an attempt to push in the latest version of a package without using `composer2nix` and using the latest instructions from the [docs](https://docs.firefly-iii.org/how-to/firefly-iii/installation/self-managed/).

From the [github repo](https://github.com/firefly-iii/firefly-iii):

> "Firefly III" is a (self-hosted) manager for your personal finances. It can help you keep track of your expenses and income, so you can spend less and save more. Firefly III supports the use of budgets, categories and tags. Using a bunch of external tools, you can import data. It also has many neat financial reports available.
> 
> Firefly III should give you insight into and control over your finances. Money should be useful, not scary. You should be able to see where it is going, to feel your expenses and to... wow, I'm going overboard with this aren't I?
> 
> But you get the idea: this is your money. These are your expenses. Stop them from controlling you. I built this tool because I started to dislike money. Having money, not having money, paying bills with money, you get the idea. But no more. I want to feel "safe", whatever my balance is. And I hope this tool can help you. I know it helps me.

I'd love to get some feedback for this because I've only tested this on my machines with sqlite and postgres. While the module should setup sqlite on its own, the postgres and mysql databases have to be created by the user. There is no web-server setup included in this module either.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
