### PR TITLE
omnictl: init at 0.32.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16600,6 +16600,12 @@
     githubId = 145816;
     name = "David McKay";
   };
+  raylas = {
+    email = "r@raymond.sh";
+    github = "raylas";
+    githubId = 8099415;
+    name = "Raymond Douglas";
+  };
   rayslash = {
     email = "stevemathewjoy@tutanota.com";
     github = "rayslash";

--- a/pkgs/by-name/om/omnictl/package.nix
+++ b/pkgs/by-name/om/omnictl/package.nix
@@ -1,0 +1,40 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "omnictl";
+  version = "0.32.2";
+
+  src = fetchFromGitHub {
+    owner = "siderolabs";
+    repo = "omni";
+    rev = "v${version}";
+    hash = "sha256-db/bYwMPrOZvD/YPtFaRK80yaYdsE70YPh0xQe0uVi4=";
+  };
+
+  vendorHash = "sha256-uwzVUdA51eT9fi2Wr0ilNPMpXx430UIYYWXQa1hpzRM=";
+
+  ldflags = [ "-s" "-w" ];
+
+  GOWORK = "off";
+
+  subPackages = [ "cmd/omnictl" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --cmd omnictl \
+      --bash <($out/bin/omnictl completion bash) \
+      --fish <($out/bin/omnictl completion fish) \
+      --zsh <($out/bin/omnictl completion zsh)
+  '';
+
+  doCheck = false; # no tests
+
+  meta = with lib; {
+    description = "A CLI for the Sidero Omni Kubernetes management platform";
+    mainProgram = "omnictl";
+    homepage = "https://omni.siderolabs.com/";
+    license = licenses.bsl11;
+    maintainers = with maintainers; [ raylas ];
+  };
+}


### PR DESCRIPTION
## Description of changes

> Omni is a Kubernetes management platform that simplifies the creation and management of Kubernetes clusters on any environment to provide a simple, secure, and resilient platform. It automates cluster creation, management and upgrades, and integrates Kubernetes and Omni access into enterprise identity providers. While Omni does provide a powerful UI, tight integration with Talos Linux means the platform is 100% API-driven from Linux to Kubernetes to Omni.

**omnictl** is the CLI client for Sidero Labs' Omni platform for management of [Talos](https://talos.dev) Kubernetes clusters.

Potential companion CLI application to [talosctl](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/networking/cluster/talosctl/default.nix).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
