### PR TITLE
openttd: 13.4 -> 14.1

### DIFF
--- a/pkgs/games/openttd/default.nix
+++ b/pkgs/games/openttd/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchzip, cmake, pkg-config
+{ lib, stdenv, fetchzip, cmake, pkg-config
 , SDL2, libpng, zlib, xz, freetype, fontconfig
 , nlohmann_json, curl, icu, harfbuzz, expat, glib, pcre2
 , withOpenGFX ? true, withOpenSFX ? true, withOpenMSX ? true
@@ -32,11 +32,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "openttd";
-  version = "13.4";
+  version = "14.0";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://cdn.openttd.org/openttd-releases/${version}/${pname}-${version}-source.tar.xz";
-    hash = "sha256-Kh3roBv+WOIYiHn0UMP6TzgZJxq0m/NI3WZUXwQNFG8=";
+    hash = "sha256-7wOyP2h5qHNFjdmHf/62W+cAb6C+UEBPswPx48p3AjU=";
   };
 
   nativeBuildInputs = [ cmake pkg-config makeWrapper ];

--- a/pkgs/games/openttd/default.nix
+++ b/pkgs/games/openttd/default.nix
@@ -32,11 +32,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "openttd";
-  version = "14.0";
+  version = "14.1";
 
   src = fetchzip {
     url = "https://cdn.openttd.org/openttd-releases/${version}/${pname}-${version}-source.tar.xz";
-    hash = "sha256-7wOyP2h5qHNFjdmHf/62W+cAb6C+UEBPswPx48p3AjU=";
+    hash = "sha256-YT4IE/rJ9pnpeMWKbOra6AbSUwW19RwOKlXkxwoMeKY=";
   };
 
   nativeBuildInputs = [ cmake pkg-config makeWrapper ];


### PR DESCRIPTION
## Description of changes

Update OpenTTD from v13.4 to v14.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).