### PR TITLE
tg-archive: init at 1.1.3

### DIFF
--- a/pkgs/by-name/tg/tg-archive/package.nix
+++ b/pkgs/by-name/tg/tg-archive/package.nix
@@ -1,0 +1,50 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+let
+  pname = "tg-archive";
+  version = "1.1.3";
+
+in python3.pkgs.buildPythonApplication {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "knadh";
+    repo = "tg-archive";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-mcobB/z+e4LzEbqELWlUzhbdV5RIM2iImeg9JdVQQZc=";
+  };
+
+  pyproject = true;
+  pythonRelaxDeps = true;
+
+  nativeBuildInputs = with python3.pkgs; [
+    pythonRelaxDepsHook
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    setuptools
+    telethon
+    jinja2
+    pyyaml
+    cryptg
+    pillow
+    feedgen
+    python-magic
+    pytz
+  ];
+
+  pythonImportsCheck = [
+    "tgarchive"
+  ];
+
+  meta = {
+    description = "A tool for exporting Telegram group chats into static websites like mailing list archives";
+    homepage = "https://github.com/knadh/tg-archive";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pacien ];
+    mainProgram = "tg-archive";
+  };
+}


### PR DESCRIPTION
## Description of changes

This introduces a package for [tg-archive], a tool for exporting Telegram group
chats into static websites like mailing list archives.

[tg-archive]: https://github.com/knadh/tg-archive


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
