### PR TITLE
supermodel: init at 0-unstable-2024-04-05

### DIFF
--- a/pkgs/by-name/su/supermodel/package.nix
+++ b/pkgs/by-name/su/supermodel/package.nix
@@ -1,0 +1,64 @@
+{ fetchFromGitHub
+, lib
+, libGLU
+, SDL2
+, SDL2_net
+, stdenv
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "supermodel";
+  version = "0-unstable-2024-04-05";
+
+  src = fetchFromGitHub {
+    owner = "trzy";
+    repo = "supermodel";
+    rev = "250f84e78eba381adf8cd731ce20b1b9be43c8c8";
+    hash = "sha256-3sDtNMW5R5Eq9GXJzKs0mQdiLUIWl6+4+rzKg8xpqEY=";
+  };
+
+  buildInputs = [
+    libGLU
+    SDL2
+    SDL2_net
+    zlib
+  ];
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=format-security";
+
+  makefile = "Makefiles/Makefile.UNIX";
+
+  makeFlags = [ "NET_BOARD=1" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/share/supermodel
+    cp bin/* $out/bin
+    cp -r Config Assets $out/share/supermodel
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A Sega Model 3 Arcade Emulator";
+    homepage = "https://github.com/trzy/supermodel";
+    license = lib.licenses.gpl3;
+    longDescription = ''
+      Supermodel requires specific files to be present in the $HOME directory of
+      the user running the emulator. To ensure these files are present, move the
+      configuration and assets as follows:
+
+      <code>cp $out/share/supermodel/Config/Supermodel.ini ~/.config/supermodel/Config/Supermodel.ini</code>
+      <code>cp -r $out/share/supermodel/Assets/* ~/.local/share/supermodel/Assets/</code>
+
+      Then the emulator can be started with:
+      <code>supermodel -game-xml-file=$out/share/supermodel/Config/Games.xml /path/to/romset</code>.
+    '';
+    mainProgram = "supermodel";
+    maintainers = with lib.maintainers; [ msanft ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add the [Supermodel](https://github.com/trzy/Supermodel) SEGA Model 3 emulator.

![image](https://github.com/NixOS/nixpkgs/assets/58110325/7cd929c5-ecc3-4fae-a347-ced643c18130)

For testing, you will need to:
- Copy / Link the configuration file to your home: `cp result/share/supermodel/Config/Supermodel.ini ~/.config/supermodel/Config/Supermodel.ini`
- Copy / Link the assets to your home: `cp -r result/share/supermodel/Assets/* ~/.local/share/supermodel/Assets/`

Then the emulator can be started with `./result/bin/supermodel -game-xml-file=result/share/supermodel/Config/Games.xml /path/to/romset`. 
While I would normally prefer to package the application to work out of the box, it unfortunately doesn't allow enough configuration to do so. (e.g. specifying a config path) Patches were not feasible for the amount of code that'd be needed.

Closes #302099 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
