### PR TITLE
jupyter related packages updates 2024-04-07

### DIFF
--- a/pkgs/development/python-modules/anywidget/default.nix
+++ b/pkgs/development/python-modules/anywidget/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "anywidget";
-  version = "0.9.4";
-  format = "pyproject";
+  version = "0.9.6";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-97nCw1PohHKW2DtY6RARk1/RlMsc1s5wajuhbY3pQxo=";
+    hash = "sha256-nhDPAXwcsxwrTBG1kEBj77bDXMb3j/Xckk3FENjCS5E=";
   };
 
   # We do not need the jupyterlab build dependency, because we do not need to
@@ -32,12 +32,12 @@ buildPythonPackage rec {
       --replace '"jupyterlab==3.*"' ""
   '';
 
-  nativeBuildInputs = [
+  build-system = [
     hatch-jupyter-builder
     hatchling
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     ipywidgets
     psygnal
     typing-extensions

--- a/pkgs/development/python-modules/ipykernel/default.nix
+++ b/pkgs/development/python-modules/ipykernel/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "ipykernel";
-  version = "6.29.3";
+  version = "6.29.4";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-4UwlDR+eo5iUkCJcwaVCeBsJWhihlEf88rXq99CsW9I=";
+    hash = "sha256-PUQHAGD5R1rCCSt2ASP63xBdLiSTwkhItmkafE9Cr1w=";
   };
 
   # debugpy is optional, see https://github.com/ipython/ipykernel/pull/767

--- a/pkgs/development/python-modules/ipyparallel/default.nix
+++ b/pkgs/development/python-modules/ipyparallel/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "ipyparallel";
-  version = "8.7.0";
+  version = "8.8.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-QDwJca5Wwrajn/6PNfMcf9FwzhJ5JGKUWc3X96C058M=";
+    hash = "sha256-JATVn4ajqqO9J79rV993e/9cE2PBxuYEA3WdFu1C3Hs=";
   };
 
   # We do not need the jupyterlab build dependency, because we do not need to

--- a/pkgs/development/python-modules/ipyvuetify/default.nix
+++ b/pkgs/development/python-modules/ipyvuetify/default.nix
@@ -11,13 +11,13 @@
 
 buildPythonPackage rec {
   pname = "ipyvuetify";
-  version = "1.9.3";
+  version = "1.9.4";
   pyproject = true;
 
   # GitHub version tries to run npm (Node JS)
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-v2EM/liQ6C8o7x+UtbYM153L7Un9596tXKrNoDboQM0=";
+    hash = "sha256-wpwfN68wpj2+lLb4w0erAZYa7OrbVhNfGMv0635oiVs=";
   };
 
   # drop pynpm which tries to install node_modules

--- a/pkgs/development/python-modules/jupyterlab-server/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-server/default.nix
@@ -21,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "jupyterlab-server";
-  version = "2.25.4";
+  version = "2.26.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "jupyterlab_server";
     inherit version;
-    hash = "sha256-IJgZjh6C4NuYJED5tRNhddc76izUKmSAqm/VAssjxPk=";
+    hash = "sha256-mzupHPKDf38ST8o21j88qArOK+1ImKY91H5lmMGrAG8=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/jupyterlab/default.nix
+++ b/pkgs/development/python-modules/jupyterlab/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "jupyterlab";
-  version = "4.1.5";
+  version = "4.1.6";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-ya11KQyxC/r/NiS/P7uFIxm0zOTEVmE/jruqmNA1JNs=";
+    hash = "sha256-eTXza6JuthUYOk9cK7yleRtRCM4qALVQX4z9EA1TZI4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/nbformat/default.nix
+++ b/pkgs/development/python-modules/nbformat/default.nix
@@ -15,25 +15,29 @@
 
 buildPythonPackage rec {
   pname = "nbformat";
-  version = "5.10.3";
-  format = "pyproject";
+  version = "5.10.4";
+  pyproject = true;
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-YO1ekQ73xiZLh9ZE8naxtJ4kARkw3u9UYFGI3eshFoU=";
+    hash = "sha256-MiFosU+Tel0RNimI7KwqSVLT2OOiy+sjGVhGMSJtWzo=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     hatchling
     hatch-nodejs-version
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     fastjsonschema
     jsonschema
     jupyter-core
     traitlets
+  ];
+
+  pythonImportsCheck = [
+    "nbformat"
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pytest-jupyter/default.nix
+++ b/pkgs/development/python-modules/pytest-jupyter/default.nix
@@ -22,14 +22,14 @@
 
 let self = buildPythonPackage rec {
   pname = "pytest-jupyter";
-  version = "0.9.1";
+  version = "0.10.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jupyter-server";
     repo = "pytest-jupyter";
     rev = "refs/tags/v${version}";
-    hash = "sha256-+NtLyTpMpJ+asbiQZNLFs1qLr00UlEOlbxortQ1B4so=";
+    hash = "sha256-RTpXBbVCRj0oyZ1TXXDv3M7sAI4kA6f3ouzTr0rXjwY=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

Update jupyter-related packages at once to avoid building hundreds of packages over and over again.

This PR is based on the commits generated by the following command.

```
nix search nixpkgs#python311Packages 'ipython|jupyter|notebook' --json | jq -r 'keys | .[]' | cut -d . -f 3,4 | xargs -n 1 nix-update --commit
```

closes https://github.com/NixOS/nixpkgs/pull/299772, closes https://github.com/NixOS/nixpkgs/pull/302312, closes https://github.com/NixOS/nixpkgs/pull/301479, closes https://github.com/NixOS/nixpkgs/pull/302106, closes https://github.com/NixOS/nixpkgs/pull/302273, closes #302425, closes https://github.com/NixOS/nixpkgs/pull/302467, closes  https://github.com/NixOS/nixpkgs/pull/302602, closes https://github.com/NixOS/nixpkgs/pull/302643, closes #303023
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
