### PR TITLE
treewide: Drop infinisil as maintainer from most packages

### DIFF
--- a/nixos/modules/services/backup/znapzend.nix
+++ b/nixos/modules/services/backup/znapzend.nix
@@ -465,5 +465,5 @@ in
     };
   };
 
-  meta.maintainers = with maintainers; [ infinisil SlothOfAnarchy ];
+  meta.maintainers = with maintainers; [ SlothOfAnarchy ];
 }

--- a/nixos/modules/services/networking/radicale.nix
+++ b/nixos/modules/services/networking/radicale.nix
@@ -200,5 +200,5 @@ in {
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ infinisil dotlambda ];
+  meta.maintainers = with lib.maintainers; [ dotlambda ];
 }

--- a/pkgs/applications/audio/synaesthesia/default.nix
+++ b/pkgs/applications/audio/synaesthesia/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     description = "Program for representing sounds visually";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.infinisil ];
+    maintainers = [ ];
     mainProgram = "synaesthesia";
   };
 }

--- a/pkgs/applications/misc/bashSnippets/default.nix
+++ b/pkgs/applications/misc/bashSnippets/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
     description = "A collection of small bash scripts for heavy terminal users";
     homepage = "https://github.com/alexanderepstein/Bash-Snippets";
     license = licenses.mit;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -82,6 +82,6 @@ with python3.pkgs; buildPythonApplication rec {
     homepage = "https://github.com/jarun/Buku";
     license = licenses.gpl3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ matthiasbeyer infinisil ];
+    maintainers = with maintainers; [ matthiasbeyer ];
   };
 }

--- a/pkgs/applications/misc/tasknc/default.nix
+++ b/pkgs/applications/misc/tasknc/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/lharding/tasknc";
     description = "A ncurses wrapper around taskwarrior";
     mainProgram = "tasknc";
-    maintainers = with maintainers; [ matthiasbeyer infinisil ];
+    maintainers = with maintainers; [ matthiasbeyer ];
     platforms = platforms.linux; # Cannot test others
     license = licenses.mit;
   };

--- a/pkgs/applications/misc/tmatrix/default.nix
+++ b/pkgs/applications/misc/tmatrix/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/M4444/TMatrix";
     license = licenses.gpl2;
     platforms = platforms.all;
-    maintainers = with maintainers; [ infinisil Br1ght0ne ];
+    maintainers = with maintainers; [ Br1ght0ne ];
     mainProgram = "tmatrix";
   };
 }

--- a/pkgs/applications/misc/translate-shell/default.nix
+++ b/pkgs/applications/misc/translate-shell/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.soimort.org/translate-shell";
     description = "Command-line translator using Google Translate, Bing Translator, Yandex.Translate, and Apertium";
     license = licenses.unlicense;
-    maintainers = with maintainers; [ ebzzry infinisil ];
+    maintainers = with maintainers; [ ebzzry ];
     mainProgram = "trans";
     platforms = platforms.unix;
   };

--- a/pkgs/applications/networking/instant-messengers/ripcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ripcord/default.nix
@@ -63,7 +63,7 @@ mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     # See: https://cancel.fm/ripcord/shareware-redistribution/
     license = licenses.unfreeRedistributable;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -51,7 +51,7 @@ let
       mainProgram = "mumble-server";
       homepage = "https://mumble.info";
       license = licenses.bsd3;
-      maintainers = with maintainers; [ infinisil felixsinger lilacious ];
+      maintainers = with maintainers; [ felixsinger lilacious ];
       platforms = platforms.linux;
     };
   });

--- a/pkgs/applications/networking/znc/modules.nix
+++ b/pkgs/applications/networking/znc/modules.nix
@@ -37,7 +37,7 @@ in
       description = "Request backlog for IRC channels.";
       homepage = "https://github.com/fruitiex/znc-backlog/";
       license = licenses.asl20;
-      maintainers = with maintainers; [ infinisil ];
+      maintainers = [ ];
     };
   };
 

--- a/pkgs/applications/science/math/almonds/default.nix
+++ b/pkgs/applications/science/math/almonds/default.nix
@@ -22,6 +22,6 @@ with python3.pkgs; buildPythonApplication rec {
     mainProgram = "almonds";
     homepage = "https://github.com/Tenchi2xh/Almonds";
     license = licenses.mit;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/interpreters/bats/libraries.nix
+++ b/pkgs/development/interpreters/bats/libraries.nix
@@ -21,7 +21,7 @@
       platforms = lib.platforms.all;
       homepage = "https://github.com/bats-core/bats-assert";
       license = lib.licenses.cc0;
-      maintainers = with lib.maintainers; [ infinisil ];
+      maintainers = [ ];
     };
   });
 
@@ -47,7 +47,7 @@
       platforms = lib.platforms.all;
       homepage = "https://github.com/bats-core/bats-file";
       license = lib.licenses.cc0;
