### PR TITLE
fgqcanvas: Init at 0.1

### DIFF
--- a/pkgs/by-name/fg/fgqcanvas/package.nix
+++ b/pkgs/by-name/fg/fgqcanvas/package.nix
@@ -1,0 +1,53 @@
+{ fetchgit
+, pkg-config
+, stdenv
+, lib
+# Package dependencies
+, qt5
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fgqcanvas";
+  version = "0-unstable-2024-02-11";
+
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/flightgear/flightgear";
+    rev = "3168828949d6b42959ccee6c202b8895493edb2b";
+    sha256 = "sha256-QiIMkrzaB/ljVf6c+RJNFWKLZa84cIjYPO5nxEFDqjg=";
+  };
+
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+    qt5.qmake
+    pkg-config
+    qt5.qttools
+  ];
+  buildInputs = [
+    qt5.qtwebsockets
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+    cd utils/fgqcanvas/
+    mkdir -p build
+    cd build
+    qmake -makefile ../fgcanvas.pro CONFIG+="release" QMAKE_CXXFLAGS+=' -Wno-deprecated-copy -Wno-deprecated -Wno-deprecated-declarations'
+    runHook postConfigure
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    mv fgqcanvas $out/bin/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://sourceforge.net/p/flightgear/flightgear/ci/next/tree/utils/fgqcanvas/README.md";
+    description = "A Qt-based remote canvas application for FlightGear";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ nayala ];
+    mainProgram = "fgqcanvas";
+  };
+}


### PR DESCRIPTION
## Description of changes

A Qt-based remote canvas application for FlightGear

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
