### PR TITLE
[23.11] nghttp2: backport the fix for CVE-2024-28182

### DIFF
--- a/pkgs/development/libraries/nghttp2/CVE-2024-28182.patch
+++ b/pkgs/development/libraries/nghttp2/CVE-2024-28182.patch
@@ -1,0 +1,198 @@
+From b45ea923dc7996bc9de6a6e179c4a386a702e237 Mon Sep 17 00:00:00 2001
+From: Tatsuhiro Tsujikawa <tatsuhiro.t@gmail.com>
+Date: Sat, 9 Mar 2024 16:26:42 +0900
+Subject: [PATCH 1/2] Limit CONTINUATION frames following an incoming HEADER
+ frame
+
+(cherry picked from commit 00201ecd8f982da3b67d4f6868af72a1b03b14e0)
+---
+ lib/includes/nghttp2/nghttp2.h |  7 ++++++-
+ lib/nghttp2_helper.c           |  2 ++
+ lib/nghttp2_session.c          |  7 +++++++
+ lib/nghttp2_session.h          | 10 ++++++++++
+ 4 files changed, 25 insertions(+), 1 deletion(-)
+
+diff --git a/lib/includes/nghttp2/nghttp2.h b/lib/includes/nghttp2/nghttp2.h
+index fa22081c..b394bde9 100644
+--- a/lib/includes/nghttp2/nghttp2.h
++++ b/lib/includes/nghttp2/nghttp2.h
+@@ -440,7 +440,12 @@ typedef enum {
+    * exhaustion on server side to send these frames forever and does
+    * not read network.
+    */
+-  NGHTTP2_ERR_FLOODED = -904
++  NGHTTP2_ERR_FLOODED = -904,
++  /**
++   * When a local endpoint receives too many CONTINUATION frames
++   * following a HEADER frame.
++   */
++  NGHTTP2_ERR_TOO_MANY_CONTINUATIONS = -905,
+ } nghttp2_error;
+ 
+ /**
+diff --git a/lib/nghttp2_helper.c b/lib/nghttp2_helper.c
+index 93dd4754..b3563d98 100644
+--- a/lib/nghttp2_helper.c
++++ b/lib/nghttp2_helper.c
+@@ -336,6 +336,8 @@ const char *nghttp2_strerror(int error_code) {
+            "closed";
+   case NGHTTP2_ERR_TOO_MANY_SETTINGS:
+     return "SETTINGS frame contained more than the maximum allowed entries";
++  case NGHTTP2_ERR_TOO_MANY_CONTINUATIONS:
++    return "Too many CONTINUATION frames following a HEADER frame";
+   default:
+     return "Unknown error code";
+   }
+diff --git a/lib/nghttp2_session.c b/lib/nghttp2_session.c
+index ec5024d0..8e4d2e7e 100644
+--- a/lib/nghttp2_session.c
++++ b/lib/nghttp2_session.c
+@@ -496,6 +496,7 @@ static int session_new(nghttp2_session **session_ptr,
+   (*session_ptr)->max_send_header_block_length = NGHTTP2_MAX_HEADERSLEN;
+   (*session_ptr)->max_outbound_ack = NGHTTP2_DEFAULT_MAX_OBQ_FLOOD_ITEM;
+   (*session_ptr)->max_settings = NGHTTP2_DEFAULT_MAX_SETTINGS;
++  (*session_ptr)->max_continuations = NGHTTP2_DEFAULT_MAX_CONTINUATIONS;
+ 
+   if (option) {
+     if ((option->opt_set_mask & NGHTTP2_OPT_NO_AUTO_WINDOW_UPDATE) &&
+@@ -6778,6 +6779,8 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
+           }
+         }
+         session_inbound_frame_reset(session);
++
++        session->num_continuations = 0;
+       }
+       break;
+     }
+@@ -6899,6 +6902,10 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
+       }
+ #endif /* DEBUGBUILD */
+ 
++      if (++session->num_continuations > session->max_continuations) {
++        return NGHTTP2_ERR_TOO_MANY_CONTINUATIONS;
++      }
++
+       readlen = inbound_frame_buf_read(iframe, in, last);
+       in += readlen;
+ 
+diff --git a/lib/nghttp2_session.h b/lib/nghttp2_session.h
+index b119329a..ef8f7b27 100644
+--- a/lib/nghttp2_session.h
++++ b/lib/nghttp2_session.h
+@@ -110,6 +110,10 @@ typedef struct {
+ #define NGHTTP2_DEFAULT_STREAM_RESET_BURST 1000
+ #define NGHTTP2_DEFAULT_STREAM_RESET_RATE 33
+ 
++/* The default max number of CONTINUATION frames following an incoming
++   HEADER frame. */
++#define NGHTTP2_DEFAULT_MAX_CONTINUATIONS 8
++
+ /* Internal state when receiving incoming frame */
+ typedef enum {
+   /* Receiving frame header */
+@@ -290,6 +294,12 @@ struct nghttp2_session {
+   size_t max_send_header_block_length;
+   /* The maximum number of settings accepted per SETTINGS frame. */
+   size_t max_settings;
++  /* The maximum number of CONTINUATION frames following an incoming
++     HEADER frame. */
++  size_t max_continuations;
++  /* The number of CONTINUATION frames following an incoming HEADER
++     frame.  This variable is reset when END_HEADERS flag is seen. */
++  size_t num_continuations;
+   /* Next Stream ID. Made unsigned int to detect >= (1 << 31). */
+   uint32_t next_stream_id;
+   /* The last stream ID this session initiated.  For client session,
+-- 
+2.44.0
+
+
+From a425367ad06675ef588432f7aa5f221b06d39c9a Mon Sep 17 00:00:00 2001
+From: Tatsuhiro Tsujikawa <tatsuhiro.t@gmail.com>
+Date: Sat, 9 Mar 2024 16:48:10 +0900
+Subject: [PATCH 2/2] Add nghttp2_option_set_max_continuations
+
+(cherry picked from commit d71a4668c6bead55805d18810d633fbb98315af9)
+---
+ lib/includes/nghttp2/nghttp2.h | 11 +++++++++++
+ lib/nghttp2_option.c           |  5 +++++
+ lib/nghttp2_option.h           |  5 +++++
+ lib/nghttp2_session.c          |  4 ++++
+ 5 files changed, 26 insertions(+)
+
+diff --git a/lib/includes/nghttp2/nghttp2.h b/lib/includes/nghttp2/nghttp2.h
+index b394bde9..4d3339b5 100644
+--- a/lib/includes/nghttp2/nghttp2.h
++++ b/lib/includes/nghttp2/nghttp2.h
+@@ -2778,6 +2778,17 @@ NGHTTP2_EXTERN void
+ nghttp2_option_set_stream_reset_rate_limit(nghttp2_option *option,
+                                            uint64_t burst, uint64_t rate);
+ 
++/**
++ * @function
++ *
++ * This function sets the maximum number of CONTINUATION frames
++ * following an incoming HEADER frame.  If more than those frames are
++ * received, the remote endpoint is considered to be misbehaving and
++ * session will be closed.  The default value is 8.
++ */
++NGHTTP2_EXTERN void nghttp2_option_set_max_continuations(nghttp2_option *option,
++                                                         size_t val);
++
+ /**
+  * @function
+  *
+diff --git a/lib/nghttp2_option.c b/lib/nghttp2_option.c
+index 43d4e952..53144b9b 100644
+--- a/lib/nghttp2_option.c
++++ b/lib/nghttp2_option.c
+@@ -150,3 +150,8 @@ void nghttp2_option_set_stream_reset_rate_limit(nghttp2_option *option,
+   option->stream_reset_burst = burst;
+   option->stream_reset_rate = rate;
+ }
++
++void nghttp2_option_set_max_continuations(nghttp2_option *option, size_t val) {
++  option->opt_set_mask |= NGHTTP2_OPT_MAX_CONTINUATIONS;
++  option->max_continuations = val;
++}
+diff --git a/lib/nghttp2_option.h b/lib/nghttp2_option.h
+index 2259e184..c89cb97f 100644
+--- a/lib/nghttp2_option.h
++++ b/lib/nghttp2_option.h
+@@ -71,6 +71,7 @@ typedef enum {
+   NGHTTP2_OPT_SERVER_FALLBACK_RFC7540_PRIORITIES = 1 << 13,
+   NGHTTP2_OPT_NO_RFC9113_LEADING_AND_TRAILING_WS_VALIDATION = 1 << 14,
+   NGHTTP2_OPT_STREAM_RESET_RATE_LIMIT = 1 << 15,
++  NGHTTP2_OPT_MAX_CONTINUATIONS = 1 << 16,
+ } nghttp2_option_flag;
+ 
+ /**
+@@ -98,6 +99,10 @@ struct nghttp2_option {
+    * NGHTTP2_OPT_MAX_SETTINGS
+    */
+   size_t max_settings;
++  /**
++   * NGHTTP2_OPT_MAX_CONTINUATIONS
++   */
++  size_t max_continuations;
+   /**
+    * Bitwise OR of nghttp2_option_flag to determine that which fields
+    * are specified.
+diff --git a/lib/nghttp2_session.c b/lib/nghttp2_session.c
+index 8e4d2e7e..ced7517b 100644
+--- a/lib/nghttp2_session.c
++++ b/lib/nghttp2_session.c
+@@ -585,6 +585,10 @@ static int session_new(nghttp2_session **session_ptr,
+                            option->stream_reset_burst,
+                            option->stream_reset_rate);
+     }
++
++    if (option->opt_set_mask & NGHTTP2_OPT_MAX_CONTINUATIONS) {
++      (*session_ptr)->max_continuations = option->max_continuations;
++    }
+   }
+ 
+   rv = nghttp2_hd_deflate_init2(&(*session_ptr)->hd_deflater,
+-- 
+2.44.0
+

--- a/pkgs/development/libraries/nghttp2/default.nix
+++ b/pkgs/development/libraries/nghttp2/default.nix
@@ -39,6 +39,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-xjdnfLrESU6q+LDgOGFzFGhFgw76/+To3JL7O0KOWtI=";
   };
 
+  patches = [
+    ./CVE-2024-28182.patch
+  ];
+
   outputs = [ "out" "dev" "lib" "doc" "man" ];
 
   nativeBuildInputs = [ pkg-config ]


### PR DESCRIPTION
## Description of changes

https://github.com/nghttp2/nghttp2/security/advisories/GHSA-x6x3-gv8h-m57q

The changes to `doc/Makefile.am` were not backported to avoid dealing with `automake`.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (and `passthru.tests`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
