### PR TITLE
googleearth-pro: more specific vulnerability description

### DIFF
--- a/pkgs/applications/misc/googleearth-pro/default.nix
+++ b/pkgs/applications/misc/googleearth-pro/default.nix
@@ -120,6 +120,6 @@ mkDerivation rec {
     license = licenses.unfree;
     maintainers = with maintainers; [ friedelino shamilton ];
     platforms = platforms.linux;
-    knownVulnerabilities = [ "Includes vulnerable bundled libraries." ];
+    knownVulnerabilities = [ "Includes vulnerable versions of bundled libraries: openssl, ffmpeg, gdal, and proj." ];
   };
 }


### PR DESCRIPTION
The current description of the vulnerabilities in Google Earth Pro is rather vague, so I have added a more detailed description to help someone evaluate if it is safe to use or not. This is according to:

https://github.com/NixOS/nixpkgs/issues/141239#issuecomment-942911083