### PR TITLE
llvmPackages_{9,12,13,14,15,16,17,18,git}.clang: fix libLTO.dylib path

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,1025 +1,1025 @@
 {
-  version = "124.0.2";
+  version = "125.0";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ach/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ach/firefox-125.0.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "744f980be5ec9d1befc9fcd92e4a6d8d4b9cf4cc190e7e382d043c20929b5303";
+      sha256 = "43a9c6387fceae99bd387a23202a29b87224111a828e0a0b50a26a958af4bfcd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/af/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/af/firefox-125.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "d35303a4ebf34e2d2230de5fdca2da3e68bb3530250903390a474c216e500f64";
+      sha256 = "4903c60481695ead92cb8af458a7ca0dabb36a6509ec25825ec44f272b6ddabc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/an/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/an/firefox-125.0.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "0fdc4ae7ad1bb18cc6029544d7634881957cc2b89ae7e1e2424fcd6be45e9e4d";
+      sha256 = "460007ffba895b5e088443875109b5889496970c619d8e928a222dec138cc148";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ar/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ar/firefox-125.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "74ae14ac2d73fe11e4999ffbe7bfcab93bc30fc0cebd3ad799048e2f843d1d0c";
+      sha256 = "d56ef7f731235a3a15fb177a5d70e3b8c1295bd3210ea7e17d3d5dbc9eed887a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ast/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ast/firefox-125.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "70876f5fe8fa834bb046326d6b82ec9ee22de159f60898147d4412d912368396";
+      sha256 = "d0ebc0df263004d270f65a0cc94d72e3fbb44874996022bfbac4d44a8a2a680b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/az/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/az/firefox-125.0.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "8396e7efccfd87d6bf1565964ac5574ed738e12969e8ef918a86166febc1b361";
+      sha256 = "d292c2648ba768b8d67ad1e246d1781aa79ca1d56df172e426dd138205c2e25e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/be/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/be/firefox-125.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "1efc6ab83a47e038f9d09aa1dbb05094eaebb13526a9a7826f034c53333d53d7";
+      sha256 = "976528528bb24d467c58012ccfdf2afa775c7eaaab8bdc364a080678b0f77a2c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/bg/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/bg/firefox-125.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "803600b31c997723d6c0e05cf18a0d0568879e95099ab4e25c000e101f1e6cec";
+      sha256 = "9985c2bbb0077f61f336dd436eaf97e3c04938289f657f830916ba1b824f98d1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/bn/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/bn/firefox-125.0.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "4ca30806103b52dc9937c71895d9d89050a067e344668b83b14cc8581a844016";
+      sha256 = "d214c97c0eab0ea16bd9739a035e0bfee092bd9bf690fe0ffac1629465772f2e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/br/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/br/firefox-125.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "440abc189826180a7c36267dd659bb970a384396c52ea0855296729ce10394e6";
+      sha256 = "8078037c97902dd3ba7b58badda045091ab980d7402216fd9b276497d17c7779";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/bs/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/bs/firefox-125.0.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "50b5d3d01cdd729cf5c63679777e7b52627cff888629832c03a8813c026872b2";
+      sha256 = "2a34d80e0e9c9c3e54eeba4e4556df8d5960a988c775be562450a51548fb6813";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ca-valencia/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ca-valencia/firefox-125.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "16f945c66c7ad7e2bb4bd15995882c3fdc70910c334259ce657332efd8a34d08";
+      sha256 = "0530c19a1ae1e6bc00549222fb41d69c1fa93d24b7f2519b598b7b5b24f7ccb2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ca/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ca/firefox-125.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "02c2524b516fb1931104e65b4cec3093d32889e1aa9cf85c7452ccbea5a50983";
+      sha256 = "36c215c4b0281a671137e20bf68c452c53d70c45db68db8297ae0fced8c2fc45";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/cak/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/cak/firefox-125.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "4a1f77b97f8daf3ca1bba2927676fdda2202959ec6531d1a23cbdc22e2cc1705";
+      sha256 = "6a81954693eb37d03ff531115ad789dc86940f7912a240528406047729de1c57";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/cs/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/cs/firefox-125.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "70145ccd0d908b3cb340c8c3d2b512701fd947c0ecffca6dacb01c72f24b4e6a";
+      sha256 = "a79391ab06e098e0d5b7e01c2b36ba402ab0204aa89d25568ce95c20448dd25f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/cy/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/cy/firefox-125.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "9adb57cedce315e3e3af77098cff97042ffd79c1b155b0a5f0709a0d614f475c";
+      sha256 = "8d143fd49b5eeb6c853c31823e90aaa5717fff2666e0958d4542ecca7f3844cf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/da/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/da/firefox-125.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "a057635c19615edc3d66c5dab019bed2ee60caffde03d55f729c50091fbd6b81";
+      sha256 = "781f37af37f46df56573d44c3ba700acde1a88192f2d3547a1e3be4f6c23c537";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/de/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/de/firefox-125.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "2e735f4809ae9a236ae942099ff08ac89315acdb0174c298cf5022450560355e";
+      sha256 = "078b53e5bd658fb1588746d7b1a94bf64e9d906c4cc401591a93f1c4cf4553f7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/dsb/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/dsb/firefox-125.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "eb738753a3b41ffc8bdbb3c0f2654d8df06759cc380befe31e5ea70c5260493a";
+      sha256 = "6f8e0912e94beb68e280fbba37051118659f0dc3fadf818add98dd51ff3e7fc1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/el/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/el/firefox-125.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "7b66861b60ca7ee95344d4ff87aba1095c3e6b578339d9f4a00fc135af5a97f2";
+      sha256 = "06d429df5af566e819a1697994ddac18339b508351ab6ebabdf9e166a841dd4a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/en-CA/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/en-CA/firefox-125.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "b84521eba86530ad62b8ecf0e4581fc76fcf27431688f42b16eb989957da7164";
+      sha256 = "235a29be39e2dae99c22eab5227c5a7222292974e6e59c76e9e1c71dc472653d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/en-GB/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/en-GB/firefox-125.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "883457618a09b02ad36eae54642fff12aa1e6761504abd3272deedc5109be87e";
+      sha256 = "83b7633b77b6aff4fb0f2b60c3ee0a8659ae3610b395f1880f546d4a01376cf1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/en-US/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/en-US/firefox-125.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "5e007cb52a42ef60e404e76a8aa70c38b889848fcd8c373fa048c0f8a2b0f2bf";
+      sha256 = "3108abece953442b52d3da2716388a779ebb79b0936877c7c0826593f6fce7a6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/eo/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/eo/firefox-125.0.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "81f984539ce8bfece18e46487842d2bb768e0e632b0775d549143e7196ddd5eb";
+      sha256 = "5e3b749d767f25b673c58701928671319ac84d9861ed527d0967c9071b43fd58";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/es-AR/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/es-AR/firefox-125.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "4ad3625df4dca022058e7609db007b38942ec5dc9e033097e51f94f6ffbc21a9";
+      sha256 = "093742a8410aed5bc7b2a782481720db3481c3d91ccb9442d994f02f246e4421";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/es-CL/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/es-CL/firefox-125.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "c3bc8d742ea2f30525d45e3d3eea7fb86df66ef6b654873f76b30beb865809a3";
+      sha256 = "f0c008e72c9748d607c779c85826e1b7585564470163d1a22db310f120d811a2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/es-ES/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/es-ES/firefox-125.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "0fc731002d7dc124bc274b4f90d5bb07d27c84627e65cf4f30d6621515ae8f2c";
+      sha256 = "43076e5d52d849786e196916926fb6ab31f4035db2c8cc5d2577722ed6b6dff7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/es-MX/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/es-MX/firefox-125.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "95b290bf9eca16e5c967c3d50d55641475b3d198d968cb0d7c0f32ce285ba9ae";
+      sha256 = "1ca00ea77c6e7348ee0d6ed30f651f3db103cf87e04bc2f23fcae248c4060fae";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/et/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/et/firefox-125.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "a87d188cb85748e66877cd5a11cbbf12169338f37999db069208b7ab9a741f84";
+      sha256 = "892dc42b81715205aa232444b7c291fd60635e85a5b872e0f07a85ebf5a80c11";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/eu/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/eu/firefox-125.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "defb916d48fe05fcf64945ed09454d942cb44e6b5ab156c6a86e95168f9ca299";
+      sha256 = "41b741049595225a5c21684cab903a029dd1f47eabc2dc43ee0379bdd0fa45e7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/fa/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/fa/firefox-125.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "7d4dba91869e998028bd378a66463758b632257a1ac68f36dbf7c79dcace51a3";
+      sha256 = "33cc8fd42bbd30b547ee97d02a540a7367af6c611fe9fe6af7ea34ab0c3dab8a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ff/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ff/firefox-125.0.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "061ffc17f62061f4b0264f1c7644ef017bb2462ff0b4f234c0915d99f9eae176";
+      sha256 = "2f92e8db9441a8522d13cdd586b3f9df0f5e4521700c8cdb9014b7fced3406ad";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/fi/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/fi/firefox-125.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "3adf706317c19c61b4775d9eb8be16a2c1def6c39627e381179e1a818214e4f7";
+      sha256 = "2476c63b9ca0900083834143602734228518e7b6d87ebdca2bffed7de7461031";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/fr/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/fr/firefox-125.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "6dac2721c5d5252c3f28c0448264a36383e665bf0a7d5f894846cde404ba3400";
+      sha256 = "ac92cf6fcbedd5a0724bf2af4e1977bd916513b37a194d67672977a3f633aea9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/fur/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/fur/firefox-125.0.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "3cc1838229723aac4f281addee05e12a31a1417b0df2c22bf5a725e1763f502c";
+      sha256 = "d0cd8cf77b82364a2cf2e173d0f5ac6e1608534763a070a9158c523be5bba606";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/fy-NL/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/fy-NL/firefox-125.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "dfabd8bb86ff6b79b14f8b519139cfcc6391b96db26c8f4b8ffba42c7f2572d1";
+      sha256 = "24476a96dcddd8d1408ba224517fb6f23c823677cf5f5d62c0c4cbb9d4f43aba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ga-IE/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ga-IE/firefox-125.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "e9a52761ff6e7f1202f651d2cce2333c704ce516c52a62feb2827b62933195ba";
+      sha256 = "1fbf2ab391bb98d0d5c769d15df31fe4e102f5369b7ca1943d33378b7a4e784c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/gd/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/gd/firefox-125.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "4062740bcfaa8295df24c0c4e342378ebccb7f2c074ceeb6324b6ffb1326c200";
+      sha256 = "79a57701e4aba823cbb2838089af637e8f4c00769ec1d5c1dc358daac252c2cb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/gl/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/gl/firefox-125.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "92a08e9c252a409db44df26b9a68860d1e6c6e0c2f2829262edebdba9da2dd47";
+      sha256 = "acea1f6f1fd642f9347034fc15639c69c92bf37a36949e27d925604d8e458721";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/gn/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/gn/firefox-125.0.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "d568a26862892ff933dfad4100700fe0bcbe19f49c3658aa8eb02d754782db46";
+      sha256 = "2ac1ad3a1148513375a69563bf3645269fe5eff389a2609f67c99c23a9be9f3d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/gu-IN/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/gu-IN/firefox-125.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "510e8c8093d444d24f81f4cf70630d787a58d8c8e64c50ab65acc364136645cd";
+      sha256 = "07bca9e0371e6c1a78dae545c16ddf328e7f9f1b0d26159b628f4a31c287a898";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/he/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/he/firefox-125.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "bc973cf3c97c3d10b60424b5c538fa5e3b8f6f757254e2f1813187f05aa0e5ae";
+      sha256 = "7ca0db5fd17789aca489f7d556316c1589f40c316db42d4d8406f93a667580b4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/hi-IN/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/hi-IN/firefox-125.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "07cea9c96b207be77b5820fcf6192e25e4f76969f13c89eaa402a57c4b0b642f";
+      sha256 = "2215bcee409d4bfef43b9aa3ca34a1f99d5bc4942d6bc7b0619c6d62c79debe9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/hr/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/hr/firefox-125.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "2259fc968f99ec71a4bc803830e987db1d48c9cbd8240a041754a2bbea948708";
+      sha256 = "8746f8de0caec3911948e9bee199f974fa2f51a45cb730b77af3ae405b60e611";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/hsb/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/hsb/firefox-125.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "cef462fede5c1cfeffc9aedcd5b3d25b9f7fcb95614e3369c124495aada38433";
+      sha256 = "3ffb9114b23a9963509cf9fc83c97dd0187b1849ff97e835ee2bc0410e2324d9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/hu/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/hu/firefox-125.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "78416228108a3ad86f640a19e2c05fbde329d6d5d3b47274baedee07aa5df4cb";
+      sha256 = "33afb47955da9c44fad4621cfb82858d3ae2373a9be09b5efb68ffc741162894";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/hy-AM/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/hy-AM/firefox-125.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "17f0389ede806835d99fff502ae8b78981fde8c6285471d449c2ab82c4acc602";
+      sha256 = "b66b72210c092a80ba3ce94bbb38108e12c68b4abbbac02d94035e4ab64a4b47";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ia/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ia/firefox-125.0.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "df6e12d00cc969dd271ea4ba20ee907d952d87cd8ccf997e0315d7709fe535f5";
+      sha256 = "c9ecbb4c2a4a994dd6f8492ec0424117d48efd16c7c451322a5d4804f24ef947";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/id/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/id/firefox-125.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "d7ceabc8181f8acc04d81bcfc47a281307105e2bc28e5c4a890b493a95ad6562";
+      sha256 = "75983dc67da52131887574bc089c2772db0ef337994359bf3fba44ddec0f1589";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/is/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/is/firefox-125.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "25d08596cb61364f7e7bb44134819a6f9d1039323eb70620a9ea9dddfe208351";
+      sha256 = "027aefa28806150bca02d7189db345149828fabee596321a7ffd363a857babcb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/it/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/it/firefox-125.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "082786c39805eeef717a811c153b90f4c1de2ce58780cb15fb78148ce2e378c7";
+      sha256 = "8d22abadec3f62930785f0663e5948197b0ddae8b69afcdc4d72f764a9fc765c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ja/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ja/firefox-125.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "058f2b569df04018bf94a2da7f8d382602445fa4569d9a65a1e6a3771ab55856";
+      sha256 = "fb2317f8df879674e27b9eb9059693a1f9fb7fb54569a0a951a23dd5bfab8ac7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ka/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ka/firefox-125.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "33c421d193bee5d797b63ac2f5569f8d4e6d7e36cc11f9156e28acb37d855fca";
+      sha256 = "655d39d44e9f1faa772164a4056c3f4f1c359115ce97ed1fb385c7af949168aa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/kab/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/kab/firefox-125.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "3f709523c6574f68482e1c53fb5017d80d29c831f24a8ea6d5def8a5f13ad5c4";
+      sha256 = "b4b56f61ac10478891d680469afa2c93f4bc95be80adab3d302c79ad9604705d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/kk/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/kk/firefox-125.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "b4d73ecb4ccf960a698086771f1f266ba39e90ded96e979b366869b4b97fd9c8";
+      sha256 = "26665ef55828c80b27f1a76f64908c924a97e4a68a22a92fe04743031f68be0b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/km/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/km/firefox-125.0.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "3877aaa1a27a7d7e51f362b640063859a6aa1f22c8932c3aff6df4234c93883c";
+      sha256 = "6bc5b9c314d6b855188229d2715b7ade515bc31fc77afde27dea018679943172";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/kn/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/kn/firefox-125.0.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "17089c7e0f7ee9331aa9fbc4a5e4980ec7f1e95aeaa5d40f20c6491f65b6f8f1";
+      sha256 = "61251de2cf77a2b8dde9822f55288b5f2dd210c18f5fafc9973f5375fb21900a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ko/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ko/firefox-125.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "35ca4e6a00dc834359ab2596a0089972c5dc4b7fe4ccc60e7de049d52884dd5b";
+      sha256 = "0c5723432ece5ee3f4041892abd544d580364a9d25f2e6afe47e15786ea4e755";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/lij/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/lij/firefox-125.0.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "9e174c86515c2842360419f7d0041b6ae093954ae186533cf072148fcaa6f301";
+      sha256 = "2cbfcd2398289b05e7eafcd2a778efaa57e562f1e8e16b3c46e3ecff18839af2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/lt/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/lt/firefox-125.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "571f61d4e6b7539ed208ae66ee48acd8ffc33a3ca28f00a8d704a59b9a39fd11";
+      sha256 = "3b411b1a238bb22973ec736e68b9dd35f8e5c04213e81706d64f3336e061efcd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/lv/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/lv/firefox-125.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "7a6ee82cc546a31128b5df8449a469a63ae2076795bb5264594f82bee8112c8f";
+      sha256 = "eeeabd1207eb43a5dfa1239e32bf1e78c1277c06bdbd248a27f06adb8384da0d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/mk/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/mk/firefox-125.0.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "54f5d9e1b55d08caf750f5037a0bb5805f0c6e5632336012c8fbb79721cfe105";
+      sha256 = "79578fb9be0d6d3cbc4f856e101f5c7ade4ba9c4019d2cc2ef54a71337365c74";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/mr/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/mr/firefox-125.0.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "88ee140df6a7e46663b82cdb7270dc2a71107bf794a1cc29bbe1c6b308384a4e";
+      sha256 = "f27fac0e3a1410deee755337aded0a4839477c7de80dff6d15c75f3c96cd952b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ms/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ms/firefox-125.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "057e49cfb93b54696bd921cf4434949984fea9e946e4c1d2c85fe8f553ec3018";
+      sha256 = "46e793e02906193809ad2d3bc148210e3adc885bd414581356eea8dc314ee379";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/my/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/my/firefox-125.0.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "33e98e2ac8d3d7671f11cb2a36a732d98e2febb3b36dd493889b89f16d128e37";
+      sha256 = "28546a869bde30c56bc7924d6019c2ee02452abb96cdad354aee13051d31eff4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/nb-NO/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/nb-NO/firefox-125.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "0c229954ff93170457a04d18a0dc3bf258ebebeab71aa8d535b9e6ae065ff9e1";
+      sha256 = "aaf59d8b863a37b178268545b436ca852770650513644cec4f56faf7d0a494ec";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ne-NP/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ne-NP/firefox-125.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "e59e2287f0a29409214d0b7a45be052deb08f77824b871a2162e8ce77b7e913b";
+      sha256 = "89121430ce75bf4ce1b5b2de0fb942227ca3645d7a02507e8711cbb211fbeb33";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/nl/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/nl/firefox-125.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "c57e6a919f78a3116b4bf386061f9509cb141cc70df32c4d81363b7b307d3af7";
+      sha256 = "bd739471f11a5d73411fdb88e87426323794dee0c1e2816abedc47b9a4de5e51";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/nn-NO/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/nn-NO/firefox-125.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "c0c2da290418d8f3d5ec5c4bd1d783ecf2f140dc146592fbeec406bcb87eca9f";
+      sha256 = "ea370a48f050588b87ececc9397736d22e2592e6cab7d359e50653829ecd59f8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/oc/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/oc/firefox-125.0.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "77d28b812e7bda0b60c00279277f387a4685cd9e0364dffdde7f79ccd2f71ee1";
+      sha256 = "78c2bc1d232c32ef8cf49fbda9585c8598cd53468a834d7448b2df37b1b1d148";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/pa-IN/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/pa-IN/firefox-125.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "0e27914066b8e239ccae36c121376582cfec727a3a51cfd078a52958cecaf9af";
+      sha256 = "ba78e96d13baa5ddbf98d741a74edc218a11bd49c63ce37c1346ca769a246dc8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/pl/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/pl/firefox-125.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "d8a18abb9393f3f5cf6a957bcddf9f775cfbc0f2d1006affcf7f73caf325e75d";
+      sha256 = "f75b279798db8d768fb006d5555c6c48eaec7d8a8dfc912fd989423e67283f9b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/pt-BR/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/pt-BR/firefox-125.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "c413db29e589e96a31f560641a30a5f0be2465784f1cf0b0d006738256ba28c5";
+      sha256 = "91aa1c7326ddf42fe1cdfee5c92a4b2639cab2960bb303d1ee85af4a46bfcaf1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/pt-PT/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/pt-PT/firefox-125.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "da30b339a9afe68a2414d1f8410ec4772a9d5ece9b7b6ae941f48c788b08da1b";
+      sha256 = "267917c1ad0971e7d7f355d554a326f55e7a78984e9b96a77afd9a86355907a6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/rm/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/rm/firefox-125.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "082695bf3730afe88498c8f16cb69d4e358f00bf642110cc4b56e778c8b5aec2";
+      sha256 = "35f0d9d8efc4d0f8b0d8177dee220f8325e68edf5a6104c73860de0ca3bb37e5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ro/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ro/firefox-125.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "26d00a86d0b4671955486356c03fc050b73ba3932f131d3b2357e8f7b551a75c";
+      sha256 = "303709d620dd81649b8526106aecb5e70260f3e1b9263e515c61be87ebd38fb1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ru/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ru/firefox-125.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "8c44022233d480f25c5127978bb629408d742bd9fe7a08e467b0945020e715a5";
+      sha256 = "44ff7b590b7c972c2806fb5204d226488b0f4d450338e47a5b0743668991fdbe";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/sat/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/sat/firefox-125.0.tar.bz2";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "238ff1adacdb83940f8ea1cb7b39064378cf9ef07a64343f94ea50ff3f2083d0";
+      sha256 = "ea05fa877caf4ae6903a92db7603e4fb50905bdbdcbaf84567b8b2c735ea35d7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/sc/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/sc/firefox-125.0.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "b4224c7dac28e4d04741c919dbc3e76e89fe619b7d76df6d9dc98e758950838b";
+      sha256 = "c008da32211a5a82982d79cf22f04bec23d75ee03fc67e4658debf5885ff9aca";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/sco/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/sco/firefox-125.0.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "9f09edff045cb11d7a0f51ca0c4d3cc1eef8e27058b5d10b98210e2783bed834";
+      sha256 = "9eacf7c1a95ace0bf5335a84e11fa1df4b38a442aeca44ad81f24eb22512055c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/si/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/si/firefox-125.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "b945c90c24eba6b7e4f2d9c6d350af9adba230180819e89e28ede7fa8db86a07";
+      sha256 = "ab5971b56872d4eef20dd0ad235f8b43fc6316a0bbfe7cc5f6a80e2089b3b72a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/sk/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/sk/firefox-125.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "2afc1c70eb64301c874dffec427d52346fb0dae59f43fa3db4e938c26c4f4b25";
+      sha256 = "8c11aaa46f216ca645b87b0188ec5b3aabb6c3f39c511ef248d13dbc0729ae5c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/sl/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/sl/firefox-125.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "219e4e4c97b34a97e9cdf5538e04e7b07933fc67e5cc02710044fa6666276832";
+      sha256 = "51433c8c0f3e132d5b0c70e80143214a964c28b512e453667483582e8a1b4835";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/son/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/son/firefox-125.0.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "9c3a206c3ff7387c598cb3222e2fce89e773ea735aa23a9f151514c467f50069";
+      sha256 = "71e4b18dbcda401b3cf0aeef4f596be017a49800c2718048dd7203561d33e27a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/sq/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/sq/firefox-125.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "a85066030a870b23419ffed6af7340c0b796b5d03d9fd9ba6cd0d973232c23c0";
+      sha256 = "0ab963e66bbd224aaa2e53e3d26d39720b64a669179981dfe0d6ee1cede10eed";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/sr/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/sr/firefox-125.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "9014647c8496d135317f044fd542c6319ba1b9e63d00bdb74de8941eee54c0ee";
+      sha256 = "795a12328ef65900cb0a636c963570d875937344929378db2c5371578344d05d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/sv-SE/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/sv-SE/firefox-125.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "e3ec01fe25ff3e0b697f87c8d933cf46057e60289cf52a92e080753db8082506";
+      sha256 = "09b13e24e4db2a1f72f4018972331c9a569de10b0092aba9daca2f4f5c80d00d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/szl/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/szl/firefox-125.0.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "9b2bcaa83f7dc44af009bf203477322c621b1552d8ee351e64531e824b3be145";
+      sha256 = "54c8129ae4e76b75e2944711ee3167963c42fe820985b37189881a8a1d73d0e0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ta/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ta/firefox-125.0.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "63a3031adae8c8104c74c13139d0db0a9b2ffcc6c1a5db04e0331e73b9817b90";
+      sha256 = "0cae99091fb4b3aa0f3d11b84110666fb0dfacceee2dbddf5a9e72205648ddd7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/te/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/te/firefox-125.0.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "b3d9daf9ad075666a21c184a02f193f8ae803b47095e54d3bbb1389e81340a33";
+      sha256 = "59e689109afcbcb16aa2275f068cf28b01fb8707208b17ddce4e04f60360ee5b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/tg/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/tg/firefox-125.0.tar.bz2";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "1f9442024539a6d149bbfc784e99c802c7be4a40bd10cac99a25713fe3028f45";
+      sha256 = "0685f3701adbc3fafa288720647a47ea7f132f142b80edced642a9e9090646e6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/th/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/th/firefox-125.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "9b3066c583b199339a1b4f400d7878767e36f825155574f42b3a04efc665363a";
+      sha256 = "fc5416ef7066719198245900eaa5e22fb2f22933763388fc44aaa71e216ecc6b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/tl/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/tl/firefox-125.0.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "fdd12c04b7777bd8a5681f20bd5b83d570f31145c97b55c50966bc811c0b4680";
+      sha256 = "471c7efd8fdbc2bc9c3f0581f34546efece4ee0cf2342f4f8c9a708800ed6336";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/tr/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/tr/firefox-125.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "9a1ef751dea5ff91251cebf3aa547cdee38fa05656d0030d427bdc0d4bf4a4cd";
+      sha256 = "d4bacdbc386ccae5a9b3dc802b71a59a038c8cf8876189305cf596a601a31cff";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/trs/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/trs/firefox-125.0.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "9fb8cabc149e9922267c01845e2af722f66b9ae41db0543eb4cc44023be49ccf";
+      sha256 = "aadc15d5bd35b14d8870bca86a05d020c9cd9224cb358b692d6b85a928cf2b2a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/uk/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/uk/firefox-125.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "8414567384006d7fa8896c247f08797d3f2160ad207b30924107ef4db4eeeda5";
+      sha256 = "07b958014f7cce8ccf654bebe62b115e080fc65abd19cdb76ca1b44c11afc46c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/ur/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/ur/firefox-125.0.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "b474238a109ab392399c16997df768b6a22c71cd14066bb48f6ac409c08fd400";
+      sha256 = "59d0885af25a3f646f3dd771672578120e4faf94cd355e6c98f797031a503e21";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/uz/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/uz/firefox-125.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "cf1c313974a99933e34c7dc31f4d0a556152bfe5d5f96b23adb0791bd0c7729c";
+      sha256 = "13f71d1b99203b0073697ec0f56da452ad23a6fa8ed0f22a7dfafba61551c75c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/vi/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/vi/firefox-125.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "f96173dbd328ed53e209f0a1ea2e92ccee2a9025eaaeff77adcd38425e71fde2";
+      sha256 = "5549d579bd4d0e95bd2425164f6e12cbe290a1d72d917e8720833e5c1f3e73d8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/xh/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/xh/firefox-125.0.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "a7cf0f825f74a8b17470a01fa84786d422f324c8e36d3e2190574b354ebf8310";
+      sha256 = "d7669235cfc52c13b894a6655eed1dcc9fbb637195ff6ee8e8fd0c5e07c0afaf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/zh-CN/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/zh-CN/firefox-125.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "2dffda2f149c896c235d85ae398d16f6ca966e5b7211f834d790b34167c6407c";
+      sha256 = "5ad73aa4eea6685e00cda0322f78b3d9d1619743504db06cbf6bb4258f69c6f6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-x86_64/zh-TW/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-x86_64/zh-TW/firefox-125.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "23f6d07ac673ac3fda660c5dc82662110141f78335f3134f44f345fbca290a70";
+      sha256 = "32259822145540762446a3731799decdea7461c88e3184a3bd788444c903a71e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ach/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ach/firefox-125.0.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "b830c404e3fa947519dea03a8ede8d7e19da4a8150745bd416b6a5ca87eebb71";
+      sha256 = "d68f01ada9c805cba2bc8fb2b38746d437dc80702ced6c6b71ee3ca363dce1fe";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/af/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/af/firefox-125.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "4657769aebd1c52e77b358c9f4104e7c37d9d21e2e1a6e1c200eadc7e1f2b1c1";
+      sha256 = "86150934721778389a0c36185d783307305629fcae0a8b6553ac96d4d67638c0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/an/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/an/firefox-125.0.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "1dfdafc43b3b59fc7d0ac379c107fd60444459a6c95aa6678f150e0082bfec7a";
+      sha256 = "4570bf6578ad0e70578fe62b642253aaf7381970b10cc915e80f48b4e3069395";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ar/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ar/firefox-125.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "e8fbea6690e61bef8c8a4a4cbcf36c04f954d66d7d40cd66be60f9998c0d1e07";
+      sha256 = "8d87da4edfbbd7812a4aa042710ec272acf453401070664d8a20a172b74aa9f6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ast/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ast/firefox-125.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "6a4b102e083b82bfad215eca6e3e75438c33ba57aec520d8af6d7d32583d9204";
+      sha256 = "37244f5fd0564de8a23fad1576c18c43bbe569f224b091134b92d09258b830bc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/az/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/az/firefox-125.0.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "c7ede86e9d097fbf0f86788b3be9fb3767d39a79f5d79464b3029b762daf803d";
+      sha256 = "4d54ce7295425ad3afb02b56de28253e922516babc2302ec19dc0ec1e7df497d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/be/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/be/firefox-125.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "d710b1be59fbca2e3de067455518448647c4de1986d2ae784a0527040fe83d48";
+      sha256 = "57265ad4bd227fcada5844242619531ccbf7034f017d35ca70e5dcbacb7cc999";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/bg/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/bg/firefox-125.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "c7c04df709ec1e4c382327ac21d7ba46f24257ccfdea1d480fb6c4e75f2d8754";
+      sha256 = "565cc627badd404ca2968d3619dad5b8dbf5149480c217a7bcd1335443a2afc0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/bn/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/bn/firefox-125.0.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "35a3255b44a26d613d5f7637de2d263cc09d21ad9c5e053a6ff6207272b76d1f";
+      sha256 = "fc7ff1529071b1ef7c3fdad11128ae4060bef54313b4aae38e2158b89f276ca6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/br/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/br/firefox-125.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "1b438a34acc7d2a8aff6bd45fe4ce5270dafc4f9cb78de2a0433e18e0aac0227";
+      sha256 = "a08077fe3b151ee6d2fd039170d89b14c2968c6693102a2028266c8a55527463";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/bs/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/bs/firefox-125.0.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "2a6ef42c9bf0efd4868508966d50bdb83ddcd4b6aca114870019742d28b2e425";
+      sha256 = "a43b952e5c56b066e6ef27286842f55dda55268b20d477a71b09bd7d5b73b625";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ca-valencia/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ca-valencia/firefox-125.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "a7cecab82426c01b4add5f12f73537b4b290c7cb38c1196cc23fb86ad67da602";
+      sha256 = "07f67c87bac7c2b6ee26827b1d2fbdc09cfefb266b57aa4a8442123485e4fe06";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ca/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ca/firefox-125.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "829b43b4eca0dedf3fd0274539a4fe28a27ffec0df6c0e557c2ea3abbd09ebfc";
+      sha256 = "8398e648d9ee0b9e0000e9f7aa3d2d779691d5ed2d909c94cfc64e39739cc69b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/cak/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/cak/firefox-125.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "0184cbf1ca5c504ec12de93f5784401c3675cafa9fdd00c7ffdf99395f5c6400";
+      sha256 = "88c94bcaa22ee2de5f76351874db91b8711bc946d5a49cb44933c355a0972ee7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/cs/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/cs/firefox-125.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "77122b80e5d18d2e098665d6695b79ced7ac3dce6419ecbe54c58166b573dc01";
+      sha256 = "2fa442456f228e129aaf68ce931828f060480f3c737529f844305b4f384dd8ad";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/cy/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/cy/firefox-125.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "f882f6c89fa68c3c7917b83694d2ed9a1119c5899a0d0f201fac349aab72383e";
+      sha256 = "ca88969f81897b8b9963ea1de386947d6c16237973760cbb3fe4650f980ca4f5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/da/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/da/firefox-125.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "1608da5dfbe5137c3d38577083ba27dd9af8f97e07d0765aba98946611c2eff0";
+      sha256 = "44c2208ae0d8a2c0640e06d480ca972dd3999b15878c7d29d996f06a03dce905";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/de/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/de/firefox-125.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "d867e87a198ff113e23a40d9f39cf1e25e56104b295b9a2cbd87a5673977e271";
+      sha256 = "a5a324780efd77f1a7c97c4963b09affc6a190714f9af438f55dda2b721ada0d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/dsb/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/dsb/firefox-125.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "71ecf4d43f04fc2f27f119e07cbeafb38553cf1272c3b23f3400b55cf94c0932";
+      sha256 = "58529325670989cd4274201a06be99bca57d2e2ab60089284e3b0b41d1032bd0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/el/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/el/firefox-125.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "ea19afce9837eed608465b0ca549f3d049a5afb6e4fd1a6bd38371ca5efea5ad";
+      sha256 = "fdc1844c0c8e839fecfacf864840e25803ba3db379c2d35153da10873a502bb6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/en-CA/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/en-CA/firefox-125.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "d71b1683f0c336280b94b7530fa03bfbdc30a1e4a3900265ef7ac403145a2a54";
+      sha256 = "7ffdb8fe6f01118822edd398e48f6fea36558cdc06a2d6db3f5f2c1c6654bda7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/en-GB/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/en-GB/firefox-125.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "a778f372c52880f45155cdbaa414c255b8cb784235b6dea72943a1e94796902e";
+      sha256 = "ae5501f787fd32690ffcc99043971f1801171bf7c1ed6d7f7aeae4e374ceea8a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/en-US/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/en-US/firefox-125.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "610da1830f5e45adaa025305fa1061995f2f8c6f9d541b6f723b5ae874b8ed62";
+      sha256 = "fa26ff3121f199d3334bcd1fee7f04b12a387e451e3f535592ad001723994887";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/eo/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/eo/firefox-125.0.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "bb11c0cd83526a207363634b56d38ba1f471d52dee3a47dacf1dbbd7d9c8f2b0";
+      sha256 = "a8e20d5fff93237d7697811c26bf02bba1a7866f4dbdeea7d0eb1bb25816739b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/es-AR/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/es-AR/firefox-125.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "54e7ff2fc9907fdb2115c01ee35cefd48e50a3b49876c77a0db82508d027fd40";
+      sha256 = "dc1fff305dd2c7e9f806f9d54bd9c70c8b760c32b7263ba380f7e6e5eccd6dea";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/es-CL/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/es-CL/firefox-125.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "b7bd475ff2cdcbe264b025abba2fd073834c0f9699bdff25d946dcfb5bf5749f";
+      sha256 = "8db6efaa9fcc59633012e3739f8a15ab897cb30bdfb87a40efa273e391f4408e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/es-ES/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/es-ES/firefox-125.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "fa2caec9abbcb2ed7809c3fc78ae2d4598acf285c2d7df1b9b0ebb1772dcb75a";
+      sha256 = "b794fc4e0d96bdee8575996019d238703477e08bc6d111ebd80a86b062257861";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/es-MX/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/es-MX/firefox-125.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "6e5ed9bae6aae18d2eb9dffa2ea88bec0c2387d65d030c36b1011218b44ad9bf";
+      sha256 = "36e83dbc77b69e98b82557746a57cd26bc9320a7e9c3bea3d6fec6811d2746c0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/et/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/et/firefox-125.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "f4e7e0b08f5480ca4a96abd94c09903a7edb63dbf27449b41cdc715b6b74a4f3";
+      sha256 = "7e20535a37ece7294b4db56c92ce47704a44b87c8acbe94d14e61278f3347037";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/eu/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/eu/firefox-125.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "9e9a1d2c7e24fdb3f1d0fe0b3a626f28f65ad8b6701467a0e23f6195a8f0ff4c";
+      sha256 = "7517d31e80dd452dc3f4ce272b67a172228a4f0fda8867dc7efe4e6fc083bd90";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/fa/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/fa/firefox-125.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "56ce9cc578d6ac62dc1c18442b4c15dee075e38f018c2139da9ee42cd999b11d";
+      sha256 = "c9ea5320502cfe51ab7a50585b17e06f9137ed6ec564f182a14ad066da6ece18";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ff/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ff/firefox-125.0.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "2e8ecd1b3cdce3a14f92413c7923416b728ea0e3c29e5047d7ad6dc79a615bb5";
+      sha256 = "13f237a47643194c6938535deaae54ae637a97933615367ca2b210bd6a51fd90";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/fi/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/fi/firefox-125.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "4f72768850aba89220b5a848a4d1650908a7bb76b82e564473ffd3a1a8af8eb4";
+      sha256 = "85df1a1976ef6b884db820b1413a1433cfdd8177990c5b16d256220107e5c865";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/fr/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/fr/firefox-125.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "1e65307e3fc558f49ccf4fb46669f8a05c3f762c8d0037eb435b7c05c7802561";
+      sha256 = "b2f061ea3d76b97d3e889d21816f2b68bb0c0fa4370168cb4d7d83895eee0bb9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/fur/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/fur/firefox-125.0.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "a0c721261d64e667290eb47fe685e92503527b628fcadbd314fe29c48049c0f3";
+      sha256 = "96509e3fd301280bf97ffcd3048818d6bab8166227222eea8bb3c491c32dc054";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/fy-NL/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/fy-NL/firefox-125.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "2b30e840716e316a42f6272055836c08b928f28e57c176125b0c0f93b96eeb4c";
+      sha256 = "5ac180974631f41203bd44ba277d645e30809e0c3cb9e05e367157bcbee9aa5a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ga-IE/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ga-IE/firefox-125.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "dd2d984a202acf6dcc99538b30b6a4353170ab0385d91a6e719b85a7390834f2";
+      sha256 = "630bad12dc187f665cfeefa3f916648e2534a66826f0b00e39e579e2c6102352";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/gd/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/gd/firefox-125.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "18dfc8aeccb256438b7a29621807102ecd18132a9cff174ff65b2cf69d14a669";
+      sha256 = "5ee670d3c26a434bc2e2cacb1c11abfe8cd246b2c73a52ae31a9724276a087ba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/gl/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/gl/firefox-125.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "4dab3d6ad35db6dfd2e3d8eed06380eee0cd1663dbe102c11eae01aca5083e96";
+      sha256 = "2acd3c832d9df37e4c947b467fb4a97d412cdf3ca273324caeff3fb110de4f63";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/gn/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/gn/firefox-125.0.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "414c0c6d199c23a0d01b1274b5bc9a88e78ac06cd2272c74841f157979fdd7aa";
+      sha256 = "e613108798294638e36629fba32bfaf0913bdc5ac3c6a30c820ba4be72d9f304";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/gu-IN/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/gu-IN/firefox-125.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "3e53073f9c9e78af93c73bc48b9f4a8b476990eca8d37d5bd095dd6ae790c00d";
+      sha256 = "b26f0cd7ba59f4cf78510551fb13657506fab632a17cb434e38d6c6f6910e1d3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/he/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/he/firefox-125.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "cddb0457e50a446419997a492a809e9ea6aea898bedb0732a7be2cbba70d0a48";
+      sha256 = "235c08a65e95375badf7aa18440b8cff2a4be86540bf5ee83b95947961ad0d43";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/hi-IN/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/hi-IN/firefox-125.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "b5efc66bb4fff6f2b0516654a55ea6f88064b8d8c85f5bb368ff8e9848920115";
+      sha256 = "18f128c18c132ab7e6a2219f5e33c6fa985b7655ba8000a9a1107ee93265f570";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/hr/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/hr/firefox-125.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "649f1f315cfa82b5bf1266aed4fc175e75fb0bcbba80c6b0955aed22d0edf598";
+      sha256 = "4749f5d32474743a686bf89b7aecdc48d8234080ace912b49169072f7c5e0170";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/hsb/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/hsb/firefox-125.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "8f26618725a726b9d9cb9dd644766b25cac87fa6d3094620217a1450ee12352c";
+      sha256 = "bf6e0b2fe84c0fcb4d98d2919109c248c1acbe423fc03d49185a43a718d6dff5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/hu/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/hu/firefox-125.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "0bb8f4f26ebad781cc481b477312c7e14ac5f4d7ab4cb4e4253ec33a044fa0f7";
+      sha256 = "78b29147eaa4b50e480e5b1f2b607f53745dff933f428e63b9a7d5ecde37d980";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/hy-AM/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/hy-AM/firefox-125.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "0d5e5eb1b1302a11837c47fc0b413f6891a841a91c07ec779738b344f2744b5c";
+      sha256 = "92179af9751f285ddfd6ea847af19bd51e007b60cc87743893a1474a72231e33";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ia/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ia/firefox-125.0.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "8afb73c1a7beccbbc1842097a94a0316fda12f0f6cbabba948d6818606d372fb";
+      sha256 = "302c15e893b15584fc45876ab37931994a0da2c141b1bf8085300a43a7dbbdd1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/id/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/id/firefox-125.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "a411edc960c483d51d7e6731650e413eedc1e16aae68c2b8ea1b1a03e6ed58d1";
+      sha256 = "e34ad44258e7161c0afc9b53780506497f547f3e7477a2294a748c39eb603c27";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/is/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/is/firefox-125.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "e89a9810f5e67b09e485a6751b3b66a74be55581a86819e0c48b07ed60e54198";
+      sha256 = "bbe96ac1d146830204e516aca3df7c0cf9dfe4a7a48199bb52bdf6a4aebc6e8d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/it/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/it/firefox-125.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "93061ab964d2e6a833d0cc9ce977c296caf39fb0408cd2f93cb4e94ac49decf1";
+      sha256 = "5525522820cc4799ef08303a2557ebf7a8d15ae9d1ebd12cae49beebddfba125";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ja/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ja/firefox-125.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "94ec18cf7a3a187b111462288ed99d52a900ef3d6ca8d9b4278ab145ca003d20";
+      sha256 = "56fda01ab0b8764cf5e02a1c648e3c119778ce3b18425b3a13b31b380daa022f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ka/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ka/firefox-125.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "1b4b18a3e53c2aa787af7a87fb6a6edf3af67f2b7746bbdf3f3445e088433006";
+      sha256 = "c98d04c8a378af5b4c54ae68055e66cd155805b3ab861a69d74894d5e47879d4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/kab/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/kab/firefox-125.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "6a786415b93830ec4d592ca995449cc608bd9442ece7594ea5125770ac3e7cbb";
+      sha256 = "1c90292288d950f23f452160621987cc3f8fa8e3783a15d6b7926ca839c81945";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/kk/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/kk/firefox-125.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "8ca1eed66513bdd3976ce54b1ef1515fa2795fac07f2a5a9a216c711e7e3780b";
+      sha256 = "5775923b5258600a890368ecb063f3c07a7f1aeec83ada8560a2851bdfd27ae1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/km/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/km/firefox-125.0.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "0bf8da7ebca829d55e2937c42a0c0d14951c4aae5748cf7b9681d12d2f438fd1";
+      sha256 = "bde7fd43fd1f76a07ea7429a74d65a507efaea83f9bab8265cedb50f49001659";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/kn/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/kn/firefox-125.0.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "e42db34f05140a4ef2ec654ecedfaab57eca7e6fe462f29c215c69c9e2d4867a";
+      sha256 = "0131edc04d6af00480fd82bb83099e64395f5eb231dc362b9fca5e7d5fda4c4b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ko/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ko/firefox-125.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "a9de2c2cc3312a372a1eb0b1efc81b252a94fe034e4f39b60b82242806aa4969";
+      sha256 = "8585263ea8381f5a820f13990caf7bff790cf12c3892040eac2d5bb70e3c275f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/lij/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/lij/firefox-125.0.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "5735dbc702e200a9aa2b49c7a245444f874bca8d84ff1ee9061354310d0e9899";
+      sha256 = "20f11433660b0faf79f91df059217a4467accf444a902db24ac13b71e2f53f4e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/lt/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/lt/firefox-125.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "5f930e3f95c120caab991d49fc70efa5de82b843ce996c2c8fe82c41a02a62e9";
+      sha256 = "8c6cd6c938e077fb5be0257f6279b0ffd8eab0692e7a12cd5244120b8351e20d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/lv/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/lv/firefox-125.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "5703c100ada1fce700795a62e3a932b895e8d46cf29f50134530620667c6b087";
+      sha256 = "4abca58f84c546037aaef974df3592c6a0151bd27e522010719beed7b48acce8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/mk/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/mk/firefox-125.0.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "30bdb37a118563687ce4dec4d5fa200db3ab282398dff5907c6716c8a5c92980";
+      sha256 = "e8059921b668cefeb316568ec8425a0df42bc2d7ebed577970829b9f6c87f930";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/mr/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/mr/firefox-125.0.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "74a512f5b55bb87f581521099351fcf56b98ae72d987974b4a295b2e79610213";
+      sha256 = "28caffc25509474466c88982e8fe94a7256547fc0a0e1be98bb034e177a54dff";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ms/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ms/firefox-125.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "e243932c6aaafd51f611a951d4ec754325596e5508396fd9729bb63163b8dbd4";
+      sha256 = "577177dfb5bee9860def97c893435462d7eab86691a85a520012d603b836d19f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/my/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/my/firefox-125.0.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "d885aa9bc919e79147dc4a7c8014f85b06e3a1c9cb59ebb1f6180224f4f358bb";
+      sha256 = "d00dae52dfa8bbb0cad2cc2b7eac9fc1359cd82ec78e5970f924bd62ddf7494c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/nb-NO/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/nb-NO/firefox-125.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "1aae59536fa4d474634b63043ca8706d591c38f321e8ce83c7c98d52cad9aa65";
+      sha256 = "d7b3c20b55551787ba6a7a66c637a63fc3d1195bb5f3731550bd2abac4ea9076";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ne-NP/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ne-NP/firefox-125.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "d04fb92b154e4b8edc50f10aeaef9288f816542778872a5afe5d9d40b0498905";
+      sha256 = "b665390b65c7792bed2071b7d74ca164c7de641650eb0e415c97a540c0a6765e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/nl/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/nl/firefox-125.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "032d910c99c142452c8278061b066c6a7c6ed3095d9050033c6407f754606f98";
+      sha256 = "1b17bf181f68ebd4bd067bff733cd12c338285993d62b51695a6130427dc49b5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/nn-NO/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/nn-NO/firefox-125.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "64d0a272339b85336d20afbd3ad85e366cf1dfaf153e9fb20b7d60114e961e3c";
+      sha256 = "4b1bee182a9415f99d097e124c5a70cdff62c7975cde67cec70cb5fa0f883087";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/oc/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/oc/firefox-125.0.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "eb2cb014741eccab18fd6f953aca16de654e075be0db33836b80ee3fc16cede6";
+      sha256 = "6a5016c0b59dcab3bf4dd2d2a16413a22a394b8debd2aee90176cb26bc50ed53";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/pa-IN/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/pa-IN/firefox-125.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "37f3d84f0988ff87a68235f89ccdd25b78ad1a989fb770e5213f7ac240aaf496";
+      sha256 = "cb2d40dd901eda48d38a588f4580064f61ef88270f5f9cd26cd3fd4ea6c3d211";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/pl/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/pl/firefox-125.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "0513859bd0bfdf5f09469d8037d6a30b2eb91b88c07c4dda1e56f3d02df46454";
+      sha256 = "b0eaa474d632f534852500f0c6f1e3fdca377c34510e89b9369c8427d9d5c595";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/pt-BR/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/pt-BR/firefox-125.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "2ef165de2147dda2dcaa90d89f4ed49e1967a16feca830c51caefa12fb8ccad8";
+      sha256 = "864346951eed6e5b6685c4f46dec2f3e92f0ee6f570851cfa261da4751f4beef";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/pt-PT/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/pt-PT/firefox-125.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "3188bfbee95f33247533321e15fdd1f849afcdd028fa37439d4eeaf4d7547aa0";
+      sha256 = "0d534823d47246addd93d0c39225fb8a282813e7ec3f95a7c2f0375cfe233d0e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/rm/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/rm/firefox-125.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "1feb3008fa86962c270eba9ae12f702c571013e7ac83d658f93bf31ff79892a1";
+      sha256 = "e38a4ebcbf6d67082080b173f7816fcbf1fccc0804eb3add9c63b7c54d775a22";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ro/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ro/firefox-125.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "1ba9e950bcabb207c2c3954d504246d89ca9fef6f97cf35f96394f07acb89907";
+      sha256 = "e2d745ab5be3a2cce968a2d237f36386bf942b7d50813f24ace1ac0cc418a7ca";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ru/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ru/firefox-125.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "5792d97355f7e71af94e8a233ae553acbac04e3a62e5d39121eadd777b70607d";
+      sha256 = "f5e4c7bf8fea564005a35940a1aa556511cc8ecb7c69be6f335451cdaa4243d1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/sat/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/sat/firefox-125.0.tar.bz2";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "3029ccc9d44544ae8de8b13a17145acee14e52c0e320653d67e180713064d3ce";
+      sha256 = "f666e500b8d11f4d9112598f48cec4b864cf9c924975a1e5bf89343119ca949d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/sc/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/sc/firefox-125.0.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "8476836cf107518768644cce8b869e3405b762736cbb09666df0f3dc6adb73da";
+      sha256 = "426c81821627605de0ea318524be41b2e1566a2ac68f7c1dc1482256109320d7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/sco/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/sco/firefox-125.0.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "4fc3fe9aa7d9106325598aa5a55cc15d3d0f810969953cbb96b3c466131f941a";
+      sha256 = "d2a7e442eb42b2a4dc1731829d1d56b580ce0f861de0f66d24ae52771df9de52";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/si/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/si/firefox-125.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "fb6fc3e5aa01d892e9df1c24590bdf0622de44a34f88ca255fb52691eb1b4c12";
+      sha256 = "0484955a3c33b8aecc1c11ab5d1196ee595bf7f3ea420dc8d4ac8e6e37b0ae21";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/sk/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/sk/firefox-125.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "8102b889aafcc51a4ff35b17abc63f94d5481b9bb46cca843f61c9d97f591862";
+      sha256 = "64c2e76db783b4ab98f7ca90f4100b14623adaa75fb7a4d99132b055238b2123";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/sl/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/sl/firefox-125.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "ef4f1cef88b7f4603a85496f4497f291bf4455d6ac9371ce12526f4576a3e340";
+      sha256 = "85207cbe07d42e9c50201152e6c55218025617b6c4aadf7b07f77d4818a9357c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/son/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/son/firefox-125.0.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "43ec5bf2c34099f0867d26e3b577a133165d4d01c848ea3effbd3bbeda7b9f39";
+      sha256 = "2e8c1bc9411848fc1ea2222d0e57e45a6792461353fd7c923e68f430da7a0163";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/sq/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/sq/firefox-125.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "7dc7b114661c8afad3780f0517c130cedaf36f8c6d8b5055db02bb261c11a110";
+      sha256 = "316f57e91311b6cdd463b842835cf6ffce6d6cabf806484cebd579c6a5548e8d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/sr/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/sr/firefox-125.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "3c3e81b0454c050ae88842ba945369e8cf1757199614afdbd8702735c4c3a912";
+      sha256 = "f01da4f91ed7711307798bb4f470248d561a615fedee3fec1aa635c46e5a66f1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/sv-SE/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/sv-SE/firefox-125.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "57b8e9765928f6b7f35721a0352a1969d77af09d51f1ddb449454fd561aeb099";
+      sha256 = "67d8dd3e0e63e0476f0c2b9e19627e6803ae1a60c692c36f68aa01f6decf148c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/szl/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/szl/firefox-125.0.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "48230573e8631b548d6eb2f193eeaf624edd4566b44c841ba8fad43d96980a3c";
+      sha256 = "236990be5b40ca4d88306882c5c87e54798229f56412c3c7aba2c37aac1b4709";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ta/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ta/firefox-125.0.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "66848675d94e3bd818d727ae57a4a83ddc64c847fea9c4f4f0a402c83b2a3db1";
+      sha256 = "f516155f2372d51f103e3565711d043e9c6791d057b395c26ed5efd13019896b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/te/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/te/firefox-125.0.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "371b3cad98004b1441af79ec2eb5fb69ba0fd49e7c4389347c850364f26eb8af";
+      sha256 = "4d3c097a50c492fe585439399ff4d7ec076a2d2a580ca85d371a5792d0f4a145";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/tg/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/tg/firefox-125.0.tar.bz2";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "04ef37293c7d2941a983a2153b557fe254e46a1f8339112bcba4dec15d0ec70f";
+      sha256 = "09ab48c508a372e535f6e7d4f8a62ef6f4e6f5a487ad0a79575df41bcb78e3a8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/th/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/th/firefox-125.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "b21cfa5237881348325ad793231bc85b10dbf33d6eb55617fe0109fad367befd";
+      sha256 = "d4ac19a4e723d46a06ed05f233684dc49f802cb6df832319b81f61e797c2a2df";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/tl/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/tl/firefox-125.0.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "c23c6308e8e6f5f30ea5181bb43fedc2100f28c8f69c3159867840f3c98b1d80";
+      sha256 = "d979cdc257b1a5c398031e75c3bd9a8e6b24f65f606376c997d87b684e6be15e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/tr/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/tr/firefox-125.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "352599082c9117580b0c20f611cefe5dbb7229c0051f44a3e1c24338cbb9b738";
+      sha256 = "2dc41ed5db88130efaf80a295a3eaff01e67297167f3e8fb14f34a977556af9e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/trs/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/trs/firefox-125.0.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "caa824f63306efb20d29809dc677c39854e35028cbb4be8831bc8005df6be83f";
+      sha256 = "29e827e0aa6cf4bb1d6d8cc4a04373b94f29bde8dd0bbb062106ab6df29da28d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/uk/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/uk/firefox-125.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "b2f42bc31ae0e26c4aec1fb0a613a455399ad092c56dda6ff4e3ff0c074c70fc";
+      sha256 = "9b793cc14f936223534a5a33af6b71cf0dc6a6f5c0d4a86ce5814b6f1f08f7d0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/ur/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/ur/firefox-125.0.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "a3cca1b23bca534f8823490f5c3434797b3713be29d34a1b732d474c3a240702";
+      sha256 = "3797f148587d913af044b99c776667d90917c2ca381ae6bbc70b30c03cfcb41c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/uz/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/uz/firefox-125.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "af4ec2e4e0821fbc18f02b8ae1df7384cee4305bec768e309716013924dfce66";
+      sha256 = "8ad7f2985335020b5f491db258fa50039d6e2b26a7589d637bf7103d74ddc28b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/vi/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/vi/firefox-125.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "54e24c229a5a9a7e4394ed4f67320e67fc3a18c08c7f46ff397ac7e93285dd37";
+      sha256 = "377a4c7fa82d6713ef03fac26128d782a926cd3b5c6ee884baab9f7843ff8aac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/xh/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/xh/firefox-125.0.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "22c4722d2b7a975eca72891b2624c68889b870ec4b85421e4b5109c1271af0b9";
+      sha256 = "1fa24f1227b0395a4dfca700611cea0bc352a94f0376f6ed03484a13351e7339";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/zh-CN/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/zh-CN/firefox-125.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "7834d65e16240d9fe8ef42ccf076af9505259979eba0c72de3edcdbb870d3a8d";
+      sha256 = "d7b9b4a047b127bceb761479a1107ccd46eb474d467cb560db0c90f035de7c15";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/124.0.2/linux-i686/zh-TW/firefox-124.0.2.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0/linux-i686/zh-TW/firefox-125.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "c6433348eb61af98a6379c951b47353d6163ca2785e6fe998e4c6ec933bef653";
+      sha256 = "2ff211aaf5743e31875c8bcdbd6dac6cb1f49cc35e6f8b755eefbbad78204ad6";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -3,10 +3,10 @@
 {
   firefox = buildMozillaMach rec {
     pname = "firefox";
-    version = "124.0.2";
+    version = "125.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "8cf340de6e34812f8ae3363265859a263330af770d981c3dd1ca1e7e0cfe513604d3e68184d4aa1446569aefbdf359d561fbc200faf19a5ed020a1709d9ef10e";
+      sha512 = "c520070e5a8872f3df4f5e35b9a605eef95f61254f6242040f02b2b68d6c8eef993885a18144353326a7488ac27115fa4ad2ef5615885e5155ab3f8194a61977";
     };
 
     extraPatches = [

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -94,11 +94,11 @@
 
   firefox-esr-115 = buildMozillaMach rec {
     pname = "firefox-esr-115";
-    version = "115.9.1esr";
+    version = "115.10.0esr";
     applicationName = "Mozilla Firefox ESR";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "9ccaede2fcda13a07f98a2110bb8f99c7324601d66bff311f3070a669576a1598fe1d7de2d005d725d1f44dbe3934a9c0fd0b7950f60686047d4ce8d9d812310";
+      sha512 = "0626e2c68ce43f24dfc2b9216e2565537ad8781daf4195d53420e1b78d57d0f6360fbe56b0ddbedae3818546c72472c85c1ff2b208c123d32a0543e666f42b65";
     };
 
     meta = {

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -71,7 +71,11 @@ let
       "-DCLANG_PSEUDO_GEN=${buildLlvmTools.libclang.dev}/bin/clang-pseudo-gen"
     ]);
 
-    postPatch = (if lib.versionOlder release_version "13" then ''
+    postPatch = ''
+      # Make sure clang passes the correct location of libLTO to ld64
+      substituteInPlace lib/Driver/ToolChains/Darwin.cpp \
+        --replace-fail 'StringRef P = llvm::sys::path::parent_path(D.Dir);' 'StringRef P = "${lib.getLib libllvm}";'
+    '' + (if lib.versionOlder release_version "13" then ''
       sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' \
              -e 's/Args.hasArg(options::OPT_nostdlibinc)/true/' \
              lib/Driver/ToolChains/*.cpp

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -203,10 +203,8 @@ let
           } ./hooks/qmake-hook.sh)
         { };
     } // lib.optionalAttrs config.allowAliases {
-      # Convert to a throw on 03-01-2023 and backport the change.
-      # Warnings show up in various cli tool outputs, throws do not.
-      # Remove completely before 24.05
-      overrideScope' = lib.warnIf (lib.isInOldestRelease 2311) "qt6 now uses makeScopeWithSplicing which does not have \"overrideScope'\", use \"overrideScope\"." self.overrideScope;
+      # Remove completely before 24.11
+      overrideScope' = builtins.throw "qt6 now uses makeScopeWithSplicing which does not have \"overrideScope'\", use \"overrideScope\".";
     };
 
   baseScope = makeScopeWithSplicing' {

