### PR TITLE
streamlink-twitch-gui-bin: desktop icons

### DIFF
--- a/pkgs/applications/video/streamlink-twitch-gui/bin.nix
+++ b/pkgs/applications/video/streamlink-twitch-gui/bin.nix
@@ -92,8 +92,13 @@ stdenv.mkDerivation rec {
     # Install all files, remove unnecessary ones
     cp -a . $out/opt/${basename}/
     rm -r $out/opt/${basename}/{{add,remove}-menuitem.sh,credits.html,icons/}
-    ln -s "$out/opt/${basename}/${basename}" $out/bin/
-    cp -r "${desktopItem}/share/applications" $out/share/
+    ln -s $out/opt/${basename}/${basename} $out/bin/
+    for res in 16 32 48 64 128 256; do
+      install -Dm644 \
+        icons/icon-"$res".png \
+        $out/share/icons/hicolor/"$res"x"$res"/apps/${basename}.png
+    done
+    ln -s $desktopItem/share/applications $out/share/
     runHook postInstall
   '';
 

--- a/pkgs/applications/video/streamlink-twitch-gui/bin.nix
+++ b/pkgs/applications/video/streamlink-twitch-gui/bin.nix
@@ -1,6 +1,7 @@
 { autoPatchelfHook
 , fetchurl
 , lib
+, copyDesktopItems
 , makeDesktopItem
 , makeWrapper
 , stdenv
@@ -52,6 +53,7 @@ stdenv.mkDerivation rec {
     alsa-lib
     autoPatchelfHook
     cairo
+    copyDesktopItems
     cups.lib
     dbus.lib
     expat
@@ -98,7 +100,6 @@ stdenv.mkDerivation rec {
         icons/icon-"$res".png \
         $out/share/icons/hicolor/"$res"x"$res"/apps/${basename}.png
     done
-    ln -s $desktopItem/share/applications $out/share/
     runHook postInstall
   '';
 
@@ -110,14 +111,14 @@ stdenv.mkDerivation rec {
     )
   '';
 
-  desktopItem = makeDesktopItem {
+  desktopItems = [(makeDesktopItem {
     name = basename;
     exec = basename;
     icon = basename;
     desktopName = "Streamlink Twitch GUI";
     genericName = meta.description;
     categories = [ "AudioVideo" "Network" ];
-  };
+  })];
 
   meta = with lib; {
     description = "Twitch.tv browser for Streamlink";


### PR DESCRIPTION
## Description of changes
Adds desktop icons. Uses `copyDesktopItems` instead of a manual copy.
AUR package reference: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=streamlink-twitch-gui-bin
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
