### PR TITLE
vscode-extensions: add documentation and move extensions with parameters to a directory

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/README.md
+++ b/pkgs/applications/editors/vscode/extensions/README.md
@@ -1,0 +1,37 @@
+# Visual Studio Code Extensions
+
+## Conventions for adding new extensions
+
+* Extensions are named in the **lowercase** version of the extension's unique identifier. Which is found on the marketplace extension page, and is the name under which the extension is installed by VSCode under `~/.vscode`.
+  Extension location should be: ${lib.strings.toLower mktplcRef.publisher}.${lib.string.toLower mktplcRef.name}
+
+* Move extension to a discrete directory whenever the extension needs extra parameters/packages (at top of the file) or other files (such as patches, update script, components). Global index file parameters/packages should be utilities shared by many extensions. Extension specific parameters/packages should not be in the global index page.
+
+* Currently `nixfmt-rfc-style` formatter is being used to format the VSCode extensions.
+
+* Respect `alphabetical order` whenever adding extensions. On disorder, please, kindly open a PR re-establishing the order.
+
+* Avoid [unnecessary](https://nix.dev/guides/best-practices.html#with-scopes) use of `with`, particularly `nested with`.
+
+* Use `hash` instead of `sha256`.
+
+* On `meta` field:
+  - add a `changelog`.
+  - `description` should mention it is a Visual Studio Code extension.
+  - `downloadPage` is the VSCode marketplace URL.
+  - `homepage` is the source-code URL.
+  - verify `license` in upstream.
+
+* On commit messages:
+  - Naming convention for:
+    - Adding a new extension:
+
+      > vscode-extensions.publisher.extension-name: init 1.2.3
+      >
+      > Release: https://github.com/owner/project/releases/tag/1.2.3
+    - Updating an extension:
+
+      > vscode-extensions.publisher.extension-name: 1.2.3 -> 2.3.4
+      >
+      > Release: https://github.com/owner/project/releases/tag/2.3.4
+  - Multiple extensions can be added in a single PR, but each extension requires it's own commit.

--- a/pkgs/applications/editors/vscode/extensions/asciidoctor.asciidoctor-vscode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/asciidoctor.asciidoctor-vscode/default.nix
@@ -1,0 +1,27 @@
+{
+  asciidoctor,
+  lib,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "asciidoctor-vscode";
+    publisher = "asciidoctor";
+    version = "2.8.9";
+    sha256 = "1xkxx5i3nhd0dzqhhdmx0li5jifsgfhv0p5h7xwsscz3gzgsdcyb";
+  };
+
+  postPatch = ''
+    substituteInPlace dist/src/text-parser.js \
+      --replace "get('asciidoctor_command', 'asciidoctor')" \
+                "get('asciidoctor_command', '${asciidoctor}/bin/asciidoctor')"
+    substituteInPlace dist/src/commands/exportAsPDF.js \
+      --replace "get('asciidoctorpdf_command', 'asciidoctor-pdf')" \
+                "get('asciidoctorpdf_command', '${asciidoctor}/bin/asciidoctor-pdf')"
+  '';
+
+  meta = {
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/azdavis.millet/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/azdavis.millet/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  jq,
+  moreutils,
+  millet,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "Millet";
+    publisher = "azdavis";
+    version = "0.13.5";
+    hash = "sha256-sWM7N+axgu1zOGWexR4JVupVmYhZrd4cZz3pmLxRj8Q=";
+  };
+  nativeBuildInputs = [
+    jq
+    moreutils
+  ];
+  postInstall = ''
+    cd "$out/$installPrefix"
+    jq '.contributes.configuration.properties."millet.server.path".default = "${millet}/bin/millet-ls"' package.json | sponge package.json
+  '';
+  meta = {
+    description = "Standard ML support for VS Code";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=azdavis.millet";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.smasher164 ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/b4dm4n.vscode-nixpkgs-fmt/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/b4dm4n.vscode-nixpkgs-fmt/default.nix
@@ -1,0 +1,27 @@
+{
+  vscode-utils,
+  jq,
+  lib,
+  moreutils,
+  nixpkgs-fmt,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "nixpkgs-fmt";
+    publisher = "B4dM4n";
+    version = "0.0.1";
+    hash = "sha256-vz2kU36B1xkLci2QwLpl/SBEhfSWltIDJ1r7SorHcr8=";
+  };
+  nativeBuildInputs = [
+    jq
+    moreutils
+  ];
+  postInstall = ''
+    cd "$out/$installPrefix"
+    jq '.contributes.configuration.properties."nixpkgs-fmt.path".default = "${nixpkgs-fmt}/bin/nixpkgs-fmt"' package.json | sponge package.json
+  '';
+  meta = {
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/betterthantomorrow.calva/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/betterthantomorrow.calva/default.nix
@@ -1,0 +1,27 @@
+{
+  clojure-lsp,
+  jq,
+  lib,
+  moreutils,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "calva";
+    publisher = "betterthantomorrow";
+    version = "2.0.374";
+    hash = "sha256-VwdHOkduSSIrcOvrcVf7K8DSp3N1u9fvbaCVDCxp+bk=";
+  };
+  nativeBuildInputs = [
+    jq
+    moreutils
+  ];
+  postInstall = ''
+    cd "$out/$installPrefix"
+    jq '.contributes.configuration[0].properties."calva.clojureLspPath".default = "${clojure-lsp}/bin/clojure-lsp"' package.json | sponge package.json
+  '';
+  meta = {
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -9,7 +9,6 @@
 , jdk
 , llvmPackages
 , llvmPackages_14
-, nixpkgs-fmt
 , protobuf
 , jq
 , shellcheck
@@ -422,22 +421,7 @@ let
 
       azdavis.millet = callPackage ./azdavis.millet { };
 
-      b4dm4n.vscode-nixpkgs-fmt = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "nixpkgs-fmt";
-          publisher = "B4dM4n";
-          version = "0.0.1";
-          hash = "sha256-vz2kU36B1xkLci2QwLpl/SBEhfSWltIDJ1r7SorHcr8=";
-        };
-        nativeBuildInputs = [ jq moreutils ];
-        postInstall = ''
-          cd "$out/$installPrefix"
-          jq '.contributes.configuration.properties."nixpkgs-fmt.path".default = "${nixpkgs-fmt}/bin/nixpkgs-fmt"' package.json | sponge package.json
-        '';
-        meta = {
-          license = lib.licenses.mit;
-        };
-      };
+      b4dm4n.vscode-nixpkgs-fmt = callPackage ./b4dm4n.vscode-nixpkgs-fmt { };
 
       baccata.scaladex-search = buildVscodeMarketplaceExtension {
         mktplcRef = {

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -15,7 +15,6 @@
 , shellcheck
 , moreutils
 , typst-lsp
-, typst-preview
 , autoPatchelfHook
 , zlib
 , stdenv
@@ -2630,35 +2629,7 @@ let
         };
       };
 
-      # Keep pkgs/by-name/ty/typst-preview/package.nix in sync with this
-      # extension
-      mgt19937.typst-preview = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "typst-preview";
-          publisher = "mgt19937";
-          version = "0.11.4";
-          hash = "sha256-GwlzFphZmP87pLys01+PWTv13imcdGjunCMH6atz9xs=";
-        };
-
-        buildInputs = [
-          typst-preview
-        ];
-
-        nativeBuildInputs = [ jq moreutils ];
-
-        postInstall = ''
-          cd "$out/$installPrefix"
-          jq '.contributes.configuration.properties."typst-preview.executable".default = "${lib.getExe typst-preview}"' package.json | sponge package.json
-        '';
-
-        meta = {
-          description = "Typst Preview is an extension for previewing your Typst files in vscode instantly";
-          downloadPage = "https://marketplace.visualstudio.com/items?itemName=mgt19937.typst-preview";
-          homepage = "https://github.com/Enter-tainer/typst-preview-vscode";
-          license = lib.licenses.mit;
-          maintainers = [ lib.maintainers.drupol ];
-        };
-      };
+      mgt19937.typst-preview = callPackage ./mgt19937.typst-preview { };
 
       mhutchie.git-graph = buildVscodeMarketplaceExtension {
         mktplcRef = {

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -18,7 +18,6 @@
 , racket
 , alejandra
 , millet
-, craftos-pc
 , shfmt
 , tinymist
 , typst-lsp
@@ -2273,38 +2272,7 @@ let
         };
       };
 
