### PR TITLE
tests.importCargoLock: fix self-inclusive src listings in .nix files

### DIFF
--- a/pkgs/build-support/rust/test/import-cargo-lock/basic-dynamic/default.nix
+++ b/pkgs/build-support/rust/test/import-cargo-lock/basic-dynamic/default.nix
@@ -1,10 +1,19 @@
-{ rustPlatform }:
-
+{ lib, rustPlatform }:
+let
+  fs = lib.fileset;
+in
 rustPlatform.buildRustPackage {
   pname = "basic-dynamic";
   version = "0.1.0";
 
-  src = ./.;
+  src = fs.toSource {
+    root = ./.;
+    fileset = fs.unions [
+      ./Cargo.toml
+      ./Cargo.lock
+      ./src
+    ];
+  };
 
   cargoLock.lockFileContents = builtins.readFile ./Cargo.lock;
 

--- a/pkgs/build-support/rust/test/import-cargo-lock/basic/default.nix
+++ b/pkgs/build-support/rust/test/import-cargo-lock/basic/default.nix
@@ -1,10 +1,19 @@
-{ rustPlatform }:
-
+{ lib, rustPlatform }:
+let
+  fs = lib.fileset;
+in
 rustPlatform.buildRustPackage {
   pname = "basic";
   version = "0.1.0";
 
-  src = ./.;
+  src = fs.toSource {
+    root = ./.;
+    fileset = fs.unions [
+      ./Cargo.toml
+      ./Cargo.lock
+      ./src
+    ];
+  };
 
   cargoLock = {
     lockFile = ./Cargo.lock;

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-branch/default.nix
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-branch/default.nix
@@ -1,10 +1,19 @@
-{ rustPlatform }:
-
+{ lib, rustPlatform }:
+let
+  fs = lib.fileset;
+in
 rustPlatform.buildRustPackage {
   pname = "git-dependency-branch";
   version = "0.1.0";
 
-  src = ./.;
+  src = fs.toSource {
+    root = ./.;
+    fileset = fs.unions [
+      ./Cargo.toml
+      ./Cargo.lock
+      ./src
+    ];
+  };
 
   cargoLock = {
     lockFile = ./Cargo.lock;

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-rev-non-workspace-nested-crate/default.nix
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-rev-non-workspace-nested-crate/default.nix
@@ -1,10 +1,19 @@
 { rustPlatform, pkg-config, openssl, lib, darwin, stdenv }:
-
+let
+  fs = lib.fileset;
+in
 rustPlatform.buildRustPackage {
   pname = "git-dependency-rev-non-workspace-nested-crate";
   version = "0.1.0";
 
-  src = ./.;
+  src = fs.toSource {
+    root = ./.;
+    fileset = fs.unions [
+      ./Cargo.toml
+      ./Cargo.lock
+      ./src
+    ];
+  };
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-rev/default.nix
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-rev/default.nix
@@ -1,10 +1,19 @@
-{ rustPlatform }:
-
+{ lib, rustPlatform }:
+let
+  fs = lib.fileset;
+in
 rustPlatform.buildRustPackage {
   pname = "git-dependency-rev";
   version = "0.1.0";
 
-  src = ./.;
+  src = fs.toSource {
+    root = ./.;
+    fileset = fs.unions [
+      ./Cargo.toml
+      ./Cargo.lock
+      ./src
+    ];
+  };
 
   cargoLock = {
     lockFile = ./Cargo.lock;

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-tag/default.nix
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-tag/default.nix
@@ -1,10 +1,19 @@
-{ rustPlatform }:
-
+{ lib, rustPlatform }:
+let
+  fs = lib.fileset;
+in
 rustPlatform.buildRustPackage {
   pname = "git-dependency-tag";
   version = "0.1.0";
 
-  src = ./.;
+  src = fs.toSource {
+    root = ./.;
+    fileset = fs.unions [
+      ./Cargo.toml
+      ./Cargo.lock
+      ./src
+    ];
+  };
 
   cargoLock = {
     lockFile = ./Cargo.lock;

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency/default.nix
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency/default.nix
@@ -1,10 +1,19 @@
-{ rustPlatform }:
-
+{ lib, rustPlatform }:
+let
+  fs = lib.fileset;
+in
 rustPlatform.buildRustPackage {
   pname = "git-dependency";
   version = "0.1.0";
 
-  src = ./.;
+  src = fs.toSource {
+    root = ./.;
+    fileset = fs.unions [
+      ./Cargo.toml
+      ./Cargo.lock
+      ./src
+    ];
+  };
 
   cargoLock = {
     lockFile = ./Cargo.lock;

--- a/pkgs/build-support/rust/test/import-cargo-lock/v1/default.nix
+++ b/pkgs/build-support/rust/test/import-cargo-lock/v1/default.nix
@@ -1,10 +1,19 @@
-{ rustPlatform }:
-
+{ lib, rustPlatform }:
+let
+  fs = lib.fileset;
+in
 rustPlatform.buildRustPackage {
   pname = "v1";
   version = "0.1.0";
 
-  src = ./.;
+  src = fs.toSource {
+    root = ./.;
+    fileset = fs.unions [
+      ./Cargo.toml
+      ./Cargo.lock
+      ./src
+    ];
+  };
 
   cargoLock = {
     lockFile = ./Cargo.lock;


### PR DESCRIPTION
## Description of changes

Replace `src = ./.` instances with more explicit source listings using `lib.fileset`. Otherwise, derivations will be rebuilt on any change to the files defining them (e.g. formatting via nixfmt-rfc-style).

Related: #301014

Quick testing instructions:
1. `nix-build -A tests.importCargoLock` (run relevant tests)
1. `nix run nixpkgs#nixfmt-rfc-style -- pkgs/build-support/rust/test/import-cargo-lock/` (two source files should be reformatted)
1. `nix-build -A tests.importCargoLock` (attempt to re-run tests, noticing that the reformatting has not caused any tests to actually be rebuilt)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
