### PR TITLE
electron: Add libnotify, pipewire, and several other runtime dependencies to RPATH; fixes desktop notifications and screenshare

### DIFF
--- a/pkgs/applications/blockchains/terra-station/default.nix
+++ b/pkgs/applications/blockchains/terra-station/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv
 , fetchurl
-, gcc-unwrapped
 , dpkg
 , util-linux
 , bash
@@ -57,8 +56,7 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     makeWrapper ${electron}/bin/electron $out/bin/${pname} \
-      --add-flags $out/share/${pname}/resources/app.asar \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ gcc-unwrapped.lib ]}"
+      --add-flags $out/share/${pname}/resources/app.aasar
   '';
 
   meta = with lib; {

--- a/pkgs/applications/editors/standardnotes/default.nix
+++ b/pkgs/applications/editors/standardnotes/default.nix
@@ -1,5 +1,12 @@
-{ lib, stdenv, fetchurl, dpkg, makeWrapper, electron, libsecret
-, desktop-file-utils , callPackage }:
+{ lib
+, stdenv
+, fetchurl
+, dpkg
+, makeWrapper
+, electron
+, desktop-file-utils
+, callPackage
+}:
 
 let
 
@@ -33,8 +40,7 @@ stdenv.mkDerivation rec {
     cp -R opt/Standard\ Notes/resources/app.asar $out/share/standardnotes/
 
     makeWrapper ${electron}/bin/electron $out/bin/standardnotes \
-      --add-flags $out/share/standardnotes/app.asar \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libsecret stdenv.cc.cc.lib ]}
+      --add-flags $out/share/standardnotes/app.asar
 
     ${desktop-file-utils}/bin/desktop-file-install --dir $out/share/applications \
       --set-key Exec --set-value standardnotes usr/share/applications/standard-notes.desktop

--- a/pkgs/applications/misc/logseq/default.nix
+++ b/pkgs/applications/misc/logseq/default.nix
@@ -60,8 +60,7 @@ in {
     makeWrapper ${electron_27}/bin/electron $out/bin/${pname} \
       --set "LOCAL_GIT_DIRECTORY" ${git} \
       --add-flags $out/share/${pname}/resources/app \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
@@ -16,7 +16,6 @@
 , AppKit
 , CoreServices
 , desktopToDarwinBundle
-, libnotify
 , useKeytar ? true
 }:
 
