### PR TITLE
valkey: init at 7.2.5

### DIFF
--- a/pkgs/by-name/va/valkey/package.nix
+++ b/pkgs/by-name/va/valkey/package.nix
@@ -1,0 +1,85 @@
+{ lib, stdenv, fetchFromGitHub, lua, jemalloc, pkg-config
+, tcl, which, ps, getconf
+, withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd, systemd
+# dependency ordering is broken at the moment when building with openssl
+, tlsSupport ? !stdenv.hostPlatform.isStatic, openssl
+
+# Using system jemalloc fixes cross-compilation and various setups.
+# However the experimental 'active defragmentation' feature of valkey requires
+# their custom patched version of jemalloc.
+, useSystemJemalloc ? true
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "valkey";
+  version = "7.2.5";
+
+  src = fetchFromGitHub {
+    owner = "valkey-io";
+    repo = "valkey";
+    rev = finalAttrs.version;
+    hash = "sha256-nDAQbxlSBXKSJqZgvElsrZeDnHw4A4eA8f9ecXdx0/U=";
+  };
+
+  patches = lib.optional useSystemJemalloc ./use_system_jemalloc.patch;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ lua ]
+    ++ lib.optional useSystemJemalloc jemalloc
+    ++ lib.optional withSystemd systemd
+    ++ lib.optional tlsSupport openssl;
+
+  preBuild = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace src/Makefile --replace-fail "-flto" ""
+  '';
+
+  # More cross-compiling fixes.
+  makeFlags = [ "PREFIX=${placeholder "out"}" ]
+    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "AR=${stdenv.cc.targetPrefix}ar" "RANLIB=${stdenv.cc.targetPrefix}ranlib" ]
+    ++ lib.optionals withSystemd [ "USE_SYSTEMD=yes" ]
+    ++ lib.optionals tlsSupport [ "BUILD_TLS=yes" ];
+
+  enableParallelBuilding = true;
+
+  hardeningEnable = lib.optionals (!stdenv.isDarwin) [ "pie" ];
+
+  env.NIX_CFLAGS_COMPILE = toString (lib.optionals stdenv.cc.isClang [ "-std=c11" ]);
+
+  # darwin currently lacks a pure `pgrep` which is extensively used here
+  doCheck = !stdenv.isDarwin;
+  nativeCheckInputs = [ which tcl ps ] ++ lib.optionals stdenv.hostPlatform.isStatic [ getconf ];
+  checkPhase = ''
+    runHook preCheck
+
+    # disable test "Connect multiple replicas at the same time": even
+    # upstream find this test too timing-sensitive
+    substituteInPlace tests/integration/replication.tcl \
+      --replace-fail 'foreach mdl {no yes}' 'foreach mdl {}'
+
+    substituteInPlace tests/support/server.tcl \
+      --replace-fail 'exec /usr/bin/env' 'exec env'
+
+    sed -i '/^proc wait_load_handlers_disconnected/{n ; s/wait_for_condition 50 100/wait_for_condition 50 500/; }' \
+      tests/support/util.tcl
+
+    ./runtest \
+      --no-latency \
+      --timeout 2000 \
+      --clients $NIX_BUILD_CORES \
+      --tags -leaks \
+      --skipunit integration/failover # flaky and slow
+
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://valkey.io/";
+    description = "A high-performance data structure server that primarily serves key/value workloads";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ rucadi ];
+    changelog = "https://github.com/valkey-io/valkey/releases/tag/${finalAttrs.version}";
+    mainProgram = "valkey-cli";
+  };
+})

--- a/pkgs/by-name/va/valkey/use_system_jemalloc.patch
+++ b/pkgs/by-name/va/valkey/use_system_jemalloc.patch
@@ -1,0 +1,15 @@
+diff --git a/src/Makefile b/src/Makefile
+index 3bc9f11c0..a4b23d986 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -229,8 +229,8 @@ endif
+ 
+ ifeq ($(MALLOC),jemalloc)
+ 	DEPENDENCY_TARGETS+= jemalloc
+-	FINAL_CFLAGS+= -DUSE_JEMALLOC -I../deps/jemalloc/include
+-	FINAL_LIBS := ../deps/jemalloc/lib/libjemalloc.a $(FINAL_LIBS)
++	FINAL_CFLAGS+= -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE -I/usr/include/jemalloc
++	FINAL_LIBS := -ljemalloc $(FINAL_LIBS)
+ endif
+ 
+ ifeq ($(BUILD_TLS),yes)


### PR DESCRIPTION
## Description of changes

From: #[armijnhemel](https://github.com/armijnhemel) closes  https://github.com/NixOS/nixpkgs/issues/299796
A little while ago Redis went closed source, so a community fork of Redis was launched: valkey. A release is expected soon.

Although the name in the README says "PlaceholderKV" it is called "valkey":

https://www.linuxfoundation.org/press/linux-foundation-launches-open-source-valkey-community

Metadata

homepage URL: https://github.com/valkey-io/valkey
source URL: https://github.com/valkey-io/valkey
license: bsd
platforms: linux


In general, this is a copy of the Redis package, however, one of the patches on the redis package was already applied on valkey, so only the jemalloc patch remains.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
