### PR TITLE
linuxManualConfig: Use a pure-Nix readConfig

### DIFF
--- a/doc/packages/linux.section.md
+++ b/doc/packages/linux.section.md
@@ -56,7 +56,6 @@ An example of this is building a kernel for use in a VM or micro VM. You can use
   configfile = ./path_to_config_file;
   linux = pkgs.linuxManualConfig {
     inherit version src configfile;
-    allowImportFromDerivation = true;
   };
 }
 ```
@@ -74,10 +73,11 @@ If necessary, the version string can be slightly modified to explicitly mark it 
   configfile = ./path_to_config_file;
   linux = pkgs.linuxManualConfig {
     inherit version modDirVersion src configfile;
-    allowImportFromDerivation = true;
   };
 }
 ```
+
+If `configfile` is a derivation instead of a path, pass `allowImportFromDerivation = true;` to linuxManualConfig to allow reading the config file to detect options from it.
 
 :::
 

--- a/pkgs/os-specific/linux/kernel/read-config.nix
+++ b/pkgs/os-specific/linux/kernel/read-config.nix
@@ -1,0 +1,26 @@
+# Parse Kconfig .config file as an attrset
+
+{ lib }:
+
+configfile:
+
+let
+  configRegex = "(CONFIG_[^.]+)=(([^\"]*)|(\".*\"))";
+  process = line:
+    let
+      matches = lib.strings.match configRegex line;
+      name = lib.elemAt matches 0;
+      valSimple = lib.elemAt matches 2;
+      valQuoted = lib.elemAt matches 3;
+      value =
+        if valSimple == null
+        then lib.strings.fromJSON valQuoted
+        else valSimple;
+    in
+      if matches == null
+      then [ ]
+      else [ { inherit name value; } ];
+
+  lines = lib.strings.splitString "\n" (lib.readFile configfile);
+in
+  lib.listToAttrs (lib.lists.concatMap process lines)


### PR DESCRIPTION
## Description of changes

Use a pure-Nix implementation to parse the configfile so that IFD can be
avoided in many cases.

The original decade-old readConfig function uses a bash script and requires an
IFD even when readFile would suffice. This is really unnecessary for many uses
of linuxManualConfig.

I'm not sure whether this is a good way to do it. Please advise on code organization and whether the interface should work like this.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
