### PR TITLE
wayfarer: init at 1.2.4

### DIFF
--- a/pkgs/by-name/wa/wayfarer/package.nix
+++ b/pkgs/by-name/wa/wayfarer/package.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, blueprint-compiler
+, desktop-file-utils
+, gst_all_1
+, gtk4
+, libpulseaudio
+, meson
+, ninja
+, pipewire
+, pkg-config
+, vala
+, wrapGAppsHook4
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wayfarer";
+  version = "1.2.4";
+
+  src = fetchFromGitHub {
+    owner = "stronnag";
+    repo = "wayfarer";
+    rev = finalAttrs.version;
+    hash = "sha256-Vuiy2SjpK2T1ekbwa/KyIFa1V4BJsnJRIj4b+Yx0VEw=";
+  };
+
+  postPatch = ''
+    patchShebangs src/getinfo.sh
+
+    # OS release information is not available in the sandbox
+    substituteInPlace meson/baseinfo.py \
+      --replace-warn 'platform.freedesktop_os_release()["NAME"]' '"NixOS"'
+  '';
+
+  nativeBuildInputs = [
+    blueprint-compiler
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    vala
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-ugly
+    gtk4
+    libpulseaudio
+    pipewire
+  ];
+
+  meta = with lib; {
+    description = "Screen recorder for GNOME / Wayland / pipewire";
+    homepage = "https://github.com/stronnag/wayfarer";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ fgaz ];
+    mainProgram = "wayfarer";
+    platforms = subtractLists platforms.darwin platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

Doesn't work for me on `sway` (similar failure as `kooha`), but maybe it works fine for GNOME users

Closes #248285

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
