### PR TITLE
charmcraft: init at 2.6.0

### DIFF
--- a/pkgs/by-name/ch/charmcraft/package.nix
+++ b/pkgs/by-name/ch/charmcraft/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  git,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "charmcraft";
+  version = "2.6.0";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "canonical";
+    repo = "charmcraft";
+    rev = "refs/tags/${version}";
+    hash = "sha256-B0ZcOORW6yaSIpisPLnq5/S/CcqqvHNTXcfP1sKW2KQ=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail 'version=determine_version()' 'version="${version}"'
+  '';
+
+  propagatedBuildInputs = with python3Packages; [
+    craft-cli
+    craft-parts
+    craft-providers
+    craft-store
+    distro
+    humanize
+    jinja2
+    jsonschema
+    pydantic_1
+    python-dateutil
+    pyyaml
+    requests
+    requests-toolbelt
+    requests-unixsocket
+    snap-helpers
+    tabulate
+    urllib3
+  ];
+
+  nativeBuildInputs = with python3Packages; [
+    pythonRelaxDepsHook
+    setuptools
+  ];
+
+  pythonRelaxDeps = [
+    "urllib3"
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pyfakefs
+    pytest-check
+    pytest-mock
+    pytest-subprocess
+    pytestCheckHook
+    responses
+  ] ++ [ git ];
+
+  preCheck = ''
+    mkdir -p check-phase
+    export HOME="$(pwd)/check-phase"
+  '';
+
+  pytestFlagsArray = [ "tests/unit" ];
+
+  disabledTests = [
+    # Relies upon the `charm` tool being installed
+    "test_validate_missing_charm"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "charmcraft";
+    description = "Build and publish Charmed Operators for deployment with Juju";
+    homepage = "https://github.com/canonical/charmcraft";
+    changelog = "https://github.com/canonical/charmcraft/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/craft-parts/default.nix
+++ b/pkgs/development/python-modules/craft-parts/default.nix
@@ -21,6 +21,7 @@
 , squashfsTools
 , setuptools
 , setuptools-scm
+, stdenv
 }:
 
 buildPythonPackage rec {
@@ -103,6 +104,10 @@ buildPythonPackage rec {
     "tests/unit/packages/test_apt_cache.py"
     "tests/unit/packages/test_deb.py"
     "tests/unit/packages/test_chisel.py"
+  ] ++ lib.optionals stdenv.isAarch64 [
+    # These tests have hardcoded "amd64" strings which fail on aarch64
+    "tests/unit/executor/test_environment.py"
+    "tests/unit/features/overlay/test_executor_environment.py"
   ];
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/development/python-modules/craft-providers/default.nix
+++ b/pkgs/development/python-modules/craft-providers/default.nix
@@ -21,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "craft-providers";
-  version = "1.23.0";
+  version = "1.23.1";
 
   pyproject = true;
 
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     owner = "canonical";
     repo = "craft-providers";
     rev = "refs/tags/${version}";
-    hash = "sha256-9ZoNgpuGytwozRsw0wnS3d2UBOIsh3VI/uzB1RD2Zac=";
+    hash = "sha256-opVgOtbwZD+uQJ10Q8QlgQaS9KjRFnQ4h98Ak7Ze5qQ=";
   };
 
   patches = [
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     # The urllib3 incompat: https://github.com/msabramo/requests-unixsocket/pull/69
     # This is already patched in nixpkgs.
     substituteInPlace pyproject.toml \
-      --replace-fail "setuptools==67.8.0" "setuptools" \
+      --replace-fail "setuptools==69.1.1" "setuptools" \
       --replace-fail "urllib3<2" "urllib3"
   '';
 

--- a/pkgs/development/python-modules/craft-store/default.nix
+++ b/pkgs/development/python-modules/craft-store/default.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  setuptools,
+  setuptools-scm,
+  pytest-check,
+  pytest-mock,
+  pydantic_1,
+  pyyaml,
+  pytestCheckHook,
+  keyring,
+  macaroonbakery,
+  overrides,
+  pyxdg,
+  requests,
+  requests-toolbelt,
+}:
+
+buildPythonPackage rec {
+  pname = "craft-store";
+  version = "2.6.0";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "canonical";
+    repo = "craft-store";
+    rev = "refs/tags/${version}";
+    hash = "sha256-VtKOe3IrvGcNWfp1/tg1cO94xtfkP7AbIHh0WTdlfbQ=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools==67.7.2" "setuptools"
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    keyring
+    macaroonbakery
+    overrides
+    pydantic_1
+    pyxdg
+    requests
+    requests-toolbelt
+  ];
+
+  pythonImportsCheck = [ "craft_store" ];
+
+  nativeCheckInputs = [
+    pydantic_1
+    pytest-check
+    pytest-mock
+    pytestCheckHook
+    pyyaml
+  ];
+
+  pytestFlagsArray = [ "tests/unit" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Interfaces for communicating with Canonical Stores (e.g. Snap Store)";
+    homepage = "https://github.com/canonical/craft-store";
+    changelog = "https://github.com/canonical/craft-store/releases/tag/${version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/macaroonbakery/default.nix
+++ b/pkgs/development/python-modules/macaroonbakery/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  protobuf3,
+  pymacaroons,
+  pynacl,
+  pyrfc3339,
+  requests,
+  setuptools,
+  httmock,
+  fixtures,
+  pytestCheckHook,
+  mock,
+}:
+
+buildPythonPackage rec {
+  pname = "macaroonbakery";
+  version = "1.3.4";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "go-macaroon-bakery";
+    repo = "py-macaroon-bakery";
+    rev = "refs/tags/${version}";
+    hash = "sha256-NEhr8zkrHceeLbAyuUvc7U6dyQxkpkj0m5LlnBMafA0=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [
+    protobuf3
+    pymacaroons
+    pynacl
+    pyrfc3339
+    requests
+  ];
+
+  pythonImportsCheck = [ "macaroonbakery" ];
+
+  nativeCheckInputs = [
+    fixtures
+    httmock
+    mock
+    pytestCheckHook
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A Python library for working with macaroons";
+    homepage = "https://github.com/go-macaroon-bakery/py-macaroon-bakery";
+    changelog = "https://github.com/go-macaroon-bakery/py-macaroon-bakery/releases/tag/${version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/pydantic-yaml-0/default.nix
+++ b/pkgs/development/python-modules/pydantic-yaml-0/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, nix-update-script
 , deprecated
 , importlib-metadata
 , pydantic_1
@@ -54,8 +53,6 @@ buildPythonPackage rec {
     pytest-mock
     pytestCheckHook
   ];
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "A small helper library that adds some YAML capabilities to pydantic";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2486,6 +2486,8 @@ self: super: with self; {
 
   craft-providers = callPackage ../development/python-modules/craft-providers { };
 
+  craft-store = callPackage ../development/python-modules/craft-store { };
+
   cram = callPackage ../development/python-modules/cram { };
 
   cramjam = callPackage ../development/python-modules/cramjam { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7053,6 +7053,8 @@ self: super: with self; {
 
   regress = callPackage ../development/python-modules/regress { };
 
+  macaroonbakery = callPackage ../development/python-modules/macaroonbakery { };
+
   mail-parser = callPackage ../development/python-modules/mail-parser { };
 
   makefun = callPackage ../development/python-modules/makefun { };


### PR DESCRIPTION
## Description of changes

Follow on from #295646 to add the `craft` build tools to NixOS.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