-      jackmacwindows.craftos-pc = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "craftos-pc";
-          publisher = "jackmacwindows";
-          version = "1.2.2";
-          hash = "sha256-A+MNroXv0t9Mw/gr0Fyov3cXyF/GGzwRLKrIxQ2tKCE=";
-        };
-        nativeBuildInputs = [ jq moreutils ];
-        postInstall = ''
-          cd "$out/$installPrefix"
-
-          jq -e '
-            .contributes.configuration.properties."craftos-pc.executablePath.linux".default =
-              "${lib.meta.getExe craftos-pc}" |
-            .contributes.configuration.properties."craftos-pc.executablePath.mac".default =
-              "${lib.meta.getExe craftos-pc}" |
-            .contributes.configuration.properties."craftos-pc.executablePath.windows".default =
-              "${lib.meta.getExe craftos-pc}"
-          ' \
-          < package.json \
-          | sponge package.json
-        '';
-        meta = {
-          changelog = "https://marketplace.visualstudio.com/items/jackmacwindows.craftos-pc/changelog";
-          description = "A Visual Studio Code extension for opening a CraftOS-PC window";
-          downloadPage = "https://marketplace.visualstudio.com/items?itemName=jackmacwindows.craftos-pc";
-          homepage = "https://www.craftos-pc.cc/docs/extension";
-          license = lib.licenses.mit;
-          maintainers = with lib.maintainers; [ tomodachi94 ];
-          platforms = craftos-pc.meta.platforms;
-        };
-      };
+      jackmacwindows.craftos-pc = callPackage ./jackmacwindows.craftos-pc { };
 
       james-yu.latex-workshop = buildVscodeMarketplaceExtension {
         mktplcRef = {

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -14,7 +14,6 @@
 , jq
 , shellcheck
 , moreutils
-, typst-lsp
 , autoPatchelfHook
 , zlib
 , stdenv
@@ -3140,36 +3139,7 @@ let
         };
       };
 
