### PR TITLE
ethercat: Kernel module, documentation, NixOS module and VM test

### DIFF
--- a/nixos/modules/hardware/network/ethercat.nix
+++ b/nixos/modules/hardware/network/ethercat.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.hardware.ethercat;
+
+  macAddress = lib.types.strMatching "^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$";
+
+  master = lib.types.submodule {
+    options = {
+      primary = lib.mkOption {
+        description = "MAC address of an network interface to use for the EtherCAT master.";
+        type = macAddress;
+      };
+      backup = lib.mkOption {
+        description = "MAC address of an network interface to use as a backup for the EtherCAT master.";
+        type = lib.types.nullOr macAddress;
+      };
+    };
+  };
+in
+{
+  options.hardware.ethercat = {
+    enable = lib.mkEnableOption "EtherCAT master support";
+
+    masters = lib.mkOption {
+      type = lib.types.listOf master;
+      default = [ ];
+      description = ''
+        A list of EtherCAT master interfaces to configure.
+      '';
+    };
+
+    deviceModules = lib.mkOption {
+      description = ''
+        A list of driver modules to load for EtherCAT operation.
+      '';
+      type = lib.types.listOf (
+        lib.types.enum [
+          "8139too"
+          "e100"
+          "e1000"
+          "e1000e"
+          "r8169"
+          "generic"
+          "ccat"
+          "igb"
+          "igc"
+          "genet"
+          "dwmac-intel"
+          "stmmac-pci"
+        ]
+      );
+      default = [ "generic" ];
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot = {
+      extraModulePackages = [ config.boot.kernelPackages.ethercat ];
+      kernelModules = [ "ec_master" ] ++ map (m: "ec_${m}") cfg.deviceModules;
+      blacklistedKernelModules = builtins.filter (m: m != "generic" && m != "ccat") cfg.deviceModules;
+
+      extraModprobeConfig =
+        let
+          mainDevices = map (m: m.primary) cfg.masters;
+          backupDevices = map (m: "") cfg.masters;
+        in
+        ''
+          options ec_master main_devices=${builtins.concatStringsSep "," mainDevices} backup_devices=${builtins.concatStringsSep "," backupDevices}
+        '';
+    };
+
+    environment.systemPackages = [ pkgs.ethercat ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -83,6 +83,7 @@
   ./hardware/mcelog.nix
   ./hardware/network/ath-user-regd.nix
   ./hardware/network/b43.nix
+  ./hardware/network/ethercat.nix
   ./hardware/network/eg25-manager.nix
   ./hardware/network/intel-2200bg.nix
   ./hardware/new-lg4ff.nix

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -323,6 +323,7 @@ in {
   etcd-cluster = handleTestOn [ "aarch64-linux" "x86_64-linux" ] ./etcd/etcd-cluster.nix {};
   etebase-server = handleTest ./etebase-server.nix {};
   etesync-dav = handleTest ./etesync-dav.nix {};
+  ethercat = handleTest ./ethercat.nix {};
   evcc = handleTest ./evcc.nix {};
   fail2ban = handleTest ./fail2ban.nix { };
   fakeroute = handleTest ./fakeroute.nix {};

--- a/nixos/tests/ethercat.nix
+++ b/nixos/tests/ethercat.nix
@@ -1,0 +1,68 @@
+import ./make-test-python.nix (
+  {
+    pkgs,
+    lib,
+    ...
+  }:
+  let
+    macAddress = "00:11:22:33:44:55";
+
+    # ec_e1000 module is not supported on more recent kernels
+    kernelPackages = pkgs.linuxPackages_5_15;
+  in
+  {
+    name = "ethercat";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ stv0g ];
+    };
+
+    nodes.machine =
+      { pkgs, config, ... }:
+      {
+        boot.kernelPackages = kernelPackages;
+
+        virtualisation.qemu.networkingOptions = [
+          "-net"
+          "nic,model=e1000,macaddr=${macAddress}"
+        ];
+
+        hardware.ethercat = {
+          enable = true;
+
+          masters = [
+            {
+              primary = macAddress;
+            }
+          ];
+
+          deviceModules = [
+            "e1000"
+          ];
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      with subtest("EtherCAT kernel modules are loaded"):
+        out = machine.succeed("lsmod")
+        modules = [line.split()[0] for line in out.splitlines()]
+
+        assert "ec_master" in modules, "ec_master not loaded"
+        assert "ec_e1000" in modules, "ec_e1000 not loaded"
+
+      with subtest("EtherCAT master is configured"):
+        out = machine.succeed("dmesg")
+        assert "EtherCAT: Master driver ${kernelPackages.ethercat.version}" in out
+        assert "EtherCAT: Accepting ${macAddress} as main device for master 0." in out
+        assert "EtherCAT: 1 master waiting for devices." in out
+        assert "EtherCAT 0: Link state of ecm0 changed to UP" in out
+
+      with subtest("Command line tool works"):
+        out = machine.succeed("ethercat master --master 0")
+        assert "Phase: Idle" in out
+        assert "Link: UP" in out
+        assert "Main: ${macAddress} (attached)" in out
+    '';
+  }
+)

--- a/pkgs/by-name/et/ethercat/common.nix
+++ b/pkgs/by-name/et/ethercat/common.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  fetchFromGitLab,
+  stdenv,
+  gitUpdater,
+  autoreconfHook,
+  pkg-config,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ethercat";
+  version = "1.6.2";
+
+  src = fetchFromGitLab {
+    owner = "etherlab.org";
+    repo = "ethercat";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-NgRyvNvHy04jr7ieOscBYULRdWJ7YuHbuYbRrSfXYRU=";
+    fetchSubmodules = true;
+    leaveDotGit = true;
+  };
+
+  configureFlags = [
+    # Features
+    "--enable-eoe=yes"
+    "--enable-cycles=yes"
+    "--enable-rtmutex=yes"
+    "--enable-hrtimer=yes"
+    "--enable-regalias=yes"
+    "--enable-refclkop=yes"
+    "--enable-tty=no" # Is broken in Kernel 6.6
+    "--enable-wildcards"
+
+    # Debugging
+    "--enable-debug-if=yes"
+    "--enable-debug-ring=no" # Is broken
+
+    # Devices
+    "--enable-generic"
+    "--enable-ccat"
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  enableParallelBuilding = true;
+  separateDebugInfo = true;
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "IgH EtherCAT Master for Linux";
+    homepage = "https://etherlab.org/ethercat";
+    changelog = "https://gitlab.com/etherlab.org/ethercat/-/blob/1.6-devel/NEWS";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.stv0g ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/et/ethercat/common.nix
+++ b/pkgs/by-name/et/ethercat/common.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "IgH EtherCAT Master for Linux";
     homepage = "https://etherlab.org/ethercat";
-    changelog = "https://gitlab.com/etherlab.org/ethercat/-/blob/1.6-devel/NEWS";
+    changelog = "https://gitlab.com/etherlab.org/ethercat/-/blob/${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.stv0g ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/et/ethercat/common.nix
+++ b/pkgs/by-name/et/ethercat/common.nix
@@ -1,10 +1,13 @@
 {
-  lib,
-  fetchFromGitLab,
-  stdenv,
-  gitUpdater,
   autoreconfHook,
+  fetchFromGitLab,
+  gitUpdater,
+  lib,
+  nixosTests,
   pkg-config,
+  stdenv,
+
+  # Options
   withDocs ? false,
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -60,7 +63,12 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
   separateDebugInfo = true;
 
-  passthru.updateScript = gitUpdater { };
+  passthru = {
+    updateScript = gitUpdater { };
+    tests = {
+      inherit (nixosTests) ethercat;
+    };
+  };
 
   meta = {
     description = "IgH EtherCAT Master for Linux";

--- a/pkgs/by-name/et/ethercat/common.nix
+++ b/pkgs/by-name/et/ethercat/common.nix
@@ -5,19 +5,32 @@
   gitUpdater,
   autoreconfHook,
   pkg-config,
+  withDocs ? false,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "ethercat";
   version = "1.6.2";
 
-  src = fetchFromGitLab {
-    owner = "etherlab.org";
-    repo = "ethercat";
-    rev = "refs/tags/${finalAttrs.version}";
-    hash = "sha256-NgRyvNvHy04jr7ieOscBYULRdWJ7YuHbuYbRrSfXYRU=";
-    fetchSubmodules = true;
-    leaveDotGit = true;
-  };
+  src = fetchFromGitLab (
+    {
+      owner = "etherlab.org";
+      repo = "ethercat";
+      rev = "refs/tags/${finalAttrs.version}";
+
+    }
+    // (
+      if withDocs then
+        {
+          hash = "sha256-b04T33eYmlCkLE+bVdYkUGtNaQDUZ+xlDdXM2w3Me3k=";
+          fetchSubmodules = true;
+          leaveDotGit = true;
+        }
+      else
+        {
+          hash = "sha256-NgRyvNvHy04jr7ieOscBYULRdWJ7YuHbuYbRrSfXYRU=";
+        }
+    )
+  );
 
   configureFlags = [
     # Features

--- a/pkgs/by-name/et/ethercat/kernel.nix
+++ b/pkgs/by-name/et/ethercat/kernel.nix
@@ -1,0 +1,199 @@
+{
+  autoreconfHook,
+  pkg-config,
+  stdenv,
+  pkgs,
+  lib,
+  kernel,
+}:
+let
+  deviceKernelCompatabilities = {
+    "6.6" = [ "igc" ];
+    "6.4" = [
+      "e100"
+      "igc"
+    ];
+    "6.1" = [
+      "8139too"
+      "bcmgenet"
+      "e100"
+      # "e1000" # Is broken
+      "e1000e"
+      "igb"
+      # "igc" # Is broken
+      "r8169"
+    ];
+    "5.15" = [
+      "8139too"
+      "e100"
+      "e1000"
+      "e1000e"
+      "igb"
+      "r8169"
+    ];
+    "5.14" = [
+      "8139too"
+      "bcmgenet"
+      "e100"
+      "e1000"
+      "e1000e"
+      "igb"
+      "igc"
+      "r8169"
+    ];
+    "5.10" = [
+      "8139too"
+      "bcmgenet"
+      "e100"
+      "e1000"
+      "e1000e"
+      "igb"
+      "r8169"
+    ];
+    "5.4" = [
+      "e100"
+      "e1000e"
+    ];
+    "4.19" = [ "igb" ];
+    "4.4" = [
+      "8139too"
+      "e100"
+      "e1000"
+      "e1000e"
+      "igb"
+      "r8169"
+    ];
+    "3.18" = [ "igb" ];
+    "3.16" = [
+      "8139too"
+      "e100"
+      "e1000"
+      "e1000e"
+      "r8169"
+    ];
+    "3.14" = [
+      "8139too"
+      "e100"
+      "e1000"
+      "e1000e"
+      "r8169"
+    ];
+    "3.12" = [
+      "8139too"
+      "e100"
+      "e1000"
+      "e1000e"
+      "r8169"
+    ];
+    "3.10" = [
+      "8139too"
+      "e100"
+      "e1000"
+      "e1000e"
+      "r8169"
+    ];
+    "3.8" = [
+      "8139too"
+      "e100"
+      "e1000"
+      "e1000e"
+      "r8169"
+    ];
+    "3.6" = [
+      "8139too"
+      "e100"
+      "e1000"
+      "e1000e"
+      "r8169"
+    ];
+    "3.4" = [
+      "8139too"
+      "e100"
+      "e1000"
+      "e1000e"
+      "r8169"
+    ];
+    "3.2" = [
+      "8139too"
+      "e1000e"
+      "r8169"
+    ];
+    "3.0" = [
+      "8139too"
+      "e100"
+      "e1000"
+    ];
+  };
+
+  kernelVersionMajorMinor = builtins.concatStringsSep "." (
+    lib.lists.take 2 (builtins.splitVersion kernel.version)
+  );
+
+  supportedDrivers = deviceKernelCompatabilities.${kernelVersionMajorMinor};
+in
+stdenv.mkDerivation (
+  finalAttrs:
+  (
+    with pkgs.ethercat;
+    {
+      inherit version;
+      inherit src;
+      inherit meta;
+    }
+    // {
+      pname = "ethercat-kernel";
+
+      separateDebugInfo = true;
+      hardeningDisable = [
+        "pic"
+        "format"
+      ];
+
+      nativeBuildInputs = [
+        autoreconfHook
+        pkg-config
+        kernel.moduleBuildDependencies
+      ];
+
+      enableParallelBuilding = true;
+
+      makeFlags = [
+        "KERNELRELEASE=${kernel.modDirVersion}"
+        "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+        "INSTALL_MOD_PATH=$(out)"
+      ];
+
+      configureFlags = [
+        # Components
+        "--enable-tool=no"
+        "--enable-userlib=no"
+        "--enable-kernel=yes"
+
+        # Features
+        "--enable-eoe=yes"
+        "--enable-cycles=yes"
+        "--enable-rtmutex=yes"
+        "--enable-hrtimer=yes"
+        "--enable-regalias=yes"
+        "--enable-refclkop=yes"
+        "--enable-tty=no" # Is broken
+        "--enable-wildcards"
+
+        # Devices
+        "--enable-generic"
+        "--enable-ccat"
+
+        # Kernel
+        "--with-linux-dir=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+
+        # Debugging
+        "--enable-debug-if=yes"
+        "--enable-debug-ring=no" # Is broken
+      ] ++ builtins.map (driver: "--enable-${driver}=yes") supportedDrivers;
+
+      buildFlags = [ "modules" ];
+
+      installTargets = [ "modules_install" ];
+    }
+  )
+)

--- a/pkgs/by-name/et/ethercat/package.nix
+++ b/pkgs/by-name/et/ethercat/package.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   separateDebugInfo = true;
+  enableParallelBuilding = true;
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/by-name/et/ethercat/package.nix
+++ b/pkgs/by-name/et/ethercat/package.nix
@@ -6,6 +6,7 @@
   fetchFromGitLab,
   gitUpdater,
   pkg-config,
+  systemdMinimal,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "ethercat";
@@ -25,6 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
+  buildInputs = [ systemdMinimal ];
+
   outputs = [
     "bin"
     "dev"
@@ -35,6 +38,8 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-tool=yes"
     "--enable-userlib=yes"
     "--enable-kernel=no"
+
+    "--with-systemdsystemunitdir=$$out/lib/systemd/system"
 
     # Features
     "--enable-eoe=yes"

--- a/pkgs/by-name/et/ethercat/package.nix
+++ b/pkgs/by-name/et/ethercat/package.nix
@@ -2,6 +2,8 @@
   autoreconfHook,
   callPackage,
   git,
+  iproute2,
+  kmod,
   lib,
   systemdMinimal,
 
@@ -90,6 +92,10 @@ common.overrideAttrs (
 
     postFixup = ''
       mv $out/{share,lib,etc} $bin
+      sed -i \
+        -e 's|=/sbin|=${kmod}/bin|' \
+        -e 's|=/bin|=${iproute2}/bin|' \
+        "$bin"/bin/ethercatctl
     '';
   }
 )

--- a/pkgs/by-name/et/ethercat/package.nix
+++ b/pkgs/by-name/et/ethercat/package.nix
@@ -7,6 +7,13 @@
   gitUpdater,
   pkg-config,
   systemdMinimal,
+  doxygen,
+  fig2dev,
+  python3,
+  inkscape,
+  graphviz,
+  texlive,
+  git,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "ethercat";
@@ -17,6 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "ethercat";
     rev = "refs/tags/${finalAttrs.version}";
     hash = "sha256-NgRyvNvHy04jr7ieOscBYULRdWJ7YuHbuYbRrSfXYRU=";
+    fetchSubmodules = true;
+    leaveDotGit = true;
   };
 
   separateDebugInfo = true;
@@ -31,6 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "bin"
     "dev"
+    "doc"
   ];
 
   configureFlags = [
@@ -57,6 +67,38 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   passthru.updateScript = gitUpdater { };
+
+  # See: https://gitlab.com/etherlab.org/ethercat/-/blob/6e8119b95563ba955954a68e5e2f4f3f861ac72e/.gitlab-ci.yml#L117
+  postPatch = ''
+    git show -s --format="\def\revision{%h}\def\gitversion{%(describe)}\def\gittag{%(describe:abbrev=0)}\def\gitauthor{%an}\def\isodate#1-#2-#3x{\day=#3 \month=#2 \year=#1}\isodate %csx" HEAD > documentation/git.tex
+  '';
+
+  postInstall = ''
+    mkdir -p $doc
+
+    echo "Build Doxygen docs"
+    make doc
+    cp -r doxygen-output/html $doc/html
+
+    echo "Build Doxygen LaTeX docs"
+    make -C doxygen-output/latex
+    cp -r doxygen-output/latex/refman.pdf $doc/ethercat_ref.pdf
+
+    echo "Build LateX manual"
+    mkdir -p documentation/external
+    make -C documentation
+    make -C documentation index
+    make -C documentation
+
+    cp documentation/*.pdf $doc
+  '';
+
+  postFixup = ''
+    mv $out/{share,lib,etc} $bin
+    find $out
+    echo
+    find $bin
+  '';
 
   meta = with lib; {
     description = "IgH EtherCAT Master for Linux";

--- a/pkgs/by-name/et/ethercat/package.nix
+++ b/pkgs/by-name/et/ethercat/package.nix
@@ -5,6 +5,7 @@
   stdenv,
   fetchFromGitLab,
   gitUpdater,
+  pkg-config,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "ethercat";
@@ -24,9 +25,30 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
+  outputs = [
+    "bin"
+    "dev"
+  ];
+
   configureFlags = [
+    # Components
+    "--enable-tool=yes"
     "--enable-userlib=yes"
     "--enable-kernel=no"
+
+    # Features
+    "--enable-eoe=yes"
+    "--enable-cycles=yes"
+    "--enable-rtmutex=yes"
+    "--enable-hrtimer=yes"
+    "--enable-regalias=yes"
+    "--enable-refclkop=yes"
+    "--enable-tty=no" # Is broken in Kernel 6.6
+    "--enable-wildcards"
+
+    # Debugging
+    "--enable-debug-if=yes"
+    "--enable-debug-ring=yes"
   ];
 
   passthru.updateScript = gitUpdater { };
@@ -37,6 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://gitlab.com/etherlab.org/ethercat/-/blob/${finalAttrs.version}/NEWS";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ stv0g ];
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.linux;
   };
 })

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -357,6 +357,8 @@ in {
 
     dpdk-kmods = callPackage ../os-specific/linux/dpdk-kmods { };
 
+    ethercat = callPackage ../by-name/et/ethercat/kernel.nix {};
+
     exfat-nofuse = if lib.versionOlder kernel.version "5.8" then callPackage ../os-specific/linux/exfat { } else null;
 
     evdi = callPackage ../os-specific/linux/evdi { };


### PR DESCRIPTION
## Description of changes

This PR packages the kernel modules, documentation and SystemD unit file of the IgH Ethercat master.

See also: https://github.com/NixOS/nixpkgs/issues/274191

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
