### PR TITLE
haskellPackages.Agda: Split outputs to reduce closure size

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/agda2-mode/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/agda2-mode/default.nix
@@ -1,21 +1,23 @@
 { trivialBuild
 , haskellPackages
 }:
-
-trivialBuild rec {
+let
+  Agda = haskellPackages.Agda.bin;
+in
+trivialBuild {
   pname = "agda-mode";
-  version = haskellPackages.Agda.version;
+  version = Agda.version;
 
   dontUnpack = true;
 
   # already byte-compiled by Agda builder
   buildPhase = ''
-    agda=`${haskellPackages.Agda}/bin/agda-mode locate`
+    agda=`${Agda}/bin/agda-mode locate`
     cp `dirname $agda`/*.el* .
   '';
 
   meta = {
-    inherit (haskellPackages.Agda.meta) homepage license;
+    inherit (Agda.meta) homepage license;
     description = "Agda2-mode for Emacs extracted from Agda package";
     longDescription = ''
       Wrapper packages that liberates init.el from `agda-mode locate` magic.

--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -40,13 +40,14 @@ let
         allPackages = withPackages (filter self.lib.isUnbrokenAgdaPackage (attrValues self));
       };
     };
-    inherit (Agda) meta;
+    # Agda is a split package with multiple outputs; do not inherit them here.
+    meta = removeAttrs Agda.meta [ "outputsToInstall" ];
   } ''
     mkdir -p $out/bin
-    makeWrapper ${Agda}/bin/agda $out/bin/agda \
+    makeWrapper ${Agda.bin}/bin/agda $out/bin/agda \
       --add-flags "--with-compiler=${ghc}/bin/ghc" \
       --add-flags "--library-file=${library-file}"
-    ln -s ${Agda}/bin/agda-mode $out/bin/agda-mode
+    ln -s ${Agda.bin}/bin/agda-mode $out/bin/agda-mode
     '';
 
   withPackages = arg: if isAttrs arg then withPackages' arg else withPackages' { pkgs = arg; };

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1073,6 +1073,8 @@ self: super: builtins.intersectAttrs super {
     # very useful.
     # Flag added in Agda 2.6.4.1, was always enabled before
     (enableCabalFlag "debug")
+    # Split outputs to reduce closure size
+    enableSeparateBinOutput
   ];
 
   # ats-format uses cli-setup in Setup.hs which is quite happy to write


### PR DESCRIPTION
After enabling a separate binary output for the `Agda` Haskell package, the new `bin` output measures ~100MiB, compared to the ~4.5GiB before. Using it in `agdaWithPackages` reduces the closure size of an Agda installation from ~5GiB to ~3GiB.  The remaining space is taken up mostly by the GHC backend.

With this change, derivations depending on `haskellPackages.Agda` directly need to pick the right (binary) output.  This concerns in particular `emacsPackages.agda2-mode`.

This is an attempt to resolve #285261.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
