### PR TITLE
lightningcss: 1.24.0 -> 1.24.1

### DIFF
--- a/pkgs/by-name/li/lightningcss/0001-napi-fix-build-error-in-cargo-auditable.patch
+++ b/pkgs/by-name/li/lightningcss/0001-napi-fix-build-error-in-cargo-auditable.patch
@@ -1,0 +1,16 @@
+diff --git a/napi/Cargo.toml b/napi/Cargo.toml
+index 3360a9c..86d6ba5 100644
+--- a/napi/Cargo.toml
++++ b/napi/Cargo.toml
+@@ -10,7 +10,7 @@ edition = "2021"
+ [features]
+ default = []
+ visitor = ["lightningcss/visitor"]
+-bundler = ["dep:crossbeam-channel", "dep:rayon"]
++bundler = ["dep:crossbeam-channel", "rayon"]
+ 
+ [dependencies]
+ serde = { version = "1.0.123", features = ["derive"] }
+-- 
+2.44.0
+

--- a/pkgs/by-name/li/lightningcss/package.nix
+++ b/pkgs/by-name/li/lightningcss/package.nix
@@ -6,16 +6,23 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "lightningcss";
-  version = "1.24.0";
+  version = "1.24.1";
 
   src = fetchFromGitHub {
     owner = "parcel-bundler";
     repo = "lightningcss";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Ai6zvLR5w2AarjZIWMPoDsU1Dr5kvREgL6oyg6TF+TU=";
+    hash = "sha256-HRuL7zwpN2e51+/Ltvif+eh+WBss/FtHCOlJfa/eVdE=";
   };
 
-  cargoHash = "sha256-HHuj7uAqipPtbjkOsxxMq+JWXww2vUDTNGgnHd3UY3o=";
+  cargoHash = "sha256-HavdTNaLTGctePa890dy/jGlXZXXZu1QFeFJOpjOiME=";
+
+  patches = [
+    # Backport fix for build error for lightningcss-napi
+    # see https://github.com/parcel-bundler/lightningcss/pull/713
+    # FIXME: remove when merged upstream
+    ./0001-napi-fix-build-error-in-cargo-auditable.patch
+  ];
 
   buildFeatures = [
     "cli"


### PR DESCRIPTION
## Description of changes
lightningcss: 1.24.0 -> 1.24.1 - [Changelog](https://github.com/parcel-bundler/lightningcss/releases/tag/v1.24.1)

Additionally patch ./napi/Cargo.toml to allow building lightningcss-napi. See parcel-bundler/lightningcss#713 parcel-bundler/lightningcss#702.

Without this patch, v1.24.1 won't build at all since an entire dependency napi was added in this release.

Closes #296639.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Pinging maintainer: @toastal

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
