### PR TITLE
treewide: avoid double wrapping with python3Packages and wrapGAppsHook

### DIFF
--- a/pkgs/applications/audio/blanket/default.nix
+++ b/pkgs/applications/audio/blanket/default.nix
@@ -56,6 +56,12 @@ python3Packages.buildPythonApplication rec {
       --replace gtk-update-icon-cache gtk4-update-icon-cache
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/rafaelmardojai/blanket";
     description = "Listen to different sounds";

--- a/pkgs/applications/audio/easyabc/default.nix
+++ b/pkgs/applications/audio/easyabc/default.nix
@@ -71,6 +71,12 @@ in python.pkgs.buildPythonApplication {
     runHook postInstall
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = {
     description = "ABC music notation editor";
     mainProgram = "easyabc";

--- a/pkgs/applications/audio/gpodder/default.nix
+++ b/pkgs/applications/audio/gpodder/default.nix
@@ -82,7 +82,14 @@ python3Packages.buildPythonApplication rec {
     LC_ALL=C PYTHONPATH=src/:$PYTHONPATH pytest tests --ignore=src/gpodder/utilwin32ctypes.py --ignore=src/mygpoclient --cov=gpodder
   '';
 
-  makeWrapperArgs = [ "--suffix PATH : ${lib.makeBinPath [ xdg-utils ]}" ];
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      --suffix PATH : ${lib.makeBinPath [ xdg-utils ]}
+      "''${gappsWrapperArgs[@]}"
+    )
+  '';
 
   passthru.updateScript = gitUpdater {};
 

--- a/pkgs/applications/audio/gspeech/default.nix
+++ b/pkgs/applications/audio/gspeech/default.nix
@@ -60,6 +60,12 @@ python3.pkgs.buildPythonApplication rec {
     install -Dm444 icons/*.svg -t $out/share/icons/hicolor/scalable/apps
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   postFixup = ''
     wrapProgram $out/bin/gspeech --prefix PATH : ${lib.makeBinPath [ picotts sox ]}
     wrapProgram $out/bin/gspeech-cli --prefix PATH : ${lib.makeBinPath [ picotts sox ]}

--- a/pkgs/applications/audio/hushboard/default.nix
+++ b/pkgs/applications/audio/hushboard/default.nix
@@ -63,6 +63,12 @@ buildPythonApplication {
   # There are no tests
   doCheck = false;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     homepage = "https://kryogenix.org/code/hushboard/";
     license = licenses.mit;

--- a/pkgs/applications/audio/indicator-sound-switcher/default.nix
+++ b/pkgs/applications/audio/indicator-sound-switcher/default.nix
@@ -52,6 +52,12 @@ python3Packages.buildPythonApplication rec {
     keybinder3
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Sound input/output selector indicator for Linux";
     mainProgram = "indicator-sound-switcher";

--- a/pkgs/applications/audio/pithos/default.nix
+++ b/pkgs/applications/audio/pithos/default.nix
@@ -31,6 +31,12 @@ pythonPackages.buildPythonApplication rec {
     (with gst_all_1; [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-ugly gst-plugins-bad ]) ++
     (with pythonPackages; [ pygobject3 pylast ]);
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     broken = stdenv.isDarwin;
     description = "Pandora Internet Radio player for GNOME";

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -150,8 +150,12 @@ python3.pkgs.buildPythonApplication rec {
     runHook postCheck
   '';
 
+  dontWrapGApps = true;
+
   preFixup = lib.optionalString (kakasi != null) ''
-    gappsWrapperArgs+=(--prefix PATH : ${kakasi}/bin)
+    makeWrapperArgs+=(--prefix PATH : ${kakasi}/bin)
+  '' + ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
   meta = with lib; {

--- a/pkgs/applications/audio/sonata/default.nix
+++ b/pkgs/applications/audio/sonata/default.nix
@@ -44,6 +44,12 @@ in buildPythonApplication rec {
     sed -i '/localmpd/d' sonata/consts.py
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = {
     description = "An elegant client for the Music Player Daemon";
     mainProgram = "sonata";

--- a/pkgs/applications/audio/soundconverter/default.nix
+++ b/pkgs/applications/audio/soundconverter/default.nix
@@ -70,6 +70,12 @@ python3Packages.buildPythonApplication rec {
   # Necessary to set GDK_PIXBUF_MODULE_FILE.
   strictDeps = false;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     homepage = "https://soundconverter.org/";
     description = "Leading audio file converter for the GNOME Desktop";

--- a/pkgs/applications/audio/sublime-music/default.nix
+++ b/pkgs/applications/audio/sublime-music/default.nix
@@ -116,6 +116,12 @@ python.pkgs.buildPythonApplication rec {
     done
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "GTK3 Subsonic/Airsonic client";
     mainProgram = "sublime-music";

--- a/pkgs/applications/editors/formiko/default.nix
+++ b/pkgs/applications/editors/formiko/default.nix
@@ -42,6 +42,12 @@ buildPythonApplication rec {
   # Needs a display
   doCheck = false;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "reStructuredText editor and live previewer";
     homepage = "https://github.com/ondratu/formiko";

--- a/pkgs/applications/editors/setzer/default.nix
+++ b/pkgs/applications/editors/setzer/default.nix
@@ -67,6 +67,12 @@ python3.pkgs.buildPythonApplication rec {
     meson test --print-errorlogs
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "LaTeX editor written in Python with Gtk";
     mainProgram = "setzer";

--- a/pkgs/applications/graphics/drawing/default.nix
+++ b/pkgs/applications/graphics/drawing/default.nix
@@ -61,6 +61,12 @@ python3.pkgs.buildPythonApplication rec {
 
   strictDeps = false;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "A free basic image editor, similar to Microsoft Paint, but aiming at the GNOME desktop";
     mainProgram = "drawing";

--- a/pkgs/applications/graphics/gscreenshot/default.nix
+++ b/pkgs/applications/graphics/gscreenshot/default.nix
@@ -57,6 +57,12 @@ python3Packages.buildPythonApplication rec {
 
   patches = [ ./0001-Changing-paths-to-be-nix-compatible.patch ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = {
     description = "A screenshot frontend (CLI and GUI) for a variety of screenshot backends";
 

--- a/pkgs/applications/graphics/mypaint/default.nix
+++ b/pkgs/applications/graphics/mypaint/default.nix
@@ -108,6 +108,12 @@ in buildPythonApplication rec {
     runHook postCheck
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "A graphics application for digital painters";
     homepage = "http://mypaint.org/";

--- a/pkgs/applications/graphics/pick-colour-picker/default.nix
+++ b/pkgs/applications/graphics/pick-colour-picker/default.nix
@@ -42,6 +42,12 @@ buildPythonPackage rec {
     gtk3
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     homepage = "https://kryogenix.org/code/pick/";
     license = licenses.mit;

--- a/pkgs/applications/misc/caerbannog/default.nix
+++ b/pkgs/applications/misc/caerbannog/default.nix
@@ -50,6 +50,12 @@ python3.pkgs.buildPythonApplication rec {
     pygobject3
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Mobile-friendly Gtk frontend for password-store";
     mainProgram = "caerbannog";

--- a/pkgs/applications/misc/diffuse/default.nix
+++ b/pkgs/applications/misc/diffuse/default.nix
@@ -58,9 +58,14 @@ python3.pkgs.buildPythonApplication rec {
   # to avoid running gtk-update-icon-cache, update-desktop-database and glib-compile-schemas
   DESTDIR = "/";
 
-  makeWrapperArgs = [
-      "--prefix XDG_DATA_DIRS : ${hicolor-icon-theme}/share"
-  ];
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix XDG_DATA_DIRS : ${hicolor-icon-theme}/share
+    )
+  '';
 
   passthru = {
     updateScript = gitUpdater {

--- a/pkgs/applications/misc/fluxboxlauncher/default.nix
+++ b/pkgs/applications/misc/fluxboxlauncher/default.nix
@@ -39,9 +39,6 @@ python3.pkgs.buildPythonApplication rec {
     fluxbox
   ];
 
-  makeWrapperArgs = [ "--set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive"
-                      "--set CHARSET en_us.UTF-8" ];
-
   propagatedBuildInputs = with python3.pkgs; [
     pygobject3
   ];
@@ -49,6 +46,16 @@ python3.pkgs.buildPythonApplication rec {
   postInstall = ''
     install -Dm444 fluxboxlauncher.desktop -t $out/share/applications
     install -Dm444 fluxboxlauncher.svg -t $out/share/icons/hicolor/scalable/apps
+  '';
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive
+      --set CHARSET en_us.UTF-8
+    )
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/kupfer/default.nix
+++ b/pkgs/applications/misc/kupfer/default.nix
@@ -50,6 +50,12 @@ buildPythonApplication rec {
 
   doCheck = false; # no tests
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "A smart, quick launcher";
     homepage    = "https://kupferlauncher.github.io/";

--- a/pkgs/applications/misc/metadata-cleaner/default.nix
+++ b/pkgs/applications/misc/metadata-cleaner/default.nix
@@ -55,6 +55,12 @@ python3.pkgs.buildPythonApplication rec {
     pygobject3
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Python GTK application to view and clean metadata in files, using mat2";
     mainProgram = "metadata-cleaner";

--- a/pkgs/applications/misc/minigalaxy/default.nix
+++ b/pkgs/applications/misc/minigalaxy/default.nix
@@ -59,6 +59,12 @@ python3Packages.buildPythonApplication rec {
     webkitgtk
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   # Run Linux games using the Steam Runtime by using steam-run in the wrapper
   # FIXME: not working with makeBinaryWrapper
   postFixup = ''

--- a/pkgs/applications/misc/nwg-wrapper/default.nix
+++ b/pkgs/applications/misc/nwg-wrapper/default.nix
@@ -20,6 +20,8 @@ python3Packages.buildPythonPackage rec {
   # No tests
   doCheck = false;
 
+  dontWrapGApps = true;
+
   preFixup = ''
     makeWrapperArgs+=(
       "''${gappsWrapperArgs[@]}"

--- a/pkgs/applications/misc/onboard/default.nix
+++ b/pkgs/applications/misc/onboard/default.nix
@@ -164,6 +164,12 @@ python3.pkgs.buildPythonApplication rec {
     glib-compile-schemas $out/share/glib-2.0/schemas/
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   # Remove ubuntu icons.
   postFixup = ''
     rm -rf  $out/share/icons/ubuntu-mono-*

--- a/pkgs/applications/misc/orca/default.nix
+++ b/pkgs/applications/misc/orca/default.nix
@@ -89,6 +89,12 @@ buildPythonApplication rec {
     gst_all_1.gst-plugins-good
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/applications/misc/pdf-quench/default.nix
+++ b/pkgs/applications/misc/pdf-quench/default.nix
@@ -26,6 +26,12 @@ python3.pkgs.buildPythonApplication {
     install -D -T -m 755 src/pdf_quench.py $out/bin/pdf-quench
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/linuxerwang/pdf-quench";
     description = "A visual tool for cropping pdf files";

--- a/pkgs/applications/misc/polychromatic/default.nix
+++ b/pkgs/applications/misc/polychromatic/default.nix
@@ -67,7 +67,7 @@ python3Packages.buildPythonApplication rec {
     usbutils
   ];
 
-  dontWrapGapps = true;
+  dontWrapGApps = true;
   dontWrapQtApps = true;
 
   makeWrapperArgs = [

--- a/pkgs/applications/misc/pytrainer/default.nix
+++ b/pkgs/applications/misc/pytrainer/default.nix
@@ -60,10 +60,6 @@ in python.pkgs.buildPythonApplication rec {
     gdk-pixbuf
   ];
 
-  makeWrapperArgs = [
-    "--prefix" "PATH" ":" (lib.makeBinPath [ perl gpsbabel ])
-  ];
-
   nativeCheckInputs = [
     glibcLocales
     perl
@@ -86,6 +82,15 @@ in python.pkgs.buildPythonApplication rec {
       LC_TIME=C \
       xvfb-run -s '-screen 0 800x600x24' \
       ${python.interpreter} setup.py test
+  '';
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix PATH : ${lib.makeBinPath [ perl gpsbabel ]}
+    )
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/skytemple/default.nix
+++ b/pkgs/applications/misc/skytemple/default.nix
@@ -62,6 +62,12 @@ python3Packages.buildPythonApplication rec {
     install -Dm444 installer/skytemple.ico $out/share/icons/hicolor/256x256/apps/org.skytemple.SkyTemple.ico
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/SkyTemple/skytemple";
     description = "ROM hacking tool for Pokémon Mystery Dungeon Explorers of Sky";

--- a/pkgs/applications/misc/snapper-gui/default.nix
+++ b/pkgs/applications/misc/snapper-gui/default.nix
@@ -32,6 +32,12 @@ python3Packages.buildPythonApplication rec {
     snapper
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Graphical interface for snapper";
     mainProgram = "snapper-gui";

--- a/pkgs/applications/misc/themechanger/default.nix
+++ b/pkgs/applications/misc/themechanger/default.nix
@@ -50,6 +50,12 @@ python3Packages.buildPythonApplication rec {
     patchShebangs postinstall.py
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/ALEX11BR/ThemeChanger";
     description = "A theme changing utility for Linux";

--- a/pkgs/applications/networking/giara/default.nix
+++ b/pkgs/applications/networking/giara/default.nix
@@ -67,6 +67,12 @@ python3.pkgs.buildPythonApplication rec {
       --replace "item { custom: profile; }" 'item { custom: "profile"; }'
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "A Reddit app, built with Python, GTK and Handy; Created with mobile Linux in mind";
     maintainers = with maintainers; [ dasj19 ];

--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -81,6 +81,12 @@ let
         rm -r $out/share/{icons,man/man1/deluge-gtk*,pixmaps}
       '');
 
+      dontWrapGApps = true;
+
+      preFixup = ''
+        makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+      '';
+
       postFixup = ''
         for f in $out/lib/systemd/system/*; do
           substituteInPlace $f --replace /usr/bin $out/bin

--- a/pkgs/applications/networking/protonvpn-gui/default.nix
+++ b/pkgs/applications/networking/protonvpn-gui/default.nix
@@ -92,6 +92,12 @@ buildPythonApplication rec {
   # Gets a segmentation fault after the widgets test
   doCheck = false;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Proton VPN GTK app for Linux";
     homepage = "https://github.com/ProtonVPN/proton-vpn-gtk-app";

--- a/pkgs/applications/networking/protonvpn-gui/legacy.nix
+++ b/pkgs/applications/networking/protonvpn-gui/legacy.nix
@@ -68,6 +68,12 @@ buildPythonApplication rec {
   # Project has a dummy test
   doCheck = false;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Official ProtonVPN Linux app";
     homepage = "https://github.com/ProtonVPN/linux-app";

--- a/pkgs/applications/office/banking/default.nix
+++ b/pkgs/applications/office/banking/default.nix
@@ -59,6 +59,12 @@ python3.pkgs.buildPythonApplication rec {
     schwifty
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Banking application for small screens";
     homepage = "https://tabos.gitlab.io/projects/banking/";

--- a/pkgs/applications/office/gtg/default.nix
+++ b/pkgs/applications/office/gtg/default.nix
@@ -70,6 +70,12 @@ python3Packages.buildPythonApplication rec {
 
   checkPhase = "xvfb-run pytest ../tests/";
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = " A personal tasks and TODO-list items organizer";
     mainProgram = "gtg";

--- a/pkgs/applications/office/pympress/default.nix
+++ b/pkgs/applications/office/pympress/default.nix
@@ -40,6 +40,12 @@ python3Packages.buildPythonApplication rec {
 
   doCheck = false; # there are no tests
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Simple yet powerful PDF reader designed for dual-screen presentations";
     mainProgram = "pympress";

--- a/pkgs/applications/office/tryton/default.nix
+++ b/pkgs/applications/office/tryton/default.nix
@@ -61,6 +61,12 @@ python3Packages.buildPythonApplication rec {
 
   doCheck = false;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = {
     description = "The client of the Tryton application platform";
     mainProgram = "tryton";

--- a/pkgs/applications/radio/chirp/default.nix
+++ b/pkgs/applications/radio/chirp/default.nix
@@ -36,6 +36,12 @@ python3.pkgs.buildPythonApplication rec {
   # "running build_ext" fails with no output
   doCheck = false;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   passthru.updateScript = unstableGitUpdater {
     branch = "py3";
   };

--- a/pkgs/applications/system/thumbdrives/default.nix
+++ b/pkgs/applications/system/thumbdrives/default.nix
@@ -52,6 +52,12 @@ python3.pkgs.buildPythonApplication rec {
     pyxdg
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "USB mass storage emulator for Linux handhelds";
     homepage = "https://sr.ht/~martijnbraam/thumbdrives/";

--- a/pkgs/applications/terminal-emulators/guake/default.nix
+++ b/pkgs/applications/terminal-emulators/guake/default.nix
@@ -42,8 +42,6 @@ python3.pkgs.buildPythonApplication rec {
     vte
   ];
 
-  makeWrapperArgs = [ "--set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive" ];
-
   propagatedBuildInputs = with python3.pkgs; [
     dbus-python
     pycairo
@@ -56,8 +54,14 @@ python3.pkgs.buildPythonApplication rec {
     "PREFIX=${placeholder "out"}"
   ];
 
+  dontWrapGApps = true;
+
   preFixup = ''
-    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libutempter ]}")
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libutempter ]}"
+    )
   '';
 
   passthru.tests.test = nixosTests.terminal-emulators.guake;

--- a/pkgs/applications/version-management/meld/default.nix
+++ b/pkgs/applications/version-management/meld/default.nix
@@ -56,6 +56,12 @@ python3.pkgs.buildPythonApplication rec {
     patchShebangs meson_shebang_normalisation.py
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/applications/video/devede/default.nix
+++ b/pkgs/applications/video/devede/default.nix
@@ -35,6 +35,12 @@ in buildPythonApplication rec {
       --replace "/usr/local/share" "$out/share"
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "DVD Creator for Linux";
     homepage = "http://www.rastersoft.com/programas/devede.html";

--- a/pkgs/applications/video/gnomecast/default.nix
+++ b/pkgs/applications/video/gnomecast/default.nix
@@ -29,8 +29,13 @@ buildPythonApplication rec {
   # https://nixos.org/manual/nixpkgs/stable/#ssec-gnome-hooks-gobject-introspection
   strictDeps = false;
 
+  dontWrapGApps = true;
+
   preFixup = ''
-    gappsWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ ffmpeg ]})
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg ]}
+    )
   '';
 
   # no tests

--- a/pkgs/applications/video/kazam/default.nix
+++ b/pkgs/applications/video/kazam/default.nix
@@ -52,6 +52,12 @@ python3Packages.buildPythonApplication rec {
   # no tests
   doCheck = false;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "A screencasting program created with design in mind";
     homepage = "https://github.com/niknah/kazam";

--- a/pkgs/applications/video/pitivi/default.nix
+++ b/pkgs/applications/video/pitivi/default.nix
@@ -75,8 +75,11 @@ python3.pkgs.buildPythonApplication rec {
     librosa
   ];
 
+  dontWrapGApps = true;
+
   preFixup = ''
-    gappsWrapperArgs+=(
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
       # The icon theme is hardcoded.
       --prefix XDG_DATA_DIRS : "${hicolor-icon-theme}/share"
     )

--- a/pkgs/applications/video/tartube/default.nix
+++ b/pkgs/applications/video/tartube/default.nix
@@ -64,9 +64,14 @@ python3Packages.buildPythonApplication rec {
 
   doCheck = false;
 
-  makeWrapperArgs = [
-    "--prefix PATH : ${lib.makeBinPath [ youtube-dl ]}"
-  ];
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix PATH : ${lib.makeBinPath [ youtube-dl ]}
+    )
+  '';
 
   meta = with lib; {
     description = "A GUI front-end for youtube-dl";

--- a/pkgs/by-name/ad/adwsteamgtk/package.nix
+++ b/pkgs/by-name/ad/adwsteamgtk/package.nix
@@ -41,6 +41,12 @@ python3Packages.buildPythonApplication rec {
     pygobject3
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = {
     description = "A simple Gtk wrapper for Adwaita-for-Steam";
     homepage = "https://github.com/Foldex/AdwSteamGtk";

--- a/pkgs/by-name/co/connman-notify/package.nix
+++ b/pkgs/by-name/co/connman-notify/package.nix
@@ -26,6 +26,12 @@ python3Packages.buildPythonApplication {
     install -D -t $out/share/doc README.rst
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Desktop notification integration for connman";
     mainProgram = "connman-notify";

--- a/pkgs/by-name/ed/eduvpn-client/package.nix
+++ b/pkgs/by-name/ed/eduvpn-client/package.nix
@@ -48,6 +48,12 @@ python3Packages.buildPythonApplication rec {
     pytestCheckHook
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     changelog = "https://raw.githubusercontent.com/eduvpn/python-eduvpn-client/${version}/CHANGES.md";
     description = "Linux client for eduVPN";

--- a/pkgs/by-name/la/labwc-gtktheme/package.nix
+++ b/pkgs/by-name/la/labwc-gtktheme/package.nix
@@ -41,6 +41,12 @@ python3Packages.buildPythonApplication rec {
     runHook postInstall
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   passthru.updateScript = unstableGitUpdater { };
 
   meta = {

--- a/pkgs/by-name/me/menulibre/package.nix
+++ b/pkgs/by-name/me/menulibre/package.nix
@@ -46,6 +46,12 @@ python3Packages.buildPythonApplication rec {
     export HOME=$TMPDIR
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   passthru = {
     updateScript = nix-update-script { };
     tests.version = testers.testVersion {

--- a/pkgs/by-name/mo/monophony/package.nix
+++ b/pkgs/by-name/mo/monophony/package.nix
@@ -46,9 +46,12 @@ python3Packages.buildPythonApplication rec {
 
   installFlags = [ "prefix=$(out)" ];
 
+  dontWrapGApps = true;
+
   preFixup = ''
     buildPythonPath "$pythonPath"
-    gappsWrapperArgs+=(
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
       --prefix PYTHONPATH : "$program_PYTHONPATH"
       --prefix PATH : "${lib.makeBinPath [yt-dlp]}"
     )

--- a/pkgs/by-name/ni/nicotine-plus/package.nix
+++ b/pkgs/by-name/ni/nicotine-plus/package.nix
@@ -32,8 +32,11 @@ python3Packages.buildPythonApplication rec {
     ln -s $out/bin/nicotine $out/bin/nicotine-plus
   '';
 
+  dontWrapGApps = true;
+
   preFixup = ''
-    gappsWrapperArgs+=(
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
       --prefix XDG_DATA_DIRS : "${gtk4}/share/gsettings-schemas/${gtk4.name}"
     )
   '';

--- a/pkgs/by-name/nw/nwg-hello/package.nix
+++ b/pkgs/by-name/nw/nwg-hello/package.nix
@@ -56,6 +56,12 @@ python3Packages.buildPythonApplication rec {
   doCheck = false;
   pythonImportsCheck = [ "nwg_hello" ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = {
     homepage = "https://github.com/nwg-piotr/nwg-hello";
     description = "GTK3-based greeter for the greetd daemon, written in python";

--- a/pkgs/by-name/sa/satellite/package.nix
+++ b/pkgs/by-name/sa/satellite/package.nix
@@ -42,6 +42,12 @@ python3.pkgs.buildPythonApplication rec {
 
   strictDeps = true;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "A program for showing navigation satellite data";
     longDescription = ''

--- a/pkgs/desktops/mate/mozo/default.nix
+++ b/pkgs/desktops/mate/mozo/default.nix
@@ -42,6 +42,12 @@ python3.pkgs.buildPythonApplication rec {
 
   enableParallelBuilding = true;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   passthru.updateScript = mateUpdateScript { inherit pname; };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/controku/default.nix
+++ b/pkgs/development/python-modules/controku/default.nix
@@ -40,6 +40,12 @@ python3Packages.buildPythonPackage rec {
     pygobject3
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   pythonImportsCheck = [ "controku" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/mat2/default.nix
+++ b/pkgs/development/python-modules/mat2/default.nix
@@ -95,6 +95,12 @@ buildPythonPackage rec {
     "test_all_parametred"
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "A handy tool to trash your metadata";
     homepage = "https://0xacab.org/jvoisin/mat2";

--- a/pkgs/development/python-modules/openrazer/daemon.nix
+++ b/pkgs/development/python-modules/openrazer/daemon.nix
@@ -50,6 +50,12 @@ buildPythonPackage (common // {
   # no tests run
   doCheck = false;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = common.meta // {
     description = "An entirely open source user-space daemon that allows you to manage your Razer peripherals on GNU/Linux";
     mainProgram = "openrazer-daemon";

--- a/pkgs/development/python-modules/skytemple-ssb-debugger/default.nix
+++ b/pkgs/development/python-modules/skytemple-ssb-debugger/default.nix
@@ -53,6 +53,12 @@ buildPythonPackage rec {
   doCheck = false; # requires Pokémon Mystery Dungeon ROM
   pythonImportsCheck = [ "skytemple_ssb_debugger" ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/SkyTemple/skytemple-ssb-debugger";
     description = "Script Engine Debugger for Pokémon Mystery Dungeon Explorers of Sky";

--- a/pkgs/development/tools/click/default.nix
+++ b/pkgs/development/tools/click/default.nix
@@ -39,8 +39,11 @@ buildPythonApplication {
     "--with-systemduserunitdir=${placeholder "out"}/lib/systemd/user"
   ];
 
+  dontWrapGApps = true;
+
   preFixup = ''
     makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
       --prefix LD_LIBRARY_PATH : "$out/lib"
     )
   '';

--- a/pkgs/games/gscrabble/default.nix
+++ b/pkgs/games/gscrabble/default.nix
@@ -24,10 +24,13 @@ buildPythonApplication {
 
   propagatedBuildInputs = with python3Packages; [ gst-python pygobject3 ];
 
+  dontWrapGApps = true;
+
   preFixup = ''
-    gappsWrapperArgs+=(
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
       --prefix PYTHONPATH : "$out/share/GScrabble/modules"
-      )
+    )
   '';
 
   meta = with lib; {

--- a/pkgs/games/gshogi/default.nix
+++ b/pkgs/games/gshogi/default.nix
@@ -30,6 +30,12 @@ python3.pkgs.buildPythonApplication rec {
     pycairo
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     homepage = "http://johncheetham.com/projects/gshogi/";
     description = "A graphical implementation of the Shogi board game, also known as Japanese Chess";

--- a/pkgs/misc/drivers/sc-controller/default.nix
+++ b/pkgs/misc/drivers/sc-controller/default.nix
@@ -33,8 +33,13 @@ buildPythonApplication rec {
 
   LD_LIBRARY_PATH = lib.makeLibraryPath [ libX11 libXext libXfixes libusb1 udev bluez ];
 
+  dontWrapGApps = true;
+
   preFixup = ''
-    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "$LD_LIBRARY_PATH")
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix LD_LIBRARY_PATH : "$LD_LIBRARY_PATH"
+    )
   '';
 
   postFixup = ''

--- a/pkgs/misc/solfege/default.nix
+++ b/pkgs/misc/solfege/default.nix
@@ -63,6 +63,12 @@ buildPythonApplication rec {
 
   enableParallelBuilding = true;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Ear training program";
     homepage = "https://www.gnu.org/software/solfege/";

--- a/pkgs/os-specific/linux/piper/default.nix
+++ b/pkgs/os-specific/linux/piper/default.nix
@@ -31,6 +31,12 @@ python3.pkgs.buildPythonApplication rec {
     patchShebangs meson_install.sh data/generate-piper-gresource.xml.py
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "GTK frontend for ratbagd mouse config daemon";
     mainProgram = "piper";

--- a/pkgs/os-specific/linux/tuna/default.nix
+++ b/pkgs/os-specific/linux/tuna/default.nix
@@ -51,6 +51,12 @@ buildPythonApplication rec {
   doCheck = false;
   pythonImportsCheck = [ "tuna" ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Thread and IRQ affinity setting GUI and cmd line tool";
     mainProgram = "tuna";

--- a/pkgs/tools/X11/arandr/default.nix
+++ b/pkgs/tools/X11/arandr/default.nix
@@ -31,6 +31,12 @@ buildPythonApplication rec {
   nativeBuildInputs = [ gobject-introspection wrapGAppsHook ];
   propagatedBuildInputs = [ xrandr pygobject3 ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     homepage = "https://christian.amsuess.com/tools/arandr/";
     description = "A simple visual front end for XRandR";

--- a/pkgs/tools/X11/wpgtk/default.nix
+++ b/pkgs/tools/X11/wpgtk/default.nix
@@ -37,6 +37,12 @@ python3Packages.buildPythonApplication rec {
   # No test exist
   doCheck = false;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Template based wallpaper/colorscheme generator and manager";
     longDescription = ''

--- a/pkgs/tools/X11/xborders/default.nix
+++ b/pkgs/tools/X11/xborders/default.nix
@@ -47,6 +47,12 @@ python3Packages.buildPythonPackage rec {
     ln -s ${setup} setup.py
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Active window border replacement for window managers";
     homepage = "https://github.com/deter0/xborder";

--- a/pkgs/tools/audio/mpdris2/default.nix
+++ b/pkgs/tools/audio/mpdris2/default.nix
@@ -44,6 +44,12 @@ python3.pkgs.buildPythonApplication rec {
     pygobject3
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "MPRIS 2 support for mpd";
     homepage = "https://github.com/eonpatapon/mpDris2/";

--- a/pkgs/tools/audio/volctl/default.nix
+++ b/pkgs/tools/audio/volctl/default.nix
@@ -42,9 +42,14 @@ python3Packages.buildPythonApplication rec {
 
   pythonImportsCheck = [ "volctl" ];
 
+  dontWrapGApps = true;
+
   preFixup = ''
     glib-compile-schemas ${glib.makeSchemaPath "$out" "${pname}-${version}"}
-    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${libpulseaudio}/lib")
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix LD_LIBRARY_PATH : "${libpulseaudio}/lib"
+    )
   '';
 
   meta = with lib; {

--- a/pkgs/tools/games/mymcplus/default.nix
+++ b/pkgs/tools/games/mymcplus/default.nix
@@ -24,6 +24,12 @@ pythonPackages.buildPythonApplication rec {
     wxpython
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     homepage = "https://git.sr.ht/~thestr4ng3r/mymcplus";
     description = "A PlayStation 2 memory card manager";

--- a/pkgs/tools/graphics/escrotum/default.nix
+++ b/pkgs/tools/graphics/escrotum/default.nix
@@ -41,6 +41,12 @@ with python3Packages; buildPythonApplication {
     cp man/escrotum.1 $man/share/man/man1/
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/Roger/escrotum";
     description = "Linux screen capture using pygtk, inspired by scrot";

--- a/pkgs/tools/misc/nautilus-open-any-terminal/default.nix
+++ b/pkgs/tools/misc/nautilus-open-any-terminal/default.nix
@@ -53,6 +53,12 @@ python3.pkgs.buildPythonPackage rec {
     glib-compile-schemas "$out/share/glib-2.0/schemas"
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Extension for nautilus, which adds an context-entry for opening other terminal-emulators then `gnome-terminal`";
     license = licenses.gpl3Plus;

--- a/pkgs/tools/misc/system-config-printer/default.nix
+++ b/pkgs/tools/misc/system-config-printer/default.nix
@@ -63,10 +63,6 @@ stdenv.mkDerivation rec {
   postInstall =
     ''
       buildPythonPath "$out $pythonPath"
-      gappsWrapperArgs+=(
-        --prefix PATH : "$program_PATH"
-        --set CUPS_DATADIR "${cups-filters}/share/cups"
-      )
 
       find $out/share/system-config-printer -name \*.py -type f -perm -0100 -print0 | while read -d "" f; do
         patchPythonScript "$f"
@@ -76,6 +72,16 @@ stdenv.mkDerivation rec {
       substituteInPlace $out/etc/udev/rules.d/70-printers.rules \
         --replace "udev-configure-printer" "$out/etc/udev/udev-configure-printer"
     '';
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix PATH : "$program_PATH"
+      --set CUPS_DATADIR "${cups-filters}/share/cups"
+    )
+  '';
 
   meta = {
     homepage = "https://github.com/openprinting/system-config-printer";

--- a/pkgs/tools/misc/woeusb-ng/default.nix
+++ b/pkgs/tools/misc/woeusb-ng/default.nix
@@ -46,6 +46,12 @@ buildPythonApplication rec {
   # Unable to access the X Display, is $DISPLAY set properly?
   doCheck = false;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "A tool to create a Windows USB stick installer from a real Windows DVD or image";
     homepage = "https://github.com/WoeUSB/WoeUSB-ng";

--- a/pkgs/tools/networking/gp-saml-gui/default.nix
+++ b/pkgs/tools/networking/gp-saml-gui/default.nix
@@ -31,8 +31,11 @@ buildPythonPackage rec {
     openconnect
   ] ++ lib.optional stdenv.isLinux webkitgtk;
 
+  dontWrapGApps = true;
+
   preFixup = ''
-    gappsWrapperArgs+=(
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
       --set WEBKIT_DISABLE_COMPOSITING_MODE "1"
     )
   '';

--- a/pkgs/tools/networking/whatip/default.nix
+++ b/pkgs/tools/networking/whatip/default.nix
@@ -53,6 +53,12 @@ python3.pkgs.buildPythonApplication rec {
     pygobject3
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Info on your IP";
     mainProgram = "whatip";

--- a/pkgs/tools/security/gnome-keysign/default.nix
+++ b/pkgs/tools/security/gnome-keysign/default.nix
@@ -53,6 +53,12 @@ python3.pkgs.buildPythonApplication rec {
   # bunch of linting
   doCheck = false;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "GTK/GNOME application to use GnuPG for signing other peoples’ keys";
     homepage = "https://wiki.gnome.org/Apps/Keysign";

--- a/pkgs/tools/security/onioncircuits/default.nix
+++ b/pkgs/tools/security/onioncircuits/default.nix
@@ -47,6 +47,12 @@ python3.pkgs.buildPythonApplication rec {
     cp apparmor/usr.bin.onioncircuits $out/etc/apparmor.d
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     broken = stdenv.isDarwin;
     homepage = "https://tails.boum.org";

--- a/pkgs/tools/system/cm-rgb/default.nix
+++ b/pkgs/tools/system/cm-rgb/default.nix
@@ -42,6 +42,12 @@ buildPythonApplication rec {
       > $out/etc/udev/rules.d/60-cm-rgb.rules
   '';
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Control AMD Wraith Prism RGB LEDs";
     longDescription = ''


### PR DESCRIPTION
## Description of changes

As the documentation suggests. https://nixos.org/manual/nixpkgs/unstable/#sec-language-gnome

> When using wrapGAppsHook with special derivers you can end up with double wrapped binaries.

> This is because derivers like python.pkgs.buildPythonApplication or qt5.mkDerivation have setup-hooks automatically added that produce wrappers with makeWrapper. The simplest way to workaround that is to disable the wrapGAppsHook automatic wrapping with dontWrapGApps = true; and pass the arguments it intended to pass to makeWrapper to another.

> In the case of a Python application it could look like:
```nix
python3.pkgs.buildPythonApplication {
  pname = "gnome-music";
  version = "3.32.2";

  nativeBuildInputs = [
    wrapGAppsHook
    gobject-introspection
    ...
  ];

  dontWrapGApps = true;

  # Arguments to be passed to `makeWrapper`, only used by buildPython*
  preFixup = ''
    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
  '';
}
```

We can confirm these packages really have double wrapped binaries, for example, blanket:

```
├── bin                                                                                                                                                   
│   ├── blanket                                                                                                                                           
│   ├── .blanket-wrapped                                                                                                                                  
│   └── ..blanket-wrapped-wrapped
```

This is tested with:

```bash
grep -rl buildPythonApplication pkgs | xargs grep -l wrapGAppsHook | xargs grep -L dontWrapGApps
```

and:

```bash
grep -rl buildPythonPackage pkgs | xargs grep -l wrapGAppsHook | xargs grep -L dontWrapGApps
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
