### PR TITLE
foomatic-db-engine: unstable-2024-02-10 -> unstable-2024-04-05

### DIFF
--- a/pkgs/misc/cups/drivers/foomatic-db-engine/default.nix
+++ b/pkgs/misc/cups/drivers/foomatic-db-engine/default.nix
@@ -24,8 +24,8 @@ perlPackages.buildPerlPackage rec {
     # but it gets deleted quickly and would provoke 404 errors
     owner = "OpenPrinting";
     repo = "foomatic-db-engine";
-    rev = "fa91bdfd87da9005591ac2ef2c9c7b8ecdd19511";
-    hash = "sha256-Ufy9BtYMD7sUUVfraTmO5e8+nZ4C4up5a5GXeGTtejg=";
+    rev = "a2b12271e145fe3fd34c3560d276a57e928296cb";
+    hash = "sha256-qM12qtGotf9C0cjO9IkmzlW9GWCkT2Um+6dU3mZm3DU=";
   };
 
   outputs = [ "out" ];
@@ -37,9 +37,10 @@ perlPackages.buildPerlPackage rec {
   ];
 
   buildInputs =
+       [ curl ]
        # provide some "cups-*" commands to `foomatic-{configure,printjob}`
        # so that they can manage a local cups server (add queues, add jobs...)
-       lib.optionals withCupsAccess [ cups cups-filters curl ]
+    ++ lib.optionals withCupsAccess [ cups cups-filters ]
        # the commands `foomatic-{configure,getpjloptions}` need
        # netcat if they are used to query or alter a network
        # printer via AppSocket/HP JetDirect protocol


### PR DESCRIPTION
## Description of changes

Simple package update.

Note: Due to the sole new commit ["Fix wget / curl auto-detection at configure"](https://github.com/OpenPrinting/foomatic-db-engine/commit/a2b12271e145fe3fd34c3560d276a57e928296cb) `curl` (or `wget`) is now a mandatory (runtime!) dependency.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

ppd files in packages `foomatic-db-ppds` and `foomatic-db-ppds-withNonfreeDb` are not affected by this update in any way (they are bit-wise identical).

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>foomatic-db-engine</li>
    <li>foomatic-db-ppds</li>
    <li>foomatic-db-ppds-withNonfreeDb</li>
    <li>ptouch-driver</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc