### PR TITLE
asahi-*: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11787,6 +11787,12 @@
     githubId = 30468956;
     name = "Lukas Heiligenbrunner";
   };
+  lukaslihotzki = {
+    email = "lukas@lihotzki.de";
+    github = "lukaslihotzki";
+    githubId = 10326063;
+    name = "Lukas Lihotzki";
+  };
   lukaswrz = {
     email = "lukas@wrz.one";
     github = "lukaswrz";

--- a/pkgs/by-name/as/asahi-bless/package.nix
+++ b/pkgs/by-name/as/asahi-bless/package.nix
@@ -1,0 +1,26 @@
+{ lib
+, fetchCrate
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "asahi-bless";
+  version = "0.3.0";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-pgl424SqeHODsjGwNRJtVHT6sKRlYxlXl3esEKK02jc=";
+  };
+
+  cargoHash = "sha256-ilblP8nqb/eY0+9Iua298M7NQKv+IwtdliGd9ZYAVaM=";
+  cargoDepsName = pname;
+
+  meta = with lib; {
+    description = "A tool to select active boot partition on ARM Macs";
+    homepage = "https://crates.io/crates/asahi-bless";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lukaslihotzki ];
+    mainProgram = "asahi-bless";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/as/asahi-btsync/package.nix
+++ b/pkgs/by-name/as/asahi-btsync/package.nix
@@ -1,0 +1,26 @@
+{ lib
+, fetchCrate
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "asahi-btsync";
+  version = "0.2.0";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-jp05WcwY1cWh4mBQj+3jRCZoG32OhDvTB84hOAGemX8=";
+  };
+
+  cargoHash = "sha256-XsgWqdwb0DDsK6HkaoVGQB/mm1U1TVzJM5q/gt9GryA=";
+  cargoDepsName = pname;
+
+  meta = with lib; {
+    description = "A tool to sync Bluetooth pairing keys with macos on ARM Macs";
+    homepage = "https://crates.io/crates/asahi-btsync";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lukaslihotzki ];
+    mainProgram = "asahi-btsync";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/as/asahi-nvram/package.nix
+++ b/pkgs/by-name/as/asahi-nvram/package.nix
@@ -1,0 +1,26 @@
+{ lib
+, fetchCrate
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "asahi-nvram";
+  version = "0.2.1";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-bFUFjHVTYj0eUmhijraOdeCvAt2UGX8+yyvooYN1Uo0=";
+  };
+
+  cargoHash = "sha256-WhySIQew8xxdwXLWkpvTYQZFiqCEPjEAjr7NVxfjDkU=";
+  cargoDepsName = pname;
+
+  meta = with lib; {
+    description = "A tool to read and write nvram variables on ARM Macs";
+    homepage = "https://crates.io/crates/asahi-nvram";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lukaslihotzki ];
+    mainProgram = "asahi-nvram";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/as/asahi-wifisync/package.nix
+++ b/pkgs/by-name/as/asahi-wifisync/package.nix
@@ -1,0 +1,26 @@
+{ lib
+, fetchCrate
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "asahi-wifisync";
+  version = "0.2.0";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-wKd6rUUnegvl6cHODVQlllaOXuAGlmwx9gr73I/2l/c=";
+  };
+
+  cargoHash = "sha256-UF1T0uAFO/ydTWigYXOP9Ju1qgV1oBmJuXSq4faSzJM=";
+  cargoDepsName = pname;
+
+  meta = with lib; {
+    description = "A tool to sync Wifi passwords with macos on ARM Macs";
+    homepage = "https://crates.io/crates/asahi-wifisync";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lukaslihotzki ];
+    mainProgram = "asahi-wifisync";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

This PR adds a set of binaries to interact with the NVRAM on Apple Silicon machines, which are also packaged by the Fedora Asahi Remix. In https://github.com/tpwrules/nixos-apple-silicon/pull/179 it was recommended to add these to the main nixpkgs.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] riscv64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
