### PR TITLE
nixos-icons: 2021-02-24 -> 0-unstable-2024-04-10

### DIFF
--- a/pkgs/data/misc/nixos-artwork/icons.nix
+++ b/pkgs/data/misc/nixos-artwork/icons.nix
@@ -1,25 +1,39 @@
 { stdenv
+, lib
 , fetchFromGitHub
 , imagemagick
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "nixos-icons";
-  version = "2021-02-24";
+  version = "0-unstable-2024-04-10";
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "nixos-artwork";
-    rev = "488c22aad523c709c44169d3e88d34b4691c20dc";
-    sha256 = "ZoanCzn4pqGB1fyMzMyGQVT0eIhNdL7ZHJSn1VZWVRs=";
+    rev = "f84c13adae08e860a7c3f76ab3a9bef916d276cc";
+    hash = "sha256-lO/2dLGK2f9pzLHudRIs4PUcGUliy7kfyt9r4CbhbVg=";
   };
+
+  sourceRoot = "${finalAttrs.src.name}/icons";
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     imagemagick
   ];
 
   makeFlags = [
-    "DESTDIR=${placeholder "out"}"
-    "prefix="
+    "prefix=${placeholder "out"}"
   ];
-}
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Icons of the Nix logo, in Freedesktop Icon Directory Layout";
+    homepage = "https://github.com/NixOS/nixos-artwork";
+    license = licenses.cc-by-40;
+    maintainers = with maintainers; [];
+    platforms = platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

- Update so we can ship https://github.com/NixOS/nixos-artwork/pull/120
- Address https://github.com/NixOS/nixpkgs/issues/65718
- Add `enableParallelBuilding` for small speedup
- Add some basic `meta`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
