### PR TITLE
maintainers: remove avery

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1989,12 +1989,6 @@
     githubId = 687218;
     name = "averelld";
   };
-  avery = {
-    email = "averyl+nixos@protonmail.com";
-    github = "AveryLychee";
-    githubId = 9147625;
-    name = "Avery Lychee";
-  };
   avh4 = {
     email = "gruen0aermel@gmail.com";
     github = "avh4";

--- a/pkgs/applications/office/treesheets/default.nix
+++ b/pkgs/applications/office/treesheets/default.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     '';
 
     homepage = "https://strlen.com/treesheets/";
-    maintainers = with maintainers; [ obadz avery ];
+    maintainers = with maintainers; [ obadz ];
     platforms = platforms.unix;
     license = licenses.zlib;
   };


### PR DESCRIPTION
## Description of changes
Remove Avery Lychee from maintainers list and from the `treesheets` maintainers array, persuant to Discord conversation.

Fixes #302222.

## Things done
- [x] Remove Avery Lychee from maintainers list
- [x] Remove Avery Lychee from `treesheets` maintainers list

- Built on platform(s)
Not relevant

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