-      nvarner.typst-lsp = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "typst-lsp";
-          publisher = "nvarner";
-          # Please update the corresponding binary (typst-lsp) when updating
-          # this extension.
-          version = "0.12.1";
-          hash = "sha256-JcfFaR1wU5XwapH8vnfVy7Cb7DfUWVeoLfBV3wEtCpE=";
-        };
-
-        nativeBuildInputs = [ jq moreutils ];
-
-        buildInputs = [
-          typst-lsp
-        ];
-
-        postInstall = ''
-          cd "$out/$installPrefix"
-          jq '.contributes.configuration.properties."typst-lsp.serverPath".default = "${lib.getExe typst-lsp}"' package.json | sponge package.json
-        '';
-
-        meta = {
-          changelog = "https://marketplace.visualstudio.com/items/nvarner.typst-lsp/changelog";
-          description = "A VSCode extension for providing a language server for Typst";
-          downloadPage = "https://marketplace.visualstudio.com/items?itemName=nvarner.typst-lsp";
-          homepage = "https://github.com/nvarner/typst-lsp";
-          license = lib.licenses.mit;
-          maintainers = [ lib.maintainers.drupol ];
-        };
-      };
+      nvarner.typst-lsp = callPackage ./nvarner.typst-lsp { };
 
       ocamllabs.ocaml-platform = buildVscodeMarketplaceExtension {
         meta = {

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -11,7 +11,6 @@
 , llvmPackages_14
 , protobuf
 , jq
-, shellcheck
 , moreutils
 , autoPatchelfHook
 , zlib
@@ -4035,26 +4034,7 @@ let
         };
       };
 
-      timonwong.shellcheck = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "shellcheck";
-          publisher = "timonwong";
-          version = "0.37.0";
-          sha256 = "1d0blynn6c2hz4y9fk7b5wsa3x168gxyycr5d05zqp0rx520m5wc";
-        };
-        nativeBuildInputs = [ jq moreutils ];
-        postInstall = ''
-          cd "$out/$installPrefix"
-          jq '.contributes.configuration.properties."shellcheck.executablePath".default = "${shellcheck}/bin/shellcheck"' package.json | sponge package.json
-        '';
-        meta = {
-          description = "Integrates ShellCheck into VS Code, a linter for Shell scripts";
-          downloadPage = "https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck";
-          homepage = "https://github.com/vscode-shellcheck/vscode-shellcheck";
-          license = lib.licenses.mit;
-          maintainers = [ lib.maintainers.raroh73 ];
-        };
-      };
+      timonwong.shellcheck = callPackage ./timonwong.shellcheck { };
 
       tobiasalthoff.atom-material-theme = buildVscodeMarketplaceExtension {
         mktplcRef = {

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -16,7 +16,6 @@
 , shellcheck
 , moreutils
 , racket
-, clojure-lsp
 , alejandra
 , millet
 , craftos-pc
@@ -587,24 +586,9 @@ let
         };
       };
 
