### PR TITLE
tabby-terminal: init at 1.0.207

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3582,6 +3582,12 @@
     githubId = 1118859;
     name = "Scott Worley";
   };
+  ChocolateLoverRaj = {
+    github = "ChocolateLoverRaj";
+    githubId = 52586855;
+    matrix = "@chocolateloverraj:matrix.org";
+    name = "Rajas Paranjpe";
+  };
   choochootrain = {
     email = "hurshal@imap.cc";
     github = "choochootrain";

--- a/pkgs/by-name/ta/tabby-terminal/package.nix
+++ b/pkgs/by-name/ta/tabby-terminal/package.nix
@@ -1,0 +1,64 @@
+{ stdenv, fetchurl, pkgs, lib, alsa-lib }:
+
+stdenv.mkDerivation rec {
+  pname = "tabby-terminal";
+  version = "1.0.207";
+  src = fetchurl {
+    url = "https://github.com/Eugeny/tabby/releases/download/v${version}/tabby-${version}-linux-x64.deb";
+    hash = "sha256-PTTkL3+mYb7KM8fDUmgCuAF2lU88fYOstGWp/O5WZas=";
+  };
+
+  nativeBuildInputs = with pkgs; [
+    dpkg
+    makeWrapper
+  ];
+
+  buildInputs = with pkgs; [
+    glib
+    nss
+    nspr
+    atk
+    cups
+    dbus
+    libdrm
+    gtk3
+    pango
+    cairo
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXrandr
+    libxkbcommon
+    mesa
+    expat
+    xorg.libxcb
+    alsa-lib
+    libGL
+    libsecret
+    musl
+  ];
+
+  postInstall = ''
+    mkdir -p $out/{opt,bin}
+    cp -r opt $out
+    wrapProgram "$out/opt/Tabby/tabby" --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations}} --no-sandbox" --set LD_LIBRARY_PATH=${lib.makeLibraryPath buildInputs}
+    cp -r usr/* $out
+
+    ln -s $out/opt/Tabby/tabby $out/bin/tabby
+
+    substituteInPlace $out/share/applications/tabby.desktop \
+      --replace "/opt" $out/opt
+  '';
+
+  meta = with lib; {
+    homepage = "https://tabby.sh";
+    description = "A terminal for a more modern age";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ChocolateLoverRaj ];
+    mainProgram = "tabby";
+    platforms = platforms.linux;
+    downloadPage = "https://github.com/Eugeny/tabby/releases/latest";
+  };
+}


### PR DESCRIPTION
## Description of changes
Added a package for [Tabby](https://tabby.sh/). I'm new to creating Nix packages so there is probably a lot of room for improvement of the `default.nix` file I created. I tested it by adding `(callPackage /home/rajas/Documents/nixpkgs/pkgs/applications/terminal-emulators/tabby { })` to my system packages in NixOS config file. Closes #233509.

Things that are missing:
- ARM package (Tabby does build them)
- MacOS package (Tabby does build them)
- Maybe there is a way of _adding to_ `LD_LIBRARY_PATH` paths instead of overriding it, but I'm not sure how
- Doesn't follow #296939


Also the name conflicts with [`tabby` from `unstable`](https://search.nixos.org/packages?channel=unstable&show=tabby&from=0&size=50&sort=relevance&type=packages&query=tabby)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
