### PR TITLE
stdenv: avoid setuid issues 

### DIFF
--- a/pkgs/os-specific/linux/lxc/default.nix
+++ b/pkgs/os-specific/linux/lxc/default.nix
@@ -61,9 +61,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  # https://github.com/NixOS/nixpkgs/issues/300635
-  postInstall = ''chmod -R u-s,g-s "$out"'';
-
   passthru = {
     tests = {
       incus-legacy-init = nixosTests.incus.container-legacy-init;

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1421,7 +1421,8 @@ fixupPhase() {
     # Make sure everything is writable so "strip" et al. work.
     local output
     for output in $(getAllOutputNames); do
-        if [ -e "${!output}" ]; then chmod -R u+w "${!output}"; fi
+        # for set*id bits see #300635
+        if [ -e "${!output}" ]; then chmod -R u+w,u-s,g-s "${!output}"; fi
     done
 
     runHook preFixup

--- a/pkgs/tools/misc/plocate/default.nix
+++ b/pkgs/tools/misc/plocate/default.nix
@@ -33,9 +33,6 @@ stdenv.mkDerivation rec {
     "-Ddbpath=locatedb"
   ];
 
-  # https://github.com/NixOS/nixpkgs/issues/300635
-  postInstall = ''chmod -R u-s,g-s "$out"'';
-
   meta = with lib; {
     description = "Much faster locate";
     homepage = "https://plocate.sesse.net/";


### PR DESCRIPTION
Maybe in time we'll have a better solution.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
