### PR TITLE
python312Packages.av: 11.0.0 -> 12.0.0

### DIFF
--- a/pkgs/development/python-modules/av/default.nix
+++ b/pkgs/development/python-modules/av/default.nix
@@ -1,15 +1,16 @@
-{ lib
-, stdenv
-, buildPythonPackage
-, cython
-, fetchFromGitHub
-, ffmpeg_5-headless
-, numpy
-, pillow
-, pkg-config
-, pytestCheckHook
-, pythonOlder
-, setuptools
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  cython,
+  fetchFromGitHub,
+  ffmpeg_5-headless,
+  numpy,
+  pillow,
+  pkg-config,
+  pytestCheckHook,
+  pythonOlder,
+  setuptools,
 }:
 
 buildPythonPackage rec {
@@ -26,18 +27,14 @@ buildPythonPackage rec {
     hash = "sha256-+xbVkNyFg5VKIf+G6AbAAYVqTSwxFE0Hyc52XSmibAw=";
   };
 
-  build-system = [
-    setuptools
-  ];
+  build-system = [ setuptools ];
 
   nativeBuildInputs = [
     cython
     pkg-config
   ];
 
-  buildInputs = [
-    ffmpeg_5-headless
-  ];
+  buildInputs = [ ffmpeg_5-headless ];
 
   preCheck = ''
     # ensure we import the built version
@@ -50,71 +47,73 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTests = [
-    # urlopen fails during DNS resolution
-    "test_writing_to_custom_io"
-    "test_decode_close_then_use"
-    "test_bits_per_coded_sample"
-    "test_codec_delay"
-    "test_frame_index"
-    "test_penguin_joke"
-    "test_sky_timelapse"
-    "test_flush_decoded_video_frame_count"
-    "test_path_input"
-    "test_path_output"
-    "test_str_input"
-    "test_str_output"
-    "test_is_corrupt"
-    "test_is_discard"
-    "test_is_disposable"
-    "test_is_keyframe"
-    "test_noside_data"
-    "test_side_data"
-    # Tests that want to download FATE data, https://github.com/PyAV-Org/PyAV/issues/955
-    "test_vobsub"
-    "test_transcode"
-    "test_stream_tuples"
-    "test_stream_seek"
-    "test_stream_probing"
-    "test_seek_start"
-    "test_seek_middle"
-    "test_seek_int64"
-    "test_seek_float"
-    "test_seek_end"
-    "test_roundtrip"
-    "test_reading_from_write_readonl"
-    "test_reading_from_pipe_readonly"
-    "test_reading_from_file"
-    "test_reading_from_buffer"
-    "test_reading_from_buffer_no_see"
-    "test_parse"
-    "test_movtext"
-    "test_encoding_xvid"
-    "test_encoding_tiff"
-    "test_encoding_png"
-    "test_encoding_pcm_s24le"
-    "test_encoding_mpeg4"
-    "test_encoding_mpeg1video"
-    "test_encoding_mp2"
-    "test_encoding_mjpeg"
-    "test_encoding_h264"
-    "test_encoding_dvvideo"
-    "test_encoding_dnxhd"
-    "test_encoding_aac"
-    "test_decoded_video_frame_count"
-    "test_decoded_time_base"
-    "test_decoded_motion_vectors"
-    "test_decode_half"
-    "test_decode_audio_sample_count"
-    "test_data"
-    "test_container_probing"
-    "test_codec_tag"
-    "test_selection"
-  ] ++ lib.optionals (stdenv.isDarwin) [
-    # Segmentation Faults
-    "test_encoding_with_pts"
-    "test_bayer_write"
-  ];
+  disabledTests =
+    [
+      # urlopen fails during DNS resolution
+      "test_writing_to_custom_io"
+      "test_decode_close_then_use"
+      "test_bits_per_coded_sample"
+      "test_codec_delay"
+      "test_frame_index"
+      "test_penguin_joke"
+      "test_sky_timelapse"
+      "test_flush_decoded_video_frame_count"
+      "test_path_input"
+      "test_path_output"
+      "test_str_input"
+      "test_str_output"
+      "test_is_corrupt"
+      "test_is_discard"
+      "test_is_disposable"
+      "test_is_keyframe"
+      "test_noside_data"
+      "test_side_data"
+      # Tests that want to download FATE data, https://github.com/PyAV-Org/PyAV/issues/955
+      "test_vobsub"
+      "test_transcode"
+      "test_stream_tuples"
+      "test_stream_seek"
+      "test_stream_probing"
+      "test_seek_start"
+      "test_seek_middle"
+      "test_seek_int64"
+      "test_seek_float"
+      "test_seek_end"
+      "test_roundtrip"
+      "test_reading_from_write_readonl"
+      "test_reading_from_pipe_readonly"
+      "test_reading_from_file"
+      "test_reading_from_buffer"
+      "test_reading_from_buffer_no_see"
+      "test_parse"
+      "test_movtext"
+      "test_encoding_xvid"
+      "test_encoding_tiff"
+      "test_encoding_png"
+      "test_encoding_pcm_s24le"
+      "test_encoding_mpeg4"
+      "test_encoding_mpeg1video"
+      "test_encoding_mp2"
+      "test_encoding_mjpeg"
+      "test_encoding_h264"
+      "test_encoding_dvvideo"
+      "test_encoding_dnxhd"
+      "test_encoding_aac"
+      "test_decoded_video_frame_count"
+      "test_decoded_time_base"
+      "test_decoded_motion_vectors"
+      "test_decode_half"
+      "test_decode_audio_sample_count"
+      "test_data"
+      "test_container_probing"
+      "test_codec_tag"
+      "test_selection"
+    ]
+    ++ lib.optionals (stdenv.isDarwin) [
+      # Segmentation Faults
+      "test_encoding_with_pts"
+      "test_bayer_write"
+    ];
 
   disabledTestPaths = [
     # urlopen fails during DNS resolution

--- a/pkgs/development/python-modules/av/default.nix
+++ b/pkgs/development/python-modules/av/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "av";
-  version = "11.0.0";
+  version = "12.0.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -23,13 +23,16 @@ buildPythonPackage rec {
     owner = "mikeboers";
     repo = "PyAV";
     rev = "refs/tags/v${version}";
-    hash = "sha256-pCKP+4ZmZCJcG7/Qy9H6aS4svQdgaRA9S1QVNWFYhSQ=";
+    hash = "sha256-+xbVkNyFg5VKIf+G6AbAAYVqTSwxFE0Hyc52XSmibAw=";
   };
+
+  build-system = [
+    setuptools
+  ];
 
   nativeBuildInputs = [
     cython
     pkg-config
-    setuptools
   ];
 
   buildInputs = [
@@ -51,6 +54,22 @@ buildPythonPackage rec {
     # urlopen fails during DNS resolution
     "test_writing_to_custom_io"
     "test_decode_close_then_use"
+    "test_bits_per_coded_sample"
+    "test_codec_delay"
+    "test_frame_index"
+    "test_penguin_joke"
+    "test_sky_timelapse"
+    "test_flush_decoded_video_frame_count"
+    "test_path_input"
+    "test_path_output"
+    "test_str_input"
+    "test_str_output"
+    "test_is_corrupt"
+    "test_is_discard"
+    "test_is_disposable"
+    "test_is_keyframe"
+    "test_noside_data"
+    "test_side_data"
     # Tests that want to download FATE data, https://github.com/PyAV-Org/PyAV/issues/955
     "test_vobsub"
     "test_transcode"
@@ -131,10 +150,10 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Pythonic bindings for FFmpeg/Libav";
-    mainProgram = "pyav";
     homepage = "https://github.com/mikeboers/PyAV/";
     changelog = "https://github.com/PyAV-Org/PyAV/blob/v${version}/CHANGELOG.rst";
     license = licenses.bsd2;
     maintainers = with maintainers; [ ];
+    mainProgram = "pyav";
   };
 }


### PR DESCRIPTION
Diff: https://github.com/PyAV-Org/PyAV/compare/refs/tags/v11.0.0...v12.0.0

Changelog: https://github.com/PyAV-Org/PyAV/blob/v12.0.0/CHANGELOG.rst

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
