### PR TITLE
dbus-broker: 35 -> 36

### DIFF
--- a/pkgs/os-specific/linux/dbus-broker/default.nix
+++ b/pkgs/os-specific/linux/dbus-broker/default.nix
@@ -40,13 +40,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dbus-broker";
-  version = "35";
+  version = "36";
 
   src = fetchFromGitHub {
     owner = "bus1";
     repo = "dbus-broker";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Qwi9X5jXHiQ3TOWefzv/p7x8/JkQW1QgdYji5SpLej0=";
+    hash = "sha256-5dAMKjybqrHG57vArbtWEPR/svSj2ION75JrjvnnpVM=";
   };
 
   patches = [

--- a/pkgs/os-specific/linux/dbus-broker/disable-test.patch
+++ b/pkgs/os-specific/linux/dbus-broker/disable-test.patch
@@ -1,11 +1,14 @@
---- b/src/meson.build
-+++ a/src/meson.build
-@@ -196,9 +195,6 @@
- test_fdlist = executable('test-fdlist', ['util/test-fdlist.c'], dependencies: dep_bus)
- test('Utility File-Desciptor Lists', test_fdlist)
-
--test_fs = executable('test-fs', ['util/test-fs.c'], dependencies: dep_bus)
--test('File System Helpers', test_fs)
+diff --git a/src/meson.build b/src/meson.build
+index 4b9bc71..221ed5c 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -202,9 +202,6 @@ test('Error Handling', test_error, suite: 'unit')
+ test_fdlist = executable('test-fdlist', sources: ['util/test-fdlist.c'], kwargs: test_kwargs)
+ test('Utility File-Desciptor Lists', test_fdlist, suite: 'unit')
+ 
+-test_fs = executable('test-fs', sources: ['util/test-fs.c'], kwargs: test_kwargs)
+-test('File System Helpers', test_fs, suite: 'unit')
 -
- test_match = executable('test-match', ['bus/test-match.c'], dependencies: dep_bus)
- test('D-Bus Match Handling', test_match)
+ test_match = executable('test-match', sources: ['bus/test-match.c'], kwargs: test_kwargs)
+ test('D-Bus Match Handling', test_match, suite: 'unit')
+ 


### PR DESCRIPTION
## Description of changes

See https://github.com/bus1/dbus-broker/releases/tag/v36

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
