### PR TITLE
pomodoro-gtk: init at 1.4.1

### DIFF
--- a/pkgs/by-name/po/pomodoro-gtk/package.nix
+++ b/pkgs/by-name/po/pomodoro-gtk/package.nix
@@ -1,0 +1,63 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, gjs
+, gobject-introspection
+, blueprint-compiler
+, wrapGAppsHook4
+, desktop-file-utils
+, libadwaita
+, libgda6
+, gsound
+, gst_all_1
+, libportal-gtk4
+}:
+
+stdenv.mkDerivation {
+  pname = "pomodoro-gtk";
+  version = "1.4.1";
+
+  src = fetchFromGitLab {
+    owner = "idevecore";
+    repo = "pomodoro";
+    rev = "44b724557539084991f3eb55b9593053a2c73eba"; # author didn't make a tag
+    fetchSubmodules = true;
+    hash = "sha256-krVRVMrrzuqPY/3P9dCz7rVCCW7/j5cpT95XniGpBEs=";
+  };
+
+  postPatch = ''
+    patchShebangs --build troll/gjspack/bin/gjspack
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gjs # runtime for gjspack
+    gobject-introspection
+    blueprint-compiler
+    wrapGAppsHook4
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    gjs
+    libadwaita
+    libgda6
+    gsound
+    gst_all_1.gst-plugins-base
+    libportal-gtk4
+  ];
+
+  meta = {
+    description = "A simple and intuitive timer application (also named Planytimer)";
+    homepage = "https://gitlab.com/idevecore/pomodoro";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "pomodoro";
+    maintainers = with lib.maintainers; [ aleksana ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

![image](https://github.com/NixOS/nixpkgs/assets/42209822/dcbebfec-f98f-4435-aca5-4903e3a31cad)

Closes https://github.com/NixOS/nixpkgs/issues/299041

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
