### PR TITLE
Revert "NixOS Integration Tests: Enable again for darwin"

### DIFF
--- a/nixos/lib/testing/meta.nix
+++ b/nixos/lib/testing/meta.nix
@@ -36,7 +36,7 @@ in
           };
           platforms = lib.mkOption {
             type = types.listOf types.raw;
-            default = lib.platforms.linux ++ lib.platforms.darwin;
+            default = lib.platforms.linux;
             description = ''
               Sets the [`meta.platforms`](https://nixos.org/manual/nixpkgs/stable/#var-meta-platforms) attribute on the [{option}`test`](#test-opt-test) derivation.
             '';


### PR DESCRIPTION
Reverts NixOS/nixpkgs#303150

This broke ofborg's eval

cc @tfc

```
$ nix-env -qaP --no-name --out-path --arg checkMeta false --argstr path $PWD -f outpaths.nix --show-trace
error:
       … while evaluating call site

       at «none»:0: (source not available)

       … while calling anonymous lambda

       at /root/nixpkgs/outpaths.nix:48:12:

           47|   tweak = lib.mapAttrs
           48|     (name: val:
             |            ^
           49|       if name == "recurseForDerivations" then true

       … while evaluating call site

       at /root/nixpkgs/lib/attrsets.nix:1214:43:

         1213|     f:
         1214|     listToAttrs (map (n: nameValuePair n (f n)) names);
             |                                           ^
         1215|

       … while calling anonymous lambda

       at /root/nixpkgs/pkgs/top-level/release-lib.nix:145:6:

          144|   testOnCross = crossSystem: metaPatterns: f: forMatchingSystems metaPatterns
          145|     (system: hydraJob' (f (pkgsForCross crossSystem system)));
             |      ^
          146|

       … while evaluating call site

       at /root/nixpkgs/pkgs/top-level/release-lib.nix:145:14:

          144|   testOnCross = crossSystem: metaPatterns: f: forMatchingSystems metaPatterns
          145|     (system: hydraJob' (f (pkgsForCross crossSystem system)));
             |              ^
          146|

       … while calling 'hydraJob'

       at /root/nixpkgs/lib/customisation.nix:388:14:

          387|   */
          388|   hydraJob = drv:
             |              ^
          389|     let

       … while evaluating the attribute 'outPath'

       at /root/nixpkgs/lib/customisation.nix:404:13:

          403|           value = commonAttrs // {
          404|             outPath = output.outPath;
             |             ^
          405|             drvPath = output.drvPath;

       error: attribute 'out' missing

       at /root/nixpkgs/lib/customisation.nix:401:22:

          400|       makeOutput = outputName:
          401|         let output = drv.${outputName}; in
             |                      ^
          402|         { name = outputName;
```