### PR TITLE
brainstem: init at 2.10.5

### DIFF
--- a/pkgs/by-name/br/brainstem/package.nix
+++ b/pkgs/by-name/br/brainstem/package.nix
@@ -1,0 +1,90 @@
+{ stdenv
+, lib
+, autoPatchelfHook
+, fetchzip
+, curl
+, systemd
+, zlib
+, writeText
+, withUpdater ? true
+, ...
+}:
+
+let
+  version = "2.10.5";
+  # Upstream has a udev.sh script asking for mode and group, but with uaccess we
+  # don't need any of that and can make it entirely static.
+  # For any rule adding the uaccess tag to be effective, the name of the file it
+  # is defined in has to lexically precede 73-seat-late.rules.
+  udevRule = writeText "60-brainstem.rules" ''
+    # Acroname Brainstem control devices
+    SUBSYSTEM=="usb", ATTRS{idVendor}=="24ff", TAG+="uaccess"
+
+    # Acroname recovery devices (pb82, pb242, pb167)
+    SUBSYSTEM=="tty", ATTRS{idVendor}=="0424", ATTRS{idProduct}=="274e", TAG+="uaccess"
+    SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", TAG+="uaccess"
+    KERNEL=="hidraw*", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="0130", TAG+="uaccess"
+  '';
+
+  src = fetchzip {
+    url = "https://acroname.com/sites/default/files/software/brainstem_sdk/${version}/brainstem_sdk_${version}_Ubuntu_LTS_22.04_x86_64.tgz";
+    hash = "sha256-S6u9goxTMCI12sffP/WKUF7bv0pLeNmNog7Hle+vpR4=";
+    # There's no "brainstem" parent directory in the archive.
+    stripRoot = false;
+  };
+in
+
+stdenv.mkDerivation {
+  pname = "brainstem";
+  inherit version src;
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [
+    # libudev
+    (lib.getLib systemd)
+    # libstdc++.so libgcc_s.so
+    stdenv.cc.cc.lib
+  ] ++ lib.optionals withUpdater [
+    # libcurl.so.4
+    curl
+    # libz.so.1
+    zlib
+  ];
+
+  # Unpack the CLI tools, documentation, library and C headers.
+  # There's also a python .whl, containing more libraries, which might be used
+  # to support more architectures, too, but let's only do that if we need it.
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m744 cli/AcronameHubCLI $out/bin
+    install -m744 cli/Updater $out/bin/AcronameHubUpdater
+
+    mkdir -p $out/lib/udev/rules.d
+    cp ${udevRule} $out/lib/udev/rules.d/60-brainstem.rules
+
+    mkdir -p $doc
+    cp docs/* $doc/
+    cp {license,version}.txt $doc/
+
+    mkdir -p $lib/lib
+    cp api/lib/libBrainStem2.* $lib/lib
+
+    mkdir -p $dev/include
+    cp -R api/lib/BrainStem2 $dev/include/
+  '';
+
+  outputs = [ "out" "lib" "dev" "doc" ];
+
+  meta = with lib; {
+    description = "BrainStem Software Development Kit";
+    longDescription = ''
+      The BrainStem SDK provides a library to access and control Acroname smart
+      USB switches, as well as a CLI interface, and a firmware updater.
+    '';
+    homepage = "https://acroname.com/software/brainstem-development-kit";
+    platforms = [ "x86_64-linux" ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ flokli ];
+    mainProgram = "AcronameHubCLI";
+  };
+}


### PR DESCRIPTION
This provides a library and CLI tools to control Acroname USB Smart switches, as well as a firmware updater.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
