### PR TITLE
electrum: fix check without qt

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -73,6 +73,9 @@ python3.pkgs.buildPythonApplication rec {
     lib.optionals enableQt [
       pyqt6
     ];
+  disabledTestPaths = lib.optionals (!enableQt) [
+    "tests/test_qml_types.py"
+  ];
 
   postPatch =
     if enableQt then


### PR DESCRIPTION
## Description of changes

Resolves the following build error:
```
nix-build --expr '(import <nixpkgs> {}).electrum.override { enableQt = false; }'

electrum> ============================= test session starts ==============================
electrum> platform linux -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
electrum> rootdir: /build/Electrum-4.5.4
electrum> collected 679 items / 1 error
electrum> ==================================== ERRORS ====================================
electrum> ___________________ ERROR collecting tests/test_qml_types.py ___________________
electrum> ImportError while importing test module '/build/Electrum-4.5.4/tests/test_qml_types.py'.
electrum> Hint: make sure your test modules/packages have valid Python names.
electrum> Traceback:
electrum> electrum/gui/qml/__init__.py:8: in <module>
electrum>     import PyQt6
electrum> E   ModuleNotFoundError: No module named 'PyQt6'
electrum> The above exception was the direct cause of the following exception:
electrum> /nix/store/gd3shnza1i50zn8zs04fa729ribr88m9-python3-3.11.8/lib/python3.11/importlib/__init__.py:126: in import_module
electrum>     return _bootstrap._gcd_import(name[level:], package, level)
electrum> tests/test_qml_types.py:5: in <module>
electrum>     from electrum.gui.qml.qetypes import QEAmount
electrum> electrum/gui/qml/__init__.py:11: in <module>
electrum>     raise GuiImportError(
electrum> E   electrum.GuiImportError: Error: Could not import PyQt6. On Linux systems, you may try 'sudo apt-get install python3-pyqt6'
electrum> =========================== short test summary info ============================
electrum> ERROR tests/test_qml_types.py
electrum> !!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
electrum> =============================== 1 error in 1.06s ===============================
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
