### PR TITLE
tildefriends: init at 0.0.17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19462,6 +19462,13 @@
     githubId = 506181;
     name = "Peter Marheine";
   };
+  tasiaiso = {
+    email = "tasiaiso@proton.me";
+    matrix = "@tasiaiso:kitsunes.club";
+    github = "tasiaiso";
+    githubId = 164172552;
+    name = "Tasia Iso";
+  };
   tasmo = {
     email = "tasmo@tasmo.de";
     github = "tasmo";

--- a/pkgs/by-name/ti/tildefriends/package.nix
+++ b/pkgs/by-name/ti/tildefriends/package.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, fetchFromGitea
+, gnumake
+, openssl
+, which
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tildefriends";
+  version = "0.0.17";
+
+  src = fetchFromGitea {
+    domain = "dev.tildefriends.net";
+    owner = "cory";
+    repo = "tildefriends";
+    rev = "v${version}";
+    hash = "sha256-Wc9MvafA2rPmjnRvmMB3qmRyDQNhF688weKItHw3E8I=";
+  };
+
+  nativeBuildInputs = [
+    gnumake
+    openssl
+    which
+  ];
+
+  buildPhase = ''
+    make -j $NIX_BUILD_CORES release
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    cp -r out/release/* $out/bin
+  '';
+
+  doCheck = false;
+
+  meta = {
+    homepage = "https://tildefriends.net";
+    description = "Make apps and friends from the comfort of your web browser.";
+    mainProgram = "tildefriends";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ tasiaiso ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

[Tilde Friends](https://tildefriends.net) is an app that allows users to communicate through the [Secure Scuttlebutt](https://en.wikipedia.org/wiki/Secure_Scuttlebutt) protocol. Currently, it writes to a database in the current working directory and exposes a web interface on port 12345.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
