### PR TITLE
sourcehut.*: update all packages

### DIFF
--- a/pkgs/applications/version-management/sourcehut/builds.nix
+++ b/pkgs/applications/version-management/sourcehut/builds.nix
@@ -16,28 +16,28 @@
 , setuptools
 }:
 let
-  version = "0.89.13";
+  version = "0.89.15";
   gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.39"; };
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "builds.sr.ht";
     rev = version;
-    hash = "sha256-JpRVRzuHB6cgk/qW1j4zF8/K1xwz3J4nZhijmz5kVWU=";
+    hash = "sha256-rmNaBnTPDDQO/ImkGkMwW8fyjQyBUBchTEnbtAK24pw=";
   };
 
   buildsrht-api = buildGoModule ({
     inherit src version;
     pname = "buildsrht-api";
     modRoot = "api";
-    vendorHash = "sha256-kTqoUfFEoNdDDzVNJ7XIbH7tbsl5MdBL+/UDHFv7D+A=";
+    vendorHash = "sha256-dwpuB+aYqzhGSdGVq/F9FTdHWMBkGMtVuZ7I3hB3b+Q=";
   } // gqlgen);
 
   buildsrht-worker = buildGoModule ({
     inherit src version;
     pname = "buildsrht-worker";
     modRoot = "worker";
-    vendorHash = "sha256-kTqoUfFEoNdDDzVNJ7XIbH7tbsl5MdBL+/UDHFv7D+A=";
+    vendorHash = "sha256-dwpuB+aYqzhGSdGVq/F9FTdHWMBkGMtVuZ7I3hB3b+Q=";
   } // gqlgen);
 in
 buildPythonPackage rec {

--- a/pkgs/applications/version-management/sourcehut/core.nix
+++ b/pkgs/applications/version-management/sourcehut/core.nix
@@ -28,7 +28,7 @@
 
 buildPythonPackage rec {
   pname = "srht";
-  version = "0.71.5";
+  version = "0.71.8";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     owner = "~sircmpwn";
     repo = "core.sr.ht";
     rev = version;
-    hash = "sha256-YIoKOiTi/9X4bSiG+GvnwzvKYhbfywrv/dTjxaJOOTQ=";
+    hash = "sha256-rDpm2HJOWScvIxOmHcat6y4CWdBE9T2gE/jZskYAFB0=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/version-management/sourcehut/fix-gqlgen-trimpath.nix
+++ b/pkgs/applications/version-management/sourcehut/fix-gqlgen-trimpath.nix
@@ -1,5 +1,5 @@
 { unzip
-, gqlgenVersion ? "0.17.42"
+, gqlgenVersion
 }:
 {
   overrideModAttrs = (_: {

--- a/pkgs/applications/version-management/sourcehut/fix-gqlgen-trimpath.nix
+++ b/pkgs/applications/version-management/sourcehut/fix-gqlgen-trimpath.nix
@@ -6,8 +6,8 @@
     # No need to workaround -trimpath: it's not used in goModules,
     # but do download `go generate`'s dependencies nonetheless.
     preBuild = ''
-      go generate ./loaders
-      go generate ./graph
+      if [ -d ./loaders ]; then go generate ./loaders; fi
+      if [ -d ./graph ]; then go generate ./graph; fi
     '';
   });
 
@@ -25,8 +25,8 @@
   # If it fails, the gqlgenVersion may have to be updated.
   preBuild = ''
     unzip ''${GOPROXY#"file://"}/github.com/99designs/gqlgen/@v/v${gqlgenVersion}.zip
-    go generate ./loaders
-    go generate ./graph
+    if [ -d ./loaders ]; then go generate ./loaders; fi
+    if [ -d ./graph ]; then go generate ./graph; fi
     rm -rf github.com
   '';
 }

--- a/pkgs/applications/version-management/sourcehut/git.nix
+++ b/pkgs/applications/version-management/sourcehut/git.nix
@@ -13,28 +13,28 @@
 , setuptools
 }:
 let
-  version = "0.85.7";
-  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; };
+  version = "0.85.9";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.42"; };
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "git.sr.ht";
     rev = version;
-    hash = "sha256-jkESrrVE+0O2g64zzPOpqhl8DpvmosQvuF0s6Xd+lbM=";
+    hash = "sha256-tmbBw6x3nqN9nRIR3xOXQ+L5EACXLQYLXQYK3lsOsAI=";
   };
 
   gitApi = buildGoModule ({
     inherit src version;
     pname = "gitsrht-api";
     modRoot = "api";
-    vendorHash = "sha256-yWVpldqwpEZmeI18tvdIgof8GgSFEP70c8T5XDkryn0=";
+    vendorHash = "sha256-4KwnUi6ILUagMDXzuBG9CRT2N8uyjvRM74TwJqIzicc=";
   } // gqlgen);
 
   gitDispatch = buildGoModule ({
     inherit src version;
     pname = "gitsrht-dispatch";
     modRoot = "gitsrht-dispatch";
-    vendorHash = "sha256-yWVpldqwpEZmeI18tvdIgof8GgSFEP70c8T5XDkryn0=";
+    vendorHash = "sha256-4KwnUi6ILUagMDXzuBG9CRT2N8uyjvRM74TwJqIzicc=";
 
     postPatch = ''
       substituteInPlace gitsrht-dispatch/main.go \
@@ -46,7 +46,7 @@ let
     inherit src version;
     pname = "gitsrht-keys";
     modRoot = "gitsrht-keys";
-    vendorHash = "sha256-yWVpldqwpEZmeI18tvdIgof8GgSFEP70c8T5XDkryn0=";
+    vendorHash = "sha256-4KwnUi6ILUagMDXzuBG9CRT2N8uyjvRM74TwJqIzicc=";
 
     postPatch = ''
       substituteInPlace gitsrht-keys/main.go \
@@ -58,7 +58,7 @@ let
     inherit src version;
     pname = "gitsrht-shell";
     modRoot = "gitsrht-shell";
-    vendorHash = "sha256-yWVpldqwpEZmeI18tvdIgof8GgSFEP70c8T5XDkryn0=";
+    vendorHash = "sha256-4KwnUi6ILUagMDXzuBG9CRT2N8uyjvRM74TwJqIzicc=";
 
     postPatch = ''
       substituteInPlace gitsrht-shell/main.go \
@@ -70,7 +70,7 @@ let
     inherit src version;
     pname = "gitsrht-update-hook";
     modRoot = "gitsrht-update-hook";
-    vendorHash = "sha256-yWVpldqwpEZmeI18tvdIgof8GgSFEP70c8T5XDkryn0=";
+    vendorHash = "sha256-4KwnUi6ILUagMDXzuBG9CRT2N8uyjvRM74TwJqIzicc=";
 
     postPatch = ''
       substituteInPlace gitsrht-update-hook/main.go \

--- a/pkgs/applications/version-management/sourcehut/hg.nix
+++ b/pkgs/applications/version-management/sourcehut/hg.nix
@@ -14,8 +14,8 @@
 }:
 
 let
-  version = "0.32.4";
-  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.20"; };
+  version = "0.33.0";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.45"; };
 
   pyproject = true;
 
@@ -25,7 +25,7 @@ let
     owner = "~sircmpwn";
     repo = "hg.sr.ht";
     rev = version;
-    hash = "sha256-mYkA44c9wy/Iy1h1lXkVpc9gN7rQXFm4T3YBlQ1Dj60=";
+    hash = "sha256-+BYeE+8dXY/MLLYyBBLD+eKqmrPiKyyCGIZLkCPzNYM=";
     vc = "hg";
   };
 
@@ -33,7 +33,7 @@ let
     inherit src version;
     pname = "hgsrht-api";
     modRoot = "api";
-    vendorHash = "sha256-vuOYpnF3WjA6kOe9MVSuVMhJBQqCmIex+QUBJrP+VDs=";
+    vendorHash = "sha256-K+KMhcvkG/qeQTnlHS4xhLCcvBQNNp2DcScJPm8Dbic=";
   } // gqlgen);
 
   hgsrht-keys = buildGoModule {

--- a/pkgs/applications/version-management/sourcehut/hub.nix
+++ b/pkgs/applications/version-management/sourcehut/hub.nix
@@ -12,21 +12,21 @@
 }:
 
 let
-  version = "0.17.5";
-  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.41"; };
+  version = "0.17.7";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.43"; };
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "hub.sr.ht";
     rev = version;
-    hash = "sha256-GbBxK3XE+Y6Jiap0Nxa8vk4Kv6IbcdSi4NN59AeKwjA=";
+    hash = "sha256-IyY7Niy/vZSAXjYZMlxY6uuQ8nH/4yT4+MaRjHtl6G4=";
   };
 
   hubsrht-api = buildGoModule ({
     inherit src version;
     pname = "hubsrht-api";
     modRoot = "api";
-    vendorHash = "sha256-wmuM0SxQbohTDaU8zmkw1TQTmqhOy1yAl1jRWk6TKL8=";
+    vendorHash = "sha256-GVN11nEJqIHh8MtKvIXe4zcUwJph9eTSkJ2R+ufD+ic=";
   } // gqlgen);
 in
 buildPythonPackage rec {

--- a/pkgs/applications/version-management/sourcehut/lists.nix
+++ b/pkgs/applications/version-management/sourcehut/lists.nix
@@ -15,21 +15,21 @@
 }:
 
 let
-  version = "0.57.14";
-  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.36"; };
+  version = "0.57.18";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.45"; };
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "lists.sr.ht";
     rev = version;
-    hash = "sha256-rzOxlat7Lbgt0Wl6vvnAC+fS3MynFVKFvVdIdxgA5e0=";
+    hash = "sha256-l+QPocnwHTjrU+M0wnm4tBrbz8KmSb6DovC+skuAnLc=";
   };
 
   listssrht-api = buildGoModule ({
     inherit src version;
     pname = "listssrht-api";
     modRoot = "api";
-    vendorHash = "sha256-OWgrPvXVlvJPcoABP0ZxKzoYFhU44j/I44sBBRbd6KY=";
+    vendorHash = "sha256-UeVs/+uZNtv296bzXIBio2wcg3Uzu3fBM4APzF9O0hY=";
   } // gqlgen);
 in
 buildPythonPackage rec {

--- a/pkgs/applications/version-management/sourcehut/man.nix
+++ b/pkgs/applications/version-management/sourcehut/man.nix
@@ -12,21 +12,21 @@
 }:
 
 let
-  version = "0.16.3";
-  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.36"; };
+  version = "0.16.5";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.43"; };
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "man.sr.ht";
     rev = version;
-    hash = "sha256-o1A3LmwH6WgpFqjKyL3UTru9q7TgKdOdbKZfJHR6fCA=";
+    hash = "sha256-JFMtif2kIE/fs5PNcQtkJikAFNszgZTU7BG/8fTncTI=";
   };
 
   mansrht-api = buildGoModule ({
     inherit src version;
     pname = "mansrht-api";
     modRoot = "api";
-    vendorHash = "sha256-6AzKWytdyuofCFaDEdeO24mv1mtpnQEJydrjVWGY2eU=";
+    vendorHash = "sha256-GVN11nEJqIHh8MtKvIXe4zcUwJph9eTSkJ2R+ufD+ic=";
   } // gqlgen);
 in
 buildPythonPackage rec {

--- a/pkgs/applications/version-management/sourcehut/meta.nix
+++ b/pkgs/applications/version-management/sourcehut/meta.nix
@@ -18,21 +18,21 @@
 , setuptools
 }:
 let
-  version = "0.68.5";
-  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.36"; };
+  version = "0.69.8";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.43"; };
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "meta.sr.ht";
     rev = version;
-    hash = "sha256-mwUqBzi7nMTZL7uwv7hBjGkO8U3krXXpvfUCaYHgHBU=";
+    hash = "sha256-K7p6cytkPYgUuYr7BVfU/+sVbSr2YEmreIDnTatUMyk=";
   };
 
   metasrht-api = buildGoModule ({
     inherit src version;
     pname = "metasrht-api";
     modRoot = "api";
-    vendorHash = "sha256-4T1xnHDjxsIyddA51exNwwz6ZWeuT7N8LBsCJ7c8sRI=";
+    vendorHash = "sha256-vIkUK1pigVU8vZL5xpHLeinOga5eXXHTuDkHxwUz6uM=";
   } // gqlgen);
 in
 buildPythonPackage rec {

--- a/pkgs/applications/version-management/sourcehut/pages.nix
+++ b/pkgs/applications/version-management/sourcehut/pages.nix
@@ -6,21 +6,25 @@
 
 buildGoModule (rec {
   pname = "pagessrht";
-  version = "0.15.4";
+  version = "0.15.7";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "pages.sr.ht";
     rev = version;
-    hash = "sha256-3kdQVIL7xaIPu2elxj1k+4/y75bd+OKP5+VPSniF7w8=";
+    hash = "sha256-Lobuf12ybSO7Y4ztOLMFW0dmPFaBSEPCy4Nmh89tylI=";
   };
 
   postPatch = ''
     substituteInPlace Makefile \
       --replace "all: server" ""
+
+    # fix build failure due to unused import
+    substituteInPlace server.go \
+      --replace-warn '	"fmt"' ""
   '';
 
-  vendorHash = "sha256-DP+6rxjiXzs0RbSuMD20XwO/+v7QXCNgXj2LxZ96lWE=";
+  vendorHash = "sha256-9hpOkP6AYSZe7MW1mrwFEKq7TvVt6OcF6eHWY4jARuU=";
 
   postInstall = ''
     mkdir -p $out/share/sql/
@@ -36,4 +40,4 @@ buildGoModule (rec {
   };
   # There is no ./loaders but this does not cause troubles
   # to go generate
-} // import ./fix-gqlgen-trimpath.nix { inherit unzip; })
+} // import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.42"; })

--- a/pkgs/applications/version-management/sourcehut/paste.nix
+++ b/pkgs/applications/version-management/sourcehut/paste.nix
@@ -12,21 +12,21 @@
 }:
 
 let
-  version = "0.15.2";
-  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.20"; };
+  version = "0.15.4";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.45"; };
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "paste.sr.ht";
     rev = version;
-    hash = "sha256-ZZzcd14Jbo1MfET7B56X/fl9xWXpCJ8TuKrGVgJwZfQ=";
+    hash = "sha256-M38hAMRdMzcqxJv7j7foOIYEImr/ZYz/lbYOF9R9g2M=";
   };
 
   pastesrht-api = buildGoModule ({
     inherit src version;
     pname = "pastesrht-api";
     modRoot = "api";
-    vendorHash = "sha256-jiE73PUPSHxtWp7XBdH4mJw95pXmZjCl4tk2wQUf2M4=";
+    vendorHash = "sha256-vt5nSPcx+Y/SaWcqjV38DTL3ZtzmdjbkJYMv5Fhhnq4=";
   } // gqlgen);
 in
 buildPythonPackage rec {

--- a/pkgs/applications/version-management/sourcehut/scm.nix
+++ b/pkgs/applications/version-management/sourcehut/scm.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "scmsrht";
-  version = "0.22.23";
+  version = "0.22.24";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "~sircmpwn";
     repo = "scm.sr.ht";
     rev = version;
-    hash = "sha256-058dOEYJDY3jtxH1VkV1CFq5CZTkauSnTWg57DCnNtw=";
+    hash = "sha256-9IgMmYzInfrten7z8bznlSFJlUjHf3k3z76lkP6tP50=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/version-management/sourcehut/todo.nix
+++ b/pkgs/applications/version-management/sourcehut/todo.nix
@@ -13,21 +13,21 @@
 }:
 
 let
-  version = "0.75.6";
-  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.36"; };
+  version = "0.75.10";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.45"; };
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "todo.sr.ht";
     rev = version;
-    hash = "sha256-BPJ1M9dX+xNIw++VZ0Si/rjnfI9BY95TE2o+u7JRVAU=";
+    hash = "sha256-3dVZdupsygM7/6T1Mn7yRc776aa9pKgwF0hgZX6uVQ0=";
   };
 
   todosrht-api = buildGoModule ({
     inherit src version;
     pname = "todosrht-api";
     modRoot = "api";
-    vendorHash = "sha256-vTKIJFE8AFR2eZFwG9ba6FWPW02og3ZVcrsqUnOkJIQ=";
+    vendorHash = "sha256-fImOQLnQLHTrg5ikuYRZ+u+78exAiYA19DGQoUjQBOM=";
   } // gqlgen);
 in
 buildPythonPackage rec {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

New round of updates for all sourcehut packages, mostly just some very small minor bumps. Staying this close to upstream in a ~(bi-)monthly just makes life easier. 
Testsuite look good.

Also fixes the following build failure for me, on unstable (~31-03-2024):
<details>
<pre>
error: builder for '/nix/store/vrq2hrm1b9viyq22s35g43iv48yb2wqq-buildsrht-worker-0.89.13.drv' failed with exit code 1;
       last 10 log lines:
       >   inflating: github.com/99designs/gqlgen@v0.17.39/plugin/resolvergen/testdata/singlefile/out/model.go
       >   inflating: github.com/99designs/gqlgen@v0.17.39/plugin/resolvergen/testdata/singlefile/out/resolver.go
       >   inflating: github.com/99designs/gqlgen@v0.17.39/plugin/servergen/server.go
       >   inflating: github.com/99designs/gqlgen@v0.17.39/plugin/servergen/server.gotpl
       >   inflating: github.com/99designs/gqlgen@v0.17.39/plugin/stubgen/stubs.go
       >   inflating: github.com/99designs/gqlgen@v0.17.39/plugin/stubgen/stubs.gotpl
       >   inflating: github.com/99designs/gqlgen@v0.17.39/testdata/gomod-with-leading-comments.mod
       >   inflating: github.com/99designs/gqlgen@v0.17.39/testdata/gqlgen.go
       > stat /build/source/worker/loaders: directory not found
       > /nix/store/c8dj731bkcdzhgrpawhc8qvdgls4xfjv-stdenv-linux/setup: line 131: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/vrq2hrm1b9viyq22s35g43iv48yb2wqq-buildsrht-worker-0.89.13.drv'.
error: builder for '/nix/store/kk0rvs8n41pqlla65cgqgnkil5aqsqs0-gitsrht-dispatch-0.85.7.drv' failed with exit code 1;
       last 10 log lines:
       >   inflating: github.com/99designs/gqlgen@v0.17.42/plugin/resolvergen/testdata/singlefile/out/model.go
       >   inflating: github.com/99designs/gqlgen@v0.17.42/plugin/resolvergen/testdata/singlefile/out/resolver.go
       >   inflating: github.com/99designs/gqlgen@v0.17.42/plugin/servergen/server.go
       >   inflating: github.com/99designs/gqlgen@v0.17.42/plugin/servergen/server.gotpl
       >   inflating: github.com/99designs/gqlgen@v0.17.42/plugin/stubgen/stubs.go
       >   inflating: github.com/99designs/gqlgen@v0.17.42/plugin/stubgen/stubs.gotpl
       >   inflating: github.com/99designs/gqlgen@v0.17.42/testdata/gomod-with-leading-comments.mod
       >   inflating: github.com/99designs/gqlgen@v0.17.42/testdata/gqlgen.go
       > stat /build/source/gitsrht-dispatch/loaders: directory not found
       > /nix/store/c8dj731bkcdzhgrpawhc8qvdgls4xfjv-stdenv-linux/setup: line 131: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/kk0rvs8n41pqlla65cgqgnkil5aqsqs0-gitsrht-dispatch-0.85.7.drv'.
error: builder for '/nix/store/i8c5gy87p8k9chk595xqz5flzrrcm127-hubsrht-api-0.17.5.drv' failed with exit code 1;
       last 10 log lines:
       >   inflating: github.com/99designs/gqlgen@v0.17.41/plugin/resolvergen/testdata/singlefile/out/model.go
       >   inflating: github.com/99designs/gqlgen@v0.17.41/plugin/resolvergen/testdata/singlefile/out/resolver.go
       >   inflating: github.com/99designs/gqlgen@v0.17.41/plugin/servergen/server.go
       >   inflating: github.com/99designs/gqlgen@v0.17.41/plugin/servergen/server.gotpl
       >   inflating: github.com/99designs/gqlgen@v0.17.41/plugin/stubgen/stubs.go
       >   inflating: github.com/99designs/gqlgen@v0.17.41/plugin/stubgen/stubs.gotpl
       >   inflating: github.com/99designs/gqlgen@v0.17.41/testdata/gomod-with-leading-comments.mod
       >   inflating: github.com/99designs/gqlgen@v0.17.41/testdata/gqlgen.go
       > stat /build/source/api/loaders: directory not found
       > /nix/store/c8dj731bkcdzhgrpawhc8qvdgls4xfjv-stdenv-linux/setup: line 131: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/i8c5gy87p8k9chk595xqz5flzrrcm127-hubsrht-api-0.17.5.drv'.
error: builder for '/nix/store/xb4jik4ms04zyjyygzjh129hln62l9bw-mansrht-api-0.16.3.drv' failed with exit code 1;
       last 10 log lines:
       >   inflating: github.com/99designs/gqlgen@v0.17.36/plugin/resolvergen/testdata/singlefile/out/model.go
       >   inflating: github.com/99designs/gqlgen@v0.17.36/plugin/resolvergen/testdata/singlefile/out/resolver.go
       >   inflating: github.com/99designs/gqlgen@v0.17.36/plugin/servergen/server.go
       >   inflating: github.com/99designs/gqlgen@v0.17.36/plugin/servergen/server.gotpl
       >   inflating: github.com/99designs/gqlgen@v0.17.36/plugin/stubgen/stubs.go
       >   inflating: github.com/99designs/gqlgen@v0.17.36/plugin/stubgen/stubs.gotpl
       >   inflating: github.com/99designs/gqlgen@v0.17.36/testdata/gomod-with-leading-comments.mod
       >   inflating: github.com/99designs/gqlgen@v0.17.36/testdata/gqlgen.go
       > stat /build/source/api/loaders: directory not found
       > /nix/store/c8dj731bkcdzhgrpawhc8qvdgls4xfjv-stdenv-linux/setup: line 131: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/xb4jik4ms04zyjyygzjh129hln62l9bw-mansrht-api-0.16.3.drv'.
</pre>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
