### PR TITLE
treewide: remove unused copyDesktopItems from some packages

### DIFF
--- a/pkgs/applications/emulators/duckstation/default.nix
+++ b/pkgs/applications/emulators/duckstation/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , SDL2
 , cmake
-, copyDesktopItems
 , cubeb
 , curl
 , extra-cmake-modules
@@ -48,7 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    copyDesktopItems
     extra-cmake-modules
     ninja
     pkg-config

--- a/pkgs/games/ecwolf/default.nix
+++ b/pkgs/games/ecwolf/default.nix
@@ -2,7 +2,6 @@
 , lib
 , fetchFromBitbucket
 , cmake
-, copyDesktopItems
 , pkg-config
 , makeWrapper
 , zlib
@@ -25,7 +24,7 @@ stdenv.mkDerivation rec {
     sha256 = "V2pSP8i20zB50WtUMujzij+ISSupdQQ/oCYYrOaTU1g=";
   };
 
-  nativeBuildInputs = [ cmake copyDesktopItems pkg-config ]
+  nativeBuildInputs = [ cmake pkg-config ]
     ++ lib.optionals stdenv.isDarwin [ makeWrapper ];
   buildInputs = [ zlib bzip2 libjpeg SDL2 SDL2_net SDL2_mixer gtk3 ];
 

--- a/pkgs/tools/misc/valeronoi/default.nix
+++ b/pkgs/tools/misc/valeronoi/default.nix
@@ -4,7 +4,6 @@
 , boost
 , cgal
 , cmake
-, copyDesktopItems
 , gpp
 , mpfr
 , qtbase
@@ -36,7 +35,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    copyDesktopItems
     wrapQtAppsHook
   ];
 


### PR DESCRIPTION
## Description of changes

This is the other side of https://github.com/NixOS/nixpkgs/pull/303573.

I've checked these packages. They have the correct desktop entries in their $out, and they don't have `desktopItems` defined, so they have nothing to do with `copyDesktopItems`. Removed these to avoid confusion.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
