### PR TITLE
treewide: support NIX_SSL_CERT_FILE as an impureEnvVar

### DIFF
--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -157,6 +157,12 @@ Here are security considerations for this scenario:
 
   In more concrete terms, if you use any other hash, the [`--insecure` flag](https://curl.se/docs/manpage.html#-k) will be passed to the underlying call to `curl` when downloading content.
 
+## Proxy usage {#sec-pkgs-fetchers-proxy}
+
+Nixpkgs fetchers can make use of a http(s) proxy. Each fetcher will automatically inherit proxy-related environment variables (`http_proxy`, `https_proxy`, etc) via [impureEnvVars](https://nixos.org/manual/nix/stable/language/advanced-attributes#adv-attr-impureEnvVars).
+
+The environment variable `NIX_SSL_CERT_FILE` is also inherited in fetchers, and can be used to provide a custom certificate bundle to fetchers. This is usually required for a https proxy to work without certificate validation errors.
+
 []{#fetchurl}
 ## `fetchurl` {#sec-pkgs-fetchers-fetchurl}
 

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -9,6 +9,9 @@
     # by definition pure.
     "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"
     "HTTP_PROXY" "HTTPS_PROXY" "FTP_PROXY" "ALL_PROXY" "NO_PROXY"
+
+    # https proxies typically need to inject custom root CAs too
+    "NIX_SSL_CERT_FILE"
   ];
 
 }

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -67,7 +67,7 @@ stdenvNoCC.mkDerivation {
   builder = ./builder.sh;
   fetcher = ./nix-prefetch-git;
 
-  nativeBuildInputs = [ git ]
+  nativeBuildInputs = [ git cacert ]
     ++ lib.optionals fetchLFS [ git-lfs ];
 
   outputHashAlgo = if hash != "" then null else "sha256";
@@ -93,8 +93,6 @@ stdenvNoCC.mkDerivation {
     export NETRC=$PWD/.netrc
     export HOME=$PWD
   '';
-
-  GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
   impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ netrcImpureEnvVars ++ [
     "GIT_PROXY_COMMAND" "NIX_GIT_SSL_CAINFO" "SOCKS_SERVER"

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -17,9 +17,9 @@ branchName=$NIX_PREFETCH_GIT_BRANCH_NAME
 out=${out:-}
 http_proxy=${http_proxy:-}
 
-# allow overwriting cacert's ca-bundle.crt with a custom one
-# this can be done by setting NIX_GIT_SSL_CAINFO and NIX_SSL_CERT_FILE environment variables for the nix-daemon
-GIT_SSL_CAINFO=${NIX_GIT_SSL_CAINFO:-$GIT_SSL_CAINFO}
+# NOTE: use of NIX_GIT_SSL_CAINFO is for backwards compatibility; NIX_SSL_CERT_FILE is preferred
+# as of PR#303307
+GIT_SSL_CAINFO=${NIX_GIT_SSL_CAINFO:-$NIX_SSL_CERT_FILE}
 
 # populated by clone_user_rev()
 fullRev=

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -136,6 +136,7 @@ in
         exit 10
       fi
 
+      export GIT_SSL_CAINFO=$NIX_SSL_CERT_FILE
       ${if finalAttrs.proxyVendor then ''
         mkdir -p "''${GOPATH}/pkg/mod/cache/download"
         go mod download

--- a/pkgs/data/misc/cacert/setup-hook.sh
+++ b/pkgs/data/misc/cacert/setup-hook.sh
@@ -1,7 +1,7 @@
-export NIX_SSL_CERT_FILE=@out@/etc/ssl/certs/ca-bundle.crt
+export NIX_SSL_CERT_FILE="${NIX_SSL_CERT_FILE:-@out@/etc/ssl/certs/ca-bundle.crt}"
 
 # compatibility
 #  - openssl
-export SSL_CERT_FILE=@out@/etc/ssl/certs/ca-bundle.crt
+export SSL_CERT_FILE=$NIX_SSL_CERT_FILE
 #  - Haskell x509-system
-export SYSTEM_CERTIFICATE_PATH=@out@/etc/ssl/certs/ca-bundle.crt
+export SYSTEM_CERTIFICATE_PATH=$NIX_SSL_CERT_FILE


### PR DESCRIPTION
(this is a reopened version of https://github.com/NixOS/nixpkgs/pull/271161 for technical reasons)

## Description of changes

**tl;dr** this PR makes `NIX_SSL_CERT_FILE` the preferred way to control CA certificates throughout nix, by allowing it to be set as in impureEnvVar, including it in proxyImpureEnvVars, and ensuring fetchers support it.

----

Nix (the executable) as well as much of its packaged software respects `NIX_SSL_CERT_FILE` as the preferred way to specify a custom set of root certificates. Within derivations, this is typically done by the setup hook of `cacert`.

However, there's no way to inject this variable from _outside_ (with impure env vars used in fetchers). This is required for most use cases of an an https proxy, as the proxy's own certificate will not likely be trusted by nix's builtin cacert package.

Functionality for injecting a custom trust store has been added to `fetchgit`, but because the setuphook will always override `NIX_SSL_CERT_FILE`, a different envvar had to be used (`NIX_GIT_SSL_CAINFO`). I have [an open PR](https://github.com/NixOS/nixpkgs/pull/266643) to add this same customisation to the go module fetcher.

However, it'd be preferable if we didn't invent a new envvar, and instead made `NIX_SSL_CERT_FILE` the single way to control this setting for both fetchers and nix itself.

For this to work, we need two small changes:
 - `cacert` should only set this variable if it's not already set, so that any impure version is not overwritten
   - this is in a setuphook so it's a mass rebuild
 - add `"NIX_SSL_CERT_FILE"` to `proxyImpureEnvVars` (fetcher.nix). It's not strictly a proxy-only variable, but:
   - this needs to be overridden for all HTTPS proxy use cases, and most things are https these days. Currently fetcher support for custom certs is patchy, because they're all doing their own thing (see below notes)
   - using the certificates the system has explicitly set for nix (if any) is inline with user expectations even outside proxy setups, and this only affects fixed-output derivations anyway

Various fetchers current (and updated) behaviour is oulined below:

 - fetchgit: previously added explicit support for `NIX_GIT_SSL_CAINFO` as the impure overrideable version. This is still supported, but the standard `NIX_SSL_CERT_FILE` now works and is preferred.
 - fetchurl: passes `--insecure` to curl for a fixed-output derivation, so I guess it doesn't need modification
 - fetchgomodule: previously no support for custom certs for git dependencies, now sets `GIT_SSL_CAINFO` to the value of `NIX_SSL_CERT_FILE` using whatever's provided by the user / setup hook

Looking through other fetchers, it seems most of them either have their own schemes or delegate to fetchurl. So this isn't a wide-reaching code change, but I think it's important to support `NIX_SSL_CERT_FILE` as an impureEnvVar, so that we don't force fetchers to invent their own envvars for this purpose.

## Things done

Since this is a mass-rebuild, I tested locally by only applying these changes to the version of `cacert` used by fetchers. With these modifications I tested fetching over https (using custom certs) with:
 - fetchurl
 - fetchgit (over https)
 - go modules fetch (git https)  

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

