### PR TITLE
nix-health: 0.2.3 -> 0.3.0

### DIFF
--- a/pkgs/by-name/ni/nix-health/package.nix
+++ b/pkgs/by-name/ni/nix-health/package.nix
@@ -9,15 +9,15 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "nix-health";
-  version = "0.2.3";
+  version = "0.3.0";
 
   src = fetchCrate {
     inherit version;
     pname = "nix_health";
-    hash = "sha256-WdzzEFk9VPld6AFTNRsaQbMymw1+mNn/TViGO/Qv0so=";
+    hash = "sha256-u5ipQnux/ulllfPFyUdeLj7gAf3Vu7KL2Q4uYxtv1q4=";
   };
 
-  cargoHash = "sha256-xmuosy9T/52D90uXMQAIxtaYDOlCekNCtzpu/3GyQXE=";
+  cargoHash = "sha256-oTO9V+zGmMgDXrt6w1fB81b+WmK3MRI/eCTNEuVM0hk=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libiconv openssl ]
@@ -30,9 +30,9 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "Check the health of your Nix setup";
-    homepage = "https://zero-to-flakes.com/health/";
+    homepage = "https://github.com/juspay/nix-health";
     license = licenses.asl20;
-    maintainers = with maintainers; [ srid ];
+    maintainers = with maintainers; [ srid shivaraj-bh ];
     mainProgram = "nix-health";
   };
 }


### PR DESCRIPTION
## Description of changes

https://crates.io/crates/nix-health/0.3.0

nix-health now lives in a new repository: <https://github.com/juspay/nix-health>

Additionally, I contribute to the project and would also like to maintain it in nixpkgs, hence adding myself as a maintainer.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
