### PR TITLE
fheroes2: set platforms.unix instead of platforms.linux

### DIFF
--- a/pkgs/games/fheroes2/default.nix
+++ b/pkgs/games/fheroes2/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, fetchFromGitHub, imagemagick
 , gettext, glibcLocalesUtf8, libpng, SDL2, SDL2_image, SDL2_mixer, SDL2_ttf, zlib
+, libiconv
 
 , gitUpdater
 }:
@@ -17,7 +18,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ imagemagick ];
 
-  buildInputs = [ gettext glibcLocalesUtf8 libpng SDL2 SDL2_image SDL2_mixer SDL2_ttf zlib ];
+  buildInputs = [ gettext glibcLocalesUtf8 libpng SDL2 SDL2_image SDL2_mixer SDL2_ttf zlib ]
+    ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   makeFlags = [
     "FHEROES2_STRICT_COMPILATION=1"
@@ -67,6 +69,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.karolchmist ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
## Description of changes

enabled platforms.unix as per freeheroes works everywhere not only on Linux

fixes #302354