### PR TITLE
xpra: 4.4.6 -> 5.0.9

### DIFF
--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -1,5 +1,5 @@
 { lib
-, fetchurl
+, fetchFromGitHub
 , substituteAll
 , pkg-config
 , runCommand
@@ -70,11 +70,13 @@ let
   '';
 in buildPythonApplication rec {
   pname = "xpra";
-  version = "4.4.6";
+  version = "5.0.9";
 
-  src = fetchurl {
-    url = "https://xpra.org/src/${pname}-${version}.tar.xz";
-    hash = "sha256-BWf3nypfSrYCzpJ0OfBkecoHGbG1lEgu5jLZhfkIejQ=";
+  src = fetchFromGitHub {
+    owner = "Xpra-org";
+    repo = "xpra";
+    rev = "v${version}";
+    hash = "sha256-gwo5plCAryGC8/BKVEqyMkgB+3FM8HXG6sESomDOtNM=";
   };
 
   patches = [
@@ -86,9 +88,8 @@ in buildPythonApplication rec {
     ./fix-122159.patch # https://github.com/NixOS/nixpkgs/issues/122159
   ];
 
-  # Note: xposix is renamed to posix in v5.
   postPatch = lib.optionalString stdenv.isLinux ''
-    substituteInPlace xpra/platform/xposix/features.py \
+    substituteInPlace xpra/platform/posix/features.py \
       --replace-fail "/usr/bin/xdg-open" "${xdg-utils}/bin/xdg-open"
   '';
 

--- a/pkgs/tools/X11/xpra/fix-122159.patch
+++ b/pkgs/tools/X11/xpra/fix-122159.patch
@@ -1,9 +1,9 @@
 diff --git a/xpra/scripts/main.py b/xpra/scripts/main.py
-index 031a41f9e..6232ba830 100755
+index 58c8bf6464..36f4b3cd3d 100755
 --- a/xpra/scripts/main.py
 +++ b/xpra/scripts/main.py
-@@ -377,11 +377,7 @@ def run_mode(script_file, cmdline, error_cb, options, args, mode, defaults):
-         "seamless", "desktop", "shadow", "expand",
+@@ -389,11 +389,7 @@ def run_mode(script_file:str, cmdline, error_cb, options, args, mode:str, defaul
+         "seamless", "desktop", "shadow", "shadow-screen", "expand",
          "upgrade", "upgrade-seamless", "upgrade-desktop",
          ) and not display_is_remote and use_systemd_run(options.systemd_run):
 -        #make sure we run via the same interpreter,
@@ -11,6 +11,6 @@ index 031a41f9e..6232ba830 100755
          argv = list(cmdline)
 -        if argv[0].find("python")<0:
 -            argv.insert(0, "python%i.%i" % (sys.version_info.major, sys.version_info.minor))
-         return systemd_run_wrap(mode, argv, options.systemd_run_args)
+         return systemd_run_wrap(mode, argv, options.systemd_run_args, user=getuid()!=0)
      configure_env(options.env)
      configure_logging(options, mode)

--- a/pkgs/tools/X11/xpra/fix-41106.patch
+++ b/pkgs/tools/X11/xpra/fix-41106.patch
@@ -1,15 +1,15 @@
 diff --git a/xpra/server/server_util.py b/xpra/server/server_util.py
-index f46998ee9f..60068f21b6 100644
+index 2e83712bb8..2dd0bf73d2 100644
 --- a/xpra/server/server_util.py
 +++ b/xpra/server/server_util.py
-@@ -157,6 +157,10 @@ def xpra_env_shell_script(socket_dir, env):
-     return b"\n".join(script)
+@@ -166,6 +166,10 @@ def xpra_env_shell_script(socket_dir, env : Dict[str,str]) -> str:
+     return "\n".join(script)
  
- def xpra_runner_shell_script(xpra_file, starting_dir):
+ def xpra_runner_shell_script(xpra_file:str, starting_dir:str) -> str:
 +    # Nixpkgs contortion:
 +    # xpra_file points to a shell wrapper, not to the python script.
 +    dirname, basename = os.path.split(xpra_file)
 +    xpra_file = os.path.join(dirname, "."+basename+"-wrapped")
-     script = []
      # We ignore failures in cd'ing, b/c it's entirely possible that we were
      # started from some temporary directory and all paths are absolute.
+     qdir = sh_quotemeta(starting_dir)

--- a/pkgs/tools/X11/xpra/fix-paths.patch
+++ b/pkgs/tools/X11/xpra/fix-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/xpra/x11/fakeXinerama.py b/xpra/x11/fakeXinerama.py
-index d5c1c8bb10..88c77e8142 100755
+index a5289e0e43..527cdf90c9 100755
 --- a/xpra/x11/fakeXinerama.py
 +++ b/xpra/x11/fakeXinerama.py
-@@ -22,31 +22,7 @@ fakeXinerama_config_files = [
+@@ -23,31 +23,7 @@ fakeXinerama_config_files = [
             ]
  
  def find_libfakeXinerama():
@@ -29,7 +29,7 @@ index d5c1c8bb10..88c77e8142 100755
 -        except Exception as e:
 -            log("find_libfakeXinerama()", exc_info=True)
 -            log.error("Error: cannot launch ldconfig -p to locate libfakeXinerama:")
--            log.error(" %s", e)
+-            log.estr(e)
 -    return find_lib("libfakeXinerama.so.1")
 +    return "@libfakeXinerama@/lib/libfakeXinerama.so.1.0"
  


### PR DESCRIPTION
## Description of changes

Update [Xpra](https://xpra.org/) from 4.4.6 to 5.0.8.

Tested:
- Connecting from a remote client on macOS via ssh and running apps in seamless mode
- Running Xpra itself on NixOS: GIU works, running apps from the same host in seamless mode but in Xpra's X server works
- Running `xpra start` and `xpra shadow`: couldn't reproduce the issue reported by @kashw2 in https://github.com/NixOS/nixpkgs/issues/270566#issuecomment-1830737443 on my NixOS 24.05.git.f0154a9104b0 aarch64.

Not tested:
- Desktop mode
- Shadow mode aside from just starting the server and then stopping it
- Xpra display manager NixOS module

TODO: check the changelog and see if there are any breaking changes or incompatibilities in the major release. Add a release notes entry if necessary.

Closes: https://github.com/NixOS/nixpkgs/issues/270566

cc maintainers @offlinehacker @numinit @mvnetbiz 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
