### PR TITLE
nextcloud-talk-desktop: init at 1.0.0

### DIFF
--- a/pkgs/by-name/ne/nextcloud-talk-desktop/package.nix
+++ b/pkgs/by-name/ne/nextcloud-talk-desktop/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  autoPatchelfHook,
+  nss,
+  cairo,
+  xorg,
+  libxkbcommon,
+  alsa-lib,
+  at-spi2-core,
+  mesa,
+  pango,
+  libdrm,
+  vivaldi-ffmpeg-codecs,
+  gtk3,
+  libGL,
+  libglvnd,
+  systemd,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nextcloud-talk-desktop";
+  version = "1.0.0";
+
+  # Building from source would require building also building Server and Talk components
+  # See https://github.com/nextcloud/talk-desktop?tab=readme-ov-file#%EF%B8%8F-prerequisites
+  src = fetchzip {
+    url = "https://github.com/nextcloud-releases/talk-desktop/releases/download/v${finalAttrs.version}/Nextcloud.Talk-linux-x64.zip";
+    hash = "sha256-XQa4Fa9eEaFlYrWa00S9aMWKJOPPFGSo4NAlRqE23jM=";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs =
+    [
+      nss
+      cairo
+      alsa-lib
+      at-spi2-core
+      pango
+      libdrm
+      libxkbcommon
+      gtk3
+      vivaldi-ffmpeg-codecs
+      mesa
+      libGL
+      libglvnd
+    ]
+    ++ (with xorg; [
+      libX11
+      libXcomposite
+      libXdamage
+      libXrandr
+      libXfixes
+      libXcursor
+    ]);
+
+  # Required to launch the application and proceed past the zygote_linux fork() process
+  # Fixes `Zygote could not fork`
+  runtimeDependencies = [ systemd ];
+
+  preInstall = ''
+    mkdir -p $out/bin
+    mkdir -p $out/opt
+
+    cp -r $src/* $out/opt/
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # Link the application in $out/bin away from contents of `preInstall`
+    ln -s "$out/opt/Nextcloud Talk-linux-x64/Nextcloud Talk" $out/bin/nextcloud-talk-desktop
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Nextcloud Talk Desktop Client";
+    homepage = "https://github.com/nextcloud/talk-desktop";
+    changelog = "https://github.com/nextcloud/talk-desktop/blob/${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ kashw2 ];
+    mainProgram = "nextcloud-talk-desktop";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
## Description of changes

closes https://github.com/NixOS/nixpkgs/issues/253243

https://nextcloud.com/talk/
https://github.com/nextcloud/talk-desktop

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
