### PR TITLE
 vector: 0.37.0 → 0.37.1

### DIFF
--- a/pkgs/tools/misc/vector/Cargo.lock
+++ b/pkgs/tools/misc/vector/Cargo.lock
@@ -1145,7 +1145,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes 1.5.0",
  "fastrand 2.0.1",
- "h2 0.3.24",
+ "h2 0.3.26",
  "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.28",
@@ -3747,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes 1.5.0",
  "fnv",
@@ -3766,9 +3766,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
 dependencies = [
  "bytes 1.5.0",
  "fnv",
@@ -4210,14 +4210,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.24",
+ "h2 0.3.26",
  "http 0.2.9",
  "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing 0.1.40",
@@ -7515,7 +7515,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.24",
+ "h2 0.3.26",
  "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.28",
@@ -9371,7 +9371,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes 1.5.0",
  "flate2",
- "h2 0.3.24",
+ "h2 0.3.26",
  "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.28",
@@ -10017,7 +10017,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vector"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "apache-avro",
  "approx",
@@ -10083,7 +10083,7 @@ dependencies = [
  "governor",
  "greptimedb-client",
  "grok",
- "h2 0.4.3",
+ "h2 0.4.4",
  "hash_hasher",
  "hashbrown 0.14.3",
  "headers",

--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -37,7 +37,7 @@
 
 let
   pname = "vector";
-  version = "0.37.0";
+  version = "0.37.1";
 in
 rustPlatform.buildRustPackage {
   inherit pname version;
@@ -46,16 +46,13 @@ rustPlatform.buildRustPackage {
     owner = "vectordotdev";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-v93ZsNGoswPpey409V7qKqsBsfRt5pgY5PxGti4MlDg=";
+    hash = "sha256-wRXwgy+UY2z5fIWpQbDxRti54GE357WMGWXM/xKjz18=";
   };
 
   patches = [
     # Enable LTO to bring down binary size
-    (fetchpatch {
-      name = "vector-20034-lto.patch";
-      url  = "https://patch-diff.githubusercontent.com/raw/vectordotdev/vector/pull/20034.diff";
-      hash = "sha256-X6YWnW0x5WpKAgyqIaLjKF1F1/G4JgvmNhAHtozXrPQ=";
-    })
+    # Adapted from https://github.com/vectordotdev/vector/pull/20034
+    ./vector-lto.patch
   ];
 
   cargoLock = {

--- a/pkgs/tools/misc/vector/vector-lto.patch
+++ b/pkgs/tools/misc/vector/vector-lto.patch
@@ -1,0 +1,12 @@
+--- ./Cargo.toml	2024-04-10 00:01:12.033806583 +0100
++++ ./Cargo.toml	2024-04-10 00:01:48.324228125 +0100
+@@ -45,7 +45,8 @@ path = "tests/e2e/mod.rs"
+ # This results in roughly a 5% reduction in performance when compiling locally vs when
+ # compiled via the CI pipeline.
+ [profile.release]
+-debug = false # Do not include debug symbols in the executable.
++lto = true
++codegen-units = 1
+ 
+ [profile.bench]
+ debug = true


### PR DESCRIPTION
## Description of changes

* https://vector.dev/releases/0.37.1/
* https://github.com/vectordotdev/vector/releases/tag/v0.37.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
