### PR TITLE
mlton: enable aarch64-darwin

### DIFF
--- a/pkgs/development/compilers/mlton/20210117-binary.nix
+++ b/pkgs/development/compilers/mlton/20210117-binary.nix
@@ -17,6 +17,11 @@ stdenv.mkDerivation rec {
         url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.amd64-darwin-19.6.gmp-static.tgz";
         sha256 = "0xndr2awlxdqr81j6snl9zqjx8r6f5fy9x65j1w899kf2dh9zsjv";
       })
+    else if stdenv.hostPlatform.system == "aarch64-darwin" then
+      (fetchurl {
+        url = "https://projects.laas.fr/tina/software/mlton-${version}-1.arm64-darwin-21.6-gmp-static.tgz";
+        sha256 = "1s61ayk3yj2xw8ilqk3fhb03x5x1wcakkmbhhvcsfb2hdw2c932x";
+      })
     else
       throw "Architecture not supported";
 

--- a/pkgs/development/compilers/mlton/20210117-binary.nix
+++ b/pkgs/development/compilers/mlton/20210117-binary.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, patchelf, gmp }:
+{ lib, stdenv, fetchpatch, fetchurl, patchelf, gmp }:
 let
   dynamic-linker = stdenv.cc.bintools.dynamicLinker;
 in
@@ -9,16 +9,25 @@ stdenv.mkDerivation rec {
   src =
     if stdenv.hostPlatform.system == "x86_64-linux" then
       (fetchurl {
-        url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.amd64-linux-glibc2.31.tgz.tgz";
-        sha256 = "0f4q575yfm5dpg4a2wsnqn4l2zrar96p6rlsk0dw10ggyfwvsjlf";
+        url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.amd64-linux-glibc2.31.tgz";
+        sha256 = "1lj51xg9p75qj1x5036lvjvd4a2j21kfi6vh8d0n9kdcdffvb73l";
       })
     else if stdenv.hostPlatform.system == "x86_64-darwin" then
       (fetchurl {
         url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.amd64-darwin-19.6.gmp-static.tgz";
-        sha256 = "1cw7yhw48qp12q0adwf8srpjzrgkp84kmlkqw3pz8vkxz4p9hbdv";
+        sha256 = "0xndr2awlxdqr81j6snl9zqjx8r6f5fy9x65j1w899kf2dh9zsjv";
       })
     else
       throw "Architecture not supported";
+
+  patches = [
+    (fetchpatch {
+      name = "remove-duplicate-if.patch";
+      url = "https://github.com/MLton/mlton/commit/22002cd0a53a1ab84491d74cb8dc6a4e50c1f7b7.patch";
+      decode = "sed -e 's|Makefile\.binary|Makefile|g'";
+      hash = "sha256-Gtmc+OIh+m7ordSn74fpOKVDQDtYyLHe6Le2snNCBYQ=";
+    })
+  ];
 
   buildInputs = [ gmp ];
   nativeBuildInputs = lib.optional stdenv.isLinux patchelf;

--- a/pkgs/development/compilers/mlton/default.nix
+++ b/pkgs/development/compilers/mlton/default.nix
@@ -15,14 +15,14 @@ rec {
   mlton20210117Binary = callPackage ./20210117-binary.nix { };
 
   mlton20210117 = callPackage ./from-git-source.nix {
-    mltonBootstrap = mlton20180207Binary;
+    mltonBootstrap = mlton20210117Binary;
     version = "20210117";
     rev = "on-20210117-release";
     sha256 = "sha256-rqL8lnzVVR+5Hc7sWXK8dCXN92dU76qSoii3/4StODM=";
   };
 
   mltonHEAD = callPackage ./from-git-source.nix {
-    mltonBootstrap = mlton20180207Binary;
+    mltonBootstrap = mlton20210117Binary;
     version = "HEAD";
     rev = "875f7912a0b135a9a7e86a04ecac9cacf0bfe5e5";
     sha256 = "sha256-/MIoVqqv8qrJPehU7VRFpXtAAo8UUzE3waEvB7WnS9A=";

--- a/pkgs/development/compilers/mlton/meta.nix
+++ b/pkgs/development/compilers/mlton/meta.nix
@@ -11,5 +11,5 @@
 
   homepage = "http://mlton.org/";
   license = "bsd";
-  platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin"];
+  platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" "aarch64-darwin"];
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This enables aarch64-darwin for the current mlton package. In order to do this, I had to move the binary bootstrap to the latest version. (There is a small patch to the binary's Makefile required, pulled from upstream git.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
