### PR TITLE
potreeconverter: Don't unnecessarily override patchPhase/fixupPhase.

### DIFF
--- a/pkgs/applications/graphics/potreeconverter/default.nix
+++ b/pkgs/applications/graphics/potreeconverter/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     cmake
   ];
 
-  patchPhase = ''
+  postPatch = ''
     runHook prePatch
 
     substituteInPlace ./CMakeLists.txt \
@@ -37,12 +37,12 @@ stdenv.mkDerivation rec {
     # prevent inheriting permissions from /nix/store when copying
     substituteInPlace Converter/src/main.cpp --replace \
       'fs::copy(templateDir, pagedir, fs::copy_options::overwrite_existing | fs::copy_options::recursive)' 'string cmd = "cp --no-preserve=mode -r " + templateDir + " " + pagedir; system(cmd.c_str());'
-
-    runHook postPatch
   '';
 
+  # The upstream build system does not provide an install target.
   installPhase = ''
     runHook preInstall
+
     mkdir -p $out/{bin,lib}
     mv liblaszip.so $out/lib
     mv PotreeConverter $out/bin
@@ -56,10 +56,8 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  fixupPhase = ''
-    runHook preFixup
+  postFixup = ''
     ln -s $src/resources $out/bin/resources
-    runHook postFixup
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Overriding `patchPhase` makes declaring or overriding `patches = [...]` have no effect.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
