### PR TITLE
virtualbox & virtualboxGuestAdditions: cleanup

### DIFF
--- a/nixos/modules/virtualisation/virtualbox-guest.nix
+++ b/nixos/modules/virtualisation/virtualbox-guest.nix
@@ -52,7 +52,7 @@ in
       description = "Whether to enable seamless mode. When activated windows from the guest appear next to the windows of the host.";
     };
 
-    draganddrop = mkOption {
+    dragAndDrop = mkOption {
       default = true;
       type = types.bool;
       description = "Whether to enable drag and drop support.";
@@ -109,6 +109,11 @@ in
     (
       mkIf cfg.seamless {
         systemd.user.services.virtualboxClientSeamless = mkVirtualBoxUserService "--seamless";
+      }
+    )
+    (
+      mkIf cfg.dragAndDrop {
+        systemd.user.services.virtualboxClientDragAndDrop = mkVirtualBoxUserService "--draganddrop";
       }
     )
   ]);

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -27,8 +27,6 @@ assert enableKvm -> !enableHardening;
 # The web services use Java infrastructure.
 assert enableWebService -> javaBindings;
 
-with lib;
-
 let
   buildType = "release";
   # Use maintainers/scripts/update.nix to update the version and all related hashes or
@@ -40,6 +38,8 @@ let
   withModsrc = !enableKvm;
 
   virtualboxGuestAdditionsIso = callPackage guest-additions-iso/default.nix { };
