### PR TITLE
doom64ex-minus: init at 1

### DIFF
--- a/pkgs/by-name/do/doom64ex-minus/package.nix
+++ b/pkgs/by-name/do/doom64ex-minus/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchFromSourcehut,
+  sdl3,
+  fluidsynth,
+  libGL,
+  libpng,
+  pkg-config,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "doom64ex-minus";
+  version = "1";
+
+  src = fetchFromSourcehut {
+    owner = "~marcin-serwin";
+    repo = "Doom64EX-Minus";
+    rev = "z${finalAttrs.version}";
+    hash = "sha256-V0+p+UGSMxJSVX22VL9e8MNHlXDRrhdoEND+Dfv04HI=";
+  };
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    fluidsynth
+    libGL
+    libpng
+    sdl3
+  ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin { LDFLAGS = "-framework OpenGL"; };
+  preBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    buildFlagsArray+=('LIBS=sdl3 fluidsynth libpng')
+  '';
+
+  meta = {
+    description = "Improved, modern version of Doom64EX";
+    homepage = "https://git.sr.ht/~marcin-serwin/Doom64EX-Minus";
+    license = with lib.licenses; [
+      gpl2Plus
+      unfree
+    ];
+    longDescription = ''
+      You will need DOOM64.WAD from Nightdive Studios'
+      DOOM 64 Remastered release. To extract it from the GOG
+      installer, run:
+      ``` bash
+      nix-shell -p innoextract.out --run \
+      'innoextract -g /path/to/installer.exe \
+      -I DOOM64.WAD -d ~/.local/share/doom64ex-minus'
+      ```
+    '';
+    maintainers = with lib.maintainers; [
+      keenanweaver
+      marcin-serwin
+    ];
+    mainProgram = "doom64ex-minus";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

Adds ~`doom64ex-plus`~`doom64ex-minus`, closes https://github.com/NixOS/nixpkgs/issues/299262

Cannot test locally for darwin or aarch64.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
