### PR TITLE
avrdude: updates and enablement of compile-time features

### DIFF
--- a/pkgs/development/embedded/avrdude/default.nix
+++ b/pkgs/development/embedded/avrdude/default.nix
@@ -26,9 +26,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ hidapi libusb1 libelf libftdi1 libserialport readline ];
 
-  cmakeFlags = lib.optionals docSupport [
-    "-DBUILD_DOC=ON"
-  ];
+  cmakeFlags = lib.optionals stdenv.hostPlatform.isLinux [ "-DHAVE_LINUXSPI=ON" ]
+    ++ lib.optionals docSupport [ "-DBUILD_DOC=ON" ];
 
   # dvips output references texlive in comments, resulting in a huge closure
   postInstall = lib.optionalString docSupport ''

--- a/pkgs/development/embedded/avrdude/default.nix
+++ b/pkgs/development/embedded/avrdude/default.nix
@@ -26,6 +26,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ hidapi libusb1 libelf libftdi1 libserialport readline ];
 
+  # Not used:
+  #
+  #   -DHAVE_LINUXGPIO=ON    because it's incompatible with libgpiod 2.x
+  #
   cmakeFlags = lib.optionals stdenv.hostPlatform.isLinux [ "-DHAVE_LINUXSPI=ON" ]
     ++ lib.optionals docSupport [ "-DBUILD_DOC=ON" ];
 

--- a/pkgs/development/embedded/avrdude/default.nix
+++ b/pkgs/development/embedded/avrdude/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, bison, flex, libusb-compat-0_1, libelf
+{ lib, stdenv, fetchFromGitHub, cmake, bison, flex, libusb1, libelf
 , libftdi1, readline, libserialport
 # documentation building is broken on darwin
 , docSupport ? (!stdenv.isDarwin), texliveMedium, texinfo, texi2html, unixtools }:
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     texi2html
   ];
 
-  buildInputs = [ libusb-compat-0_1 libelf libftdi1 libserialport readline ];
+  buildInputs = [ libusb1 libelf libftdi1 libserialport readline ];
 
   cmakeFlags = lib.optionals docSupport [
     "-DBUILD_DOC=ON"

--- a/pkgs/development/embedded/avrdude/default.nix
+++ b/pkgs/development/embedded/avrdude/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, bison, flex, libusb1, libelf
-, libftdi1, readline, libserialport
+, libftdi1, readline, libserialport, hidapi
 # documentation building is broken on darwin
 , docSupport ? (!stdenv.isDarwin), texliveMedium, texinfo, texi2html, unixtools }:
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     texi2html
   ];
 
