### PR TITLE
python311Packages.pyperscan: 0.2.2 -> 0.3.0

### DIFF
--- a/pkgs/development/python-modules/pyperscan/default.nix
+++ b/pkgs/development/python-modules/pyperscan/default.nix
@@ -10,20 +10,20 @@
 
 buildPythonPackage rec {
   pname = "pyperscan";
-  version = "0.2.2";
+  version = "0.3.0";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "vlaci";
     repo = "pyperscan";
     rev = "v${version}";
-    hash = "sha256-ioNGEmWy+lEzazF1RzMFS06jYLNYll3QSlWAF0AoU7Y=";
+    hash = "sha256-uGZ0XFxnZHSLEWcwoHVd+xMulDRqEIrQ5Lf7886GdlM=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-2zppyxJ+XaI/JCkp7s27/jgtSbwxnI4Yil5KT8WgrVI=";
+    hash = "sha256-a4jNofPIHoKwsD82y2hG2QPu+eM5D7FSGCm2nDo2cLA=";
   };
 
   nativeBuildInputs = with rustPlatform; [
@@ -36,14 +36,12 @@ buildPythonPackage rec {
 
   buildInputs = [ vectorscan ] ++ lib.optional stdenv.isDarwin libiconv;
 
-  # Disable default features to use the system vectorscan library instead of a vendored one.
-  maturinBuildFlags = [ "--no-default-features" ];
-
   pythonImportsCheck = [ "pyperscan" ];
 
   meta = with lib; {
     description = "a hyperscan binding for Python, which supports vectorscan";
-    homepage = "https://github.com/vlaci/pyperscan";
+    homepage = "https://vlaci.github.io/pyperscan/";
+    changelog = "https://github.com/vlaci/pyperscan/releases/tag/${src.rev}";
     platforms = platforms.unix;
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ tnias vlaci ];


### PR DESCRIPTION
## Description of changes

Bump version, update metadata and remove redundant build flag.

Changelog: https://github.com/vlaci/pyperscan/releases/tag/v0.3.0
All changes: https://github.com/vlaci/pyperscan/compare/v0.2.2...v0.3.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
I locally ran the nixpkgs-review on aarch64-linux and x86_64-linux. Both directly on master and on top of the new vectorscan version from https://github.com/NixOS/nixpkgs/pull/303207 (their reports are the same, except that they also list vectorscan as a built package).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>python311Packages.pyperscan</li>
    <li>python311Packages.pyperscan.dist</li>
    <li>python312Packages.pyperscan</li>
    <li>python312Packages.pyperscan.dist</li>
  </ul>
</details>

Result of `nixpkgs-review` run on aarch64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>python311Packages.pyperscan</li>
    <li>python311Packages.pyperscan.dist</li>
    <li>python312Packages.pyperscan</li>
    <li>python312Packages.pyperscan.dist</li>
  </ul>
</details>

---

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
