### PR TITLE
vectorscan: 5.4.10.1 -> 5.4.11

### DIFF
--- a/pkgs/development/libraries/vectorscan/default.nix
+++ b/pkgs/development/libraries/vectorscan/default.nix
@@ -30,11 +30,37 @@ stdenv.mkDerivation rec {
     boost
   ];
 
-  cmakeFlags = lib.optional enableShared "-DBUILD_STATIC_AND_SHARED=ON"
-    ++ [ "-DFAT_RUNTIME=${if stdenv.hostPlatform.isLinux then "ON" else "OFF"}" ]
-    ++ lib.optional stdenv.hostPlatform.avx2Support "-DBUILD_AVX2=ON"
-    ++ lib.optional stdenv.hostPlatform.avx512Support "-DBUILD_AVX512=ON"
-  ;
+  # FAT_RUNTIME bundles optimized implementations for different CPU extensions and uses CPUID to
+  # transparently select the fastest for the current hardware.
+  # This feature is only available on linux for x86, x86_64, and aarch64.
+  #
+  # If FAT_RUNTIME is not available, we fall back to building for a single extension based
+  # on stdenv.hostPlatform.
+  #
+  # For generic builds (e.g. x86_64) this can mean using an implementation not optimized for the
+  # potentially available more modern hardware extensions (e.g. x86_64 with AVX512).
+  cmakeFlags = [ (if enableShared then "-DBUILD_SHARED_LIBS=ON" else "BUILD_STATIC_LIBS=ON") ]
+    ++
+    (if lib.elem stdenv.hostPlatform.system [ "x86_64-linux" "i686-linux" ] then
+      [ "-DBUILD_AVX2=ON" "-DBUILD_AVX512=ON" "-DBUILD_AVX512VBMI=ON" "-DFAT_RUNTIME=ON" ]
+    else
+      (if (stdenv.isLinux && stdenv.isAarch64) then
+        [ "-DBUILD_SVE=ON" "-DBUILD_SVE2=ON" "-DBUILD_SVE2_BITPERM=ON" "-DFAT_RUNTIME=ON" ]
+      else
+        [ "-DFAT_RUNTIME=OFF" ]
+          ++ lib.optional stdenv.hostPlatform.avx2Support "-DBUILD_AVX2=ON"
+          ++ lib.optional stdenv.hostPlatform.avx512Support "-DBUILD_AVX512=ON"
+      )
+    );
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+
+    ./bin/unit-hyperscan
+
+    runHook postCheck
+  '';
 
   meta = with lib; {
     description = "A portable fork of the high-performance regular expression matching library";

--- a/pkgs/development/libraries/vectorscan/default.nix
+++ b/pkgs/development/libraries/vectorscan/default.nix
@@ -2,32 +2,38 @@
 , stdenv
 , fetchFromGitHub
 , cmake
+, pkg-config
 , ragel
 , util-linux
 , python3
-, boost
+, boost184
+, sqlite
+, pcre
 , enableShared ? !stdenv.hostPlatform.isStatic
 }:
 
 stdenv.mkDerivation rec {
   pname = "vectorscan";
-  version = "5.4.10.1";
+  version = "5.4.11";
 
   src = fetchFromGitHub {
     owner = "VectorCamp";
     repo = "vectorscan";
     rev = "vectorscan/${version}";
-    hash = "sha256-x6FefOrUvpN/A4GXTd+3SGZEAQL6pXt83ufxRIY3Q9k=";
+    hash = "sha256-wz2oIhau/vjnri3LOyPZSCFAWg694FTLVt7+SZYEsL4=";
   };
 
   nativeBuildInputs = [
     cmake
+    pkg-config
     ragel
     python3
   ] ++ lib.optional stdenv.isLinux util-linux;
 
   buildInputs = [
-    boost
+    boost184
+    sqlite
+    pcre
   ];
 
   # FAT_RUNTIME bundles optimized implementations for different CPU extensions and uses CPUID to


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release: https://github.com/VectorCamp/vectorscan/releases/tag/vectorscan%2F5.4.11
Changelog: https://github.com/VectorCamp/vectorscan/blob/develop/CHANGELOG-vectorscan.md#5411-2023-11-19

tldr: This PR bumps the version *and* explicitly enables all available CPU extensions the `FAT_RUNTIME` binaries.

With the version bump the `FAT_RUNTIME` won't build without AVX2 support explicitly enabled.
And [upsteam now enabled all extensions for fat binaries](https://github.com/VectorCamp/vectorscan/pull/220) (not released yet).
And [Debian has almost all extensions enabled](https://sources.debian.org/src/vectorscan/5.4.11-2/debian/rules/). (I assume they did not enable BUILD_AVX512VBMI, because they want it to be buildable by an older toolchain?)

This let me to belive it would be sensible enable all `FAT_RUNTIME` extensions.

`FAT_RUNTIME` bundles optimized implementations for different CPU extensions and uses CPUID to transparently select the fastest for the current hardware.
This feature is only available on linux for x86, x86_64, and aarch64.

If `FAT_RUNTIME` is not available, we fall back to building for a single extension based on stdenv.hostPlatform.
For generic builds (e.g. x86_64) this can mean using an implementation not optimized for the potentially available more modern hardware extensions (e.g. x86_64 with AVX512).

Effectively this adds avx512 and avx512vbmi support for linux x86_64 binaries and follows upstreams direction.

<details>
<summary>"nm -D ..." showing what symbols are available from what library builds</summary>
linux x86_64:

```
# before
$ nm -D result/lib/libhs.so | grep -E "_hs_scan_stream"
00000000005bdbb0 T avx2_hs_scan_stream
00000000003b7140 T core2_hs_scan_stream
00000000004bb1b0 T corei7_hs_scan_stream

# after
$ nm -D result-/lib/libhs.so | grep -E "_hs_scan_stream"
00000000005c0bf0 T avx2_hs_scan_stream
00000000006d72a0 T avx512_hs_scan_stream
00000000007ff920 T avx512vbmi_hs_scan_stream
00000000003ba180 T core2_hs_scan_stream
00000000004be1f0 T corei7_hs_scan_stream
```

linux aarch64:

```
#before
$ nm -D result-old/lib/libhs.so | grep -E "_hs_scan_stream"
000000000033a7c4 T neon_hs_scan_stream
0000000000505994 T sve2_hs_scan_stream
0000000000421034 T sve_hs_scan_stream

#after
$ nm -D result-new/lib/libhs.so | grep -E "_hs_scan_stream"
000000000033a7c4 T neon_hs_scan_stream
0000000000506744 T sve2_hs_scan_stream
0000000000421034 T sve_hs_scan_stream
```
</details>

---

Result of `nixpkgs-review pr 303207` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages built:</summary>
  <ul>
    <li>python311Packages.pyperscan</li>
    <li>python311Packages.pyperscan.dist</li>
    <li>python312Packages.pyperscan</li>
    <li>python312Packages.pyperscan.dist</li>
    <li>vectorscan</li>
  </ul>
</details>

Result of `nixpkgs-review pr 303207` run on aarch64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages built:</summary>
  <ul>
    <li>python311Packages.pyperscan</li>
    <li>python311Packages.pyperscan.dist</li>
    <li>python312Packages.pyperscan</li>
    <li>python312Packages.pyperscan.dist</li>
    <li>vectorscan</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin (ofborg did)
  - [x] aarch64-darwin (ofborg did)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
