### PR TITLE
devilutionx: 1.4.1 -> 1.5.2

### DIFF
--- a/pkgs/games/devilutionx/default.nix
+++ b/pkgs/games/devilutionx/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , fetchurl
 , bzip2
 , cmake
@@ -9,8 +8,9 @@
 , gettext
 , libsodium
 , SDL2
-, SDL_audiolib
 , SDL2_image
+, SDL_audiolib
+, flac
 , fmt
 , libpng
 , smpq
@@ -21,20 +21,20 @@ let
 
   # fork with patches, far behind upstream
   asio = fetchurl {
-    url = "https://github.com/diasurgical/asio/archive/ebeff99f539da23d27c2e8d4bdbc1ee011968644.tar.gz";
-    sha256 = "0vhb4cig40mm0a98i74grpmfkcmby8zxg6vqa38dpryxpgvp5fw8";
+    url = "https://github.com/diasurgical/asio/archive/bd1c839ef741b14365e77964bdd5a78994c05934.tar.gz";
+    sha256 = "sha256-ePcdyvOfO5tyPVP+8t3+cS/XeEp47lfaE8gERRVoJSM=";
   };
 
   # fork with patches, upstream seems to be dead
   libmpq = fetchurl {
-    url = "https://github.com/diasurgical/libmpq/archive/0f10bd1600f406b13932bf5351ba713361262184.tar.gz";
-    sha256 = "sha256-7hc/Xtsg8WJIJljLydS7hLZA9lEEHWhsCteyrxK68qE=";
+    url = "https://github.com/diasurgical/libmpq/archive/b78d66c6fee6a501cc9b95d8556a129c68841b05.tar.gz";
+    sha256 = "sha256-NIzZwr6cBn38uKLWzW+Uet5QiOFUPB5dsf3FsS22ruo=";
   };
 
   # not "real" package with pkg-config or cmake file, just collection of source files
   libsmackerdec = fetchurl {
-    url = "https://github.com/diasurgical/libsmackerdec/archive/2997ee0e41e91bb723003bc09234be553b190e38.tar.gz";
-    sha256 = "sha256-QMDcIZQ94i4VPVanmSxiGkKgxWx82DP4uE+Q5I2nU+o=";
+    url = "https://github.com/diasurgical/libsmackerdec/archive/91e732bb6953489077430572f43fc802bf2c75b2.tar.gz";
+    sha256 = "sha256-5WXjfvGuT4hG2cnCS4YbxW/c4tek7OR95EjgCqkEi4c=";
   };
 
   # fork with patches, far behind upstream
@@ -42,45 +42,49 @@ let
     owner = "diasurgical";
     repo = "libzt";
     fetchSubmodules = true;
-    rev = "37a2efb0b925df632299ef07dc78c0af5f6b4756";
-    sha256 = "sha256-+o4ZTVqh4MDZES9m7mkfkMRlRDMBytDBuA0QIlnp73U=";
+    rev = "d6c6a069a5041a3e89594c447ced3f15d77618b8";
+    sha256 = "sha256-ttRJLfaGHzhS4jd8db7BNPWROCti3ZxuRouqsL/M5ew=";
   };