-      betterthantomorrow.calva = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "calva";
-          publisher = "betterthantomorrow";
-          version = "2.0.374";
-          hash = "sha256-VwdHOkduSSIrcOvrcVf7K8DSp3N1u9fvbaCVDCxp+bk=";
-        };
-        nativeBuildInputs = [ jq moreutils ];
-        postInstall = ''
-          cd "$out/$installPrefix"
-          jq '.contributes.configuration[0].properties."calva.clojureLspPath".default = "${clojure-lsp}/bin/clojure-lsp"' package.json | sponge package.json
-        '';
-        meta = {
-          license = lib.licenses.mit;
-        };
-      };
+      betterthantomorrow.calva = callPackage ./betterthantomorrow.calva { };
 
-       bierner.docs-view = buildVscodeMarketplaceExtension {
+      bierner.docs-view = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "docs-view";
           publisher = "bierner";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -14,7 +14,6 @@
 , jq
 , shellcheck
 , moreutils
-, shfmt
 , typst-lsp
 , typst-preview
 , autoPatchelfHook
@@ -1687,28 +1686,7 @@ let
         };
       };
 
-      foxundermoon.shell-format = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "shell-format";
-          publisher = "foxundermoon";
-          version = "7.2.5";
-          hash = "sha256-kfpRByJDcGY3W9+ELBzDOUMl06D/vyPlN//wPgQhByk=";
-        };
-
-        nativeBuildInputs = [ jq moreutils ];
-
-        postInstall = ''
-          cd "$out/$installPrefix"
-          jq '.contributes.configuration.properties."shellformat.path".default = "${shfmt}/bin/shfmt"' package.json | sponge package.json
-        '';
-
-        meta = {
-          downloadPage = "https://marketplace.visualstudio.com/items?itemName=foxundermoon.shell-format";
-          homepage = "https://github.com/foxundermoon/vs-shell-format";
-          license = lib.licenses.mit;
-          maintainers = [ lib.maintainers.dbirks ];
-        };
-      };
+      foxundermoon.shell-format = callPackage ./foxundermoon.shell-format { };
 
       freebroccolo.reasonml = buildVscodeMarketplaceExtension {
         meta = {

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1,3 +1,5 @@
+# Before adding a new extension, read ./README.md
+
 { config
 , lib
 , fetchurl
@@ -31,15 +33,6 @@
 let
   inherit (vscode-utils) buildVscodeMarketplaceExtension;
 
-  #
-  # Unless there is a good reason not to, we attempt to use the lowercase
-  # version of the extension's unique identifier. The unique identifier can be
-  # found on the marketplace extension page, and is the name under which the
-  # extension is installed by VSCode under `~/.vscode`.
-  #
-  # This means an extension should be located at
-  # ${lib.strings.toLower mktplcRef.publisher}.${lib.string.toLower mktplcRef.name}
-  #
   baseExtensions = self: lib.mapAttrs (_n: lib.recurseIntoAttrs)
     {
       "13xforever".language-x86-64-assembly = buildVscodeMarketplaceExtension {

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -14,7 +14,6 @@
 , jq
 , shellcheck
 , moreutils
-, alejandra
 , shfmt
 , typst-lsp
 , typst-preview
@@ -2428,33 +2427,7 @@ let
         };
       };
 
-      kamadorueda.alejandra = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "alejandra";
-          publisher = "kamadorueda";
-          version = "1.0.0";
-          hash = "sha256-COlEjKhm8tK5XfOjrpVUDQ7x3JaOLiYoZ4MdwTL8ktk=";
-        };
-        nativeBuildInputs = [ jq moreutils ];
-        postInstall = ''
-          cd "$out/$installPrefix"
-
-          jq -e '
-            .contributes.configuration.properties."alejandra.program".default =
-              "${alejandra}/bin/alejandra" |
-            .contributes.configurationDefaults."alejandra.program" =
-              "${alejandra}/bin/alejandra"
-          ' \
-          < package.json \
-          | sponge package.json
-        '';
-        meta = {
-          description = "The Uncompromising Nix Code Formatter";
-          homepage = "https://github.com/kamadorueda/alejandra";
-          license = lib.licenses.unlicense;
-          maintainers = [ lib.maintainers.kamadorueda ];
-        };
-      };
+      kamadorueda.alejandra = callPackage ./kamadorueda.alejandra { };
 
       kamikillerto.vscode-colorize = buildVscodeMarketplaceExtension {
         mktplcRef = {

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -16,7 +16,6 @@
 , moreutils
 , alejandra
 , shfmt
-, tinymist
 , typst-lsp
 , typst-preview
 , autoPatchelfHook
@@ -3134,36 +3133,7 @@ let
         };
       };
 
-      myriad-dreamin.tinymist = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "tinymist";
-          publisher = "myriad-dreamin";
-          # Please update the corresponding binary (tinymist) when updating
-          # this extension.
-          version = "0.11.4";
-          hash = "sha256-VR+vl6mctwq9oSIgnfutvPFwfGUdEco8fCOjzMvPtII=";
-        };
-
-        nativeBuildInputs = [ jq moreutils ];
-
-        buildInputs = [
-          tinymist
-        ];
-
-        postInstall = ''
-          cd "$out/$installPrefix"
-          jq '.contributes.configuration.properties."tinymist.serverPath".default = "${lib.getExe tinymist}"' package.json | sponge package.json
-        '';
-
-        meta = {
-          changelog = "https://marketplace.visualstudio.com/items/myriad-dreamin.tinymist/changelog";
-          description = "A VSCode extension for providing an integration solution for Typst";
-          downloadPage = "https://marketplace.visualstudio.com/items?itemName=myriad-dreamin.tinymist";
-          homepage = "https://github.com/myriad-dreamin/tinymist";
-          license = lib.licenses.asl20;
-          maintainers = [ lib.maintainers.drupol ];
-        };
-      };
+      myriad-dreamin.tinymist = callPackage ./myriad-dreamin.tinymist { };
 
       naumovs.color-highlight = buildVscodeMarketplaceExtension {
         mktplcRef = {

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -6,7 +6,6 @@
 , callPackage
 , vscode-utils
 , asciidoctor
-, nodePackages
 , python3Packages
 , jdk
 , llvmPackages
@@ -2972,25 +2971,7 @@ let
 
       ms-python.python = callPackage ./ms-python.python { };
 
-      ms-python.vscode-pylance = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "vscode-pylance";
-          publisher = "MS-python";
-          version = "2023.8.50";
-          hash = "sha256-xJU/j5r/Idp/0VorEfciT4SFKRBpMCv9Z0LKO/++1Gk=";
-        };
-
-        buildInputs = [ nodePackages.pyright ];
-
-        meta = {
-          changelog = "https://marketplace.visualstudio.com/items/ms-python.vscode-pylance/changelog";
-          description = "A performant, feature-rich language server for Python in VS Code";
-          downloadPage = "https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance";
-          homepage = "https://github.com/microsoft/pylance-release";
-          license = lib.licenses.unfree;
-          maintainers = [ lib.maintainers.ericthemagician ];
-        };
-      };
+      ms-python.vscode-pylance = callPackage ./ms-python.vscode-pylance { };
 
       ms-toolsai.datawrangler = buildVscodeMarketplaceExtension {
         mktplcRef = {

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -17,7 +17,6 @@
 , moreutils
 , racket
 , alejandra
-, millet
 , shfmt
 , tinymist
 , typst-lsp
@@ -448,25 +447,7 @@ let
         };
       };
 
