### PR TITLE
python311Packages.tpm2-pytss: fix cross-compilation

### DIFF
--- a/pkgs/development/python-modules/tpm2-pytss/cross.patch
+++ b/pkgs/development/python-modules/tpm2-pytss/cross.patch
@@ -1,0 +1,22 @@
+diff --git a/setup.py b/setup.py
+index 1b5f513..d660b9a 100644
+--- a/setup.py
++++ b/setup.py
+@@ -184,7 +184,8 @@ class type_generator(build_ext):
+                 f"unable to find tss2_tpm2_types.h in {pk['include_dirs']}"
+             )
+         pdata = preprocess_file(
+-            header_path, cpp_args=["-D__extension__=", "-D__attribute__(x)="]
++            header_path, cpp_args=["-D__extension__=", "-D__attribute__(x)="],
++            cpp_path="@crossPrefix@-cpp",
+         )
+         parser = c_parser.CParser()
+         ast = parser.parse(pdata, "tss2_tpm2_types.h")
+@@ -210,6 +211,7 @@ class type_generator(build_ext):
+                         "-D__float128=long double",
+                         "-D_FORTIFY_SOURCE=0",
+                     ],
++                    cpp_path="@crossPrefix@-cpp",
+                 )
+                 parser = c_parser.CParser()
+                 past = parser.parse(pdata, "tss2_policy.h")


### PR DESCRIPTION
When tpm2-pytss builds, it will parse headers files from tpm2-tss. Those files are fed through cpp via pycparser.

Because our cross-compilation environment uses prefixed binaries like `aarch64-unknown-linux-gnu-cpp`, those can't be found by pycparser.

This adds a patch to the setup.py to provide the name of the binary.

Fixes #302878

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
