### PR TITLE
dosbox-x: set --disable-shared configure flags to fix IPX support

### DIFF
--- a/pkgs/applications/emulators/dosbox-x/default.nix
+++ b/pkgs/applications/emulators/dosbox-x/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Tests for SDL_net.h for modem & IPX support, not automatically picked up due to being in SDL2 subdirectory
   env.NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL2_net}/include/SDL2";
 
-  configureFlags = [ "--enable-sdl2" ];
+  configureFlags = [ "--enable-sdl2" "--disable-shared" ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
## Description of changes

dosbox-x: set --disable-shared configure flags to fix IPX support

fixes #302558
