### PR TITLE
shanggu-fonts: init at 1.020

### DIFF
--- a/pkgs/by-name/sh/shanggu-fonts/package.nix
+++ b/pkgs/by-name/sh/shanggu-fonts/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  p7zip,
+}:
+let
+  version = "1.020";
+
+  source =
+    with lib.attrsets;
+    mapAttrs'
+      (
+        name: hash:
+        nameValuePair (lib.strings.toLower name) (fetchurl {
+          url = "https://github.com/GuiWonder/Shanggu/releases/download/${version}/Shanggu${name}TTCs.7z";
+          inherit hash;
+        })
+      )
+      {
+        Mono = "sha256-PcP4zJk8pptuX9tchr4qOorqAvj8YMRBcVrtCbp/1Zo=";
+        Round = "sha256-3wqMdnpdn4xpw7wO+QmIpl5/vZjQGgcfTMdtewK28B8=";
+        Sans = "sha256-isRqIVcH24knPqPI+a+9CpxEKd+PG642giUS9+VbC60=";
+        Serif = "sha256-k0I0NXStE1hcdOaOykuESy6sYqBHHaMaDxxr3tJUSYU=";
+      };
+in
+stdenvNoCC.mkDerivation {
+  pname = "shanggu-fonts";
+  inherit version;
+
+  outputs = [ "out" ] ++ builtins.attrNames source;
+
+  nativeBuildInputs = [ p7zip ];
+
+  unpackPhase = ''
+    runHook preUnpack
+  '' + lib.strings.concatLines (
+    lib.attrsets.mapAttrsToList (name: value: ''
+      7z x ${value} -o${name}
+    '') source
+  ) + ''
+    runHook postUnpack
+  '';
+
+  installPhase =
+    ''
+      runHook preInstall
+
+      mkdir -p $out/share/fonts/truetype
+    ''
+    + lib.strings.concatLines (
+      lib.lists.forEach (builtins.attrNames source) (
+        name: (''
+          install -Dm444 ${name}/*.ttc -t $'' + name + ''/share/fonts/truetype
+          ln -s $'' + name + ''/share/fonts/truetype/*.ttc $out/share/fonts/truetype
+          ''
+        )
+      )
+    ) + ''
+      runHook postInstall
+    '';
+
+  meta = with lib; {
+    homepage = "https://github.com/GuiWonder/Shanggu";
+    description = "Heritage glyph (old glyph) font based on Siyuan";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ Cryolitia ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Add a set of CJK fonts Shanggu 

「 尙古黑體｜尙古明體｜尙古等宽｜尙古圓體」

https://github.com/GuiWonder/Shanggu

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
