### PR TITLE
pynmeagps: init at 1.0.35

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5409,6 +5409,12 @@
     githubId = 6689924;
     name = "David Terry";
   };
+  dylan-gonzalez = {
+    email = "dylcg10@gmail.com";
+    github = "dylan-gonzalez";
+    githubId = 45161987;
+    name = "Dylan Gonzalez";
+  };
   dylanmtaylor = {
     email = "dylan@dylanmtaylor.com";
     github = "dylanmtaylor";

--- a/pkgs/development/python-modules/pynmeagps/default.nix
+++ b/pkgs/development/python-modules/pynmeagps/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, setuptools
+, pytest-cov
+}:
+
+buildPythonPackage rec {
+  pname = "pynmeagps";
+  version = "1.0.35";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "semuconsulting";
+    repo = "pynmeagps";
+    rev = "v${version}";
+    hash = "sha256-ULGBfTHCFGUSF3cmJ4GEUrgGDo4uJwstBj8nZ7tj0AA=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov
+  ];
+
+  pythonImportsCheck = [
+    "pynmeagps"
+  ];
+
+  meta = {
+    homepage = "https://github.com/semuconsulting/pynmeagps";
+    description = "NMEA protocol parser and generator";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ dylan-gonzalez ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11290,6 +11290,8 @@ self: super: with self; {
 
   pynmea2 = callPackage ../development/python-modules/pynmea2 { };
 
+  pynmeagps = callPackage ../development/python-modules/pynmeagps { };
+
   pynput = callPackage ../development/python-modules/pynput { };
 
   pynrrd = callPackage ../development/python-modules/pynrrd { };


### PR DESCRIPTION
## Description of changes
Add the pynmeagps python package

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).