### PR TITLE
nixos/oddjobd: enable dbus service to fix service startup

### DIFF
--- a/nixos/modules/programs/oddjobd.nix
+++ b/nixos/modules/programs/oddjobd.nix
@@ -4,26 +4,28 @@ let
   cfg = config.programs.oddjobd;
 in
 {
-  options.programs.oddjobd = {
-    enable = lib.mkEnableOption "oddjob";
-    package = lib.mkPackageOption pkgs "oddjob" {};
+  options = {
+    programs.oddjobd = {
+      enable = lib.mkEnableOption "oddjob";
+      package = lib.mkPackageOption pkgs "oddjob" {};
+    };
   };
 
   config = lib.mkIf cfg.enable {
-    systemd.packages = [ cfg.package ];
-
     systemd.services.oddjobd = {
-      wantedBy = [ "multi-user.target"];
-      after = [ "network.target"];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" "dbus.service" ];
       description = "DBUS Odd-job Daemon";
       enable = true;
       documentation = [ "man:oddjobd(8)" "man:oddjobd.conf(5)" ];
       serviceConfig = {
-        Type = "dbus";
-        BusName = "org.freedesktop.oddjob";
-        ExecStart = "${lib.getBin cfg.package}/bin/oddjobd";
+        Type = "simple";
+        PIDFile = "/run/oddjobd.pid";
+        ExecStart = "${lib.getBin cfg.package}/bin/oddjobd -n -p /run/oddjobd.pid -t 300";
       };
     };
+
+    services.dbus.packages = [ cfg.package ];
   };
 
   meta.maintainers = with lib.maintainers; [ SohamG ];

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -652,6 +652,7 @@ in {
   nzbget = handleTest ./nzbget.nix {};
   nzbhydra2 = handleTest ./nzbhydra2.nix {};
   ocis = handleTest ./ocis.nix {};
+  oddjobd = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./oddjobd.nix {};
   oh-my-zsh = handleTest ./oh-my-zsh.nix {};
   ollama = handleTest ./ollama.nix {};
   ombi = handleTest ./ombi.nix {};

--- a/nixos/tests/oddjobd.nix
+++ b/nixos/tests/oddjobd.nix
@@ -1,0 +1,23 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "oddjobd";
+  meta.maintainers = [ lib.maintainers.anthonyroussel ];
+
+  nodes.machine = { ... } : {
+    environment.systemPackages = [
+      pkgs.oddjob
+    ];
+
+    programs.oddjobd.enable = true;
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("oddjobd.service")
+    machine.wait_for_file("/run/oddjobd.pid")
+
+    with subtest("send oddjob listall request"):
+      result = machine.succeed("oddjob_request -s com.redhat.oddjob -o /com/redhat/oddjob -i com.redhat.oddjob listall")
+      assert ('(service="com.redhat.oddjob",object="/com/redhat/oddjob",interface="com.redhat.oddjob",method="listall")' in result)
+  '';
+})

--- a/pkgs/os-specific/linux/oddjob/default.nix
+++ b/pkgs/os-specific/linux/oddjob/default.nix
@@ -1,14 +1,15 @@
-{ lib
-, fetchpatch
-, fetchurl
-, stdenv
-, autoreconfHook
-, dbus
-, libxml2
-, nixosTests
-, pam
-, pkg-config
-, systemd
+{
+  autoreconfHook,
+  dbus,
+  fetchpatch,
+  fetchurl,
+  lib,
+  libxml2,
+  nixosTests,
+  pam,
+  pkg-config,
+  stdenv,
+  systemd,
 }:
 
 stdenv.mkDerivation rec {
@@ -16,8 +17,8 @@ stdenv.mkDerivation rec {
   version = "0.34.7";
 
   src = fetchurl {
-     url = "https://pagure.io/oddjob/archive/${pname}-${version}/oddjob-${pname}-${version}.tar.gz";
-     hash = "sha256-SUOsMH55HtEsk5rX0CXK0apDObTj738FGOaL5xZRnIM=";
+    url = "https://pagure.io/oddjob/archive/${pname}-${version}/oddjob-${pname}-${version}.tar.gz";
+    hash = "sha256-SUOsMH55HtEsk5rX0CXK0apDObTj738FGOaL5xZRnIM=";
   };
 
   patches = [
@@ -33,9 +34,9 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
-  buildInputs =[
-    libxml2
+  buildInputs = [
     dbus
+    libxml2
     pam
     systemd
   ];
@@ -60,12 +61,12 @@ stdenv.mkDerivation rec {
     inherit (nixosTests) oddjobd;
   };
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://pagure.io/oddjob/blob/oddjob-${version}/f/ChangeLog";
     description = "Odd Job Daemon";
     homepage = "https://pagure.io/oddjob";
-    changelog = "https://pagure.io/oddjob/blob/oddjob-${version}/f/ChangeLog";
-    license = licenses.bsd0;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ SohamG ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ SohamG ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/oddjob/default.nix
+++ b/pkgs/os-specific/linux/oddjob/default.nix
@@ -1,4 +1,5 @@
 { lib
+, fetchpatch
 , fetchurl
 , stdenv
 , autoreconfHook
@@ -19,6 +20,14 @@ stdenv.mkDerivation rec {
      hash = "sha256-SUOsMH55HtEsk5rX0CXK0apDObTj738FGOaL5xZRnIM=";
   };
 
+  patches = [
+    # Define SystemD service location using `with-systemdsystemunitdir` configure flag
+    (fetchpatch {
+      url = "https://pagure.io/oddjob/c/f63287a35107385dcb6e04a4c742077c9d1eab86.patch";
+      hash = "sha256-2mmw4pJhrIk4/47FM8zKH0dTQJWnntHPNmq8VAUWqJI=";
+    })
+  ];
+
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
@@ -31,18 +40,12 @@ stdenv.mkDerivation rec {
     systemd
   ];
 
-  postPatch = ''
-    substituteInPlace configure.ac \
-      --replace 'SYSTEMDSYSTEMUNITDIR=`pkg-config --variable=systemdsystemunitdir systemd 2> /dev/null`' "SYSTEMDSYSTEMUNITDIR=${placeholder "out"}" \
-      --replace 'SYSTEMDSYSTEMUNITDIR=`pkg-config --variable=systemdsystemunitdir systemd`' "SYSTEMDSYSTEMUNITDIR=${placeholder "out"}"
-  '';
-
   configureFlags = [
     "--prefix=${placeholder "out"}"
     "--sysconfdir=${placeholder "out"}/etc"
     "--with-selinux-acls=no"
     "--with-selinux-labels=no"
-    "--disable-systemd"
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
   ];
 
   postConfigure = ''

--- a/pkgs/os-specific/linux/oddjob/default.nix
+++ b/pkgs/os-specific/linux/oddjob/default.nix
@@ -4,6 +4,7 @@
 , autoreconfHook
 , dbus
 , libxml2
+, nixosTests
 , pam
 , pkg-config
 , systemd
@@ -48,6 +49,13 @@ stdenv.mkDerivation rec {
     substituteInPlace src/oddjobd.c \
       --replace "globals.selinux_enabled" "FALSE"
   '';
+
+  # Requires a dbus-daemon environment
+  doCheck = false;
+
+  passthru.tests = {
+    inherit (nixosTests) oddjobd;
+  };
 
   meta = with lib; {
     description = "Odd Job Daemon";


### PR DESCRIPTION
## Description of changes

* Add oddjob package to services.dbus.packages in NixOS module to enable DBUS service
* Fix the oddjobd SystemD service as [stated upstream](https://pagure.io/oddjob/blob/master/f/scripts/oddjobd.service.in)
* Remove `with lib;` and reformat using nixfmt-rfc-style

Required to continue work on module of [realmd package](https://github.com/NixOS/nixpkgs/issues/302069)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
