### PR TITLE
ironwail: rename quake binary to ironwail.

### DIFF
--- a/pkgs/games/ironwail/default.nix
+++ b/pkgs/games/ironwail/default.nix
@@ -30,9 +30,20 @@ stdenv.mkDerivation (finalAttrs: {
   sourceRoot = "${finalAttrs.pname}-${finalAttrs.version}/Quake";
 
   nativeBuildInputs = [
-    copyDesktopItems pkg-config vulkan-headers
-    gzip libvorbis libmad flac curl libopus
-    opusfile libogg libxmp vulkan-loader SDL2
+    copyDesktopItems
+    pkg-config
+    vulkan-headers
+    gzip
+    libvorbis
+    libmad
+    flac
+    curl
+    libopus
+    opusfile
+    libogg
+    libxmp
+    vulkan-loader
+    SDL2
   ];
 
   buildFlags = [
@@ -55,8 +66,8 @@ stdenv.mkDerivation (finalAttrs: {
   preInstall = ''
     mkdir -p "$out/bin"
     mkdir -p "$out/share/quake"
-    substituteInPlace Makefile --replace "cp ironwail.pak /usr/local/games/quake" "cp ironwail.pak $out/share/quake/ironwail.pak"
-    substituteInPlace Makefile --replace "/usr/local/games" "$out/bin"
+    substituteInPlace Makefile --replace-fail "cp ironwail.pak /usr/local/games/quake" "cp ironwail.pak $out/share/quake/ironwail.pak"
+    substituteInPlace Makefile --replace-fail "/usr/local/games/quake" "$out/bin/ironwail"
   '';
 
   enableParallelBuilding = true;
@@ -64,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
   desktopItems = [
     (makeDesktopItem {
       name = "ironwail";
-      exec = "quake";
+      exec = "ironwail";
       desktopName = "Ironwail";
       categories = [ "Game" ];
     })
@@ -86,6 +97,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.necrophcodr ];
-    mainProgram = "quake";
+    mainProgram = "ironwail";
   };
 })


### PR DESCRIPTION
## Description of changes

A simple rename of the `quake` output binary to avoid clashing with other quake engines. This partially solves #302065 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
