### PR TITLE
_86Box: reformat according to RFC166, 4.1 -> 4.1.1

### DIFF
--- a/pkgs/applications/emulators/86box/default.nix
+++ b/pkgs/applications/emulators/86box/default.nix
@@ -1,12 +1,30 @@
-{ stdenv, lib, fetchFromGitHub, cmake, pkg-config, makeWrapper, freetype, SDL2
-, glib, pcre2, openal, rtmidi, fluidsynth, jack2, alsa-lib, qt5, libvncserver
-, discord-gamesdk, libpcap, libslirp
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  makeWrapper,
+  freetype,
+  SDL2,
+  glib,
+  pcre2,
+  openal,
+  rtmidi,
+  fluidsynth,
+  jack2,
+  alsa-lib,
+  qt5,
+  libvncserver,
+  discord-gamesdk,
+  libpcap,
+  libslirp,
 
-, enableDynarec ? with stdenv.hostPlatform; isx86 || isAarch
-, enableNewDynarec ? enableDynarec && stdenv.hostPlatform.isAarch
-, enableVncRenderer ? false
-, unfreeEnableDiscord ? false
-, unfreeEnableRoms ? false
+  enableDynarec ? with stdenv.hostPlatform; isx86 || isAarch,
+  enableNewDynarec ? enableDynarec && stdenv.hostPlatform.isAarch,
+  enableVncRenderer ? false,
+  unfreeEnableDiscord ? false,
+  unfreeEnableRoms ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -40,27 +58,28 @@ stdenv.mkDerivation (finalAttrs: {
     libslirp
     qt5.qtbase
     qt5.qttools
-  ] ++ lib.optional stdenv.isLinux alsa-lib
-    ++ lib.optional enableVncRenderer libvncserver;
+  ] ++ lib.optional stdenv.isLinux alsa-lib ++ lib.optional enableVncRenderer libvncserver;
 
-  cmakeFlags = lib.optional stdenv.isDarwin "-DCMAKE_MACOSX_BUNDLE=OFF"
+  cmakeFlags =
+    lib.optional stdenv.isDarwin "-DCMAKE_MACOSX_BUNDLE=OFF"
     ++ lib.optional enableNewDynarec "-DNEW_DYNAREC=ON"
     ++ lib.optional enableVncRenderer "-DVNC=ON"
     ++ lib.optional (!enableDynarec) "-DDYNAREC=OFF"
     ++ lib.optional (!unfreeEnableDiscord) "-DDISCORD=OFF";
 
-  postInstall = lib.optionalString stdenv.isLinux ''
-    install -Dm644 -t $out/share/applications $src/src/unix/assets/net.86box.86Box.desktop
+  postInstall =
+    lib.optionalString stdenv.isLinux ''
+      install -Dm644 -t $out/share/applications $src/src/unix/assets/net.86box.86Box.desktop
 
-    for size in 48 64 72 96 128 192 256 512; do
-      install -Dm644 -t $out/share/icons/hicolor/"$size"x"$size"/apps \
-        $src/src/unix/assets/"$size"x"$size"/net.86box.86Box.png
-    done;
-  ''
-  + lib.optionalString unfreeEnableRoms ''
-    mkdir -p $out/share/86Box
-    ln -s ${finalAttrs.passthru.roms} $out/share/86Box/roms
-  '';
+      for size in 48 64 72 96 128 192 256 512; do
+        install -Dm644 -t $out/share/icons/hicolor/"$size"x"$size"/apps \
+          $src/src/unix/assets/"$size"x"$size"/net.86box.86Box.png
+      done;
+    ''
+    + lib.optionalString unfreeEnableRoms ''
+      mkdir -p $out/share/86Box
+      ln -s ${finalAttrs.passthru.roms} $out/share/86Box/roms
+    '';
 
   passthru = {
     roms = fetchFromGitHub {
@@ -73,21 +92,20 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Some libraries are loaded dynamically, but QLibrary doesn't seem to search
   # the runpath, so use a wrapper instead.
-  preFixup = let
-    libPath = lib.makeLibraryPath ([
-      libpcap
-    ] ++ lib.optional unfreeEnableDiscord discord-gamesdk);
-    libPathVar = if stdenv.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
-  in ''
-    makeWrapperArgs+=(--prefix ${libPathVar} : "${libPath}")
-  '';
+  preFixup =
+    let
+      libPath = lib.makeLibraryPath ([ libpcap ] ++ lib.optional unfreeEnableDiscord discord-gamesdk);
+      libPathVar = if stdenv.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
+    in
+    ''
+      makeWrapperArgs+=(--prefix ${libPathVar} : "${libPath}")
+    '';
 
   meta = with lib; {
     description = "Emulator of x86-based machines based on PCem.";
     mainProgram = "86Box";
     homepage = "https://86box.net/";
-    license = with licenses; [ gpl2Only ]
-      ++ optional (unfreeEnableDiscord || unfreeEnableRoms) unfree;
+    license = with licenses; [ gpl2Only ] ++ optional (unfreeEnableDiscord || unfreeEnableRoms) unfree;
     maintainers = [ maintainers.jchw ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/emulators/86box/default.nix
+++ b/pkgs/applications/emulators/86box/default.nix
@@ -29,13 +29,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "86Box";
-  version = "4.1";
+  version = "4.1.1";
 
   src = fetchFromGitHub {
     owner = "86Box";
     repo = "86Box";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-JYOJFXiUTLRs6AEMYNx88PwcVw13ChQzV1ZE5OtX6Ds=";
+    hash = "sha256-ioE0EVIXv/biXXvLqwhmtZ/RJM0nLqcE+i+CU+WXBY4=";
   };
 
   nativeBuildInputs = [
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
       owner = "86Box";
       repo = "roms";
       rev = "v${finalAttrs.version}";
-      hash = "sha256-1HtoizO0QIGNjQTW0clzRp40h1ulw55+iTYz12UJSms=";
+      hash = "sha256-58nNTOLund/KeDlNwzwwihjFVigs/P0K8SN07zExE2c=";
     };
   };
 


### PR DESCRIPTION
## Description of changes
I was a bit slow to respond to the r-ryantm update at #297673, and it became stale. Sorry!

Reformats the 86Box derivation using `nixfmt-rfc-style` and updates it from 4.1 to 4.1.1. The formatting update isn't strictly necessary, but I already have my editor configured to use `nixfmt-rfc-style`, so it was legitimately more work to not do it for me. I can revert it if desired. (It does seem like there is some precedent for this, in fact I pulled the commit description "reformat according to RFC166" from recently merged commits.)

86Box 4.1.1 release announcement: https://86box.net/2024/03/20/86box-v4-1-1.html

86Box 4.1.1 release notes: https://github.com/86Box/86Box/releases/tag/v4.1.1

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
