### PR TITLE
bitbake-language-server: 0.0.8 -> 0.0.14

### DIFF
--- a/pkgs/by-name/bi/bitbake-language-server/package.nix
+++ b/pkgs/by-name/bi/bitbake-language-server/package.nix
@@ -1,19 +1,20 @@
 { lib
 , nix-update-script
 , python3
+, oelint-adv
 , fetchFromGitHub
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "bitbake-language-server";
-  version = "0.0.8";
+  version = "0.0.14";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "Freed-Wu";
     repo = pname;
     rev = version;
-    hash = "sha256-WJpa2LP95vrJG/OjiLSx8zEPO5ZOw66M5s3r2dufQJA=";
+    hash = "sha256-aGj9lW420A+iTQWSCdIITAJj3p89VUkPvdhQ/0M6uXo=";
   };
 
   nativeBuildInputs = with python3.pkgs; [
@@ -22,18 +23,17 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python3.pkgs; [
-    oelint-parser
     pygls
-  ];
+  ] ++ [ oelint-adv ];
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Language server for bitbake";
     mainProgram = "bitbake-language-server";
     homepage = "https://github.com/Freed-Wu/bitbake-language-server";
-    changelog = "https://github.com/Freed-Wu/bitbake-language-server/releases/tag/v${version}";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ otavio ];
+    changelog = "https://github.com/Freed-Wu/bitbake-language-server/releases/tag/${version}";
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.otavio ];
   };
 }


### PR DESCRIPTION

Depends on #303419 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc