### PR TITLE
pgadmin4: fix CSRF issue

### DIFF
--- a/pkgs/tools/admin/pgadmin/default.nix
+++ b/pkgs/tools/admin/pgadmin/default.nix
@@ -26,7 +26,18 @@ let
 
   # keep the scope, as it is used throughout the derivation and tests
   # this also makes potential future overrides easier
-  pythonPackages = python3.pkgs.overrideScope (final: prev: rec { });
+  pythonPackages = python3.pkgs.overrideScope (final: prev: rec {
+    # Flask 5.4.3 introduces an CSRF error which makes it impossible to login
+    # So either we downgrade flask here or use "WTF_CSRF_ENABLED = false" in the
+    # module config to disable CSRF.
+    flask-security-too = prev.flask-security-too.overridePythonAttrs (oldAttrs: rec {
+      version = "5.4.1";
+      src = oldAttrs.src.override {
+        inherit version;
+        hash = "sha256-Ay7+gk+zuUlXtw0LDdsnvSa22z+yE6VR1guu9QmiFvw=";
+      };
+    });
+  });
 
   offlineCache = fetchYarnDeps {
     yarnLock = ./yarn.lock;


### PR DESCRIPTION
## Description of changes

Currently `pgadmin4` builds, but is unusable, because of an CSRF error. This has been detected by the nixosTests, which also fail.

The error reported is:
```
vm-test-run-pgadmin> machine # [  236.575825] pgadmin4[1048]: During handling of the above exception, another exception occurred:
vm-test-run-pgadmin> machine # [  236.580809] pgadmin4[1048]: Traceback (most recent call last):
vm-test-run-pgadmin> machine # [  236.584512] pgadmin4[1048]:   File "/nix/store/xby1yvrm51w58mc3779rj83sh83f1mjh-python3.11-flask-3.0.2/lib/pythot
vm-test-run-pgadmin> machine # [  236.592745] pgadmin4[1048]:     rv = self.dispatch_request()
vm-test-run-pgadmin> machine # [  236.596476] pgadmin4[1048]:          ^^^^^^^^^^^^^^^^^^^^^^^
vm-test-run-pgadmin> machine # [  236.600238] pgadmin4[1048]:   File "/nix/store/xby1yvrm51w58mc3779rj83sh83f1mjh-python3.11-flask-3.0.2/lib/pythot
vm-test-run-pgadmin> machine # [  236.608399] pgadmin4[1048]:     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type]
vm-test-run-pgadmin> machine # [  236.614746] pgadmin4[1048]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vm-test-run-pgadmin> machine # [  236.619824] pgadmin4[1048]:   File "/nix/store/sncgkv4r22mgsmn1g0y8x38b06b04bl4-python3.11-flask-security-too-5.d
vm-test-run-pgadmin> machine # [  236.628693] pgadmin4[1048]:     _csrf.protect()
vm-test-run-pgadmin> machine # [  236.631817] pgadmin4[1048]:   File "/nix/store/ng6000k66z46srnp87357sg6fsn3dvvc-python3.11-flask-wtf-1.2.1/lib/pt
vm-test-run-pgadmin> machine # [  236.639818] pgadmin4[1048]:     self._error_response(e.args[0])
vm-test-run-pgadmin> machine # [  236.643649] pgadmin4[1048]:   File "/nix/store/ng6000k66z46srnp87357sg6fsn3dvvc-python3.11-flask-wtf-1.2.1/lib/python3.11/site-packages/flask_wtf/csrf.py", line 307, in _error_response
vm-test-run-pgadmin> machine # [  236.652669] pgadmin4[1048]:     raise CSRFError(reason)
vm-test-run-pgadmin> machine # [  236.655687] pgadmin4[1048]: flask_wtf.csrf.CSRFError: 400 Bad Request: The CSRF token is missing.
```


Most likely https://github.com/Flask-Middleware/flask-security/issues/954 (from the [changelog](https://flask-security-too.readthedocs.io/en/stable/changelog.html)) is the issue here. Downgrading `flask-security-too` to version 5.4.1 solves the issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] tested in a VM

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
