### PR TITLE
erlang_27: init at 27-rc2

### DIFF
--- a/pkgs/development/interpreters/erlang/27-rc2.nix
+++ b/pkgs/development/interpreters/erlang/27-rc2.nix
@@ -1,0 +1,6 @@
+{ mkDerivation }:
+
+mkDerivation {
+  version = "27.0-rc2";
+  sha256 = "sha256-o+uqQMlrh7wJQbiecMnn3/tv6nqSJh7unOj0A95mMb0=";
+}

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -18,9 +18,11 @@
 , libGLU ? null
 , wxGTK ? null
 , xorg ? null
+, exdoc ? null
 , parallelBuild ? false
 , systemd
 , wxSupport ? true
+, exdocSupport ? false
 , systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd # systemd support in epmd
   # updateScript deps
 , writeScript
@@ -77,6 +79,7 @@ else libGL != null && libGLU != null && wxGTK != null && xorg != null);
 
 assert odbcSupport -> unixODBC != null;
 assert javacSupport -> openjdk11 != null;
+assert exdocSupport -> exdoc != null;
 
 let
   inherit (lib) optional optionals optionalAttrs optionalString;
@@ -114,8 +117,21 @@ stdenv.mkDerivation ({
     ${postPatch}
   '';
 
+  # For OTP 27+ we need ex_doc to build the documentation
+  # When exdocSupport is enabled, grab the raw ex_doc executable from the exdoc
+  # derivation. Next, patch the first line to use the escript that will be
+  # built during the build phase of this derivation. Finally, building the
+  # documentation requires the erlang-logo.png asset.
   preConfigure = ''
     ./otp_build autoconf
+  '' + optionalString exdocSupport ''
+    mkdir -p $out/bin
+    cp ${exdoc}/bin/.ex_doc-wrapped $out/bin/ex_doc
+    sed -i "1 s:^.*$:#!$out/bin/escript:" $out/bin/ex_doc
+    export EX_DOC=$out/bin/ex_doc
+
+    mkdir -p $out/lib/erlang/system/doc/assets
+    cp $src/system/doc/assets/erlang-logo.png $out/lib/erlang/system/doc/assets
   '';
 
   configureFlags = [ "--with-ssl=${lib.getOutput "out" opensslPackage}" ]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17364,7 +17364,7 @@ with pkgs;
   };
 
   inherit (beam.interpreters)
-    erlang erlang_26 erlang_25 erlang_24
+    erlang erlang_27-rc2 erlang_26 erlang_25 erlang_24
     erlang_odbc erlang_javac erlang_odbc_javac
     elixir elixir_1_16 elixir_1_15 elixir_1_14 elixir_1_13 elixir_1_12 elixir_1_11 elixir_1_10
     elixir-ls;

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -41,6 +41,15 @@ in
 
     # Standard Erlang versions, using the generic builder.
 
+    erlang_27-rc2 = self.beamLib.callErlang ../development/interpreters/erlang/27-rc2.nix {
+      wxGTK = wxGTK32;
+      parallelBuild = true;
+      autoconf = buildPackages.autoconf269;
+      exdocSupport = true;
+      exdoc = self.packages.erlang_26.ex_doc;
+      inherit wxSupport systemdSupport;
+    };
+
     erlang_26 = self.beamLib.callErlang ../development/interpreters/erlang/26.nix {
       wxGTK = wxGTK32;
       parallelBuild = true;


### PR DESCRIPTION
## Description of changes

OTP 27 RC2 has been released: https://www.erlang.org/news/168

I previously merged #301005 which contains a new dependency for OTP 27

I tried to make the most generic changes possible, but I am absolutely open to modifying them. I tried to be as descriptive as possible in my self-review.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



```
[nix-shell:~/.cache/nixpkgs-review/rev-3606a46d2bf6f5ad7236f4beca31d086a6ef7fa5]$ erl
Erlang/OTP 27 [RELEASE CANDIDATE 2] [erts-14.3] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

Eshell V14.3 (press Ctrl+G to abort, type help(). for help)
1> q().
ok
2>
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
