### PR TITLE
castero: init at 0.9.5

### DIFF
--- a/pkgs/by-name/ca/castero/package.nix
+++ b/pkgs/by-name/ca/castero/package.nix
@@ -1,0 +1,67 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "castero";
+  version = "0.9.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "xgi";
+    repo = "castero";
+    rev = "v${version}";
+    hash = "sha256-6/7oCKBMEcQeJ8PaFP15Xef9sQRYCpigtzINv2M6GUY=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    requests
+    grequests
+    cjkwrap
+    pytz
+    beautifulsoup4
+    lxml
+    mpv
+    python-vlc
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "tests"
+  ];
+
+  disabledTests = [ "test_datafile_download" ];
+
+  pythonImportCheck = [
+    "castero"
+  ];
+
+  # Resolve configuration tests, which access $HOME
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  # Satisfy the python-mpv depedency, which is mpv within NixOS
+  postPatch = ''
+    substituteInPlace setup.py --replace-fail "python-mpv" "mpv"
+  '';
+
+  # VLC currently doesn't support Darwin on NixOS
+  meta = with lib; {
+    mainProgram = "castero";
+    description = "TUI podcast client for the terminal";
+    homepage = "https://github.com/xgi/castero";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ keto ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Closes #300248.

Add `castero`, a podcast TUI for the terminal.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
