### PR TITLE
nixos/gns3-server: fix ubridge support

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -298,6 +298,15 @@
   a static `user` and `group`. The `writablePaths` option has been removed and
   the models directory is now always exempt from sandboxing.
 
+- The `gns3-server` service now runs under the `gns3` system user
+  instead of a dynamically created one via `DynamicUser`.
+  The use of SUID wrappers is incompatible with SystemD's `DynamicUser` setting,
+  and GNS3 requires calling ubridge through its SUID wrapper to function properly.
+  This change requires to manually move the following directories:
+    * from `/var/lib/private/gns3` to `/var/lib/gns3`
+    * from `/var/log/private/gns3` to `/var/log/gns3`
+  and to change the ownership of these directories and their contents to `gns3` (including `/etc/gns3`).
+
 - Legacy package `stalwart-mail_0_6` was dropped, please note the
   [manual upgrade process](https://github.com/stalwartlabs/mail-server/blob/main/UPGRADING.md)
   before changing the package to `pkgs.stalwart-mail` in

--- a/nixos/modules/services/networking/gns3-server.nix
+++ b/nixos/modules/services/networking/gns3-server.nix
@@ -150,7 +150,7 @@ in {
         };
       }
       (lib.mkIf (cfg.ubridge.enable) {
-        Server.ubridge_path = lib.mkDefault (lib.getExe cfg.ubridge.package);
+        Server.ubridge_path = lib.mkDefault "/run/wrappers/bin/ubridge";
       })
       (lib.mkIf (cfg.auth.enable) {
         Server = {

--- a/nixos/modules/services/networking/gns3-server.nix
+++ b/nixos/modules/services/networking/gns3-server.nix
@@ -233,14 +233,27 @@ in {
         User = "gns3";
         WorkingDirectory = "%S/gns3";
 
+        # Required for ubridge integration to work
+        #
+        # GNS3 needs to run SUID binaries (ubridge)
+        # but NoNewPrivileges breaks execution of SUID binaries
+        DynamicUser = false;
+        NoNewPrivileges = false;
+        RestrictSUIDSGID = false;
+        PrivateUsers = false;
+
         # Hardening
-        DeviceAllow = lib.optional flags.enableLibvirtd "/dev/kvm";
+        DeviceAllow = [
+          # ubridge needs access to tun/tap devices
+          "/dev/net/tap rw"
+          "/dev/net/tun rw"
+        ] ++ lib.optionals flags.enableLibvirtd [
+          "/dev/kvm"
+        ];
         DevicePolicy = "closed";
         LockPersonality = true;
         MemoryDenyWriteExecute = true;
-        NoNewPrivileges = true;
         PrivateTmp = true;
-        PrivateUsers = true;
         # Don't restrict ProcSubset because python3Packages.psutil requires read access to /proc/stat
         # ProcSubset = "pid";
         ProtectClock = true;
@@ -261,8 +274,7 @@ in {
         ];
         RestrictNamespaces = true;
         RestrictRealtime = true;
-        RestrictSUIDSGID = true;
-        UMask = "0077";
+        UMask = "0022";
       };
     };
   };

--- a/nixos/modules/services/networking/gns3-server.nix
+++ b/nixos/modules/services/networking/gns3-server.nix
@@ -129,7 +129,14 @@ in {
       }
     ];
 
+    users.groups.gns3 = { };
+
     users.groups.ubridge = lib.mkIf cfg.ubridge.enable { };
+
+    users.users.gns3 = {
+      group = "gns3";
+      isSystemUser = true;
+    };
 
     security.wrappers.ubridge = lib.mkIf cfg.ubridge.enable {
       capabilities = "cap_net_raw,cap_net_admin=eip";
@@ -206,7 +213,6 @@ in {
       serviceConfig = {
         ConfigurationDirectory = "gns3";
         ConfigurationDirectoryMode = "0750";
-        DynamicUser = true;
         Environment = "HOME=%S/gns3";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         ExecStart = "${lib.getExe cfg.package} ${commandArgs}";


### PR DESCRIPTION
## Description of changes

Fixes #292258
See [this comment](https://github.com/NixOS/nixpkgs/issues/292258#issuecomment-2050392583) for explanations.

The usage of SUID wrappers is incompatible with SystemD DynamicUser & hardenings.
And GNS3 needs to call ubridge via its SUID Wrapper to work.

:warning: These changes are not backwards compatible, but are needed to fix the module. You will need to run `chown -R gns3:gns3 /var/lib/gns3 /etc/gns3 /var/log/gns3` to fix the permissions (see release notes).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
