### PR TITLE
nixos/logrotate docs: clarify settings

### DIFF
--- a/nixos/modules/services/logging/logrotate.nix
+++ b/nixos/modules/services/logging/logrotate.nix
@@ -104,9 +104,12 @@ in
         default = { };
         description = lib.mdDoc ''
           logrotate freeform settings: each attribute here will define its own section,
-          ordered by priority, which can either define files to rotate with their settings
+          ordered by {option}`services.logrotate.settings.<name>.priority`,
+          which can either define files to rotate with their settings
           or settings common to all further files settings.
-          Refer to <https://linux.die.net/man/8/logrotate> for details.
+          All attribute names not explicitly defined as sub-options here are passed through
+          as logrotate config directives,
+          refer to <https://linux.die.net/man/8/logrotate> for details.
         '';
         example = literalExpression ''
           {
@@ -124,6 +127,14 @@ in
                 "/var/log/first*.log"
                 "/var/log/second.log"
               ];
+            };
+            # specify custom order of sections
+            "/var/log/myservice/*.log" = {
+              # ensure lower priority
+              priority = 110;
+              postrotate = '''
+                systemctl reload myservice
+              ''';
             };
           };
           '';


### PR DESCRIPTION
## Description of changes

I found the description text of the freeform settings a bit unclear regarding the priority and ordering of sections:
It was not immediately clear to me that the `priority` was a NixOS module-level sub option instead of a logrotate-native configuration directive.

To clarify this, I extend the examples and higlight `priority` as a module option.

Note: Unfortunately, the `{option}` role does not seem to support linking to sub-attr options with `<name>` as a placeholder. `{option}\`priority\`` does not correctly resolve to a link either.
As other options documentation already uses the full option path specification despite these not being rendered correctly, I've decided to accept this for now.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Built NixOS manual, verified the changes in options.html
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
