### PR TITLE
ber_metaocaml: 111 -> 114

### DIFF
--- a/pkgs/development/compilers/ocaml/ber-metaocaml.nix
+++ b/pkgs/development/compilers/ocaml/ber-metaocaml.nix
@@ -9,9 +9,9 @@ let
    x11deps = [ libX11 xorgproto ];
    inherit (lib) optionals;
 
-   baseOcamlBranch  = "4.11";
+   baseOcamlBranch  = "4.14";
    baseOcamlVersion = "${baseOcamlBranch}.1";
-   metaocamlPatch   = "111";
+   metaocamlPatch   = "114";
 in
 
 stdenv.mkDerivation rec {
@@ -20,12 +20,12 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://caml.inria.fr/pub/distrib/ocaml-${baseOcamlBranch}/ocaml-${baseOcamlVersion}.tar.gz";
-    sha256 = "sha256-3Yi2OFvZLgrZInMuKMxoyHd4QXcOoAPCC9FS9dtEFc4=";
+    sha256 = "sha256-GDl53JwJyw9YCiMraFMaCbAlqmKLjY1ydEnxRv1vX+4=";
   };
 
   metaocaml = fetchurl {
     url = "http://okmij.org/ftp/ML/ber-metaocaml-${metaocamlPatch}.tar.gz";
-    sha256 = "sha256-hDb0w0ZCm0hCz8jktZKmr/7gPSfBoKPT/cc7sPjt0yE=";
+    sha256 = "sha256-vvq3xI4jSAsrXcDk97TPbFDYgO9NcQeN/yBcUbcb/y0=";
   };
 
   x11env = buildEnv { name = "x11env"; paths = x11deps; };
@@ -37,17 +37,6 @@ stdenv.mkDerivation rec {
 
   dontStrip = true;
   buildInputs = [ ncurses ] ++ optionals useX11 x11deps;
-
-  patches = [
-    # glibc 2.34 changed SIGSTKSZ from a #define'd integer to an
-    # expression involving a function call.  This broke all code that
-    # used SIGSTKSZ as the size of a statically-allocated array.  This
-    # patch is also applied by the ocaml/4.07.nix expression.
-    (fetchpatch {
-      url = "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch";
-      sha256 = "sha256-OmyovAu+8sgg3n5YD29Cytx3u/9PO2ofMsmrwiKUxks=";
-    })
-  ];
 
   postConfigure = ''
     tar -xvzf $metaocaml


### PR DESCRIPTION
## Description of changes

This is an update to the latest version for https://okmij.org/ftp/ML/ber-metaocaml-ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
