### PR TITLE
treewide: use copyDesktopItems for desktop entry installation 

### DIFF
--- a/pkgs/applications/audio/lyrebird/default.nix
+++ b/pkgs/applications/audio/lyrebird/default.nix
@@ -5,19 +5,11 @@
 , wrapGAppsHook
 , gtk3
 , gobject-introspection
+, copyDesktopItems
 , sox
 , pulseaudio
 }:
-let
-  desktopItem = makeDesktopItem {
-    name = "lyrebird";
-    exec = "lyrebird";
-    icon = "${placeholder "out"}/share/lyrebird/icon.png";
-    desktopName = "Lyrebird";
-    genericName = "Voice Changer";
-    categories = [ "AudioVideo" "Audio" ];
-  };
-in
+
 python3Packages.buildPythonApplication rec {
   pname = "lyrebird";
   version = "1.2.0";
@@ -34,7 +26,7 @@ python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3Packages; [ toml pygobject3 ];
 
-  nativeBuildInputs = [ wrapGAppsHook gobject-introspection ];
+  nativeBuildInputs = [ wrapGAppsHook gobject-introspection copyDesktopItems ];
 
   buildInputs = [ gtk3 sox ];
 
@@ -49,9 +41,19 @@ python3Packages.buildPythonApplication rec {
   installPhase = ''
     mkdir -p $out/{bin,share/{applications,lyrebird}}
     cp -at $out/share/lyrebird/ app icon.png
-    cp -at $out/share/applications/ ${desktopItem}
     install -Dm755 app.py $out/bin/lyrebird
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "lyrebird";
+      exec = "lyrebird";
+      icon = "${placeholder "out"}/share/lyrebird/icon.png";
+      desktopName = "Lyrebird";
+      genericName = "Voice Changer";
+      categories = [ "AudioVideo" "Audio" ];
+    })
+  ];
 
   meta = with lib; {
     description = "Simple and powerful voice changer for Linux, written in GTK 3";

--- a/pkgs/applications/audio/plugdata/default.nix
+++ b/pkgs/applications/audio/plugdata/default.nix
@@ -14,20 +14,9 @@
 , xorg
 , python3
 , makeWrapper
+, copyDesktopItems
 }:
 
