### PR TITLE
bind: allow recursive queries from IPv6 loopback

### DIFF
--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -121,7 +121,7 @@ in
       package = mkPackageOption pkgs "bind" { };
 
       cacheNetworks = mkOption {
-        default = [ "127.0.0.0/24" ];
+        default = [ "127.0.0.0/24" "::1/128" ];
         type = types.listOf types.str;
         description = lib.mdDoc ''
           What networks are allowed to use us as a resolver.  Note


### PR DESCRIPTION
# Issue

After fc060cc3cb1ceb1825cc015abd16dc0fce326836 (#296159), DNS resolution got broken for systems with `bind` enabled.

# Steps to reproduce

Minimal `configuration.nix`:
```nix
{
  services.bind.enable = true;

  users.users.root.hashedPassword = "";
  system.stateVersion = "24.05";
}
```

Run VM:
```sh
nix-build '<nixpkgs/nixos>' -A vm \
    -I nixpkgs=path-to-nixpkgs \
    -I nixos-config=./configuration.nix \
    && rm -f nixos.qcow2 \
    && ./result/bin/run-nixos-vm
```

Login as root and try to resolve a domain:
```console
$ ping nixos.org
ping: nixos.org: Name or service not known
```

The `bind` logs show the following:
```console
$ journalctl -n2 -u bind
Apr 06 23:38:23 nixos named[775]: client @0x7f76d5254f68 ::1#57206 (nixos.org): query (cache) 'nixos.org/A/IN' denied (allow-query-cache did not match)
Apr 06 23:38:23 nixos named[775]: client @0x7f76d521fd68 ::1#57206 (nixos.org): query (cache) 'nixos.org/AAAA/IN' denied (allow-query-cache did not match)
```

# Cause

The default `resolv.conf` contains an IPv6 loopback address, `::1`:
```console
$ cat /etc/resolv.conf
# Generated by resolvconf
nameserver ::1
options edns0
```

But the default bind `named.conf` allows queries only from IPv4 loopbaack, `127.0.0.1/24`:
```console
$ cat /nix/store/8pplcdfpfdc1sqkbiy3d7pwk1k43gzrs-named.conf   
…
acl cachenetworks {  127.0.0.0/24;  };
options {
  …
  allow-query { cachenetworks; };
  …
};
…
```

# Solution
This PR appends `::1/128` to the `options.services.bind.cacheNetworks` default value.
