### PR TITLE
storcli: 7.2309.00 -> 7.2904.00, move to by-name

### DIFF
--- a/pkgs/by-name/st/storcli/package.nix
+++ b/pkgs/by-name/st/storcli/package.nix
@@ -2,15 +2,17 @@
 , stdenvNoCC
 , fetchzip
 , rpmextract
+, testers
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "storcli";
-  version = "7.2309.00";
+  version = "7.2904.00";
+  phase = "30";
 
   src = fetchzip {
-    url = "https://docs.broadcom.com/docs-and-downloads/raid-controllers/raid-controllers-common-files/Unified_storcli_all_os_${version}00.0000.zip";
-    sha256 = "sha256-n2MzT2LHLHWMWhshWXJ/Q28w9EnLrW6t7hLNveltxLo=";
+    url = "https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_nvme_12g_p${finalAttrs.phase}/STORCLI_SAS3.5_P${finalAttrs.phase}.zip";
+    hash = "sha256-VfK71eiDonzWdR6g5zkXgRRi25vwoI4DDL6xy3zsfak=";
   };
 
   nativeBuildInputs = [ rpmextract ];
@@ -23,7 +25,7 @@ stdenvNoCC.mkDerivation rec {
     };
     platform = platforms.${system} or (throw "unsupported system: ${system}");
   in ''
-    rpmextract $src/${platform}/storcli-00${version}00.0000-1.*.rpm
+    rpmextract $src/univ_viva_cli_rel/Unified_storcli_all_os/${platform}/storcli-00${finalAttrs.version}00.0000-1.*.rpm
   '';
 
   dontPatch = true;
@@ -38,15 +40,22 @@ stdenvNoCC.mkDerivation rec {
   # Not needed because the binary is statically linked
   dontFixup = true;
 
+  passthru.tests = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "${finalAttrs.meta.mainProgram} -v";
+    version = "00${finalAttrs.version}00.0000";
+  };
+
   meta = with lib; {
     # Unfortunately there is no better page for this.
     # Filter for downloads, set 100 items per page. Sort by newest does not work.
     # Then search manually for the latest version.
-    homepage = "https://www.broadcom.com/site-search?q=storcli";
+    homepage = "https://www.broadcom.com/support/download-search?pg=&pf=Host+Bus+Adapters&pn=&pa=&po=&dk=storcli&pl=&l=false";
     description = "Storage Command Line Tool";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     maintainers = with maintainers; [ panicgh ];
+    mainProgram = "storcli";
     platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13297,8 +13297,6 @@ with pkgs;
 
   stm32loader = with python3Packages; toPythonApplication stm32loader;
 
-  storcli = callPackage ../tools/misc/storcli { };
-
   stremio = qt5.callPackage ../applications/video/stremio { };
 
   sunwait = callPackage ../applications/misc/sunwait { };


### PR DESCRIPTION
## Description of changes

https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_nvme_12g_p30/README_STORCLI_SAS3.5_P30.txt

<summary>Supported Controllers:</summary>
<details>

```
SAS3004
SAS3008
SAS3108_1
SAS3108_2
SAS3108_3
SAS3108_4
SAS3108_5
SAS3108_6
SAS3216
SAS3224
SAS3316_1
SAS3316_2
SAS3316_3
SAS3316_4
SAS3324_1
SAS3324_2
SAS3324_3
SAS3324_4
```
</details>

Release notes are contained in a PDF inside the source archive, for example:

```console
$ echo $(nix build -f . storcli.src --no-link --print-out-paths)/MR_SAS_Unified_StorCLI--007.2904.0000.0000.pdf
/nix/store/izl65i1wq9316ihqczdk629v73dpmnqm-source/MR_SAS_Unified_StorCLI--007.2904.0000.0000.pdf
```

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
