### PR TITLE
vrc-get: 1.5.2 -> 1.8.0

### DIFF
--- a/pkgs/tools/misc/vrc-get/default.nix
+++ b/pkgs/tools/misc/vrc-get/default.nix
@@ -1,28 +1,23 @@
-{ fetchFromGitHub, lib, rustPlatform, pkg-config, openssl, stdenv, Security, SystemConfiguration }:
+{ fetchCrate, lib, rustPlatform, pkg-config, stdenv, Security, SystemConfiguration }:
 
 rustPlatform.buildRustPackage rec {
   pname = "vrc-get";
-  version = "1.5.2";
+  version = "1.8.0";
 
-  src = fetchFromGitHub {
-    owner = "anatawa12";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-DTiYyTZKYNprQSsAjHmpGdnS6dkXa3hSRGmIiLT/xr8=";
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-+xbHw1DpFmapjsFoUvxUqTok8TKMebMw3gYjO/rx/iU=";
   };
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security SystemConfiguration ];
+  buildInputs = lib.optionals stdenv.isDarwin [ Security SystemConfiguration ];
 
-  # Make openssl-sys use pkg-config.
-  OPENSSL_NO_VENDOR = 1;
-
-  cargoHash = "sha256-4bhle98/zfw1uGNx+m1/4H9n63DnIezg/ZdV+zj0JNA=";
+  cargoHash = "sha256-iuLhDcii+wXDNUsUMo8lj4kfJve5RAz7FT5Pxs9yFPQ=";
 
   meta = with lib; {
     description = "Command line client of VRChat Package Manager, the main feature of VRChat Creator Companion (VCC)";
-    homepage = "https://github.com/anatawa12/vrc-get";
+    homepage = "https://github.com/vrc-get/vrc-get";
     license = licenses.mit;
     maintainers = with maintainers; [ bddvlpr ];
     mainProgram = "vrc-get";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR upgrades vrc-get to 1.8.0
Obsolates #285844

CHANGELOG: https://github.com/vrc-get/vrc-get/blob/master/CHANGELOG.md#180---2024-03-31

I had never used the nix / nixos.
One user of vrc-get ask me about one bug that is fixed in the latest release.
I asked them to upgrade package, they told me that on their package manager it's latest and they are using nixpkgs.
So, I created this pull request to upgrade the vrc-get.

This PR switches download source from github to crates.io.
The vrc-get repository contains vrc-get-gui and vrc-get-litedb, which are not used by vrc-get so I switched to crates.io to reduce download size.

In addition, this PR removes openssl from dependencies since vrc-get uses rustls by default for TLS implementation since version 1.3.1.

I could not found documentation to get the suitable `hash` of `fetchCrate` and `cargoHash` so I ran `nix-build -A vrc-get` and get new hash from the error message.
Could you let me know what's the best way to get hashes?

If nixpkgs team allows, I want to update nixpkgs in my deployment CD (on github actions) and add to README.
Could you let me know if it is allowed to create pull requests automatically and preferred action / workflow for updating nixpkgs distribution?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
