### PR TITLE
immich-go: init at 0.13.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10141,6 +10141,11 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kai-tub = {
+    name = "Kai Norman Clasen";
+    github = "kai-tub";
+    githubId = 46302524;
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/by-name/im/immich-go/package.nix
+++ b/pkgs/by-name/im/immich-go/package.nix
@@ -1,0 +1,47 @@
+{ lib, buildGoModule, fetchFromGitHub, nix-update-script, testers, immich-go }:
+buildGoModule rec {
+  pname = "immich-go";
+  version = "0.13.2";
+
+  src = fetchFromGitHub {
+    owner = "simulot";
+    repo = "immich-go";
+    rev = "${version}";
+    hash = "sha256-zYqPPLDfBx4FLvZIo5E6nAeIiFfBCLI00xLieXFkMxs=";
+  };
+
+  vendorHash = "sha256-Y5BujN2mk662oKxQpenjFlxazST2GqWr9ug0sOsxKbY=";
+
+  # options used by upstream:
+  # https://github.com/simulot/immich-go/blob/0.13.2/.goreleaser.yaml
+  ldflags = [
+    "-s"
+    "-w"
+    "-extldflags=-static"
+    "-X main.version=${version}"
+    "-X main.commit=${version}"
+    "-X main.date=unknown"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.versionTest = testers.testVersion {
+      package = immich-go;
+      command = "immich-go -h";
+      version = version;
+    };
+  };
+
+  meta = {
+    description = "Immich client tool for bulk-uploads";
+    longDescription = ''
+      Immich-Go is an open-source tool designed to streamline uploading
+      large photo collections to your self-hosted Immich server.
+    '';
+    homepage = "https://github.com/simulot/immich-go";
+    mainProgram = "immich-go";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ kai-tub ];
+    changelog = "https://github.com/simulot/immich-go/releases/tag/${version}";
+  };
+}


### PR DESCRIPTION
## Description of changes

- Add [immich-go](https://github.com/simulot/immich-go) to nixpkgs at the latest release version [0.13.2](https://github.com/simulot/immich-go/releases/tag/0.13.2).
- Add me as maintainer in the maintainer's list and as a maintainer for the package

Immich-go is a cross-platform Go program that allows bulk-uploading pictures/videos to [immich](https://immich.app/).
It supports importing data from Google photo takeout archives and is recommended/endorsed by the [official immich documentation](https://immich.app/docs/features/command-line-interface).
But, it is not limited to Google Photos and can iterate over directory trees and zip archives as well.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

I have one Go-specific nixpkgs question. What is 'official' stance on these linked variables in `ldflags`, like `"-X main.commit=${version}"` ?
As a user, I find it a bit confusing if the output of the `commit` value refers to the version and if the date refers to either a string or UNIX timestamp 0. I have seen that the `pdfcpu` package is _forced_ to fix the output as upstream checks for these values, but it doesn't seem that this option is generally preferred within nixpkgs.

https://github.com/NixOS/nixpkgs/blob/311fab91ae73d254e7f141afbe390780ef857284/pkgs/applications/graphics/pdfcpu/default.nix#L12-L32

So would it be _bad style_ if I apply the same patching logic as used in `pdfcpu` just because I personally find it more "accessible"?

PS: It is my first time contributing a package. I have tried reading all the relevant documentation, but I could've easily missed something. Let me know how I can improve it! 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