--- a/pkgs/tools/misc/goose/default.nix
+++ b/pkgs/tools/misc/goose/default.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
   proxyVendor = true;
   vendorHash = "sha256-aoBxReKRk7dkFR/fJ5uHDZrJRGutLTU2BhDWCTBN2BA=";
 
-  # end-to-end tests require a docker daemon
+  # skipping: end-to-end tests require a docker daemon
   postPatch = ''
     rm -r tests/e2e
     rm -r tests/gomigrations
@@ -32,8 +32,10 @@ buildGoModule rec {
   ];
 
   checkFlags = [
-    # these also require a docker daemon
-    "-skip=TestClickUpDown|TestClickHouseFirstThree"
+    # NOTE:
+    # - skipping: these also require a docker daemon
+    # - these are for go tests that live outside of the /tests directory
+    "-skip=TestClickUpDown|TestClickHouseFirstThree|TestLockModeAdvisorySession|TestDialectStore|TestGoMigrationStats|TestPostgresSessionLocker"
   ];
 
   doCheck = !stdenv.isDarwin;
@@ -46,3 +48,5 @@ buildGoModule rec {
     mainProgram = "goose";
   };
 }
+
+

--- a/pkgs/tools/misc/goose/default.nix
+++ b/pkgs/tools/misc/goose/default.nix
@@ -48,5 +48,3 @@ buildGoModule rec {
     mainProgram = "goose";
   };
 }
