### PR TITLE
[23.11] searxng: unstable-2023-10-31 -> 0-unstable-2024-03-08 

### DIFF
--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -218,7 +218,7 @@ in
       serviceConfig = {
         User  = "searx";
         Group = "searx";
-        ExecStart = "${cfg.package}/bin/searx-run";
+        ExecStart = lib.getExe cfg.package;
       } // optionalAttrs (cfg.environmentFile != null)
         { EnvironmentFile = builtins.toPath cfg.environmentFile; };
       environment = {

--- a/nixos/tests/searx.nix
+++ b/nixos/tests/searx.nix
@@ -36,7 +36,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
   };
 
   # fancy setup: run in uWSGI and use nginx as proxy
-  nodes.fancy = { ... }: {
+  nodes.fancy = { config, ... }: {
     imports = [ ../modules/profiles/minimal.nix ];
 
     services.searx = {
@@ -65,7 +65,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
           include ${pkgs.nginx}/conf/uwsgi_params;
           uwsgi_pass unix:/run/searx/uwsgi.sock;
         '';
-      locations."/searx/static/".alias = "${pkgs.searx}/share/static/";
+      locations."/searx/static/".alias = "${config.services.searx.package}/share/static/";
     };
 
     # allow nginx access to the searx socket
@@ -108,7 +108,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
               "${pkgs.curl}/bin/curl --fail http://localhost/searx >&2"
           )
           fancy.succeed(
-              "${pkgs.curl}/bin/curl --fail http://localhost/searx/static/themes/oscar/js/bootstrap.min.js >&2"
+              "${pkgs.curl}/bin/curl --fail http://localhost/searx/static/themes/simple/js/leaflet.js >&2"
           )
     '';
 })

--- a/pkgs/by-name/se/searxng/package.nix
+++ b/pkgs/by-name/se/searxng/package.nix
@@ -5,13 +5,13 @@
 
 python3.pkgs.toPythonModule (python3.pkgs.buildPythonApplication rec {
   pname = "searxng";
-  version = "0-unstable-2024-02-24";
+  version = "0-unstable-2024-03-08";
 
   src = fetchFromGitHub {
     owner = "searxng";
     repo = "searxng";
-    rev = "d72fa99bd0a4d702a55188b07919ce5a764b1d6c";
-    hash = "sha256-1A7dyWrF63fSSvWP+2HrCS6H8o/4CUlqiP0KANVZHUA=";
+    rev = "9c08a0cdddae7ceafbe5e00ce94cf7f1d36c97e0";
+    hash = "sha256-0qlOpJqpOmseIeIafd0NLd2lF5whu18QxmwOua8dKzg=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/se/searxng/package.nix
+++ b/pkgs/by-name/se/searxng/package.nix
@@ -73,6 +73,7 @@ python3.pkgs.toPythonModule (python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/searxng/searxng";
     description = "A fork of Searx, a privacy-respecting, hackable metasearch engine";
     license = licenses.agpl3Plus;
+    mainProgram = "searxng-run";
     maintainers = with maintainers; [ SuperSandro2000 _999eagle ];
   };
 })

--- a/pkgs/by-name/se/searxng/package.nix
+++ b/pkgs/by-name/se/searxng/package.nix
@@ -5,13 +5,13 @@
 
 python3.pkgs.toPythonModule (python3.pkgs.buildPythonApplication rec {
   pname = "searxng";
-  version = "unstable-2023-10-31";
+  version = "0-unstable-2024-02-24";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
-    rev = "b05a15540e1dc2dfb8e4e25aa537b2a68e713844";
-    hash = "sha256-x0PyS+A4KjbBnTpca17Wx3BQjtOHvVuWpusPPc1ULnU=";
+    owner = "searxng";
+    repo = "searxng";
+    rev = "d72fa99bd0a4d702a55188b07919ce5a764b1d6c";
+    hash = "sha256-1A7dyWrF63fSSvWP+2HrCS6H8o/4CUlqiP0KANVZHUA=";
   };
 
   postPatch = ''
@@ -20,7 +20,7 @@ python3.pkgs.toPythonModule (python3.pkgs.buildPythonApplication rec {
 
   preBuild =
     let
-      versionString = lib.concatStringsSep "." (builtins.tail (lib.splitString "-" version));
+      versionString = lib.concatStringsSep "." (builtins.tail (lib.splitString "-" (lib.removePrefix "0-" version)));
       commitAbbrev = builtins.substring 0 8 src.rev;
     in
     ''
@@ -66,7 +66,7 @@ python3.pkgs.toPythonModule (python3.pkgs.buildPythonApplication rec {
     ln -s ../${python3.sitePackages}/searx/static $out/share/
 
     # copy config schema for the limiter
-    cp searx/botdetection/limiter.toml $out/${python3.sitePackages}/searx/botdetection/limiter.toml
+    cp searx/limiter.toml $out/${python3.sitePackages}/searx/limiter.toml
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Backport of searxng recent updates and fixes necessary to run the test.
I haven't been following searxng development, so I'm not sure if it's ok to backport.
If not, I would at least patch https://github.com/searxng/searxng/pull/3168, because this issue is very annoying.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested via `nixosTests.searx`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
