### PR TITLE
tomb,win-pvdrivers,tomcat,axis2,jetty: use stdenvNoCC

### DIFF
--- a/pkgs/applications/virtualization/driver/win-pvdrivers/default.nix
+++ b/pkgs/applications/virtualization/driver/win-pvdrivers/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
 let
   # Upstream versioned download links are broken
@@ -40,7 +40,7 @@ let
   ];
 
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "win-pvdrivers";
   version = "unstable-2023-08-17";
 

--- a/pkgs/os-specific/linux/tomb/default.nix
+++ b/pkgs/os-specific/linux/tomb/default.nix
@@ -38,7 +38,7 @@ stdenvNoCC.mkDerivation rec {
   postPatch = ''
     # if not, it shows .tomb-wrapped when running
     substituteInPlace tomb \
-      --replace 'TOMBEXEC=$0' 'TOMBEXEC=tomb'
+      --replace-fail 'TOMBEXEC=$0' 'TOMBEXEC=tomb'
   '';
 
   installPhase = ''

--- a/pkgs/os-specific/linux/tomb/default.nix
+++ b/pkgs/os-specific/linux/tomb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ stdenvNoCC
 , lib
 , fetchFromGitHub
 , substituteAll
@@ -20,7 +20,7 @@
 , nix-update-script
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "tomb";
   version = "2.10";
 

--- a/pkgs/servers/http/jetty/common.nix
+++ b/pkgs/servers/http/jetty/common.nix
@@ -1,8 +1,8 @@
 { version, hash }:
 
-{ lib, stdenv, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "jetty";
 
   inherit version;

--- a/pkgs/servers/http/tomcat/axis2/default.nix
+++ b/pkgs/servers/http/tomcat/axis2/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, apacheAnt, jdk, unzip }:
+{ lib, stdenvNoCC, fetchurl, apacheAnt, jdk, unzip }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "axis2";
   version = "1.8.2";
 

--- a/pkgs/servers/http/tomcat/default.nix
+++ b/pkgs/servers/http/tomcat/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, lib, fetchurl, nixosTests, testers, jre }:
+{ stdenvNoCC, lib, fetchurl, nixosTests, testers, jre }:
 
 let
-  common = { version, hash }: stdenv.mkDerivation (finalAttrs: {
+  common = { version, hash }: stdenvNoCC.mkDerivation (finalAttrs: {
     pname = "apache-tomcat";
     inherit version;
 


### PR DESCRIPTION
## Description of changes

These packages do not need a C compiler to be compiled.
We must therefore use `stdenvNoCC` instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
