### PR TITLE
Add nixos-needsreboot to NixOS

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -80,6 +80,8 @@ Use `services.pipewire.extraConfig` or `services.pipewire.configPackages` for Pi
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- [nixos-needsreboot](https://github.com/thefossguy/nixos-needsreboot), determines if you need to reboot your NixOS machine.
+
 - [ownCloud Infinite Scale Stack](https://owncloud.com/infinite-scale-4-0/), a modern and scalable rewrite of ownCloud.
 
 - [Handheld Daemon](https://github.com/hhd-dev/hhd), support for gaming handhelds like the Legion Go, ROG Ally, and GPD Win. Available as [services.handheld-daemon](#opt-services.handheld-daemon.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -753,6 +753,7 @@
   ./services/misc/nix-gc.nix
   ./services/misc/nix-optimise.nix
   ./services/misc/nix-ssh-serve.nix
+  ./services/misc/nixos-needsreboot.nix
   ./services/misc/novacomd.nix
   ./services/misc/ntfy-sh.nix
   ./services/misc/nzbget.nix

--- a/nixos/modules/services/misc/nixos-needsreboot.nix
+++ b/nixos/modules/services/misc/nixos-needsreboot.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.nixos-needsreboot;
+in
+{
+  options = {
+    services.nixos-needsreboot = {
+      enable = lib.mkEnableOption "nixos-needsreboot, which determines if you need to reboot your NixOS machine";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [{
+      assertion = config.system.autoUpgrade.enable == true;
+      message  = "Please enable 'system.autoUpgrade'.";
+    }];
+
+    systemd.services.nixos-needsreboot = {
+      description = "Determine if you need to reboot your NixOS machine";
+      requires = [ "nixos-upgrade.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = lib.getExe pkgs.nixos-needsreboot;
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ thefossguy ];
+}

--- a/pkgs/by-name/ni/nixos-needsreboot/package.nix
+++ b/pkgs/by-name/ni/nixos-needsreboot/package.nix
@@ -1,0 +1,26 @@
+{ fetchFromGitHub
+, lib
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nixos-needsreboot";
+  version = "0.1.10";
+
+  src = fetchFromGitHub {
+    owner = "thefossguy";
+    repo = "nixos-needsreboot";
+    rev = version;
+    hash = "sha256-0MpqqkkpTMiq5xgzSOqBZMLUfVhtfEfRXWZzt2tqRKI=";
+  };
+
+  cargoHash = "sha256-LzO1kkrpWTjLnqs0HH5AIFLOZxtg0kUDIqXCVKSqsAc=";
+
+  meta = with lib; {
+    description = "Determine if you need to reboot your NixOS machine";
+    homepage = "https://github.com/thefossguy/nixos-needsreboot";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ thefossguy ];
+    mainProgram = "nixos-needsreboot";
+  };
+}


### PR DESCRIPTION
## Description of changes

This PR adds my stupid package that compares the current and latest NixOS generations and creates a file to let you know if you "_need_" to reboot or not.

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
