### PR TITLE
kdePackages.kservice: handle sycoca disappearing better

### DIFF
--- a/pkgs/kde/frameworks/kservice/default.nix
+++ b/pkgs/kde/frameworks/kservice/default.nix
@@ -2,10 +2,12 @@
 mkKdeDerivation {
   pname = "kservice";
 
+  # FIXME(later): upstream
   patches = [
     # follow symlinks when generating sycoca
-    # FIXME(later): upstream
     ./qdiriterator-follow-symlinks.patch
+    # explode less when sycoca is deleted
+    ./handle-sycoca-deletion.patch
   ];
   meta.mainProgram = "kbuildsycoca6";
 }

--- a/pkgs/kde/frameworks/kservice/handle-sycoca-deletion.patch
+++ b/pkgs/kde/frameworks/kservice/handle-sycoca-deletion.patch
@@ -1,0 +1,14 @@
+diff --git a/src/sycoca/ksycoca.cpp b/src/sycoca/ksycoca.cpp
+index 981342e6..5940f65f 100644
+--- a/src/sycoca/ksycoca.cpp
++++ b/src/sycoca/ksycoca.cpp
+@@ -218,6 +218,10 @@ KSycoca::KSycoca()
+         connect(d->m_fileWatcher.get(), &KDirWatch::dirty, this, [this]() {
+             d->slotDatabaseChanged();
+         });
++        // NIXPKGS: we sometimes delete sycoca externally
++        connect(d->m_fileWatcher.get(), &KDirWatch::deleted, this, [this]() {
++            d->slotDatabaseChanged();
++        });
+     }
+ }


### PR DESCRIPTION
## Description of changes

This is not a complete fix, the whole thing is still full of races, but at least this gets it to explode a lot less often.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