-
-

--- a/pkgs/tools/misc/tmuxp/default.nix
+++ b/pkgs/tools/misc/tmuxp/default.nix
@@ -2,12 +2,12 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "tmuxp";
-  version = "1.45.0";
+  version = "1.46.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-I7P/CohipEwrxoelU/ePSv2PHgM3HXdVVadpntVFcrQ=";
+    hash = "sha256-+aXpsB4mjw9sZLalv3knW8okP+mh2P/nbZCiCwa3UBU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -293,9 +293,7 @@ in (noExtraAttrs (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdP
 
   yuview = callPackage ../applications/video/yuview { };
 }) // lib.optionalAttrs pkgs.config.allowAliases {
-  # Convert to a throw on 01-01-2023.
-  # Warnings show up in various cli tool outputs, throws do not.
-  # Remove completely before 24.05
-  overrideScope' = lib.warn "libsForQt5 now uses makeScopeWithSplicing which does not have \"overrideScope'\", use \"overrideScope\"." self.overrideScope;
+  # Remove completely before 24.11
+  overrideScope' = builtins.throw "libsForQt5 now uses makeScopeWithSplicing which does not have \"overrideScope'\", use \"overrideScope\".";
 }));
 }

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -115,9 +115,7 @@ makeScopeWithSplicing' {
   wayqt = callPackage ../development/libraries/wayqt { };
 
   } // lib.optionalAttrs pkgs.config.allowAliases {
