### PR TITLE
plover.dev: 4.0.0.dev10 -> 4.0.0

### DIFF
--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -2,59 +2,158 @@
   lib,
   config,
   fetchFromGitHub,
-  python3Packages,
-  wmctrl,
-  qtbase,
-  mkDerivationWith,
+  # Plover is currently tested with python 3.10 and do not seems to work with more recent versions
+  # https://github.com/openstenoproject/plover/commits/a8ac3631bee1971eec2b41b74fbebdad4750291a
+  python310Packages,
+  qt5,
+  dbus,
 }:
 
 {
   dev =
-    with python3Packages;
-    mkDerivationWith buildPythonPackage rec {
-      pname = "plover";
-      version = "4.0.0.dev10";
+    let
+      inherit (python310Packages)
+        appdirs
+        babel
+        buildPythonPackage
+        evdev
+        pyqt5
+        pyserial
+        pytest-qt
+        pytestCheckHook
+        setuptools
+        stdenv
+        wcwidth
+        xlib
+        ;
+      inherit (lib) licenses maintainers platforms;
+      plover_stroke = buildPythonPackage rec {
+        pname = "plover_stroke";
+        version = "1.1.0";
 
-      meta = with lib; {
-        broken = stdenv.hostPlatform.isDarwin;
-        description = "OpenSteno Plover stenography software";
-        maintainers = with maintainers; [
-          twey
-          kovirobi
-        ];
-        license = licenses.gpl2;
+        pyproject = true;
+
+        src = fetchFromGitHub {
+          owner = "openstenoproject";
+          repo = "plover_stroke";
+          rev = "refs/tags/${version}";
+          sha256 = "sha256-A75OMzmEn0VmDAvmQCp6/7uptxzwWJTwsih3kWlYioA=";
+        };
+
+        propagatedBuildInputs = [ setuptools ];
+
+        nativeCheckInputs = [ pytestCheckHook ];
+        pythonImportsCheck = [ "plover_stroke" ];
+
+        meta = {
+          description = "Stroke handling helper library for Plover";
+          license = licenses.gpl2Plus;
+          homepage = "https://github.com/openstenoproject/plover_stroke";
+          platforms = platforms.linux ++ platforms.windows;
+          maintainers = [ maintainers.FirelightFlagboy ];
+        };
       };
+
+      rtf_tokenize = buildPythonPackage rec {
+        pname = "rtf_tokenize";
+        version = "1.0.0";
+
+        pyproject = true;
+
+        src = fetchFromGitHub {
+          owner = "openstenoproject";
+          repo = "rtf_tokenize";
+          rev = "refs/tags/${version}";
+          sha256 = "sha256-zwD2sRYTY1Kmm/Ag2hps9VRdUyQoi4zKtDPR+F52t9A=";
+        };
+
+        propagatedBuildInputs = [ setuptools ];
+
+        nativeCheckInputs = [ pytestCheckHook ];
+        pythonImportsCheck = [ "rtf_tokenize" ];
+
+        meta = {
+          description = "Simple RTF tokenizer";
+          license = licenses.gpl2Plus;
+          homepage = "https://github.com/openstenoproject/rtf_tokenize";
+          platforms = platforms.linux ++ platforms.windows;
+          maintainers = [ maintainers.FirelightFlagboy ];
+        };
+      };
+    in
+    buildPythonPackage rec {
+      pname = "plover";
+      version = "4.0.0";
+
+      pyproject = true;
 
       src = fetchFromGitHub {
         owner = "openstenoproject";
         repo = "plover";
-        rev = "v${version}";
-        sha256 = "sha256-oJ7+R3ZWhUbNTTAw1AfMg2ur8vW1XEbsa5FgSTam1Ns=";
+        rev = "refs/tags/v${version}";
+        sha256 = "sha256-9oDsAbpF8YbLZyRzj9j5tk8QGi0o1F+8vB5YLJGqN+4=";
       };
 
-      # I'm not sure why we don't find PyQt5 here but there's a similar
-      # sed on many of the platforms Plover builds for
-      postPatch = "sed -i /PyQt5/d setup.cfg";
+      postPatch = ''
+        # Plover dynamically tries to loads the dbus library, but as issue finding it's path so we manually set it.
+        substituteInPlace plover/oslayer/linux/log_dbus.py \
+          --replace-fail "ctypes.util.find_library('dbus-1')" "'${dbus.lib}/lib/libdbus-1.so'"
+
+        # This fix loading the QT Gui in plover, it should no longer be needed once plover is updated to 4.0.1.
+        # https://stackoverflow.com/questions/66125129/unknownextra-error-when-installing-via-setup-py-but-not-via-pip
+        substituteInPlace setup.cfg --replace-fail "plover.gui_qt.main [gui_qt]" "plover.gui_qt.main"
+      '';
+
+      nativeBuildInputs = [
+        setuptools
+        qt5.wrapQtAppsHook
+      ];
+
+      propagatedBuildInputs = [
+        appdirs
+        babel
+        evdev
+        plover_stroke
+        pyqt5
+        pyserial
+        rtf_tokenize
+        setuptools
+        wcwidth
+        xlib
+      ];
+
+      buildInputs = [
+        qt5.qtwayland
+      ];
 
       nativeCheckInputs = [
-        pytest
-        mock
+        pytestCheckHook
+        pytest-qt
       ];
-      propagatedBuildInputs = [
-        babel
-        pyqt5
-        xlib
-        pyserial
-        appdirs
-        wcwidth
-        setuptools
-      ];
+
+      preCheck = ''
+        export HOME=$(mktemp -d)
+        export QT_PLUGIN_PATH="${qt5.qtbase.bin}/${qt5.qtbase.qtPluginPrefix}"
+        export QT_QPA_PLATFORM_PLUGIN_PATH="${qt5.qtbase.bin}/lib/qt-${qt5.qtbase.version}/plugins";
+        export QT_QPA_PLATFORM=offscreen
+      '';
 
       dontWrapQtApps = true;
 
       preFixup = ''
         makeWrapperArgs+=("''${qtWrapperArgs[@]}")
       '';
+
+      meta = {
+        mainProgram = "plover";
+        broken = stdenv.hostPlatform.isDarwin;
+        description = "OpenSteno Plover stenography software";
+        homepage = "https://www.openstenoproject.org/plover/";
+        maintainers = builtins.attrValues {
+          inherit (maintainers) FirelightFlagboy twey kovirobi;
+        };
+        license = licenses.gpl2Plus;
+      };
     };
 }
 // lib.optionalAttrs config.allowAliases {


### PR DESCRIPTION
## Description of changes

Changelog for [plover-v4.0.0rc2](https://github.com/openstenoproject/plover/releases/tag/v4.0.0rc2).

This updates the Plover development version to 4.0.0.rc2.

- I was having an issue first when build the project without `pyproject = true`.

  The error was `Requirements should be satisfied by a PEP 517 installer.`

- With `pyproject` enabled, 2 dependencies were missing: `plover_stroke` and `rtf_tokenize`.

- `postPatch` step was removed since the `setup.cfg` file no longer specify `PyQt5`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
