### PR TITLE
paperjam: init at 1.2.1

### DIFF
--- a/pkgs/by-name/pa/paperjam/package.nix
+++ b/pkgs/by-name/pa/paperjam/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  qpdf,
+  libiconv,
+  libpaper,
+  asciidoc,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "paperjam";
+  version = "1.2.1";
+
+  src = fetchurl {
+    url = "https://mj.ucw.cz/download/linux/paperjam-${finalAttrs.version}.tar.gz";
+    hash = "sha256-vTjtNTkBHwfoRDshmFu1zZfGVuEtk2NXH5JdA5Ekg5s=";
+  };
+
+  buildInputs = [
+    qpdf
+    libpaper
+    asciidoc
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin libiconv;
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    # prevent real build date which is impure
+    "BUILD_DATE=\<unknown\>"
+    "BUILD_COMMIT=\<unknown\>"
+  ];
+
+  # provide backward compatible PointerHolder, suppress deprecation warnings
+  env.NIX_CFLAGS_COMPILE = "-DPOINTERHOLDER_TRANSITION=1";
+  env.NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-liconv";
+
+  meta = {
+    homepage = "https://mj.ucw.cz/sw/paperjam/";
+    description = "Program for transforming PDF files";
+    longDescription = ''
+      PaperJam is a program for transforming PDF files. It can re-arrange
+      pages, scale and rotate them, put multiple pages on a single sheet, draw
+      cropmarks, and many other tricks.
+    '';
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "paperjam";
+    maintainers = with lib.maintainers; [ cbley ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

[Paperjam](https://mj.ucw.cz/sw/paperjam/) is a simple command line tool for manipulating PDF files (rotate pages, reorder them, put multiple pages on one for cheaper printing…). It is similar to pspdftool, but maintained (can correctly handle compressed PDFs for example).

previously: https://github.com/NixOS/nixpkgs/pull/216782
previously: https://github.com/jvns/nixpkgs/blob/22b70a48a797538c76b04261b3043165896d8f69/paperjam.nix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
