### PR TITLE
fheroes2: platforms.unix instead of platforms.linux

### DIFF
--- a/pkgs/games/fheroes2/default.nix
+++ b/pkgs/games/fheroes2/default.nix
@@ -67,6 +67,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.karolchmist ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
## Description of changes

enabled platforms.unix as per freeheroes works everywhere not only on Linux

fixes #302354