### PR TITLE
nixos/davfs2: fix rfc42 conversion, make settings and extraConfig mutually exclusive, and other cleanup

### DIFF
--- a/nixos/modules/services/network-filesystems/davfs2.nix
+++ b/nixos/modules/services/network-filesystems/davfs2.nix
@@ -23,7 +23,7 @@ in
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Whether to enable davfs2.
       '';
     };
@@ -31,7 +31,7 @@ in
     davUser = mkOption {
       type = types.str;
       default = "davfs2";
-      description = lib.mdDoc ''
+      description = ''
         When invoked by root the mount.davfs daemon will run as this user.
         Value must be given as name, not as numerical id.
       '';
@@ -40,7 +40,7 @@ in
     davGroup = mkOption {
       type = types.str;
       default = "davfs2";
-      description = lib.mdDoc ''
+      description = ''
         The group of the running mount.davfs daemon. Ordinary users must be
         member of this group in order to mount a davfs2 file system. Value must
         be given as name, not as numerical id.
@@ -55,7 +55,7 @@ in
         proxy foo.bar:8080
         use_locks 0
       '';
-      description = lib.mdDoc ''
+      description = ''
         Extra lines appended to the configuration of davfs2.
         See {manpage}`davfs2.conf(5)` for available settings.
 
@@ -77,7 +77,7 @@ in
           use_locks = 0;
         }
       '';
-      description = lib.mdDoc ''
+      description = ''
         Extra settings appended to the configuration of davfs2.
         See {manpage}`davfs2.conf(5)` for available settings.
       ''  ;

--- a/nixos/modules/services/network-filesystems/davfs2.nix
+++ b/nixos/modules/services/network-filesystems/davfs2.nix
@@ -87,7 +87,8 @@ in
   config = mkIf cfg.enable {
 
     warnings = lib.optional (cfg.extraConfig != "") ''
-      services.davfs2.extraConfig will be deprecated in future releases, please use the settings option now.
+      services.davfs2.extraConfig will be deprecated in future releases;
+      please use services.davfs2.settings instead.
     '';
 
     environment.systemPackages = [ pkgs.davfs2 ];

--- a/nixos/modules/services/network-filesystems/davfs2.nix
+++ b/nixos/modules/services/network-filesystems/davfs2.nix
@@ -86,7 +86,7 @@ in
 
   config = mkIf cfg.enable {
 
-    warnings = lib.optional (cfg.extraConfig != null) ''
+    warnings = lib.optional (cfg.extraConfig != "") ''
       services.davfs2.extraConfig will be deprecated in future releases, please use the settings option now.
     '';
 

--- a/nixos/modules/services/network-filesystems/davfs2.nix
+++ b/nixos/modules/services/network-filesystems/davfs2.nix
@@ -50,9 +50,14 @@ in
       type = lines;
       default = "";
       example = ''
-        kernel_fs coda
         proxy foo.bar:8080
         use_locks 0
+
+        [/media/dav]
+        use_locks 1
+
+        [/home/otto/mywebspace]
+        gui_optimize 1
       '';
       description = ''
         Extra lines appended to the configuration of davfs2.


### PR DESCRIPTION
## Description of changes

Fixes #302243.
Also fixes some additional issue around spurious warnings, mentioned in the comments of #297014.

Also, update the settings option to allow multiple sections (breaking change), and ensure it's mutually exclusive with extraConfig (breaking change).

Finally, update the config generation to conform to the following rules:

> ## General Syntax Rules
> 
> Lines that only contain spaces and tabs (empty lines) are ignored.
> 
> `#` indicates a comment. The rest of the line is ignored.
> 
> `\` is the escape character.
> 
> `""` is used for quotation.
> 
> If a value contains one of the special characters space, tab, `#`, `\`, or `"`, this character must be escaped by a preceding `\`. Use `\ ` instead of ` `, `\#` instead of `#`, `\\` instead of `\` and `\"` instead of `"`.
> 
> Values containing spaces, tabs or `#` may instead be enclosed in double quotes. But `"` and `’` must be escaped even within double quotes. If the starting line of a section is enclosed in double quotes, the square brakets must be within the quotes (like `"[/home/otto/with space]"`).
> 
> Boolean option values (yes/no) must be given as numerical value. `0` for no, `1` for yes.

- fix the warning that deprecates extraConfig
- clarify warning message
- remove `lib.mdDoc` (no-op)
- remove `with lib;`
- fix settings option
- ensure extraConfig and settings are mutually exclusive
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
