### PR TITLE
tvheadend: Add additional network params.

### DIFF
--- a/nixos/modules/services/networking/tvheadend.nix
+++ b/nixos/modules/services/networking/tvheadend.nix
@@ -2,61 +2,122 @@
 
 with lib;
 
-let cfg     = config.services.tvheadend;
-    pidFile = "${config.users.users.tvheadend.home}/tvheadend.pid";
-in
+let
+  cfg = config.services.tvheadend;
+  dataDir = "/var/lib/tvheadend";
+  pidFile = "${dataDir}/tvheadend.pid";
 
-{
+in {
   options = {
     services.tvheadend = {
       enable = mkEnableOption "Tvheadend";
+
+      package = mkPackageOption pkgs "tvheadend" { };
+
+      user = mkOption {
+        default = "tvheadend";
+        type = types.str;
+        description = ''
+          User account under which Tvheadend runs.
+
+          ::: {.note}
+          If left as the default value this user will automatically be created
+          on system activation, otherwise you are responsible for
+          ensuring the user exists before the Tvheadend service starts.
+          :::
+        '';
+      };
+
+      group = mkOption {
+        default = "tvheadend";
+        type = types.str;
+        description = ''
+          Group under which Tvheadend runs.
+
+          ::: {.note}
+          If left as the default value this group will automatically be created
+          on system activation, otherwise you are responsible for
+          ensuring the user exists before the Tvheadend service starts.
+          :::
+        '';
+      };
+
       httpPort = mkOption {
-        type        = types.int;
-        default     = 9981;
+        type = types.int;
+        default = 9981;
         description = "Port to bind HTTP to.";
       };
 
       htspPort = mkOption {
-        type        = types.int;
-        default     = 9982;
+        type = types.int;
+        default = 9982;
         description = "Port to bind HTSP to.";
+      };
+
+      ipv6 = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Listen on IPv6.";
+      };
+
+      bindAddr = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = "Specify bind address.";
+        example = "127.0.0.1";
       };
     };
   };
 
   config = mkIf cfg.enable {
-    users.users.tvheadend = {
+    environment = { systemPackages = [ cfg.package ]; };
+
+    users.groups.tvheadend = mkIf (cfg.group == "tvheadend") { };
+
+    users.users.tvheadend = mkIf (cfg.user == "tvheadend") {
       description = "Tvheadend Service user";
-      home        = "/var/lib/tvheadend";
-      createHome  = true;
+      home = dataDir;
+      createHome = true;
       isSystemUser = true;
-      group = "tvheadend";
+      group = cfg.group;
+      extraGroups = [ "video" ]; # In order to access tuner adapters.
     };
-    users.groups.tvheadend = {};
 
     systemd.services.tvheadend = {
       description = "Tvheadend TV streaming server";
-      wantedBy    = [ "multi-user.target" ];
-      after       = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
 
       serviceConfig = {
-        Type         = "forking";
-        PIDFile      = pidFile;
-        Restart      = "always";
-        RestartSec   = 5;
-        User         = "tvheadend";
-        Group        = "video";
-        ExecStart    = ''
-                       ${pkgs.tvheadend}/bin/tvheadend \
-                       --http_port ${toString cfg.httpPort} \
-                       --htsp_port ${toString cfg.htspPort} \
-                       -f \
-                       -C \
-                       -p ${pidFile} \
-                       -u tvheadend \
-                       -g video
-                       '';
-        ExecStop     = "${pkgs.coreutils}/bin/rm ${pidFile}";
+        Type = "forking";
+        PIDFile = pidFile;
+        Restart = "always";
+        RestartSec = 5;
+        User = cfg.user;
+        Group = cfg.group;
+        # CLI options reference -
+        # https://github.com/tvheadend/tvheadend/blob/ab6ea89b11b1f1a8dcbfd7cfc29d65b3013f2702/src/main.c#L878
+        ExecStart = "${cfg.package}/bin/tvheadend " +
+          # Specify alternative http port
+          "--http_port ${toString cfg.httpPort} " +
+          # Specify alternative htsp port
+          "--htsp_port ${toString cfg.htspPort} " +
+          # Fork and run as daemon 
+          "-f " +
+          # First run.
+          "-C " +
+          # Alternate PID path
+          "-p ${pidFile} " +
+          # Run as user
+          "-u ${cfg.user} " +
+          # Run as group
+          "-g ${cfg.group} " +
+          # Specify bind address
+          optionalString (cfg.bindAddr != null) "--bindaddr ${cfg.bindAddr} " +
+          # Listen on IPv6
+          optionalString (cfg.ipv6) "--ipv6 ";
+        ExecStop = "${pkgs.coreutils}/bin/rm ${pidFile}";
       };
     };
   };

--- a/nixos/modules/services/networking/tvheadend.nix
+++ b/nixos/modules/services/networking/tvheadend.nix
@@ -103,7 +103,7 @@ in {
           "--http_port ${toString cfg.httpPort} " +
           # Specify alternative htsp port
           "--htsp_port ${toString cfg.htspPort} " +
-          # Fork and run as daemon 
+          # Fork and run as daemon
           "-f " +
           # First run.
           "-C " +


### PR DESCRIPTION
Initially i was just going to add ipv6 options as thats what i needed. I ended up giving this module a birthday as well.

Outline of changes:

- Add options for ipv6 and bindAddr
- Add configurable user/group/package
- Update systemd service (docs/cfg options)
- Ran `nixfmt` over file

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
