### PR TITLE
corrosion: 0.4.7 -> 0.4.8

### DIFF
--- a/pkgs/development/tools/build-managers/corrosion/default.nix
+++ b/pkgs/development/tools/build-managers/corrosion/default.nix
@@ -3,39 +3,48 @@
 , fetchFromGitHub
 , cargo
 , cmake
-, rustPlatform
 , rustc
 , libiconv
 }:
 
 stdenv.mkDerivation rec {
   pname = "corrosion";
-  version = "0.4.7";
+  version = "0.4.8";
 
   src = fetchFromGitHub {
     owner = "corrosion-rs";
     repo = "corrosion";
     rev = "v${version}";
-    hash = "sha256-6jjcBBc1gtMG2sYppOIRa/tYjmUgW4kFxAuoGj7Tpgw=";
-  };
-
-  cargoRoot = "generator";
-
-  cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit src;
-    sourceRoot = "${src.name}/${cargoRoot}";
-    name = "${pname}-${version}";
-    hash = "sha256-M5Wnx+SfVvdhC5bHVZa0Di2up3Qt5z1jog8yxIKvG/Y=";
+    hash = "sha256-ChoeN7qQRR1YmYYvPdJVJ2SVGTDGlM7PsN9jzFjQEyU=";
   };
 
   buildInputs = lib.optional stdenv.isDarwin libiconv;
 
   nativeBuildInputs = [
     cmake
-    rustPlatform.cargoSetupHook
     cargo
     rustc
   ];
+
+  doCheck = true;
+
+  checkPhase = let
+    excludedTests = [
+      "cbindgen_rust2cpp_build"
+      "cbindgen_rust2cpp_run_cpp-exe"
+      "hostbuild_build"
+      "hostbuild_run_rust-host-program"
+      "parse_target_triple_build"
+      "rustup_proxy_build"
+    ];
+    excludedTestsRegex = lib.concatStringsSep "|" excludedTests;
+  in ''
+    runHook preCheck
+
+    ctest -E "${excludedTestsRegex}"
+
+    runHook postCheck
+  '';
 
   meta = with lib; {
     description = "Tool for integrating Rust into an existing CMake project";

--- a/pkgs/kde/gear/akonadi-search/default.nix
+++ b/pkgs/kde/gear/akonadi-search/default.nix
@@ -26,8 +26,9 @@ mkKdeDerivation rec {
   extraNativeBuildInputs = [
     rustPlatform.cargoSetupHook
     cargo
+    corrosion
     rustc
   ];
 
-  extraBuildInputs = [corrosion xapian];
+  extraBuildInputs = [xapian];
 }

--- a/pkgs/kde/gear/angelfish/default.nix
+++ b/pkgs/kde/gear/angelfish/default.nix
@@ -25,8 +25,9 @@ mkKdeDerivation rec {
   extraNativeBuildInputs = [
     rustPlatform.cargoSetupHook
     cargo
+    corrosion
     rustc
   ];
 
-  extraBuildInputs = [corrosion qtsvg qtwebengine qcoro];
+  extraBuildInputs = [qtsvg qtwebengine qcoro];
 }

--- a/pkgs/kde/gear/kdepim-addons/default.nix
+++ b/pkgs/kde/gear/kdepim-addons/default.nix
@@ -28,8 +28,9 @@ mkKdeDerivation rec {
   extraNativeBuildInputs = [
     rustPlatform.cargoSetupHook
     cargo
+    corrosion
     rustc
   ];
 
-  extraBuildInputs = [corrosion discount alpaka];
+  extraBuildInputs = [discount alpaka];
 }


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/corrosion-rs/corrosion/compare/v0.4.7...v0.4.8

Changelog: https://github.com/corrosion-rs/corrosion/blob/v0.4.8/RELEASES.md



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
