### PR TITLE
python311Packages.etelemetry: 0.2.1 -> 0.3.1

### DIFF
--- a/pkgs/development/python-modules/etelemetry/default.nix
+++ b/pkgs/development/python-modules/etelemetry/default.nix
@@ -1,20 +1,37 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27, ci-info, ci-py, requests }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, ci-info
+, ci-py
+, requests
+, setuptools
+}:
 
 buildPythonPackage rec {
-  version = "0.2.1";
-  format = "setuptools";
   pname = "etelemetry";
-  disabled = isPy27;
+  version = "0.3.1";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1rw8im09ppnb7z7p7rx658rp5ib8zca8byxg1kiflqwgx5c8zddz";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "sensein";
+    repo = "etelemetry-client";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-UaE5JQhv2AtzXKY7YD2/g6Kj1igKhmnY3zlf1P9B/iQ=";
   };
 
-  propagatedBuildInputs = [ ci-info ci-py requests ];
+  nativeBuildInputs = [ setuptools ];
 
-  # all 2 of the tests both try to pull down from a url
-  doCheck = false;
+  propagatedBuildInputs = [
+    ci-info
+    ci-py
+    requests
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [
     "etelemetry"
@@ -24,7 +41,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Lightweight python client to communicate with the etelemetry server";
-    homepage = "https://github.com/mgxd/etelemetry-client";
+    homepage = "https://github.com/sensein/etelemetry-client";
+    changelog = "https://github.com/sensein/etelemetry-client/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ ];
   };


### PR DESCRIPTION
## Description of changes

Update and minor refactor; unbreaks the Python 3.12 build.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
