### PR TITLE
check-cherry-picks.sh maintainer script: fix handling of cherry-pick-less branches

### DIFF
--- a/maintainers/scripts/check-cherry-picks.sh
+++ b/maintainers/scripts/check-cherry-picks.sh
@@ -12,6 +12,9 @@ PICKABLE_BRANCHES=${PICKABLE_BRANCHES:-master staging release-??.?? staging-??.?
 problem=0
 
 while read new_commit_sha ; do
+  if [ -z "$new_commit_sha" ] ; then
+    continue  # skip empty lines
+  fi
   if [ "$GITHUB_ACTIONS" = 'true' ] ; then
     echo "::group::Commit $new_commit_sha"
   else

--- a/maintainers/scripts/check-cherry-picks.sh
+++ b/maintainers/scripts/check-cherry-picks.sh
@@ -60,6 +60,8 @@ while read new_commit_sha ; do
 
           $range_diff_common --color
 
+          echo "Note this should not necessarily be treated as a hard fail, but a reviewer's attention should" \
+            "be drawn to it and github actions have no way of doing that but to raise a 'failure'"
           problem=1
         else
           echo "  ✔ $original_commit_sha highly similar to $new_commit_sha"


### PR DESCRIPTION
## Description of changes
PRs with no commits mentioning cherry-picks will produce an empty output from the git command. This behaviour will have changed when I chose a different iteration approach shortly before merging :crying_cat_face: 

This should fix situations like #303093

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
