### PR TITLE
home-assistant-custom-components: add a bunch of stuff

### DIFF
--- a/pkgs/development/python-modules/midea-beautiful-air/default.nix
+++ b/pkgs/development/python-modules/midea-beautiful-air/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, cryptography
+, requests
+, pytestCheckHook
+, pytest-socket
+, requests-mock
+}:
+
+buildPythonPackage rec {
+  pname = "midea-beautiful-air";
+  version = "0.10.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "nbogojevic";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-1IOv9K8f69iRpYaCx3k0smVrCKPmDxlT/1uVoTyvIjU=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    cryptography
+    requests
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-socket
+    requests-mock
+  ];
+
+  disabledTestPaths = [
+    # tests optional dependencies + network
+    "tests/test_cli.py"
+  ];
+
+  pythonImportsCheck = [ "midea_beautiful" ];
+
+  meta = with lib; {
+    description = "Python client for accessing Midea air conditioners and dehumidifiers (Midea, Comfee, Inventor EVO) via local network";
+    homepage = "https://github.com/nbogojevic/midea-beautiful-air";
+    changelog = "https://github.com/nbogojevic/midea-beautiful-air/releases/tag/v${version}";
+    maintainers = with maintainers; [ k900 ];
+    mainProgram = "midea-beautiful-air-cli";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -22,6 +22,8 @@
 
   localtuya = callPackage ./localtuya {};
 
+  midea-air-appliances-lan = callPackage ./midea-air-appliances-lan {};
+
   miele = callPackage ./miele {};
 
   moonraker = callPackage ./moonraker {};

--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -35,4 +35,6 @@
   smartthinq-sensors = callPackage ./smartthinq-sensors {};
 
   waste_collection_schedule = callPackage ./waste_collection_schedule {};
+
+  yassi = callPackage ./yassi {};
 }

--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -32,5 +32,7 @@
 
   sensi = callPackage ./sensi {};
 
+  smartthinq-sensors = callPackage ./smartthinq-sensors {};
+
   waste_collection_schedule = callPackage ./waste_collection_schedule {};
 }

--- a/pkgs/servers/home-assistant/custom-components/midea-air-appliances-lan/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/midea-air-appliances-lan/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildHomeAssistantComponent
+, fetchFromGitHub
+, midea-beautiful-air
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "nbogojevic";
+  domain = "midea_dehumidifier_lan";
+  version = "0.9.2";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "homeassistant-midea-air-appliances-lan";
+    rev = "v${version}";
+    hash = "sha256-CNvtpC7g0XR+cNDV9sMWc3sRLsy4bXFSDvkP+I7W1Gc=";
+  };
+
+  propagatedBuildInputs = [ midea-beautiful-air ];
+
+  meta = with lib; {
+    description = "Home Assistant custom component adding support for controlling Midea air conditioners and dehumidifiers on local network";
+    homepage = "https://github.com/nbogojevic/homeassistant-midea-air-appliances-lan";
+    changelog = "https://github.com/nbogojevic/homeassistant-midea-air-appliances-lan/releases/tag/v${version}";
+    maintainers = with maintainers; [ k900 ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/moonraker/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/moonraker/default.nix
@@ -7,13 +7,13 @@
 buildHomeAssistantComponent rec {
   owner = "marcolivierarsenault";
   domain = "moonraker";
-  version = "1.1.1";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "marcolivierarsenault";
     repo = "moonraker-home-assistant";
     rev = "refs/tags/${version}";
-    hash = "sha256-jxMi4hmSVBU9ztoHxFINoJo8klirfo6j7gWty7FXFkQ=";
+    hash = "sha256-oFHV9+5byWCOUxUhOvGHNilCZaoOp2xxb33nF8+CYjE=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/custom-components/smartthinq-sensors/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/smartthinq-sensors/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildHomeAssistantComponent
+, fetchFromGitHub
+, charset-normalizer
+, pycountry
+, xmltodict
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "ollo69";
+  domain = "smartthinq_sensors";
+  version = "0.39.0";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "ha-smartthinq-sensors";
+    rev = "v${version}";
+    hash = "sha256-mt5/XHDAUeoMUA1jWdCNXTUgZBQkqabL5Y4MxwxcweY=";
+  };
+
+  propagatedBuildInputs = [
+    charset-normalizer
+    pycountry
+    xmltodict
+  ];
+
+  meta = with lib; {
+    description = "Home Assistant custom integration for SmartThinQ LG devices configurable with Lovelace User Interface";
+    homepage = "https://github.com/ollo69/ha-smartthinq-sensors";
+    changelog = "https://github.com/ollo69/ha-smartthinq-sensors/releases/tag/v${version}";
+    maintainers = with maintainers; [ k900 ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/yassi/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/yassi/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildHomeAssistantComponent
+, fetchFromGitHub
+, pysmartthings
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "samuelspagl";
+  domain = "samsung_soundbar";
+  version = "0.4.0b2";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "ha_samsung_soundbar";
+    rev = version;
+    hash = "sha256-htAUCQe8mpk+GFwxXkPVnWS0m3mZd2hUt+f4qES+W4U=";
+  };
+
+  propagatedBuildInputs = [ pysmartthings ];
+
+  meta = with lib; {
+    description = "A HomeAssistant integration for Samsung Soundbars";
+    homepage = "https://ha-samsung-soundbar.vercel.app/";
+    changelog = "https://github.com/samuelspagl/ha_samsung_soundbar/releases/tag/${version}";
+    maintainers = with maintainers; [ k900 ];
+    # https://github.com/samuelspagl/ha_samsung_soundbar/issues/31
+    license = licenses.unfree;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7337,6 +7337,8 @@ self: super: with self; {
 
   microsoft-kiota-serialization-text = callPackage ../development/python-modules/microsoft-kiota-serialization-text { };
 
+  midea-beautiful-air = callPackage ../development/python-modules/midea-beautiful-air { };
+
   midiutil = callPackage ../development/python-modules/midiutil { };
 
   mido = callPackage ../development/python-modules/mido { };


### PR DESCRIPTION
## Description of changes

An update + some new components for stuff that I use, now that I'm finally migrating my HASS setup to nixpkgs components instead of HACS.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
