### PR TITLE
libtorch-bin: 2.0.0 -> 2.2.2

### DIFF
--- a/pkgs/development/libraries/science/math/libtorch/bin.nix
+++ b/pkgs/development/libraries/science/math/libtorch/bin.nix
@@ -17,7 +17,7 @@ let
   # this derivation. However, we should ensure on version bumps
   # that the CUDA toolkit for `passthru.tests` is still
   # up-to-date.
-  version = "2.0.0";
+  version = "2.2.2";
   device = if cudaSupport then "cuda" else "cpu";
   srcs = import ./binary-hashes.nix version;
   unavailable = throw "libtorch is not available for this platform";

--- a/pkgs/development/libraries/science/math/libtorch/binary-hashes.nix
+++ b/pkgs/development/libraries/science/math/libtorch/binary-hashes.nix
@@ -1,19 +1,24 @@
 version : builtins.getAttr version {
-  "2.0.0" = {
+  "2.2.2" = {
     x86_64-darwin-cpu = {
-      name = "libtorch-macos-2.0.0.zip";
-      url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.0.0.zip";
-      hash = "sha256-u6y5IeYoiOC0yQ/k6JCChDs9lXWccLxUorgR8L62lkM=";
+      name = "libtorch-macos-x86_64-2.2.2.zip";
+      url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-x86_64-2.2.2.zip";
+      hash = "sha256-GcMf+0Cwfz6D8FC5bhtxCdBC4NgysO+2xA7EqXeb2fk=";
+    };
+    aarch64-darwin-cpu = {
+      name = "libtorch-macos-arm64-2.2.2.zip";
+      url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.2.2.zip";
+      hash = "sha256-zXviMxGW0wpJDIbb++qaJLL8OwJPuT38KqRRXkEFGeA=";
     };
     x86_64-linux-cpu = {
-      name = "libtorch-cxx11-abi-shared-with-deps-2.0.0-cpu.zip";
-      url = "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.0.0%2Bcpu.zip";
-      hash = "sha256-BoZQ2MC1CDVVGfX3SHC3mEpLGWO8XK7AcLcHJXDsXuc=";
+      name = "libtorch-cxx11-abi-shared-with-deps-2.2.2-cpu.zip";
+      url = "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.2.2%2Bcpu.zip";
+      hash = "sha256-REVmlpMC9xGHfKXtPbw1wOzhNf+G0wNRJBwmwen8fLE=";
     };
     x86_64-linux-cuda = {
-      name = "libtorch-cxx11-abi-shared-with-deps-2.0.0-cu118.zip";
-      url = "https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-2.0.0%2Bcu118.zip";
-      hash = "sha256-Dpw9kQdA1NI9EOT7JBKwQP4wZT6lizcnKKTQ8WVJCZc=";
+      name = "libtorch-cxx11-abi-shared-with-deps-2.2.2-cu118.zip";
+      url = "https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-2.2.2%2Bcu118.zip";
+      hash = "sha256-oL1x6VzdQHEW8qp9cFNN3/wi4B/5vhMnWJGKK1yj2Dg=";
     };
   };
 }

--- a/pkgs/development/libraries/science/math/libtorch/prefetch.sh
+++ b/pkgs/development/libraries/science/math/libtorch/prefetch.sh
@@ -6,7 +6,7 @@ set -eou pipefail
 version=$1
 
 bucket="https://download.pytorch.org/libtorch"
-CUDA_VERSION=cu116
+CUDA_VERSION=cu118
 
 url_and_key_list=(
   "x86_64-darwin-cpu $bucket/cpu/libtorch-macos-${version}.zip libtorch-macos-${version}.zip"


### PR DESCRIPTION
## Description of changes

Release notes:
https://github.com/pytorch/pytorch/releases/tag/v2.2.2

### Updated

- [x] Source: version, link and hash
  - [x] Darwin + CPU
  - [x] aarch64 Darwin + CPU (NEW)
  - [x] Linux + CPU
  - [x] Linux + GPU
- [x] CUDA version in tests (synchronized with `nixpkgs` stable version 11.8)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
