### PR TITLE
Disallow output changes in `installCheckPhase`

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -17,7 +17,7 @@ argsStdenv@{ name ? "stdenv", preHook ? "", initialPath
   # (see all-packages.nix).
   fetchurlBoot
 
-, setupScript ? ./setup.sh
+, setupScript ? config.setupScript or ./setup.sh
 
 , extraNativeBuildInputs ? []
 , extraBuildInputs ? []

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1,5 +1,21 @@
 # shellcheck shell=bash
 # shellcheck disable=1090,2154,2123,2034,2178,2048,2068,1091
+
+# TESTING
+
+# This file can be tested without mass-rebuild.
+# See `pkgs/test/setup/default.nix`.
+
+# DOCUMENTATION
+
+# This file is sourced by the derivation `builder` and is responsible for
+# some shell setup, loading scripts from inputs, and running phases and hooks.
+#
+# Comments in this file are implementation oriented. User facing documentation
+# is maintained outside of this file, so that it can be improved without mass
+# rebuilds.
+# See https://nixos.org/manual/nixpkgs/unstable/index.html#chap-stdenv
+
 __nixpkgs_setup_set_original=$-
 set -eu
 set -o pipefail

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1499,6 +1499,45 @@ installCheckPhase() {
 }
 
 
+# Summarize the relevant state of a directory. Distinct NARs will produce
+# distinct manifests.
+# Note: these manifests are purely an internal construct of stdenv to verify
+#       that installCheckPhase does not alter outputs.
+unsortedDirectoryManifest() {
+    sha256sum $(find "$1" -type f) \
+        | sed -e 's/\([0-9a-fA-F]\{64\}\)[[:space:]]*\(.*\)/\2: file with contents sha256:\1/'
+    find "$1" -type d -printf '%p: directory\n'
+    find "$1" -type l -printf '%p: symlink to %l\n'
+    find "$1" -type f -executable -printf '%p: executable\n'
+}
+
+# Summarize the state of the outputs, see unsortedDirectoryManifest.
+outputsManifest() {
+    local output
+    for output in $outputs; do
+        unsortedDirectoryManifest "${!output}"
+    done | sort
+}
+
+saveOutputHashes() {
+    outputsManifest >"$TMPDIR/before-installCheck"
+}
+
+checkOutputHashes() {
+    outputsManifest >"$TMPDIR/after-installCheck"
+    if ! diff "$TMPDIR/before-installCheck" "$TMPDIR/after-installCheck" -U0 --color=auto; then
+        cat <<EOF
+ERROR: Files were changed during installCheckPhase.
+       See the output above for the diff from before to after the checks.
+       Please make sure that the installation process prior to the installation
+       checks is complete and that the software is configured not to write to
+       its installation directory.
+EOF
+        false
+    fi
+}
+
+
 distPhase() {
     runHook preDist
 
@@ -1566,6 +1605,10 @@ runPhase() {
 
     local startTime=$(date +"%s")
 
+    if [[ "$curPhase" = installCheckPhase && -z "${allowWriteInInstallCheck:-}" ]]; then
+        saveOutputHashes
+    fi
+
     # Evaluate the variable named $curPhase if it exists, otherwise the
     # function named $curPhase.
     eval "${!curPhase:-$curPhase}"
@@ -1579,6 +1622,10 @@ runPhase() {
         [ -n "${sourceRoot:-}" ] && chmod +x "${sourceRoot}"
 
         cd "${sourceRoot:-.}"
+    fi
+
+    if [[ "$curPhase" = installCheckPhase && -z "${allowWriteInInstallCheck:-}" ]]; then
+        checkOutputHashes
     fi
 }
 

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -86,6 +86,29 @@ with pkgs;
   stdenv-inputs = callPackage ./stdenv-inputs { };
   stdenv = callPackage ./stdenv { };
 
+  # Unit tests for setup.sh
+  setup = import ./setup {
+    # NB: ^^^^^^
+    #     `import` and not `callPackage`, because we manipulate the whole `pkgs`
+    #     so that we can unit test without rebuilding everything; see setup/default.nix.
+    basePkgs =
+      if ! pkgs.config?baseCommit then pkgs
+      else import ../.. {
+        inherit (pkgs.stdenv.hostPlatform) system;
+        config = {
+          # Set the setup script to the version in the base commit
+          # We need setup.sh to be a single file with the same store path as "${./setup.sh}",
+          # so that stdenv equals stdenv for the base commit,
+          # which turns out to be a bit complicated when it comes from a fetched source.
+          setupScript = "${
+            let oldPkgsStr = builtins.fetchGit { url = ../..; ref = pkgs.config.baseCommit; };
+                oldPkgsPath = /. + builtins.unsafeDiscardStringContext (oldPkgsStr);
+            in oldPkgsPath + "/pkgs/stdenv/generic/setup.sh"
+          }";
+        };
+    };
+  };
+
   hardeningFlags = recurseIntoAttrs (callPackage ./cc-wrapper/hardening.nix {});
   hardeningFlags-gcc = recurseIntoAttrs (callPackage ./cc-wrapper/hardening.nix {
     stdenv = gccStdenv;

--- a/pkgs/test/setup/default.nix
+++ b/pkgs/test/setup/default.nix
@@ -1,0 +1,219 @@
+# To run these tests, without bootstrapping:
+#
+#   nix-build -A tests.setup --arg config "{ baseCommit = ''$(git merge-base HEAD upstream/master)''; }"
+#
+# Note that `tests.stdenv` currently also contains relevant tests, which are slower, but could be ported here.
+
+{
+  # A Nixpkgs which may use the old setup.sh, for which we have binaries in the cache.
+  basePkgs
+}:
+
+let
+  stdenv = basePkgs.stdenv.override {
+    # Restore setup.sh, but only for new derivations
+    setupScript = ../../stdenv/generic/setup.sh;
+  };
+  inherit (basePkgs) lib testers;
+in
+lib.recurseIntoAttrs rec {
+
+  # A manual testing tool.
+  # This works for a few packages. Could be developed further, but it's a tarpit.
+  # Example:
+  #   nix-build -A tests.setup.try-override-shallow.pkgs.hello --arg config "{ baseCommit = ''$(git merge-base HEAD upstream/master)''; }"
+  try-override-shallow = {
+    # no recurseIntoAttrs!
+    pkgs = lib.mapAttrs (name: old:
+      let new = old.override { inherit stdenv; };
+      in
+        assert lib.isDerivation old;
+        assert old != new;
+        new) basePkgs;
+  };
+
+  test-happy = stdenv.mkDerivation {
+    name = "hi";
+    dontUnpack = true;
+    buildPhase = ":";
+    installPhase = ''
+      mkdir -p $out/bin $out/empty
+      echo foo >$out/regular
+      echo bar >$out/bin/script
+      chmod a+x $out/bin/script
+      ln -s ../regular $out/symlink
+    '';
+    doInstallCheck = true;
+  };
+
+  test-installPhase-modified-regular =
+    basePkgs.runCommand "test-installPhase-modified-regular" {
+      failure = testers.testBuildFailure (
+        test-happy.overrideAttrs {
+          installCheckPhase = ''
+            echo baz >$out/regular
+          '';
+        }
+      );
+    } ''
+      echo $failure/testBuildFailure.log
+      (
+        set -x
+        grep 'ERROR: Files were changed during installCheckPhase' $failure/testBuildFailure.log >/dev/null
+        grep "$failure/regular" $failure/testBuildFailure.log >/dev/null
+      )
+      touch $out
+    '';
+
+  test-installPhase-modified-exe-bit =
+    basePkgs.runCommand "test-installPhase-modified-exe-bit" {
+      failure = testers.testBuildFailure (
+        test-happy.overrideAttrs {
+          installCheckPhase = ''
+            chmod a-x $out/bin/script
+          '';
+        }
+      );
+    } ''
+      echo $failure/testBuildFailure.log
+      (
+        set -x
+        grep 'ERROR: Files were changed during installCheckPhase' $failure/testBuildFailure.log >/dev/null
+        grep "$failure/bin/script" $failure/testBuildFailure.log >/dev/null
+      )
+      touch $out
+    '';
+
+  test-installPhase-modified-new-file =
+    basePkgs.runCommand "test-installPhase-modified-new-file" {
+      failure = testers.testBuildFailure (
+        test-happy.overrideAttrs {
+          installCheckPhase = ''
+            echo baz >$out/new
+          '';
+        }
+      );
+    } ''
+      echo $failure/testBuildFailure.log
+      (
+        set -x
+        grep 'ERROR: Files were changed during installCheckPhase' $failure/testBuildFailure.log >/dev/null
+        grep "$failure/new" $failure/testBuildFailure.log >/dev/null
+      )
+      touch $out
+    '';
+
+  test-installPhase-modified-remove-empty-dir =
+    basePkgs.runCommand "test-installPhase-modified-remove-empty-dir" {
+      failure = testers.testBuildFailure (
+        test-happy.overrideAttrs {
+          installCheckPhase = ''
+            rmdir $out/empty
+          '';
+        }
+      );
+    } ''
+      echo $failure/testBuildFailure.log
+      (
+        set -x
+        grep 'ERROR: Files were changed during installCheckPhase' $failure/testBuildFailure.log >/dev/null
+        grep "$failure/empty" $failure/testBuildFailure.log >/dev/null
+      )
+      touch $out
+    '';
+
+  test-installPhase-modified-remove-regular =
+    basePkgs.runCommand "test-installPhase-modified-remove-regular" {
+      failure = testers.testBuildFailure (
+        test-happy.overrideAttrs {
+          installCheckPhase = ''
+            rm $out/regular
+          '';
+        }
+      );
+    } ''
+      echo $failure/testBuildFailure.log
+      (
+        set -x
+        grep 'ERROR: Files were changed during installCheckPhase' $failure/testBuildFailure.log >/dev/null
+        grep "$failure/regular" $failure/testBuildFailure.log >/dev/null
+      )
+      touch $out
+    '';
+
+  test-installPhase-modified-remove-symlink =
+    basePkgs.runCommand "test-installPhase-modified-remove-symlink" {
+      failure = testers.testBuildFailure (
+        test-happy.overrideAttrs {
+          installCheckPhase = ''
+            rm $out/symlink
+          '';
+        }
+      );
+    } ''
+      echo $failure/testBuildFailure.log
+      (
+        set -x
+        grep 'ERROR: Files were changed during installCheckPhase' $failure/testBuildFailure.log >/dev/null
+        grep "$failure/symlink" $failure/testBuildFailure.log >/dev/null
+      )
+      touch $out
+    '';
+
+  test-installPhase-modified-remove-bin =
+    basePkgs.runCommand "test-installPhase-modified-remove-bin" {
+      failure = testers.testBuildFailure (
+        test-happy.overrideAttrs {
+          installCheckPhase = ''
+            rm $out/bin/script
+          '';
+        }
+      );
+    } ''
+      echo $failure/testBuildFailure.log
+      (
+        set -x
+        grep 'ERROR: Files were changed during installCheckPhase' $failure/testBuildFailure.log >/dev/null
+        grep "$failure/bin/script" $failure/testBuildFailure.log >/dev/null
+      )
+      touch $out
+    '';
+
+  test-installPhase-modified-symlink =
+    basePkgs.runCommand "test-installPhase-modified-symlink" {
+      failure = testers.testBuildFailure (
+        test-happy.overrideAttrs {
+          installCheckPhase = ''
+            ln -sf ../bin/script $out/symlink
+          '';
+        }
+      );
+    } ''
+      echo $failure/testBuildFailure.log
+      (
+        set -x
+        grep 'ERROR: Files were changed during installCheckPhase' $failure/testBuildFailure.log >/dev/null
+        grep "$failure/symlink" $failure/testBuildFailure.log >/dev/null
+      )
+      touch $out
+    '';
+
+  test-installPhase-modified-new-symlink =
+    basePkgs.runCommand "test-installPhase-modified-new-symlink" {
+      failure = testers.testBuildFailure (
+        test-happy.overrideAttrs {
+          installCheckPhase = ''
+            ln -sf ../bin/script $out/new
+          '';
+        }
+      );
+    } ''
+      echo $failure/testBuildFailure.log
+      (
+        set -x
+        grep 'ERROR: Files were changed during installCheckPhase' $failure/testBuildFailure.log >/dev/null
+        grep "$failure/new" $failure/testBuildFailure.log >/dev/null
+      )
+      touch $out
+    '';
+}


### PR DESCRIPTION
## Description of changes

- Spot installation script problems and avoid tests polluting the installation.
- Add `tests.setup` which runs quicker than `tests.stdenv`. cc @Artturin 

This will indicate errors in the install script fixed up by the installed software, or software or configuration that relies on a writable installation directory.

NOTE: this only works for derivations which use the installCheck phase as intended. Some language integrations, like `pythonPackages`, need to call the new functions on their own.

- Replaces mass-ping #143862.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
