### PR TITLE
orc: fix build on 32-bit ARM

### DIFF
--- a/pkgs/development/compilers/orc/default.nix
+++ b/pkgs/development/compilers/orc/default.nix
@@ -25,10 +25,7 @@ in stdenv.mkDerivation rec {
     sha256 = "sha256-g7B0y2cxfVi+8ejQzIYveuinekW7/wVqH5h8ZIiy9f0=";
   };
 
-  postPatch = lib.optionalString stdenv.isAarch32 ''
-    # https://gitlab.freedesktop.org/gstreamer/orc/-/issues/20
-    sed -i '/exec_opcodes_sys/d' testsuite/meson.build
-  '' + lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''
+  postPatch = lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''
     # This benchmark times out on Hydra.nixos.org
     sed -i '/memcpy_speed/d' testsuite/meson.build
   '';


### PR DESCRIPTION
## Description of changes

In 0.4.36, the sed expression that tries to disable the `exec_opcodes_sys` test also deletes other lines that break the file syntax. The build fails with:

```
testsuite/meson.build:23:25: ERROR: Expecting endif got colon.
                  install: false,
                         ^
For a block that started at 22,2
  if enabled_backends.contains('sse') and enabled_backends.contains('avx')
  ^
```

The test has apparently been fixed since 0.4.33 anyway ([see commit](https://gitlab.freedesktop.org/gstreamer/orc/-/commit/5d5515ea5b01c82bbe559029255f528082c4fce1)), so just get rid of this sed patch. I'm trying to confirm that the test passes in the native build, but this is a slow process.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] armv6l-linux (cross)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

cc @wegank 