### PR TITLE
[Backport release-23.11] forgejo: fix FOD hashes, add missing internal version ldflags, nixosTests.forgejo: test /api/forgejo/v1/version 

### DIFF
--- a/nixos/tests/forgejo.nix
+++ b/nixos/tests/forgejo.nix
@@ -108,6 +108,12 @@ let
 
         assert "BEGIN PGP PUBLIC KEY BLOCK" in server.succeed("curl http://localhost:3000/api/v1/signing-key.gpg")
 
+        api_version = json.loads(server.succeed("curl http://localhost:3000/api/forgejo/v1/version")).get("version")
+        assert "development" != api_version and "-gitea-" in api_version, (
+            "/api/forgejo/v1/version should not return 'development' "
+            + f"but should contain a gitea compatibility version string. Got '{api_version}' instead."
+        )
+
         server.succeed(
             "curl --fail http://localhost:3000/user/sign_up | grep 'Registration is disabled. "
             + "Please contact your site administrator.'"

--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -50,10 +50,10 @@ buildGoModule rec {
     # https://codeberg.org/forgejo/forgejo/pulls/2443
     # https://codeberg.org/forgejo/forgejo/commit/2fe5f6f73283c2f6935ded62440a1f15ded12dcd
     rev = "2fe5f6f73283c2f6935ded62440a1f15ded12dcd";
-    hash = "sha256-s+hYFpgQ6MJgQBRW3Ze7BIjvsc765D5sAcrtO/wmIgo=";
+    hash = "sha256-qk30Sixd4G9ivkpC1c9IAjCkSNU2ohzDPL9WSyQ6NIw=";
   };
 
-  vendorHash = "sha256-dgtZjsLBwblhdge3BvdbK/mN/TeZKps9K5dJbqomtjo=";
+  vendorHash = "sha256-HDKirjQI4KvHvzDCqKe9nHvQUv3VNRl5tkr0rO7gcAY=";
 
   subPackages = [ "." ];
 

--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -50,7 +50,23 @@ buildGoModule rec {
     # https://codeberg.org/forgejo/forgejo/pulls/2443
     # https://codeberg.org/forgejo/forgejo/commit/2fe5f6f73283c2f6935ded62440a1f15ded12dcd
     rev = "2fe5f6f73283c2f6935ded62440a1f15ded12dcd";
-    hash = "sha256-qk30Sixd4G9ivkpC1c9IAjCkSNU2ohzDPL9WSyQ6NIw=";
+    hash = "sha256-U80HfHDSOKN+MGOX9Tu85lgN+8KeEzjSjpZXVFGmLKQ=";
+    # Forgejo has multiple different version strings that need to be provided
+    # via ldflags.  main.ForgejoVersion for example is a combination of a
+    # hardcoded gitea compatibility version string (in the Makefile) and
+    # git describe and is easiest to get by invoking the Makefile.
+    # So we do that, store it the src FOD to then extend the ldflags array
+    # in preConfigure.
+    # The `echo -e >> Makefile` is temporary and already part of the next
+    # major release.  Furthermore, the ldflags will change next major release
+    # and need to be updated accordingly.
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      echo -e 'show-version-full:\n\t@echo ''${FORGEJO_VERSION}' >> Makefile
+      make show-version-full > FULL_VERSION
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
   };
 
   vendorHash = "sha256-HDKirjQI4KvHvzDCqKe9nHvQUv3VNRl5tkr0rO7gcAY=";
@@ -79,6 +95,10 @@ buildGoModule rec {
     "-X main.Version=${version}"
     "-X 'main.Tags=${lib.concatStringsSep " " tags}'"
   ];
+
+  preConfigure = ''
+    export ldflags+=" -X code.gitea.io/gitea/routers/api/forgejo/v1.ForgejoVersion=$(cat FULL_VERSION) -X main.ForgejoVersion=$(cat FULL_VERSION)"
+  '';
 
   preBuild = ''
     go run build/merge-forgejo-locales.go


### PR DESCRIPTION
## Description of changes

Manual backport of #300981.

Security label because #290725 did not update the FOD hashes which is a huge issue, because #290725 was a security version bump, and not updating the FOD hash rendered the security fix ineffective.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
