### PR TITLE
ocamlPackages.landmarks{,-ppx}: init at 1.4

### DIFF
--- a/pkgs/development/ocaml-modules/landmarks-ppx/default.nix
+++ b/pkgs/development/ocaml-modules/landmarks-ppx/default.nix
@@ -1,0 +1,18 @@
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, landmarks, ppxlib }:
+
+buildDunePackage {
+  pname = "landmarks-ppx";
+  minimalOCamlVersion = "4.08";
+
+  inherit (landmarks) src version;
+
+  buildInputs = [ ppxlib ];
+  propagatedBuildInputs = [ landmarks ];
+
+  doCheck = lib.versionAtLeast ocaml.version "4.08"
+    && lib.versionOlder ocaml.version "5.0";
+
+  meta = landmarks.meta // {
+    description = "Preprocessor instrumenting code using the landmarks library";
+  };
+}

--- a/pkgs/development/ocaml-modules/landmarks/default.nix
+++ b/pkgs/development/ocaml-modules/landmarks/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchFromGitHub, buildDunePackage, ocaml }:
+
+buildDunePackage {
+  pname = "landmarks";
+  version = "1.4";
+  minimalOCamlVersion = "4.08";
+
+  src = fetchFromGitHub {
+    owner = "LexiFi";
+    repo = "landmarks";
+    rev = "b0c753cd2a4c4aa00dffdd3be187d8ed592fabf7";
+    hash = "sha256-Wpr76JURUFrj7v39rdM/2Lr7boa7nL/bnPEz1vMrmQo";
+  };
+
+  doCheck = lib.versionAtLeast ocaml.version "4.08"
+    && lib.versionOlder ocaml.version "5.0";
+
+  meta = with lib; {
+    description = "A Simple Profiling Library for OCaml";
+    maintainers = [ maintainers.kenran ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -930,6 +930,10 @@ let
       inherit (pkgs) lame;
     };
 
+    landmarks = callPackage ../development/ocaml-modules/landmarks { };
+
+    landmarks-ppx = callPackage ../development/ocaml-modules/landmarks-ppx { };
+
     lastfm = callPackage ../development/ocaml-modules/lastfm { };
 
     lem = callPackage ../development/ocaml-modules/lem { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added the [landmarks / landmarks-ppx](https://github.com/LexiFi/landmarks) profiling libraries for OCaml. Notes:

- Tests have slightly different output with OCaml >= 5, so I disabled them there.
- I used `HEAD` instead of the actual version, as there now seems to be support for `aarch64-darwin` (https://github.com/LexiFi/landmarks/commit/cd772ed6f44b8419b708a6f014a12bf8a416ef84).
- I was not sure whether it would be a good or bad idea to set the sources of `landmarks-ppx` to that of `landmarks`, as they're the same repository.
- I tested the libraries by using them in personal OCaml project of mine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