-      maintainers = with lib.maintainers; [ infinisil ];
+      maintainers = [ ];
     };
   });
 
@@ -98,7 +98,7 @@
       platforms = lib.platforms.all;
       homepage = "https://github.com/bats-core/bats-support";
       license = lib.licenses.cc0;
-      maintainers = with lib.maintainers; [ infinisil ];
+      maintainers = [ ];
     };
   });
 }

--- a/pkgs/development/libraries/libimobiledevice-glue/default.nix
+++ b/pkgs/development/libraries/libimobiledevice-glue/default.nix
@@ -37,6 +37,6 @@ stdenv.mkDerivation rec {
     description = "Library with common code used by the libraries and tools around the libimobiledevice project";
     license = licenses.lgpl21Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/libimobiledevice/default.nix
+++ b/pkgs/development/libraries/libimobiledevice/default.nix
@@ -77,6 +77,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.lgpl21Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/libplist/default.nix
+++ b/pkgs/development/libraries/libplist/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     description = "A library to handle Apple Property List format in binary or XML";
     homepage = "https://github.com/libimobiledevice/libplist";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
     platforms = platforms.unix;
     mainProgram = "plistutil";
   };

--- a/pkgs/development/libraries/libusbmuxd/default.nix
+++ b/pkgs/development/libraries/libusbmuxd/default.nix
@@ -37,6 +37,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/libimobiledevice/libusbmuxd";
     license = licenses.lgpl21Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pymumble/default.nix
+++ b/pkgs/development/python-modules/pymumble/default.nix
@@ -48,6 +48,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/azlux/pymumble";
     changelog = "https://github.com/azlux/pymumble/releases/tag/${version}";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ thelegy infinisil ];
+    maintainers = with maintainers; [ thelegy ];
   };
 }

--- a/pkgs/development/python-modules/pyradios/default.nix
+++ b/pkgs/development/python-modules/pyradios/default.nix
@@ -32,6 +32,6 @@ buildPythonPackage rec {
     description = "Python client for the https://api.radio-browser.info";
     homepage = "https://github.com/andreztz/pyradios";
     license = licenses.mit;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/wand/default.nix
+++ b/pkgs/development/python-modules/wand/default.nix
@@ -43,6 +43,6 @@ buildPythonPackage rec {
     description = "Ctypes-based simple MagickWand API binding for Python";
     homepage = "http://wand-py.org/";
     license = [ licenses.mit ];
-    maintainers = with maintainers; [ infinisil dotlambda ];
+    maintainers = with maintainers; [ dotlambda ];
   };
 }

--- a/pkgs/games/minecraft/default.nix
+++ b/pkgs/games/minecraft/default.nix
@@ -147,7 +147,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Official launcher for Minecraft, a sandbox-building game";
     homepage = "https://minecraft.net";
-    maintainers = with maintainers; [ cpages ryantm infinisil ];
+    maintainers = with maintainers; [ cpages ryantm ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];

--- a/pkgs/games/pacvim/default.nix
+++ b/pkgs/games/pacvim/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/jmoon018/PacVim";
     description = "A game that teaches you vim commands";
     mainProgram = "pacvim";
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
     license = licenses.lgpl3;
     platforms = platforms.unix;
   };

--- a/pkgs/servers/invidious/default.nix
+++ b/pkgs/servers/invidious/default.nix
@@ -110,6 +110,6 @@ crystal.buildCrystalPackage rec {
     mainProgram = "invidious";
     homepage = "https://invidious.io/";
     license = licenses.agpl3Plus;
-    maintainers = with maintainers; [ infinisil sbruder ];
+    maintainers = with maintainers; [ sbruder ];
   };
 }

--- a/pkgs/servers/radicale/2.x.nix
+++ b/pkgs/servers/radicale/2.x.nix
@@ -46,6 +46,6 @@ python3.pkgs.buildPythonApplication rec {
       on mobile phones or computers.
     '';
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ edwtjo pSub infinisil ];
+    maintainers = with maintainers; [ edwtjo pSub ];
   };
 }

--- a/pkgs/tools/X11/xwinwrap/default.nix
+++ b/pkgs/tools/X11/xwinwrap/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.hpnd;
     homepage = "https://shantanugoel.com/2008/09/03/shantz-xwinwrap/";
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
     platforms = platforms.linux;
     mainProgram = "xwinwrap";
   };

--- a/pkgs/tools/audio/botamusique/default.nix
+++ b/pkgs/tools/audio/botamusique/default.nix
@@ -151,7 +151,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/azlux/botamusique";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
     mainProgram = "botamusique";
   };
 }

--- a/pkgs/tools/filesystems/ifuse/default.nix
+++ b/pkgs/tools/filesystems/ifuse/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.lgpl21Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
     mainProgram = "ifuse";
   };
 }

--- a/pkgs/tools/graphics/blockhash/default.nix
+++ b/pkgs/tools/graphics/blockhash/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
       Fan Gu and Xiamu Niu.
     '';
     license = licenses.mit;
-    maintainers = [ maintainers.infinisil ];
+    maintainers = [ ];
     platforms = platforms.unix;
     mainProgram = "blockhash";
   };

--- a/pkgs/tools/graphics/jpegexiforient/default.nix
+++ b/pkgs/tools/graphics/jpegexiforient/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     # to be free since it's from IJG, the current maintainers of libjpeg
     license = licenses.free;
     platforms = platforms.all;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
     mainProgram = "jpegexiforient";
   };
 }

--- a/pkgs/tools/misc/dijo/default.nix
+++ b/pkgs/tools/misc/dijo/default.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
     description = "Scriptable, curses-based, digital habit tracker";
     homepage = "https://github.com/NerdyPepper/dijo";
     license = licenses.mit;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
     mainProgram = "dijo";
   };
 }

--- a/pkgs/tools/misc/hueadm/default.nix
+++ b/pkgs/tools/misc/hueadm/default.nix
@@ -22,7 +22,7 @@ buildNpmPackage rec {
     description = "Command line management interface to Philips Hue";
     homepage = "https://github.com/bahamas10/hueadm";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ infinisil ];
+    maintainers = [ ];
     mainProgram = "hueadm";
   };
 }

--- a/pkgs/tools/misc/ideviceinstaller/default.nix
+++ b/pkgs/tools/misc/ideviceinstaller/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ aristid infinisil ];
+    maintainers = with maintainers; [ aristid ];
     mainProgram = "ideviceinstaller";
   };
 }

--- a/pkgs/tools/misc/nms/default.nix
+++ b/pkgs/tools/misc/nms/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       effect seen in the 1992 movie Sneakers.
     '';
     license = licenses.gpl3;
-    maintainers = [ maintainers.infinisil ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/pdd/default.nix
+++ b/pkgs/tools/misc/pdd/default.nix
@@ -28,7 +28,7 @@ buildPythonApplication rec {
       program arguments are specified it shows the current date, time and
       timezone.
     '';
-    maintainers = [ maintainers.infinisil ];
+    maintainers = [ ];
     license = licenses.gpl3;
     mainProgram = "pdd";
   };

--- a/pkgs/tools/misc/sta/default.nix
+++ b/pkgs/tools/misc/sta/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
     '';
     license = licenses.mit;
     homepage = "https://github.com/simonccarter/sta";
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
     platforms = platforms.all;
     badPlatforms = platforms.darwin;
     mainProgram = "sta";

--- a/pkgs/tools/misc/usbmuxd/default.nix
+++ b/pkgs/tools/misc/usbmuxd/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
     mainProgram = "usbmuxd";
   };
 }

--- a/pkgs/tools/networking/bukubrow/default.nix
+++ b/pkgs/tools/networking/bukubrow/default.nix
@@ -42,7 +42,7 @@ in rustPlatform.buildRustPackage rec {
     description = "A WebExtension for Buku, a command-line bookmark manager";
     homepage = "https://github.com/SamHH/bukubrow-host";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
     mainProgram = "bukubrow";
   };
 }

--- a/pkgs/tools/networking/shadowfox/default.nix
+++ b/pkgs/tools/networking/shadowfox/default.nix
@@ -34,7 +34,7 @@ buildGoModule rec {
     description = "Universal dark theme for Firefox while adhering to the modern design principles set by Mozilla";
     homepage = "https://overdodactyl.github.io/ShadowFox/";
     license = licenses.mit;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
     mainProgram = "shadowfox-updater";
   };
 }

--- a/pkgs/tools/security/browserpass/default.nix
+++ b/pkgs/tools/security/browserpass/default.nix
@@ -69,6 +69,6 @@ buildGoModule rec {
     mainProgram = "browserpass";
     homepage = "https://github.com/browserpass/browserpass-native";
     license = licenses.isc;
-    maintainers = with maintainers; [ rvolosatovs infinisil ];
+    maintainers = with maintainers; [ rvolosatovs ];
   };
 }

--- a/pkgs/tools/system/s-tui/default.nix
+++ b/pkgs/tools/system/s-tui/default.nix
@@ -30,7 +30,7 @@ python3Packages.buildPythonPackage rec {
     homepage = "https://amanusk.github.io/s-tui/";
     description = "Stress-Terminal UI monitoring tool";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = [ ];
     broken = stdenv.isDarwin; # https://github.com/amanusk/s-tui/issues/49
     mainProgram = "s-tui";
   };


### PR DESCRIPTION
## Description of changes

I'm not going anywhere, I'm just focusing my energy on other issues, and getting pinged as a maintainer for packages is a bit distracting (also I'm not using most of these packages anyways!).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
