### PR TITLE
python312Packages.s3transfer: 0.10.0 -> 0.10.1 

### DIFF
--- a/pkgs/development/python-modules/s3transfer/default.nix
+++ b/pkgs/development/python-modules/s3transfer/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "s3transfer";
-  version = "0.10.0";
+  version = "0.10.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "boto";
     repo = "s3transfer";
     rev = "refs/tags/${version}";
-    hash = "sha256-21xycx1+84uY4gFr7N+ra98dpsEwxy9zeSl4QA66nUc=";
+    hash = "sha256-EHNkYviafnuU8AADp9oyaDuAnoPOdOVNSLCcoONnHPY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/s3transfer/default.nix
+++ b/pkgs/development/python-modules/s3transfer/default.nix
@@ -1,11 +1,12 @@
-{ lib
-, stdenv
-, botocore
-, buildPythonPackage
-, fetchFromGitHub
-, pytestCheckHook
-, pythonOlder
-, setuptools
+{
+  lib,
+  stdenv,
+  botocore,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  pythonOlder,
+  setuptools,
 }:
 
 buildPythonPackage rec {
@@ -22,38 +23,28 @@ buildPythonPackage rec {
     hash = "sha256-EHNkYviafnuU8AADp9oyaDuAnoPOdOVNSLCcoONnHPY=";
   };
 
-  nativeBuildInputs = [
-    setuptools
-  ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
-    botocore
-  ];
-
-  nativeCheckInputs = [
-    pytestCheckHook
-  ];
-
-  disabledTestPaths = [
-    # Requires network access
-    "tests/integration"
-  ] ++
-  # There was a change in python 3.8 that defaults multiprocessing to spawn instead of fork on macOS
-  # See https://bugs.python.org/issue33725 and https://github.com/python/cpython/pull/13603.
-  # I suspect the underlying issue here is that upstream tests aren't compatible with spawn multiprocessing, and pass on linux where the default is still fork
-  lib.optionals stdenv.isDarwin [
-    "tests/unit/test_compat.py"
-  ];
-
-  pythonImportsCheck = [
-    "s3transfer"
-  ];
+  dependencies = [ botocore ];
 
   passthru.optional-dependencies = {
-    crt = [
-      botocore.optional-dependencies.crt
-    ];
+    crt = [ botocore.optional-dependencies.crt ];
   };
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths =
+    [
+      # Requires network access
+      "tests/integration"
+    ]
+    ++
+    # There was a change in Python 3.8 that defaults multiprocessing to spawn instead of fork on macOS
+    # See https://bugs.python.org/issue33725 and https://github.com/python/cpython/pull/13603.
+    # I suspect the underlying issue here is that upstream tests aren't compatible with spawn multiprocessing, and pass on linux where the default is still fork
+    lib.optionals stdenv.isDarwin [ "tests/unit/test_compat.py" ];
+
+  pythonImportsCheck = [ "s3transfer" ];
 
   meta = with lib; {
     description = "Library for managing Amazon S3 transfers";


### PR DESCRIPTION
Diff: https://github.com/boto/s3transfer/compare/refs/tags/0.10.0...0.10.1

Changelog: https://github.com/boto/s3transfer/blob/0.10.1/CHANGELOG.rst

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
