### PR TITLE
bats: 1.10.0 -> 1.11.0, resholve: fix related test breakage

### DIFF
--- a/pkgs/development/interpreters/bats/default.nix
+++ b/pkgs/development/interpreters/bats/default.nix
@@ -27,13 +27,13 @@
 
 resholve.mkDerivation rec {
   pname = "bats";
-  version = "1.10.0";
+  version = "1.11.0";
 
   src = fetchFromGitHub {
     owner = "bats-core";
     repo = "bats-core";
     rev = "v${version}";
-    sha256 = "sha256-gy4dyoKRlf2WFmH1/mSNwhVR3df92BgpT4TjTpV4FyQ=";
+    hash = "sha256-goHIhbBoCf1eb1N8xIHdVvAURofvLDgEDXofhDHrr7Y=";
   };
 
   patchPhase = ''
@@ -69,11 +69,13 @@ resholve.mkDerivation rec {
         external = [
           "greadlink"
           "shlock"
+        ] ++ lib.optionals stdenv.isDarwin [
           "pkill" # procps doesn't supply this on darwin
         ];
       };
       fix = {
         "$BATS_ROOT" = [ "${placeholder "out"}" ];
+        "$BATS_LIBDIR" = [ "lib" ];
         "$BATS_LIBEXEC" = [ "${placeholder "out"}/libexec/bats-core" ];
       };
       keep = {
@@ -99,6 +101,7 @@ resholve.mkDerivation rec {
         "$BATS_LINE_REFERENCE_FORMAT" = "comma_line";
         "$BATS_LOCKING_IMPLEMENTATION" = "${flock}/bin/flock";
         "$parallel_binary_name" = "${parallel}/bin/parallel";
+        "${placeholder "out"}/libexec/bats-core/bats-preprocess" = true;
       };
       execer = [
         /*
@@ -115,6 +118,10 @@ resholve.mkDerivation rec {
         # these do exec, but other internal files
         "cannot:libexec/bats-core/bats-exec-file"
         "cannot:libexec/bats-core/bats-exec-suite"
+        "cannot:libexec/bats-core/bats-gather-tests"
+      ] ++ lib.optionals (!stdenv.isDarwin) [
+        # checked invocations for exec
+        "cannot:${procps}/bin/pkill"
       ];
     };
   };

--- a/pkgs/development/interpreters/bats/default.nix
+++ b/pkgs/development/interpreters/bats/default.nix
@@ -18,6 +18,11 @@
 , makeWrapper
 , runCommand
 , doInstallCheck ? true
+# packages that use bats (for update testing)
+, bash-preexec
+, kikit
+, locate-dominating-file
+, packcc
 }:
 
 resholve.mkDerivation rec {
@@ -207,6 +212,16 @@ resholve.mkDerivation rec {
         touch $out
       '';
     });
+
+    # to see when updates would break things, include packages
+    # that use nixpkgs' bats for testing (as long as they
+    # aren't massive builds)
+    inherit bash-preexec locate-dominating-file packcc;
+    resholve = resholve.tests.cli;
+  } // lib.optionalAttrs (!stdenv.isDarwin) {
+    # TODO: kikit's kicad dependency is marked broken on darwin atm
+    # may be able to fold this up if that resolves.
+    inherit kikit;
   };
 
   meta = with lib; {

--- a/pkgs/development/misc/resholve/test.nix
+++ b/pkgs/development/misc/resholve/test.nix
@@ -18,6 +18,7 @@
 , gettext
 , rSrc
 , runDemo ? false
+, fetchpatch
 , binlore
 , sqlite
 , unixtools
@@ -121,6 +122,21 @@ rec {
   cli = stdenv.mkDerivation {
     name = "resholve-test";
     src = rSrc;
+
+    # TODO: should be removable on next resholve update--just
+    # temporarily work around test breaks caused by changes in
+    # bats 1.10.0. Since this is just about fixing tests, I'm
+    # patching test source to avoid going through staging.
+    patches = [
+      (fetchpatch {
+        url = "https://github.com/abathur/resholve/commit/e1d6ccbc9cd5ec26122997610954dcb7d826f652.patch";
+        hash = "sha256-XA9KUc/OAD2S8Vpt+C7KcjTP44rnZ4FLdgnnRqVWdWY=";
+      })
+      (fetchpatch {
+        url = "https://github.com/abathur/resholve/commit/50db1a6a97baa7d7543a8abe33dddda62b487c65.patch";
+        hash = "sha256-m1dKaLI02Wag7uacG4BkcdCXw30Kn6J4ydTqPd7bsak=";
+      })
+    ];
 
     dontBuild = true;
 


### PR DESCRIPTION
## Description of changes

- Update bats to 1.11.0 ([changelog entry for 1.11.0](https://github.com/bats-core/bats-core/blob/12c23eda62065af5e4c80cc81a28a4ce4af34224/docs/CHANGELOG.md#1110---2024-03-24))
- Work around some resholve tests broken by this update. This uses patches (for now) to avoid needing to go through staging.

  Despite this, I'm deferring to the maintainer's opinion that this behavior shift doesn't rise to the level of a major/breaking change. After discussing with them, it sounds like I held it ~wrong and ended up depending on a ~quirky/buggy/misleading implementation detail that they needed to fix (for posterity, here's that [discussion comment](https://github.com/orgs/bats-core/discussions/850#discussioncomment-8648385)). They released a month ago (after a couple months in the release candidate stage) and I haven't seen issues/chatter indicating that this broke anyone else.

- Add bats-tested packages to bats passthru.tests to reduce the likelihood we merge an update that'll break any of them (and do a little reformatting to aid this)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>bash-preexec</li>
    <li>bats</li>
    <li>locate-dominating-file</li>
    <li>packcc</li>
  </ul>
</details>

> *Note*: I'll update this later with results from NixOS; don't have access to the system atm. 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
