### PR TITLE
insync-nautilus: init at 3.8.7.50516

### DIFF
--- a/pkgs/by-name/in/insync-nautilus/package.nix
+++ b/pkgs/by-name/in/insync-nautilus/package.nix
@@ -1,0 +1,48 @@
+{ stdenv,
+  fetchurl,
+  lib,
+  dpkg,
+  gnome,
+  insync
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "insync-nautilus";
+  version = lib.getVersion insync;
+  pyproject = true;
+
+  # Download latest from: https://www.insynchq.com/downloads/linux#nautilus
+
+  src = fetchurl {
+    urls = [
+      "https://cdn.insynchq.com/builds/linux/insync-nautilus_${finalAttrs.version}_all.deb"
+      "https://web.archive.org/web/20240409080611/https://cdn.insynchq.com/builds/linux/insync-nautilus_${finalAttrs.version}_all.deb"
+    ];
+    hash = "sha256-aB1/ZzcQH3T1lviMZO8jXbtdbe4TW20f0TAcv4HDOGI=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+  ];
+
+  buildInputs = [
+    gnome.nautilus-python
+    insync
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -R usr/share $out/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ hellwolf ];
+    homepage = "https://www.insynchq.com";
+    description = "This package contains the Python extension and icons for integrating Insync with Nautilus";
+  };
+})


### PR DESCRIPTION
## Description of changes

insync-nautilus: initial package

This package allows nautilus file manager to show insync emblems of syncing status:

![image](https://github.com/NixOS/nixpkgs/assets/186660/a8b0fea1-538e-4ef6-ad62-9c556f029355)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