-      azdavis.millet = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "Millet";
-          publisher = "azdavis";
-          version = "0.13.5";
-          hash = "sha256-sWM7N+axgu1zOGWexR4JVupVmYhZrd4cZz3pmLxRj8Q=";
-        };
-        nativeBuildInputs = [ jq moreutils ];
-        postInstall = ''
-          cd "$out/$installPrefix"
-          jq '.contributes.configuration.properties."millet.server.path".default = "${millet}/bin/millet-ls"' package.json | sponge package.json
-        '';
-        meta = {
-          description = "Standard ML support for VS Code";
-          downloadPage = "https://marketplace.visualstudio.com/items?itemName=azdavis.millet";
-          license = lib.licenses.mit;
-          maintainers = [ lib.maintainers.smasher164 ];
-        };
-      };
+      azdavis.millet = callPackage ./azdavis.millet { };
 
       b4dm4n.vscode-nixpkgs-fmt = buildVscodeMarketplaceExtension {
         mktplcRef = {

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -15,7 +15,6 @@
 , jq
 , shellcheck
 , moreutils
-, racket
 , alejandra
 , shfmt
 , tinymist
@@ -1590,27 +1589,7 @@ let
         };
       };
 
-      eugleo.magic-racket = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "magic-racket";
-          publisher = "evzen-wybitul";
-          version = "0.6.4";
-          hash = "sha256-Hxa4VPm3QvJICzpDyfk94fGHu1hr+YN9szVBwDB8X4U=";
-        };
-        nativeBuildInputs = [ jq moreutils ];
-        postInstall = ''
-          cd "$out/$installPrefix"
-          jq '.contributes.configuration.properties."magicRacket.general.racketPath".default = "${racket}/bin/racket"' package.json | sponge package.json
-          jq '.contributes.configuration.properties."magicRacket.general.racoPath".default = "${racket}/bin/raco"' package.json | sponge package.json
-        '';
-        meta = {
-          changelog = "https://marketplace.visualstudio.com/items/evzen-wybitul.magic-racket/changelog";
-          description = "The best coding experience for Racket in VS Code";
-          downloadPage = "https://marketplace.visualstudio.com/items?itemName=evzen-wybitul.magic-racket";
-          homepage = "https://github.com/Eugleo/magic-racket";
-          license = lib.licenses.agpl3Only;
-        };
-      };
+      eugleo.magic-racket = callPackage ./eugleo.magic-racket { };
 
       ExiaHuang.dictionary = buildVscodeMarketplaceExtension {
         mktplcRef = {

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -5,7 +5,6 @@
 , fetchurl
 , callPackage
 , vscode-utils
-, asciidoctor
 , python3Packages
 , jdk
 , llvmPackages
@@ -356,27 +355,7 @@ let
         };
       };
 