-  buildInputs = [ libusb1 libelf libftdi1 libserialport readline ];
+  buildInputs = [ hidapi libusb1 libelf libftdi1 libserialport readline ];
 
   cmakeFlags = lib.optionals docSupport [
     "-DBUILD_DOC=ON"

--- a/pkgs/development/embedded/avrdude/default.nix
+++ b/pkgs/development/embedded/avrdude/default.nix
@@ -1,7 +1,10 @@
 { lib, stdenv, fetchFromGitHub, cmake, bison, flex, libusb1, libelf
-, libftdi1, readline, libserialport, hidapi
-# documentation building is broken on darwin
-, docSupport ? (!stdenv.isDarwin), texliveMedium, texinfo, texi2html, unixtools }:
+, libftdi1, readline, hidapi, libserialport
+# Documentation building doesn't work on Darwin. It fails with:
+#   Undefined subroutine &Locale::Messages::dgettext called in ... texi2html
+#
+# https://github.com/NixOS/nixpkgs/issues/224761
+, docSupport ? (!stdenv.hostPlatform.isDarwin), texliveMedium, texinfo, texi2html, unixtools }:
 
 stdenv.mkDerivation rec {
   pname = "avrdude";

--- a/pkgs/development/embedded/avrdude/default.nix
+++ b/pkgs/development/embedded/avrdude/default.nix
@@ -10,14 +10,14 @@ let
   useElfutils = lib.meta.availableOn stdenv.hostPlatform elfutils;
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "avrdude";
   version = "7.3";
 
   src = fetchFromGitHub {
     owner = "avrdudes";
-    repo = pname;
-    rev = "v${version}";
+    repo = "avdude";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-JqW3AOMmAfcy+PQRcqviWlxA6GoMSEfzIFt1pRYY7Dw=";
   };
 
@@ -43,16 +43,13 @@ stdenv.mkDerivation rec {
   '';
 
   # Not used:
-  #
   #   -DHAVE_LINUXGPIO=ON    because it's incompatible with libgpiod 2.x
-  #
-  cmakeFlags = [ ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ "-DHAVE_LINUXSPI=ON" "-DHAVE_PARPORT=ON" ]
-    ++ lib.optionals docSupport [ "-DBUILD_DOC=ON" ];
+  cmakeFlags = lib.optionals docSupport [ "-DBUILD_DOC=ON" ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ "-DHAVE_LINUXSPI=ON" "-DHAVE_PARPORT=ON" ];
 
   # dvips output references texlive in comments, resulting in a huge closure
   postInstall = lib.optionalString docSupport ''
-    rm $out/share/doc/${pname}/*.ps
+    rm $out/share/doc/avrdude/*.ps
   '';
 
   passthru = {
@@ -74,4 +71,4 @@ stdenv.mkDerivation rec {
     platforms = with platforms; linux ++ darwin;
     maintainers = [ maintainers.bjornfor ];
   };
-}
+})

--- a/pkgs/development/embedded/avrdude/default.nix
+++ b/pkgs/development/embedded/avrdude/default.nix
@@ -30,7 +30,8 @@ stdenv.mkDerivation rec {
   #
   #   -DHAVE_LINUXGPIO=ON    because it's incompatible with libgpiod 2.x
   #
-  cmakeFlags = lib.optionals stdenv.hostPlatform.isLinux [ "-DHAVE_LINUXSPI=ON" ]
+  cmakeFlags = [ ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ "-DHAVE_LINUXSPI=ON" "-DHAVE_PARPORT=ON" ]
     ++ lib.optionals docSupport [ "-DBUILD_DOC=ON" ];
 
   # dvips output references texlive in comments, resulting in a huge closure

--- a/pkgs/development/embedded/avrdude/libelf.nix
+++ b/pkgs/development/embedded/avrdude/libelf.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation {
+  pname = "libelf";
+  version = "0.8.13-unstable-2023-01-14";
+
+  src = fetchFromGitHub {
+    owner = "avrdudes";
+    repo = "libelf";
+    rev = "0c55bfe1d3020a20bddf6ce57c0d9d98ccb12586";
+    hash = "sha256-jz7Ef0Eg673IJVZvVNklY40s13LCuMVAc7FGrRI7scQ=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib
+    cp liblibelf.a $out/lib/libelf.a
+    cp -r $src/include $out/include
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "ELF object file access library (vendored by avrdudes)";
+    homepage = "https://github.com/avrdudes/libelf";
+    license = lib.licenses.lgpl2Plus;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.bjornfor ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Sort of a smörgåsbord.

- [x] Switch from using unmaintained `libelf` to `elfutils` if possible; otherwise, use the vendored and slightly modified copy of `libelf` from https://github.com/avrdudes/libelf. See https://github.com/NixOS/nixpkgs/issues/271473
- [x] Use `finalAttrs` instead of `rec`. See https://github.com/NixOS/nixpkgs/pull/119942.
- [x] Enable parallel port support on Linux.
- [x] Enable SPI support on Linux.
- [x] Enable [hidapi](https://github.com/libusb/hidapi) support on all platforms.
- [x] Switch from `libusb-compat-0_1` to `libusb1` as it appears to be compatible now
- [x] Explain why the docs don't build on macOS
- [x] Explain why we don't turn on `HAVE_LINUXGPIO`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).