### PR TITLE
Package Bitwarden desktop for macOS

### DIFF
--- a/pkgs/by-name/bi/bitwarden-desktop/darwin.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/darwin.nix
@@ -1,0 +1,35 @@
+{
+  pname,
+  meta,
+  fetchurl,
+  undmg,
+  stdenv,
+  ...
+}:
+
+let
+  version = "2024.3.2";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = (
+    fetchurl {
+      url = "https://github.com/bitwarden/clients/releases/download/desktop-v${version}/Bitwarden-${version}-universal.dmg";
+      sha256 = "sha256-SqChHwaOR4mJXeQPXsJqFpPDrAhdEjrBpT8PQaTK6B8=";
+    }
+  );
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -r *.app $out/Applications
+
+    runHook postInstall
+  '';
+}

--- a/pkgs/by-name/bi/bitwarden-desktop/linux.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/linux.nix
@@ -1,0 +1,191 @@
+{ lib
+, pname
+, meta
+, buildNpmPackage
+, cargo
+, copyDesktopItems
+, dbus
+, electron_28
+, fetchFromGitHub
+, glib
+, gnome
+, gtk3
+, jq
+, libsecret
+, makeDesktopItem
+, makeWrapper
+, moreutils
+, napi-rs-cli
+, nodejs_18
+, patchutils_0_4_2
+, pkg-config
+, python3
+, runCommand
+, rustc
+, rustPlatform
+, ...
+}:
+
+let
+  icon = "bitwarden";
+  electron = electron_28;
+in buildNpmPackage rec {
+  pname = "bitwarden-desktop";
+  version = "2024.3.0";
+
+  src = fetchFromGitHub {
+    owner = "bitwarden";
+    repo = "clients";
+    rev = "desktop-v${version}";
+    hash = "sha256-XEZB95GnfSy/wtTWpF8KlUQwyephUZmSLtbOwbcvd7g=";
+  };
+
+  patches = [
+    ./electron-builder-package-lock.patch
+  ];
+
+  # The nested package-lock.json from upstream is out-of-date, so copy the
+  # lock metadata from the root package-lock.json.
+  postPatch = ''
+    cat {,apps/desktop/src/}package-lock.json \
+      | ${lib.getExe jq} -s '
+        .[1].packages."".dependencies.argon2 = .[0].packages."".dependencies.argon2
+          | .[0].packages."" = .[1].packages.""
+          | .[1].packages = .[0].packages
+          | .[1]
+        ' \
+      | ${moreutils}/bin/sponge apps/desktop/src/package-lock.json
+  '';
+
+  nodejs = nodejs_18;
+
+  makeCacheWritable = true;
+  npmFlags = [ "--legacy-peer-deps" ];
+  npmWorkspace = "apps/desktop";
+  npmDepsHash = "sha256-EpZXA+GkmHl5eqwIPTGHJZqrpr6k8gXneJG+GXumlkc=";
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    name = "${pname}-${version}";
+    inherit src;
+    patches = map
+      (patch: runCommand
+        (builtins.baseNameOf patch)
+        { nativeBuildInputs = [ patchutils_0_4_2 ]; }
+        ''
+          < ${patch} filterdiff -p1 --include=${lib.escapeShellArg cargoRoot}'/*' > $out
+        ''
+      )
+      patches;
+    patchFlags = [ "-p4" ];
+    sourceRoot = "${src.name}/${cargoRoot}";
+    hash = "sha256-qAqEFlUzT28fw6kLB8d7U8yXWevAU+q03zjN2xWsGyI=";
+  };
+  cargoRoot = "apps/desktop/desktop_native";
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  nativeBuildInputs = [
+    cargo
+    copyDesktopItems
+    jq
+    makeWrapper
+    moreutils
+    napi-rs-cli
+    pkg-config
+    python3
+    rustc
+    rustPlatform.cargoCheckHook
+    rustPlatform.cargoSetupHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    libsecret
+  ];
+
+  preBuild = ''
+    if [[ $(jq --raw-output '.devDependencies.electron' < package.json | grep -E --only-matching '^[0-9]+') != ${lib.escapeShellArg (lib.versions.major electron.version)} ]]; then
+      echo 'ERROR: electron version mismatch'
+      exit 1
+    fi
+  '';
+
+  postBuild = ''
+    pushd apps/desktop
+
+    # desktop_native/index.js loads a file of that name regarldess of the libc being used
+    mv desktop_native/desktop_native.* desktop_native/desktop_native.linux-x64-musl.node
+
+    npm exec electron-builder -- \
+      --dir \
+      -c.electronDist=${electron}/libexec/electron \
+      -c.electronVersion=${electron.version}
+
+    popd
+  '';
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    dbus
+    (gnome.gnome-keyring.override { useWrappedDaemon = false; })
+  ];
+
+  checkFlags = [
+    "--skip=password::password::tests::test"
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    pushd ${cargoRoot}
+    export HOME=$(mktemp -d)
+    export -f cargoCheckHook runHook _eval _callImplicitHook
+    export cargoCheckType=release
+    dbus-run-session \
+      --config-file=${dbus}/share/dbus-1/session.conf \
+      -- bash -e -c cargoCheckHook
+    popd
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+
+    pushd apps/desktop/dist/linux-unpacked
+    mkdir -p $out/opt/Bitwarden
+    cp -r locales resources{,.pak} $out/opt/Bitwarden
+    popd
+
+    makeWrapper '${electron}/bin/electron' "$out/bin/bitwarden" \
+      --add-flags $out/opt/Bitwarden/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --set-default ELECTRON_IS_DEV 0 \
+      --inherit-argv0
+
+    pushd apps/desktop/resources/icons
+    for icon in *.png; do
+      dir=$out/share/icons/hicolor/"''${icon%.png}"/apps
+      mkdir -p "$dir"
+      cp "$icon" "$dir"/${icon}.png
+    done
+    popd
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "bitwarden";
+      exec = "bitwarden %U";
+      inherit icon;
+      comment = meta.description;
+      desktopName = "Bitwarden";
+      categories = [ "Utility" ];
+    })
+  ];
+}

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -1,199 +1,21 @@
 { lib
-, buildNpmPackage
-, cargo
-, copyDesktopItems
-, dbus
-, electron_28
-, fetchFromGitHub
-, glib
-, gnome
-, gtk3
-, jq
-, libsecret
-, makeDesktopItem
-, makeWrapper
-, moreutils
-, napi-rs-cli
-, nodejs_18
-, patchutils_0_4_2
-, pkg-config
-, python3
-, runCommand
-, rustc
-, rustPlatform
-}:
+, stdenv
+, callPackage
+, ...
+}@args:
 
 let