-      asciidoctor.asciidoctor-vscode = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "asciidoctor-vscode";
-          publisher = "asciidoctor";
-          version = "2.8.9";
-          sha256 = "1xkxx5i3nhd0dzqhhdmx0li5jifsgfhv0p5h7xwsscz3gzgsdcyb";
-        };
-
-        postPatch = ''
-          substituteInPlace dist/src/text-parser.js \
-            --replace "get('asciidoctor_command', 'asciidoctor')" \
-                      "get('asciidoctor_command', '${asciidoctor}/bin/asciidoctor')"
-          substituteInPlace dist/src/commands/exportAsPDF.js \
-            --replace "get('asciidoctorpdf_command', 'asciidoctor-pdf')" \
-                      "get('asciidoctorpdf_command', '${asciidoctor}/bin/asciidoctor-pdf')"
-        '';
-
-        meta = {
-          license = lib.licenses.mit;
-        };
-      };
+      asciidoctor.asciidoctor-vscode = callPackage ./asciidoctor.asciidoctor-vscode { };
 
       asdine.cue = buildVscodeMarketplaceExtension {
         mktplcRef = {

--- a/pkgs/applications/editors/vscode/extensions/eugleo.magic-racket/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/eugleo.magic-racket/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  jq,
+  moreutils,
+  racket,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "magic-racket";
+    publisher = "evzen-wybitul";
+    version = "0.6.4";
+    hash = "sha256-Hxa4VPm3QvJICzpDyfk94fGHu1hr+YN9szVBwDB8X4U=";
+  };
+  nativeBuildInputs = [
+    jq
+    moreutils
+  ];
+  postInstall = ''
+    cd "$out/$installPrefix"
+    jq '.contributes.configuration.properties."magicRacket.general.racketPath".default = "${racket}/bin/racket"' package.json | sponge package.json
+    jq '.contributes.configuration.properties."magicRacket.general.racoPath".default = "${racket}/bin/raco"' package.json | sponge package.json
+  '';
+  meta = {
+    changelog = "https://marketplace.visualstudio.com/items/evzen-wybitul.magic-racket/changelog";
+    description = "The best coding experience for Racket in VS Code";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=evzen-wybitul.magic-racket";
+    homepage = "https://github.com/Eugleo/magic-racket";
+    license = lib.licenses.agpl3Only;
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/foxundermoon.shell-format/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/foxundermoon.shell-format/default.nix
@@ -1,0 +1,33 @@
+{
+  jq,
+  lib,
+  moreutils,
+  shfmt,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "shell-format";
+    publisher = "foxundermoon";
+    version = "7.2.5";
+    hash = "sha256-kfpRByJDcGY3W9+ELBzDOUMl06D/vyPlN//wPgQhByk=";
+  };
+
+  nativeBuildInputs = [
+    jq
+    moreutils
+  ];
+
+  postInstall = ''
+    cd "$out/$installPrefix"
+    jq '.contributes.configuration.properties."shellformat.path".default = "${shfmt}/bin/shfmt"' package.json | sponge package.json
+  '';
+
+  meta = {
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=foxundermoon.shell-format";
+    homepage = "https://github.com/foxundermoon/vs-shell-format";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dbirks ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/jackmacwindows.craftos-pc/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/jackmacwindows.craftos-pc/default.nix
@@ -1,0 +1,43 @@
+{
+  vscode-utils,
+  craftos-pc,
+  jq,
+  lib,
+  moreutils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "craftos-pc";
+    publisher = "jackmacwindows";
+    version = "1.2.2";
+    hash = "sha256-A+MNroXv0t9Mw/gr0Fyov3cXyF/GGzwRLKrIxQ2tKCE=";
+  };
+  nativeBuildInputs = [
+    jq
+    moreutils
+  ];
+  postInstall = ''
+    cd "$out/$installPrefix"
+
+    jq -e '
+      .contributes.configuration.properties."craftos-pc.executablePath.linux".default =
+        "${lib.meta.getExe craftos-pc}" |
+      .contributes.configuration.properties."craftos-pc.executablePath.mac".default =
+        "${lib.meta.getExe craftos-pc}" |
+      .contributes.configuration.properties."craftos-pc.executablePath.windows".default =
+        "${lib.meta.getExe craftos-pc}"
+    ' \
+    < package.json \
+    | sponge package.json
+  '';
+  meta = {
+    changelog = "https://marketplace.visualstudio.com/items/jackmacwindows.craftos-pc/changelog";
+    description = "A Visual Studio Code extension for opening a CraftOS-PC window";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=jackmacwindows.craftos-pc";
+    homepage = "https://www.craftos-pc.cc/docs/extension";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tomodachi94 ];
+    platforms = craftos-pc.meta.platforms;
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/kamadorueda.alejandra/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/kamadorueda.alejandra/default.nix
@@ -1,0 +1,38 @@
+{
+  alejandra,
+  jq,
+  lib,
+  moreutils,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "alejandra";
+    publisher = "kamadorueda";
+    version = "1.0.0";
+    hash = "sha256-COlEjKhm8tK5XfOjrpVUDQ7x3JaOLiYoZ4MdwTL8ktk=";
+  };
+  nativeBuildInputs = [
+    jq
+    moreutils
+  ];
+  postInstall = ''
+    cd "$out/$installPrefix"
+
+    jq -e '
+      .contributes.configuration.properties."alejandra.program".default =
+        "${alejandra}/bin/alejandra" |
+      .contributes.configurationDefaults."alejandra.program" =
+        "${alejandra}/bin/alejandra"
+    ' \
+    < package.json \
+    | sponge package.json
+  '';
+  meta = {
+    description = "The Uncompromising Nix Code Formatter";
+    homepage = "https://github.com/kamadorueda/alejandra";
+    license = lib.licenses.unlicense;
+    maintainers = [ lib.maintainers.kamadorueda ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/mgt19937.typst-preview/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/mgt19937.typst-preview/default.nix
@@ -1,0 +1,38 @@
+# Keep pkgs/by-name/ty/typst-preview/package.nix in sync with this extension
+
+{
+  vscode-utils,
+  lib,
+  jq,
+  moreutils,
+  typst-preview,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "typst-preview";
+    publisher = "mgt19937";
+    version = "0.11.4";
+    hash = "sha256-GwlzFphZmP87pLys01+PWTv13imcdGjunCMH6atz9xs=";
+  };
+
+  buildInputs = [ typst-preview ];
+
+  nativeBuildInputs = [
+    jq
+    moreutils
+  ];
+
+  postInstall = ''
+    cd "$out/$installPrefix"
+    jq '.contributes.configuration.properties."typst-preview.executable".default = "${lib.getExe typst-preview}"' package.json | sponge package.json
+  '';
+
+  meta = {
+    description = "Typst Preview is an extension for previewing your Typst files in vscode instantly";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=mgt19937.typst-preview";
+    homepage = "https://github.com/Enter-tainer/typst-preview-vscode";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.drupol ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/ms-python.vscode-pylance/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-python.vscode-pylance/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  nodePackages,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "vscode-pylance";
+    publisher = "MS-python";
+    version = "2023.8.50";
+    hash = "sha256-xJU/j5r/Idp/0VorEfciT4SFKRBpMCv9Z0LKO/++1Gk=";
+  };
+
+  buildInputs = [ nodePackages.pyright ];
+
+  meta = {
+    changelog = "https://marketplace.visualstudio.com/items/ms-python.vscode-pylance/changelog";
+    description = "A performant, feature-rich language server for Python in VS Code";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance";
+    homepage = "https://github.com/microsoft/pylance-release";
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.ericthemagician ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/myriad-dreamin.tinymist/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/myriad-dreamin.tinymist/default.nix
@@ -1,0 +1,39 @@
+{
+  jq,
+  lib,
+  moreutils,
+  tinymist,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "tinymist";
+    publisher = "myriad-dreamin";
+    # Please update the corresponding binary (tinymist) when updating
+    # this extension.
+    version = "0.11.4";
+    hash = "sha256-VR+vl6mctwq9oSIgnfutvPFwfGUdEco8fCOjzMvPtII=";
+  };
+
+  nativeBuildInputs = [
+    jq
+    moreutils
+  ];
+
+  buildInputs = [ tinymist ];
+
+  postInstall = ''
+    cd "$out/$installPrefix"
+    jq '.contributes.configuration.properties."tinymist.serverPath".default = "${lib.getExe tinymist}"' package.json | sponge package.json
+  '';
+
+  meta = {
+    changelog = "https://marketplace.visualstudio.com/items/myriad-dreamin.tinymist/changelog";
+    description = "A VSCode extension for providing an integration solution for Typst";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=myriad-dreamin.tinymist";
+    homepage = "https://github.com/myriad-dreamin/tinymist";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.drupol ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/nvarner.typst-lsp/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/nvarner.typst-lsp/default.nix
@@ -1,0 +1,39 @@
+{
+  jq,
+  lib,
+  moreutils,
+  typst-lsp,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "typst-lsp";
+    publisher = "nvarner";
+    # Please update the corresponding binary (typst-lsp) when updating
+    # this extension.
+    version = "0.12.1";
+    hash = "sha256-JcfFaR1wU5XwapH8vnfVy7Cb7DfUWVeoLfBV3wEtCpE=";
+  };
+
+  nativeBuildInputs = [
+    jq
+    moreutils
+  ];
+
+  buildInputs = [ typst-lsp ];
+
+  postInstall = ''
+    cd "$out/$installPrefix"
+    jq '.contributes.configuration.properties."typst-lsp.serverPath".default = "${lib.getExe typst-lsp}"' package.json | sponge package.json
+  '';
+
+  meta = {
+    changelog = "https://marketplace.visualstudio.com/items/nvarner.typst-lsp/changelog";
+    description = "A VSCode extension for providing a language server for Typst";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=nvarner.typst-lsp";
+    homepage = "https://github.com/nvarner/typst-lsp";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.drupol ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/timonwong.shellcheck/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/timonwong.shellcheck/default.nix
@@ -1,0 +1,31 @@
+{
+  jq,
+  lib,
+  moreutils,
+  shellcheck,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "shellcheck";
+    publisher = "timonwong";
+    version = "0.37.0";
+    sha256 = "1d0blynn6c2hz4y9fk7b5wsa3x168gxyycr5d05zqp0rx520m5wc";
+  };
+  nativeBuildInputs = [
+    jq
+    moreutils
+  ];
+  postInstall = ''
+    cd "$out/$installPrefix"
+    jq '.contributes.configuration.properties."shellcheck.executablePath".default = "${shellcheck}/bin/shellcheck"' package.json | sponge package.json
+  '';
+  meta = {
+    description = "Integrates ShellCheck into VS Code, a linter for Shell scripts";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck";
+    homepage = "https://github.com/vscode-shellcheck/vscode-shellcheck";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.raroh73 ];
+  };
+}


### PR DESCRIPTION
vscode-extensions:

1. Document the criteria I have been using to review vscode extensions.

2. Avoid to keep adding new extensions with new parameters at the global index, because these parameters don't get removed whenever the extension gets updated/removed. It is extra work to do that kind of checking and it also gets messy as the number of packages grow. Doing this facilitates upkeep and avoids trivial feedback on reviews.

CC @deviant @jonringer