### PR TITLE
monero-{cli,gui}: 0.18.3.2 -> 0.18.3.3

### DIFF
--- a/pkgs/applications/blockchains/monero-cli/default.nix
+++ b/pkgs/applications/blockchains/monero-cli/default.nix
@@ -12,26 +12,26 @@ let
     owner = "monero-project";
     repo = "supercop";
     rev = "633500ad8c8759995049ccd022107d1fa8a1bbc9";
-    sha256 = "26UmESotSWnQ21VbAYEappLpkEMyl0jiuCaezRYd/sE=";
+    hash = "sha256-26UmESotSWnQ21VbAYEappLpkEMyl0jiuCaezRYd/sE=";
   };
   trezor-common = fetchFromGitHub {
     owner = "trezor";
     repo = "trezor-common";
-    rev = "bff7fdfe436c727982cc553bdfb29a9021b423b0";
-    sha256 = "VNypeEz9AV0ts8X3vINwYMOgO8VpNmyUPC4iY3OOuZI=";
+    rev = "bc28c316d05bf1e9ebfe3d7df1ab25831d98d168";
+    hash = "sha256-F1Hf1WwHqXMd/5OWrdkpomszACTozDuC7DQXW3p6248=";
   };
 
 in
 
 stdenv.mkDerivation rec {
   pname = "monero-cli";
-  version = "0.18.3.2";
+  version = "0.18.3.3";
 
   src = fetchFromGitHub {
     owner = "monero-project";
     repo = "monero";
     rev = "v${version}";
-    hash = "sha256-iVxy5SKBowTd8tY1L/MrXAu3r2S7bv67up3qWf0xJiw=";
+    hash = "sha256-1LkKIrud317BEE+713t5wiJV6FcDlJdj4ypXPR0bKTs=";
   };
 
   patches = [


### PR DESCRIPTION
## Description of changes

Version bump

Note: monero-gui was accidentally updated in https://github.com/NixOS/nixpkgs/pull/301678

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change (`monero-cli`, `monero-gui`)
- [x] Tested basic functionality of all binary files
- [x] Tested creating a wallet
- [x] Tested connecting monero-wallet-gui to a remote node
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