-    # Convert to a throw on 01-01-2023.
-    # Warnings show up in various cli tool outputs, throws do not.
-    # Remove completely before 24.05
-    overrideScope' = lib.warn "qt6Packages now uses makeScopeWithSplicing which does not have \"overrideScope'\", use \"overrideScope\"." self.overrideScope;
+    # Remove completely before 24.11
+    overrideScope' = builtins.throw "qt6Packages now uses makeScopeWithSplicing which does not have \"overrideScope'\", use \"overrideScope\".";
   });
 }


### PR DESCRIPTION
## Description of changes

Clang assumes that `libLTO.dylib` is located at `../lib` in the same prefix as `clang`, but that’s not true in nixpkgs. `libLTO.dylib` is actually located at `libllvm^lib/lib.libLTO.dylib`.

This is the first piece to fixing LTO on Darwin. The other is updating ld64, which I will be doing in a separate PR later this week. This PR does not depend on that PR because there is no harm passing the correct path to ld64. It does not perform LTO by default, and trying to use `-flto` even with the correct path remains broken.

Testing was done using my WIP PR for ld64 with clang 16. See https://github.com/NixOS/nixpkgs/issues/19098#issuecomment-2041752524 for output. It can also be validated by setting `NIX_DEBUG=1` when running clang, then confirming that the path passed to `-lto_library` actually exists in the store.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
