### PR TITLE
adventure-games-studio: init at 3.6.1.23

### DIFF
--- a/pkgs/by-name/ad/adventure-games-studio/package.nix
+++ b/pkgs/by-name/ad/adventure-games-studio/package.nix
@@ -1,0 +1,61 @@
+{ lib
+, fetchurl
+, stdenv
+
+, autoPatchelfHook
+, makeWrapper
+, dpkg
+
+, libogg
+, libtheora
+, libvorbis
+, SDL2
+, SDL2_sound
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ags3";
+  version = "3.6.1.23";
+
+  src = fetchurl {
+    url = "https://github.com/adventuregamestudio/ags/releases/download/v3.6.1.23/ags_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-dWL9V+mS5hxpF+QIWbiI+uBEwSOTc63gNN4JJ9F6ApM=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    autoPatchelfHook
+    dpkg
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    libogg
+    libtheora
+    libvorbis
+    SDL2
+    SDL2_sound
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,share}
+    cp usr/bin/ags $out/bin/ags3
+    cp -r usr/share $out/share
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.adventuregamestudio.co.uk/";
+    description = "Adventure Game Studio engine (version 3) meant for running adventure games.";
+    license = licenses.artistic2;
+    maintainers = with maintainers; [ ByteSudoer ];
+    platforms = platforms.unix;
+    mainProgram = "ags3";
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adventure Game Studio (AGS) - is the IDE and the engine meant for creating and running videogames of adventure (aka "quest") genre.

The IDE is not available for Linux/Mac, just the engine.

Metadata
- homepage URL: https://www.adventuregamestudio.co.uk/
- source URL: https://github.com/adventuregamestudio/ags
- license: Artistic License 2.0
- platforms: linux, darwin
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
