### PR TITLE
rkboot: init

### DIFF
--- a/pkgs/by-name/rk/rkbin/package.nix
+++ b/pkgs/by-name/rk/rkbin/package.nix
@@ -31,6 +31,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/rockchip-linux/rkbin";
     license = licenses.unfreeRedistributable;
     maintainers = with maintainers; [ thefossguy ];
-    platforms = [ "aarch64-linux" ];
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/rk/rkboot/package.nix
+++ b/pkgs/by-name/rk/rkboot/package.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, lib
+, rkbin
+, box64
+}:
+
+stdenv.mkDerivation {
+  name = "rkboot";
+
+  src = rkbin.src;
+
+  postPatch = ''
+    substituteInPlace RKBOOT/*.ini --replace 'PATH=' 'PATH=rkboot/'
+  '';
+
+  buildPhase = ''
+    mkdir rkboot
+    for i in $(ls ./RKBOOT/*.ini)
+    do
+      # The proprietary, statically linked binaries to perform boot_merge are
+      # x86_64 only. Though we use box64 to emulate if building on aarch64-linux
+      ${lib.optionalString stdenv.isAarch64 "${lib.getExe box64}"} ./tools/boot_merger "$i" || true
+    done
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    if [ -z "$(ls -A rkboot)" ]; then
+      echo "Error: The 'rkboot' directory is empty."
+      exit 1
+    else
+      mv rkboot $out/bin
+    fi
+  '';
+
+  meta = with lib; {
+    description = "Rockchip proprietary SPL bootloader blobs";
+    homepage = "https://github.com/rockchip-linux/rkbin";
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ matthewcroughan ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Initialises a derivation which generates all of the SPL loaders for rockchip platforms. Without these SPL loaders, interaction with the maskroms via `rkdeveloptool` is not possible, so these SPL loaders have to be sourced from somewhere when developing for the chips.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
