### PR TITLE
Define gccFromSrc to allow building gcc from a source

### DIFF
--- a/pkgs/development/compilers/gcc/common/dependencies.nix
+++ b/pkgs/development/compilers/gcc/common/dependencies.nix
@@ -50,7 +50,7 @@ in
   ]
   ++ optionals (perl != null) [ perl ]
   ++ optionals javaAwtGtk [ pkg-config ]
-  ++ optionals (with stdenv.targetPlatform; isVc4 || isRedox && flex != null) [ flex ]
+  ++ optionals (lib.versionAtLeast version "14" || (with stdenv.targetPlatform; isVc4 || isRedox && flex != null)) [ flex ]
   ++ optionals langAda [ gnat-bootstrap ]
   # The builder relies on GNU sed (for instance, Darwin's `sed' fails with
   # "-i may not be used with stdin"), and `stdenvNative' doesn't provide it.

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, targetPackages, fetchurl, fetchpatch, noSysDirs
+{ lib, stdenv, targetPackages, fetchFromGitHub, fetchurl, fetchpatch, noSysDirs
 , langC ? true, langCC ? true, langFortran ? false
 , langAda ? false
 , langObjC ? stdenv.targetPlatform.isDarwin
@@ -45,11 +45,15 @@
 , libXrender ? null, xorgproto ? null
 , libXrandr ? null, libXi ? null
 , x11Support ? langJava
+
+, gccSrc ? null
 }:
 
 let
   versions = import ./versions.nix;
-  version = versions.fromMajorMinor majorMinorVersion;
+  version = if gccSrc != null
+    then majorMinorVersion
+    else versions.fromMajorMinor majorMinorVersion;
 
   majorVersion = lib.versions.major version;
   atLeast14 = lib.versionAtLeast version "14";
@@ -236,7 +240,9 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
   pname = "${crossNameAddon}${name}";
   inherit version;
 
-  src = if is6 && stdenv.targetPlatform.isVc4 then fetchFromGitHub {
+  src = if gccSrc != null
+  then gccSrc
+  else if is6 && stdenv.targetPlatform.isVc4 then fetchFromGitHub {
     owner = "itszor";
     repo = "gcc-vc4";
     rev = "e90ff43f9671c760cf0d1dd62f569a0fb9bf8918";

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -52,6 +52,7 @@ let
   version = versions.fromMajorMinor majorMinorVersion;
 
   majorVersion = lib.versions.major version;
+  atLeast14 = lib.versionAtLeast version "14";
   atLeast13 = lib.versionAtLeast version "13";
   atLeast12 = lib.versionAtLeast version "12";
   atLeast11 = lib.versionAtLeast version "11";
@@ -61,6 +62,7 @@ let
   atLeast7  = lib.versionAtLeast version  "7";
   atLeast6  = lib.versionAtLeast version  "6";
   atLeast49 = lib.versionAtLeast version  "4.9";
+  is14 = majorVersion == "14";
   is13 = majorVersion == "13";
   is12 = majorVersion == "12";
   is11 = majorVersion == "11";
@@ -221,6 +223,8 @@ let inherit version;
         url = "https://www.antlr.org/download/antlr-4.4-complete.jar";
         sha256 = "02lda2imivsvsis8rnzmbrbp8rh1kb8vmq4i67pqhkwz7lf8y6dz";
       };
+    } // lib.optionalAttrs atLeast14 {
+      inherit flex;
     });
 
 in

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -63,6 +63,7 @@ in
 ++ optionals (noSysDirs) (
   [(if atLeast12 then ./gcc-12-no-sys-dirs.patch else ./no-sys-dirs.patch)] ++
   ({
+    "14" = [ ./13/no-sys-dirs-riscv.patch ./13/mangle-NIX_STORE-in-__FILE__.patch ];
     "13" = [ ./13/no-sys-dirs-riscv.patch ./13/mangle-NIX_STORE-in-__FILE__.patch ];
     "12" = [ ./no-sys-dirs-riscv.patch ./12/mangle-NIX_STORE-in-__FILE__.patch ];
     "11" = [ ./no-sys-dirs-riscv.patch ];


### PR DESCRIPTION
## Description of changes

This PR defines a `pkgs.gccFromSrc` function which uses `gccFun` and `wrapCC` to allow building a custom `gcc` package from a `src`, such as a local directory or a GitHub repository.

It also updates some parts of the `gcc` definitions slightly to account for upcoming version 14. Basically the only real change necessary is that `flex` needs to be provided as an input.

With this change, it's possible to define custom GCC 14 as in the following example. Below, we define `pkgs.gcc14` and `pkgs.pkgsCross.riscv64.gcc14`, with the intention to use the RISC-V targeting cross compiler for building an installer image for system supporting `xthead` extensions.

```nix
{
  nixpkgs.overlays = [
    (_final: prev: {
      gcc14 = prev.gccFromSrc {
        majorMinorVersion = "14.0.1";
        src = /path/to/gcc/repo;
      };
    })
    (_final: prev: {
      pkgsCross = lib.mapAttrs
        (_name: value: value // {
          gcc14 = value.gcc14.override {
            # NOTE: needed to build `libstdc++-v3` since it uses `std=gnu++26` which `13.2.0`
            # doesn't support, and local `xgcc` doesn't get built when `buildPlatform !=
            # hostPlatform`.
            stdenv = prev.overrideCC value.stdenv value.buildPackages.gcc14;
          };
        })
        prev.pkgsCross;
    })
  ];

  environment.systemPackages = with pkgs; [
    pkgsCross.riscv64.buildPackages.gcc14
    pkgsCross.riscv64.gcc14
  ];
}
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@Synthetica9 @vcunat @Ericson2314 @trofi @skeuchel 