@@ -79,11 +78,6 @@ stdenv.mkDerivation (finalAttrs: builtins.removeAttrs pinData [ "hashes" ] // {
   '';
 
   installPhase =
-    let
-      libPath = lib.makeLibraryPath [
-        libnotify
-      ];
-    in
   ''
     runHook preInstall
 
@@ -111,7 +105,6 @@ stdenv.mkDerivation (finalAttrs: builtins.removeAttrs pinData [ "hashes" ] // {
     # LD_PRELOAD workaround for sqlcipher not found: https://github.com/matrix-org/seshat/issues/102
     makeWrapper '${electron}/bin/electron' "$out/bin/${executableName}" \
       --set LD_PRELOAD ${sqlcipher}/lib/libsqlcipher.so \
-      --set LD_LIBRARY_PATH "${libPath}" \
       --add-flags "$out/share/element/electron" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
 

--- a/pkgs/applications/networking/instant-messengers/jitsi-meet-electron/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jitsi-meet-electron/default.nix
@@ -10,7 +10,6 @@
 , libXtst
 , zlib
 , electron
-, pipewire
 }:
 
 buildNpmPackage rec {
@@ -72,7 +71,6 @@ buildNpmPackage rec {
 
     makeWrapper ${lib.getExe electron} $out/bin/jitsi-meet-electron \
         --add-flags $out/share/jitsi-meet-electron/resources/app.asar \
-        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ pipewire ]} \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
         --inherit-argv0
 

--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
@@ -9,9 +9,6 @@
 , fetchYarnDeps
 , prefetch-yarn-deps
 , electron
-, libnotify
-, libpulseaudio
-, pipewire
 , alsa-utils
 , which
 , testers
@@ -72,11 +69,10 @@ stdenv.mkDerivation (finalAttrs: {
     done
     popd
 
-    # Linux needs 'aplay' for notification sounds, 'libpulse' for meeting sound, 'libpipewire' for screen sharing and 'libnotify' for notifications
+    # Linux needs 'aplay' for notification sounds
     makeWrapper '${electron}/bin/electron' "$out/bin/teams-for-linux" \
       ${lib.optionalString stdenv.isLinux ''
         --prefix PATH : ${lib.makeBinPath [ alsa-utils which ]} \
-        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libpulseaudio pipewire libnotify ]} \
       ''} \
       --add-flags "$out/share/teams-for-linux/app.asar" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"

--- a/pkgs/applications/networking/instant-messengers/webcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/webcord/default.nix
@@ -3,9 +3,6 @@
 , fetchFromGitHub
 , copyDesktopItems
 , python3
-, pipewire
-, libpulseaudio
-, libnotify
 , xdg-utils
 , electron_29
 , makeDesktopItem

--- a/pkgs/applications/networking/instant-messengers/webcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/webcord/default.nix
@@ -42,11 +42,6 @@ buildNpmPackage rec {
   # override installPhase so we can copy the only folders that matter
   installPhase =
     let
-      libPath = lib.makeLibraryPath [
-        libpulseaudio
-        pipewire
-        libnotify
-      ];
       binPath = lib.makeBinPath [ xdg-utils ];
     in
   ''
@@ -62,7 +57,6 @@ buildNpmPackage rec {
 
     # Add xdg-utils to path via suffix, per PR #181171
     makeWrapper '${lib.getExe electron_29}' $out/bin/webcord \
-      --prefix LD_LIBRARY_PATH : ${libPath}:$out/opt/webcord \
       --suffix PATH : "${binPath}" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
       --add-flags $out/lib/node_modules/webcord/

--- a/pkgs/applications/office/super-productivity/default.nix
+++ b/pkgs/applications/office/super-productivity/default.nix
@@ -38,8 +38,7 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     makeWrapper ${electron}/bin/electron $out/bin/${pname} \
-      --add-flags $out/share/${pname}/resources/app.asar \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc ]}"
+      --add-flags $out/share/${pname}/resources/app.asar
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -8,15 +8,11 @@
 , copyDesktopItems
 , vencord
 , electron
-, pipewire
-, libpulseaudio
 , libicns
-, libnotify
 , jq
 , moreutils
 , cacert
 , nodePackages
-, speechd
 , withTTS ? true
   # Enables the use of vencord from nixpkgs instead of
   # letting vesktop manage it's own version
@@ -116,15 +112,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   # this is consistent with other nixpkgs electron packages and upstream, as far as I am aware
   installPhase =
-    let
-      # this is mainly required for venmic
-      libPath = lib.makeLibraryPath ([
-        libpulseaudio
-        libnotify
-        pipewire
-        stdenv.cc.cc.lib
-      ] ++ lib.optional withTTS speechd);
-    in
     ''
       runHook preInstall
 
@@ -139,7 +126,6 @@ stdenv.mkDerivation (finalAttrs: {
       done
 
       makeWrapper ${electron}/bin/electron $out/bin/vesktop \
-        --prefix LD_LIBRARY_PATH : ${libPath} \
         --add-flags $out/opt/Vesktop/resources/app.asar \
         ${lib.optionalString withTTS "--add-flags \"--enable-speech-dispatcher\""} \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"

--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -14,6 +14,7 @@
 , pkgs
 , pkgsBuildHost
 , pipewire
+, libsecret
 , info
 }:
 
@@ -196,6 +197,7 @@ in (chromium.override { upstream-info = info.chromium; }).mkDerivation (base: {
         libnotify
         pipewire
         stdenv.cc.cc.lib
+        libsecret
       ];
     in
   base.postFixup + ''

--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -13,7 +13,7 @@
 , unzip
 , pkgs
 , pkgsBuildHost
-
+, pipewire
 , info
 }:
 
@@ -194,6 +194,7 @@ in (chromium.override { upstream-info = info.chromium; }).mkDerivation (base: {
     let
       libPath = lib.makeLibraryPath [
         libnotify
+        pipewire
       ];
     in
   base.postFixup + ''

--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -190,6 +190,18 @@ in (chromium.override { upstream-info = info.chromium; }).mkDerivation (base: {
     runHook postInstall
   '';
 
+  postFixup =
+    let
+      libPath = lib.makeLibraryPath [
+        libnotify
+      ];
+    in
+  base.postFixup + ''
+    patchelf \
+      --add-rpath "${libPath}" \
+      $out/libexec/electron/electron
+  '';
+
   requiredSystemFeatures = [ "big-parallel" ];
 
   passthru = {

--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -15,6 +15,7 @@
 , pkgsBuildHost
 , pipewire
 , libsecret
+, libpulseaudio
 , info
 }:
 
@@ -198,6 +199,7 @@ in (chromium.override { upstream-info = info.chromium; }).mkDerivation (base: {
         pipewire
         stdenv.cc.cc.lib
         libsecret
+        libpulseaudio
       ];
     in
   base.postFixup + ''

--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -16,6 +16,7 @@
 , pipewire
 , libsecret
 , libpulseaudio
+, speechd
 , info
 }:
 
@@ -200,6 +201,7 @@ in (chromium.override { upstream-info = info.chromium; }).mkDerivation (base: {
         stdenv.cc.cc.lib
         libsecret
         libpulseaudio
+        speechd
       ];
     in
   base.postFixup + ''

--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -195,6 +195,7 @@ in (chromium.override { upstream-info = info.chromium; }).mkDerivation (base: {
       libPath = lib.makeLibraryPath [
         libnotify
         pipewire
+        stdenv.cc.cc.lib
       ];
     in
   base.postFixup + ''


### PR DESCRIPTION
mattermost-desktop is missing the libnotify runtime dependency, so desktop notifications are not shown.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