-  description = "A secure and free password manager for all of your devices";
-  icon = "bitwarden";
-  electron = electron_28;
-in buildNpmPackage rec {
+  extraArgs = removeAttrs args [ "callPackage" ];
+
   pname = "bitwarden-desktop";
-  version = "2024.3.0";
-
-  src = fetchFromGitHub {
-    owner = "bitwarden";
-    repo = "clients";
-    rev = "desktop-v${version}";
-    hash = "sha256-XEZB95GnfSy/wtTWpF8KlUQwyephUZmSLtbOwbcvd7g=";
-  };
-
-  patches = [
-    ./electron-builder-package-lock.patch
-  ];
-
-  # The nested package-lock.json from upstream is out-of-date, so copy the
-  # lock metadata from the root package-lock.json.
-  postPatch = ''
-    cat {,apps/desktop/src/}package-lock.json \
-      | ${lib.getExe jq} -s '
-        .[1].packages."".dependencies.argon2 = .[0].packages."".dependencies.argon2
-          | .[0].packages."" = .[1].packages.""
-          | .[1].packages = .[0].packages
-          | .[1]
-        ' \
-      | ${moreutils}/bin/sponge apps/desktop/src/package-lock.json
-  '';
-
-  nodejs = nodejs_18;
-
-  makeCacheWritable = true;
-  npmFlags = [ "--legacy-peer-deps" ];
-  npmWorkspace = "apps/desktop";
-  npmDepsHash = "sha256-EpZXA+GkmHl5eqwIPTGHJZqrpr6k8gXneJG+GXumlkc=";
-
-  cargoDeps = rustPlatform.fetchCargoTarball {
-    name = "${pname}-${version}";
-    inherit src;
-    patches = map
-      (patch: runCommand
-        (builtins.baseNameOf patch)
-        { nativeBuildInputs = [ patchutils_0_4_2 ]; }
-        ''
-          < ${patch} filterdiff -p1 --include=${lib.escapeShellArg cargoRoot}'/*' > $out
-        ''
-      )
-      patches;
-    patchFlags = [ "-p4" ];
-    sourceRoot = "${src.name}/${cargoRoot}";
-    hash = "sha256-qAqEFlUzT28fw6kLB8d7U8yXWevAU+q03zjN2xWsGyI=";
-  };
-  cargoRoot = "apps/desktop/desktop_native";
-
-  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
-
-  nativeBuildInputs = [
-    cargo
-    copyDesktopItems
-    jq
-    makeWrapper
-    moreutils
-    napi-rs-cli
-    pkg-config
-    python3
-    rustc
-    rustPlatform.cargoCheckHook
-    rustPlatform.cargoSetupHook
-  ];
-
-  buildInputs = [
-    glib
-    gtk3
-    libsecret
-  ];
-
-  preBuild = ''
-    if [[ $(jq --raw-output '.devDependencies.electron' < package.json | grep -E --only-matching '^[0-9]+') != ${lib.escapeShellArg (lib.versions.major electron.version)} ]]; then
-      echo 'ERROR: electron version mismatch'
-      exit 1
-    fi
-  '';
-
-  postBuild = ''
-    pushd apps/desktop
-
-    # desktop_native/index.js loads a file of that name regarldess of the libc being used
-    mv desktop_native/desktop_native.* desktop_native/desktop_native.linux-x64-musl.node
-
-    npm exec electron-builder -- \
-      --dir \
-      -c.electronDist=${electron}/libexec/electron \
-      -c.electronVersion=${electron.version}
-
-    popd
-  '';
-
-  doCheck = true;
-
-  nativeCheckInputs = [
-    dbus
-    (gnome.gnome-keyring.override { useWrappedDaemon = false; })
-  ];
-
-  checkFlags = [
-    "--skip=password::password::tests::test"
-  ];
-
-  checkPhase = ''
-    runHook preCheck
-
-    pushd ${cargoRoot}
-    export HOME=$(mktemp -d)
-    export -f cargoCheckHook runHook _eval _callImplicitHook
-    export cargoCheckType=release
-    dbus-run-session \
-      --config-file=${dbus}/share/dbus-1/session.conf \
-      -- bash -e -c cargoCheckHook
-    popd
-
-    runHook postCheck
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir $out
-
-    pushd apps/desktop/dist/linux-unpacked
-    mkdir -p $out/opt/Bitwarden
-    cp -r locales resources{,.pak} $out/opt/Bitwarden
-    popd
-
-    makeWrapper '${electron}/bin/electron' "$out/bin/bitwarden" \
-      --add-flags $out/opt/Bitwarden/resources/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
-      --set-default ELECTRON_IS_DEV 0 \
-      --inherit-argv0
-
-    pushd apps/desktop/resources/icons
-    for icon in *.png; do
-      dir=$out/share/icons/hicolor/"''${icon%.png}"/apps
-      mkdir -p "$dir"
-      cp "$icon" "$dir"/${icon}.png
-    done
-    popd
-
-    runHook postInstall
-  '';
-
-  desktopItems = [
-    (makeDesktopItem {
-      name = "bitwarden";
-      exec = "bitwarden %U";
-      inherit icon;
-      comment = description;
-      desktopName = "Bitwarden";
-      categories = [ "Utility" ];
-    })
-  ];
 
   meta = {
-    changelog = "https://github.com/bitwarden/clients/releases/tag/${src.rev}";
-    inherit description;
+    description = "A secure and free password manager for all of your devices";
     homepage = "https://bitwarden.com";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ amarshall kiwi ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "bitwarden";
   };
-}
+in
+  callPackage ./linux.nix (extraArgs // { inherit pname meta; })

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -14,8 +14,11 @@ let
     homepage = "https://bitwarden.com";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ amarshall kiwi ];
-    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; if stdenv.isDarwin then [ binaryNativeCode ] else [ fromSource ];
+    platforms = [ "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
     mainProgram = "bitwarden";
   };
-in
+in if stdenv.isDarwin then
+  callPackage ./darwin.nix (extraArgs // { inherit pname meta; })
+else
   callPackage ./linux.nix (extraArgs // { inherit pname meta; })


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

In this PR I package Bitwarden's desktop app for Darwin, both x86_64 and aarch64. As checked below, the packaged application works on my aarch64 Mac. I don't have an x86 Mac to test, but as I'm grabbing the universal .dmg I suspect it works. I tried to build the Linux version on my Linux machine but I got an error during the build, one I suspect is _not_ due to my changes. I'm hoping the CI build of this branch picks it up, otherwise I'm gonna need some help to fix that :)

I've left some of the checkboxes for reviewers to tick. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