-let
-  # data copied from build system: https://build.opensuse.org/package/view_file/home:plugdata/plugdata/PlugData.desktop
-  desktopItem = makeDesktopItem {
-    name = "PlugData";
-    desktopName = "PlugData";
-    exec = "plugdata";
-    icon = "plugdata_logo.png";
-    comment = "Pure Data as a plugin, with a new GUI";
-    type = "Application";
-    categories = [ "AudioVideo" "Music" ];
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "plugdata";
   version = "0.8.0";
@@ -47,6 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     imagemagick
     python3
     makeWrapper
+    copyDesktopItems
   ];
   buildInputs = [
     alsa-lib
@@ -88,7 +78,6 @@ stdenv.mkDerivation (finalAttrs: {
     icon_name="plugdata_logo.png"
     icon_path="Resources/Icons/$icon_name"
 
-    install -m644 -D "${desktopItem}"/share/applications/* -t $out/share/applications
     for size in 16 24 32 48 64 128 256 512; do
       mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
       convert -resize "$size"x"$size" "$icon_path" $out/share/icons/hicolor/"$size"x"$size"/apps/"$icon_name"
@@ -96,6 +85,19 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  # data copied from build system: https://build.opensuse.org/package/view_file/home:plugdata/plugdata/PlugData.desktop
+  desktopItems = [
+    (makeDesktopItem {
+      name = "PlugData";
+      desktopName = "PlugData";
+      exec = "plugdata";
+      icon = "plugdata_logo.png";
+      comment = "Pure Data as a plugin, with a new GUI";
+      type = "Application";
+      categories = [ "AudioVideo" "Music" ];
+    })
+  ];
 
   postInstall = ''
       # Ensure zenity is available, or it won't be able to open new files.

--- a/pkgs/applications/audio/psst/default.nix
+++ b/pkgs/applications/audio/psst/default.nix
@@ -1,19 +1,5 @@
-{ lib, fetchFromGitHub, rustPlatform, alsa-lib, atk, cairo, dbus, gdk-pixbuf, glib, gtk3, pango, pkg-config, makeDesktopItem }:
+{ lib, fetchFromGitHub, rustPlatform, alsa-lib, atk, cairo, dbus, gdk-pixbuf, glib, gtk3, pango, pkg-config, makeDesktopItem, copyDesktopItems }:
 
-let
-  desktopItem = makeDesktopItem {
-    name = "Psst";
-    exec = "psst-gui";
-    comment = "Fast and multi-platform Spotify client with native GUI";
-    desktopName = "Psst";
-    type = "Application";
-    categories = [ "Audio" "AudioVideo" ];
-    icon = "psst";
-    terminal = false;
-    startupWMClass = "psst-gui";
-  };
-
-in
 rustPlatform.buildRustPackage rec {
   pname = "psst";
   version = "unstable-2024-04-01";
@@ -36,7 +22,7 @@ rustPlatform.buildRustPackage rec {
   # specify the subdirectory of the binary crate to build from the workspace
   buildAndTestSubdir = "psst-gui";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config copyDesktopItems ];
 
   buildInputs = [
     alsa-lib
@@ -56,8 +42,21 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     install -Dm444 psst-gui/assets/logo_512.png $out/share/icons/hicolor/512x512/apps/${pname}.png
-    install -Dm444 -t $out/share/applications ${desktopItem}/share/applications/*
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Psst";
+      exec = "psst-gui";
+      comment = "Fast and multi-platform Spotify client with native GUI";
+      desktopName = "Psst";
+      type = "Application";
+      categories = [ "Audio" "AudioVideo" ];
+      icon = "psst";
+      terminal = false;
+      startupWMClass = "psst-gui";
+    })
+  ];
 
   passthru = {
     updateScript = ./update.sh;

--- a/pkgs/applications/audio/roomeqwizard/default.nix
+++ b/pkgs/applications/audio/roomeqwizard/default.nix
@@ -1,4 +1,5 @@
-{ coreutils
+{ copyDesktopItems
+, coreutils
 , fetchurl
 , gawk
 , gnused
@@ -23,14 +24,16 @@ stdenv.mkDerivation rec {
 
   dontUnpack = true;
 
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = pname;
-    icon = pname;
-    desktopName = "REW";
-    genericName = "Software for audio measurements";
-    categories = [ "AudioVideo" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      icon = pname;
+      desktopName = "REW";
+      genericName = "Software for audio measurements";
+      categories = [ "AudioVideo" ];
+    })
+  ];
 
   responseFile = writeTextFile {
     name = "response.varfile";
@@ -51,7 +54,7 @@ stdenv.mkDerivation rec {
     SUBSYSTEM=="usb", ATTR{idVendor}=="2752", ATTR{idProduct}=="0007", TAG+="uaccess"
   '';
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
 
   buildPhase = ''
     runHook preBuild
@@ -77,7 +80,6 @@ stdenv.mkDerivation rec {
       --set INSTALL4J_JAVA_HOME_OVERRIDE ${jdk8} \
       --prefix PATH : ${lib.makeBinPath [ coreutils gnused gawk ]}
 
-    cp -r "$desktopItem/share/applications" $out/share/
     cp $out/share/roomeqwizard/.install4j/roomeqwizard.png "$out/share/icons/hicolor/256x256/apps/${pname}.png"
 
     ${lib.optionalString recommendedUdevRules ''echo "$udevRules" > $out/lib/udev/rules.d/90-roomeqwizard.rules''}

--- a/pkgs/applications/audio/samplebrain/default.nix
+++ b/pkgs/applications/audio/samplebrain/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, copyDesktopItems
 , fetchFromGitLab
 , fftw
 , liblo
@@ -23,6 +24,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    copyDesktopItems
     qmake
     wrapQtAppsHook
   ];
@@ -35,15 +37,17 @@ stdenv.mkDerivation rec {
     qtbase
   ];
 
-  desktopItem = makeDesktopItem {
-    type = "Application";
-    desktopName = pname;
-    name = pname;
-    comment = "A sample masher designed by Aphex Twin";
-    exec = pname;
-    icon = pname;
-    categories = [ "Audio" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      desktopName = pname;
+      name = pname;
+      comment = "A sample masher designed by Aphex Twin";
+      exec = pname;
+      icon = pname;
+      categories = [ "Audio" ];
+    })
+  ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, wrapQtAppsHook, makeDesktopItem
 , fetchFromGitHub
-, cmake, qttools, pkg-config
+, cmake, qttools, pkg-config, copyDesktopItems
 , qtbase, qtdeclarative, qtgraphicaleffects
 , qtmultimedia, qtxmlpatterns
 , qtquickcontrols, qtquickcontrols2
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    cmake pkg-config wrapQtAppsHook
+    cmake pkg-config wrapQtAppsHook copyDesktopItems
     (lib.getDev qttools)
   ];
 
@@ -70,20 +70,18 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DARCH=default" ];
 
-  desktopItem = makeDesktopItem {
-    name = "monero-wallet-gui";
-    exec = "monero-wallet-gui";
-    icon = "monero";
-    desktopName = "Monero";
-    genericName = "Wallet";
-    categories  = [ "Network" "Utility" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "monero-wallet-gui";
+      exec = "monero-wallet-gui";
+      icon = "monero";
+      desktopName = "Monero";
+      genericName = "Wallet";
+      categories  = [ "Network" "Utility" ];
+    })
+  ];
 
   postInstall = ''
-    # install desktop entry
-    install -Dm644 -t $out/share/applications \
-      ${desktopItem}/share/applications/*
-
     # install icons
     for n in 16 24 32 48 64 96 128 256; do
       size=$n"x"$n

--- a/pkgs/applications/blockchains/wasabiwallet/default.nix
+++ b/pkgs/applications/blockchains/wasabiwallet/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , autoPatchelfHook
 , makeWrapper
+, copyDesktopItems
 , fetchurl
 , makeDesktopItem
 , lttng-ust_2_12
@@ -34,16 +35,18 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
 
-  desktopItem = makeDesktopItem {
-    name = "wasabi";
-    exec = "wasabiwallet";
-    desktopName = "Wasabi";
-    genericName = "Bitcoin wallet";
-    comment = meta.description;
-    categories = [ "Network" "Utility" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "wasabi";
+      exec = "wasabiwallet";
+      desktopName = "Wasabi";
+      genericName = "Bitcoin wallet";
+      comment = meta.description;
+      categories = [ "Network" "Utility" ];
+    })
+  ];
 
-  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper copyDesktopItems ];
   buildInputs = runtimeLibs ++ [
     lttng-ust_2_12
   ];
@@ -57,8 +60,6 @@ stdenv.mkDerivation rec {
 
     makeWrapper "$out/opt/${pname}/wassabeed" "$out/bin/${pname}d" \
       --suffix "LD_LIBRARY_PATH" : "${lib.makeLibraryPath runtimeLibs}"
-
-    cp -v $desktopItem/share/applications/* $out/share/applications
   '';
 
   meta = with lib; {

--- a/pkgs/applications/editors/eclipse/build-eclipse.nix
+++ b/pkgs/applications/editors/eclipse/build-eclipse.nix
@@ -1,23 +1,25 @@
 { lib, stdenv, makeDesktopItem, freetype, fontconfig, libX11, libXrender
 , zlib, jdk, glib, glib-networking, gtk, libXtst, libsecret, gsettings-desktop-schemas, webkitgtk
-, makeWrapper, perl, ... }:
+, makeWrapper, perl, copyDesktopItems, ... }:
 
 { name, src ? builtins.getAttr stdenv.hostPlatform.system sources, sources ? null, description, productVersion }:
 
 stdenv.mkDerivation rec {
   inherit name src;
 
-  desktopItem = makeDesktopItem {
-    name = "Eclipse";
-    exec = "eclipse";
-    icon = "eclipse";
-    comment = "Integrated Development Environment";
-    desktopName = "Eclipse IDE";
-    genericName = "Integrated Development Environment";
-    categories = [ "Development" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Eclipse";
+      exec = "eclipse";
+      icon = "eclipse";
+      comment = "Integrated Development Environment";
+      desktopName = "Eclipse IDE";
+      genericName = "Integrated Development Environment";
+      categories = [ "Development" ];
+    })
+  ];
 
-  nativeBuildInputs = [ makeWrapper perl ];
+  nativeBuildInputs = [ makeWrapper perl copyDesktopItems ];
   buildInputs = [
     fontconfig freetype glib gsettings-desktop-schemas gtk jdk libX11
     libXrender libXtst libsecret zlib
@@ -48,7 +50,6 @@ stdenv.mkDerivation rec {
 
     # Create desktop item.
     mkdir -p $out/share/applications
-    cp ${desktopItem}/share/applications/* $out/share/applications
     mkdir -p $out/share/pixmaps
     ln -s $out/eclipse/icon.xpm $out/share/pixmaps/eclipse.xpm
 

--- a/pkgs/applications/editors/jetbrains/bin/linux.nix
+++ b/pkgs/applications/editors/jetbrains/bin/linux.nix
@@ -47,16 +47,18 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
   passthru.buildNumber = buildNumber;
   meta = args.meta // { mainProgram = pname; };
 
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = pname;
-    comment = lib.replaceStrings [ "\n" ] [ " " ] meta.longDescription;
-    desktopName = product;
-    genericName = meta.description;
-    categories = [ "Development" ];
-    icon = pname;
-    startupWMClass = wmClass;
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      comment = lib.replaceStrings [ "\n" ] [ " " ] meta.longDescription;
+      desktopName = product;
+      genericName = meta.description;
+      categories = [ "Development" ];
+      icon = pname;
+      startupWMClass = wmClass;
+    })
+  ];
 
   vmoptsFile = lib.optionalString (vmopts != null) (writeText vmoptsName vmopts);
 
@@ -100,7 +102,6 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
     cp ${fsnotifier}/bin/fsnotifier $out/$pname/bin/fsnotifier
 
     jdk=${jdk.home}
-    item=${desktopItem}
 
     wrapProgram  "$out/$pname/bin/${loName}.sh" \
       --prefix PATH : "${lib.makeBinPath [ jdk coreutils gnugrep which git ]}" \
@@ -119,7 +120,6 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
     echo -e '#!/usr/bin/env bash\n'"$out/$pname/bin/remote-dev-server.sh"' "$@"' > $out/$pname/bin/remote-dev-server-wrapped.sh
     chmod +x $out/$pname/bin/remote-dev-server-wrapped.sh
     ln -s "$out/$pname/bin/remote-dev-server-wrapped.sh" $out/bin/$pname-remote-dev-server
-    ln -s "$item/share/applications" $out/share
 
     runHook postInstall
   '';

--- a/pkgs/applications/editors/leo-editor/default.nix
+++ b/pkgs/applications/editors/leo-editor/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, python3, fetchFromGitHub, makeWrapper, wrapQtAppsHook, makeDesktopItem }:
+{ lib, mkDerivation, python3, fetchFromGitHub, makeWrapper, wrapQtAppsHook, copyDesktopItems, makeDesktopItem }:
 
 mkDerivation rec {
   pname = "leo-editor";
@@ -13,37 +13,36 @@ mkDerivation rec {
 
   dontBuild = true;
 
-  nativeBuildInputs = [ wrapQtAppsHook makeWrapper python3 ];
+  nativeBuildInputs = [ wrapQtAppsHook makeWrapper python3 copyDesktopItems ];
   propagatedBuildInputs = with python3.pkgs; [ pyqt5 docutils ];
 
-  desktopItem = makeDesktopItem {
-    name = "leo-editor";
-    exec = "leo %U";
-    icon = "leoapp32";
-    type = "Application";
-    comment = meta.description;
-    desktopName = "Leo";
-    genericName = "Text Editor";
-    categories = [ "Application" "Development" "IDE" ];
-    startupNotify = false;
-    mimeTypes = [
-      "text/plain" "text/asp" "text/x-c" "text/x-script.elisp" "text/x-fortran"
-      "text/html" "application/inf" "text/x-java-source" "application/x-javascript"
-      "application/javascript" "text/ecmascript" "application/x-ksh" "text/x-script.ksh"
-      "application/x-tex" "text/x-script.rexx" "text/x-pascal" "text/x-script.perl"
-      "application/postscript" "text/x-script.scheme" "text/x-script.guile" "text/sgml"
-      "text/x-sgml" "application/x-bsh" "application/x-sh" "application/x-shar"
-      "text/x-script.sh" "application/x-tcl" "text/x-script.tcl" "application/x-texinfo"
-      "application/xml" "text/xml" "text/x-asm"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "leo-editor";
+      exec = "leo %U";
+      icon = "leoapp32";
+      type = "Application";
+      comment = meta.description;
+      desktopName = "Leo";
+      genericName = "Text Editor";
+      categories = [ "Application" "Development" "IDE" ];
+      startupNotify = false;
+      mimeTypes = [
+        "text/plain" "text/asp" "text/x-c" "text/x-script.elisp" "text/x-fortran"
+        "text/html" "application/inf" "text/x-java-source" "application/x-javascript"
+        "application/javascript" "text/ecmascript" "application/x-ksh" "text/x-script.ksh"
+        "application/x-tex" "text/x-script.rexx" "text/x-pascal" "text/x-script.perl"
+        "application/postscript" "text/x-script.scheme" "text/x-script.guile" "text/sgml"
+        "text/x-sgml" "application/x-bsh" "application/x-sh" "application/x-shar"
+        "text/x-script.sh" "application/x-tcl" "text/x-script.tcl" "application/x-texinfo"
+        "application/xml" "text/xml" "text/x-asm"
+      ];
+    })
+  ];
 
   installPhase = ''
     mkdir -p "$out/share/icons/hicolor/32x32/apps"
     cp leo/Icons/leoapp32.png "$out/share/icons/hicolor/32x32/apps"
-
-    mkdir -p "$out/share/applications"
-    cp $desktopItem/share/applications/* $out/share/applications
 
     mkdir -p $out/share/leo-editor
     mv * $out/share/leo-editor

--- a/pkgs/applications/editors/netbeans/default.nix
+++ b/pkgs/applications/editors/netbeans/default.nix
@@ -1,18 +1,20 @@
-{ lib, stdenv, fetchurl, makeWrapper, makeDesktopItem, which, unzip, libicns, imagemagick
+{ lib, stdenv, fetchurl, makeWrapper, makeDesktopItem, copyDesktopItems, which, unzip, libicns, imagemagick
 , jdk, perl
 }:
 
 let
   version = "20";
-  desktopItem = makeDesktopItem {
-    name = "netbeans";
-    exec = "netbeans";
-    comment = "Integrated Development Environment";
-    desktopName = "Apache NetBeans IDE";
-    genericName = "Integrated Development Environment";
-    categories = [ "Development" ];
-    icon = "netbeans";
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "netbeans";
+      exec = "netbeans";
+      comment = "Integrated Development Environment";
+      desktopName = "Apache NetBeans IDE";
+      genericName = "Integrated Development Environment";
+      categories = [ "Development" ];
+      icon = "netbeans";
+    })
+  ];
 in
 stdenv.mkDerivation {
   pname = "netbeans";
@@ -54,10 +56,9 @@ stdenv.mkDerivation {
 
     # Create desktop item, so we can pick it from the KDE/GNOME menu
     mkdir -pv $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications
   '';
 
-  nativeBuildInputs = [ makeWrapper unzip ];
+  nativeBuildInputs = [ makeWrapper unzip copyDesktopItems ];
   buildInputs = [ perl libicns imagemagick ];
 
   meta = {

--- a/pkgs/applications/editors/sublime/2/default.nix
+++ b/pkgs/applications/editors/sublime/2/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, lib, stdenv, glib, xorg, cairo, gtk2, makeDesktopItem }:
+{ fetchurl, lib, stdenv, glib, xorg, cairo, gtk2, copyDesktopItems, makeDesktopItem }:
 let
   libPath = lib.makeLibraryPath [ glib xorg.libX11 gtk2 cairo ];
 in
@@ -26,6 +26,9 @@ stdenv.mkDerivation rec {
         ];
         sha256 = "115b71nbv9mv8cz6bkjwpbdf2ywnjc1zy2d3080f6ck4sqqfvfh1";
       };
+
+  nativeBuildInputs = [ copyDesktopItems ];
+
   buildCommand = ''
     tar xvf ${src}
     mkdir -p $out/bin
@@ -45,19 +48,19 @@ stdenv.mkDerivation rec {
       mkdir -p $out/share/icons/hicolor/$x/apps
       cp -v $out/sublime/Icon/$x/* $out/share/icons/hicolor/$x/apps
     done
-
-    ln -sv "${desktopItem}/share/applications" $out/share
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "sublime2";
-    exec = "sublime2 %F";
-    comment = meta.description;
-    desktopName = "Sublime Text";
-    genericName = "Text Editor";
-    categories = [ "TextEditor" "Development" ];
-    icon = "sublime_text";
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "sublime2";
+      exec = "sublime2 %F";
+      comment = meta.description;
+      desktopName = "Sublime Text";
+      genericName = "Text Editor";
+      categories = [ "TextEditor" "Development" ];
+      icon = "sublime_text";
+    })
+  ];
 
   meta = {
     description = "Sophisticated text editor for code, markup and prose";

--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -122,38 +122,40 @@ in
     inherit rev vscodeServer;
   };
 
-  desktopItem = makeDesktopItem {
-    name = executableName;
-    desktopName = longName;
-    comment = "Code Editing. Redefined.";
-    genericName = "Text Editor";
-    exec = "${executableName} %F";
-    icon = "vs${executableName}";
-    startupNotify = true;
-    startupWMClass = shortName;
-    categories = [ "Utility" "TextEditor" "Development" "IDE" ];
-    mimeTypes = [ "text/plain" "inode/directory" ];
-    keywords = [ "vscode" ];
-    actions.new-empty-window = {
-      name = "New Empty Window";
-      exec = "${executableName} --new-window %F";
+  desktopItems = [
+    (makeDesktopItem {
+      name = executableName;
+      desktopName = longName;
+      comment = "Code Editing. Redefined.";
+      genericName = "Text Editor";
+      exec = "${executableName} %F";
       icon = "vs${executableName}";
-    };
-  };
+      startupNotify = true;
+      startupWMClass = shortName;
+      categories = [ "Utility" "TextEditor" "Development" "IDE" ];
+      mimeTypes = [ "text/plain" "inode/directory" ];
+      keywords = [ "vscode" ];
+      actions.new-empty-window = {
+        name = "New Empty Window";
+        exec = "${executableName} --new-window %F";
+        icon = "vs${executableName}";
+      };
+    })
 
-  urlHandlerDesktopItem = makeDesktopItem {
-    name = executableName + "-url-handler";
-    desktopName = longName + " - URL Handler";
-    comment = "Code Editing. Redefined.";
-    genericName = "Text Editor";
-    exec = executableName + " --open-url %U";
-    icon = "vs${executableName}";
-    startupNotify = true;
-    categories = [ "Utility" "TextEditor" "Development" "IDE" ];
-    mimeTypes = [ "x-scheme-handler/vs${executableName}" ];
-    keywords = [ "vscode" ];
-    noDisplay = true;
-  };
+    (makeDesktopItem {
+      name = executableName + "-url-handler";
+      desktopName = longName + " - URL Handler";
+      comment = "Code Editing. Redefined.";
+      genericName = "Text Editor";
+      exec = executableName + " --open-url %U";
+      icon = "vs${executableName}";
+      startupNotify = true;
+      categories = [ "Utility" "TextEditor" "Development" "IDE" ];
+      mimeTypes = [ "x-scheme-handler/vs${executableName}" ];
+      keywords = [ "vscode" ];
+      noDisplay = true;
+    })
+  ];
 
   buildInputs = [ libsecret libXScrnSaver libxshmfence ]
     ++ lib.optionals (!stdenv.isDarwin) [ alsa-lib at-spi2-atk libkrb5 mesa nss nspr systemd xorg.libxkbfile ];
@@ -183,10 +185,6 @@ in
     cp -r ./* "$out/lib/vscode"
 
     ln -s "$out/lib/vscode/bin/${sourceExecutableName}" "$out/bin/${executableName}"
-
-    mkdir -p "$out/share/applications"
-    ln -s "$desktopItem/share/applications/${executableName}.desktop" "$out/share/applications/${executableName}.desktop"
-    ln -s "$urlHandlerDesktopItem/share/applications/${executableName}-url-handler.desktop" "$out/share/applications/${executableName}-url-handler.desktop"
 
     # These are named vscode.png, vscode-insiders.png, etc to match the name in upstream *.deb packages.
     mkdir -p "$out/share/pixmaps"

--- a/pkgs/applications/editors/xxe-pe/default.nix
+++ b/pkgs/applications/editors/xxe-pe/default.nix
@@ -6,21 +6,13 @@
 , openjdk11
 , makeDesktopItem
 , icoutils
+, copyDesktopItems
 , config
 , acceptLicense ? config.xxe-pe.acceptLicense or false
 }:
 
 let
   pkg_path = "$out/lib/xxe";
-
-  desktopItem = makeDesktopItem {
-    name = "XMLmind XML Editor Personal Edition";
-    exec = "xxe";
-    icon = "xxe";
-    desktopName = "xxe";
-    genericName = "XML Editor";
-    categories = [ "Development" "IDE" "TextEditor" "Java" ];
-  };
 in
 stdenv.mkDerivation rec {
   pname = "xxe-pe";
@@ -42,15 +34,14 @@ stdenv.mkDerivation rec {
     unzip
     makeWrapper
     icoutils
+    copyDesktopItems
   ];
 
   dontStrip = true;
 
   installPhase = ''
     mkdir -p "${pkg_path}"
-    mkdir -p "${pkg_path}" "$out/share/applications"
     cp -a * "${pkg_path}"
-    ln -s ${desktopItem}/share/applications/* $out/share/applications
 
     icotool -x "${pkg_path}/bin/icon/xxe.ico"
     ls
@@ -66,6 +57,17 @@ stdenv.mkDerivation rec {
     makeWrapper "${pkg_path}/bin/xxe" "$out/bin/xxe" \
       --prefix PATH : ${lib.makeBinPath [ openjdk11 ]}
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "XMLmind XML Editor Personal Edition";
+      exec = "xxe";
+      icon = "xxe";
+      desktopName = "xxe";
+      genericName = "XML Editor";
+      categories = [ "Development" "IDE" "TextEditor" "Java" ];
+    })
+  ];
 
   meta = with lib; {
     description = "Strictly validating, near WYSIWYG, XML editor with DocBook support";

--- a/pkgs/applications/emulators/ccemux/default.nix
+++ b/pkgs/applications/emulators/ccemux/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeDesktopItem, makeWrapper, jre
+{ lib, stdenv, fetchurl, makeDesktopItem, makeWrapper, copyDesktopItems, jre
 , useCCTweaked ? true
 }:
 
@@ -22,15 +22,6 @@ let
     url = "https://github.com/CCEmuX/CCEmuX/raw/${rev}/src/main/resources/img/icon.png";
     hash = "sha256-gqWURXaOFD/4aZnjmgtKb0T33NbrOdyRTMmLmV42q+4=";
   };
-  desktopItem =  makeDesktopItem {
-    name = "CCEmuX";
-    exec = "ccemux";
-    icon = desktopIcon;
-    comment = "A modular ComputerCraft emulator";
-    desktopName = "CCEmuX";
-    genericName = "ComputerCraft Emulator";
-    categories = [ "Emulator" ];
-  };
 in
 
 stdenv.mkDerivation rec {
@@ -40,14 +31,13 @@ stdenv.mkDerivation rec {
   src = jar;
   dontUnpack = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
   buildInputs = [ jre ];
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/{bin,share/ccemux}
-    cp -r ${desktopItem}/share/applications $out/share/applications
 
     install -D ${src} $out/share/ccemux/ccemux.jar
     install -D ${desktopIcon} $out/share/pixmaps/ccemux.png
@@ -57,6 +47,18 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "CCEmuX";
+      exec = "ccemux";
+      icon = desktopIcon;
+      comment = "A modular ComputerCraft emulator";
+      desktopName = "CCEmuX";
+      genericName = "ComputerCraft Emulator";
+      categories = [ "Emulator" ];
+    })
+  ];
 
   meta = with lib; {
     description = "A modular ComputerCraft emulator";

--- a/pkgs/applications/emulators/zsnes/default.nix
+++ b/pkgs/applications/emulators/zsnes/default.nix
@@ -1,18 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, nasm, SDL, zlib, libpng, ncurses, libGLU, libGL
+{ lib, stdenv, fetchFromGitHub, copyDesktopItems, nasm, SDL, zlib, libpng, ncurses, libGLU, libGL
 , makeDesktopItem }:
 
-let
-  desktopItem = makeDesktopItem {
-    name = "zsnes";
-    exec = "zsnes";
-    icon = "zsnes";
-    comment = "A SNES emulator";
-    desktopName = "zsnes";
-    genericName = "zsnes";
-    categories = [ "Game" ];
-  };
-
-in stdenv.mkDerivation {
+stdenv.mkDerivation {
   pname = "zsnes";
   version = "1.51";
 
@@ -27,6 +16,8 @@ in stdenv.mkDerivation {
     ./zlib-1.3.patch
     ./fortify3.patch
   ];
+
+  nativeBuildInputs = [ copyDesktopItems ];
 
   buildInputs = [ nasm SDL zlib libpng ncurses libGLU libGL ];
 
@@ -59,10 +50,19 @@ in stdenv.mkDerivation {
     installIcon "32x32"
     installIcon "48x48"
     installIcon "64x64"
-
-    mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications/
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "zsnes";
+      exec = "zsnes";
+      icon = "zsnes";
+      comment = "A SNES emulator";
+      desktopName = "zsnes";
+      genericName = "zsnes";
+      categories = [ "Game" ];
+    })
+  ];
 
   meta = {
     description = "A Super Nintendo Entertainment System Emulator";

--- a/pkgs/applications/graphics/avocode/default.nix
+++ b/pkgs/applications/graphics/avocode/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, makeDesktopItem, fetchurl, unzip
 , gdk-pixbuf, glib, gtk3, atk, at-spi2-atk, pango, cairo, freetype, fontconfig, dbus, nss, nspr, alsa-lib, cups, expat, udev, gnome
-, xorg, mozjpeg, makeWrapper, wrapGAppsHook, libuuid, at-spi2-core, libdrm, mesa, libxkbcommon
+, xorg, mozjpeg, makeWrapper, wrapGAppsHook, copyDesktopItems, libuuid, at-spi2-core, libdrm, mesa, libxkbcommon
 }:
 
 stdenv.mkDerivation rec {
@@ -50,17 +50,19 @@ stdenv.mkDerivation rec {
     mesa
   ]);
 
-  desktopItem = makeDesktopItem {
-    name = "Avocode";
-    exec = "avocode";
-    icon = "avocode";
-    desktopName = "Avocode";
-    genericName = "Design Inspector";
-    categories = [ "Development" ];
-    comment = "The bridge between designers and developers";
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Avocode";
+      exec = "avocode";
+      icon = "avocode";
+      desktopName = "Avocode";
+      genericName = "Design Inspector";
+      categories = [ "Development" ];
+      comment = "The bridge between designers and developers";
+    })
+  ];
 
-  nativeBuildInputs = [makeWrapper wrapGAppsHook unzip];
+  nativeBuildInputs = [ makeWrapper wrapGAppsHook unzip copyDesktopItems ];
   buildInputs = [ gtk3 gnome.adwaita-icon-theme ];
 
   # src is producing multiple folder on unzip so we must
@@ -75,8 +77,7 @@ stdenv.mkDerivation rec {
       --replace /path/to/avocode-dir/Avocode $out/bin/avocode \
       --replace /path/to/avocode-dir/avocode.png avocode
 
-    mkdir -p share/applications share/pixmaps
-    mv avocode.desktop.in share/applications/avocode.desktop
+    mkdir -p share/pixmaps
     mv avocode.png share/pixmaps/
 
     rm resources/cjpeg

--- a/pkgs/applications/graphics/swingsane/default.nix
+++ b/pkgs/applications/graphics/swingsane/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeDesktopItem, unzip, jre, runtimeShell }:
+{ lib, stdenv, fetchurl, makeDesktopItem, unzip, copyDesktopItems, jre, runtimeShell }:
 
 stdenv.mkDerivation rec {
   pname = "swingsane";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/swingsane/swingsane-${version}-bin.zip";
   };
 
-  nativeBuildInputs = [ unzip ];
+  nativeBuildInputs = [ unzip copyDesktopItems ];
 
   dontConfigure = true;
 
@@ -20,16 +20,6 @@ stdenv.mkDerivation rec {
       exec ${jre}/bin/java -jar $out/share/java/swingsane/swingsane-${version}.jar "$@"
     '';
 
-    desktopItem = makeDesktopItem {
-      name = "swingsane";
-      exec = "swingsane";
-      icon = "swingsane";
-      desktopName = "SwingSane";
-      genericName = "Scan from local or remote SANE servers";
-      comment = meta.description;
-      categories = [ "Office" ];
-    };
-
   in ''
     install -v -m 755    -d $out/share/java/swingsane/
     install -v -m 644 *.jar $out/share/java/swingsane/
@@ -39,9 +29,19 @@ stdenv.mkDerivation rec {
 
     unzip -j swingsane-${version}.jar "com/swingsane/images/*.png"
     install -v -D -m 644 swingsane_512x512.png $out/share/pixmaps/swingsane.png
-
-    cp -v -r ${desktopItem}/share/applications $out/share
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "swingsane";
+      exec = "swingsane";
+      icon = "swingsane";
+      desktopName = "SwingSane";
+      genericName = "Scan from local or remote SANE servers";
+      comment = meta.description;
+      categories = [ "Office" ];
+    })
+  ];
 
   meta = with lib; {
     description = "Java GUI for SANE scanner servers (saned)";

--- a/pkgs/applications/graphics/unigine-heaven/default.nix
+++ b/pkgs/applications/graphics/unigine-heaven/default.nix
@@ -14,6 +14,7 @@
 , openal
 , imagemagick
 , makeDesktopItem
+, copyDesktopItems
 }:
 let
   version = "4.0";
@@ -25,14 +26,6 @@ let
       "x86"
     else
       throw "Unsupported platform ${stdenv.hostPlatform.system}";
-
-  desktopItem = makeDesktopItem {
-    name = "Heaven";
-    exec = "heaven";
-    genericName = "A GPU Stress test tool from the UNIGINE";
-    icon = "Heaven";
-    desktopName = "Heaven Benchmark";
-  };
 in
 stdenv.mkDerivation
 {
@@ -50,7 +43,6 @@ stdenv.mkDerivation
 
       mkdir -p $out/lib/unigine/heaven/bin
       mkdir -p $out/bin
-      mkdir -p $out/share/applications/
       mkdir -p $out/share/icons/hicolor
 
       install -m 0755 $name/bin/browser_${arch} $out/lib/unigine/heaven/bin
@@ -71,8 +63,6 @@ stdenv.mkDerivation
           mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
           convert $out/lib/unigine/heaven/data/launcher/icon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/Heaven.png
       done
-
-      ln -s ${desktopItem}/share/applications/* $out/share/applications
     '';
 
   nativeBuildInputs =
@@ -80,6 +70,7 @@ stdenv.mkDerivation
       autoPatchelfHook
       makeWrapper
       imagemagick
+      copyDesktopItems
     ];
 
   buildInputs =
@@ -93,6 +84,16 @@ stdenv.mkDerivation
       libXrender
       libXinerama
     ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Heaven";
+      exec = "heaven";
+      genericName = "A GPU Stress test tool from the UNIGINE";
+      icon = "Heaven";
+      desktopName = "Heaven Benchmark";
+    })
+  ];
 
   dontUnpack = true;
 

--- a/pkgs/applications/graphics/write_stylus/default.nix
+++ b/pkgs/applications/graphics/write_stylus/default.nix
@@ -1,15 +1,5 @@
-{ mkDerivation, stdenv, lib, qtbase, qtsvg, libglvnd, libX11, libXi, fetchurl, makeDesktopItem }:
-let
-  desktopItem = makeDesktopItem {
-    name = "Write";
-    exec = "Write";
-    comment = "A word processor for handwriting";
-    icon = "write_stylus";
-    desktopName = "Write";
-    genericName = "Write";
-    categories = [ "Office" "Graphics" ];
-  };
-in
+{ mkDerivation, stdenv, lib, copyDesktopItems, qtbase, qtsvg, libglvnd, libX11, libXi, fetchurl, makeDesktopItem }:
+
 mkDerivation rec {
   pname = "write_stylus";
   version = "300";
@@ -21,6 +11,8 @@ mkDerivation rec {
 
   sourceRoot = ".";
 
+  nativeBuildInputs = [ copyDesktopItems ];
+
   dontBuild = true;
 
   installPhase = ''
@@ -29,9 +21,6 @@ mkDerivation rec {
     # symlink the binary to bin/
     ln -s $out/Write/Write $out/bin/Write
 
-    # Create desktop item
-    mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications/
     mkdir -p $out/share/icons
     ln -s $out/Write/Write144x144.png $out/share/icons/write_stylus.png
   '';
@@ -50,6 +39,18 @@ mkDerivation rec {
       --set-rpath "${libPath}" \
       $out/Write/Write
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Write";
+      exec = "Write";
+      comment = "A word processor for handwriting";
+      icon = "write_stylus";
+      desktopName = "Write";
+      genericName = "Write";
+      categories = [ "Office" "Graphics" ];
+    })
+  ];
 
   meta = with lib; {
     homepage = "http://www.styluslabs.com/";

--- a/pkgs/applications/graphics/xournal/default.nix
+++ b/pkgs/applications/graphics/xournal/default.nix
@@ -2,7 +2,7 @@
 , ghostscript, atk, gtk2, glib, fontconfig, freetype
 , libgnomecanvas
 , pango, libX11, xorgproto, zlib, poppler
-, autoconf, automake, libtool, pkg-config}:
+, autoconf, automake, libtool, pkg-config, copyDesktopItems }:
 
 let
   isGdkQuartzBackend = (gtk2.gdktarget == "quartz");
@@ -22,21 +22,23 @@ stdenv.mkDerivation rec {
     pango libX11 xorgproto zlib poppler
   ];
 
-  nativeBuildInputs = [ autoconf automake libtool pkg-config ];
+  nativeBuildInputs = [ autoconf automake libtool pkg-config copyDesktopItems ];
 
   NIX_LDFLAGS = "-lz"
     + lib.optionalString (!isGdkQuartzBackend) " -lX11";
 
-  desktopItem = makeDesktopItem {
-    name = "xournal-${version}";
-    exec = "xournal";
-    icon = "xournal";
-    desktopName = "Xournal";
-    comment = meta.description;
-    categories = [ "Office" "Graphics" ];
-    mimeTypes = [ "application/pdf" "application/x-xoj" ];
-    genericName = "PDF Editor";
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "xournal-${version}";
+      exec = "xournal";
+      icon = "xournal";
+      desktopName = "Xournal";
+      comment = meta.description;
+      categories = [ "Office" "Graphics" ];
+      mimeTypes = [ "application/pdf" "application/x-xoj" ];
+      genericName = "PDF Editor";
+    })
+  ];
 
   postInstall=''
       mkdir --parents $out/share/mime/packages
@@ -48,7 +50,6 @@ stdenv.mkDerivation rec {
          </mime-type>
       </mime-info>
       EOF
-      cp --recursive ${desktopItem}/share/applications $out/share
       mkdir --parents $out/share/icons
       cp $out/share/xournal/pixmaps/xournal.png $out/share/icons
   '';

--- a/pkgs/applications/misc/freeplane/default.nix
+++ b/pkgs/applications/misc/freeplane/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , makeWrapper
 , makeDesktopItem
+, copyDesktopItems
 , writeText
 , runtimeShell
 , jdk17
@@ -91,6 +92,7 @@ in stdenv.mkDerivation rec {
     makeWrapper
     jdk
     gradle
+    copyDesktopItems
   ];
 
   buildPhase = ''

--- a/pkgs/applications/misc/ganttproject-bin/default.nix
+++ b/pkgs/applications/misc/ganttproject-bin/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchzip, makeDesktopItem, makeWrapper
+{ lib, stdenv, fetchzip, makeDesktopItem, makeWrapper, copyDesktopItems
 , jre
 }:
 
@@ -12,20 +12,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-U9x64UIBuVtW44zbsdWuMRZyEJhZ8VUWbDVtapTGPMo=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
   buildInputs = [ jre ];
 
   installPhase = let
-
-    desktopItem = makeDesktopItem {
-      name = "ganttproject";
-      exec = "ganttproject";
-      icon = "ganttproject";
-      desktopName = "GanttProject";
-      genericName = "Shedule and manage projects";
-      comment = meta.description;
-      categories = [ "Office" ];
-    };
 
     javaOptions = [
       "-Dawt.useSystemAAFontSettings=on"
@@ -41,9 +31,19 @@ stdenv.mkDerivation rec {
       --set _JAVA_OPTIONS "${builtins.toString javaOptions}"
 
     mv -v "$out/share/ganttproject/ganttproject" "$out/bin"
-
-    cp -rv "${desktopItem}/share/applications" "$out/share"
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ganttproject";
+      exec = "ganttproject";
+      icon = "ganttproject";
+      desktopName = "GanttProject";
+      genericName = "Shedule and manage projects";
+      comment = meta.description;
+      categories = [ "Office" ];
+    })
+  ];
 
   meta = with lib; {
     description = "Project scheduling and management";

--- a/pkgs/applications/misc/golden-cheetah/default.nix
+++ b/pkgs/applications/misc/golden-cheetah/default.nix
@@ -2,18 +2,10 @@
 , qtbase, qtsvg, qtserialport, qtwebengine, qtmultimedia, qttools
 , qtconnectivity, qtcharts, libusb-compat-0_1, gsl, blas
 , bison, flex, zlib, qmake, makeDesktopItem, wrapQtAppsHook
+, copyDesktopItems
 }:
 
 let
-  desktopItem = makeDesktopItem {
-    name = "goldencheetah";
-    exec = "GoldenCheetah";
-    icon = "goldencheetah";
-    desktopName = "GoldenCheetah";
-    genericName = "GoldenCheetah";
-    comment = "Performance software for cyclists, runners and triathletes";
-    categories = [ "Utility" ];
-  };
 in mkDerivation rec {
   pname = "golden-cheetah";
   version = "3.6";
@@ -39,7 +31,7 @@ in mkDerivation rec {
     gsl
     blas
   ];
-  nativeBuildInputs = [ flex wrapQtAppsHook qmake bison ];
+  nativeBuildInputs = [ flex wrapQtAppsHook qmake bison copyDesktopItems ];
 
   patches = [
     # allow building with bison 3.7
@@ -66,11 +58,22 @@ in mkDerivation rec {
 
     mkdir -p $out/bin
     cp src/GoldenCheetah $out/bin
-    install -Dm644 "${desktopItem}/share/applications/"* -t $out/share/applications/
     install -Dm644 src/Resources/images/gc.png $out/share/pixmaps/goldencheetah.png
 
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "goldencheetah";
+      exec = "GoldenCheetah";
+      icon = "goldencheetah";
+      desktopName = "GoldenCheetah";
+      genericName = "GoldenCheetah";
+      comment = "Performance software for cyclists, runners and triathletes";
+      categories = [ "Utility" ];
+    })
+  ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/applications/misc/ipmiview/default.nix
+++ b/pkgs/applications/misc/ipmiview/default.nix
@@ -2,6 +2,7 @@
 , fetchurl
 , makeDesktopItem
 , makeWrapper
+, copyDesktopItems
 , patchelf
 , fontconfig
 , freetype
@@ -21,7 +22,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-ZN0vadGbjGj9U2wPqvHLjS9fsk3DNCbXoNvzUfnn8IM=";
   };
 
-  nativeBuildInputs = [ patchelf makeWrapper ];
+  nativeBuildInputs = [ patchelf makeWrapper copyDesktopItems ];
   buildPhase = with xorg;
     let
       stunnelBinary = if stdenv.hostPlatform.system == "x86_64-linux" then "linux/stunnel64"
@@ -39,21 +40,21 @@ stdenv.mkDerivation rec {
     runHook postBuild
   '';
 
-  desktopItem = makeDesktopItem rec {
-    name = "IPMIView";
-    exec = "IPMIView";
-    desktopName = name;
-    genericName = "Supermicro BMC manager";
-    categories = [ "Network" ];
-  };
+  desktopItems = [
+    (makeDesktopItem rec {
+      name = "IPMIView";
+      exec = "IPMIView";
+      desktopName = name;
+      genericName = "Supermicro BMC manager";
+      categories = [ "Network" ];
+    })
+  ];
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/bin
     cp -R . $out/
-
-    ln -s ${desktopItem}/share $out/share
 
     # LD_LIBRARY_PATH: fontconfig is used from java code
     # PATH: iputils is used for ping, and psmisc is for killall

--- a/pkgs/applications/misc/michabo/default.nix
+++ b/pkgs/applications/misc/michabo/default.nix
@@ -3,17 +3,13 @@
 , makeDesktopItem
 , fetchFromGitLab
 , qmake
+, copyDesktopItems
 # qt
 , qtbase
 , qtwebsockets
 }:
 
 let
-  desktopItem = makeDesktopItem {
-    name = "Michabo";
-    desktopName = "Michabo";
-    exec = "Michabo";
-  };
 
 in mkDerivation rec {
   pname = "michabo";
@@ -29,6 +25,7 @@ in mkDerivation rec {
 
   nativeBuildInputs = [
     qmake
+    copyDesktopItems
   ];
   buildInputs = [
     qtbase
@@ -37,9 +34,13 @@ in mkDerivation rec {
 
   qmakeFlags = [ "michabo.pro" "DESTDIR=${placeholder "out"}/bin" ];
 
-  postInstall = ''
-    ln -s ${desktopItem}/share $out/share
-  '';
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Michabo";
+      desktopName = "Michabo";
+      exec = "Michabo";
+    })
+  ];
 
   meta = with lib; {
     description = "A native desktop app for Pleroma and Mastodon servers";

--- a/pkgs/applications/misc/obsidian/default.nix
+++ b/pkgs/applications/misc/obsidian/default.nix
@@ -5,6 +5,7 @@
 , electron
 , makeDesktopItem
 , imagemagick
+, copyDesktopItems
 , writeScript
 , undmg
 , unzip
@@ -33,20 +34,22 @@ let
     hash = "sha256-EZsBuWyZ9zYJh0LDKfRAMTtnY70q6iLK/ggXlplDEoA=";
   };
 
-  desktopItem = makeDesktopItem {
-    name = "obsidian";
-    desktopName = "Obsidian";
-    comment = "Knowledge base";
-    icon = "obsidian";
-    exec = "obsidian %u";
-    categories = [ "Office" ];
-    mimeTypes = [ "x-scheme-handler/obsidian" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "obsidian";
+      desktopName = "Obsidian";
+      comment = "Knowledge base";
+      icon = "obsidian";
+      exec = "obsidian %u";
+      categories = [ "Office" ];
+      mimeTypes = [ "x-scheme-handler/obsidian" ];
+    })
+  ];
 
   linux = stdenv.mkDerivation {
-    inherit pname version src desktopItem icon;
+    inherit pname version src desktopItems icon;
     meta = meta // { platforms = [ "x86_64-linux" "aarch64-linux" ]; };
-    nativeBuildInputs = [ makeWrapper imagemagick ];
+    nativeBuildInputs = [ makeWrapper imagemagick copyDesktopItems ];
     installPhase = ''
       runHook preInstall
       mkdir -p $out/bin
@@ -55,8 +58,6 @@ let
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland}}"
       install -m 444 -D resources/app.asar $out/share/obsidian/app.asar
       install -m 444 -D resources/obsidian.asar $out/share/obsidian/obsidian.asar
-      install -m 444 -D "${desktopItem}/share/applications/"* \
-        -t $out/share/applications/
       for size in 16 24 32 48 64 128 256 512; do
         mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
         convert -background none -resize "$size"x"$size" ${icon} $out/share/icons/hicolor/"$size"x"$size"/apps/obsidian.png

--- a/pkgs/applications/misc/pdfsam-basic/default.nix
+++ b/pkgs/applications/misc/pdfsam-basic/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, makeDesktopItem, fetchurl, jdk21, wrapGAppsHook, glib }:
+{ lib, stdenv, makeDesktopItem, fetchurl, jdk21, wrapGAppsHook, copyDesktopItems, glib }:
 
 stdenv.mkDerivation rec {
   pname = "pdfsam-basic";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     tar xvf data.tar.gz
   '';
 
-  nativeBuildInputs = [ wrapGAppsHook ];
+  nativeBuildInputs = [ wrapGAppsHook copyDesktopItems ];
   buildInputs = [ glib ];
 
   preFixup = ''
@@ -24,20 +24,21 @@ stdenv.mkDerivation rec {
   installPhase = ''
     cp -R opt/pdfsam-basic/ $out/
     mkdir -p "$out"/share/icons
-    cp --recursive ${desktopItem}/share/applications $out/share
     cp $out/icon.svg "$out"/share/icons/pdfsam-basic.svg
   '';
 
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = pname;
-    icon = pname;
-    comment = meta.description;
-    desktopName = "PDFsam Basic";
-    genericName = "PDF Split and Merge";
-    mimeTypes = [ "application/pdf" ];
-    categories = [ "Office" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      icon = pname;
+      comment = meta.description;
+      desktopName = "PDFsam Basic";
+      genericName = "PDF Split and Merge";
+      mimeTypes = [ "application/pdf" ];
+      categories = [ "Office" ];
+    })
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/torakiki/pdfsam";

--- a/pkgs/applications/misc/plater/default.nix
+++ b/pkgs/applications/misc/plater/default.nix
@@ -1,5 +1,6 @@
 { mkDerivation
 , cmake
+, copyDesktopItems
 , fetchFromGitHub
 , lib
 , libGLU
@@ -19,21 +20,22 @@ mkDerivation rec {
     sha256 = "0r20mbzd16zv1aiadjqdy7z6sp09rr6lgfxhvir4ll3cpakkynr4";
   };
 
-  nativeBuildInputs = [ cmake wrapQtAppsHook ];
+  nativeBuildInputs = [ cmake wrapQtAppsHook copyDesktopItems ];
   buildInputs = [ libGLU qtbase ];
 
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = pname;
-    icon = pname;
-    desktopName = "Ideamaker";
-    genericName = meta.description;
-    categories = ["Utility" "Engineering"];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      icon = pname;
+      desktopName = "Ideamaker";
+      genericName = meta.description;
+      categories = ["Utility" "Engineering"];
+    })
+  ];
 
   postInstall = ''
     mkdir -p $out/share/pixmaps
-    ln -s ${desktopItem}/share/applications $out/share/
     cp $src/gui/img/plater.png $out/share/pixmaps/${pname}.png
   '';
 

--- a/pkgs/applications/misc/remnote/default.nix
+++ b/pkgs/applications/misc/remnote/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchurl, appimageTools, makeDesktopItem }:
+{ lib, stdenv, fetchurl, copyDesktopItems, appimageTools, makeDesktopItem }:
 
 stdenv.mkDerivation (finalAttrs: let
-  inherit (finalAttrs) pname version src appexec icon desktopItem;
+  inherit (finalAttrs) pname version src appexec icon;
 
 in
 {
@@ -13,6 +13,8 @@ in
     hash = "sha256-6WBdTOj/seinx1wJGb/4if3PzCPmtzHyNAFmQwmsrvE=";
   };
 
+  nativeBuildInputs = [ copyDesktopItems ];
+
   appexec = appimageTools.wrapType2 {
     inherit pname version src;
   };
@@ -22,16 +24,18 @@ in
     hash = "sha256-r5D7fNefKPdjtmV7f/88Gn3tqeEG8LGuD4nHI/sCk94=";
   };
 
-  desktopItem = makeDesktopItem {
-    type = "Application";
-    name = "remnote";
-    desktopName = "RemNote";
-    comment = "Spaced Repetition";
-    icon = "remnote";
-    exec = "remnote %u";
-    categories = [ "Office" ];
-    mimeTypes = [ "x-scheme-handler/remnote" "x-scheme-handler/rn" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      name = "remnote";
+      desktopName = "RemNote";
+      comment = "Spaced Repetition";
+      icon = "remnote";
+      exec = "remnote %u";
+      categories = [ "Office" ];
+      mimeTypes = [ "x-scheme-handler/remnote" "x-scheme-handler/rn" ];
+    })
+  ];
 
   dontUnpack = true;
   dontConfigure = true;
@@ -41,7 +45,6 @@ in
     runHook preInstall
 
     install -Dm755 ${appexec}/bin/remnote-${version} $out/bin/remnote
-    install -Dm444 "${desktopItem}/share/applications/"* -t $out/share/applications/
     install -Dm444 ${icon} $out/share/pixmaps/remnote.png
 
     runHook postInstall

--- a/pkgs/applications/misc/robo3t/default.nix
+++ b/pkgs/applications/misc/robo3t/default.nix
@@ -11,6 +11,7 @@
 , freetype
 , xkeyboard_config
 , makeDesktopItem
+, copyDesktopItems
 , makeWrapper
 }:
 
@@ -29,17 +30,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-2PkUxBq2ow0wl09k8B6LJJUQ+y4GpnmoAeumKN1u5xg=";
   };
 
-  desktopItem = makeDesktopItem {
-    name = "robo3t";
-    exec = "robo3t";
-    icon = icon;
-    comment = "Query GUI for mongodb";
-    desktopName = "Robo3T";
-    genericName = "MongoDB management tool";
-    categories = [ "Development" "IDE" ];
-  };
-
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
 
   ldLibraryPath = lib.makeLibraryPath [
     stdenv.cc.cc
@@ -70,9 +61,6 @@ stdenv.mkDerivation rec {
     mkdir -p $BASEDIR/lib
     cp -r lib/* $BASEDIR/lib
 
-    mkdir -p $out/share/applications
-    cp $desktopItem/share/applications/* $out/share/applications
-
     mkdir -p $out/share/icons
     cp ${icon} $out/share/icons/robomongo.png
 
@@ -86,6 +74,18 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "robo3t";
+      exec = "robo3t";
+      icon = icon;
+      comment = "Query GUI for mongodb";
+      desktopName = "Robo3T";
+      genericName = "MongoDB management tool";
+      categories = [ "Development" "IDE" ];
+    })
+  ];
 
   meta = with lib; {
     homepage = "https://robomongo.org/";

--- a/pkgs/applications/misc/slic3r/default.nix
+++ b/pkgs/applications/misc/slic3r/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, perl, makeWrapper
 , makeDesktopItem, which, perlPackages, boost, wrapGAppsHook
+, copyDesktopItems
 }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-cf0QTOzhLyTcbJryCQoTVzU8kfrPV6SLpqi4s36X5N0=";
   };
 
-  nativeBuildInputs = [ makeWrapper which wrapGAppsHook ];
+  nativeBuildInputs = [ makeWrapper which wrapGAppsHook copyDesktopItems ];
   buildInputs =
   [boost] ++
   (with perlPackages; [ perl
@@ -25,15 +26,17 @@ stdenv.mkDerivation rec {
     DevelChecklib locallib
   ]);
 
-  desktopItem = makeDesktopItem {
-    name = "slic3r";
-    exec = "slic3r";
-    icon = "slic3r";
-    comment = "G-code generator for 3D printers";
-    desktopName = "Slic3r";
-    genericName = "3D printer tool";
-    categories = [ "Development" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "slic3r";
+      exec = "slic3r";
+      icon = "slic3r";
+      comment = "G-code generator for 3D printers";
+      desktopName = "Slic3r";
+      genericName = "3D printer tool";
+      categories = [ "Development" ];
+    })
+  ];
 
   prePatch = ''
     # In nix ioctls.h isn't available from the standard kernel-headers package
@@ -83,8 +86,6 @@ stdenv.mkDerivation rec {
     ln -s "$out/share/slic3r/slic3r.pl" "$out/bin/slic3r"
     mkdir -p "$out/share/pixmaps/"
     ln -s "$out/share/slic3r/var/Slic3r.png" "$out/share/pixmaps/slic3r.png"
-    mkdir -p "$out/share/applications"
-    cp "$desktopItem"/share/applications/* "$out/share/applications/"
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/stretchly/default.nix
+++ b/pkgs/applications/misc/stretchly/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchurl
 , makeWrapper
+, copyDesktopItems
 , electron
 , common-updater-scripts
 , writeShellScript
@@ -22,16 +23,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-tO0cNKopG/recQus7KDUTyGpApvR5/tpmF5C4V14DnI=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/bin $out/share/${finalAttrs.pname}/
     mv resources/app.asar* $out/share/${finalAttrs.pname}/
-
-    mkdir -p $out/share/applications
-    ln -s ${finalAttrs.desktopItem}/share/applications/* $out/share/applications/
 
     makeWrapper ${electron}/bin/electron $out/bin/${finalAttrs.pname} \
       --add-flags $out/share/${finalAttrs.pname}/app.asar
@@ -52,14 +50,16 @@ stdenv.mkDerivation (finalAttrs: {
     '';
   };
 
-  desktopItem = makeDesktopItem {
-    name = finalAttrs.pname;
-    exec = finalAttrs.pname;
-    icon = finalAttrs.icon;
-    desktopName = "Stretchly";
-    genericName = "Stretchly";
-    categories = [ "Utility" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = finalAttrs.pname;
+      exec = finalAttrs.pname;
+      icon = finalAttrs.icon;
+      desktopName = "Stretchly";
+      genericName = "Stretchly";
+      categories = [ "Utility" ];
+    })
+  ];
 
   meta = with lib; {
     description = "A break time reminder app";

--- a/pkgs/applications/networking/apache-directory-studio/default.nix
+++ b/pkgs/applications/networking/apache-directory-studio/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, jdk, makeWrapper, autoPatchelfHook, makeDesktopItem, glib, libsecret, webkitgtk }:
+{ lib, stdenv, fetchurl, jdk, makeWrapper, autoPatchelfHook, copyDesktopItems, makeDesktopItem, glib, libsecret, webkitgtk }:
 
 stdenv.mkDerivation rec {
   pname = "apache-directory-studio";
@@ -13,18 +13,20 @@ stdenv.mkDerivation rec {
       }
     else throw "Unsupported system: ${stdenv.hostPlatform.system}";
 
-  desktopItem = makeDesktopItem {
-    name = "apache-directory-studio";
-    exec = "ApacheDirectoryStudio";
-    icon = "apache-directory-studio";
-    comment = "Eclipse-based LDAP browser and directory client";
-    desktopName = "Apache Directory Studio";
-    genericName = "Apache Directory Studio";
-    categories = [ "Java" "Network" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "apache-directory-studio";
+      exec = "ApacheDirectoryStudio";
+      icon = "apache-directory-studio";
+      comment = "Eclipse-based LDAP browser and directory client";
+      desktopName = "Apache Directory Studio";
+      genericName = "Apache Directory Studio";
+      categories = [ "Java" "Network" ];
+    })
+  ];
 
   buildInputs = [ glib libsecret ];
-  nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
+  nativeBuildInputs = [ makeWrapper autoPatchelfHook copyDesktopItems ];
 
   installPhase = ''
     dest="$out/libexec/ApacheDirectoryStudio"
@@ -40,7 +42,6 @@ stdenv.mkDerivation rec {
         --prefix PATH : "${jdk}/bin" \
         --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath ([ webkitgtk ])}
     install -D icon.xpm "$out/share/pixmaps/apache-directory-studio.xpm"
-    install -D -t "$out/share/applications" ${desktopItem}/share/applications/*
   '';
 
   meta = with lib; {

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -1,5 +1,6 @@
 { pname, version, src, meta, binaryName, desktopName, autoPatchelfHook
-, makeDesktopItem, lib, stdenv, wrapGAppsHook, makeShellWrapper, alsa-lib, at-spi2-atk
+, makeDesktopItem, lib, stdenv, wrapGAppsHook, makeShellWrapper, copyDesktopItems
+, alsa-lib, at-spi2-atk
 , at-spi2-core, atk, cairo, cups, dbus, expat, fontconfig, freetype, gdk-pixbuf
 , glib, gtk3, libcxx, libdrm, libglvnd, libnotify, libpulseaudio, libuuid, libX11
 , libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext, libXfixes
@@ -46,6 +47,7 @@ stdenv.mkDerivation rec {
     nss
     wrapGAppsHook
     makeShellWrapper
+    copyDesktopItems
   ];
 
   dontWrapGApps = true;
@@ -120,8 +122,6 @@ stdenv.mkDerivation rec {
     ln -s $out/opt/${binaryName}/discord.png $out/share/pixmaps/${pname}.png
     ln -s $out/opt/${binaryName}/discord.png $out/share/icons/hicolor/256x256/apps/${pname}.png
 
-    ln -s "$desktopItem/share/applications" $out/share/
-
     runHook postInstall
   '';
 
@@ -134,15 +134,17 @@ stdenv.mkDerivation rec {
     echo 'require("${vencord}/patcher.js")' > $out/opt/${binaryName}/resources/app.asar/index.js
   '';
 
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = binaryName;
-    icon = pname;
-    inherit desktopName;
-    genericName = meta.description;
-    categories = [ "Network" "InstantMessaging" ];
-    mimeTypes = [ "x-scheme-handler/discord" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = binaryName;
+      icon = pname;
+      inherit desktopName;
+      genericName = meta.description;
+      categories = [ "Network" "InstantMessaging" ];
+      mimeTypes = [ "x-scheme-handler/discord" ];
+    })
+  ];
 
   passthru = {
     # make it possible to run disableBreakingUpdates standalone

--- a/pkgs/applications/networking/instant-messengers/fluffychat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fluffychat/default.nix
@@ -2,6 +2,7 @@
 , fetchzip
 , fetchFromGitHub
 , imagemagick
+, copyDesktopItems
 , mesa
 , libdrm
 , flutter
@@ -47,7 +48,7 @@ flutter.buildFlutterApplication (rec {
     sourceProvenance = [ sourceTypes.fromSource ];
   };
 } // lib.optionalAttrs (targetFlutterPlatform == "linux") {
-  nativeBuildInputs = [ imagemagick ];
+  nativeBuildInputs = [ imagemagick copyDesktopItems ];
 
   runtimeDependencies = [ pulseaudio ];
 
@@ -55,22 +56,22 @@ flutter.buildFlutterApplication (rec {
 
   env.NIX_LDFLAGS = "-rpath-link ${libwebrtcRpath}";
 
-  desktopItem = makeDesktopItem {
-    name = "Fluffychat";
-    exec = "fluffychat";
-    icon = "fluffychat";
-    desktopName = "Fluffychat";
-    genericName = "Chat with your friends (matrix client)";
-    categories = [ "Chat" "Network" "InstantMessaging" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Fluffychat";
+      exec = "fluffychat";
+      icon = "fluffychat";
+      desktopName = "Fluffychat";
+      genericName = "Chat with your friends (matrix client)";
+      categories = [ "Chat" "Network" "InstantMessaging" ];
+    })
+  ];
 
   postInstall = ''
     FAV=$out/app/data/flutter_assets/assets/favicon.png
     ICO=$out/share/icons
 
     install -D $FAV $ICO/fluffychat.png
-    mkdir $out/share/applications
-    cp $desktopItem/share/applications/*.desktop $out/share/applications
     for size in 24 32 42 64 128 256 512; do
       D=$ICO/hicolor/''${s}x''${s}/apps
       mkdir -p $D

--- a/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchurl, makeWrapper, makeDesktopItem, zlib, glib, libpng, freetype, openssl
 , xorg, fontconfig, qtbase, qtwebengine, qtwebchannel, qtsvg, qtwebsockets, xkeyboard_config
 , alsa-lib, libpulseaudio ? null, libredirect, quazip, which, unzip, perl, llvmPackages
+, copyDesktopItems
 }:
 
 let
@@ -15,16 +16,6 @@ let
       xorg.libxcb fontconfig xorg.libXext xorg.libX11 alsa-lib qtbase qtwebengine qtwebchannel qtsvg
       qtwebsockets libpulseaudio quazip llvmPackages.libcxx
     ];
-
-  desktopItem = makeDesktopItem {
-    name = "teamspeak";
-    exec = "ts3client";
-    icon = "teamspeak";
-    comment = "The TeamSpeak voice communication tool";
-    desktopName = "TeamSpeak";
-    genericName = "TeamSpeak";
-    categories = [ "Network" ];
-  };
 in
 
 stdenv.mkDerivation rec {
@@ -48,6 +39,7 @@ stdenv.mkDerivation rec {
     which
     unzip
     perl # Installer script needs `shasum`
+    copyDesktopItems
   ];
 
   # This just runs the installer script. If it gets stuck at something like
@@ -85,10 +77,9 @@ stdenv.mkDerivation rec {
       mv * $out/lib/teamspeak/
 
       # Make a desktop item
-      mkdir -p $out/share/applications/ $out/share/icons/hicolor/64x64/apps/
+      mkdir -p $out/share/icons/hicolor/64x64/apps/
       unzip ${pluginsdk}
       cp pluginsdk/docs/client_html/images/logo.png $out/share/icons/hicolor/64x64/apps/teamspeak.png
-      cp ${desktopItem}/share/applications/* $out/share/applications/
 
       # Make a symlink to the binary from bin.
       mkdir -p $out/bin/
@@ -104,6 +95,18 @@ stdenv.mkDerivation rec {
 
   dontStrip = true;
   dontPatchELF = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "teamspeak";
+      exec = "ts3client";
+      icon = "teamspeak";
+      comment = "The TeamSpeak voice communication tool";
+      desktopName = "TeamSpeak";
+      genericName = "TeamSpeak";
+      categories = [ "Network" ];
+    })
+  ];
 
   meta = with lib; {
     description = "The TeamSpeak voice communication tool";

--- a/pkgs/applications/networking/instant-messengers/tensor/default.nix
+++ b/pkgs/applications/networking/instant-messengers/tensor/default.nix
@@ -26,16 +26,18 @@ mkDerivation rec {
   buildInputs = [ qtbase qtquickcontrols ];
   nativeBuildInputs = [ qmake ];
 
-  desktopItem = makeDesktopItem {
-    name = "tensor";
-    exec = "@bin@";
-    icon = "tensor.png";
-    comment = meta.description;
-    desktopName = "Tensor Matrix Client";
-    genericName = meta.description;
-    categories = [ "Chat" "Utility" ];
-    mimeTypes = [ "application/x-chat" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "tensor";
+      exec = "tensor";
+      icon = "tensor.png";
+      comment = meta.description;
+      desktopName = "Tensor Matrix Client";
+      genericName = meta.description;
+      categories = [ "Chat" "Utility" ];
+      mimeTypes = [ "application/x-chat" ];
+    })
+  ];
 
   installPhase = if stdenv.isDarwin then ''
     runHook preInstall
@@ -50,11 +52,6 @@ mkDerivation rec {
     install -Dm755 tensor $out/bin/tensor
     install -Dm644 client/logo.png \
                    $out/share/icons/hicolor/512x512/apps/tensor.png
-    install -Dm644 ${desktopItem}/share/applications/tensor.desktop \
-                   $out/share/applications/tensor.desktop
-
-    substituteInPlace $out/share/applications/tensor.desktop \
-      --subst-var-by bin $out/bin/tensor
 
     runHook postInstall
   '';

--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -7,6 +7,7 @@
 , lib
 , udev
 , wrapGAppsHook
+, copyDesktopItems
 , cpio
 , xar
 , libdbusmenu
@@ -77,16 +78,18 @@ let
       inherit hash;
     };
 
-    desktopItem = makeDesktopItem {
-      categories = [ "Network" "InstantMessaging" "Chat" "VideoConference" ];
-      comment = "Secure messenger for everyone";
-      desktopName = "Wire";
-      exec = "wire-desktop %U";
-      genericName = "Secure messenger";
-      icon = "wire-desktop";
-      name = "wire-desktop";
-      startupWMClass = "Wire";
-    };
+    desktopItems = [
+      (makeDesktopItem {
+        categories = [ "Network" "InstantMessaging" "Chat" "VideoConference" ];
+        comment = "Secure messenger for everyone";
+        desktopName = "Wire";
+        exec = "wire-desktop %U";
+        genericName = "Secure messenger";
+        icon = "wire-desktop";
+        name = "wire-desktop";
+        startupWMClass = "Wire";
+      })
+    ];
 
     dontBuild = true;
     dontConfigure = true;
@@ -99,6 +102,7 @@ let
       dpkg
       makeWrapper
       wrapGAppsHook
+      copyDesktopItems
     ];
 
     buildInputs = [
@@ -124,10 +128,6 @@ let
       cp -R "opt" "$out"
       cp -R "usr/share" "$out/share"
       chmod -R g-w "$out"
-
-      # Desktop file
-      mkdir -p "$out/share/applications"
-      cp "${desktopItem}/share/applications/"* "$out/share/applications"
 
       runHook postInstall
     '';

--- a/pkgs/applications/networking/localsend/default.nix
+++ b/pkgs/applications/networking/localsend/default.nix
@@ -5,6 +5,7 @@
 , flutter313
 , makeDesktopItem
 , pkg-config
+, copyDesktopItems
 , libayatana-appindicator
 , undmg
 , makeBinaryWrapper
@@ -33,7 +34,7 @@ let
       "tray_manager" = "sha256-eF14JGf5jclsKdXfCE7Rcvp72iuWd9wuSZ8Bej17tjg=";
     };
 
-    nativeBuildInputs = [ pkg-config ];
+    nativeBuildInputs = [ pkg-config copyDesktopItems ];
 
     buildInputs = [ libayatana-appindicator ];
 
@@ -43,20 +44,19 @@ let
         mkdir -p $d
         ln -s $out/app/data/flutter_assets/assets/img/logo-''${s}.png $d/localsend.png
       done
-      mkdir -p $out/share/applications
-      cp $desktopItem/share/applications/*.desktop $out/share/applications
-      substituteInPlace $out/share/applications/*.desktop --subst-var out
     '';
 
-    desktopItem = makeDesktopItem {
-      name = "LocalSend";
-      exec = "@out@/bin/localsend_app";
-      icon = "localsend";
-      desktopName = "LocalSend";
-      startupWMClass = "localsend_app";
-      genericName = "An open source cross-platform alternative to AirDrop";
-      categories = [ "Network" ];
-    };
+    desktopItems = [
+      (makeDesktopItem {
+        name = "LocalSend";
+        exec = "localsend_app";
+        icon = "localsend";
+        desktopName = "LocalSend";
+        startupWMClass = "localsend_app";
+        genericName = "An open source cross-platform alternative to AirDrop";
+        categories = [ "Network" ];
+      })
+    ];
 
     passthru.updateScript = ./update.sh;
 

--- a/pkgs/applications/networking/p2p/frostwire/default.nix
+++ b/pkgs/applications/networking/p2p/frostwire/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, gradle_6, perl, jre, makeWrapper, makeDesktopItem, mplayer }:
+{ lib, stdenv, fetchFromGitHub, gradle_6, perl, jre, makeWrapper, copyDesktopItems, makeDesktopItem, mplayer }:
 
 let
   version = "6.6.7-build-529";
@@ -8,16 +8,6 @@ let
     repo = "frostwire";
     rev = "frostwire-desktop-${version}";
     sha256 = "03wdj2kr8akzx8m1scvg98132zbaxh81qjdsxn2645b3gahjwz0m";
-  };
-
-  desktopItem = makeDesktopItem {
-    name = "frostwire";
-    desktopName = "FrostWire";
-    genericName = "P2P Bittorrent client";
-    exec = "frostwire";
-    icon = "frostwire";
-    comment = "Search and explore all kinds of files on the Bittorrent network";
-    categories = [ "Network" "FileTransfer" "P2P" ];
   };
 
   # fake build to pre-download deps into fixed-output derivation
@@ -46,7 +36,7 @@ in stdenv.mkDerivation {
   pname = "frostwire-desktop";
   inherit version src;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
   buildInputs = [ gradle_6 ];
 
   buildPhase = ''
@@ -78,11 +68,21 @@ in stdenv.mkDerivation {
           }.${stdenv.hostPlatform.system} or (throw "unsupported system ${stdenv.hostPlatform.system}")
         } $out/lib
 
-    cp -dpR ${desktopItem}/share $out
-
     makeWrapper ${jre}/bin/java $out/bin/frostwire \
       --add-flags "-Djava.library.path=$out/lib -jar $out/share/java/frostwire.jar"
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "frostwire";
+      desktopName = "FrostWire";
+      genericName = "P2P Bittorrent client";
+      exec = "frostwire";
+      icon = "frostwire";
+      comment = "Search and explore all kinds of files on the Bittorrent network";
+      categories = [ "Network" "FileTransfer" "P2P" ];
+    })
+  ];
 
   meta = with lib; {
     homepage = "https://www.frostwire.com/";

--- a/pkgs/applications/networking/p2p/transgui/default.nix
+++ b/pkgs/applications/networking/p2p/transgui/default.nix
@@ -38,22 +38,22 @@ stdenv.mkDerivation rec {
 
   LCL_PLATFORM = "gtk2";
 
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = "${pname} %U";
-    icon = pname;
-    type = "Application";
-    comment = meta.description;
-    desktopName = "Transmission Remote GUI";
-    genericName = "BitTorrent Client";
-    categories = [ "Network" "FileTransfer" "P2P" "GTK" ];
-    startupNotify = true;
-    mimeTypes = [ "application/x-bittorrent" "x-scheme-handler/magnet" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = "${pname} %U";
+      icon = pname;
+      type = "Application";
+      comment = meta.description;
+      desktopName = "Transmission Remote GUI";
+      genericName = "BitTorrent Client";
+      categories = [ "Network" "FileTransfer" "P2P" "GTK" ];
+      startupNotify = true;
+      mimeTypes = [ "application/x-bittorrent" "x-scheme-handler/magnet" ];
+    })
+  ];
 
   postInstall = ''
-    mkdir -p "$out/share/applications"
-    cp $desktopItem/share/applications/* $out/share/applications
     mkdir -p "$out/share/icons/hicolor/48x48/apps"
     cp transgui.png "$out/share/icons/hicolor/48x48/apps"
     mkdir -p "$out/share/transgui"

--- a/pkgs/applications/networking/termius/default.nix
+++ b/pkgs/applications/networking/termius/default.nix
@@ -1,6 +1,7 @@
 { autoPatchelfHook
 , squashfsTools
 , alsa-lib
+, copyDesktopItems
 , fetchurl
 , makeDesktopItem
 , makeWrapper
@@ -27,15 +28,17 @@ stdenv.mkDerivation rec {
     hash = "sha512-M/cyLfSnoCFJcdGXlA5/kH/MuyRpYcfBoyp6y6KSsTyh8Goq6niGZAQcCdIjNX8KVUvmcTWISsx8so4W5BrkCw==";
   };
 
-  desktopItem = makeDesktopItem {
-    categories = [ "Network" ];
-    comment = "The SSH client that works on Desktop and Mobile";
-    desktopName = "Termius";
-    exec = "termius-app";
-    genericName = "Cross-platform SSH client";
-    icon = "termius-app";
-    name = "termius-app";
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      categories = [ "Network" ];
+      comment = "The SSH client that works on Desktop and Mobile";
+      desktopName = "Termius";
+      exec = "termius-app";
+      genericName = "Cross-platform SSH client";
+      icon = "termius-app";
+      name = "termius-app";
+    })
+  ];
 
   dontBuild = true;
   dontConfigure = true;
@@ -43,7 +46,13 @@ stdenv.mkDerivation rec {
   dontWrapGApps = true;
 
   # TODO: migrate off autoPatchelfHook and use nixpkgs' electron
-  nativeBuildInputs = [ autoPatchelfHook squashfsTools makeWrapper wrapGAppsHook ];
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    squashfsTools
+    makeWrapper
+    wrapGAppsHook
+  ];
 
   buildInputs = [
     alsa-lib
@@ -63,8 +72,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/opt/termius
     cp -r ./ $out/opt/termius
 
-    mkdir -p "$out/share/applications" "$out/share/pixmaps/termius-app.png"
-    cp "${desktopItem}/share/applications/"* "$out/share/applications"
+    mkdir -p "$out/share/pixmaps/termius-app.png"
     cp meta/gui/icon.png $out/share/pixmaps/termius-app.png
 
     runHook postInstall

--- a/pkgs/applications/networking/xpipe/default.nix
+++ b/pkgs/applications/networking/xpipe/default.nix
@@ -3,6 +3,7 @@
 , fetchzip
 , makeDesktopItem
 , autoPatchelfHook
+, copyDesktopItems
 , zlib
 , fontconfig
 , udev
@@ -50,6 +51,7 @@ in stdenvNoCC.mkDerivation rec {
   nativeBuildInputs = [
     autoPatchelfHook
     makeShellWrapper
+    copyDesktopItems
   ];
 
   # Ignore libavformat dependencies as we don't need them
@@ -76,15 +78,17 @@ in stdenvNoCC.mkDerivation rec {
       libXxf86vm
     ];
 
-  desktopItem = makeDesktopItem {
-    categories = [ "Network" ];
-    comment = "Your entire server infrastructure at your fingertips";
-    desktopName = displayname;
-    exec = "/opt/${pname}/cli/bin/xpipe open %U";
-    genericName = "Shell connection hub";
-    icon = "/opt/${pname}/logo.png";
-    name = displayname;
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      categories = [ "Network" ];
+      comment = "Your entire server infrastructure at your fingertips";
+      desktopName = displayname;
+      exec = "xpipe open %U";
+      genericName = "Shell connection hub";
+      icon = "${placeholder "out"}/opt/${pname}/logo.png";
+      name = displayname;
+    })
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -96,14 +100,8 @@ in stdenvNoCC.mkDerivation rec {
     mkdir -p "$out/bin"
     ln -s "$out/opt/$pkg/cli/bin/xpipe" "$out/bin/$pkg"
 
-    mkdir -p "$out/share/applications"
-    cp -r "${desktopItem}/share/applications/" "$out/share/"
-
     mkdir -p "$out/etc/bash_completion.d"
     ln -s "$out/opt/$pkg/cli/xpipe_completion" "$out/etc/bash_completion.d/$pkg"
-
-    substituteInPlace "$out/share/applications/${displayname}.desktop" --replace "Exec=" "Exec=$out"
-    substituteInPlace "$out/share/applications/${displayname}.desktop" --replace "Icon=" "Icon=$out"
 
     mv "$out/opt/$pkg/app/bin/xpiped" "$out/opt/$pkg/app/bin/xpiped_raw"
     mv "$out/opt/$pkg/app/lib/app/xpiped.cfg" "$out/opt/$pkg/app/lib/app/xpiped_raw.cfg"

--- a/pkgs/applications/office/jameica/default.nix
+++ b/pkgs/applications/office/jameica/default.nix
@@ -5,6 +5,7 @@
 , makeWrapper
 , wrapGAppsHook
 , stripJavaArchivesHook
+, copyDesktopItems
 , ant
 , jdk
 , jre
@@ -25,16 +26,6 @@ let
     else if stdenv.hostPlatform.system == "aarch64-linux" then "linux-arm64"
     else if stdenv.hostPlatform.system == "x86_64-darwin" then "macos64"
     else throw "Unsupported system: ${stdenv.hostPlatform.system}";
-
-  desktopItem = makeDesktopItem {
-    name = "jameica";
-    exec = "jameica";
-    comment = "Free Runtime Environment for Java Applications.";
-    desktopName = "Jameica";
-    genericName = "Jameica";
-    icon = "jameica";
-    categories = [ "Office" ];
-  };
 in
 stdenv.mkDerivation rec {
   pname = "jameica";
@@ -47,7 +38,14 @@ stdenv.mkDerivation rec {
     hash = "sha256-MSVSd5DyVL+dcfTDv1M99hxickPwT2Pt6QGNsu6DGZI=";
   };
 
-  nativeBuildInputs = [ ant jdk wrapGAppsHook makeWrapper stripJavaArchivesHook ];
+  nativeBuildInputs = [
+    ant
+    jdk
+    wrapGAppsHook
+    makeWrapper
+    stripJavaArchivesHook
+    copyDesktopItems
+  ];
   buildInputs = lib.optionals stdenv.isLinux [ gtk2 glib libXtst ]
     ++ lib.optional stdenv.isDarwin Cocoa;
 
@@ -64,7 +62,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/libexec $out/lib $out/bin $out/share/{applications,jameica-${version},java}/
+    mkdir -p $out/libexec $out/lib $out/bin $out/share/{jameica-${version},java}/
 
     # copy libraries except SWT
     cp $(find lib -type f -iname '*.jar' | grep -ve 'swt/.*/swt.jar') $out/share/jameica-${version}/
@@ -74,7 +72,6 @@ stdenv.mkDerivation rec {
     install -Dm644 releases/${_version}-*/jameica/jameica.jar $out/share/java/
     install -Dm644 plugin.xml $out/share/java/
     install -Dm644 build/jameica-icon.png $out/share/pixmaps/jameica.png
-    cp ${desktopItem}/share/applications/* $out/share/applications/
 
     runHook postInstall
   '';
@@ -88,6 +85,18 @@ stdenv.mkDerivation rec {
       --chdir "$out/share/java/" \
       "''${gappsWrapperArgs[@]}"
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "jameica";
+      exec = "jameica";
+      comment = "Free Runtime Environment for Java Applications.";
+      desktopName = "Jameica";
+      genericName = "Jameica";
+      icon = "jameica";
+      categories = [ "Office" ];
+    })
+  ];
 
   meta = with lib; {
     homepage = "https://www.willuhn.de/products/jameica/";

--- a/pkgs/applications/office/portfolio/default.nix
+++ b/pkgs/applications/office/portfolio/default.nix
@@ -11,18 +11,10 @@
 , makeDesktopItem
 , webkitgtk
 , wrapGAppsHook
+, copyDesktopItems
 , writeScript
 }:
 let
-  desktopItem = makeDesktopItem {
-    name = "Portfolio";
-    exec = "portfolio";
-    icon = "portfolio";
-    comment = "Calculate Investment Portfolio Performance";
-    desktopName = "Portfolio Performance";
-    categories = [ "Office" ];
-  };
-
   runtimeLibs = lib.makeLibraryPath [ gtk3 webkitgtk ];
 in
 stdenv.mkDerivation rec {
@@ -37,6 +29,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoPatchelfHook
     wrapGAppsHook
+    copyDesktopItems
   ];
 
   buildInputs = [
@@ -54,12 +47,20 @@ stdenv.mkDerivation rec {
       --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
       --prefix PATH : ${jre}/bin
 
-    # Create desktop item
-    mkdir -p $out/share/applications
-    cp ${desktopItem}/share/applications/* $out/share/applications
     mkdir -p $out/share/pixmaps
     ln -s $out/portfolio/icon.xpm $out/share/pixmaps/portfolio.xpm
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Portfolio";
+      exec = "portfolio";
+      icon = "portfolio";
+      comment = "Calculate Investment Portfolio Performance";
+      desktopName = "Portfolio Performance";
+      categories = [ "Office" ];
+    })
+  ];
 
   passthru.updateScript = writeScript "update.sh" ''
     #!/usr/bin/env nix-shell

--- a/pkgs/applications/office/tusk/default.nix
+++ b/pkgs/applications/office/tusk/default.nix
@@ -35,8 +35,6 @@ in appimageTools.wrapType2 rec {
   extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
   extraInstallCommands = ''
     mv $out/bin/{${pname}-${version},${pname}}
-    mkdir "$out/share"
-    ln -s "${desktopItem}/share/applications" "$out/share/"
   '';
 
   meta = with lib; {

--- a/pkgs/applications/office/zotero/default.nix
+++ b/pkgs/applications/office/zotero/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchurl
 , wrapGAppsHook
+, copyDesktopItems
 , makeDesktopItem
 , atk
 , cairo
@@ -49,7 +50,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-HAVLmamEPuFf0548/iEXes+f4XnQ7kU1u9hyOYhVyZ0=";
   };
 
-  nativeBuildInputs = [ wrapGAppsHook ];
+  nativeBuildInputs = [ wrapGAppsHook copyDesktopItems ];
   buildInputs =
     [ gsettings-desktop-schemas glib gtk3 gnome.adwaita-icon-theme dconf ];
 
@@ -96,17 +97,19 @@ stdenv.mkDerivation rec {
     sed -i '/pref("app.update.enabled", true);/c\pref("app.update.enabled", false);' defaults/preferences/prefs.js
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "zotero";
-    exec = "zotero -url %U";
-    icon = "zotero";
-    comment = meta.description;
-    desktopName = "Zotero";
-    genericName = "Reference Management";
-    categories = [ "Office" "Database" ];
-    startupNotify = true;
-    mimeTypes = [ "x-scheme-handler/zotero" "text/plain" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "zotero";
+      exec = "zotero -url %U";
+      icon = "zotero";
+      comment = "Collect, organize, cite, and share your research sources";
+      desktopName = "Zotero";
+      genericName = "Reference Management";
+      categories = [ "Office" "Database" ];
+      startupNotify = true;
+      mimeTypes = [ "x-scheme-handler/zotero" "text/plain" ];
+    })
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -116,9 +119,7 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/bin"
     ln -s "$prefix/usr/lib/zotero-bin-${version}/zotero" "$out/bin/"
 
-    # install desktop file and icons.
-    mkdir -p $out/share/applications
-    cp ${desktopItem}/share/applications/* $out/share/applications/
+    # install icons.
     for size in 16 32 48 256; do
       install -Dm444 chrome/icons/default/default$size.png \
         $out/share/icons/hicolor/''${size}x''${size}/apps/zotero.png

--- a/pkgs/applications/office/zotero/zotero_7.nix
+++ b/pkgs/applications/office/zotero/zotero_7.nix
@@ -3,6 +3,7 @@
 , fetchurl
 , wrapGAppsHook
 , autoPatchelfHook
+, copyDesktopItems
 , makeDesktopItem
 , atk
 , cairo
@@ -54,6 +55,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     wrapGAppsHook
     autoPatchelfHook
+    copyDesktopItems
   ];
   buildInputs = [
     gsettings-desktop-schemas
@@ -101,17 +103,19 @@ stdenv.mkDerivation rec {
   dontStrip = true;
 
 
-  desktopItem = makeDesktopItem {
-    name = "zotero";
-    exec = "zotero -url %U";
-    icon = "zotero";
-    comment = meta.description;
-    desktopName = "Zotero";
-    genericName = "Reference Management";
-    categories = [ "Office" "Database" ];
-    startupNotify = true;
-    mimeTypes = [ "x-scheme-handler/zotero" "text/plain" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "zotero";
+      exec = "zotero -url %U";
+      icon = "zotero";
+      comment = "Collect, organize, cite, and share your research sources";
+      desktopName = "Zotero";
+      genericName = "Reference Management";
+      categories = [ "Office" "Database" ];
+      startupNotify = true;
+      mimeTypes = [ "x-scheme-handler/zotero" "text/plain" ];
+    })
+  ];
 
 
   installPhase = ''
@@ -122,9 +126,7 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/bin"
     ln -s "$prefix/usr/lib/zotero-bin-${version}/zotero" "$out/bin/"
 
-    # install desktop file and icons.
-    mkdir -p $out/share/applications
-    cp ${desktopItem}/share/applications/* $out/share/applications/
+    # install icons.
     for size in 32 64 128; do
       install -Dm444 icons/icon$size.png \
         $out/share/icons/hicolor/''${size}x''${size}/apps/zotero.png

--- a/pkgs/applications/radio/svxlink/default.nix
+++ b/pkgs/applications/radio/svxlink/default.nix
@@ -1,18 +1,8 @@
 { lib, stdenv, cmake, pkg-config, fetchFromGitHub, makeDesktopItem, alsa-lib, speex
 , libopus, curl, gsm, libgcrypt, libsigcxx, popt, qtbase, qttools
-, wrapQtAppsHook, rtl-sdr, tcl, doxygen, groff }:
+, wrapQtAppsHook, copyDesktopItems, rtl-sdr, tcl, doxygen, groff }:
 
-let
-  desktopItem = makeDesktopItem rec {
-    name = "Qtel";
-    exec = "qtel";
-    icon = "qtel";
-    desktopName = name;
-    genericName = "EchoLink Client";
-    categories = [ "HamRadio" "Qt" "Network" ];
-  };
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "svxlink";
   version = "19.09.2";
 
@@ -31,7 +21,14 @@ in stdenv.mkDerivation rec {
   ];
   dontWrapQtApps = true;
 
-  nativeBuildInputs = [ cmake pkg-config doxygen groff wrapQtAppsHook ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    doxygen
+    groff
+    wrapQtAppsHook
+    copyDesktopItems
+  ];
 
   buildInputs = [
     alsa-lib
@@ -50,11 +47,21 @@ in stdenv.mkDerivation rec {
 
   postInstall = ''
     rm -f $out/share/applications/*
-    cp -v ${desktopItem}/share/applications/* $out/share/applications
     mv $out/share/icons/link.xpm $out/share/icons/qtel.xpm
 
     wrapQtApp $out/bin/qtel
   '';
+
+  desktopItems = [
+    (makeDesktopItem rec {
+      name = "Qtel";
+      exec = "qtel";
+      icon = "qtel";
+      desktopName = name;
+      genericName = "EchoLink Client";
+      categories = [ "HamRadio" "Qt" "Network" ];
+    })
+  ];
 
   meta = with lib; {
     description = "Advanced repeater controller and EchoLink software";

--- a/pkgs/applications/science/chemistry/jmol/default.nix
+++ b/pkgs/applications/science/chemistry/jmol/default.nix
@@ -1,28 +1,13 @@
 { stdenv
 , lib
 , fetchurl
+, copyDesktopItems
 , unzip
 , makeDesktopItem
 , jre
 }:
 
 let
-  desktopItem = makeDesktopItem {
-    name = "jmol";
-    exec = "jmol";
-    desktopName = "JMol";
-    genericName = "Molecular Modeler";
-    mimeTypes = [
-      "chemical/x-pdb"
-      "chemical/x-mdl-molfile"
-      "chemical/x-mol2"
-      "chemical/seq-aa-fasta"
-      "chemical/seq-na-fasta"
-      "chemical/x-xyz"
-      "chemical/x-mdl-sdf"
-    ];
-    categories = [ "Graphics" "Education" "Science" "Chemistry" ];
-  };
 in
 stdenv.mkDerivation rec {
   version = "16.1.63";
@@ -35,6 +20,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-zUX3msosz0LNQJuEUbFgT32Hw0Wq4CgW1iHMkvReysU=";
   };
 
+  nativeBuildInputs = [ copyDesktopItems ];
+
   patchPhase = ''
     sed -i -e "4s:.*:command=${jre}/bin/java:" -e "10s:.*:jarpath=$out/share/jmol/Jmol.jar:" -e "11,21d" jmol
   '';
@@ -45,11 +32,29 @@ stdenv.mkDerivation rec {
     ${unzip}/bin/unzip jsmol.zip -d "$out/share/"
 
     cp *.jar jmol.sh "$out/share/jmol"
-    cp -r ${desktopItem}/share/applications $out/share
     cp jmol $out/bin
   '';
 
   enableParallelBuilding = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "jmol";
+      exec = "jmol";
+      desktopName = "JMol";
+      genericName = "Molecular Modeler";
+      mimeTypes = [
+        "chemical/x-pdb"
+        "chemical/x-mdl-molfile"
+        "chemical/x-mol2"
+        "chemical/seq-aa-fasta"
+        "chemical/seq-na-fasta"
+        "chemical/x-xyz"
+        "chemical/x-mdl-sdf"
+      ];
+      categories = [ "Graphics" "Education" "Science" "Chemistry" ];
+    })
+  ];
 
   meta = with lib; {
      description = "A Java 3D viewer for chemical structures";

--- a/pkgs/applications/science/chemistry/pymol/default.nix
+++ b/pkgs/applications/science/chemistry/pymol/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchFromGitHub
 , makeDesktopItem
+, copyDesktopItems
 , python3
 , python3Packages
 , netcdf
@@ -16,25 +17,6 @@
 let
   pname = "pymol";
   description = "A Python-enhanced molecular graphics tool";
-
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = pname;
-    desktopName = "PyMol Molecular Graphics System";
-    genericName = "Molecular Modeler";
-    comment = description;
-    icon = pname;
-    mimeTypes = [
-      "chemical/x-pdb"
-      "chemical/x-mdl-molfile"
-      "chemical/x-mol2"
-      "chemical/seq-aa-fasta"
-      "chemical/seq-na-fasta"
-      "chemical/x-xyz"
-      "chemical/x-mdl-sdf"
-    ];
-    categories = [ "Graphics" "Education" "Science" "Chemistry" ];
-  };
 in
 python3Packages.buildPythonApplication rec {
   inherit pname;
@@ -46,7 +28,7 @@ python3Packages.buildPythonApplication rec {
     sha256 = "sha256-JdsgcVF1w1xFPZxVcyS+GcWg4a1Bd4SvxFOuSdlz9SM=";
   };
 
-  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
+  nativeBuildInputs = [ qt5.wrapQtAppsHook copyDesktopItems ];
   buildInputs = [ python3Packages.numpy python3Packages.pyqt5 glew glm libpng libxml2 freetype msgpack netcdf ];
   env.NIX_CFLAGS_COMPILE = "-I ${libxml2.dev}/include/libxml2";
   hardeningDisable = [ "format" ];
@@ -62,12 +44,32 @@ python3Packages.buildPythonApplication rec {
 
     mkdir -p "$out/share/icons/"
     ln -s ../../lib/python/pymol/pymol_path/data/pymol/icons/icon2.svg "$out/share/icons/pymol.svg"
-    cp -r "${desktopItem}/share/applications/" "$out/share/"
   '';
 
   preFixup = ''
     wrapQtApp "$out/bin/pymol"
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      desktopName = "PyMol Molecular Graphics System";
+      genericName = "Molecular Modeler";
+      comment = description;
+      icon = pname;
+      mimeTypes = [
+        "chemical/x-pdb"
+        "chemical/x-mdl-molfile"
+        "chemical/x-mol2"
+        "chemical/seq-aa-fasta"
+        "chemical/seq-na-fasta"
+        "chemical/x-xyz"
+        "chemical/x-mdl-sdf"
+      ];
+      categories = [ "Graphics" "Education" "Science" "Chemistry" ];
+    })
+  ];
 
   meta = with lib; {
     inherit description;

--- a/pkgs/applications/science/electronics/eagle/eagle.nix
+++ b/pkgs/applications/science/electronics/eagle/eagle.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, mkDerivation, fetchurl, makeDesktopItem
+{ lib, stdenv, mkDerivation, fetchurl, makeDesktopItem, copyDesktopItems
 , libXrender, libXrandr, libXcursor, libX11, libXext, libXi, libxcb
  , libGL, glib, nss, nspr, expat, alsa-lib
 , qtbase, qtdeclarative, qtsvg, qtlocation, qtwebchannel, qtwebengine
@@ -20,15 +20,19 @@ let
       sha256 = "18syygnskl286kn8aqfzzdsyzq59d2w19y1h1ynyxsnrvkyv71h0";
     };
 
-    desktopItem = makeDesktopItem {
-      name = "eagle";
-      exec = "eagle";
-      icon = "eagle";
-      comment = "Schematic capture and PCB layout";
-      desktopName = "Eagle";
-      genericName = "Schematic editor";
-      categories = [ "Development" ];
-    };
+    desktopItems = [
+      (makeDesktopItem {
+        name = "eagle";
+        exec = "eagle";
+        icon = "eagle";
+        comment = "Schematic capture and PCB layout";
+        desktopName = "Eagle";
+        genericName = "Schematic editor";
+        categories = [ "Development" ];
+      })
+    ];
+
+    nativeBuildInputs = [ copyDesktopItems ];
 
     buildInputs =
       [ libXrender libXrandr libXcursor libX11 libXext libXi libxcb
@@ -63,9 +67,7 @@ let
       rm -r "$out"/eagle-${version}/libexec
       rm -r "$out"/eagle-${version}/plugins
 
-      # Make desktop item
-      mkdir -p "$out"/share/applications
-      cp "$desktopItem"/share/applications/* "$out"/share/applications/
+      # Install icons
       mkdir -p "$out"/share/pixmaps
       ln -s "$out/eagle-${version}/bin/eagle-logo.png" "$out"/share/pixmaps/eagle.png
     '';

--- a/pkgs/applications/science/logic/isabelle/default.nix
+++ b/pkgs/applications/science/logic/isabelle/default.nix
@@ -4,6 +4,7 @@
 , coreutils
 , nettools
 , java
+, copyDesktopItems
 , scala_3
 , polyml
 , veriT
@@ -70,7 +71,7 @@ in stdenv.mkDerivation (finalAttrs: rec {
         hash = "sha256-Tzxxs0gKw6vymbaXIzH8tK5VgUrpOIp9vcWQ/zxnRCc=";
       };
 
-  nativeBuildInputs = [ java ];
+  nativeBuildInputs = [ java copyDesktopItems ];
 
   buildInputs = [ polyml veriT vampire eprover-ho nettools ]
     ++ lib.optionals (!stdenv.isDarwin) [ java ];
@@ -190,20 +191,18 @@ in stdenv.mkDerivation (finalAttrs: rec {
     # icon
     mkdir -p "$out/share/icons/hicolor/isabelle/apps"
     cp "$out/Isabelle${version}/lib/icons/isabelle.xpm" "$out/share/icons/hicolor/isabelle/apps/"
-
-    # desktop item
-    mkdir -p "$out/share"
-    cp -r "${desktopItem}/share/applications" "$out/share/applications"
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "isabelle";
-    exec = "isabelle jedit";
-    icon = "isabelle";
-    desktopName = "Isabelle";
-    comment = meta.description;
-    categories = [ "Education" "Science" "Math" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "isabelle";
+      exec = "isabelle jedit";
+      icon = "isabelle";
+      desktopName = "Isabelle";
+      comment = "A generic proof assistant";
+      categories = [ "Education" "Science" "Math" ];
+    })
+  ];
 
   meta = with lib; {
     description = "A generic proof assistant";

--- a/pkgs/applications/science/logic/tlaplus/toolbox.nix
+++ b/pkgs/applications/science/logic/tlaplus/toolbox.nix
@@ -8,22 +8,9 @@
 , glib
 , zlib
 , wrapGAppsHook
+, copyDesktopItems
 }:
 
-let
-  desktopItem = makeDesktopItem rec {
-    name = "TLA+Toolbox";
-    exec = "tla-toolbox";
-    icon = "tla-toolbox";
-    comment = "IDE for TLA+";
-    desktopName = name;
-    genericName = comment;
-    categories = [ "Development" ];
-    startupWMClass = "TLA+ Toolbox";
-  };
-
-
-in
 stdenv.mkDerivation rec {
   pname = "tla-toolbox";
   version = "1.7.1";
@@ -37,6 +24,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     makeShellWrapper
     wrapGAppsHook
+    copyDesktopItems
   ];
 
   dontWrapGApps = true;
@@ -81,11 +69,21 @@ stdenv.mkDerivation rec {
     done
     popd
 
-    echo -e "\nCreating TLA Toolbox desktop entry..."
-    cp -r "${desktopItem}/share/applications"* "$out/share/applications"
-
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem rec {
+      name = "TLA+Toolbox";
+      exec = "tla-toolbox";
+      icon = "tla-toolbox";
+      comment = "IDE for TLA+";
+      desktopName = name;
+      genericName = comment;
+      categories = [ "Development" ];
+      startupWMClass = "TLA+ Toolbox";
+    })
+  ];
 
   meta = {
     homepage = "http://research.microsoft.com/en-us/um/people/lamport/tla/toolbox.html";

--- a/pkgs/applications/science/math/geogebra/default.nix
+++ b/pkgs/applications/science/math/geogebra/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, libGL, xorg, jre, makeDesktopItem, makeWrapper, unzip, language ? "en_US" }:
+{ lib, stdenv, fetchurl, libGL, xorg, jre, makeDesktopItem, makeWrapper, copyDesktopItems, unzip, language ? "en_US" }:
 let
   pname = "geogebra";
   version = "5-0-785-0";
@@ -6,17 +6,6 @@ let
   srcIcon = fetchurl {
     url = "https://web.archive.org/web/20200227000442if_/https://static.geogebra.org/images/geogebra-logo.svg";
     hash = "sha256-Vd7Wteya04JJT4WNirXe8O1sfVKUgc0hKGOy7d47Xgc=";
-  };
-
-  desktopItem = makeDesktopItem {
-    name = "geogebra";
-    exec = "geogebra";
-    icon = "geogebra";
-    desktopName = "Geogebra";
-    genericName = "Geogebra";
-    comment = meta.description;
-    categories = [ "Education" "Science" "Math" ];
-    mimeTypes = [ "application/vnd.geogebra.file" "application/vnd.geogebra.tool" ];
   };
 
   meta = with lib; {
@@ -38,7 +27,7 @@ let
   };
 
   linuxPkg = stdenv.mkDerivation {
-    inherit pname version meta srcIcon desktopItem;
+    inherit pname version meta srcIcon;
 
     preferLocalBuild = true;
 
@@ -50,7 +39,7 @@ let
       hash = "sha256-cL4ERKZpE9Y6IdOjvYiX3nIIW3E2qoqkpMyTszvFseM=";
     };
 
-    nativeBuildInputs = [ makeWrapper ];
+    nativeBuildInputs = [ makeWrapper copyDesktopItems ];
 
     installPhase = ''
       install -D geogebra/* -t "$out/libexec/geogebra/"
@@ -64,12 +53,22 @@ let
         --set GG_PATH "$out/libexec/geogebra" \
         --add-flags "--language=${language}"
 
-      install -Dm644 "${desktopItem}/share/applications/"* \
-        -t $out/share/applications/
-
       install -Dm644 "${srcIcon}" \
         "$out/share/icons/hicolor/scalable/apps/geogebra.svg"
     '';
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = "geogebra";
+        exec = "geogebra";
+        icon = "geogebra";
+        desktopName = "Geogebra";
+        genericName = "Geogebra";
+        comment = meta.description;
+        categories = [ "Education" "Science" "Math" ];
+        mimeTypes = [ "application/vnd.geogebra.file" "application/vnd.geogebra.tool" ];
+      })
+    ];
   };
 
   darwinPkg = stdenv.mkDerivation {

--- a/pkgs/applications/science/math/geogebra/geogebra6.nix
+++ b/pkgs/applications/science/math/geogebra/geogebra6.nix
@@ -1,10 +1,9 @@
-{ lib, stdenv, unzip, fetchurl, electron, makeWrapper, geogebra }:
+{ lib, stdenv, unzip, fetchurl, electron, makeWrapper, copyDesktopItems, geogebra }:
 let
   pname = "geogebra";
   version = "6-0-794-0";
 
   srcIcon = geogebra.srcIcon;
-  desktopItem = geogebra.desktopItem;
 
   meta = with lib; {
     description = "Dynamic mathematics software with graphics, algebra and spreadsheets";
@@ -41,6 +40,7 @@ let
     nativeBuildInputs = [
       unzip
       makeWrapper
+      copyDesktopItems
     ];
 
     unpackPhase = ''
@@ -51,12 +51,12 @@ let
       mkdir -p $out/libexec/geogebra/ $out/bin
       cp -r GeoGebra-linux-x64/{resources,locales} "$out/"
       makeWrapper ${lib.getBin electron}/bin/electron $out/bin/geogebra --add-flags "$out/resources/app"
-      install -Dm644 "${desktopItem}/share/applications/"* \
-        -t $out/share/applications/
 
       install -Dm644 "${srcIcon}" \
         "$out/share/icons/hicolor/scalable/apps/geogebra.svg"
     '';
+
+    desktopItems = geogebra.desktopItems;
   };
 
   darwinPkg = stdenv.mkDerivation {

--- a/pkgs/applications/science/misc/netlogo/default.nix
+++ b/pkgs/applications/science/misc/netlogo/default.nix
@@ -1,15 +1,7 @@
-{ jre, lib, stdenv, fetchurl, makeWrapper, makeDesktopItem }:
+{ jre, lib, stdenv, fetchurl, makeWrapper, copyDesktopItems, makeDesktopItem }:
 
 let
 
-  desktopItem = makeDesktopItem rec {
-    name = "netlogo";
-    exec = name;
-    icon = name;
-    comment = "A multi-agent programmable modeling environment";
-    desktopName = "NetLogo";
-    categories = [ "Science" ];
-  };
 
 in
 
@@ -28,10 +20,10 @@ stdenv.mkDerivation rec {
     sha256 = "1i43lhr31lzva8d2r0dxpcgr58x496gb5vmb0h2da137ayvifar8";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
 
   installPhase = ''
-    mkdir -pv $out/share/netlogo $out/share/icons/hicolor/256x256/apps $out/share/applications $out/share/doc
+    mkdir -pv $out/share/netlogo $out/share/icons/hicolor/256x256/apps $out/share/doc
     cp -rv app $out/share/netlogo
     cp -v readme.md $out/share/doc/
 
@@ -41,8 +33,18 @@ stdenv.mkDerivation rec {
       --add-flags "-jar netlogo-${version}.jar"
 
     cp $src1 $out/share/icons/hicolor/256x256/apps/netlogo.png
-    cp ${desktopItem}/share/applications/* $out/share/applications
   '';
+
+  desktopItems = [
+    (makeDesktopItem rec {
+      name = "netlogo";
+      exec = name;
+      icon = name;
+      comment = "A multi-agent programmable modeling environment";
+      desktopName = "NetLogo";
+      categories = [ "Science" ];
+    })
+  ];
 
   meta = with lib; {
     description = "A multi-agent programmable modeling environment";

--- a/pkgs/applications/science/programming/groove/default.nix
+++ b/pkgs/applications/science/programming/groove/default.nix
@@ -1,16 +1,6 @@
-{ lib, stdenv, fetchurl, unzip, makeWrapper, makeDesktopItem, icoutils, jre8 }:
+{ lib, stdenv, fetchurl, unzip, makeWrapper, copyDesktopItems, makeDesktopItem, icoutils, jre8 }:
 
-let
-  desktopItem = makeDesktopItem {
-    name = "groove-simulator";
-    exec = "groove-simulator";
-    icon = "groove";
-    desktopName = "GROOVE Simulator";
-    comment = "GRaphs for Object-Oriented VErification";
-    categories = [ "Science" "ComputerScience" ];
-  };
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "groove";
   version = "5.8.1";
 
@@ -19,7 +9,7 @@ in stdenv.mkDerivation rec {
     sha256 = "sha256-JwoUlO6F2+8NtCnLC+xm5q0Jm8RIyU1rnuKGmjgJhFU=";
   };
 
-  nativeBuildInputs = [ unzip makeWrapper icoutils ];
+  nativeBuildInputs = [ unzip makeWrapper icoutils copyDesktopItems ];
 
   dontBuild = true;
 
@@ -36,13 +26,21 @@ in stdenv.mkDerivation rec {
         --add-flags "-jar $out/share/groove/bin/$bin.jar"
     done
 
-    mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications/
-
     mkdir -p $out/share/icons/hicolor/{16x16,32x32}/apps
     icotool -x -i 1 -o $out/share/icons/hicolor/32x32/apps/groove.png groove-green-g.ico
     icotool -x -i 2 -o $out/share/icons/hicolor/16x16/apps/groove.png groove-green-g.ico
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "groove-simulator";
+      exec = "groove-simulator";
+      icon = "groove";
+      desktopName = "GROOVE Simulator";
+      comment = "GRaphs for Object-Oriented VErification";
+      categories = [ "Science" "ComputerScience" ];
+    })
+  ];
 
   meta = with lib; {
     description = "GRaphs for Object-Oriented VErification";

--- a/pkgs/applications/science/robotics/betaflight-configurator/default.nix
+++ b/pkgs/applications/science/robotics/betaflight-configurator/default.nix
@@ -1,15 +1,7 @@
-{lib, stdenv, fetchurl, unzip, makeDesktopItem, nwjs, wrapGAppsHook, gsettings-desktop-schemas, gtk3 }:
+{lib, stdenv, fetchurl, unzip, copyDesktopItems, makeDesktopItem, nwjs, wrapGAppsHook, gsettings-desktop-schemas, gtk3 }:
 
 let
   pname = "betaflight-configurator";
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = pname;
-    icon = pname;
-    comment = "Betaflight configuration tool";
-    desktopName = "Betaflight Configurator";
-    genericName = "Flight controller configuration tool";
-  };
 in
 stdenv.mkDerivation rec {
   inherit pname;
@@ -24,7 +16,7 @@ stdenv.mkDerivation rec {
     find -name "lib*.so" -delete
   '';
 
-  nativeBuildInputs = [ wrapGAppsHook unzip ];
+  nativeBuildInputs = [ wrapGAppsHook unzip copyDesktopItems ];
 
   buildInputs = [ gsettings-desktop-schemas gtk3 ];
 
@@ -35,11 +27,21 @@ stdenv.mkDerivation rec {
 
     cp -r . $out/opt/${pname}/
     install -m 444 -D icon/bf_icon_128.png $out/share/icons/hicolor/128x128/apps/${pname}.png
-    cp -r ${desktopItem}/share/applications $out/share/
 
     makeWrapper ${nwjs}/bin/nw $out/bin/${pname} --add-flags $out/opt/${pname}
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      icon = pname;
+      comment = "Betaflight configuration tool";
+      desktopName = "Betaflight Configurator";
+      genericName = "Flight controller configuration tool";
+    })
+  ];
 
   meta = with lib; {
     description = "The Betaflight flight control system configuration tool";

--- a/pkgs/applications/science/robotics/mission-planner/default.nix
+++ b/pkgs/applications/science/robotics/mission-planner/default.nix
@@ -1,15 +1,7 @@
-{ lib, stdenv, fetchurl, makeDesktopItem, makeWrapper, unzip, mono }:
+{ lib, stdenv, fetchurl, copyDesktopItems, makeDesktopItem, makeWrapper, unzip, mono }:
 
 let
   pname = "mission-planner";
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = pname;
-    icon = pname;
-    comment = "MissionPlanner GCS & Ardupilot configuration tool";
-    desktopName = "MissionPlanner";
-    genericName = "Ground Control Station";
-  };
 in stdenv.mkDerivation rec {
   inherit pname;
   version = "1.3.80";
@@ -19,7 +11,7 @@ in stdenv.mkDerivation rec {
     sha256 = "sha256-iivlaQWtOMJHchmR92FoqTaosGJ9F1AgFtuFgDE/9qQ=";
   };
 
-  nativeBuildInputs = [ makeWrapper mono unzip ];
+  nativeBuildInputs = [ makeWrapper mono unzip copyDesktopItems ];
   sourceRoot = ".";
 
   AOT_FILES = [ "MissionPlanner.exe" "MissionPlanner.*.dll" ];
@@ -37,12 +29,22 @@ in stdenv.mkDerivation rec {
     runHook preInstall
     mkdir -p $out/{bin,opt/mission-planner}
     install -m 444 -D mpdesktop150.png $out/share/icons/mission-planner.png
-    cp -r ${desktopItem}/share/applications $out/share/
     mv * $out/opt/mission-planner
     makeWrapper ${mono}/bin/mono $out/bin/mission-planner \
       --add-flags $out/opt/mission-planner/MissionPlanner.exe
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      icon = pname;
+      comment = "MissionPlanner GCS & Ardupilot configuration tool";
+      desktopName = "MissionPlanner";
+      genericName = "Ground Control Station";
+    })
+  ];
 
   meta = with lib; {
     description = "An ArduPilot ground station";

--- a/pkgs/applications/terminal-emulators/mlterm/default.nix
+++ b/pkgs/applications/terminal-emulators/mlterm/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , pkg-config
 , autoconf
+, copyDesktopItems
 , makeDesktopItem
 , nixosTests
 , vte
@@ -110,6 +111,7 @@ in stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     autoconf
+    copyDesktopItems
   ] ++ lib.optionals enableTools.mlconfig [
     wrapGAppsHook
   ];
@@ -184,24 +186,25 @@ in stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     install -D contrib/icon/mlterm-icon.svg "$out/share/icons/hicolor/scalable/apps/mlterm.svg"
     install -D contrib/icon/mlterm-icon-gnome2.png "$out/share/icons/hicolor/48x48/apps/mlterm.png"
-    install -D -t $out/share/applications $desktopItem/share/applications/*
   '' + lib.optionalString stdenv.isDarwin ''
     mkdir -p $out/Applications/
     cp -a cocoa/mlterm.app $out/Applications/
     install $out/bin/mlterm -Dt $out/Applications/mlterm.app/Contents/MacOS/
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "mlterm";
-    exec = "${desktopBinary} %U";
-    icon = "mlterm";
-    type = "Application";
-    comment = "Multi Lingual TERMinal emulator";
-    desktopName = "mlterm";
-    genericName = "Terminal emulator";
-    categories = [ "System" "TerminalEmulator" ];
-    startupNotify = false;
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "mlterm";
+      exec = "${desktopBinary} %U";
+      icon = "mlterm";
+      type = "Application";
+      comment = "Multi Lingual TERMinal emulator";
+      desktopName = "mlterm";
+      genericName = "Terminal emulator";
+      categories = [ "System" "TerminalEmulator" ];
+      startupNotify = false;
+    })
+  ];
 
   passthru = {
     tests.test = nixosTests.terminal-emulators.mlterm;

--- a/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, fetchpatch, makeDesktopItem
 , libX11, libXt, libXft, libXrender, libXext
 , ncurses, fontconfig, freetype
-, pkg-config, gdk-pixbuf, perl
+, pkg-config, copyDesktopItems, gdk-pixbuf, perl
 , libptytty
 , perlSupport      ? true
 , gdkPixbufSupport ? true
@@ -14,16 +14,6 @@ let
   pname = "rxvt-unicode";
   version = "9.31";
   description = "A clone of the well-known terminal emulator rxvt";
-
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = "urxvt";
-    icon = "utilities-terminal";
-    comment = description;
-    desktopName = "URxvt";
-    genericName = pname;
-    categories = [ "System" "TerminalEmulator" ];
-  };
 
   fetchPatchFromAUR = { package, name, rev, sha256 }:
     fetchpatch rec {
@@ -44,7 +34,7 @@ stdenv.mkDerivation {
     sha256 = "qqE/y8FJ/g8/OR+TMnlYD3Spb9MS1u0GuP8DwtRmcug=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config copyDesktopItems ];
   buildInputs =
     [ libX11 libXt libXft ncurses  # required to build the terminfo file
       fontconfig freetype libXrender
@@ -106,8 +96,19 @@ stdenv.mkDerivation {
   postInstall = ''
     mkdir -p $out/nix-support
     echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
-    cp -r ${desktopItem}/share/applications/ $out/share/
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = "urxvt";
+      icon = "utilities-terminal";
+      comment = description;
+      desktopName = "URxvt";
+      genericName = pname;
+      categories = [ "System" "TerminalEmulator" ];
+    })
+  ];
 
   passthru.tests.test = nixosTests.terminal-emulators.urxvt;
 

--- a/pkgs/applications/terminal-emulators/wayst/default.nix
+++ b/pkgs/applications/terminal-emulators/wayst/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchFromGitHub
 , pkg-config
+, copyDesktopItems
 , nixosTests
 , freetype
 , fontconfig
@@ -18,18 +19,6 @@
 , makeDesktopItem
 }:
 
-let
-  desktopItem = makeDesktopItem {
-    desktopName = "Wayst";
-    name = "wayst";
-    genericName = "Terminal";
-    exec = "wayst";
-    icon = "wayst";
-    categories = [ "System" "TerminalEmulator" ];
-    keywords = [ "wayst" "terminal" ];
-    comment = "A simple terminal emulator";
-  };
-in
 stdenv.mkDerivation rec {
   pname = "wayst";
   version = "unstable-2023-07-16";
@@ -43,7 +32,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "INSTALL_DIR=\${out}/bin" ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config copyDesktopItems ];
 
   buildInputs = [
     fontconfig
@@ -70,10 +59,21 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications
     install -D icons/wayst.svg $out/share/icons/hicolor/scalable/apps/wayst.svg
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = "Wayst";
+      name = "wayst";
+      genericName = "Terminal";
+      exec = "wayst";
+      icon = "wayst";
+      categories = [ "System" "TerminalEmulator" ];
+      keywords = [ "wayst" "terminal" ];
+      comment = "A simple terminal emulator";
+    })
+  ];
 
   passthru.tests.test = nixosTests.terminal-emulators.wayst;
 

--- a/pkgs/applications/video/clipgrab/default.nix
+++ b/pkgs/applications/video/clipgrab/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchurl, makeDesktopItem, ffmpeg
-, qmake, qttools, mkDerivation
+, qmake, qttools, copyDesktopItems, mkDerivation
 , qtbase, qtdeclarative, qtlocation, qtquickcontrols2, qtwebchannel, qtwebengine
 , yt-dlp
 }:
@@ -15,7 +15,7 @@ mkDerivation rec {
   };
 
   buildInputs = [ ffmpeg qtbase qtdeclarative qtlocation qtquickcontrols2 qtwebchannel qtwebengine ];
-  nativeBuildInputs = [ qmake qttools ];
+  nativeBuildInputs = [ qmake qttools copyDesktopItems ];
 
   patches = [
     ./yt-dlp-path.patch
@@ -33,21 +33,22 @@ mkDerivation rec {
 
   qmakeFlags = [ "clipgrab.pro" ];
 
-  desktopItem = makeDesktopItem rec {
-    name = "clipgrab";
-    exec = name;
-    icon = name;
-    desktopName = "ClipGrab";
-    comment = meta.description;
-    genericName = "Web video downloader";
-    categories = [ "Qt" "AudioVideo" "Audio" "Video" ];
-  };
+  desktopItems = [
+    (makeDesktopItem rec {
+      name = "clipgrab";
+      exec = name;
+      icon = name;
+      desktopName = "ClipGrab";
+      comment = meta.description;
+      genericName = "Web video downloader";
+      categories = [ "Qt" "AudioVideo" "Audio" "Video" ];
+    })
+  ];
 
   installPhase = ''
     runHook preInstall
     install -Dm755 clipgrab $out/bin/clipgrab
     install -Dm644 icon.png $out/share/pixmaps/clipgrab.png
-    cp -r ${desktopItem}/share/applications $out/share
     runHook postInstall
   '';
 

--- a/pkgs/applications/video/streamlink-twitch-gui/bin.nix
+++ b/pkgs/applications/video/streamlink-twitch-gui/bin.nix
@@ -2,6 +2,7 @@
 , fetchurl
 , lib
 , makeDesktopItem
+, copyDesktopItems
 , makeWrapper
 , stdenv
 , wrapGAppsHook
@@ -78,6 +79,7 @@ stdenv.mkDerivation rec {
     libXtst
     makeWrapper
     wrapGAppsHook
+    copyDesktopItems
   ];
 
   buildInputs = [ streamlink ];
@@ -93,7 +95,6 @@ stdenv.mkDerivation rec {
     cp -a . $out/opt/${basename}/
     rm -r $out/opt/${basename}/{{add,remove}-menuitem.sh,credits.html,icons/}
     ln -s "$out/opt/${basename}/${basename}" $out/bin/
-    cp -r "${desktopItem}/share/applications" $out/share/
     runHook postInstall
   '';
 
@@ -105,14 +106,16 @@ stdenv.mkDerivation rec {
     )
   '';
 
-  desktopItem = makeDesktopItem {
-    name = basename;
-    exec = basename;
-    icon = basename;
-    desktopName = "Streamlink Twitch GUI";
-    genericName = meta.description;
-    categories = [ "AudioVideo" "Network" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = basename;
+      exec = basename;
+      icon = basename;
+      desktopName = "Streamlink Twitch GUI";
+      genericName = "Twitch.tv browser for Streamlink";
+      categories = [ "AudioVideo" "Network" ];
+    })
+  ];
 
   meta = with lib; {
     description = "Twitch.tv browser for Streamlink";

--- a/pkgs/applications/virtualization/looking-glass-client/default.nix
+++ b/pkgs/applications/virtualization/looking-glass-client/default.nix
@@ -4,6 +4,7 @@
 , makeDesktopItem
 , pkg-config
 , cmake
+, copyDesktopItems
 , freefont_ttf
 , spice-protocol
 , nettle
@@ -36,16 +37,6 @@
 , pulseSupport ? true
 }:
 
-let
-  desktopItem = makeDesktopItem {
-    name = "looking-glass-client";
-    desktopName = "Looking Glass Client";
-    type = "Application";
-    exec = "looking-glass-client";
-    icon = "lg-logo";
-    terminal = true;
-  };
-in
 stdenv.mkDerivation rec {
   pname = "looking-glass-client";
   version = "B6";
@@ -58,7 +49,7 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [ cmake pkg-config copyDesktopItems ];
 
   buildInputs = [ libGL libX11 freefont_ttf spice-protocol expat libbfd nettle fontconfig libffi ]
     ++ lib.optionals xorgSupport [ libxkbcommon libXi libXScrnSaver libXinerama libXcursor libXpresent libXext libXrandr ]
@@ -80,9 +71,19 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     mkdir -p $out/share/pixmaps
-    ln -s ${desktopItem}/share/applications $out/share/
     cp $src/resources/lg-logo.png $out/share/pixmaps
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "looking-glass-client";
+      desktopName = "Looking Glass Client";
+      type = "Application";
+      exec = "looking-glass-client";
+      icon = "lg-logo";
+      terminal = true;
+    })
+  ];
 
   meta = with lib; {
     description = "A KVM Frame Relay (KVMFR) implementation";

--- a/pkgs/by-name/go/gossip/package.nix
+++ b/pkgs/by-name/go/gossip/package.nix
@@ -11,6 +11,7 @@
 , openssl
 , pkg-config
 , rustPlatform
+, copyDesktopItems
 , stdenv
 , wayland
 , xorg
@@ -55,6 +56,7 @@ rustPlatform.buildRustPackage rec {
     git
     pkg-config
     rustPlatform.bindgenHook
+    copyDesktopItems
   ];
 
   buildInputs = [

--- a/pkgs/by-name/id/ida-free/package.nix
+++ b/pkgs/by-name/id/ida-free/package.nix
@@ -42,15 +42,17 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-widkv2VGh+eOauUK/6Sz/e2auCNFAsc8n9z0fdrSnW0=";
   };
 
-  desktopItem = makeDesktopItem {
-    name = "ida-free";
-    exec = "ida64";
-    icon = icon;
-    comment = meta.description;
-    desktopName = "IDA Free";
-    genericName = "Interactive Disassembler";
-    categories = [ "Development" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ida-free";
+      exec = "ida64";
+      icon = icon;
+      comment = meta.description;
+      desktopName = "IDA Free";
+      genericName = "Interactive Disassembler";
+      categories = [ "Development" ];
+    })
+  ];
 
   nativeBuildInputs = [ makeWrapper copyDesktopItems autoPatchelfHook libsForQt5.wrapQtAppsHook ];
 

--- a/pkgs/by-name/ke/keepass/package.nix
+++ b/pkgs/by-name/ke/keepass/package.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl
-, unzip, mono, makeWrapper, icoutils
+, unzip, mono, makeWrapper, copyDesktopItems, icoutils
 , substituteAll, xsel, xorg, xdotool, coreutils, unixtools, glib
 , gtk2, makeDesktopItem, plugins ? [] }:
 
@@ -18,6 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
     unzip
     mono
     makeWrapper
+    copyDesktopItems
   ];
   buildInputs = [ icoutils ];
 
@@ -114,10 +115,6 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix PATH : "$binPaths" \
       --prefix LD_LIBRARY_PATH : "$dynlibPath"
 
-    # setup desktop item with icon
-    mkdir -p "$out/share/applications"
-    cp $desktopItem/share/applications/* $out/share/applications
-
     ${./extractWinRscIconsToStdFreeDesktopDir.sh} \
       "./Translation/TrlUtil/Resources/KeePass.ico" \
       '[^\.]+_[0-9]+_([0-9]+x[0-9]+)x[0-9]+\.png' \
@@ -129,16 +126,18 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "keepass";
-    exec = "keepass";
-    comment = "Password manager";
-    icon = "keepass";
-    desktopName = "Keepass";
-    genericName = "Password manager";
-    categories = [ "Utility" ];
-    mimeTypes = [ "application/x-keepass2" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "keepass";
+      exec = "keepass";
+      comment = "Password manager";
+      icon = "keepass";
+      desktopName = "Keepass";
+      genericName = "Password manager";
+      categories = [ "Utility" ];
+      mimeTypes = [ "application/x-keepass2" ];
+    })
+  ];
 
   meta = {
     description = "GUI password manager with strong cryptography";

--- a/pkgs/by-name/li/libtas/package.nix
+++ b/pkgs/by-name/li/libtas/package.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , autoreconfHook
 , pkg-config
+, copyDesktopItems
 , SDL2
 , alsa-lib
 , ffmpeg
@@ -23,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-n4iaJG9k+/TFfGMDCYL83Z6paxpm/gY3thP9T84GeQU=";
   };
 
-  nativeBuildInputs = [ autoreconfHook qt5.wrapQtAppsHook pkg-config ];
+  nativeBuildInputs = [ autoreconfHook qt5.wrapQtAppsHook pkg-config copyDesktopItems ];
   buildInputs = [ SDL2 alsa-lib ffmpeg lua5_3 qt5.qtbase ];
 
   configureFlags = [

--- a/pkgs/by-name/po/popcorntime/package.nix
+++ b/pkgs/by-name/po/popcorntime/package.nix
@@ -49,7 +49,8 @@ stdenv.mkDerivation rec {
     "--prefix PATH : ${lib.makeBinPath [ stdenv.cc ]}"
   ];
 
-  desktopItem = makeDesktopItem {
+  desktopItems = [
+    (makeDesktopItem {
       name = pname;
       exec = pname;
       icon = pname;
@@ -58,11 +59,12 @@ stdenv.mkDerivation rec {
       type = "Application";
       desktopName = "Popcorn-Time";
       categories = [ "Video" "AudioVideo" ];
-    };
+    })
+  ];
 
   # Extract and copy executable in $out/bin
   installPhase = ''
-    mkdir -p $out/share/applications $out/bin $out/opt/bin $out/share/icons/hicolor/scalable/apps/
+    mkdir -p $out/bin $out/opt/bin $out/share/icons/hicolor/scalable/apps/
     # we can't unzip it in $out/lib, because nw.js will start with
     # an empty screen. Therefore it will be unzipped in a non-typical
     # folder and symlinked.
@@ -71,8 +73,6 @@ stdenv.mkDerivation rec {
     ln -s $out/opt/popcorntime/Popcorn-Time $out/bin/popcorntime
 
     ln -s $out/opt/popcorntime/src/app/images/icon.png $out/share/icons/hicolor/scalable/apps/popcorntime.png
-
-    ln -s ${desktopItem}/share/applications/popcorntime.desktop $out/share/applications/popcorntime.desktop
   '';
 
   # GSETTINGS_SCHEMAS_PATH is not set in installPhase

--- a/pkgs/by-name/sm/smartgithg/package.nix
+++ b/pkgs/by-name/sm/smartgithg/package.nix
@@ -7,6 +7,7 @@
 , glib
 , gnome
 , wrapGAppsHook
+, copyDesktopItems
 , libXtst
 , which
 }:
@@ -22,7 +23,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-gXfHmRPUhs8s7IQIhN0vQyx8NpLrS28ufNNYOMA4AXw=";
   };
 
-  nativeBuildInputs = [ wrapGAppsHook ];
+  nativeBuildInputs = [ wrapGAppsHook copyDesktopItems ];
 
   buildInputs = [ jre gnome.adwaita-icon-theme gtk3 ];
 
@@ -47,12 +48,11 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     sed -i '/ --login/d' bin/smartgit.sh
-    mkdir -pv $out/{bin,share/applications,share/icons/hicolor/scalable/apps/}
+    mkdir -pv $out/{bin,share/icons/hicolor/scalable/apps/}
     cp -av ./{dictionaries,lib} $out/
     cp -av bin/smartgit.sh $out/bin/smartgit
     ln -sfv $out/bin/smartgit $out/bin/smartgithg
 
-    cp -av $desktopItem/share/applications/* $out/share/applications/
     for icon_size in 32 48 64 128 256; do
         path=$icon_size'x'$icon_size
         icon=bin/smartgit-$icon_size.png
@@ -65,26 +65,28 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  desktopItem = with lib; makeDesktopItem rec {
-    name = "smartgit";
-    exec = "smartgit";
-    comment = meta.description;
-    icon = "smartgit";
-    desktopName = "SmartGit";
-    categories = [
-      "Application"
-      "Development"
-      "RevisionControl"
-    ];
-    mimeTypes = [
-      "x-scheme-handler/git"
-      "x-scheme-handler/smartgit"
-      "x-scheme-handler/sourcetree"
-    ];
-    startupNotify = true;
-    startupWMClass = name;
-    keywords = [ "git" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "smartgit";
+      exec = "smartgit";
+      comment = "GUI for Git, Mercurial, Subversion";
+      icon = "smartgit";
+      desktopName = "SmartGit";
+      categories = [
+        "Application"
+        "Development"
+        "RevisionControl"
+      ];
+      mimeTypes = [
+        "x-scheme-handler/git"
+        "x-scheme-handler/smartgit"
+        "x-scheme-handler/sourcetree"
+      ];
+      startupNotify = true;
+      startupWMClass = "smartgit";
+      keywords = [ "git" ];
+    })
+  ];
 
   meta = with lib; {
     description = "GUI for Git, Mercurial, Subversion";

--- a/pkgs/by-name/vi/vieb/package.nix
+++ b/pkgs/by-name/vi/vieb/package.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildNpmPackage, fetchFromGitHub, electron, makeWrapper, python3, makeDesktopItem, nix-update-script, lib }:
+{ stdenv, buildNpmPackage, fetchFromGitHub, electron, makeWrapper, copyDesktopItems, python3, makeDesktopItem, nix-update-script, lib }:
 
 buildNpmPackage rec {
   pname = "vieb";
@@ -19,26 +19,26 @@ buildNpmPackage rec {
   makeCacheWritable = true;
   dontNpmBuild = true;
 
-  nativeBuildInputs = [ makeWrapper ] ++ lib.optional stdenv.isAarch64 python3;
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ] ++ lib.optional stdenv.isAarch64 python3;
 
-  desktopItem = makeDesktopItem {
-    name = "vieb";
-    exec = "vieb %U";
-    icon = "vieb";
-    desktopName = "Web Browser";
-    genericName = "Web Browser";
-    categories = [ "Network" "WebBrowser" ];
-    mimeTypes = [
-      "text/html"
-      "application/xhtml+xml"
-      "x-scheme-handler/http"
-      "x-scheme-handler/https"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "vieb";
+      exec = "vieb %U";
+      icon = "vieb";
+      desktopName = "Web Browser";
+      genericName = "Web Browser";
+      categories = [ "Network" "WebBrowser" ];
+      mimeTypes = [
+        "text/html"
+        "application/xhtml+xml"
+        "x-scheme-handler/http"
+        "x-scheme-handler/https"
+      ];
+    })
+  ];
 
   postInstall = ''
-    install -Dm0644 {${desktopItem},$out}/share/applications/vieb.desktop
-
     pushd $out/lib/node_modules/vieb/app/img/icons
     for file in *.png; do
       install -Dm0644 $file $out/share/icons/hicolor/''${file//.png}/apps/vieb.png

--- a/pkgs/by-name/yt/ytdownloader/package.nix
+++ b/pkgs/by-name/yt/ytdownloader/package.nix
@@ -2,6 +2,7 @@
 , buildNpmPackage
 , fetchFromGitHub
 , makeWrapper
+, copyDesktopItems
 , ffmpeg
 , yt-dlp
 , makeDesktopItem
@@ -21,18 +22,20 @@ buildNpmPackage rec {
 
   npmDepsHash = "sha256-lhFyiWy9dgnxxaElavzqA4YpRm7cVC23pvL5Kwve58E=";
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
   buildInputs = [ ffmpeg yt-dlp ];
 
-  desktopItem = makeDesktopItem {
-    name = "ytDownloader";
-    exec = "ytdownloader %U";
-    icon = "ytdownloader";
-    desktopName = "ytDownloader";
-    comment = "A modern GUI video and audio downloader";
-    categories = [ "Utility" ];
-    startupWMClass = "ytDownloader";
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ytDownloader";
+      exec = "ytdownloader %U";
+      icon = "ytdownloader";
+      desktopName = "ytDownloader";
+      comment = "A modern GUI video and audio downloader";
+      categories = [ "Utility" ];
+      startupWMClass = "ytDownloader";
+    })
+  ];
 
   ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
@@ -56,7 +59,6 @@ buildNpmPackage rec {
         --add-flags $out/lib/node_modules/ytdownloader/main.js
 
     install -Dm444 assets/images/icon.png $out/share/pixmaps/ytdownloader.png
-    install -Dm444 "${desktopItem}/share/applications/"* -t $out/share/applications
   '';
 
   meta = {

--- a/pkgs/development/tools/database/sqldeveloper/default.nix
+++ b/pkgs/development/tools/database/sqldeveloper/default.nix
@@ -1,17 +1,7 @@
-{ lib, stdenv, makeDesktopItem, makeWrapper, requireFile, unzip, jdk }:
+{ lib, stdenv, makeDesktopItem, makeWrapper, requireFile, unzip, copyDesktopItems, jdk }:
 
 let
   version = "20.4.0.379.2205";
-
-  desktopItem = makeDesktopItem {
-    name = "sqldeveloper";
-    exec = "sqldeveloper";
-    icon = "sqldeveloper";
-    desktopName = "Oracle SQL Developer";
-    genericName = "Oracle SQL Developer";
-    comment = "Oracle's Oracle DB GUI client";
-    categories = [ "Development" ];
-  };
 in
   stdenv.mkDerivation {
 
@@ -49,21 +39,32 @@ in
     sha256 = "1h53gl41ydr7kim6q9ckg3xyhb0rhmwj7jnis0xz6vms52b3h59k";
   };
 
-  nativeBuildInputs = [ makeWrapper unzip ];
+  nativeBuildInputs = [ makeWrapper unzip copyDesktopItems ];
 
   unpackCmd = "unzip $curSrc";
 
   installPhase = ''
-    mkdir -p $out/libexec $out/share/{applications,pixmaps}
+    mkdir -p $out/libexec $out/share/{pixmaps}
     mv * $out/libexec/
 
     mv $out/libexec/icon.png $out/share/pixmaps/sqldeveloper.png
-    cp ${desktopItem}/share/applications/* $out/share/applications
 
     makeWrapper $out/libexec/sqldeveloper/bin/sqldeveloper $out/bin/sqldeveloper \
       --set JAVA_HOME ${jdk.home} \
       --chdir "$out/libexec/sqldeveloper/bin"
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "sqldeveloper";
+      exec = "sqldeveloper";
+      icon = "sqldeveloper";
+      desktopName = "Oracle SQL Developer";
+      genericName = "Oracle SQL Developer";
+      comment = "Oracle's Oracle DB GUI client";
+      categories = [ "Development" ];
+    })
+  ];
 
   meta = with lib; {
     description = "Oracle's Oracle DB GUI client";

--- a/pkgs/development/tools/database/squirrel-sql/default.nix
+++ b/pkgs/development/tools/database/squirrel-sql/default.nix
@@ -1,6 +1,6 @@
 # To enable specific database drivers, override this derivation and pass the
 # driver packages in the drivers argument (e.g. mysql_jdbc, postgresql_jdbc).
-{ lib, stdenv, fetchurl, makeDesktopItem, makeWrapper, unzip
+{ lib, stdenv, fetchurl, makeDesktopItem, copyDesktopItems, makeWrapper, unzip
 , jre
 , drivers ? []
 }:
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Y7eG2otbLjtXvs3mRXWL8jJywuhBQ9i/MfWJXvkxnuU=";
   };
 
-  nativeBuildInputs = [ makeWrapper unzip ];
+  nativeBuildInputs = [ makeWrapper unzip copyDesktopItems ];
   buildInputs = [ jre ];
 
   unpackPhase = ''
@@ -52,20 +52,21 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/icons/hicolor/32x32/apps
     ln -s $out/share/squirrel-sql/icons/acorn.png \
       $out/share/icons/hicolor/32x32/apps/squirrel-sql.png
-    ln -s ${desktopItem}/share/applications $out/share
 
     runHook postInstall
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "squirrel-sql";
-    exec = "squirrel-sql";
-    comment = meta.description;
-    desktopName = "SQuirreL SQL";
-    genericName = "SQL Client";
-    categories = [ "Development" ];
-    icon = "squirrel-sql";
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "squirrel-sql";
+      exec = "squirrel-sql";
+      comment = "Universal SQL Client";
+      desktopName = "SQuirreL SQL";
+      genericName = "SQL Client";
+      categories = [ "Development" ];
+      icon = "squirrel-sql";
+    })
+  ];
 
   meta = with lib; {
     description = "Universal SQL Client";

--- a/pkgs/development/tools/eclipse-mat/default.nix
+++ b/pkgs/development/tools/eclipse-mat/default.nix
@@ -11,6 +11,7 @@
 , libXtst
 , makeDesktopItem
 , makeWrapper
+, copyDesktopItems
 , shared-mime-info
 , stdenv
 , unzip
@@ -36,15 +37,17 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-icmo5zdK0XaH32kXwZUVaQ0VPSGEgvlLr7v7PtdbmCg=";
   };
 
-  desktopItem = makeDesktopItem {
-    name = "eclipse-mat";
-    exec = "eclipse-mat";
-    icon = "eclipse";
-    comment = "Eclipse Memory Analyzer";
-    desktopName = "Eclipse MAT";
-    genericName = "Java Memory Analyzer";
-    categories = [ "Development" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "eclipse-mat";
+      exec = "eclipse-mat";
+      icon = "eclipse";
+      comment = "Eclipse Memory Analyzer";
+      desktopName = "Eclipse MAT";
+      genericName = "Java Memory Analyzer";
+      categories = [ "Development" ];
+    })
+  ];
 
   unpackPhase = ''
     unzip $src
@@ -70,15 +73,12 @@ stdenv.mkDerivation rec {
       --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
       --add-flags "-configuration \$HOME/.eclipse-mat/''${version}/configuration"
 
-    # Create desktop item.
-    mkdir -p $out/share/applications
-    cp ${desktopItem}/share/applications/* $out/share/applications
     mkdir -p $out/share/pixmaps
     find $out/mat/plugins -name 'eclipse*.png' -type f -exec cp {} $out/share/pixmaps \;
     mv $out/share/pixmaps/eclipse64.png $out/share/pixmaps/eclipse.png
   '';
 
-  nativeBuildInputs = [ unzip makeWrapper ];
+  nativeBuildInputs = [ unzip makeWrapper copyDesktopItems ];
   buildInputs = [
     fontconfig
     freetype

--- a/pkgs/development/tools/java/visualvm/default.nix
+++ b/pkgs/development/tools/java/visualvm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, lib, makeWrapper, makeDesktopItem, jdk, gawk }:
+{ stdenv, fetchzip, lib, makeWrapper, copyDesktopItems, makeDesktopItem, jdk, gawk }:
 
 stdenv.mkDerivation rec {
   version = "2.1.8";
@@ -9,16 +9,18 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-yWSB8mqcOG7xd4/8YjPXzGvl7BgyOLdIoyAs69+/kv4=";
   };
 
-  desktopItem = makeDesktopItem {
+  desktopItems = [
+    (makeDesktopItem {
       name = "visualvm";
       exec = "visualvm";
       comment = "Java Troubleshooting Tool";
       desktopName = "VisualVM";
       genericName = "Java Troubleshooting Tool";
       categories = [ "Development" ];
-  };
+    })
+  ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
 
   installPhase = ''
     find . -type f -name "*.dll" -o -name "*.exe"  -delete;

--- a/pkgs/development/tools/jpexs/default.nix
+++ b/pkgs/development/tools/jpexs/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchzip, makeWrapper, makeDesktopItem, jdk8 }:
+{ lib, stdenv, fetchzip, makeWrapper, copyDesktopItems, makeDesktopItem, jdk8 }:
 
 stdenv.mkDerivation rec {
   pname = "jpexs";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
 
   installPhase = ''
     runHook preInstall
@@ -23,22 +23,23 @@ stdenv.mkDerivation rec {
     cp ffdec.jar $out/share/ffdec
     cp -r lib $out/share/ffdec
     cp icon.png $out/share/icons/hicolor/512x512/apps/ffdec.png
-    cp -r ${desktopItem}/share/applications $out/share
 
     makeWrapper ${jdk8}/bin/java $out/bin/ffdec \
       --add-flags "-jar $out/share/ffdec/ffdec.jar"
   '';
 
-  desktopItem = makeDesktopItem rec {
-    name = "ffdec";
-    exec = name;
-    icon = name;
-    desktopName = "JPEXS Free Flash Decompiler";
-    genericName = "Flash Decompiler";
-    comment = meta.description;
-    categories = [ "Development" "Java" ];
-    startupWMClass = "com-jpexs-decompiler-flash-gui-Main";
-  };
+  desktopItems = [
+    (makeDesktopItem rec {
+      name = "ffdec";
+      exec = name;
+      icon = name;
+      desktopName = "JPEXS Free Flash Decompiler";
+      genericName = "Flash Decompiler";
+      comment = meta.description;
+      categories = [ "Development" "Java" ];
+      startupWMClass = "com-jpexs-decompiler-flash-gui-Main";
+    })
+  ];
 
   meta = with lib; {
     description = "Flash SWF decompiler and editor";

--- a/pkgs/development/tools/misc/saleae-logic/default.nix
+++ b/pkgs/development/tools/misc/saleae-logic/default.nix
@@ -9,7 +9,7 @@
 { lib, stdenv, fetchurl, unzip, glib, libSM, libICE, gtk2, libXext, libXft
 , fontconfig, libXrender, libXfixes, libX11, libXi, libXrandr, libXcursor
 , freetype, libXinerama, libxcb, zlib, pciutils
-, makeDesktopItem, xkeyboardconfig, dbus, runtimeShell, libGL
+, makeDesktopItem, copyDesktopItems, xkeyboardconfig, dbus, runtimeShell, libGL
 }:
 
 let
@@ -34,17 +34,19 @@ stdenv.mkDerivation rec {
     sha256 = "0lhair2vsg8sjvzicvfcjfmvy30q7i01xj4z02iqh7pgzpb025h8";
   };
 
-  desktopItem = makeDesktopItem {
-    name = "saleae-logic";
-    exec = "saleae-logic";
-    icon = ""; # the package contains no icon
-    comment = "Software for Saleae logic analyzers";
-    desktopName = "Saleae Logic";
-    genericName = "Logic analyzer";
-    categories = [ "Development" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "saleae-logic";
+      exec = "saleae-logic";
+      icon = ""; # the package contains no icon
+      comment = "Software for Saleae logic analyzers";
+      desktopName = "Saleae Logic";
+      genericName = "Logic analyzer";
+      categories = [ "Development" ];
+    })
+  ];
 
-  nativeBuildInputs = [ unzip ];
+  nativeBuildInputs = [ unzip copyDesktopItems ];
 
   installPhase = ''
     # Copy prebuilt app to $out
@@ -77,10 +79,6 @@ stdenv.mkDerivation rec {
     exec "$out/Logic" "\$@"
     EOF
     chmod a+x "$out"/bin/saleae-logic
-
-    # Copy the generated .desktop file
-    mkdir -p "$out/share/applications"
-    cp "$desktopItem"/share/applications/* "$out/share/applications/"
 
     # Install provided udev rules
     mkdir -p "$out/etc/udev/rules.d"

--- a/pkgs/development/tools/react-native-debugger/default.nix
+++ b/pkgs/development/tools/react-native-debugger/default.nix
@@ -21,6 +21,7 @@
 , cups
 , expat
 , udev
+, copyDesktopItems
 , makeDesktopItem
 , libdrm
 , libxkbcommon
@@ -74,7 +75,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-RioBe0MAR47M84aavFaTJikGsJtcZDak8Tkg3WtX2l0=";
   };
 
-  nativeBuildInputs = [ makeWrapper unzip ];
+  nativeBuildInputs = [ makeWrapper unzip copyDesktopItems ];
   buildCommand = ''
     shopt -s extglob
     mkdir -p $out
@@ -93,18 +94,17 @@ stdenv.mkDerivation rec {
       --add-flags --no-sandbox
 
     ln -s $out/share/react-native-debugger $out/bin/react-native-debugger
-
-    install -Dm644 "${desktopItem}/share/applications/"* \
-      -t $out/share/applications/
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "rndebugger";
-    exec = "react-native-debugger";
-    desktopName = "React Native Debugger";
-    genericName = "React Native Debugger";
-    categories = [ "Development" "Debugger" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "rndebugger";
+      exec = "react-native-debugger";
+      desktopName = "React Native Debugger";
+      genericName = "React Native Debugger";
+      categories = [ "Development" "Debugger" ];
+    })
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/jhen0409/react-native-debugger";

--- a/pkgs/development/tools/redisinsight/default.nix
+++ b/pkgs/development/tools/redisinsight/default.nix
@@ -14,6 +14,7 @@
 , libsass
 , buildPackages
 , pkg-config
+, copyDesktopItems
 , sqlite
 , xdg-utils
 }:
@@ -46,8 +47,17 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "P99+1Dhdg/vznC2KepPrVGNlrofJFydXkZVxgwprIx4=";
   };
 
-  nativeBuildInputs = [ yarn fixup_yarn_lock nodejs makeWrapper python3 nest-cli libsass pkg-config ]
-    ++ lib.optionals stdenv.isDarwin [ desktopToDarwinBundle ];
+  nativeBuildInputs = [
+    yarn
+    fixup_yarn_lock
+    nodejs
+    makeWrapper
+    python3
+    nest-cli
+    libsass
+    pkg-config
+    copyDesktopItems
+  ] ++ lib.optionals stdenv.isDarwin [ desktopToDarwinBundle ];
 
   buildInputs = [ sqlite xdg-utils ];
 
@@ -122,8 +132,6 @@ stdenv.mkDerivation (finalAttrs: {
       ln -s "$icon" "$out/share/icons/hicolor/$(basename $icon .png)/apps/redisinsight.png"
     done
 
-    ln -s "${finalAttrs.desktopItem}/share/applications" "$out/share/applications"
-
     makeWrapper '${electron}/bin/electron' "$out/bin/redisinsight" \
       --add-flags "$out/share/redisinsight/app.asar" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
@@ -133,7 +141,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  desktopItem = makeDesktopItem {
+  desktopItems = makeDesktopItem {
     name = "redisinsight";
     exec = "redisinsight %u";
     icon = "redisinsight";

--- a/pkgs/development/tools/scenic-view/default.nix
+++ b/pkgs/development/tools/scenic-view/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, openjdk, openjfx, gradle_7, makeDesktopItem, perl, writeText, makeWrapper }:
+{ lib, stdenv, fetchFromGitHub, openjdk, openjfx, gradle_7, makeDesktopItem, perl, writeText, makeWrapper
+, copyDesktopItems
+}:
 let
   jdk = openjdk.override (lib.optionalAttrs stdenv.isLinux {
     enableJavaFX = true;
@@ -79,7 +81,7 @@ let
 
 in stdenv.mkDerivation rec {
   inherit pname version src;
-  nativeBuildInputs = [ jdk gradle makeWrapper ];
+  nativeBuildInputs = [ jdk gradle makeWrapper copyDesktopItems ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/games/brogue/default.nix
+++ b/pkgs/games/brogue/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, SDL, ncurses, libtcod, makeDesktopItem }:
+{ lib, stdenv, fetchurl, fetchpatch, copyDesktopItems, SDL, ncurses, libtcod, makeDesktopItem }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "brogue";
@@ -26,21 +26,24 @@ stdenv.mkDerivation (finalAttrs: {
     rm -rf src/libtcod*
   '';
 
+  nativeBuildInputs = [ copyDesktopItems ];
+
   buildInputs = [ SDL ncurses libtcod ];
 
-  desktopItem = makeDesktopItem {
-    name = "brogue";
-    desktopName = "Brogue";
-    genericName = "Roguelike";
-    comment = "Brave the Dungeons of Doom!";
-    icon = "brogue";
-    exec = "brogue";
-    categories = [ "Game" "AdventureGame" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "brogue";
+      desktopName = "Brogue";
+      genericName = "Roguelike";
+      comment = "Brave the Dungeons of Doom!";
+      icon = "brogue";
+      exec = "brogue";
+      categories = [ "Game" "AdventureGame" ];
+    })
+  ];
 
   installPhase = ''
     install -m 555 -D bin/brogue $out/bin/brogue
-    install -m 444 -D ${finalAttrs.desktopItem}/share/applications/brogue.desktop $out/share/applications/brogue.desktop
     install -m 444 -D bin/brogue-icon.png $out/share/icons/hicolor/256x256/apps/brogue.png
     mkdir -p $out/share/brogue
     cp -r bin/fonts $out/share/brogue/

--- a/pkgs/games/clonehero/default.nix
+++ b/pkgs/games/clonehero/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchurl
 , autoPatchelfHook
+, copyDesktopItems
 , gtk3
 , zlib
 , alsa-lib
@@ -32,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [ "out" "doc" ];
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeBuildInputs = [ autoPatchelfHook copyDesktopItems ];
 
   buildInputs = [
     # Load-time libraries (loaded from DT_NEEDED section in ELF binary)
@@ -57,14 +58,16 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
   ];
 
-  desktopItem = makeDesktopItem {
-    name = "clonehero";
-    desktopName = "Clone Hero";
-    comment = finalAttrs.meta.description;
-    icon = "clonehero";
-    exec = "clonehero";
-    categories = [ "Game" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "clonehero";
+      desktopName = "Clone Hero";
+      comment = finalAttrs.meta.description;
+      icon = "clonehero";
+      exec = "clonehero";
+      categories = [ "Game" ];
+    })
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -76,7 +79,6 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r clonehero_Data "$out/share/clonehero"
     ln -s "$out/share/clonehero" "$out/bin/clonehero_Data"
     ln -s "$out/share/clonehero/Resources/UnityPlayer.png" "$out/share/pixmaps/clonehero.png"
-    install -Dm644 "$desktopItem/share/applications/clonehero.desktop" "$out/share/applications/clonehero.desktop"
 
     mkdir -p "$doc/share/doc/clonehero"
     cp -r CLONE_HERO_MANUAL.{pdf,txt} Custom EULA.txt THIRDPARTY.txt "$doc/share/doc/clonehero"

--- a/pkgs/games/doom-ports/doomrunner/default.nix
+++ b/pkgs/games/doom-ports/doomrunner/default.nix
@@ -5,6 +5,7 @@
 , makeDesktopItem
 , wrapQtAppsHook
 , imagemagick
+, copyDesktopItems
 , fetchFromGitHub
 }:
 
@@ -20,14 +21,14 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   buildInputs = [ qtbase ];
-  nativeBuildInputs = [ qmake wrapQtAppsHook imagemagick ];
+  nativeBuildInputs = [ qmake wrapQtAppsHook imagemagick copyDesktopItems ];
 
   makeFlags = [
     "INSTALL_ROOT=${placeholder "out"}"
   ];
 
   postInstall = ''
-    mkdir -p $out/{bin,share/applications}
+    mkdir -p $out/bin
     install -Dm755 $out/usr/bin/DoomRunner $out/bin/DoomRunner
 
     for size in 16 24 32 48 64 128; do
@@ -35,19 +36,20 @@ stdenv.mkDerivation (finalAttrs: {
       convert -background none -resize "$size"x"$size" $PWD/Resources/DoomRunner.ico -flatten $out/share/icons/hicolor/"$size"x"$size"/apps/DoomRunner.png
     done;
 
-    install -m 444 -D "$desktopItem/share/applications/"* -t $out/share/applications/
     rm -rf $out/usr
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "DoomRunner";
-    desktopName = "DoomRunner";
-    comment = "Preset-oriented graphical launcher of ZDoom and derivatives";
-    categories = [ "Game" ];
-    icon = "DoomRunner";
-    type = "Application";
-    exec = "DoomRunner";
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "DoomRunner";
+      desktopName = "DoomRunner";
+      comment = "Preset-oriented graphical launcher of ZDoom and derivatives";
+      categories = [ "Game" ];
+      icon = "DoomRunner";
+      type = "Application";
+      exec = "DoomRunner";
+    })
+  ];
 
   meta = with lib; {
     description = "Graphical launcher of ZDoom and derivatives";

--- a/pkgs/games/duckmarines/default.nix
+++ b/pkgs/games/duckmarines/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, love, lua, makeWrapper, makeDesktopItem }:
+{ lib, stdenv, fetchurl, love, lua, makeWrapper, copyDesktopItems, makeDesktopItem }:
 
 stdenv.mkDerivation rec {
   pname = "duckmarines";
@@ -9,22 +9,24 @@ stdenv.mkDerivation rec {
     sha256 = "07ypbwqcgqc5f117yxy9icix76wlybp1cmykc8f3ivdps66hl0k5";
   };
 
-  desktopItem = makeDesktopItem {
-    name = "duckmarines";
-    exec = pname;
-    icon = icon;
-    comment = "Duck-themed action puzzle video game";
-    desktopName = "Duck Marines";
-    genericName = "duckmarines";
-    categories = [ "Game" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "duckmarines";
+      exec = pname;
+      icon = icon;
+      comment = "Duck-themed action puzzle video game";
+      desktopName = "Duck Marines";
+      genericName = "duckmarines";
+      categories = [ "Game" ];
+    })
+  ];
 
   src = fetchurl {
     url = "https://github.com/SimonLarsen/${pname}/releases/download/v${version}/${pname}-1.0c.love";
     sha256 = "1rvgpkvi4h9zhc4fwb4knhsa789yjcx4a14fi4vqfdyybhvg5sh9";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
   buildInputs = [ lua love ];
 
   dontUnpack = true;
@@ -39,8 +41,6 @@ stdenv.mkDerivation rec {
     makeWrapper ${love}/bin/love $out/bin/${pname} --add-flags $out/share/games/lovegames/${pname}.love
 
     chmod +x $out/bin/${pname}
-    mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications/
   '';
 
   meta = with lib; {

--- a/pkgs/games/freenukum/default.nix
+++ b/pkgs/games/freenukum/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitLab
 , makeDesktopItem
 , installShellFiles
+, copyDesktopItems
 , dejavu_fonts
 , SDL2
 , SDL2_ttf
@@ -10,18 +11,6 @@
 }:
 let
   pname = "freenukum";
-  description = "Clone of the original Duke Nukum 1 Jump'n Run game";
-
-  desktopItem = makeDesktopItem {
-    desktopName = pname;
-    name = pname;
-    exec = pname;
-    icon = pname;
-    comment = description;
-    categories = [ "Game" "ArcadeGame" "ActionGame" ];
-    genericName = pname;
-  };
-
 in
 rustPlatform.buildRustPackage rec {
   inherit pname;
@@ -39,6 +28,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     installShellFiles
+    copyDesktopItems
   ];
 
   buildInputs = [
@@ -60,8 +50,19 @@ rustPlatform.buildRustPackage rec {
     mkdir -p $out/share/doc/freenukum
     install -Dm644 README.md CHANGELOG.md $out/share/doc/freenukum/
     installManPage doc/freenukum.6
-    install -Dm644 "${desktopItem}/share/applications/"* -t $out/share/applications/
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = pname;
+      name = pname;
+      exec = pname;
+      icon = pname;
+      comment = "Clone of the original Duke Nukum 1 Jump'n Run game";
+      categories = [ "Game" "ArcadeGame" "ActionGame" ];
+      genericName = pname;
+    })
+  ];
 
   meta = with lib; {
     description = "Clone of the original Duke Nukum 1 Jump'n Run game";

--- a/pkgs/games/hyperrogue/default.nix
+++ b/pkgs/games/hyperrogue/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, SDL, SDL_ttf, SDL_gfx, SDL_mixer, libpng
+{ lib, stdenv, fetchFromGitHub, copyDesktopItems, SDL, SDL_ttf, SDL_gfx, SDL_mixer, libpng
 , glew, dejavu_fonts, makeDesktopItem }:
 
 stdenv.mkDerivation rec {
@@ -21,17 +21,21 @@ stdenv.mkDerivation rec {
   HYPERROGUE_USE_GLEW = 1;
   HYPERROGUE_USE_PNG = 1;
 
+  nativeBuildInputs = [ copyDesktopItems ];
+
   buildInputs = [ SDL SDL_ttf SDL_gfx SDL_mixer libpng glew ];
 
-  desktopItem = makeDesktopItem {
-    name = "hyperrogue";
-    desktopName = "HyperRogue";
-    genericName = "HyperRogue";
-    comment = meta.description;
-    icon = "hyperrogue";
-    exec = "hyperrogue";
-    categories = [ "Game" "AdventureGame" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "hyperrogue";
+      desktopName = "HyperRogue";
+      genericName = "HyperRogue";
+      comment = meta.description;
+      icon = "hyperrogue";
+      exec = "hyperrogue";
+      categories = [ "Game" "AdventureGame" ];
+    })
+  ];
 
   installPhase = ''
     install -d $out/share/hyperrogue/{sounds,music}
@@ -41,8 +45,6 @@ stdenv.mkDerivation rec {
     install -m 444 -D music/* $out/share/hyperrogue/music
     install -m 444 -D sounds/* $out/share/hyperrogue/sounds
 
-    install -m 444 -D ${desktopItem}/share/applications/hyperrogue.desktop \
-      $out/share/applications/hyperrogue.desktop
     install -m 444 -D hyperroid/app/src/main/res/drawable-ldpi/icon.png \
       $out/share/icons/hicolor/36x36/apps/hyperrogue.png
     install -m 444 -D hyperroid/app/src/main/res/drawable-mdpi/icon.png \

--- a/pkgs/games/maelstrom/default.nix
+++ b/pkgs/games/maelstrom/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeDesktopItem, SDL2, SDL2_net }:
+{ lib, stdenv, fetchurl, copyDesktopItems, makeDesktopItem, SDL2, SDL2_net }:
 
 stdenv.mkDerivation rec {
   pname = "maelstrom";
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
 
   # this fixes a typedef compilation error with gcc-3.x
   patches = [ ./fix-compilation.patch ];
+
+  nativeBuildInputs = [ copyDesktopItems ];
 
   buildInputs = [ SDL2 SDL2_net ];
 

--- a/pkgs/games/mrrescue/default.nix
+++ b/pkgs/games/mrrescue/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, love, lua, makeWrapper, makeDesktopItem }:
+{ lib, stdenv, fetchurl, love, lua, makeWrapper, copyDesktopItems, makeDesktopItem }:
 
 let
   pname = "mrrescue";
@@ -8,17 +8,6 @@ let
     url = "http://tangramgames.dk/img/thumb/mrrescue.png";
     sha256 = "1y5ahf0m01i1ch03axhvp2kqc6lc1yvh59zgvgxw4w7y3jryw20k";
   };
-
-  desktopItem = makeDesktopItem {
-    name = "mrrescue";
-    exec = pname;
-    icon = icon;
-    comment = "Arcade-style fire fighting game";
-    desktopName = "Mr. Rescue";
-    genericName = "mrrescue";
-    categories = [ "Game" ];
-  };
-
 in
 
 stdenv.mkDerivation {
@@ -29,7 +18,7 @@ stdenv.mkDerivation {
     sha256 = "0kzahxrgpb4vsk9yavy7f8nc34d62d1jqjrpsxslmy9ywax4yfpi";
   };
 
-  nativeBuildInputs = [ lua love makeWrapper ];
+  nativeBuildInputs = [ lua love makeWrapper copyDesktopItems ];
 
   dontUnpack = true;
 
@@ -43,9 +32,19 @@ stdenv.mkDerivation {
     makeWrapper ${love}/bin/love $out/bin/${pname} --add-flags $out/share/games/lovegames/${pname}.love
 
     chmod +x $out/bin/${pname}
-    mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications/
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "mrrescue";
+      exec = pname;
+      icon = icon;
+      comment = "Arcade-style fire fighting game";
+      desktopName = "Mr. Rescue";
+      genericName = "mrrescue";
+      categories = [ "Game" ];
+    })
+  ];
 
   meta = with lib; {
     description = "Arcade-style fire fighting game";

--- a/pkgs/games/rocksndiamonds/default.nix
+++ b/pkgs/games/rocksndiamonds/default.nix
@@ -3,6 +3,7 @@
 , fetchurl
 , fetchpatch
 , makeDesktopItem
+, copyDesktopItems
 , SDL2
 , SDL2_image
 , SDL2_mixer
@@ -19,15 +20,19 @@ stdenv.mkDerivation rec {
     hash = "sha256-e/aYjjnEM6MP14FGX+N92U9fRNEjIaDfE1znl6A+4As=";
   };
 
-  desktopItem = makeDesktopItem {
-    name = "rocksndiamonds";
-    exec = "rocksndiamonds";
-    icon = "rocksndiamonds";
-    comment = meta.description;
-    desktopName = "Rocks'n'Diamonds";
-    genericName = "Tile-based puzzle";
-    categories = [ "Game" "LogicGame" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "rocksndiamonds";
+      exec = "rocksndiamonds";
+      icon = "rocksndiamonds";
+      comment = meta.description;
+      desktopName = "Rocks'n'Diamonds";
+      genericName = "Tile-based puzzle";
+      categories = [ "Game" "LogicGame" ];
+    })
+  ];
+
+  nativeBuildInputs = [ copyDesktopItems ];
 
   buildInputs = [ SDL2 SDL2_image SDL2_mixer SDL2_net zlib ];
 
@@ -37,11 +42,9 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    appDir=$out/share/applications
     iconDir=$out/share/icons/hicolor/32x32/apps
-    mkdir -p $out/bin $appDir $iconDir $dataDir
+    mkdir -p $out/bin $iconDir $dataDir
     cp rocksndiamonds $out/bin/
-    ln -s ${desktopItem}/share/applications/* $appDir/
     ln -s $dataDir/graphics/gfx_classic/RocksIcon32x32.png $iconDir/rocksndiamonds.png
     cp -r conf docs graphics levels music sounds $dataDir
   '';

--- a/pkgs/games/scid-vs-pc/default.nix
+++ b/pkgs/games/scid-vs-pc/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, tcl, tk, libX11, zlib, makeWrapper, which, makeDesktopItem }:
+{ lib, fetchurl, tcl, tk, libX11, zlib, makeWrapper, which, copyDesktopItems, makeDesktopItem }:
 
 tcl.mkTclDerivation rec {
   pname = "scid-vs-pc";
@@ -15,7 +15,7 @@ tcl.mkTclDerivation rec {
       --replace "which fc-cache" "false"
   '';
 
-  nativeBuildInputs = [ makeWrapper which ];
+  nativeBuildInputs = [ makeWrapper which copyDesktopItems ];
   buildInputs = [ tk libX11 zlib ];
 
   configureFlags = [
@@ -24,21 +24,20 @@ tcl.mkTclDerivation rec {
   ];
 
   postInstall = ''
-    mkdir -p $out/share/applications
-    cp $desktopItem/share/applications/* $out/share/applications/
-
     install -D icons/scid.png "$out"/share/icons/hicolor/128x128/apps/scid.png
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "scid-vs-pc";
-    desktopName = "Scid vs. PC";
-    genericName = "Chess Database";
-    comment = meta.description;
-    icon = "scid";
-    exec = "scid";
-    categories = [ "Game" "BoardGame" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "scid-vs-pc";
+      desktopName = "Scid vs. PC";
+      genericName = "Chess Database";
+      comment = meta.description;
+      icon = "scid";
+      exec = "scid";
+      categories = [ "Game" "BoardGame" ];
+    })
+  ];
 
   meta = with lib; {
     description = "Chess database with play and training functionality";

--- a/pkgs/games/tome2/default.nix
+++ b/pkgs/games/tome2/default.nix
@@ -1,19 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, makeDesktopItem, ncurses, libX11, boost, cmake }:
+{ lib, stdenv, fetchFromGitHub, makeDesktopItem, ncurses, libX11, boost, cmake, copyDesktopItems }:
 
 let
   pname = "tome2";
   description = "A dungeon crawler similar to Angband, based on the works of Tolkien";
-
-  desktopItem = makeDesktopItem {
-    desktopName = pname;
-    name = pname;
-    exec = "${pname}-x11";
-    icon = pname;
-    comment = description;
-    type = "Application";
-    categories = [ "Game" "RolePlaying" ];
-    genericName = pname;
-  };
 
 in stdenv.mkDerivation {
   inherit pname;
@@ -28,16 +17,24 @@ in stdenv.mkDerivation {
 
   buildInputs = [ ncurses libX11 boost ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake copyDesktopItems ];
 
   cmakeFlags = [
     "-DSYSTEM_INSTALL=ON"
   ];
 
-  postInstall = ''
-    mkdir -p $out/share/applications
-    cp ${desktopItem}/share/applications/*.desktop $out/share/applications
-  '';
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = pname;
+      name = pname;
+      exec = "${pname}-x11";
+      icon = pname;
+      comment = description;
+      type = "Application";
+      categories = [ "Game" "RolePlaying" ];
+      genericName = pname;
+    })
+  ];
 
   meta = with lib; {
     inherit description;

--- a/pkgs/games/worldofgoo/default.nix
+++ b/pkgs/games/worldofgoo/default.nix
@@ -1,19 +1,9 @@
-{ lib, stdenv, requireFile, unzip, makeDesktopItem, SDL2, SDL2_mixer, libogg, libvorbis }:
+{ lib, stdenv, requireFile, unzip, copyDesktopItems, makeDesktopItem, SDL2, SDL2_mixer, libogg, libvorbis }:
 
 let
   arch = if stdenv.system == "x86_64-linux"
     then "x86_64"
     else "x86";
-
-  desktopItem = makeDesktopItem {
-    desktopName = "World of Goo";
-    genericName = "World of Goo";
-    categories = [ "Game" ];
-    exec = "WorldOfGoo.bin.${arch}";
-    icon = "2dboy-worldofgoo";
-    name = "worldofgoo";
-  };
-
 in
 
 stdenv.mkDerivation rec {
@@ -33,7 +23,7 @@ stdenv.mkDerivation rec {
     sha256 = "175e4b0499a765f1564942da4bd65029f8aae1de8231749c56bec672187d53ee";
   };
 
-  nativeBuildInputs = [ unzip ];
+  nativeBuildInputs = [ unzip copyDesktopItems ];
   sourceRoot = pname;
   phases = [ "unpackPhase installPhase" ];
 
@@ -49,16 +39,25 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p $out/bin $out/share/applications $out/share/icons/hicolor/256x256/apps
+    mkdir -p $out/bin $out/share/icons/hicolor/256x256/apps
 
     install -t $out/bin -m755 data/${arch}/WorldOfGoo.bin.${arch}
     cp -R data/noarch/* $out/bin
     cp data/noarch/game/gooicon.png $out/share/icons/hicolor/256x256/apps/2dboy-worldofgoo.png
-    cp ${desktopItem}/share/applications/worldofgoo.desktop \
-      $out/share/applications/worldofgoo.desktop
 
     patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath $libPath $out/bin/WorldOfGoo.bin.${arch}
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = "World of Goo";
+      genericName = "World of Goo";
+      categories = [ "Game" ];
+      exec = "WorldOfGoo.bin.${arch}";
+      icon = "2dboy-worldofgoo";
+      name = "worldofgoo";
+    })
+  ];
 
   meta = with lib; {
     description = "A physics based puzzle game";

--- a/pkgs/servers/pulseaudio/qpaeq.nix
+++ b/pkgs/servers/pulseaudio/qpaeq.nix
@@ -1,25 +1,17 @@
 { mkDerivation
 , makeDesktopItem
+, copyDesktopItems
 , python3
 , fetchurl
 , lib
 , pulseaudio
 }:
 
-let
-  desktopItem = makeDesktopItem {
-    name = "qpaeq";
-    exec = "@out@/bin/qpaeq";
-    icon = "audio-volume-high";
-    desktopName = "qpaeq";
-    genericName = "Audio equalizer";
-    categories = [ "AudioVideo" "Audio" "Mixer" ];
-    startupNotify = false;
-  };
-in
 mkDerivation rec {
   pname = "qpaeq";
   inherit (pulseaudio) version src;
+
+  nativeBuildInputs = [ copyDesktopItems ];
 
   buildInputs = [
     ((python3.withPackages (ps: with ps; [
@@ -34,7 +26,6 @@ mkDerivation rec {
   installPhase = ''
     runHook preInstall
     install -D ./src/utils/qpaeq $out/bin/qpaeq
-    install -D ${desktopItem}/share/applications/qpaeq.desktop $out/share/applications/qpaeq.desktop
     runHook postInstall
   '';
 
@@ -43,6 +34,18 @@ mkDerivation rec {
     wrapQtApp $out/bin/qpaeq
     sed "s|@out@|$out|g" -i $out/share/applications/qpaeq.desktop
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "qpaeq";
+      exec = "@out@/bin/qpaeq";
+      icon = "audio-volume-high";
+      desktopName = "qpaeq";
+      genericName = "Audio equalizer";
+      categories = [ "AudioVideo" "Audio" "Mixer" ];
+      startupNotify = false;
+    })
+  ];
 
   meta = {
     description = "An equalizer interface for pulseaudio's equalizer sinks";

--- a/pkgs/tools/misc/hakuneko/default.nix
+++ b/pkgs/tools/misc/hakuneko/default.nix
@@ -7,22 +7,14 @@
 , stdenv
 , lib
 , wrapGAppsHook
+, copyDesktopItems
 , alsa-lib
 , nss
 , nspr
 , systemd
 , xorg
 }:
-let
-  desktopItem = makeDesktopItem {
-    desktopName = "HakuNeko Desktop";
-    genericName = "Manga & Anime Downloader";
-    categories = [ "Network" "FileTransfer" ];
-    exec = "hakuneko";
-    icon = "hakuneko-desktop";
-    name = "hakuneko-desktop";
-  };
-in
+
 stdenv.mkDerivation rec {
   pname = "hakuneko";
   version = "6.1.7";
@@ -49,6 +41,7 @@ stdenv.mkDerivation rec {
     dpkg
     makeWrapper
     wrapGAppsHook
+    copyDesktopItems
   ];
 
   buildInputs = [
@@ -67,9 +60,6 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     cp -R usr "$out"
-    # Overwrite existing .desktop file.
-    cp "${desktopItem}/share/applications/hakuneko-desktop.desktop" \
-       "$out/share/applications/hakuneko-desktop.desktop"
   '';
 
   runtimeDependencies = [
@@ -80,6 +70,17 @@ stdenv.mkDerivation rec {
     makeWrapper $out/lib/hakuneko-desktop/hakuneko $out/bin/hakuneko \
       "''${gappsWrapperArgs[@]}"
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = "HakuNeko Desktop";
+      genericName = "Manga & Anime Downloader";
+      categories = [ "Network" "FileTransfer" ];
+      exec = "hakuneko";
+      icon = "hakuneko-desktop";
+      name = "hakuneko-desktop";
+    })
+  ];
 
   meta = with lib; {
     description = "Manga & Anime Downloader";

--- a/pkgs/tools/misc/hdfview/default.nix
+++ b/pkgs/tools/misc/hdfview/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
       runHook postBuild
     '';
 
-  desktopItem = makeDesktopItem rec {
+  desktopItems = makeDesktopItem rec {
     name = "HDFView";
     desktopName = name;
     exec = name;

--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -7,6 +7,7 @@
 , openjdk17
 , unzip
 , makeDesktopItem
+, copyDesktopItems
 , icoutils
 , xcbuild
 , protobuf
@@ -25,15 +26,6 @@ let
   };
 
   gradle = gradle_7;
-
-  desktopItem = makeDesktopItem {
-    name = "ghidra";
-    exec = "ghidra";
-    icon = "ghidra";
-    desktopName = "Ghidra";
-    genericName = "Ghidra Software Reverse Engineering Suite";
-    categories = [ "Development" ];
-  };
 
   # postPatch scripts.
   # Adds a gradle step that downloads all the dependencies to the gradle cache.
@@ -98,7 +90,7 @@ in stdenv.mkDerivation {
   inherit pname version src;
 
   nativeBuildInputs = [
-    gradle unzip makeWrapper icoutils protobuf
+    gradle unzip makeWrapper icoutils protobuf copyDesktopItems
   ] ++ lib.optional stdenv.isDarwin xcbuild;
 
   dontStrip = true;
@@ -120,7 +112,7 @@ in stdenv.mkDerivation {
   '';
 
   installPhase = ''
-    mkdir -p "${pkg_path}" "$out/share/applications"
+    mkdir -p "${pkg_path}"
 
     ZIP=build/dist/$(ls build/dist)
     echo $ZIP
@@ -128,8 +120,6 @@ in stdenv.mkDerivation {
     f=("${pkg_path}"/*)
     mv "${pkg_path}"/*/* "${pkg_path}"
     rmdir "''${f[@]}"
-
-    ln -s ${desktopItem}/share/applications/* $out/share/applications
 
     icotool -x "Ghidra/RuntimeScripts/Windows/support/ghidra.ico"
     rm ghidra_4_40x40x32.png
@@ -146,6 +136,17 @@ in stdenv.mkDerivation {
     wrapProgram "${pkg_path}/support/launch.sh" \
       --prefix PATH : ${lib.makeBinPath [ openjdk17 ]}
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ghidra";
+      exec = "ghidra";
+      icon = "ghidra";
+      desktopName = "Ghidra";
+      genericName = "Ghidra Software Reverse Engineering Suite";
+      categories = [ "Development" ];
+    })
+  ];
 
   meta = with lib; {
     description = "A software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission";

--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, copyDesktopItems
 , fetchzip
 , lib
 , makeWrapper
@@ -13,15 +14,6 @@ let
 
   pkg_path = "$out/lib/ghidra";
 
-  desktopItem = makeDesktopItem {
-    name = "ghidra";
-    exec = "ghidra";
-    icon = "ghidra";
-    desktopName = "Ghidra";
-    genericName = "Ghidra Software Reverse Engineering Suite";
-    categories = [ "Development" ];
-  };
-
 in stdenv.mkDerivation rec {
   pname = "ghidra";
   version = "10.4";
@@ -35,6 +27,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [
     makeWrapper
     icoutils
+    copyDesktopItems
   ]
   ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
 
@@ -47,9 +40,7 @@ in stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p "${pkg_path}"
-    mkdir -p "${pkg_path}" "$out/share/applications"
     cp -a * "${pkg_path}"
-    ln -s ${desktopItem}/share/applications/* $out/share/applications
 
     icotool -x "${pkg_path}/support/ghidra.ico"
     rm ghidra_4_40x40x32.png
@@ -67,6 +58,17 @@ in stdenv.mkDerivation rec {
     wrapProgram "${pkg_path}/support/launch.sh" \
       --prefix PATH : ${lib.makeBinPath [ openjdk17 ]}
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ghidra";
+      exec = "ghidra";
+      icon = "ghidra";
+      desktopName = "Ghidra";
+      genericName = "Ghidra Software Reverse Engineering Suite";
+      categories = [ "Development" ];
+    })
+  ];
 
   meta = with lib; {
     description = "A software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission";

--- a/pkgs/tools/security/open-ecard/default.nix
+++ b/pkgs/tools/security/open-ecard/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, jre, pcsclite, makeDesktopItem, makeWrapper }:
+{ lib, stdenv, fetchurl, jre, pcsclite, makeDesktopItem, makeWrapper, copyDesktopItems }:
 
 let
   version = "1.2.4";
@@ -24,17 +24,19 @@ in stdenv.mkDerivation rec {
 
   dontUnpack = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
 
-  desktopItem = makeDesktopItem {
-    name = pname;
-    desktopName = "Open eCard App";
-    genericName = "eCard App";
-    comment = "Client side implementation of the eCard-API-Framework";
-    icon = "oec_logo_bg-transparent.svg";
-    exec = pname;
-    categories = [ "Utility" "Security" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = "Open eCard App";
+      genericName = "eCard App";
+      comment = "Client side implementation of the eCard-API-Framework";
+      icon = "oec_logo_bg-transparent.svg";
+      exec = pname;
+      categories = [ "Utility" "Security" ];
+    })
+  ];
 
   installPhase = ''
     mkdir -p $out/share/java
@@ -42,7 +44,6 @@ in stdenv.mkDerivation rec {
     cp ${srcs.cifs} $out/share/java/cifs-${version}.jar
 
     mkdir -p $out/share/applications $out/share/pixmaps
-    cp $desktopItem/share/applications/* $out/share/applications
     cp ${srcs.logo} $out/share/pixmaps/oec_logo_bg-transparent.svg
 
     mkdir -p $out/bin


### PR DESCRIPTION
## Description of changes

As the title says. Now we use `desktopItems` + `copyDesktopItems` instead of `desktopItem` + manual installation. Also fixed some dumb mistakes.

This is tested with:

```sh
grep -rl desktopItem pkgs | xargs grep -L copyDesktopItems
```

Also some foolish usage with:

```sh
grep -rl desktopItem pkgs | xargs grep -L desktopItems | xargs grep -l copyDesktopItems
```

I found that there are even some packages that do not have the defined desktop entry installed at all...

~~I admit that I am a little dizzy now, and there are still many files that need to be modified, so I will mark as draft for the time being.~~

Test guide:

1. build all packages (Sadly I don't think my laptop can finish this in a reasonable time...) and check failures
2. Diff `$out/share/applications` with the same package in last commit

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
