### PR TITLE
ghidriff: init at 0.6.2

### DIFF
--- a/pkgs/by-name/gh/ghidriff/package.nix
+++ b/pkgs/by-name/gh/ghidriff/package.nix
@@ -1,0 +1,42 @@
+{ lib
+, python3
+, fetchFromGitHub
+, ghidra
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "ghidriff";
+  version = "0.6.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "clearbluejar";
+    repo = "ghidriff";
+    rev = "v${version}";
+    hash = "sha256-6VcaJGycqSb6HwIBY+7Ki1Us9SBuVgyMJ6EsMwb+5ok=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  propagatedBuildInputs = [
+    python3.pkgs.mdutils
+    python3.pkgs.pyhidra
+  ];
+
+  makeWrapperArgs = [
+    "--set GHIDRA_INSTALL_DIR ${ghidra}/lib/ghidra"
+  ];
+
+  pythonImportsCheck = [ "ghidriff" ];
+
+  meta = with lib; {
+    description = "Commandline binary diffing engine using Ghidra";
+    homepage = "https://clearbluejar.github.io/ghidriff/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ evanrichter ];
+    mainProgram = "ghidriff";
+  };
+}

--- a/pkgs/development/python-modules/pyhidra/default.nix
+++ b/pkgs/development/python-modules/pyhidra/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, python3
+, fetchFromGitHub
+, ghidra
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "pyhidra";
+  version = "1.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "dod-cyber-crime-center";
+    repo = "pyhidra";
+    rev = version;
+    hash = "sha256-YAtQ0jN6+EqKNLDGgvFUf3lB5FR/dDEQ+g/BfUyRhRo=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  propagatedBuildInputs = [
+    python3.pkgs.jpype1
+    python3.pkgs.tkinter
+  ];
+
+  makeWrapperArgs = [
+    "--set GHIDRA_INSTALL_DIR ${ghidra}/lib/ghidra"
+  ];
+
+  pythonImportsCheck = [ "pyhidra" ];
+
+  meta = with lib; {
+    description = "A Python library that provides direct access to the Ghidra API within a native CPython interpreter using jpype";
+    homepage = "https://github.com/dod-cyber-crime-center/pyhidra";
+    changelog = "https://github.com/dod-cyber-crime-center/pyhidra/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ evanrichter ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9741,6 +9741,8 @@ self: super: with self; {
 
   pyhepmc = callPackage ../development/python-modules/pyhepmc { };
 
+  pyhidra = callPackage ../development/python-modules/pyhidra { };
+
   pyhiveapi = callPackage ../development/python-modules/pyhiveapi { };
 
   pyhumps = callPackage ../development/python-modules/pyhumps { };


### PR DESCRIPTION
## Description of changes

[Ghidriff](https://clearbluejar.github.io/ghidriff/) is a cli tool that uses [ghidra](https://ghidra-sre.org/) to produce a textual diff of the decompilation of two related binaries, to aid in program and patch analysis.

This PR also includes [pyhidra](https://github.com/dod-cyber-crime-center/pyhidra), a dependency of ghidriff. I have verified the binaries from this dependency to work as well
- pyhidra: a python interpreter with bindings to ghidra (`import ghidra` etc)
- pyhidraw: runs ghidra and prompts the user to install the pyhidra extension

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
