### PR TITLE
nemu: init at 3.3.1

### DIFF
--- a/pkgs/by-name/ne/nemu/package.nix
+++ b/pkgs/by-name/ne/nemu/package.nix
@@ -1,0 +1,108 @@
+{ busybox
+, cmake
+, coreutils
+, dbus
+, fetchFromGitHub
+, gettext
+, graphviz
+, json_c
+, lib
+, libarchive
+, libusb1
+, libxml2
+, makeWrapper
+, ncurses
+, ninja
+, openssl
+, picocom
+, pkg-config
+, qemu
+, socat
+, sqlite
+, stdenv
+, systemd
+, tigervnc
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nemu";
+  version = "3.3.1";
+
+  src = fetchFromGitHub {
+    owner = "nemuTUI";
+    repo = "nemu";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-6WzqBkspKKs1e8kg1i71ntZHa78s5pJ1u02mXvzpiEc=";
+  };
+
+  cmakeFlags = [
+    "-DNM_WITH_DBUS=ON"
+    "-DNM_WITH_NETWORK_MAP=ON"
+    "-DNM_WITH_REMOTE=ON"
+    "-DNM_WITH_USB=ON"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    busybox # for start-stop-daemon
+    coreutils
+    dbus
+    gettext
+    graphviz
+    json_c
+    libarchive
+    libusb1
+    libxml2
+    ncurses
+    openssl
+    picocom
+    qemu
+    socat
+    sqlite
+    systemd # for libudev
+    tigervnc
+  ];
+
+  runtimeDependencies = [
+    busybox
+    picocom
+    qemu
+    socat
+    tigervnc
+  ];
+
+  postPatch = ''
+    substituteInPlace nemu.cfg.sample \
+      --replace-fail /usr/bin/vncviewer ${tigervnc}/bin/vncviewer \
+      --replace-fail "qemu_bin_path = /usr/bin" "qemu_bin_path = ${qemu}/bin"
+
+    substituteInPlace sh/ntty \
+      --replace-fail /usr/bin/socat ${socat}/bin/socat \
+      --replace-fail /usr/bin/picocom ${picocom}/bin/picocom \
+      --replace-fail start-stop-daemon ${busybox}/bin/start-stop-daemon
+
+    substituteInPlace sh/setup_nemu_nonroot.sh \
+      --replace-fail /usr/bin/nemu $out/bin/nemu
+  '';
+
+  postInstall = ''
+    wrapProgram $out/share/nemu/scripts/upgrade_db.sh \
+      --prefix PATH : "${sqlite}/bin"
+  '';
+
+  meta = {
+    changelog = "https://github.com/nemuTUI/nemu/releases/tag/v${finalAttrs.version}";
+    description = "Ncurses UI for QEMU";
+    homepage = "https://github.com/nemuTUI/nemu";
+    license = lib.licenses.bsd2;
+    mainProgram = "nemu";
+    maintainers = with lib.maintainers; [ msanft ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [NEMU](https://github.com/nemuTUI/nemu), an ncurses-based TUI for QEMU.

Closes #302371 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
