### PR TITLE
RFC: treewide: use stdenv's {configure,c?make}Flags instead of hooks

### DIFF
--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -326,7 +326,7 @@ mkDerivation (finalAttrs: {
     "--with-xpm=no"
   ])
   ++ lib.optionals (variant == "macport") [
-    "--enable-mac-app=$$out/Applications"
+    "--enable-mac-app=${placeholder "out"}/Applications"
     "--with-gnutls=yes"
     "--with-mac"
     "--with-xml2=yes"

--- a/pkgs/applications/editors/xedit/default.nix
+++ b/pkgs/applications/editors/xedit/default.nix
@@ -37,9 +37,11 @@ stdenv.mkDerivation rec {
     libXt
   ];
 
-  configureFlags = [
-    "--with-lispdir=$out/share/X11/xedit/lisp"
-    "--with-appdefaultdir=$out/share/X11/app-defaults"
+  configureFlags = let
+    out = placeholder out;
+  in [
+    "--with-lispdir=${out}/share/X11/xedit/lisp"
+    "--with-appdefaultdir=${out}/share/X11/app-defaults"
   ];
 
   meta = with lib; {

--- a/pkgs/applications/file-managers/spacefm/default.nix
+++ b/pkgs/applications/file-managers/spacefm/default.nix
@@ -30,11 +30,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-bash-path=${pkgs.bash}/bin/bash"
+    "--sysconfdir=${placeholder "out"}/etc"
   ];
-
-  preConfigure = ''
-    configureFlags="$configureFlags --sysconfdir=$out/etc"
-  '';
 
   postInstall = ''
     rm -f $out/etc/spacefm/spacefm.conf

--- a/pkgs/applications/networking/instant-messengers/silc-client/default.nix
+++ b/pkgs/applications/networking/instant-messengers/silc-client/default.nix
@@ -19,11 +19,9 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  configureFlags = [ "--with-ncurses=${ncurses.dev}" ];
-
-  preConfigure = lib.optionalString enablePlugin ''
-    configureFlags="$configureFlags --with-silc-plugin=$out/lib/irssi"
-  '';
+  configureFlags = [
+    "--with-ncurses=${ncurses.dev}"
+  ] ++ lib.optionalString enablePlugin [ "--with-silc-plugin=${placeholder "out"}/lib/irssi" ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ perl glib ncurses ];

--- a/pkgs/applications/science/logic/stp/default.nix
+++ b/pkgs/applications/science/logic/stp/default.nix
@@ -29,14 +29,13 @@ stdenv.mkDerivation rec {
   buildInputs = [ boost zlib minisat cryptominisat python3 ];
   nativeBuildInputs = [ cmake bison flex perl ];
   preConfigure = ''
-    python_install_dir=$out/${python3Packages.python.sitePackages}
-    mkdir -p $python_install_dir
-    cmakeFlagsArray=(
-      $cmakeFlagsArray
-      "-DBUILD_SHARED_LIBS=ON"
-      "-DPYTHON_LIB_INSTALL_DIR=$python_install_dir"
-    )
+    mkdir -p $out/${python3Packages.python.sitePackages}
   '';
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DPYTHON_LIB_INSTALL_DIR=${placeholder "out"}/${python3Packages.python.sitePackages}"
+  ];
 
   meta = with lib; {
     description = "Simple Theorem Prover";

--- a/pkgs/applications/science/misc/boinc/default.nix
+++ b/pkgs/applications/science/misc/boinc/default.nix
@@ -63,12 +63,14 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     ./_autosetup
-    configureFlags="$configureFlags --sysconfdir=$out/etc"
   '';
 
   enableParallelBuilding = true;
 
-  configureFlags = [ "--disable-server" ] ++ lib.optionals headless [ "--disable-manager" ];
+  configureFlags = [
+    "--disable-server"
+    "--sysconfdir=${placeholder "out"}/etc"
+  ] ++ lib.optionals headless [ "--disable-manager" ];
 
   postInstall = ''
     install --mode=444 -D 'client/scripts/boinc-client.service' "$out/etc/systemd/system/boinc.service"

--- a/pkgs/by-name/ha/havoc/package.nix
+++ b/pkgs/by-name/ha/havoc/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontConfigure = true;
 
-  installFlags = [ "PREFIX=$$out" ];
+  installFlags = [ "PREFIX=$(out)" ];
 
   postInstall = ''
     install -Dm 644 havoc.cfg -t $out/etc/havoc/

--- a/pkgs/desktops/gnustep/make/default.nix
+++ b/pkgs/desktops/gnustep/make/default.nix
@@ -17,11 +17,8 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [
     "--with-layout=fhs-system"
     "--disable-install-p"
+    "--with-config-file=${placeholder "out"}/etc/GNUstep/GNUstep.conf"
   ];
-
-  preConfigure = ''
-    configureFlags="$configureFlags --with-config-file=$out/etc/GNUstep/GNUstep.conf"
-  '';
 
   makeFlags = [
     "GNUSTEP_INSTALLATION_DOMAIN=SYSTEM"

--- a/pkgs/desktops/mate/atril/default.nix
+++ b/pkgs/desktops/mate/atril/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
 
   env.NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 
-  makeFlags = [ "cajaextensiondir=$$out/lib/caja/extensions-2.0" ];
+  makeFlags = [ "cajaextensiondir=$(out)/lib/caja/extensions-2.0" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/mate/caja-dropbox/default.nix
+++ b/pkgs/desktops/mate/caja-dropbox/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     python3
   ];
 
-  configureFlags = [ "--with-caja-extension-dir=$$out/lib/caja/extensions-2.0" ];
+  configureFlags = [ "--with-caja-extension-dir=${placeholder "out"}/lib/caja/extensions-2.0" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/mate/caja-extensions/default.nix
+++ b/pkgs/desktops/mate/caja-extensions/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  configureFlags = [ "--with-cajadir=$$out/lib/caja/extensions-2.0" ];
+  configureFlags = [ "--with-cajadir=${placeholder "out"}/lib/caja/extensions-2.0" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/mate/engrampa/default.nix
+++ b/pkgs/desktops/mate/engrampa/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
-    "--with-cajadir=$$out/lib/caja/extensions-2.0"
+    "--with-cajadir=${placeholder "out"}/lib/caja/extensions-2.0"
   ] ++ lib.optionals withMagic [
     "--enable-magic"
   ];

--- a/pkgs/desktops/mate/python-caja/default.nix
+++ b/pkgs/desktops/mate/python-caja/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     python3Packages.pygobject3
   ];
 
-  configureFlags = [ "--with-cajadir=$$out/lib/caja/extensions-2.0" ];
+  configureFlags = [ "--with-cajadir=${placeholder "out"}/lib/caja/extensions-2.0" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/mercury/default.nix
+++ b/pkgs/development/compilers/mercury/default.nix
@@ -22,14 +22,17 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  preConfigure = ''
-    mkdir -p $out/lib/mercury/cgi-bin ;
-    configureFlags="--enable-deep-profiler=$out/lib/mercury/cgi-bin";
-  '';
+  configureFlags = [
+    "--enable-deep-profiler=${placeholder "out"}/lib/mercury/cgi-bin"
+  ]
 
-  preBuild = ''
+  makeFlags = [
     # Mercury buildsystem does not take -jN directly.
-    makeFlags="PARALLEL=-j$NIX_BUILD_CORES" ;
+    "PARALLEL=-j$NIX_BUILD_CORES"
+  ];
+
+  preConfigure = ''
+    mkdir -p $out/lib/mercury/cgi-bin
   '';
 
   postInstall = ''

--- a/pkgs/development/interpreters/lfe/generic-builder.nix
+++ b/pkgs/development/interpreters/lfe/generic-builder.nix
@@ -40,7 +40,7 @@ buildRebar3 {
   doCheck     = true;
   checkTarget = "travis";
 
-  makeFlags = [ "-e" "MANDB=''" "PREFIX=$$out"];
+  makeFlags = [ "-e" "MANDB=''" "PREFIX=$(out)"];
 
   # These installPhase tricks are based on Elixir's Makefile.
   # TODO: Make, upload, and apply a patch.

--- a/pkgs/development/libraries/libofa/default.nix
+++ b/pkgs/development/libraries/libofa/default.nix
@@ -19,9 +19,10 @@ stdenv.mkDerivation rec {
 
   setOutputFlags = false;
 
-  preConfigure = ''
-    configureFlagsArray=(--includedir=$dev/include --libdir=$out/lib)
-  '';
+  configureFlags = [
+    "--includedir=${placeholder "dev"}/include"
+    "--libdir=${placeholder "out"}/lib"
+  ];
 
   propagatedBuildInputs = [ expat curl fftw ];
 

--- a/pkgs/development/libraries/tsocks/default.nix
+++ b/pkgs/development/libraries/tsocks/default.nix
@@ -14,8 +14,9 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     sed -i -e "s,\\\/usr,"$(echo $out|sed -e "s,\\/,\\\\\\\/,g")",g" tsocks
     substituteInPlace tsocks --replace /usr $out
-    export configureFlags="$configureFlags --libdir=$out/lib"
   '';
+
+  configureFlags = [ "--libdir=${placeholder "out"}/lib" ];
 
   preBuild = ''
     # We don't need the saveme binary, it is in fact never stored and we're

--- a/pkgs/development/tools/misc/dbench/default.nix
+++ b/pkgs/development/tools/misc/dbench/default.nix
@@ -22,8 +22,9 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     ./autogen.sh
-    configureFlagsArray+=("--datadir=$out/share/dbench")
   '';
+
+  configureFlags = [ "--datadir=${placeholder "out"}/share/dbench" ];
 
   postInstall = ''
     cp -R loadfiles/* $out/share/dbench/doc/dbench/loadfiles

--- a/pkgs/development/tools/ocaml/opam/installer.nix
+++ b/pkgs/development/tools/ocaml/opam/installer.nix
@@ -8,7 +8,10 @@ ocamlPackages.buildDunePackage {
   inherit (opam) version src;
   nativeBuildInputs = [ unzip ];
 
-  configureFlags = [ "--disable-checks" "--prefix=$out" ];
+  configureFlags = [
+    "--disable-checks"
+    "--prefix=${placeholder "out"}"
+  ];
   buildInputs = with ocamlPackages; [ opam-format cmdliner ];
 
   meta = opam.meta // {

--- a/pkgs/games/freesweep/default.nix
+++ b/pkgs/games/freesweep/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook installShellFiles ];
   buildInputs = [ ncurses ];
 
-  configureFlags = [ "--with-prefsdir=$out/share" ];
+  configureFlags = [ "--with-prefsdir=${placeholder "out"}/share" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/misc/cups/drivers/cups-bjnp/default.nix
+++ b/pkgs/misc/cups/drivers/cups-bjnp/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0sb0vm1sf8ismzd9ba33qswxmsirj2z1b7lnyrc9v5ixm7q0bnrm";
   };
 
-  preConfigure = ''configureFlags="--with-cupsbackenddir=$out/lib/cups/backend"'';
+  configureFlags = [ "--with-cupsbackenddir=${placeholder "out"}/lib/cups/backend" ];
 
   buildInputs = [cups];
   env.NIX_CFLAGS_COMPILE = toString [

--- a/pkgs/misc/screensavers/xlockmore/default.nix
+++ b/pkgs/misc/screensavers/xlockmore/default.nix
@@ -17,9 +17,10 @@ stdenv.mkDerivation rec {
 
   # Don't try to install `xlock' setuid. Password authentication works
   # fine via PAM without super user privileges.
-  configureFlags =
-    [ "--disable-setuid"
-    ] ++ (lib.optional (pam != null) "--enable-pam");
+  configureFlags = [
+    "--disable-setuid"
+    "--enable-appdefaultdir=${placeholder "out"}/share/X11/app-defaults"
+  ] ++ (lib.optional (pam != null) "--enable-pam");
 
   postPatch =
     let makePath = p: lib.concatMapStringsSep " " (x: x + "/" + p) buildInputs;
@@ -27,7 +28,6 @@ stdenv.mkDerivation rec {
     in ''
       sed -i 's,\(for ac_dir in\),\1 ${inputs},' configure.ac
       sed -i 's,/usr/,/no-such-dir/,g' configure.ac
-      configureFlags+=" --enable-appdefaultdir=$out/share/X11/app-defaults"
     '';
 
   hardeningDisable = [ "format" ]; # no build output otherwise

--- a/pkgs/os-specific/linux/nfs-utils/default.nix
+++ b/pkgs/os-specific/linux/nfs-utils/default.nix
@@ -63,8 +63,6 @@ stdenv.mkDerivation rec {
       sed -i "s,/usr/sbin,$out/bin,g" utils/statd/statd.c
       sed -i "s,^PATH=.*,PATH=$out/bin:${statdPath}," utils/statd/start-statd
 
-      configureFlags="--with-start-statd=$out/bin/start-statd $configureFlags"
-
       substituteInPlace systemd/nfs-utils.service \
         --replace "/bin/true" "${coreutils}/bin/true"
 
@@ -76,6 +74,10 @@ stdenv.mkDerivation rec {
 
       sed '1i#include <stdint.h>' -i support/nsm/rpc.c
     '';
+
+  configureFlags = [
+    "--with-start-statd=${placeholder "out"}/bin/start-statd"
+  ];
 
   makeFlags = [
     "sbindir=$(out)/bin"

--- a/pkgs/os-specific/linux/pam_u2f/default.nix
+++ b/pkgs/os-specific/linux/pam_u2f/default.nix
@@ -12,9 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libfido2 pam openssl ];
 
-  preConfigure = ''
-    configureFlagsArray+=("--with-pam-dir=$out/lib/security")
-  '';
+  configureFlags = [ "--with-pam-dir=${placeholder "out"}/lib/security" ];
 
   # a no-op makefile to prevent building the fuzz targets
   postConfigure = ''

--- a/pkgs/servers/http/apache-modules/mod_auth_mellon/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_auth_mellon/default.nix
@@ -15,7 +15,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkg-config autoconf automake ];
   buildInputs = [ apacheHttpd curl glib lasso libtool libxml2 libxslt openssl xmlsec ];
 
-  configureFlags = ["--with-apxs2=${apacheHttpd.dev}/bin/apxs" "--exec-prefix=$out"];
+  configureFlags = [
+    "--with-apxs2=${apacheHttpd.dev}/bin/apxs"
+    "--exec-prefix=${placeholder "out"}"
+  ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/servers/irker/default.nix
+++ b/pkgs/servers/irker/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
 
   installFlags = [
     "prefix=/"
-    "DESTDIR=$$out"
+    "DESTDIR=$(out)"
   ];
 
   meta = with lib; {

--- a/pkgs/servers/osmocom/libosmo-sccp/default.nix
+++ b/pkgs/servers/osmocom/libosmo-sccp/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-GrC++v7PCAnaEtMFt+el/ct2g+/9Axev04g/jMIGyOQ=";
   };
 
-  configureFlags = [ "--with-systemdsystemunitdir=$out" ];
+  configureFlags = [ "--with-systemdsystemunitdir=${placeholder "out"}" ];
 
   postPatch = ''
     echo "${version}" > .tarball-version

--- a/pkgs/servers/sip/sipwitch/default.nix
+++ b/pkgs/servers/sip/sipwitch/default.nix
@@ -12,9 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ ucommon libosip libexosip gnutls zlib ];
 
-  preConfigure = ''
-    export configureFlags="--sysconfdir=$out/etc"
-  '';
+  configureFlags = [ "--sysconfdir=${placeholder "out"}/etc" ];
 
   doCheck = true;
 

--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -19,6 +19,9 @@
 
 let
   gdal = gdalMinimal;
+
+  out = placeholder "out";
+  doc = placeholder "doc";
 in
 stdenv.mkDerivation rec {
   pname = "postgis";
@@ -39,12 +42,26 @@ stdenv.mkDerivation rec {
   # postgis config directory assumes /include /lib from the same root for json-c library
   env.NIX_LDFLAGS = "-L${lib.getLib json_c}/lib";
 
+  configureFlags = [
+    "--datadir=${out}/share/postgresql"
+    "--datarootdir=${out}/share/postgresql"
+    "--bindir=${out}/bin"
+    "--docdir=${doc}/share/doc/${pname}"
+    "--with-gdalconfig=${gdal}/bin/gdal-config"
+    "--with-jsondir=${json_c.dev}"
+    "--disable-extension-upgrades-install"
+  ];
+
+  makeFlags = [
+    "PERL=${perl}/bin/perl"
+    "datadir=${out}/share/postgresql"
+    "pkglibdir=${out}/lib"
+    "bindir=${out}/bin"
+    "docdir=${doc}/share/doc/${pname}"
+  ]
 
   preConfigure = ''
     sed -i 's@/usr/bin/file@${file}/bin/file@' configure
-    configureFlags="--datadir=$out/share/postgresql --datarootdir=$out/share/postgresql --bindir=$out/bin --docdir=$doc/share/doc/${pname} --with-gdalconfig=${gdal}/bin/gdal-config --with-jsondir=${json_c.dev} --disable-extension-upgrades-install"
-
-    makeFlags="PERL=${perl}/bin/perl datadir=$out/share/postgresql pkglibdir=$out/lib bindir=$out/bin docdir=$doc/share/doc/${pname}"
   '';
   postConfigure = ''
     sed -i "s|@mkdir -p \$(DESTDIR)\$(PGSQL_BINDIR)||g ;

--- a/pkgs/tools/X11/xlogo/default.nix
+++ b/pkgs/tools/X11/xlogo/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ xorg-autoconf autoreconfHook pkg-config ];
 
-  configureFlags = [ "--with-appdefaultdir=$out/share/X11/app-defaults" ];
+  configureFlags = [ "--with-appdefaultdir=${placeholder "out"}/share/X11/app-defaults" ];
 
   buildInputs = [ xorg.libX11 xorg.libXext xorg.libSM xorg.libXmu xorg.libXaw xorg.libXt ];
 

--- a/pkgs/tools/backup/tarsnap/default.nix
+++ b/pkgs/tools/backup/tarsnap/default.nix
@@ -15,9 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "1mbzq81l4my5wdhyxyma04sblr43m8p7ryycbpi6n78w1hwfbjmw";
   };
 
-  preConfigure = ''
-    configureFlags="--with-bash-completion-dir=$out/share/bash-completion/completions"
-  '';
+  configureFlags = [ "--with-bash-completion-dir=${placeholder "out"}/share/bash-completion/completions" ];
 
   patchPhase = ''
     substituteInPlace Makefile.in \

--- a/pkgs/tools/cd-dvd/brasero/default.nix
+++ b/pkgs/tools/cd-dvd/brasero/default.nix
@@ -30,9 +30,11 @@ in stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  configureFlags = [
-    "--with-girdir=$out/share/gir-1.0"
-    "--with-typelibdir=$out/lib/girepository-1.0"
+  configureFlags = let
+    out = placeholder "out";
+  in [
+    "--with-girdir=${out}/share/gir-1.0"
+    "--with-typelibdir=${out}/lib/girepository-1.0"
   ];
 
   preFixup = ''

--- a/pkgs/tools/graphics/scanbd/default.nix
+++ b/pkgs/tools/graphics/scanbd/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     "--disable-Werror"
     "--enable-udev"
     "--with-scanbdconfdir=/etc/scanbd"
-    "--with-systemdsystemunitdir=$out/lib/systemd/system"
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     # AC_FUNC_MALLOC is broken on cross builds.
     "ac_cv_func_malloc_0_nonnull=yes"

--- a/pkgs/tools/misc/libbitcoin/libbitcoin-explorer.nix
+++ b/pkgs/tools/misc/libbitcoin/libbitcoin-explorer.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     "--with-tests=no"
     "--with-boost=${boost.dev}"
     "--with-boost-libdir=${boost.out}/lib"
-    "--with-bash-completiondir=$out/share/bash-completion/completions"
+    "--with-bash-completiondir=${placeholder "out"}/share/bash-completion/completions"
   ];
 
   meta = with lib; {

--- a/pkgs/tools/misc/vorbisgain/default.nix
+++ b/pkgs/tools/misc/vorbisgain/default.nix
@@ -15,8 +15,9 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     chmod -v +x configure
-    configureFlags="--mandir=$out/share/man"
   '';
+
+  configureFlags = [ "--mandir=${placeholder "out"}/share/man" ];
 
   meta = with lib; {
     homepage = "https://sjeng.org/vorbisgain.html";

--- a/pkgs/tools/networking/curl-impersonate/default.nix
+++ b/pkgs/tools/networking/curl-impersonate/default.nix
@@ -94,10 +94,11 @@ let
       export GOPATH=$TMPDIR/go
       export GOPROXY=file://${passthru.boringssl-go-modules}
       export GOSUMDB=off
-
-      # Need to get value of $out for this flag
-      configureFlagsArray+=("--with-libnssckbi=$out/lib")
     '';
+
+    configureFlags = [
+      "with-libnssckbi=${placeholder "out"}/lib"
+    ];
 
     postInstall = ''
       # Remove vestigial *-config script

--- a/pkgs/tools/networking/zerotierone/default.nix
+++ b/pkgs/tools/networking/zerotierone/default.nix
@@ -73,7 +73,7 @@ in stdenv.mkDerivation {
     runHook postCheck
   '';
 
-  installFlags = [ "DESTDIR=$$out/upstream" ];
+  installFlags = [ "DESTDIR=$(out)/upstream" ];
 
   postInstall = ''
     mv $out/upstream/usr/sbin $out/bin

--- a/pkgs/tools/security/softhsm/default.nix
+++ b/pkgs/tools/security/softhsm/default.nix
@@ -10,11 +10,13 @@ stdenv.mkDerivation rec {
     hash = "sha256-YSSUcwVLzRgRUZ75qYmogKe9zDbTF8nCVFf8YU30dfI=";
   };
 
-  configureFlags = [
+  configureFlags = let
+    out = placeholder "out";
+  in [
     "--with-crypto-backend=botan"
     "--with-botan=${lib.getDev botan2}"
-    "--sysconfdir=$out/etc"
-    "--localstatedir=$out/var"
+    "--sysconfdir=${out}/etc"
+    "--localstatedir=${out}/var"
     ];
 
   propagatedBuildInputs =

--- a/pkgs/tools/text/highlight/default.nix
+++ b/pkgs/tools/text/highlight/default.nix
@@ -29,9 +29,12 @@ let
           --replace 'CXX=g++' 'CXX=clang++'
     '';
 
-    preConfigure = ''
-      makeFlags="PREFIX=$out conf_dir=$out/etc/highlight/ CXX=$CXX AR=$AR"
-    '';
+    makeFlags = [
+      "PREFIX=$(out)"
+      "conf_dir=$(out)/etc/highlight/"
+      "CXX=$$CXX"
+      "AR=$$AR"
+    ];
 
     # This has to happen _before_ the main build because it does a
     # `make clean' for some reason.


### PR DESCRIPTION
## Description of changes

There is a large inconsistency on how configure, make and cmake flags are set when they need to refer to environment variables such as `$out`.

The stdenv shorthands like `configureFlags` are not directly substituting environment variables. Hence usage of `$` must be escaped to `$$` or `${}`. During this refactor a couple of instances have been found where this escaping was not done. This commit also fixes them.

I stumbled over this while working on #299626

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
