### PR TITLE
python3Packages.rasterio: don't propagate setuptools

### DIFF
--- a/pkgs/development/python-modules/rasterio/default.nix
+++ b/pkgs/development/python-modules/rasterio/default.nix
@@ -5,6 +5,7 @@
 , pytestCheckHook
 , pythonOlder
 , stdenv
+, testers
 
 , affine
 , attrs
@@ -26,6 +27,8 @@
 , shapely
 , snuggs
 , wheel
+
+, rasterio  # required to run version test
 }:
 
 buildPythonPackage rec {
@@ -106,6 +109,7 @@ buildPythonPackage rec {
   postInstall = ''
     wrapPythonProgramsIn "$out/bin" "$out $setuptoolsPythonPath"
   '';
+
   doCheck = true;
 
   preCheck = ''
@@ -129,6 +133,12 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "rasterio"
   ];
+
+  passthru.tests.version = testers.testVersion {
+    package = rasterio;
+    version = version;
+    command = "${rasterio}/bin/rio --version";
+  };
 
   meta = with lib; {
     description = "Python package to read and write geospatial raster data";

--- a/pkgs/development/python-modules/rasterio/default.nix
+++ b/pkgs/development/python-modules/rasterio/default.nix
@@ -54,6 +54,12 @@ buildPythonPackage rec {
     })
   ];
 
+  postPatch = ''
+    # remove useless import statement requiring distutils to be present at the runtime
+    substituteInPlace rasterio/rio/calc.py \
+      --replace-fail "from distutils.version import LooseVersion" ""
+    '';
+
   nativeBuildInputs = [
     cython_3
     gdal
@@ -71,7 +77,6 @@ buildPythonPackage rec {
     click-plugins
     cligj
     numpy
-    setuptools
     snuggs
   ];
 
@@ -96,6 +101,11 @@ buildPythonPackage rec {
     shapely
   ];
 
+  # rio has runtime dependency on setuptools
+  setuptoolsPythonPath = [ setuptools ];
+  postInstall = ''
+    wrapPythonProgramsIn "$out/bin" "$out $setuptoolsPythonPath"
+  '';
   doCheck = true;
 
   preCheck = ''


### PR DESCRIPTION
## Description of changes

`setuptools` should't be propagated via `propagatedBuildInputs`. 

Remove useless import statement from `rasterio/rio/calc.py` which was requiring distutils to be present at the runtime. This import was [already removed](https://github.com/rasterio/rasterio/blob/main/rasterio/rio/calc.py) from rasterio master.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
