### PR TITLE
omniorbpy: move to python-modules

### DIFF
--- a/pkgs/development/python-modules/omniorbpy/default.nix
+++ b/pkgs/development/python-modules/omniorbpy/default.nix
@@ -2,9 +2,8 @@
   lib,
   buildPythonPackage,
   fetchurl,
-  omniorb,
   pkg-config,
-  python3,
+  python3Packages,
 }:
 
 buildPythonPackage rec {
@@ -24,18 +23,18 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  propagatedBuildInputs = [ omniorb ];
+  propagatedBuildInputs = [ python3Packages.omniorb ];
 
   configureFlags = [
-    "--with-omniorb=${omniorb}"
+    "--with-omniorb=${python3Packages.omniorb}"
     "PYTHON_PREFIX=$out"
-    "PYTHON=${lib.getExe python3}"
+    "PYTHON=${python3Packages.python.interpreter}"
   ];
 
   # Transform omniidl_be into a PEP420 namespace
   postInstall = ''
-    rm $out/${python3.sitePackages}/omniidl_be/__init__.py
-    rm $out/${python3.sitePackages}/omniidl_be/__pycache__/__init__.*.pyc
+    rm $out/${python3Packages.python.sitePackages}/omniidl_be/__init__.py
+    rm $out/${python3Packages.python.sitePackages}/omniidl_be/__pycache__/__init__.*.pyc
   '';
 
   # Ensure both python & cxx backends are available

--- a/pkgs/development/python-modules/omniorbpy/default.nix
+++ b/pkgs/development/python-modules/omniorbpy/default.nix
@@ -17,15 +17,14 @@ buildPythonPackage rec {
     hash = "sha256-y1cX1BKhAbr0MPWYysfWkjGITa5DctjirfPd7rxffrs=";
   };
 
-  outputs = [ "out" "dev" ];
-
-  nativeBuildInputs = [
-    pkg-config
+  outputs = [
+    "out"
+    "dev"
   ];
 
-  propagatedBuildInputs = [
-    omniorb
-  ];
+  nativeBuildInputs = [ pkg-config ];
+
+  propagatedBuildInputs = [ omniorb ];
 
   configureFlags = [
     "--with-omniorb=${omniorb}"
@@ -49,7 +48,10 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "The python backend for omniorb";
     homepage = "http://omniorb.sourceforge.net";
-    license = with licenses; [ gpl2Plus lgpl21Plus ];
+    license = with licenses; [
+      gpl2Plus
+      lgpl21Plus
+    ];
     maintainers = with maintainers; [ nim65s ];
     platforms = platforms.unix;
   };

--- a/pkgs/development/python-modules/omniorbpy/default.nix
+++ b/pkgs/development/python-modules/omniorbpy/default.nix
@@ -3,7 +3,8 @@
   buildPythonPackage,
   fetchurl,
   pkg-config,
-  python3Packages,
+  python,
+  omniorb
 }:
 
 buildPythonPackage rec {
@@ -23,18 +24,18 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  propagatedBuildInputs = [ python3Packages.omniorb ];
+  propagatedBuildInputs = [ omniorb ];
 
   configureFlags = [
-    "--with-omniorb=${python3Packages.omniorb}"
+    "--with-omniorb=${omniorb}"
     "PYTHON_PREFIX=$out"
-    "PYTHON=${python3Packages.python.interpreter}"
+    "PYTHON=${python.interpreter}"
   ];
 
   # Transform omniidl_be into a PEP420 namespace
   postInstall = ''
-    rm $out/${python3Packages.python.sitePackages}/omniidl_be/__init__.py
-    rm $out/${python3Packages.python.sitePackages}/omniidl_be/__pycache__/__init__.*.pyc
+    rm $out/${python.sitePackages}/omniidl_be/__init__.py
+    rm $out/${python.sitePackages}/omniidl_be/__pycache__/__init__.*.pyc
   '';
 
   # Ensure both python & cxx backends are available

--- a/pkgs/development/python-modules/omniorbpy/default.nix
+++ b/pkgs/development/python-modules/omniorbpy/default.nix
@@ -1,20 +1,23 @@
 {
   lib,
-  stdenv,
+  buildPythonPackage,
   fetchurl,
   omniorb,
   pkg-config,
   python3,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+buildPythonPackage rec {
   pname = "omniorbpy";
   version = "4.3.2";
+  pyproject = false;
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/omniorb/omniORBpy-${finalAttrs.version}.tar.bz2";
+    url = "http://downloads.sourceforge.net/omniorb/omniORBpy-${version}.tar.bz2";
     hash = "sha256-y1cX1BKhAbr0MPWYysfWkjGITa5DctjirfPd7rxffrs=";
   };
+
+  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [
     pkg-config
@@ -37,12 +40,11 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # Ensure both python & cxx backends are available
-  doInstallCheck = true;
-  postInstallCheck = ''
-    export PYTHONPATH=$out/${python3.sitePackages}:${omniorb}/${python3.sitePackages}:$PYTHONPATH
-    ${lib.getExe python3} -c "import omniidl_be.cxx; import omniidl_be.python"
-  '';
-
+  pythonImportsCheck = [
+    "omniidl_be.cxx"
+    "omniidl_be.python"
+    "omniORB"
+  ];
 
   meta = with lib; {
     description = "The python backend for omniorb";
@@ -51,4 +53,4 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ nim65s ];
     platforms = platforms.unix;
   };
-})
+}

--- a/pkgs/development/tools/omniorb/default.nix
+++ b/pkgs/development/tools/omniorb/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchurl
 , pkg-config
-, python3
+, python3Packages
 }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ python3 ];
+  buildInputs = [ python3Packages.python ];
 
   enableParallelBuilding = true;
   hardeningDisable = [ "format" ];
@@ -24,16 +24,16 @@ stdenv.mkDerivation rec {
   # Transform omniidl_be into a PEP420 namespace to allow other projects to define
   # their omniidl backends. Especially useful for omniorbpy, the python backend.
   postInstall = ''
-    rm $out/${python3.sitePackages}/omniidl_be/__init__.py
-    rm $out/${python3.sitePackages}/omniidl_be/__pycache__/__init__.*.pyc
+    rm $out/${python3Packages.python.sitePackages}/omniidl_be/__init__.py
+    rm $out/${python3Packages.python.sitePackages}/omniidl_be/__pycache__/__init__.*.pyc
   '';
 
   # Ensure postInstall didn't break cxx backend
   # Same as 'pythonImportsCheck = ["omniidl_be.cxx"];', but outside buildPythonPackage
   doInstallCheck = true;
   postInstallCheck = ''
-    export PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
-    ${lib.getExe python3} -c "import omniidl_be.cxx"
+    export PYTHONPATH=$out/${python3Packages.python.sitePackages}:$PYTHONPATH
+    ${python3Packages.python.interpreter} -c "import omniidl_be.cxx"
   '';
 
   meta = with lib; {

--- a/pkgs/development/tools/omniorb/default.nix
+++ b/pkgs/development/tools/omniorb/default.nix
@@ -5,13 +5,13 @@
 , python3Packages
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
 
   pname = "omniorb";
   version = "4.3.2";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/omniorb/omniORB/omniORB-${version}/omniORB-${version}.tar.bz2";
+    url = "mirror://sourceforge/project/omniorb/omniORB/omniORB-${finalAttrs.version}/omniORB-${finalAttrs.version}.tar.bz2";
     hash = "sha256-HHRTMNAZBK/Xoe0KWJa5puU6waS4ZKSFA7k8fuy/H6g=";
   };
 
@@ -49,4 +49,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ smironov ];
     platforms   = platforms.unix;
   };
-}
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8951,6 +8951,8 @@ self: super: with self; {
 
   omnilogic = callPackage ../development/python-modules/omnilogic { };
 
+  omniorbpy = callPackage ../development/python-modules/omniorbpy { };
+
   omorfi = callPackage ../development/python-modules/omorfi { };
 
   omrdatasettools = callPackage ../development/python-modules/omrdatasettools { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8951,7 +8951,7 @@ self: super: with self; {
 
   omnilogic = callPackage ../development/python-modules/omnilogic { };
 
-  omniorb = toPythonModule (pkgs.omniorb.override { python3 = self.python; });
+  omniorb = toPythonModule (pkgs.omniorb.override { python3Packages = self; });
 
   omniorbpy = callPackage ../development/python-modules/omniorbpy { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8951,7 +8951,9 @@ self: super: with self; {
 
   omnilogic = callPackage ../development/python-modules/omnilogic { };
 
-  omniorbpy = callPackage ../development/python-modules/omniorbpy { };
+  omniorb = toPythonModule (pkgs.omniorb.override { python3 = self.python; });
+
+  omniorbpy = callPackage ../development/python-modules/omniorbpy { python3Packages = self; };
 
   omorfi = callPackage ../development/python-modules/omorfi { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8953,7 +8953,7 @@ self: super: with self; {
 
   omniorb = toPythonModule (pkgs.omniorb.override { python3 = self.python; });
 
-  omniorbpy = callPackage ../development/python-modules/omniorbpy { python3Packages = self; };
+  omniorbpy = callPackage ../development/python-modules/omniorbpy { };
 
   omorfi = callPackage ../development/python-modules/omorfi { };
 


### PR DESCRIPTION
## Description of changes

Because we want `omniidl_be.python` to be importable in dependent packages build phase

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
