### PR TITLE
inkscape: fix path patch

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -3,6 +3,7 @@
 , boehmgc
 , boost
 , cairo
+, callPackage
 , cmake
 , desktopToDarwinBundle
 , fetchurl
@@ -171,6 +172,8 @@ stdenv.mkDerivation rec {
       ln -s $f $out/lib/$(basename $f)
     done
   '';
+
+  passthru.tests.ps2pdf-plugin = callPackage ./test-ps2pdf-plugin.nix { };
 
   meta = with lib; {
     description = "Vector graphics editor";

--- a/pkgs/applications/graphics/inkscape/fix-ps2pdf-path.patch
+++ b/pkgs/applications/graphics/inkscape/fix-ps2pdf-path.patch
@@ -6,7 +6,7 @@ diff -Naur inkscape-1.2.2_2022-12-01_b0a8486541.orig/share/extensions/eps_input.
      <id>org.inkscape.input.eps</id>
      <dependency type="extension">org.inkscape.input.pdf</dependency>
 -    <dependency type="executable" location="path">ps2pdf</dependency>
-+    <dependency type="executable" location="path">@ghostscript@/bin/ps2pdf</dependency>
++    <dependency type="executable" location="absolute">@ghostscript@/bin/ps2pdf</dependency>
      <param name="crop" type="bool" gui-hidden="true">true</param>
      <param name="autorotate" type="optiongroup" appearance="combo" gui-text="Determine page orientation from text direction"
      gui-description="The PS/EPS importer can try to determine the page orientation such that the majority of the text runs left-to-right.">
@@ -18,7 +18,7 @@ diff -Naur inkscape-1.2.2_2022-12-01_b0a8486541.orig/share/extensions/ps_input.i
      <id>org.inkscape.input.postscript_input</id>
      <dependency type="extension">org.inkscape.input.pdf</dependency>
 -    <dependency type="executable" location="path">ps2pdf</dependency>
-+    <dependency type="executable" location="path">@ghostscript@/bin/ps2pdf</dependency>
++    <dependency type="executable" location="absolute">@ghostscript@/bin/ps2pdf</dependency>
      <param name="autorotate" type="optiongroup" appearance="combo" gui-text="Determine page orientation from text direction"
      gui-description="The PS/EPS importer can try to determine the page orientation such that the majority of the text runs left-to-right.">
          <option value="None">Disabled</option>

--- a/pkgs/applications/graphics/inkscape/test-ps2pdf-plugin.nix
+++ b/pkgs/applications/graphics/inkscape/test-ps2pdf-plugin.nix
@@ -1,0 +1,27 @@
+{ inkscape, runCommand, writeTextFile }:
+
+let
+  svg_file = writeTextFile {
+    name = "test.svg";
+    text = ''
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="50" height="50" version="1.1">
+  <ellipse cx="1" cy="1" rx="1" ry="1" />
+</svg>'';
+  };
+in
+runCommand "inkscape-test-eps"
+{
+  nativeBuildInputs = [ inkscape ];
+} ''
+  echo ps test
+  inkscape ${svg_file} --export-type=ps -o test.ps
+  inkscape test.ps -o test.ps.svg
+
+  echo eps test
+  inkscape ${svg_file} --export-type=eps -o test.eps
+  inkscape test.eps -o test.eps.svg
+
+  # inkscape does not return an error code, only does not create files
+  [[ -f test.ps.svg && -f test.eps.svg ]] && touch $out
+''


### PR DESCRIPTION
## Bug

Not be able to open `*.ps` or `*.eps` files with inkscape

Reproduce:

create postscript file:
`nix run -- nixpkgs#barcode -u mm -g 30x10 -o /tmp/barcode.ps -e ean13 -b 5421357512346`

try to open results in an error:
```shell
nix run nixpkgs#inkscape /tmp/barcode.ps
/tmp/barcode.ps:1: parser error : Start tag expected, '<' not found
%!PS-Adobe-2.0
^
ink_file_open: '/tmp/barcode.ps' cannot be opened!
InkscapeApplication::document_open: Failed to open: /tmp/barcode.ps
ConcreteInkscapeApplication::on_open: failed to create document!
```

Not sure if this patch should be back-ported as currently you are not be able to open `*.ps` or `*.eps` files with inkscape.



## Description of changes

Fix a bug introduced in 0db4b9956990c9394006214042f31da9f00244d7
by missing the change from `location="path"` to `location="absolute"`

Add unit test for auto test this function in the future.

## Things done

I tested this patch only on gnu/Linux 23.11, I don't know how it works on `darwin`.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Maintainer:
@jtojnar

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