+
+  # breaks without this version
+  SDL_audiolib' = SDL_audiolib.overrideAttrs (oldAttrs: {
+    src = fetchFromGitHub {
+      owner = "realnc";
+      repo = "SDL_audiolib";
+      rev = "cc1bb6af8d4cf5e200259072bde1edd1c8c5137e";
+      sha256 = "sha256-xP7qlwwOkqVeTlCEZLinnvmx8LbU2co5+t//cf4n190=";
+    };
+
+    buildInputs = oldAttrs.buildInputs ++ [ flac ];
+  });
 
   # missing pkg-config and/or cmake file
   simpleini = fetchurl {
-    url = "https://github.com/brofield/simpleini/archive/9b3ed7ec815997bc8c5b9edf140d6bde653e1458.tar.gz";
-    sha256 = "sha256-93kuyp8/ew7okW/6ThJMtLMZsR1YSeFcXu9Y65ELBFE==";
+    url = "https://github.com/brofield/simpleini/archive/56499b5af5d2195c6acfc58c4630b70e0c9c4c21.tar.gz";
+    sha256 = "sha256-29tQoz0+33kfwmIjCdnD1wGi+35+K0A9P6UE4E8K3g4=";
   };
 in
 
 stdenv.mkDerivation rec {
   pname = "devilutionx";
-  version = "1.4.1";
+  version = "1.5.2";
 
   src = fetchFromGitHub {
     owner = "diasurgical";
     repo = "devilutionX";
     rev = version;
-    sha256 = "sha256-l0BhL+DXtkG2PdFqmkL0KJv41zl3N/AcuLmzw2j3jXY=";
+    sha256 = "sha256-XILPpIYSC0+CbhyVXCNvAknAhqU7VW1dWZCh2BapQjs=";
   };
 
   postPatch = ''
-    substituteInPlace Source/init.cpp --replace "/usr/share/diasurgical/devilutionx/" "${placeholder "out"}/share/diasurgical/devilutionx/"
-
-    # download dependencies ahead of time
-    substituteInPlace 3rdParty/asio/CMakeLists.txt --replace "${asio.url}" "${asio}"
-    substituteInPlace 3rdParty/libmpq/CMakeLists.txt --replace "${libmpq.url}" "${libmpq}"
-    substituteInPlace 3rdParty/libsmackerdec/CMakeLists.txt --replace "${libsmackerdec.url}" "${libsmackerdec}"
+    substituteInPlace 3rdParty/asio/CMakeLists.txt --replace-fail "${asio.url}" "${asio}"
+    substituteInPlace 3rdParty/libmpq/CMakeLists.txt --replace-fail "${libmpq.url}" "${libmpq}"
+    substituteInPlace 3rdParty/libsmackerdec/CMakeLists.txt --replace-fail "${libsmackerdec.url}" "${libsmackerdec}"
     substituteInPlace 3rdParty/libzt/CMakeLists.txt \
-      --replace "GIT_REPOSITORY https://github.com/diasurgical/libzt.git" "" \
-      --replace "GIT_TAG ${libzt.rev}" "SOURCE_DIR ${libzt}"
-    substituteInPlace 3rdParty/simpleini/CMakeLists.txt --replace "${simpleini.url}" "${simpleini}"
+      --replace-fail "GIT_REPOSITORY https://github.com/diasurgical/libzt.git" "" \
+      --replace-fail "GIT_TAG ${libzt.rev}" "SOURCE_DIR ${libzt}"
+    substituteInPlace 3rdParty/simpleini/CMakeLists.txt --replace-fail "${simpleini.url}" "${simpleini}"
   '';
-
-  cmakeFlags = [
-    "-DBINARY_RELEASE=ON"
-    "-DVERSION_NUM=${version}"
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -95,8 +99,8 @@ stdenv.mkDerivation rec {
     libpng
     libsodium
     SDL2
-    SDL_audiolib
     SDL2_image
+    SDL_audiolib'
   ];
 
   installPhase = ''
@@ -107,6 +111,7 @@ stdenv.mkDerivation rec {
     mv devilutionx.app $out/Applications
   '' else ''
     install -Dm755 -t $out/bin devilutionx
+    install -Dm755 -t $out/bin devilutionx.mpq
     install -Dm755 -t $out/share/diasurgical/devilutionx devilutionx.mpq
     install -Dm755 -t $out/share/applications ../Packaging/nix/devilutionx-hellfire.desktop ../Packaging/nix/devilutionx.desktop
     install -Dm755 ../Packaging/resources/icon.png $out/share/icons/hicolor/512x512/apps/devilutionx.png


### PR DESCRIPTION
## Description of changes

I had to use the upstream version of SDL_audiolib to get Diablo to run. I also removed the VERSION_NUM CMake flag from the derivation to get the devilutionX version to appear in-game. `devilutionx.mpq` also needed to be copied into the same directory as the binary in order to avoid the font issue from #238457.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
