### PR TITLE
ci(Check cherry-picks): gracefully fail when original commit hash cannot be identified

### DIFF
--- a/maintainers/scripts/check-cherry-picks.sh
+++ b/maintainers/scripts/check-cherry-picks.sh
@@ -23,10 +23,10 @@ while read new_commit_sha ; do
   original_commit_sha=$(
     git rev-list --max-count=1 --format=format:%B "$new_commit_sha" \
     | grep -Ei -m1 "cherry.*[0-9a-f]{40}" \
-    | grep -Eoi -m1 '[0-9a-f]{40}'
+    | grep -Eoi -m1 '[0-9a-f]{40}' || true
   )
-  if [ "$?" != "0" ] ; then
-    echo "  ? Couldn't locate original commit hash in message"
+  if [ -z "$original_commit_sha" ] ; then
+    echo "  ? Couldn't locate original commit hash in message, maybe \`git cherry-pick -x ...\` was not used?"
     [ "$GITHUB_ACTIONS" = 'true' ] && echo ::endgroup::
     continue
   fi
@@ -85,7 +85,7 @@ while read new_commit_sha ; do
   problem=1
 done <<< "$(
   git rev-list \
-    -E -i --grep="cherry.*[0-9a-f]{40}" --reverse \
+    -E -i --reverse \
     "$1..$2"
 )"
 


### PR DESCRIPTION
## Description of changes


Follow-up to this report: https://github.com/NixOS/nixpkgs/pull/172098#issuecomment-2048285741
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
