### PR TITLE
jrl-cmakemodules: init at 0-unstable-2024-04-12

### DIFF
--- a/pkgs/by-name/jr/jrl-cmakemodules/package.nix
+++ b/pkgs/by-name/jr/jrl-cmakemodules/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+
+stdenv.mkDerivation {
+  pname = "jrl-cmakemodules";
+  version = "0-unstable-2024-04-12";
+
+  src = fetchFromGitHub {
+    owner = "jrl-umi3218";
+    repo = "jrl-cmakemodules";
+    rev = "a914fa836ab4d2f01c191c93a763cfa322820dc7";
+    hash = "sha256-/VedtcRqy4SUTZfrtg01Z1lSPFRg/858hgve+nKTqPo=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "CMake utility toolbox";
+    homepage = "https://github.com/jrl-umi3218/jrl-cmakemodules";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = [ lib.maintainers.nim65s ];
+  };
+}

--- a/pkgs/development/python-modules/eigenpy/default.nix
+++ b/pkgs/development/python-modules/eigenpy/default.nix
@@ -1,25 +1,31 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, cmake
-, doxygen
-, boost
-, eigen
-, numpy
-, scipy
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  doxygen,
+  boost,
+  eigen,
+  jrl-cmakemodules,
+  numpy,
+  scipy,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "eigenpy";
-  version = "3.4.0";
+  version = "3.5.0";
 
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
-    repo = finalAttrs.pname;
+    repo = "eigenpy";
     rev = "v${finalAttrs.version}";
-    fetchSubmodules = true;
     hash = "sha256-/k5eltoeUW05FTjvStAOw+tguWLUaUced8TArrk4UDI=";
   };
+
+  outputs = [
+    "dev"
+    "out"
+  ];
 
   cmakeFlags = [
     "-DINSTALL_DOCUMENTATION=ON"
@@ -34,26 +40,26 @@ stdenv.mkDerivation (finalAttrs: {
     scipy
   ];
 
-  buildInputs = [
-    boost
-  ];
+  buildInputs = [ boost ];
 
   propagatedBuildInputs = [
     eigen
+    jrl-cmakemodules
     numpy
   ];
 
   doCheck = true;
-  pythonImportsCheck = [
-    "eigenpy"
-  ];
+  pythonImportsCheck = [ "eigenpy" ];
 
   meta = with lib; {
     description = "Bindings between Numpy and Eigen using Boost.Python";
     homepage = "https://github.com/stack-of-tasks/eigenpy";
     changelog = "https://github.com/stack-of-tasks/eigenpy/releases/tag/v${version}";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ nim65s wegank ];
+    maintainers = with maintainers; [
+      nim65s
+      wegank
+    ];
     platforms = platforms.unix;
   };
 })


### PR DESCRIPTION
## Description of changes

https://github.com/jrl-umi3218/jrl-cmakemodules is a collection of cmake helpers.
It is used as a git submodule in many projects, including eigenpy, hpp-fcl, pinocchio, crocoddyl, and others.

Packaging it will allow us to avoid the need to fetch the submodule in those projects, and prevent us from having many copies of of the same files, potentially in different versions, in nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
