### PR TITLE
lomiri.* Fix lack of output fixup in pkg-config files, update pkg-config calls with new CMake option

### DIFF
--- a/pkgs/desktops/lomiri/development/deviceinfo/default.nix
+++ b/pkgs/desktops/lomiri/development/deviceinfo/default.nix
@@ -27,6 +27,12 @@ stdenv.mkDerivation (finalAttrs: {
     "bin"
   ];
 
+  postPatch = ''
+    # For our automatic pkg-config output patcher to work, prefix must be used here
+    substituteInPlace headers/deviceinfo.pc.in \
+      --replace-fail 'libdir=''${exec_prefix}' 'libdir=''${prefix}'
+  '';
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lomiri/development/trust-store/default.nix
+++ b/pkgs/desktops/lomiri/development/trust-store/default.nix
@@ -44,12 +44,14 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     # pkg-config patching hook expects prefix variable
     substituteInPlace data/trust-store.pc.in \
-      --replace 'includedir=''${exec_prefix}' 'includedir=''${prefix}'
+      --replace-fail 'libdir=''${exec_prefix}' 'libdir=''${prefix}' \
+      --replace-fail 'includedir=''${exec_prefix}' 'includedir=''${prefix}'
 
     substituteInPlace src/core/trust/terminal_agent.h \
-      --replace '/bin/whiptail' '${lib.getExe' newt "whiptail"}'
+      --replace-fail '/bin/whiptail' '${lib.getExe' newt "whiptail"}'
   '' + lib.optionalString (!finalAttrs.doCheck) ''
-    sed -i CMakeLists.txt -e '/add_subdirectory(tests)/d'
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'add_subdirectory(tests)' ""
   '';
 
   strictDeps = true;

--- a/pkgs/desktops/lomiri/services/biometryd/default.nix
+++ b/pkgs/desktops/lomiri/services/biometryd/default.nix
@@ -38,12 +38,17 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    # Uses pkg_get_variable, cannot substitute prefix with that
+    # Substitute systemd's prefix in pkg-config call
     substituteInPlace data/CMakeLists.txt \
-      --replace 'pkg_get_variable(SYSTEMD_SYSTEM_UNIT_DIR systemd systemdsystemunitdir)' 'set(SYSTEMD_SYSTEM_UNIT_DIR "''${CMAKE_INSTALL_PREFIX}/lib/systemd/system")'
+      --replace-fail 'pkg_get_variable(SYSTEMD_SYSTEM_UNIT_DIR systemd systemdsystemunitdir)' 'pkg_get_variable(SYSTEMD_SYSTEM_UNIT_DIR systemd systemdsystemunitdir DEFINE_VARIABLES prefix=''${CMAKE_INSTALL_PREFIX})'
 
     substituteInPlace src/biometry/qml/Biometryd/CMakeLists.txt \
-      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
+      --replace-fail "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
+
+    # For our automatic pkg-config output patcher to work, prefix must be used here
+    substituteInPlace data/biometryd.pc.in \
+      --replace-fail 'libdir=''${exec_prefix}' 'libdir=''${prefix}' \
+      --replace-fail 'includedir=''${exec_prefix}' 'includedir=''${prefix}' \
   '' + lib.optionalString (!finalAttrs.doCheck) ''
     sed -i -e '/add_subdirectory(tests)/d' CMakeLists.txt
   '';


### PR DESCRIPTION
## Description of changes

1. I noticed that some pkg-config files didn't get patched with the correct outputs (`$dev` for `includedir`). It didn't cause any issues so far, but let's fix them anyway. In the case of `u1db-qt`, the pkg-config file actually has a completely broken includedir.

3. Also, since we now have a newer CMake, we can start adjusting the substitutions on pkg-config calls to just add a `prefix` substitution, instead of replacing them entirely with path hardcodings.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
