### PR TITLE
srs: init at 5.0-r2

### DIFF
--- a/pkgs/by-name/sr/srs/package.nix
+++ b/pkgs/by-name/sr/srs/package.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, unzip
+, ffmpeg
+, perl
+, tcl
+, cmake
+, which
+, coreutils
+, autoconf
+, automake
+, makeWrapper
+}:
+stdenv.mkDerivation rec {
+  pname = "srs";
+  version = "5.0-r2";
+
+  src = fetchFromGitHub {
+    owner = "ossrs";
+    repo = "srs";
+    rev = "v${version}";
+    hash = "sha256-T4kmDKAkkC24Xsi3htGAW33Ir+NKKl2HYWyAfCmO6t0=";
+  } + "/trunk";
+
+  nativeBuildInputs = [ pkg-config ffmpeg perl unzip tcl cmake which autoconf automake makeWrapper];
+
+  dontUseCmakeConfigure = true;
+  enableParallelBuilding = true;
+
+  configureFlags = [] ++ lib.optionals stdenv.isLinux ["--generic-linux=on"];
+
+  prePatch = ''
+    substituteInPlace 3rdparty/openssl-1.1-fit/config \
+      --replace-fail '/usr/bin/env' '${coreutils}/bin/env'
+
+    substituteInPlace 3rdparty/srt-1-fit/configure \
+      --replace-fail '#!/usr/bin/tclsh' '#!${tcl}/bin/tclsh'
+      '';
+
+  postInstall = ''
+      makeWrapper $out/objs/srs $out/bin/srs
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/ossrs/srs";
+    description = "A simple, high efficiency and realtime video server, supports RTMP, WebRTC, HLS, HTTP-FLV, SRT, MPEG-DASH and GB28181";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ rucadi ];
+    license = licenses.mit;
+    mainProgram = "srs";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
closes https://github.com/NixOS/nixpkgs/issues/302548

[SRS ](https://github.com/ossrs/srs) is a simple, high-efficiency, real-time video server supporting RTMP, WebRTC, HLS, HTTP-FLV, SRT, MPEG-DASH, and GB28181.
## Things done

Packaged srs, I Do not have means to test it, please, @oluceps as you were the one to raise the request, test it. 
The binary seems to do things.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
