### PR TITLE
pdfmm: fix build on (at least) macOS

### DIFF
--- a/pkgs/applications/office/pdfmm/default.nix
+++ b/pkgs/applications/office/pdfmm/default.nix
@@ -2,12 +2,11 @@
 , coreutils
 , fetchFromGitHub
 , ghostscript
-, glibc
+, locale
 , gnome
 , gnused
 , lib
 , resholve
-, xorg
 }:
 
 resholve.mkDerivation rec {
@@ -35,15 +34,16 @@ resholve.mkDerivation rec {
     inputs = [
       coreutils
       ghostscript
-      glibc
+      locale
       gnome.zenity
       gnused
-      xorg.xmessage
     ];
+    fake = {
+      # only need xmessage if zenity is unavailable
+      external = [ "xmessage" ];
+    };
     execer = [
-      "cannot:${glibc.bin}/bin/locale"
       "cannot:${gnome.zenity}/bin/zenity"
-      "cannot:${xorg.xmessage}/bin/xmessage"
     ];
     keep."$toutLu" = true;
   };
@@ -54,5 +54,6 @@ resholve.mkDerivation rec {
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ urandom ];
     mainProgram = "pdfmm";
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
## Description of changes

The package isn't marked linux-only, but pulling locale from glibc effectively limited it to linux. Using the generalized locale attr gets it building on macOS.

Also:
- While looking into this, I noticed that the script only uses xmessage if zenity isn't present, so I think we can drop that dependency.
- Not super familiar with what the package should run on, but I went ahead and set the platform meta based on what I've personally verified.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>pdfmm</li>
  </ul>
</details>

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>pdfmm</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
