### PR TITLE
sbcl: read memory from envvar

### DIFF
--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -120,6 +120,7 @@ stdenv.mkDerivation (self: rec {
     # but for Nix envvars are sufficiently useful that it’s worth maintaining
     # this functionality downstream.
     ./dynamic-space-size-envvar-feature.patch
+    ./dynamic-space-size-envvar-tests.patch
   ];
   postPatch = lib.optionalString (self.disabledTestFiles != [ ]) ''
     (cd tests ; rm -f ${lib.concatStringsSep " " self.disabledTestFiles})

--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -113,6 +113,14 @@ stdenv.mkDerivation (self: rec {
     # have it block a release.
     "futex-wait.test.sh"
   ];
+  patches = [
+    # Support the NIX_SBCL_DYNAMIC_SPACE_SIZE envvar. Upstream SBCL didn’t want
+    # to include this (see
+    # "https://sourceforge.net/p/sbcl/mailman/sbcl-devel/thread/2cf20df7-01d0-44f2-8551-0df01fe55f1a%400brg.net/"),
+    # but for Nix envvars are sufficiently useful that it’s worth maintaining
+    # this functionality downstream.
+    ./dynamic-space-size-envvar-feature.patch
+  ];
   postPatch = lib.optionalString (self.disabledTestFiles != [ ]) ''
     (cd tests ; rm -f ${lib.concatStringsSep " " self.disabledTestFiles})
   ''

--- a/pkgs/development/compilers/sbcl/dynamic-space-size-envvar-feature.patch
+++ b/pkgs/development/compilers/sbcl/dynamic-space-size-envvar-feature.patch
@@ -1,0 +1,63 @@
+From ac15f9f7c75c1fb5767514e64b609e2a75e6fe9d Mon Sep 17 00:00:00 2001
+From: Hraban Luyat <hraban@0brg.net>
+Date: Sat, 13 Apr 2024 14:04:57 -0400
+Subject: [PATCH] feat: NIX_SBCL_DYNAMIC_SPACE_SIZE envvar
+
+Read SBCL dynamic space size configuration from env if available.
+---
+ src/runtime/runtime.c | 25 +++++++++++++++++++++++++
+ 1 file changed, 25 insertions(+)
+
+diff --git a/src/runtime/runtime.c b/src/runtime/runtime.c
+index 274687c8f..970caa8f4 100644
+--- a/src/runtime/runtime.c
++++ b/src/runtime/runtime.c
+@@ -422,6 +422,29 @@ static int is_memsize_arg(char *argv[], int argi, int argc, int *merge_core_page
+     return 0;
+ }
+ 
++/**
++ * Read memory options from the environment, if present.
++ *
++ * Memory settings are read in the following priority:
++ *
++ * 1. command line arguments
++ * 2. environment variable
++ * 3. embedded options in core
++ * 4. default
++ */
++static void
++read_memsize_from_env(void) {
++  const char *val = getenv("NIX_SBCL_DYNAMIC_SPACE_SIZE");
++  // The distinction is blurry between setting an envvar to the empty string and
++  // unsetting it entirely. Depending on the calling environment it can even be
++  // tricky to properly unset an envvar in the first place. An empty envvar is
++  // practically always intended to just mean “unset”, so let’s interpret it
++  // that way.
++  if (val != NULL && (strcmp(val, "") != 0)) {
++    dynamic_space_size = parse_size_arg(val, "NIX_SBCL_DYNAMIC_SPACE_SIZE");
++  }
++}
++
+ static struct cmdline_options
+ parse_argv(struct memsize_options memsize_options,
+            int argc, char *argv[], char *envp[], char *core)
+@@ -462,6 +485,7 @@ parse_argv(struct memsize_options memsize_options,
+         dynamic_space_size = memsize_options.dynamic_space_size;
+         thread_control_stack_size = memsize_options.thread_control_stack_size;
+         dynamic_values_bytes = memsize_options.thread_tls_bytes;
++        read_memsize_from_env();
+         int stop_parsing = 0; // have we seen '--'
+         int output_index = 1;
+ 
+@@ -488,6 +512,7 @@ parse_argv(struct memsize_options memsize_options,
+         }
+         sbcl_argv[output_index] = 0;
+     } else {
++        read_memsize_from_env();
+         bool end_runtime_options = 0;
+         /* Parse our any of the command-line options that we handle from C,
+          * stopping at the first one that we don't, and leave the rest */
+-- 
+2.44.0
+

--- a/pkgs/development/compilers/sbcl/dynamic-space-size-envvar-tests.patch
+++ b/pkgs/development/compilers/sbcl/dynamic-space-size-envvar-tests.patch
@@ -1,0 +1,104 @@
+From 9d4a886a8a76ea8be51bcf754cefacdf30986f46 Mon Sep 17 00:00:00 2001
+From: Hraban Luyat <hraban@0brg.net>
+Date: Sat, 13 Apr 2024 15:39:58 -0400
+Subject: [PATCH 2/2] test: dynamic space size envvar and precedence
+
+---
+ tests/memory-args.test.sh | 22 ++++++++++++++++++++++
+ tests/save7.test.sh       | 37 ++++++++++++++++++++++++++++++++-----
+ 2 files changed, 54 insertions(+), 5 deletions(-)
+ create mode 100755 tests/memory-args.test.sh
+
+diff --git a/tests/memory-args.test.sh b/tests/memory-args.test.sh
+new file mode 100755
+index 000000000..72ef0cc79
+--- /dev/null
++++ b/tests/memory-args.test.sh
+@@ -0,0 +1,22 @@
++#!/bin/sh
++
++. ./subr.sh
++
++use_test_subdirectory
++
++set -e
++
++# Allow slight shrinkage if heap relocation has to adjust for alignment
++NIX_SBCL_DYNAMIC_SPACE_SIZE=234mb run_sbcl_with_args --script <<EOF
++(assert (<= 0 (- (* 234 1024 1024) (sb-ext:dynamic-space-size)) 65536))
++EOF
++
++NIX_SBCL_DYNAMIC_SPACE_SIZE=555mb run_sbcl_with_args --dynamic-space-size 234mb --script <<EOF
++(assert (<= 0 (- (* 234 1024 1024) (sb-ext:dynamic-space-size)) 65536))
++EOF
++
++run_sbcl_with_args --dynamic-space-size 234mb --script <<EOF
++(assert (<= 0 (- (* 234 1024 1024) (sb-ext:dynamic-space-size)) 65536))
++EOF
++
++exit $EXIT_TEST_WIN
+diff --git a/tests/save7.test.sh b/tests/save7.test.sh
+index f9225543b..3c35e7b31 100644
+--- a/tests/save7.test.sh
++++ b/tests/save7.test.sh
+@@ -59,9 +59,9 @@ run_sbcl_with_core "$tmpcore" --noinform --control-stack-size 640KB \
+   (assert (eql (extern-alien "dynamic_values_bytes" (unsigned 32))
+                (* 5000 sb-vm:n-word-bytes)))
+   ; allow slight shrinkage if heap relocation has to adjust for alignment
+-  (defun dynamic-space-size-good-p ()
+-    (<= 0 (- (* 260 1048576) (dynamic-space-size)) 65536))
+-  (assert (dynamic-space-size-good-p))
++  (defun dynamic-space-size-good-p (expected-mb)
++    (<= 0 (- (* expected-mb 1024 1024) (dynamic-space-size)) 65536))
++  (assert (dynamic-space-size-good-p 260))
+   (save-lisp-and-die "${tmpcore}2" :executable t :save-runtime-options t)
+ EOF
+ chmod u+x "${tmpcore}2"
+@@ -70,15 +70,42 @@ echo "::: INFO: prepared test core"
+   (when (and (eql (extern-alien "thread_control_stack_size" unsigned) (* 640 1024))
+              (eql (extern-alien "dynamic_values_bytes" (unsigned 32))
+                   (* 5000 sb-vm:n-word-bytes))
+-             (dynamic-space-size-good-p))
++             (dynamic-space-size-good-p 260))
+     (exit :code 42))
+ EOF
+ status=$?
+-rm "$tmpcore" "${tmpcore}2"
+ if [ $status -ne 42 ]; then
+     echo "re-saved executable used wrong memory size options"
+     exit 1
+ fi
+ echo "::: Success"
+ 
++echo "::: Running :DYNAMIC-SPACE-SIZE-ENV"
++NIX_SBCL_DYNAMIC_SPACE_SIZE=432MB ./"${tmpcore}2" --no-userinit --no-sysinit --noprint <<EOF
++  (when (dynamic-space-size-good-p 432)
++    (exit :code 42))
++EOF
++status=$?
++if [ $status -ne 42 ]; then
++    echo "re-saved executable should have prioritized memory specification from env"
++    exit 1
++fi
++echo "::: Success"
++
++echo "::: Running :DYNAMIC-SPACE-SIZE-PRECEDENCE"
++NIX_SBCL_DYNAMIC_SPACE_SIZE=432MB ./"${tmpcore}2" --dynamic-space-size 333MB \
++  --no-userinit --no-sysinit --noprint <<EOF
++  (when (dynamic-space-size-good-p 333))
++    (exit :code 42))
++EOF
++status=$?
++rm "$tmpcore" "${tmpcore}2"
++if [ $status -ne 42 ]; then
++    echo "re-saved executable should have prioritized memory specification from arg"
++    exit 1
++fi
++echo "::: Success"
++
++
++
+ exit $EXIT_TEST_WIN
+-- 
+2.44.0
+


### PR DESCRIPTION
## Description of changes

Allow controlling SBCL memory through a `SBCL_DYNAMIC_SPACE_SIZE` envvar which has the same format as the `--dynamic-space-size` cli flag.

I have tried this locally and on https://github.com/hraban/cl-nix-lite and it significantly simplifies a few hokey workarounds I had. It might also address the concerns from https://github.com/NixOS/nixpkgs/pull/298034 depending on their circumstances. And would it help clean up the ugly wrapping we do in `all-packages.nix` at the moment? https://github.com/NixOS/nixpkgs/blob/200e237951a35168aff3af66965c08667b4833af/pkgs/top-level/all-packages.nix#L25547 etc.

The idea being that memory is set from the first value found in this order:

1. from the command line args
2. from the env
3. from embedded args in a core file
4. from defaults

Notably this means that memory can be set on a per-package basis and big packages can reuse build cache from smaller packages and vice-versa. Concretely: in `cl-nix-lite` the `3d-math` package requires >3GiB of heap to build, but this meant setting the dynamic space size to 3GiB for all packages built by SBCL on CI, effectively disabling the build cache for SBCL.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
