### PR TITLE
osm2world: init at unstable-2024-02-25

### DIFF
--- a/pkgs/by-name/os/osm2world/package.nix
+++ b/pkgs/by-name/os/osm2world/package.nix
@@ -1,0 +1,63 @@
+{ stdenv, lib, maven, fetchFromGitHub, makeWrapper
+, jogl, libXxf86vm, libGL, jre, jdk17 }:
+
+let
+  mavenJdk17 = maven.override {
+    jdk = jdk17;
+  };
+in mavenJdk17.buildMavenPackage {
+  pname = "osm2world";
+  version = "unstable-2024-02-25";
+
+  src = fetchFromGitHub {
+    owner = "tordanik";
+    repo = "OSM2World";
+    rev = "dda165854fb0b5b8c1116afed12703c4ee7f3fdb";
+    hash = "sha256-4mwoM3jCwkzlTkvAVJuIAsWgPGBWH25jmFz27oFl/E4=";
+  };
+
+  mvnHash = "sha256-caFigTHVMQ/ypKR+0F56gRr+6zOzDCE1loyFpqNBWgw=";
+  mvnParameters = "-Dtest=!OverpassReaderTest"; # the test requires Internet connectivity
+
+  buildInputs = lib.optionals stdenv.isLinux [ libXxf86vm ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 target/osm2world-*.jar -t $out/share/osm2world
+    install -Dm755 target/lib/* -t $out/share/osm2world/lib
+  '' + lib.optionalString stdenv.isLinux ''
+    # use self-compiled JOGL to avoid patchelf'ing .so inside jars
+    rm $out/share/osm2world/lib/{jogl,gluegen,nativewindow}*.jar
+    install -Dm755 ${jogl}/share/java/* -t $out/share/osm2world/lib/
+
+    mv $out/share/osm2world/lib/jogl-all.jar $out/share/osm2world/lib/jogl-all-v2.4.0-rc-20210111.jar
+    mv $out/share/osm2world/lib/jogl-all-natives-linux-amd64.jar $out/share/osm2world/lib/jogl-all-natives-linux-amd64-v2.4.0-rc-20210111.jar
+
+    mv $out/share/osm2world/lib/gluegen-rt.jar $out/share/osm2world/lib/gluegen-rt-v2.4.0-rc-20210111.jar
+    mv $out/share/osm2world/lib/gluegen-rt-natives-linux-amd64.jar $out/share/osm2world/lib/gluegen-rt-natives-linux-amd64-v2.4.0-rc-20210111.jar
+  '' + ''
+    makeWrapper ${lib.getExe jre} $out/bin/osm2world \
+      --add-flags "-Djava.library.path=$out/share/osm2world/lib" \
+      ${lib.optionalString stdenv.isLinux "--prefix LD_LIBRARY_PATH : \"${lib.makeLibraryPath [ libGL ]}\""} \
+      --add-flags "-Xmx2G --add-exports java.base/java.lang=ALL-UNNAMED --add-exports java.desktop/sun.awt=ALL-UNNAMED --add-exports java.desktop/sun.java2d=ALL-UNNAMED" \
+      --add-flags "-jar $out/share/osm2world/osm2world-0.4.0-SNAPSHOT.jar"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "OSM2World is a converter that creates three-dimensional models of the world from OpenStreetMap data.";
+    homepage = "https://osm2world.org/";
+    changelog = "https://raw.githubusercontent.com/tordanik/OSM2World/master/doc/changes.txt";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ eliandoran ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode  # dependencies
+    ];
+    mainProgram = "osm2world";
+  };
+}


### PR DESCRIPTION
## Description of changes

Official website: https://osm2world.org/ 

> OSM2World is a converter that creates three-dimensional models of the world from OpenStreetMap data. It can be used as a stand-alone tool, on a server or as a library in Java programs.

![image](https://github.com/NixOS/nixpkgs/assets/21236836/39ed4e85-ef33-40d3-a4c9-06cca5c5b179)

Notes:

- Last numbered version, according to https://osm2world.org/download/ is 0.3.1, but that version is from [Dec 30, 2022](https://github.com/tordanik/OSM2World/commit/2f36c354e4691fc724e6a05038bb18f655d07ec6).
- Only one of the tests fails because it requires an internet connection, it was skipped.

### org.apache.commons.configuration.ConfigurationException: Unable to load the configuration from the URL

This exception appears in logs at startup and as a message box when opening an OSM file, however this does not seem to affect the functionality of the app.

In any case, it seems this error can be suppressed as follows:

```sh
touch test.properties
osm2world --gui --config test.properties
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
