### PR TITLE
pkgs/top-level: make package sets composable

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -844,6 +844,8 @@ let
 
     in warnDeprecation opt //
       { value = addErrorContext "while evaluating the option `${showOption loc}':" value;
+        # raw value before "apply" above
+        rawValue = addErrorContext "while evaluating the option `${showOption loc}':" res.mergedValue;
         inherit (res.defsFinal') highestPrio;
         definitions = map (def: def.value) res.defsFinal;
         files = map (def: def.file) res.defsFinal;

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -70,19 +70,24 @@ let
     ++ lib.optional (opt.localSystem.highestPrio < (lib.mkOptionDefault { }).priority) opt.localSystem
     ++ lib.optional (opt.crossSystem.highestPrio < (lib.mkOptionDefault { }).priority) opt.crossSystem;
 
+  # pkgs/top-level/default.nix takes great strides to pass the *original* localSystem/crossSystem args
+  # on to nixpkgsFun to create package sets like pkgsStatic, pkgsMusl. This is to be able to infer default
+  # values again. Since cfg.xxxPlatform and cfg.xxxSystem are elaborated via apply, those can't be passed
+  # directly. Instead we use the rawValue before the apply/elaboration step, via opt.xxx.rawValue.
   defaultPkgs =
     if opt.hostPlatform.isDefined then
       let
+        # This compares elaborated systems on purpose, **not** using rawValue.
         isCross = cfg.buildPlatform != cfg.hostPlatform;
         systemArgs =
           if isCross then
             {
-              localSystem = cfg.buildPlatform;
-              crossSystem = cfg.hostPlatform;
+              localSystem = opt.buildPlatform.rawValue;
+              crossSystem = opt.hostPlatform.rawValue;
             }
           else
             {
-              localSystem = cfg.hostPlatform;
+              localSystem = opt.hostPlatform.rawValue;
             };
       in
       import ../../.. (
@@ -96,9 +101,9 @@ let
         inherit (cfg)
           config
           overlays
-          localSystem
-          crossSystem
           ;
+        localSystem = opt.localSystem.rawValue;
+        crossSystem = opt.crossSystem.rawValue;
       };
 
   finalPkgs = if opt.pkgs.isDefined then cfg.pkgs.appendOverlays cfg.overlays else defaultPkgs;

--- a/pkgs/test/top-level/stage.nix
+++ b/pkgs/test/top-level/stage.nix
@@ -1,0 +1,128 @@
+# run like this:
+#  nix-build pkgs/test/top-level/stage.nix
+{
+  localSystem ? {
+    system = builtins.currentSystem;
+  },
+}:
+
+with import ../../top-level { inherit localSystem; };
+
+let
+  # To silence platform specific evaluation errors
+  discardEvaluationErrors = e: (builtins.tryEval e).success -> e;
+
+  # Basic test for idempotency of the package set, i.e:
+  # Applying the same package set twice should work and
+  # not change anything.
+  isIdempotent = set: discardEvaluationErrors (pkgs.${set}.stdenv == pkgs.${set}.${set}.stdenv);
+
+  # Some package sets should be noops in certain circumstances.
+  # This is very similar to the idempotency test, but not going
+  # via the super' overlay.
+  isNoop =
+    parent: child:
+    discardEvaluationErrors (
+      (lib.getAttrFromPath parent pkgs).stdenv == (lib.getAttrFromPath parent pkgs).${child}.stdenv
+    );
+
+  allMuslExamples = builtins.attrNames (
+    lib.filterAttrs (_: system: lib.hasSuffix "-musl" system.config) lib.systems.examples
+  );
+
+  allLLVMExamples = builtins.attrNames (
+    lib.filterAttrs (_: system: system.useLLVM or false) lib.systems.examples
+  );
+
+  # A package set should only change specific configuration, but needs
+  # to keep all other configuration from previous layers in place.
+  # Each package set has one or more key characteristics for which we
+  # test here. Those should be kept, even when applying the "set" package
+  # set.
+  isComposable =
+    set:
+    (
+      # Can't compose two different libcs...
+      builtins.elem set [ "pkgsLLVMLibc" ]
+      || discardEvaluationErrors (
+        pkgsCross.mingwW64.${set}.stdenv.hostPlatform.config == "x86_64-w64-mingw32"
+      )
+    )
+    && (
+      # Can't compose two different libcs...
+      builtins.elem set [ "pkgsLLVMLibc" ]
+      || discardEvaluationErrors (pkgsCross.mingwW64.${set}.stdenv.hostPlatform.libc == "msvcrt")
+    )
+    && discardEvaluationErrors (pkgsCross.ppc64-musl.${set}.stdenv.hostPlatform.gcc.abi == "elfv2")
+    && discardEvaluationErrors (
+      builtins.elem "trivialautovarinit" pkgs.pkgsExtraHardening.${set}.stdenv.cc.defaultHardeningFlags
+    )
+    && discardEvaluationErrors (pkgs.pkgsLLVM.${set}.stdenv.hostPlatform.useLLVM)
+    && (
+      # Can't compose two different libcs...
+      builtins.elem set [
+        "pkgsMusl"
+        "pkgsStatic"
+      ]
+      || discardEvaluationErrors (pkgs.pkgsLLVMLibc.${set}.stdenv.hostPlatform.isLLVMLibc)
+    )
+    && discardEvaluationErrors (pkgs.pkgsArocc.${set}.stdenv.hostPlatform.useArocc)
+    && discardEvaluationErrors (pkgs.pkgsZig.${set}.stdenv.hostPlatform.useZig)
+    && discardEvaluationErrors (pkgs.pkgsLinux.${set}.stdenv.buildPlatform.isLinux)
+    && (
+      # Can't compose two different libcs...
+      builtins.elem set [ "pkgsLLVMLibc" ]
+      || discardEvaluationErrors (pkgs.pkgsMusl.${set}.stdenv.hostPlatform.isMusl)
+    )
+    && discardEvaluationErrors (pkgs.pkgsStatic.${set}.stdenv.hostPlatform.isStatic)
+    && discardEvaluationErrors (pkgs.pkgsi686Linux.${set}.stdenv.hostPlatform.isx86_32)
+    && discardEvaluationErrors (pkgs.pkgsx86_64Darwin.${set}.stdenv.hostPlatform.isx86_64);
+in
+
+# Appends same defaultHardeningFlags again on each .pkgsExtraHardening - thus not idempotent.
+# assert isIdempotent "pkgsExtraHardening";
+# TODO: Remove the isDarwin condition, which currently results in infinite recursion.
+# Also see https://github.com/NixOS/nixpkgs/pull/330567#discussion_r1894653309
+assert (stdenv.hostPlatform.isDarwin || isIdempotent "pkgsLLVM");
+# TODO: This currently results in infinite recursion, even on Linux
+# assert isIdempotent "pkgsLLVMLibc";
+assert isIdempotent "pkgsArocc";
+assert isIdempotent "pkgsZig";
+assert isIdempotent "pkgsLinux";
+assert isIdempotent "pkgsMusl";
+assert isIdempotent "pkgsStatic";
+assert isIdempotent "pkgsi686Linux";
+assert isIdempotent "pkgsx86_64Darwin";
+
+# TODO: fails
+# assert isNoop [ "pkgsStatic" ] "pkgsMusl";
+# TODO: fails because of ppc64-musl
+# assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsMusl") allMuslExamples;
+assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsLLVM") allLLVMExamples;
+
+# TODO: fails
+# assert isComposable "pkgsExtraHardening";
+# assert isComposable "pkgsLLVM";
+# assert isComposable "pkgsLLVMLibc";
+# assert isComposable "pkgsArocc";
+# TODO: unexpected argument 'bintools' - uncomment once https://github.com/NixOS/nixpkgs/pull/331011 is done
+# assert isComposable "pkgsZig";
+# TODO: attribute 'abi' missing
+# assert isComposable "pkgsMusl";
+# TODO: fails
+# assert isComposable "pkgsStatic";
+# assert isComposable "pkgsi686Linux";
+
+# Special cases regarding buildPlatform vs hostPlatform
+# TODO: fails
+# assert discardEvaluationErrors (pkgsCross.gnu64.pkgsMusl.stdenv.hostPlatform.isMusl);
+# assert discardEvaluationErrors (pkgsCross.gnu64.pkgsi686Linux.stdenv.hostPlatform.isx86_32);
+# assert discardEvaluationErrors (pkgsCross.mingwW64.pkgsLinux.stdenv.hostPlatform.isLinux);
+# assert discardEvaluationErrors (pkgsCross.aarch64-darwin.pkgsx86_64Darwin.stdenv.hostPlatform.isx86_64);
+
+# pkgsCross should keep upper cross settings
+# TODO: fails
+# assert discardEvaluationErrors (with pkgsStatic.pkgsCross.gnu64.stdenv.hostPlatform; isGnu && isStatic);
+# assert discardEvaluationErrors (with pkgsLLVM.pkgsCross.musl64.stdenv.hostPlatform; isMusl && useLLVM);
+
+emptyFile

--- a/pkgs/test/top-level/stage.nix
+++ b/pkgs/test/top-level/stage.nix
@@ -94,35 +94,36 @@ assert isIdempotent "pkgsStatic";
 assert isIdempotent "pkgsi686Linux";
 assert isIdempotent "pkgsx86_64Darwin";
 
-# TODO: fails
-# assert isNoop [ "pkgsStatic" ] "pkgsMusl";
-# TODO: fails because of ppc64-musl
-# assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsMusl") allMuslExamples;
+assert isNoop [ "pkgsStatic" ] "pkgsMusl";
+assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsMusl") allMuslExamples;
 assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsLLVM") allLLVMExamples;
 
-# TODO: fails
-# assert isComposable "pkgsExtraHardening";
-# assert isComposable "pkgsLLVM";
+assert isComposable "pkgsExtraHardening";
+assert isComposable "pkgsLLVM";
+# TODO: Results in infinite recursion
 # assert isComposable "pkgsLLVMLibc";
-# assert isComposable "pkgsArocc";
+assert isComposable "pkgsArocc";
 # TODO: unexpected argument 'bintools' - uncomment once https://github.com/NixOS/nixpkgs/pull/331011 is done
 # assert isComposable "pkgsZig";
-# TODO: attribute 'abi' missing
-# assert isComposable "pkgsMusl";
-# TODO: fails
-# assert isComposable "pkgsStatic";
-# assert isComposable "pkgsi686Linux";
+assert isComposable "pkgsMusl";
+assert isComposable "pkgsStatic";
+assert isComposable "pkgsi686Linux";
 
 # Special cases regarding buildPlatform vs hostPlatform
 # TODO: fails
 # assert discardEvaluationErrors (pkgsCross.gnu64.pkgsMusl.stdenv.hostPlatform.isMusl);
 # assert discardEvaluationErrors (pkgsCross.gnu64.pkgsi686Linux.stdenv.hostPlatform.isx86_32);
-# assert discardEvaluationErrors (pkgsCross.mingwW64.pkgsLinux.stdenv.hostPlatform.isLinux);
-# assert discardEvaluationErrors (pkgsCross.aarch64-darwin.pkgsx86_64Darwin.stdenv.hostPlatform.isx86_64);
+assert discardEvaluationErrors (pkgsCross.mingwW64.pkgsLinux.stdenv.hostPlatform.isLinux);
+assert discardEvaluationErrors (
+  pkgsCross.aarch64-darwin.pkgsx86_64Darwin.stdenv.hostPlatform.isx86_64
+);
 
 # pkgsCross should keep upper cross settings
-# TODO: fails
-# assert discardEvaluationErrors (with pkgsStatic.pkgsCross.gnu64.stdenv.hostPlatform; isGnu && isStatic);
-# assert discardEvaluationErrors (with pkgsLLVM.pkgsCross.musl64.stdenv.hostPlatform; isMusl && useLLVM);
+assert discardEvaluationErrors (
+  with pkgsStatic.pkgsCross.gnu64.stdenv.hostPlatform; isGnu && isStatic
+);
+assert discardEvaluationErrors (
+  with pkgsLLVM.pkgsCross.musl64.stdenv.hostPlatform; isMusl && useLLVM
+);
 
 emptyFile

--- a/pkgs/test/top-level/stage.nix
+++ b/pkgs/test/top-level/stage.nix
@@ -110,9 +110,8 @@ assert isComposable "pkgsStatic";
 assert isComposable "pkgsi686Linux";
 
 # Special cases regarding buildPlatform vs hostPlatform
-# TODO: fails
-# assert discardEvaluationErrors (pkgsCross.gnu64.pkgsMusl.stdenv.hostPlatform.isMusl);
-# assert discardEvaluationErrors (pkgsCross.gnu64.pkgsi686Linux.stdenv.hostPlatform.isx86_32);
+assert discardEvaluationErrors (pkgsCross.gnu64.pkgsMusl.stdenv.hostPlatform.isMusl);
+assert discardEvaluationErrors (pkgsCross.gnu64.pkgsi686Linux.stdenv.hostPlatform.isx86_32);
 assert discardEvaluationErrors (pkgsCross.mingwW64.pkgsLinux.stdenv.hostPlatform.isLinux);
 assert discardEvaluationErrors (
   pkgsCross.aarch64-darwin.pkgsx86_64Darwin.stdenv.hostPlatform.isx86_64

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -122,22 +122,18 @@ in let
   config = lib.showWarnings configEval.config.warnings configEval.config;
 
   # A few packages make a new package set to draw their dependencies from.
-  # (Currently to get a cross tool chain, or forced-i686 package.) Rather than
-  # give `all-packages.nix` all the arguments to this function, even ones that
-  # don't concern it, we give it this function to "re-call" nixpkgs, inheriting
-  # whatever arguments it doesn't explicitly provide. This way,
-  # `all-packages.nix` doesn't know more than it needs too.
+  # Rather than give `all-packages.nix` all the arguments to this function,
+  # even ones that don't concern it, we give it this function to "re-call"
+  # nixpkgs, inheriting whatever arguments it doesn't explicitly provide. This
+  # way, `all-packages.nix` doesn't know more than it needs to.
   #
   # It's OK that `args` doesn't include default arguments from this file:
   # they'll be deterministically inferred. In fact we must *not* include them,
   # because it's important that if some parameter which affects the default is
   # substituted with a different argument, the default is re-inferred.
   #
-  # To put this in concrete terms, this function is basically just used today to
-  # use package for a different platform for the current platform (namely cross
-  # compiling toolchains and 32-bit packages on x86_64). In both those cases we
-  # want the provided non-native `localSystem` argument to affect the stdenv
-  # chosen.
+  # To put this in concrete terms, we want the provided non-native `localSystem`
+  # and `crossSystem` arguments to affect the stdenv chosen.
   #
   # NB!!! This thing gets its `config` argument from `args`, i.e. it's actually
   # `config0`. It is important to keep it to `config0` format (as opposed to the

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -142,7 +142,7 @@ in let
   # via `evalModules` is not idempotent. In other words, if you add `config` to
   # `newArgs`, expect strange very hard to debug errors! (Yes, I'm speaking from
   # experience here.)
-  nixpkgsFun = newArgs: import ./. (args // newArgs);
+  nixpkgsFun = f0: import ./. (args // f0 args);
 
   # Partially apply some arguments for building bootstraping stage pkgs
   # sets. Only apply arguments which no stdenv would want to override.

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -180,12 +180,7 @@ let
       ((config.packageOverrides or (super: {})) super);
 
   # Convenience attributes for instantitating package sets. Each of
-  # these will instantiate a new version of allPackages. Currently the
-  # following package sets are provided:
-  #
-  # - pkgsCross.<system> where system is a member of lib.systems.examples
-  # - pkgsMusl
-  # - pkgsi686Linux
+  # these will instantiate a new version of allPackages.
   otherPackageSets = self: super: {
     # This maps each entry in lib.systems.examples to its own package
     # set. Each of these will contain all packages cross compiled for

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -298,23 +298,6 @@ let
         localSystem = lib.systems.elaborate "${stdenv.hostPlatform.parsed.cpu.name}-linux";
       };
 
-    # Extend the package set with zero or more overlays. This preserves
-    # preexisting overlays. Prefer to initialize with the right overlays
-    # in one go when calling Nixpkgs, for performance and simplicity.
-    appendOverlays = extraOverlays:
-      if extraOverlays == []
-      then self
-      else nixpkgsFun { overlays = args.overlays ++ extraOverlays; };
-
-    # NOTE: each call to extend causes a full nixpkgs rebuild, adding ~130MB
-    #       of allocations. DO NOT USE THIS IN NIXPKGS.
-    #
-    # Extend the package set with a single overlay. This preserves
-    # preexisting overlays. Prefer to initialize with the right overlays
-    # in one go when calling Nixpkgs, for performance and simplicity.
-    # Prefer appendOverlays if used repeatedly.
-    extend = f: self.appendOverlays [f];
-
     # Fully static packages.
     # Currently uses Musl on Linux (couldn’t get static glibc to work).
     pkgsStatic = nixpkgsFun ({
@@ -357,6 +340,23 @@ let
         })
       ] ++ overlays;
     };
+
+    # Extend the package set with zero or more overlays. This preserves
+    # preexisting overlays. Prefer to initialize with the right overlays
+    # in one go when calling Nixpkgs, for performance and simplicity.
+    appendOverlays = extraOverlays:
+      if extraOverlays == []
+      then self
+      else nixpkgsFun { overlays = args.overlays ++ extraOverlays; };
+
+    # NOTE: each call to extend causes a full nixpkgs rebuild, adding ~130MB
+    #       of allocations. DO NOT USE THIS IN NIXPKGS.
+    #
+    # Extend the package set with a single overlay. This preserves
+    # preexisting overlays. Prefer to initialize with the right overlays
+    # in one go when calling Nixpkgs, for performance and simplicity.
+    # Prefer appendOverlays if used repeatedly.
+    extend = f: self.appendOverlays [f];
   };
 
   # The complete chain of package set builders, applied from top to bottom.


### PR DESCRIPTION
## Description of changes

The various `pkgsXYZ` top-level package sets did not pass `localSystem` / `crossSystem` options to lower levels, so far. This change propagates the original arguments, i.e. `localSystem0` / `crossSystem0` to lower levels. Those include the overrides made by an upper package set.

Example: `pkgsStatic` adds `crossSystem = { isStatic = true }`. `pkgsStatic.pkgsMusl` previously lost this setting, because it didn't propagate `crossSystem0`, yet.

The first commit removes / rewrites some outdated comments, which referred to the cross and i686 package sets. Meanwhile, we have a lot more, so I rewrote those comments to not say anything about specific sets anymore.

The second commit adds some tests to confirm composability of package sets. This helped me coming up with the fixes, I'm not sure whether it should be kept. It takes about 8-9 seconds for me to run. It also helps showing what the remaining commits fix by uncommenting the previously broken tests.

The remaining commits fix those composability issues. This:
- will fix #281596 (@yshui, @wegank)
- could possibly fix #283460 with a more principal approach (@rodarima, @alyssais, @K900)
- supersedes the fix in #136549 (@r-burns, @rnhmjoj)

~~One open question for me is how to deal with `pkgsXYZ.pkgsCross`. This has practical challenges (#114510), but is also conceptually unsound: In a way `pkgsCross` expects to reset `crossSystem` from scratch, because the whole point about this layer is to start with "well known" example configurations. IMHO, it's fine to make modifications on top of that. e.g. `pkgsCross.XYZ.pkgsLLVM` or `pkgsCross.XYZ.pkgsStatic`, but it makes little sense to have `pkgsLLVM.pkgsCross...` or `pkgsStatic.pkgsCross...`. Probably completely unusable is `pkgsCross.XYZ.pkgsCross.ABC`.~~

~~One idea would be to just restrict `pkgsCross` to be used at the top-level, for example by adding something like this in each package set, including `pkgsCross` itself: [...]~~

~~That would also disallow `pkgsMusl.pkgsCross.XYZ`, which I think is about the only remotely reasonable use-case here: "cross compiling from a native musl environment". I'm not sure whether anyone uses that, though, and whether it's worth supporting at all.~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
