### PR TITLE
python311Packages.moto: 5.0.3 -> 5.0.5; python311Packages.py-partiql-parser: 0.5.1 -> 0.5.4

### DIFF
--- a/pkgs/development/python-modules/moto/default.nix
+++ b/pkgs/development/python-modules/moto/default.nix
@@ -18,6 +18,7 @@
 , xmltodict
 
 # optional-dependencies
+, antlr4-python3-runtime
 , aws-xray-sdk
 , cfn-lint
 , flask
@@ -25,6 +26,7 @@
 , docker
 , graphql-core
 , joserfc
+, jsonpath-ng
 , jsondiff
 , multipart
 , openapi-spec-validator
@@ -41,17 +43,17 @@
 
 buildPythonPackage rec {
   pname = "moto";
-  version = "5.0.3";
+  version = "5.0.5";
   pyproject = true;
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-BwrC7fia167ihTRIHOaOLzRMimqP7+xUJ+6g1Zm/29s=";
+    hash = "sha256-Lqyi33dY9oaN9CC/ByXNC5PZhwlgbx+4sjQ7W9yCLZE=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
   ];
 
@@ -70,6 +72,7 @@ buildPythonPackage rec {
   passthru.optional-dependencies = {
     # non-exhaustive list of extras, that was cobbled together for testing
     all = [
+      antlr4-python3-runtime
       aws-xray-sdk
       cfn-lint
       docker
@@ -78,6 +81,7 @@ buildPythonPackage rec {
       graphql-core
       joserfc
       jsondiff
+      jsonpath-ng
       multipart
       openapi-spec-validator
       pyparsing

--- a/pkgs/development/python-modules/py-partiql-parser/default.nix
+++ b/pkgs/development/python-modules/py-partiql-parser/default.nix
@@ -3,13 +3,13 @@
 , fetchFromGitHub
 , pytestCheckHook
 , pythonOlder
-, setuptools
+, hatchling
 , sure
 }:
 
 buildPythonPackage rec {
   pname = "py-partiql-parser";
-  version = "0.5.1";
+  version = "0.5.4";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -18,11 +18,11 @@ buildPythonPackage rec {
     owner = "getmoto";
     repo = "py-partiql-parser";
     rev = "refs/tags/${version}";
-    hash = "sha256-BPap4f9ro269K50qpVlTiEPNyyMCvBHCr2obuSfuNos=";
+    hash = "sha256-BSqc3xibStb3J6Rua4dDp/eRD5/ns/dU1vGa4vL1Cyo=";
   };
 
-  nativeBuildInputs = [
-    setuptools
+  build-system = [
+    hatchling
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
## Description of changes

https://github.com/getmoto/moto/blob/5.0.5/CHANGELOG.md
https://github.com/getmoto/py-partiql-parser/blob/0.5.4/CHANGELOG.md

This also fixes python311Packages.moto build on aarch64-darwin https://hydra.nixos.org/build/255170681. According to https://zh.fail, this affects other 411 packages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
