### PR TITLE
ffmpeg_7: add support for MPEG-5 EVC en/decoding

### DIFF
--- a/pkgs/by-name/xe/xevd/package.nix
+++ b/pkgs/by-name/xe/xevd/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchpatch2,
+  stdenv,
+  gitUpdater,
+  cmake,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xevd";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "mpeg5";
+    repo = "xevd";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-+qC/BnP8o/kfl5ax+g1PohvXIJBL2gin/QZ9Gkvi0WU=";
+  };
+
+  patches = [
+    (fetchpatch2 {
+      name = "fix dangling pointer error";
+      url = "https://github.com/mpeg5/xevd/commit/13b86a74e26df979dd1cc3a1cb19bf1ac828e197.patch";
+      sha256 = "sha256-CeSfhN78ldooyZ9H4F2ex9wTBFXuNZdBcnLdk7GqDXI=";
+    })
+    (fetchpatch2 {
+      name = "fix invalid comparison of c_buf in write_y4m_header ";
+      url = "https://github.com/mpeg5/xevd/commit/e4ae0c567a6ec5e10c9f5ed44c61e4e3b6816c16.patch";
+      sha256 = "sha256-9bG6hyIV/AZ0mRbd3Fc/c137Xm1i6NJ1IfuGadG0vUU=";
+    })
+  ];
+
+  postPatch = ''
+    echo v$version > version.txt
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  postInstall = ''
+    ln $dev/include/xevd/* $dev/include/
+  '';
+
+  env.NIX_CFLAGS_COMPILE = toString [ "-lm" ];
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    homepage = "https://github.com/mpeg5/xevd";
+    description = "eXtra-fast Essential Video Decoder, MPEG-5 EVC";
+    license = lib.licenses.bsd3;
+    mainProgram = "xevd_app";
+    maintainers = with lib.maintainers; [ jopejoe1 ];
+    platforms = lib.platforms.all;
+    broken = !stdenv.hostPlatform.isx86;
+  };
+})

--- a/pkgs/by-name/xe/xeve/package.nix
+++ b/pkgs/by-name/xe/xeve/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  stdenv,
+  cmake,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xeve";
+  version = "0.4.3";
+
+  src = fetchFromGitHub {
+    owner = "mpeg5";
+    repo = "xeve";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-8YueEx2oIh24jV38bzpDlCVHNZB7HDOXeP5MANM8zBc=";
+  };
+
+  postPatch = ''
+    echo v$version > version.txt
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  postInstall = ''
+    ln $dev/include/xeve/* $dev/include/
+  '';
+
+  env.NIX_CFLAGS_COMPILE = toString [ "-lm" ];
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    homepage = "https://github.com/mpeg5/xeve";
+    description = "eXtra-fast Essential Video Encoder, MPEG-5 EVC";
+    license = lib.licenses.bsd3;
+    mainProgram = "xeve_app";
+    maintainers = with lib.maintainers; [ jopejoe1 ];
+    platforms = lib.platforms.all;
+    broken = !stdenv.hostPlatform.isx86;
+  };
+})

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -112,6 +112,8 @@
 , withXcbShape ? withFullDeps # X11 grabbing shape rendering
 , withXcbShm ? withFullDeps # X11 grabbing shm communication
 , withXcbxfixes ? withFullDeps # X11 grabbing mouse rendering
+, withXevd ? withFullDeps && lib.versionAtLeast version "7" && stdenv.hostPlatform.isx86 # MPEG-5 EVC decoding
+, withXeve ? withFullDeps && lib.versionAtLeast version "7" && stdenv.hostPlatform.isx86 # MPEG-5 EVC encoding
 , withXlib ? withFullDeps # Xlib support
 , withXml2 ? withFullDeps # libxml2 support, for IMF and DASH demuxers
 , withXvid ? withHeadlessDeps && withGPL # Xvid encoder, native encoder exists
@@ -279,6 +281,8 @@
 , x264
 , x265
 , xavs
+, xevd
+, xeve
 , xvidcore
 , xz
 , zeromq4
@@ -587,6 +591,10 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withXcbShape "libxcb-shape")
     (enableFeature withXcbShm "libxcb-shm")
     (enableFeature withXcbxfixes "libxcb-xfixes")
+  ] ++ optionals (versionAtLeast version "7")  [
+    (enableFeature withXevd "libxevd")
+    (enableFeature withXeve "libxeve")
+  ] ++ [
     (enableFeature withXlib "xlib")
     (enableFeature withXml2 "libxml2")
     (enableFeature withXvid "libxvid")
@@ -696,6 +704,8 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withX265 [ x265 ]
   ++ optionals withXavs [ xavs ]
   ++ optionals withXcb [ libxcb ]
+  ++ optionals withXevd [ xevd ]
+  ++ optionals withXeve [ xeve ]
   ++ optionals withXlib [ libX11 libXv libXext ]
   ++ optionals withXml2 [ libxml2 ]
   ++ optionals withXvid [ xvidcore ]


### PR DESCRIPTION
## Description of changes
Support for MPEG-5/EVC encoding and decoding was added in version 7

Samples for testing: http://fate-suite.ffmpeg.org/evc/
did a round trip with mpeg4

xevd is unstable due to latest version having compile errors.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
