### PR TITLE
nixos/fzf: add package option, fix ordering, and other cleanup

### DIFF
--- a/nixos/modules/programs/fzf.nix
+++ b/nixos/modules/programs/fzf.nix
@@ -9,12 +9,12 @@ in
 {
   imports = [
     (lib.mkRemovedOptionModule [ "programs" "fzf" "keybindings" ] ''
-      Use "programs.fzf.enable" instead, due to fzf upstream-change it's not possible to load shell-completion and keybindings separately.
-      If you want to change/disable certain keybindings please check the fzf-documentation.
+      Use "programs.fzf.enable" instead; due to fzf upstream changes, it's not possible to load shell-completion and keybindings separately.
+      If you want to change/disable certain keybindings, please check the fzf documentation.
     '')
     (lib.mkRemovedOptionModule [ "programs" "fzf" "fuzzyCompletion" ] ''
-      Use "programs.fzf.enable" instead, due to fzf upstream-change it's not possible to load shell-completion and keybindings separately.
-      If you want to change/disable certain keybindings please check the fzf-documentation.
+      Use "programs.fzf.enable" instead; due to fzf upstream changes, it's not possible to load shell-completion and keybindings separately.
+      If you want to change/disable certain keybindings, please check the fzf documentation.
     '')
   ];
 

--- a/nixos/modules/programs/fzf.nix
+++ b/nixos/modules/programs/fzf.nix
@@ -19,7 +19,7 @@ in
   ];
 
   options = {
-    programs.fzf.enable = mkEnableOption (mdDoc "fuzzy completion with fzf and keybindings");
+    programs.fzf.enable = mkEnableOption "fuzzy completion with fzf and keybindings";
   };
 
   config = mkIf cfg.enable {

--- a/nixos/modules/programs/fzf.nix
+++ b/nixos/modules/programs/fzf.nix
@@ -3,7 +3,7 @@
 let
   inherit (lib) maintainers;
   inherit (lib.meta) getExe;
-  inherit (lib.modules) mkIf mkRemovedOptionModule;
+  inherit (lib.modules) mkAfter mkIf mkRemovedOptionModule;
   inherit (lib.options) mkEnableOption mkPackageOption;
   inherit (lib.strings) optionalString;
 
@@ -33,7 +33,7 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
-    programs.bash.interactiveShellInit = ''
+    programs.bash.promptPluginInit = mkAfter ''
       eval "$(${getExe cfg.package} --bash)"
     '';
 

--- a/nixos/modules/programs/fzf.nix
+++ b/nixos/modules/programs/fzf.nix
@@ -4,7 +4,7 @@ let
   inherit (lib) maintainers;
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkRemovedOptionModule;
-  inherit (lib.options) mkEnableOption;
+  inherit (lib.options) mkEnableOption mkPackageOption;
   inherit (lib.strings) optionalString;
 
   cfg = config.programs.fzf;
@@ -23,23 +23,27 @@ in
   ];
 
   options = {
-    programs.fzf.enable = mkEnableOption "fuzzy completion with fzf and keybindings";
+    programs.fzf = {
+      enable = mkEnableOption "fuzzy completion with fzf and keybindings";
+
+      package = mkPackageOption pkgs "fzf" { };
+    };
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.fzf ];
+    environment.systemPackages = [ cfg.package ];
 
     programs.bash.interactiveShellInit = ''
-      eval "$(${getExe pkgs.fzf} --bash)"
+      eval "$(${getExe cfg.package} --bash)"
     '';
 
     programs.fish.interactiveShellInit = ''
-      ${getExe pkgs.fzf} --fish | source
+      ${getExe cfg.package} --fish | source
     '';
 
     programs.zsh = {
       interactiveShellInit = optionalString (!config.programs.zsh.ohMyZsh.enable) ''
-        eval "$(${getExe pkgs.fzf} --zsh)"
+        eval "$(${getExe cfg.package} --zsh)"
       '';
 
       ohMyZsh.plugins = mkIf (config.programs.zsh.ohMyZsh.enable) [ "fzf" ];

--- a/nixos/modules/programs/fzf.nix
+++ b/nixos/modules/programs/fzf.nix
@@ -1,18 +1,22 @@
 { pkgs, config, lib, ... }:
 
-with lib;
-
 let
+  inherit (lib) maintainers;
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf mkRemovedOptionModule;
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.strings) optionalString;
+
   cfg = config.programs.fzf;
 
 in
 {
   imports = [
-    (lib.mkRemovedOptionModule [ "programs" "fzf" "keybindings" ] ''
+    (mkRemovedOptionModule [ "programs" "fzf" "keybindings" ] ''
       Use "programs.fzf.enable" instead; due to fzf upstream changes, it's not possible to load shell-completion and keybindings separately.
       If you want to change/disable certain keybindings, please check the fzf documentation.
     '')
-    (lib.mkRemovedOptionModule [ "programs" "fzf" "fuzzyCompletion" ] ''
+    (mkRemovedOptionModule [ "programs" "fzf" "fuzzyCompletion" ] ''
       Use "programs.fzf.enable" instead; due to fzf upstream changes, it's not possible to load shell-completion and keybindings separately.
       If you want to change/disable certain keybindings, please check the fzf documentation.
     '')


### PR DESCRIPTION
## Description of changes

- fix removed option text
- remove lib.mdDoc (no-op)
- remove top-level `with lib;`
- add package option
- ensure fzf init script is evaluated after bash completions and before aliases. Fixes #303195.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