+
+  inherit (lib) optional optionals optionalString getDev getLib;
 in stdenv.mkDerivation {
   pname = "virtualbox";
   inherit version;
@@ -66,14 +66,14 @@ in stdenv.mkDerivation {
     ++ optional pulseSupport libpulseaudio
     ++ optionals headless [ libGL ]
     ++ optionals (!headless) [ qtbase qtx11extras libXinerama SDL2 libGLU ]
-    ++ optionals enableWebService [ gsoap zlib ];
+    ++ [ gsoap zlib jdk ];
 
   hardeningDisable = [ "format" "fortify" "pic" "stackprotector" ];
 
   prePatch = ''
     set -x
     sed -e 's@MKISOFS --version@MKISOFS -version@' \
-        -e 's@PYTHONDIR=.*@PYTHONDIR=${lib.optionalString pythonBindings python3}@' \
+        -e 's@PYTHONDIR=.*@PYTHONDIR=${optionalString pythonBindings python3}@' \
         -e 's@CXX_FLAGS="\(.*\)"@CXX_FLAGS="-std=c++11 \1"@' \
         ${optionalString (!headless) ''
         -e 's@TOOLQT5BIN=.*@TOOLQT5BIN="${getDev qtbase}/bin"@' \
@@ -283,9 +283,9 @@ in stdenv.mkDerivation {
       fromSource
       binaryNativeCode
     ];
-    license = licenses.gpl2;
+    license = lib.licenses.gpl2;
     homepage = "https://www.virtualbox.org/";
-    maintainers = with maintainers; [ sander friedrichaltheide blitz ];
+    maintainers = with lib.maintainers; [ sander friedrichaltheide blitz ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "VirtualBox";
   };

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -66,7 +66,7 @@ in stdenv.mkDerivation {
     ++ optional pulseSupport libpulseaudio
     ++ optionals headless [ libGL ]
     ++ optionals (!headless) [ qtbase qtx11extras libXinerama SDL2 libGLU ]
-    ++ [ gsoap zlib jdk ];
+    ++ optionals enableWebService [ gsoap zlib ];
 
   hardeningDisable = [ "format" "fortify" "pic" "stackprotector" ];
 

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -161,6 +161,9 @@ in stdenv.mkDerivation (finalAttrs: {
     VBOX_WITH_RUNPATH              := $out/libexec/virtualbox
     VBOX_PATH_APP_PRIVATE          := $out/share/virtualbox
     VBOX_PATH_APP_DOCS             := $out/doc
+
+    VBOX_WITH_UPDATE_AGENT :=
+
     ${optionalString javaBindings ''
     VBOX_JAVA_HOME                 := ${jdk}
     ''}

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -31,7 +31,11 @@ let
   buildType = "release";
   # Use maintainers/scripts/update.nix to update the version and all related hashes or
   # change the hashes in extpack.nix and guest-additions/default.nix as well manually.
-  version = "7.0.14";
+  virtualboxVersion = "7.0.14";
+  virtualboxSha256 = "45860d834804a24a163c1bb264a6b1cb802a5bc7ce7e01128072f8d6a4617ca9";
+
+  kvmPatchVersion = "20240502";
+  kvmPatchHash = "sha256-KokIrrAoJutHzPg6e5YAJgDGs+nQoVjapmyn9kG5tV0=";
 
   # The KVM build is not compatible to VirtualBox's kernel modules. So don't export
   # modsrc at all.
@@ -40,13 +44,15 @@ let
   virtualboxGuestAdditionsIso = callPackage guest-additions-iso/default.nix { };
 
   inherit (lib) optional optionals optionalString getDev getLib;
-in stdenv.mkDerivation {
+in stdenv.mkDerivation (finalAttrs: {
   pname = "virtualbox";
-  inherit version;
+  version = finalAttrs.virtualboxVersion;
+
+  inherit buildType virtualboxVersion virtualboxSha256 kvmPatchVersion kvmPatchHash virtualboxGuestAdditionsIso;
 
   src = fetchurl {
-    url = "https://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}.tar.bz2";
-    sha256 = "45860d834804a24a163c1bb264a6b1cb802a5bc7ce7e01128072f8d6a4617ca9";
+    url = "https://download.virtualbox.org/virtualbox/${finalAttrs.virtualboxVersion}/VirtualBox-${finalAttrs.virtualboxVersion}.tar.bz2";
+    sha256 = finalAttrs.virtualboxSha256;
   };
 
   outputs = [ "out" ] ++ optional withModsrc "modsrc";
@@ -102,7 +108,7 @@ in stdenv.mkDerivation {
      # No update patch disables check for update function
      # https://bugs.launchpad.net/ubuntu/+source/virtualbox-ose/+bug/272212
      (fetchpatch {
-       url = "https://salsa.debian.org/pkg-virtualbox-team/virtualbox/-/raw/debian/${version}-dfsg-1/debian/patches/16-no-update.patch";
+       url = "https://salsa.debian.org/pkg-virtualbox-team/virtualbox/-/raw/debian/7.0.14-dfsg-1/debian/patches/16-no-update.patch";
        hash = "sha256-UJHpuB6QB/BbxJorlqZXUF12lgq8gbLMRHRMsbyqRpY=";
      })]
   ++ [ ./extra_symbols.patch ]
@@ -119,14 +125,11 @@ in stdenv.mkDerivation {
   })
      # While the KVM patch should not break any other behavior if --with-kvm is not specified,
      # we don't take any chances and only apply it if people actually want to use KVM support.
-  ++ optional enableKvm (fetchpatch
-    (let
-      patchVersion = "20240502";
-    in {
-      name = "virtualbox-${version}-kvm-dev-${patchVersion}.patch";
-      url = "https://github.com/cyberus-technology/virtualbox-kvm/releases/download/dev-${patchVersion}/kvm-backend-${version}-dev-${patchVersion}.patch";
-      hash = "sha256-KokIrrAoJutHzPg6e5YAJgDGs+nQoVjapmyn9kG5tV0=";
-    }))
+  ++ optional enableKvm (fetchpatch {
+      name = "virtualbox-${finalAttrs.virtualboxVersion}-kvm-dev-${finalAttrs.kvmPatchVersion}.patch";
+      url = "https://github.com/cyberus-technology/virtualbox-kvm/releases/download/dev-${finalAttrs.kvmPatchVersion}/kvm-backend-${finalAttrs.virtualboxVersion}-dev-${finalAttrs.kvmPatchVersion}.patch";
+      hash = finalAttrs.kvmPatchHash;
+    })
   ++ [
     ./qt-dependency-paths.patch
     # https://github.com/NixOS/nixpkgs/issues/123851
@@ -195,14 +198,14 @@ in stdenv.mkDerivation {
         -i AutoConfig.kmk
     sed -e 's@arch/x86/@@' \
         -i Config.kmk
-    substituteInPlace Config.kmk --replace "VBOX_WITH_TESTCASES = 1" "#"
+    substituteInPlace Config.kmk --replace-fail "VBOX_WITH_TESTCASES = 1" "#"
   '';
 
   enableParallelBuilding = true;
 
   buildPhase = ''
     source env.sh
-    kmk -j $NIX_BUILD_CORES BUILD_TYPE="${buildType}"
+    kmk -j $NIX_BUILD_CORES BUILD_TYPE="${finalAttrs.buildType}"
   '';
 
   installPhase = ''
@@ -211,7 +214,7 @@ in stdenv.mkDerivation {
 
     # Install VirtualBox files
     mkdir -p "$libexec"
-    find out/linux.*/${buildType}/bin -mindepth 1 -maxdepth 1 \
+    find out/linux.*/${finalAttrs.buildType}/bin -mindepth 1 -maxdepth 1 \
       -name src -o -exec cp -avt "$libexec" {} +
 
     mkdir -p $out/bin
@@ -249,12 +252,12 @@ in stdenv.mkDerivation {
     ''}
 
     ${optionalString withModsrc ''
-      cp -rv out/linux.*/${buildType}/bin/src "$modsrc"
+      cp -rv out/linux.*/${finalAttrs.buildType}/bin/src "$modsrc"
     ''}
 
     mkdir -p "$out/share/virtualbox"
     cp -rv src/VBox/Main/UnattendedTemplates "$out/share/virtualbox"
-    ln -s "${virtualboxGuestAdditionsIso}" "$out/share/virtualbox/VBoxGuestAdditions.iso"
+    ln -s "${finalAttrs.virtualboxGuestAdditionsIso}" "$out/share/virtualbox/VBoxGuestAdditions.iso"
   '';
 
   preFixup = optionalString (!headless) ''
@@ -289,4 +292,4 @@ in stdenv.mkDerivation {
     platforms = [ "x86_64-linux" ];
     mainProgram = "VirtualBox";
   };
-}
+})

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -141,10 +141,6 @@ in stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     sed -i -e 's|/sbin/ifconfig|${nettools}/bin/ifconfig|' \
       src/VBox/HostDrivers/adpctl/VBoxNetAdpCtl.cpp
-  '' + optionalString headless ''
-    # Fix compile error in version 6.1.6
-    substituteInPlace src/VBox/HostServices/SharedClipboard/VBoxSharedClipboardSvc-x11-stubs.cpp \
-      --replace PSHCLFORMATDATA PSHCLFORMATS
   '';
 
   # first line: ugly hack, and it isn't yet clear why it's a problem

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
@@ -5,8 +5,6 @@
 , yasm, patchelf, makeWrapper, makeself, nasm
 , linuxHeaders, openssl, libpulseaudio}:
 
-with lib;
-
 let
   buildType = "release";
 

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
@@ -90,6 +90,7 @@ in stdenv.mkDerivation (finalAttrs: {
       VBOX_WITH_GUEST_CONTROL := 1
       VBOX_WITHOUT_LINUX_GUEST_PACKAGE := 1
       VBOX_WITH_PAM :=
+      VBOX_WITH_UPDATE_AGENT :=
 
       VBOX_BUILD_PUBLISHER := _NixOS
       LOCAL_CONFIG

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
@@ -1,9 +1,9 @@
 { config, stdenv, kernel, fetchurl, lib, pam, libxslt
 , libX11, libXext, libXcursor, libXmu
-, glib, alsa-lib, libXrandr, dbus
+, glib, libXrandr, dbus
 , pkg-config, which, zlib, xorg
 , yasm, patchelf, makeWrapper, makeself, nasm
-, linuxHeaders, openssl, libpulseaudio}:
+, linuxHeaders, openssl}:
 
 let
   buildType = "release";
@@ -20,8 +20,7 @@ in stdenv.mkDerivation (finalAttrs: {
   env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";
 
   nativeBuildInputs = [ patchelf makeWrapper pkg-config which yasm makeself nasm xorg.xorgserver openssl linuxHeaders ] ++ kernel.moduleBuildDependencies;
-  buildInputs = [ dbus libxslt libXext libXcursor
-    alsa-lib pam libXmu libXrandr libpulseaudio ];
+  buildInputs = [ dbus libxslt libXext libXcursor pam libXmu libXrandr ];
 
   KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
   KERN_INCL = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/source/include";
@@ -97,6 +96,8 @@ in stdenv.mkDerivation (finalAttrs: {
       VBOX_WITHOUT_LINUX_GUEST_PACKAGE := 1
       VBOX_WITH_PAM :=
       VBOX_WITH_UPDATE_AGENT :=
+      VBOX_WITH_AUDIO_ALSA :=
+      VBOX_WITH_AUDIO_PULSE :=
 
       VBOX_BUILD_PUBLISHER := _NixOS
       LOCAL_CONFIG

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
@@ -19,9 +19,9 @@ in stdenv.mkDerivation (finalAttrs: {
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";
 
-  nativeBuildInputs = [ patchelf makeWrapper pkg-config which yasm ];
-  buildInputs =  kernel.moduleBuildDependencies ++ [ libxslt libX11 libXext libXcursor
-    glib nasm alsa-lib makeself pam libXmu libXrandr linuxHeaders openssl libpulseaudio xorg.xorgserver ];
+  nativeBuildInputs = [ patchelf makeWrapper pkg-config which yasm makeself nasm xorg.xorgserver openssl linuxHeaders ] ++ kernel.moduleBuildDependencies;
+  buildInputs = [ dbus libxslt libXext libXcursor
+    alsa-lib pam libXmu libXrandr libpulseaudio ];
 
   KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
   KERN_INCL = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/source/include";

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
@@ -2,7 +2,7 @@
 , libX11, libXext, libXcursor, libXmu
 , glib, libXrandr, dbus
 , pkg-config, which, zlib, xorg
-, yasm, patchelf, makeWrapper, makeself, nasm
+, yasm, patchelf, makeself, nasm
 , linuxHeaders, openssl}:
 
 let
@@ -19,7 +19,7 @@ in stdenv.mkDerivation (finalAttrs: {
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";
 
-  nativeBuildInputs = [ patchelf makeWrapper pkg-config which yasm makeself nasm xorg.xorgserver openssl linuxHeaders ] ++ kernel.moduleBuildDependencies;
+  nativeBuildInputs = [ patchelf pkg-config which yasm makeself nasm xorg.xorgserver openssl linuxHeaders ] ++ kernel.moduleBuildDependencies;
   buildInputs = [ dbus libxslt libXext libXcursor pam libXmu libXrandr ];
 
   KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
@@ -28,8 +28,12 @@ in stdenv.mkDerivation (finalAttrs: {
 
   prePatch = ''
     rm -r src/VBox/Additions/x11/x11include/
+    rm -r src/VBox/Additions/3D/mesa/mesa-*/
     rm -r src/libs/openssl-*/
     rm -r src/libs/curl-*/
+    rm -r src/libs/libpng-*/
+    rm -r src/libs/libxml2-*/
+    rm -r src/libs/zlib*/
   '';
 
   patches = [

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
@@ -2,7 +2,7 @@
 , libX11, libXext, libXcursor, libXmu
 , glib, libXrandr, dbus, xz
 , pkg-config, which, zlib, xorg
-, yasm, patchelf, makeself, nasm
+, yasm, patchelf, makeself
 , linuxHeaders, openssl}:
 
 let
@@ -19,7 +19,7 @@ in stdenv.mkDerivation (finalAttrs: {
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";
 
-  nativeBuildInputs = [ patchelf pkg-config which yasm makeself nasm xorg.xorgserver openssl linuxHeaders xz ] ++ kernel.moduleBuildDependencies;
+  nativeBuildInputs = [ patchelf pkg-config which yasm makeself xorg.xorgserver openssl linuxHeaders xz ] ++ kernel.moduleBuildDependencies;
   buildInputs = [ dbus libxslt libXext libXcursor pam libXmu libXrandr ];
 
   KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
@@ -1,6 +1,6 @@
 { config, stdenv, kernel, fetchurl, lib, pam, libxslt
 , libX11, libXext, libXcursor, libXmu
-, glib, libXrandr, dbus
+, glib, libXrandr, dbus, xz
 , pkg-config, which, zlib, xorg
 , yasm, patchelf, makeself, nasm
 , linuxHeaders, openssl}:
@@ -19,7 +19,7 @@ in stdenv.mkDerivation (finalAttrs: {
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";
 
-  nativeBuildInputs = [ patchelf pkg-config which yasm makeself nasm xorg.xorgserver openssl linuxHeaders ] ++ kernel.moduleBuildDependencies;
+  nativeBuildInputs = [ patchelf pkg-config which yasm makeself nasm xorg.xorgserver openssl linuxHeaders xz ] ++ kernel.moduleBuildDependencies;
   buildInputs = [ dbus libxslt libXext libXcursor pam libXmu libXrandr ];
 
   KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
@@ -32,6 +32,7 @@ in stdenv.mkDerivation (finalAttrs: {
     rm -r src/libs/curl-*/
     rm -r src/libs/libpng-*/
     rm -r src/libs/libxml2-*/
+    rm -r src/libs/liblzma-*/
     rm -r src/libs/zlib*/
   '';
 
@@ -84,6 +85,8 @@ in stdenv.mkDerivation (finalAttrs: {
       VBOX_NO_LEGACY_XORG_X11 := 1
       SDK_VBoxLibPng_INCS :=
       SDK_VBoxLibXml2_INCS :=
+      SDK_VBoxLibLzma_INCS := ${xz.dev}/include
+      SDK_VBoxLibLzma_LIBS := ${xz.out}/lib
 
       SDK_VBoxOpenSslStatic_INCS := ${openssl.dev}/include/ssl
 

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
@@ -79,6 +79,8 @@ in stdenv.mkDerivation (finalAttrs: {
       VBOX_USE_SYSTEM_XORG_HEADERS := 1
       VBOX_USE_SYSTEM_GL_HEADERS := 1
       VBOX_NO_LEGACY_XORG_X11 := 1
+      SDK_VBoxLibPng_INCS :=
+      SDK_VBoxLibXml2_INCS :=
 
       SDK_VBoxOpenSslStatic_INCS := ${openssl.dev}/include/ssl
 

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -34,8 +34,8 @@ in stdenv.mkDerivation {
 
     env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";
 
-    nativeBuildInputs = [ patchelf makeWrapper ];
-    buildInputs = [ virtualBoxNixGuestAdditionsBuilder ] ++ kernel.moduleBuildDependencies;
+    nativeBuildInputs = [ patchelf makeWrapper virtualBoxNixGuestAdditionsBuilder ] ++ kernel.moduleBuildDependencies;
+    buildInputs = [ ];
 
     buildPhase = ''
       runHook preBuild

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -41,9 +41,7 @@ in stdenv.mkDerivation {
       runHook preBuild
 
       # Build kernel modules.
-      cd src
-      find . -type f | xargs sed 's/depmod -a/true/' -i
-      cd vboxguest-${virtualBoxNixGuestAdditionsBuilder.version}_NixOS
+      cd src/vboxguest-${virtualBoxNixGuestAdditionsBuilder.version}_NixOS
       # Run just make first. If we only did make install, we get symbol warnings during build.
       make
       cd ../..
@@ -61,6 +59,8 @@ in stdenv.mkDerivation {
     installPhase = ''
       runHook preInstall
 
+      mkdir -p $out/bin
+
       # Install kernel modules.
       cd src/vboxguest-${virtualBoxNixGuestAdditionsBuilder.version}_NixOS
       make install INSTALL_MOD_PATH=$out KBUILD_EXTRA_SYMBOLS=$PWD/vboxsf/Module.symvers
@@ -70,7 +70,6 @@ in stdenv.mkDerivation {
       install -D -m 755 other/mount.vboxsf $out/bin/mount.vboxsf
       install -D -m 755 sbin/VBoxService $out/bin/VBoxService
 
-      mkdir -p $out/bin
       install -m 755 bin/VBoxClient $out/bin
       install -m 755 bin/VBoxControl $out/bin
       install -m 755 bin/VBoxDRMClient $out/bin

--- a/pkgs/applications/virtualization/virtualbox/update.sh
+++ b/pkgs/applications/virtualization/virtualbox/update.sh
@@ -34,7 +34,9 @@ if [ ! "$oldVersion" = "$latestVersion" ]; then
   virtualBoxOldShaSum=$(oldHash ${attr}Extpack)
   extpackOldShaSum=$(oldHash ${attr}Extpack)
 
-  update-source-version $attr $latestVersion $virtualBoxShaSum
+  sed -e "s/virtualboxVersion =.*;/virtualboxVersion = \"$latestVersion\";/g" \
+      -e "s/virtualboxSha256 =.*;/virtualboxSha256 = \"$virtualBoxShaSum\";/g" \
+      -i $virtualboxNixFile
   sed -i -e 's|value = "'$extpackOldShaSum'"|value = "'$extpackShaSum'"|' $extpackNixFile
   sed -e "s/sha256 =.*;/sha256 = \"$guestAdditionsIsoShaSum\";/g" \
       -i $guestAdditionsIsoNixFile


### PR DESCRIPTION
## Description of changes

Cleanup virtualbox and virtualboxGuestAdditions related nix files
- Less includes
- Removed legacy fixes
- Changed case of draganddrop to dragAndDrop
- Added service for dragAndDrop support to virtualboxGuestAdditions
- Use finalAttrs
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
