### PR TITLE
picolisp 20.6 -> 24.3.30

### DIFF
--- a/pkgs/development/interpreters/picolisp/default.nix
+++ b/pkgs/development/interpreters/picolisp/default.nix
@@ -1,66 +1,49 @@
-{ lib, stdenv, fetchurl, jdk, w3m, openssl, makeWrapper }:
+{
+  clang,
+  fetchurl,
+  lib,
+  libffi,
+  llvm,
+  makeWrapper,
+  openssl,
+  pkg-config,
+  readline,
+  stdenv
+}:
 
-stdenv.mkDerivation rec {
-  pname = "picoLisp";
-  version = "20.6";
+stdenv.mkDerivation {
+  pname = "PicoLisp";
+  version = "24.3.30";
   src = fetchurl {
-    url = "https://www.software-lab.de/${pname}-${version}.tgz";
-    sha256 = "0l51x98bn1hh6kv40sdgp0x09pzg5i8yxbcjvm9n5bxsd6bbk5w2";
+    url = "https://www.software-lab.de/picoLisp-24.3.tgz";
+    sha256 = "sha256-FB43DAjHBFgxdysoLzBXLxii52a2CCh1skZP/RTzfdc=";
   };
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [openssl] ++ lib.optional stdenv.is64bit jdk;
-  patchPhase = ''
-    sed -i "s/which java/command -v java/g" mkAsm
 
-    ${lib.optionalString stdenv.isAarch32 ''
-      sed -i s/-m32//g Makefile
-      cat >>Makefile <<EOF
-      ext.o: ext.c
-        \$(CC) \$(CFLAGS) -fPIC -D_OS='"\$(OS)"' \$*.c
-      ht.o: ht.c
-        \$(CC) \$(CFLAGS) -fPIC -D_OS='"\$(OS)"' \$*.c
-      EOF
-    ''}
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ clang libffi llvm openssl pkg-config readline ];
+  sourceRoot = ''pil21'';
+  buildPhase = ''
+    cd src
+    make
   '';
-  sourceRoot = ''picoLisp/src${lib.optionalString stdenv.is64bit "64"}'';
-  postBuild = ''
-    cd ../src; make gate
-  '';
+
   installPhase = ''
     cd ..
-
-    mkdir -p "$out/share/picolisp" "$out/lib" "$out/bin"
-    cp -r . "$out/share/picolisp/build-dir"
-    ln -s "$out/share/picolisp/build-dir" "$out/lib/picolisp"
+    mkdir -p "$out/lib" "$out/bin" "$out/man"
+    cp -r . "$out/lib/picolisp/"
     ln -s "$out/lib/picolisp/bin/picolisp" "$out/bin/picolisp"
-    ln -s "$out/lib/picolisp/bin/httpGate" "$out/bin/httpGate"
-
-
-    makeWrapper $out/bin/picolisp $out/bin/pil \
-      --prefix PATH : ${w3m}/bin \
-      --add-flags "$out/lib/picolisp/lib.l" \
-      --add-flags "@lib/misc.l" \
-      --add-flags "@lib/btree.l" \
-      --add-flags "@lib/db.l" \
-      --add-flags "@lib/pilog.l"
-
-    mkdir -p "$out/share/emacs"
-    ln -s "$out/lib/picolisp/lib/el" "$out/share/emacs/site-lisp"
+    ln -s "$out/lib/picolisp/bin/pil" "$out/bin/pil"
+    ln -s "$out/lib/picolisp/man/man1/pil.1" "$out/man/pil.1"
+    ln -s "$out/lib/picolisp/man/man1/picolisp.1" "$out/man/picolisp.1"
+    substituteInPlace $out/bin/pil --replace /usr $out
   '';
 
   meta = with lib; {
-    # darwin: build times out
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
-    description = "A simple Lisp with an integrated database";
+    description = "A pragmatic programming language.";
     homepage = "https://picolisp.com/";
     license = licenses.mit;
-    maintainers = with maintainers; [ raskin ];
+    maintainers = with maintainers; [ nat-418 ];
     platforms = platforms.all;
   };
-
-  passthru = {
-    updateInfo = {
-      downloadPage = "https://www.software-lab.de/down.html";
-    };
-  };
 }
+


### PR DESCRIPTION
## Description of changes

Since the last update to this package four years ago, upstream has made serious changes and I have re-written the package definition. 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).