### PR TITLE
vscode-extensions.signageos.signageos-vscode-sops: init 0.9.1

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3901,6 +3901,23 @@ let
         };
       };
 
+      signageos.signageos-vscode-sops = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "signageos-vscode-sops";
+          publisher = "signageos";
+          version = "0.9.1";
+          hash = "sha256-b1Gp+tL5/e97xMuqkz4EvN0PxI7cJOObusEkcp+qKfM=";
+        };
+        meta = {
+          changelog = "https://marketplace.visualstudio.com/items/signageos.signageos-vscode-sops/changelog";
+          description = "A Visual Studio Code extension for SOPS support";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=signageos.signageos-vscode-sops";
+          homepage = "https://github.com/signageos/vscode-sops";
+          license = lib.licenses.unfree;
+          maintainers = [ lib.maintainers.superherointj ];
+        };
+      };
+
       silofy.hackthebox = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "hackthebox";


### PR DESCRIPTION
vscode-extensions.signageos.signageos-vscode-sops: init 0.9.1

Release: https://github.com/signageos/vscode-sops/releases/tag/v0.9.1