### PR TITLE
Add taskwarrior3 and taskchampion-sync-server

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13315,6 +13315,12 @@
       fingerprint = "64BE BF11 96C3 DD7A 443E  8314 1DC0 82FA DE5B A863";
     }];
   };
+  mlaradji = {
+    name = "Mohamed Laradji";
+    email = "mlaradji@pm.me";
+    github = "mlaradji";
+    githubId = 33703663;
+  };
   mlatus = {
     email = "wqseleven@gmail.com";
     github = "Ninlives";

--- a/pkgs/by-name/ta/taskchampion-sync-server/package.nix
+++ b/pkgs/by-name/ta/taskchampion-sync-server/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "taskchampion-sync-server";
+  version = "0.4.1-unstable-2024-04-08";
+  src = fetchFromGitHub {
+      owner = "GothenburgBitFactory";
+      repo = "taskchampion-sync-server";
+      rev = "31cb732f0697208ef9a8d325a79688612087185a";
+      fetchSubmodules = false;
+      sha256 = "sha256-CUgXJcrCOenbw9ZDFBody5FAvpT1dsZBojJk3wOv9U4=";
+    };
+
+  cargoHash = "sha256-TpShnVQ2eFNLXJzOTlWVaLqT56YkP4zCGCf3yVtNcvI=";
+
+  # cargo tests fail when checkType="release" (default)
+  checkType = "debug";
+
+  meta = {
+    description = "Sync server for Taskwarrior 3";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/GothenburgBitFactory/taskchampion-sync-server";
+    maintainers = with lib.maintainers; [mlaradji];
+    mainProgram = "taskchampion-sync-server";
+  };
+}

--- a/pkgs/by-name/ta/taskwarrior3/package.nix
+++ b/pkgs/by-name/ta/taskwarrior3/package.nix
@@ -1,0 +1,83 @@
+{
+  rustPlatform,
+  rustc,
+  cargo,
+  corrosion,
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  libuuid,
+  gnutls,
+  python3,
+  xdg-utils,
+  installShellFiles,
+}:
+stdenv.mkDerivation rec {
+    pname = "taskwarrior";
+    version = "3.0.0-unstable-2024-04-07";
+    src = fetchFromGitHub {
+      owner = "GothenburgBitFactory";
+      repo = "taskwarrior";
+      rev = "fd306712b85dda3ea89de4e617aebeb98b2ede80";
+      fetchSubmodules = true;
+      sha256 = "sha256-vzfHq/LHfnTx6CVGFCuO6W5aSqj1jVqldMdmyciSDDk=";
+    };
+
+  postPatch = ''
+    substituteInPlace src/commands/CmdNews.cpp \
+      --replace "xdg-open" "${lib.getBin xdg-utils}/bin/xdg-open"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    libuuid
+    python3
+    installShellFiles
+    corrosion
+    cargo
+    rustc
+    rustPlatform.cargoSetupHook
+  ];
+
+  doCheck = true;
+  preCheck = ''
+    patchShebangs --build test
+  '';
+  checkTarget = "test";
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    name = "${pname}-${version}-cargo-deps";
+    inherit src;
+    sourceRoot = src.name;
+    hash = "sha256-zQca/1tI/GUCekKhrg2iSL+h69SH6Ttsj3MqwDKj8HQ=";
+  };
+  cargoRoot = "./";
+  preConfigure = ''
+    export CMAKE_PREFIX_PATH="${corrosion}:$CMAKE_PREFIX_PATH"
+  '';
+
+  postInstall = ''
+    # ZSH is installed automatically from some reason, only bash and fish need
+    # manual installation
+    installShellCompletion --cmd task \
+      --bash $out/share/doc/task/scripts/bash/task.sh \
+      --fish $out/share/doc/task/scripts/fish/task.fish
+    rm -r $out/share/doc/task/scripts/bash
+    rm -r $out/share/doc/task/scripts/fish
+    # Install vim and neovim plugin
+    mkdir -p $out/share/vim-plugins
+    mv $out/share/doc/task/scripts/vim $out/share/vim-plugins/task
+    mkdir -p $out/share/nvim
+    ln -s $out/share/vim-plugins/task $out/share/nvim/site
+  '';
+
+  meta = with lib; {
+    description = "Highly flexible command-line tool to manage TODO lists";
+    homepage = "https://taskwarrior.org";
+    license = licenses.mit;
+    maintainers = with maintainers; [marcweber oxalica mlaradji];
+    mainProgram = "task";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

No existing packages were modified. I added myself (@mlaradji) to the maintainers list. I added new package definitions for `taskwarrior3` and its associated sync server `taskchampion-sync-server`. This PR resolves #300679.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
