### PR TITLE
rPackages.immunotation: cache external URLs

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1318,6 +1318,36 @@ let
       buildInputs = [ cacert ] ++ attrs.buildInputs;
     });
 
+
+    immunotation = let
+      MHC41alleleList = fetchurl {
+        url = "https://services.healthtech.dtu.dk/services/NetMHCpan-4.1/allele.list";
+        hash = "sha256-CRZ+0uHzcq5zK5eONucAChXIXO8tnq5sSEAS80Z7jhg=";
+      };
+
+      MHCII40alleleList = fetchurl {
+        url = "https://services.healthtech.dtu.dk/services/NetMHCIIpan-4.0/alleles_name.list";
+        hash = "sha256-K4Ic2NUs3P4IkvOODwZ0c4Yh8caex5Ih0uO5jXRHp40=";
+      };
+
+      validGeographics = fetchurl {
+        url = "http://www.allelefrequencies.net/hla6006a.asp?";
+        hash = "sha256-QoCWjQOgDSNlrvzWmxJbYcInUBF7dCHJ7WhTrZMtdfg=";
+      };
+    in old.immunotation.overrideAttrs (attrs: {
+      patches = [ ./patches/immunotation.patch ];
+      postPatch = ''
+        substituteInPlace "R/external_resources_input.R" --replace-fail \
+          "nix-NetMHCpan-4.1-allele-list" ${MHC41alleleList}
+
+        substituteInPlace "R/external_resources_input.R" --replace-fail \
+          "nix-NETMHCIIpan-4.0-alleles-name-list" ${MHCII40alleleList}
+
+        substituteInPlace "R/AFND_interface.R" --replace-fail \
+          "nix-valid-geographics" ${validGeographics}
+      '';
+    });
+
     rstan = old.rstan.overrideAttrs (attrs: {
       env = (attrs.env or { }) // {
         NIX_CFLAGS_COMPILE = attrs.env.NIX_CFLAGS_COMPILE + " -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION";

--- a/pkgs/development/r-modules/patches/immunotation.patch
+++ b/pkgs/development/r-modules/patches/immunotation.patch
@@ -1,0 +1,47 @@
+diff --git a/R/AFND_interface.R b/R/AFND_interface.R
+index b62e8e0..0f22d85 100644
+--- a/R/AFND_interface.R
++++ b/R/AFND_interface.R
+@@ -244,9 +244,9 @@ check_population <- function(hla_population) {
+ #' @return list of valid countries, regions and ethnic origin
+ #' @keywords internal
+ get_valid_geographics <- function() {
+-    url <- "http://www.allelefrequencies.net/hla6006a.asp?"
+-    html_input <- getURL(url, read_method = "html")
+-    
++    # http://www.allelefrequencies.net/hla6006a.asp?
++    html_input <- xml2::read_html("nix-valid-geographics")
++      
+     rvest_tables <- rvest::html_table(html_input, fill = TRUE)
+     
+     # country
+diff --git a/R/external_resources_input.R b/R/external_resources_input.R
+index c4b1dc1..8fc5881 100644
+--- a/R/external_resources_input.R
++++ b/R/external_resources_input.R
+@@ -74,16 +74,17 @@ getURL <- function(URL, N.TRIES=2L,
+ # MHC I
+ # netmhcI_input_template is an internal variable containing list of valid 
+ # NetMHCpan input alleles
+-netmhcI_input_template <- getURL(
+-    URL="https://services.healthtech.dtu.dk/services/NetMHCpan-4.1/allele.list",
+-    read_method = "delim", delim = "\t",
+-    col_names = c("netmhc_input", "hla_chain_name", "HLA_gene"))
++netmhcI_input_template <- readr::read_delim(
++        # https://services.healthtech.dtu.dk/services/NetMHCpan-4.1/allele.list
++	"nix-NetMHCpan-4.1-allele-list",
++	delim = "\t",
++	skip = 0,
++        col_names = c("netmhc_input", "hla_chain_name", "HLA_gene")
++    )
+ 
+ # MHC II
+-lines <- getURL(
+-    URL = paste0("https://services.healthtech.dtu.dk/services/",
+-    "NetMHCIIpan-4.0/alleles_name.list"),
+-    read_method = "lines")
++# https://services.healthtech.dtu.dk/services/NetMHCIIpan-4.0/alleles_name.list
++lines <- readr::read_lines("nix-NETMHCIIpan-4.0-alleles-name-list")
+ lines_rep <- stringr::str_replace_all(lines, "\t+|\\s\\s+", "\t")
+ netmhcII_input_template <- suppressWarnings(
+     suppressMessages(read.delim(textConnection(lines_rep), sep = "\t")))


### PR DESCRIPTION
## Description of changes

Immunotation uses 3 external URL-s, and stores them variables in the package's namespace. Package installation is not possible without internet connection, and skipping load test doesn't help, because this happens _before_ the load test.

I use fetchurl to get those external deps, and replace them in the code with a patch + substituteInPlace.

This should work in the long term for the  two MHC allele lists, but I'm not sure about the geographical region list. We'll have to see how frequently the website changes. I only found the copyright2024 notice problematic, because it could change every year, which means we'd have to update the hash. I think that would still be acceptable. If it's more frequent, we'll have to mark this as broken, I think. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
