### PR TITLE
lightning-terminal: init at 0.12.4-alpha

### DIFF
--- a/pkgs/applications/blockchains/lightning-terminal/default.nix
+++ b/pkgs/applications/blockchains/lightning-terminal/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchYarnDeps
+, mkYarnPackage
+, buildGoModule
+, nodejs
+, yarn
+, gnumake
+, go
+, git
+, fixup_yarn_lock
+}:
+
+buildGoModule rec {
+  pname = "lightning-terminal";
+  version = "0.12.4-alpha";
+  src = fetchFromGitHub {
+    owner = "lightninglabs";
+    repo = "lightning-terminal";
+    rev = "v${version}";
+    hash = "sha256-gGo9abd12zZPPTBkmEfB8BNK1ZVpea2uZNpeYRb5l00=";
+  };
+
+  app = mkYarnPackage {
+    name = "lightning-app";
+    src = "${src}/app";
+    packageJSON = "${src}/app/package.json";
+    yarnLock = "${src}/app/yarn.lock";
+  };
+
+  vendorHash = "sha256-MwVTmwOb0wW2e9lEbr/Pm2IhHXizwEgaw5j+x8+XA+E=";
+
+  ldflags = [
+    "-s -w"
+    "-X github.com/lightningnetwork/lnd/build.Commit=b5117a483a8dd8418e28b87531f130655b990825"
+    "-X github.com/lightningnetwork/lnd/build.CommitHash=8bba79222f439127e46ec3ff7ec7c650e0d88d56"
+    "-X github.com/lightningnetwork/lnd/build.GoVersion=go1.22.3"
+    "-X github.com/lightningnetwork/lnd/build.RawTags=litd,autopilotrpc,signrpc,walletrpc,chainrpc,invoicesrpc,watchtowerrpc,neutrinorpc,peersrpc"
+    "-X github.com/lightninglabs/lightning-terminal.appFilesPrefix="
+    "-X github.com/lightninglabs/lightning-terminal.Commit=b5117a483a8dd8418e28b87531f130655b990825"
+    "-X github.com/lightninglabs/loop.Commit=23b818e436ddf24013ad5a617a503801de53d783"
+    "-X github.com/lightninglabs/pool.Commit=e5d6a5ff0bc52df7a5b025b8098e709722a44d96"
+    "-X github.com/lightninglabs/taproot-assets.Commit=564795a0e4c1d1034493b498f58a552920f2e39c"
+  ];
+
+  subPackages = [ "cmd/litcli" "cmd/litd" ];
+
+  tags = [
+    "litd"
+    "autopilotrpc"
+    "signrpc"
+    "walletrpc"
+    "chainrpc"
+    "invoicesrpc"
+    "watchtowerrpc"
+    "neutrinorpc"
+    "peersrpc"
+  ];
+
+  postInstall = ''
+    cp -r $out/bin/* $out/
+  '';
+
+  meta = with lib; {
+    description =
+      "All-in-one Lightning node management tool that includes LND, Loop, Pool, Faraday, and Tapd.";
+    homepage = "https://github.com/lightninglabs/lightning-terminal";
+    license = licenses.mit;
+    maintainers = with maintainers; [ HannahMR ];
+    mainProgram = "litd";
+  };
+}


### PR DESCRIPTION
## Description of changes

This provides Lightning Terminal a browser-based interface for managing a Lightning node and for connecting to Terminal Web. Litd includes LND, Loop, Pool, Faraday, and Tapd. 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

