### PR TITLE
Seadrive

### DIFF
--- a/pkgs/by-name/se/seadrive-fuse/package.nix
+++ b/pkgs/by-name/se/seadrive-fuse/package.nix
@@ -1,0 +1,62 @@
+{ fetchFromGitHub
+, pkg-config
+, stdenv
+, autoreconfHook
+, lib
+# Package dependencies
+, libsearpc
+, libselinux
+, libuuid
+, pcre
+, libtool
+, libevent
+, sqlite
+, openssl
+, fuse
+, vala
+, intltool
+, jansson
+, curl
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "seadrive-fuse";
+  version = "2.0.16";
+
+  src = fetchFromGitHub {
+    owner = "haiwen";
+    repo = "seadrive-fuse";
+    rev = "v${version}";
+    sha256 = "072sx4wvj3gbslv3hn4sifr28fy812b8aja9d7phl1w4yix9l55z";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+  buildInputs = [
+    libsearpc
+    libselinux
+    libuuid # Satisfies the 'mount' package requirement. Contains 'mount.pc'
+    pcre
+    libtool
+    libevent
+    sqlite
+    openssl
+    fuse
+    vala
+    intltool
+    jansson
+    curl
+    python3
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/haiwen/seadrive-fuse";
+    description = "SeaDrive daemon with FUSE interface";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ nayala ];
+  };
+}

--- a/pkgs/by-name/se/seadrive-gui/fix_webkit_webengine.patch
+++ b/pkgs/by-name/se/seadrive-gui/fix_webkit_webengine.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c952008..f4afb47 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -181,6 +181,7 @@ ENDIF()
+ 
+ SET(USE_QT_LIBRARIES
+     Core Gui Widgets LinguistTools Network Test
++    ${WEBKIT_NAME} ${WEBKIT_WIDGETS_NAME}
+     )
+ 
+ IF (${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/pkgs/by-name/se/seadrive-gui/package.nix
+++ b/pkgs/by-name/se/seadrive-gui/package.nix
@@ -1,0 +1,53 @@
+{ cmake
+, fetchFromGitHub
+, pkg-config
+, stdenv
+, lib
+, extra-cmake-modules
+# Package dependencies
+, libsepol
+, seadrive-fuse
+, qt5
+}:
+
+stdenv.mkDerivation rec {
+  pname = "seadrive-gui";
+  version = "2.0.16";
+
+  src = fetchFromGitHub {
+    owner = "haiwen";
+    repo = "seadrive-gui";
+    rev = "v${version}";
+    sha256 = "0gi2l2knyl0903fslwdhkqlm3p88dznk5nns9lfimbk8as8qd0mf";
+  };
+
+  patches = [ ./fix_webkit_webengine.patch ];
+
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+    cmake
+    pkg-config
+    qt5.qttools
+    extra-cmake-modules
+  ];
+  buildInputs = [
+    libsepol
+    seadrive-fuse
+    qt5.qtwebengine
+  ] ++ seadrive-fuse.buildInputs;
+
+  # seadrive-gui calls seadrive-fuse/bin/seadrive at runtime
+  # seadrive-fuse implements the actual file syncing,
+  # while seadrive-gui is a gui to call and monitor seadrive-fuse
+  qtWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath [ seadrive-fuse ]}"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/haiwen/seadrive-gui";
+    description = "GUI part of Seafile drive";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ nayala ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds seadrive-gui as well as its dependency seadrive-fuse

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
