### PR TITLE
nixos/jotta-cli: init jotta-cli

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -113,6 +113,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [mautrix-meta](https://github.com/mautrix/meta), a Matrix <-> Facebook and Matrix <-> Instagram hybrid puppeting/relaybot bridge. Available as services.mautrix-meta
 
+- [Jottacloud Command-line Tool](https://docs.jottacloud.com/en/articles/1436834-jottacloud-command-line-tool), a CLI for the [Jottacloud](https://jottacloud.com/) cloud storage provider. Available as [user.services.jotta-cli](#opt-user.services.jotta-cli.enable).
+
 - [transfer-sh](https://github.com/dutchcoders/transfer.sh), a tool that supports easy and fast file sharing from the command-line. Available as [services.transfer-sh](#opt-services.transfer-sh.enable).
 
 - [MollySocket](https://github.com/mollyim/mollysocket) which allows getting Signal notifications via UnifiedPush.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1015,6 +1015,7 @@
   ./services/networking/jigasi.nix
   ./services/networking/jitsi-videobridge.nix
   ./services/networking/jool.nix
+  ./services/networking/jotta-cli.nix
   ./services/networking/kea.nix
   ./services/networking/keepalived/default.nix
   ./services/networking/keybase.nix

--- a/nixos/modules/services/networking/jotta-cli.md
+++ b/nixos/modules/services/networking/jotta-cli.md
@@ -1,0 +1,27 @@
+# Jottacloud Command-line Tool {#module-services-jotta-cli}
+
+The [Jottacloud Command-line Tool](https://docs.jottacloud.com/en/articles/1436834-jottacloud-command-line-tool) is a headless [Jottacloud](https://jottacloud.com) client.
+
+## Quick Start {#module-services-jotta-cli-quick-start}
+
+```nix
+{
+  user.services.jotta-cli.enable = true;
+}
+```
+
+This adds `jotta-cli` to `environment.systemPackages` and starts a user service that runs `jottad` with the default options.
+
+## Example Configuration {#module-services-jotta-cli-example-configuration}
+
+```nix
+user.services.jotta-cli = {
+  enable = true;
+  options = [ "slow" ];
+  package = pkgs.jotta-cli;
+};
+```
+
+This uses `jotta-cli` and `jottad` from the `pkgs.jotta-cli` package and starts `jottad` in low memory mode.
+
+`jottad` is also added to `environment.systemPackages`, so `jottad --help` can be used to explore options.

--- a/nixos/modules/services/networking/jotta-cli.nix
+++ b/nixos/modules/services/networking/jotta-cli.nix
@@ -1,0 +1,43 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.user.services.jotta-cli;
+in {
+  options = {
+    user.services.jotta-cli = {
+
+      enable = mkEnableOption "Jottacloud Command-line Tool";
+
+      options = mkOption {
+        default = [ "stdoutlog" "datadir" "%h/.jottad/" ];
+        example = [ ];
+        type = with types; listOf str;
+        description = "Command-line options passed to jottad.";
+      };
+
+      package = lib.mkPackageOption pkgs "jotta-cli" { };
+    };
+  };
+  config = mkIf cfg.enable {
+    systemd.user.services.jottad = {
+
+      description = "Jottacloud Command-line Tool daemon";
+
+      serviceConfig = {
+        Type = "notify";
+        EnvironmentFile = "-%h/.config/jotta-cli/jotta-cli.env";
+        ExecStart = "${lib.getExe' cfg.package "jottad"} ${concatStringsSep " " cfg.options}";
+        Restart = "on-failure";
+      };
+
+      wantedBy = [ "default.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+    };
+    environment.systemPackages = [ pkgs.jotta-cli ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ evenbrenden ];
+  meta.doc = ./jotta-cli.md;
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -446,6 +446,7 @@ in {
   jirafeau = handleTest ./jirafeau.nix {};
   jitsi-meet = handleTest ./jitsi-meet.nix {};
   jool = import ./jool.nix { inherit pkgs runTest; };
+  jotta-cli = handleTest ./jotta-cli.nix {};
   k3s = handleTest ./k3s {};
   kafka = handleTest ./kafka.nix {};
   kanidm = handleTest ./kanidm.nix {};

--- a/nixos/tests/jotta-cli.nix
+++ b/nixos/tests/jotta-cli.nix
@@ -1,0 +1,25 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+
+  name = "jotta-cli";
+  meta.maintainers = with pkgs.lib.maintainers; [ evenbrenden ];
+
+  nodes.machine = { pkgs, ... }: {
+    user.services.jotta-cli.enable = true;
+    imports = [ ./common/user-account.nix ];
+  };
+
+  testScript = { nodes, ... }:
+    let uid = toString nodes.machine.users.users.alice.uid;
+    in ''
+      machine.start()
+
+      machine.succeed("loginctl enable-linger alice")
+      machine.wait_for_unit("user@${uid}.service")
+
+      machine.wait_for_unit("jottad.service", "alice")
+      machine.wait_for_open_unix_socket("/run/user/${uid}/jottad/jottad.socket")
+
+      # "jotta-cli version" should fail if jotta-cli cannot connect to jottad
+      machine.succeed('XDG_RUNTIME_DIR=/run/user/${uid} su alice -c "jotta-cli version"')
+    '';
+})


### PR DESCRIPTION
## Description of changes

To complement the existing `jotta-cli` package, add a NixOS module with a user service that runs `jottad`. The module also adds `jotta-cli` to system packages. See https://github.com/NixOS/nixpkgs/issues/300063.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Checklist for new NixOS modules
  - [x] module path fits the guidelines
  - [x] module tests succeed on x86_64-linux
  - [x] options have appropriate types
  - [x] options have default
  - [x] options have example
  - [x] options have descriptions
  - [x] No unneeded package is added to `environment.systemPackages`
  - [x] `meta.maintainers` is set
  - [x] module documentation is declared in `meta.doc`
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc