### PR TITLE
GNOME: update extensions for v46

### DIFF
--- a/pkgs/desktops/gnome/extensions/arcmenu/default.nix
+++ b/pkgs/desktops/gnome/extensions/arcmenu/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-arcmenu";
-  version = "52";
+  version = "55";
 
   src = fetchFromGitLab {
     owner = "arcmenu";
     repo = "ArcMenu";
     rev = "v${version}";
-    sha256 = "sha256-nZRdNkS4JfSwtqQsROKa1+eqcgwMQwVsqgeWVPpZIi0=";
+    sha256 = "sha256-xLKvcrZkqcj7aHiv9JumLWSP5LbajITAyopCIwGqpkE=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/extensions/argos/default.nix
+++ b/pkgs/desktops/gnome/extensions/argos/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, lib, stdenv }:
+{ fetchFromGitHub, lib, stdenv, unstableGitUpdater }:
 
 stdenv.mkDerivation rec {
   pname = "argos";
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
   passthru = {
     extensionUuid = "argos@pew.worldwidemann.com";
     extensionPortalSlug = "argos";
+    updateScript = unstableGitUpdater { };
   };
 
   meta = with lib; {

--- a/pkgs/desktops/gnome/extensions/argos/default.nix
+++ b/pkgs/desktops/gnome/extensions/argos/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "argos";
-  version = "unstable-2023-09-26";
+  version = "unstable-2024-04-03";
 
   src = fetchFromGitHub {
     owner = "p-e-w";
     repo = "argos";
-    rev = "adfaa31e8c08f7b59e9492891a7e6f753c29b35e";  # https://github.com/p-e-w/argos/pull/150
-    hash = "sha256-st8AeMRtkvM4M/Z70qopjw9Yx0t9l0DsUke4ClQtcBU=";
+    rev = "0449229e11bc2bb5c66e6f1d8503635cdf276bcf";
+    hash = "sha256-szBk3zW+HzfxTI34lLB1DFdnwZ3W+BgeVgDkwf0UzQU=";
   };
 
   installPhase = ''

--- a/pkgs/desktops/gnome/extensions/collisions.json
+++ b/pkgs/desktops/gnome/extensions/collisions.json
@@ -348,6 +348,24 @@
     "battery-time": [
       "batime@martin.zurowietz.de",
       "batterytime@typeof.pw"
+    ],
+    "power-profile-indicator": [
+      "power-profile-indicator@laux.wtf",
+      "power-profile@fthx"
+    ]
+  },
+  "46": {
+    "applications-menu": [
+      "apps-menu@gnome-shell-extensions.gcampax.github.com",
+      "Applications_Menu@rmy.pobox.com"
+    ],
+    "persian-calendar": [
+      "PersianCalendar@oxygenws.com",
+      "persian-calendar@iamrezamousavi.gmail.com"
+    ],
+    "power-profile-indicator": [
+      "power-profile-indicator@laux.wtf",
+      "power-profile@fthx"
     ]
   }
 }

--- a/pkgs/desktops/gnome/extensions/default.nix
+++ b/pkgs/desktops/gnome/extensions/default.nix
@@ -64,9 +64,10 @@ in rec {
   gnome43Extensions = mapUuidNames (produceExtensionsList "43");
   gnome44Extensions = mapUuidNames (produceExtensionsList "44");
   gnome45Extensions = mapUuidNames (produceExtensionsList "45");
+  gnome46Extensions = mapUuidNames (produceExtensionsList "46");
 
   # Keep the last three versions in here
-  gnomeExtensions = lib.trivial.pipe (gnome43Extensions // gnome44Extensions // gnome45Extensions) [
+  gnomeExtensions = lib.trivial.pipe (gnome44Extensions // gnome45Extensions // gnome46Extensions) [
     (v: builtins.removeAttrs v [ "__attrsFailEvaluation" ])
     # Apply some custom patches for automatically packaged extensions
     (callPackage ./extensionOverrides.nix {})

--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -106,6 +106,14 @@ super: lib.trivial.pipe super [
     ];
   }))
 
+  (patchExtension "mullvadindicator@pobega.github.com" (old: {
+    patches = [
+      # Patch from https://github.com/Pobega/gnome-shell-extension-mullvad-indicator/pull/36
+      # tweaked to drop the Makefile changes to fix application
+      ./extensionOverridesPatches/mullvadindicator_at_pobega.github.com.patch
+    ];
+  }))
+
   (patchExtension "pano@elhan.io" (old: {
     patches = [
       (substituteAll {

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/mullvadindicator_at_pobega.github.com.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/mullvadindicator_at_pobega.github.com.patch
@@ -1,0 +1,25 @@
+From ea472538fc73e9ab81e50183444dbb256d32ecc0 Mon Sep 17 00:00:00 2001
+From: Sergio Rubio <rubiojr@rbel.co>
+Date: Wed, 27 Mar 2024 20:43:38 +0100
+Subject: [PATCH] Bump GNOME desktop version
+
+The extension is 46 compatible.
+
+---
+ metadata.json | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletions(-)
+
+diff --git a/metadata.json b/metadata.json
+index bc0e272..e647258 100644
+--- a/metadata.json
++++ b/metadata.json
+@@ -3,7 +3,8 @@
+   "description": "Mullvad connection status indicator",
+   "uuid": "mullvadindicator@pobega.github.com",
+   "shell-version": [
+-    "45"
++    "45",
++    "46"
+   ],
+   "url": "https://github.com/Pobega/gnome-shell-extension-mullvad-indicator",
+   "settings-schema": "org.gnome.shell.extensions.MullvadIndicator",

--- a/pkgs/desktops/gnome/extensions/impatience/default.nix
+++ b/pkgs/desktops/gnome/extensions/impatience/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-impatience";
-  version = "0.5.0";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "timbertson";
     repo = "gnome-shell-impatience";
     rev = "refs/tags/version-${version}";
-    hash = "sha256-qvRPdRxAxlylR+MRp8RLzkxIMulzxPSWbhOQ2qNuyt4=";
+    hash = "sha256-yBRnhdCDeA0bL+kkrmnIqyXAlhZzO2Vthc4Dnba80j4=";
   };
 
   buildInputs = [

--- a/pkgs/desktops/gnome/extensions/pop-shell/default.nix
+++ b/pkgs/desktops/gnome/extensions/pop-shell/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, glib, gjs, typescript }:
+{ stdenv, lib, fetchFromGitHub, glib, gjs, typescript, unstableGitUpdater }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-pop-shell";
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
   passthru = {
     extensionUuid = "pop-shell@system76.com";
     extensionPortalSlug = "pop-shell";
+    updateScript = unstableGitUpdater { };
   };
 
   postPatch = ''

--- a/pkgs/desktops/gnome/extensions/pop-shell/default.nix
+++ b/pkgs/desktops/gnome/extensions/pop-shell/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-pop-shell";
-  version = "unstable-2023-11-10";
+  version = "unstable-2024-04-04";
 
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "shell";
-    rev = "aafc9458a47a68c396933c637de00421f5198a2a";
-    hash = "sha256-74lZbEYHj7fufRSbuI2SN9rqbB3gpRa0V96qjAFc01s=";
+    rev = "cfa0c55e84b7ce339e5ce83832f76fee17e99d51";
+    hash = "sha256-IQJtTMYCkKyjqDKoR35qsgQkvXIrGLq+qtMDOTkvy08=";
   };
 
   nativeBuildInputs = [ glib gjs typescript ];

--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -21,6 +21,7 @@ supported_versions = {
     "43": "43",
     "44": "44",
     "45": "45",
+    "46": "46",
 }
 
 # Some type alias to increase readability of complex compound types


### PR DESCRIPTION
## Description of changes

Updates the GNOME extensions set in its entirety to bring in support for GNOME 46.

I've updated the `extensions.json` file with the `update-extensions.py` script, and `nix-update`'d the ones we build directly if there were compatible versions available.

Opened as a separate PR as requested here: https://github.com/NixOS/nixpkgs/pull/291339#issuecomment-2045420740

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
