### PR TITLE
kdePackages.kglobalacceld: hack around ksycoca breakage

### DIFF
--- a/pkgs/kde/plasma/kglobalacceld/default.nix
+++ b/pkgs/kde/plasma/kglobalacceld/default.nix
@@ -1,4 +1,9 @@
 {mkKdeDerivation}:
 mkKdeDerivation {
   pname = "kglobalacceld";
+
+  # Don't delete shortcuts when applications disappear from sycoca,
+  # because for us they sometimes do.
+  # FIXME: make them actually not do that instead.
+  patches = [./dont-delete-shortcuts.patch];
 }

--- a/pkgs/kde/plasma/kglobalacceld/dont-delete-shortcuts.patch
+++ b/pkgs/kde/plasma/kglobalacceld/dont-delete-shortcuts.patch
@@ -1,0 +1,14 @@
+diff --git a/src/globalshortcutsregistry.cpp b/src/globalshortcutsregistry.cpp
+index 3cbaded..9adcf38 100644
+--- a/src/globalshortcutsregistry.cpp
++++ b/src/globalshortcutsregistry.cpp
+@@ -909,7 +909,8 @@ void GlobalShortcutsRegistry::refreshServices()
+             return false;
+         }
+ 
+-        return true;
++        qCDebug(KGLOBALACCELD) << "NIXPKGS: component" << component->uniqueName() << "disappeared, keeping shortcuts anyway";
++        return false;
+     });
+ 
+     m_components.erase(it, m_components.end());


### PR DESCRIPTION
This is not great, but at least it'll get people's systems more usable again.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
