### PR TITLE
apksigner: mark broken on darwin

### DIFF
--- a/pkgs/development/tools/apksigcopier/default.nix
+++ b/pkgs/development/tools/apksigcopier/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , apksigner
 , bash
 , fetchFromGitHub
@@ -23,11 +24,14 @@ python3.pkgs.buildPythonApplication rec {
     pandoc
   ];
 
+  disallowedRequisites = [ pandoc ];
+
   propagatedBuildInputs = with python3.pkgs; [
     click
   ];
 
-  makeWrapperArgs = [
+  # due to apksigner being (as of this writing) broken on macOS
+  makeWrapperArgs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform apksigner) [
     "--prefix"
     "PATH"
     ":"
@@ -72,5 +76,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/obfusk/apksigcopier";
     license = with licenses; [ gpl3Plus ];
     maintainers = with maintainers; [ obfusk ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/tools/apksigner/default.nix
+++ b/pkgs/development/tools/apksigner/default.nix
@@ -91,5 +91,6 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ linsui ];
     platforms = platforms.unix;
+    badPlatforms = platforms.darwin;
   };
 }


### PR DESCRIPTION
## Description of changes

diffoscope breaks on darwin unexpectedly yet again from random changes :(

n.b. this is with sandbox; i think you want `__darwinAllowLocalNetworking` to fix *this*, but it is also broken for a different reason without the sandbox.

```
[1] jade@darwin01> nix log /nix/store/cf8qzslqz8v2knby2444zdrcim3llv7p-apksigner-33.0.1.drv
warning: The interpretation of store paths arguments ending in `.drv` recently changed. If this command is now failing try again with '/nix/store/cf8qzslqz8v2knby2444zdrcim3llv7p-apksigner-33.0.1.drv^*'
https://cache.nixos.org/nar/18n0nzzlyjpf1yfh130kzpn44pn0d6lysb57lkn9jrn9kyp6i4jr.nar.xz
https://cache.nixos.org/nar/1scn5fwrrhnm1knbv1arv1hbsncplc3qbdr7z57a4raya0m4lsgp.nar.xz
https://cache.nixos.org/nar/07qpmsrr9q15fvfaciq9cq83kp3s4zn9xd3hwzk66c1cv4mg3c3f.nar.xz
https://cache.nixos.org/nar/1z7r69gg86ka9q578nhq04kpwr47qvjqh6qrlzh3pflhmn7pa55m.nar.xz
https://cache.nixos.org/nar/1ja66p5ljl7ya5bwx1n0r4jxqwpkmzj7sp5slnzi0f20bpzx542l.nar.xz
https://cache.nixos.org/nar/1p7449374swyxzv7c61c7jk6h8d8nij4vdvx7vbd2i8h5hhjhw8w.nar.xz
https://cache.nixos.org/hly3z3kv0wkxj0c87dw6wgd2qks8hlwp.narinfo
https://nix-community.cachix.org/hly3z3kv0wkxj0c87dw6wgd2qks8hlwp.narinfo
Running phase: unpackPhase
unpacking source archive /nix/store/6sxf6k11rvas3n263rshi1s79mpgfkgf-apksigner
source root is apksigner
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase

Welcome to Gradle 7.6.4!

Here are the highlights of this release:
 - Added support for Java 19.
 - Introduced `--rerun` flag for individual task rerun.
 - Improved dependency block for test suites to be strongly typed.
 - Added a pluggable system for Java toolchains provisioning.

For more details see https://docs.gradle.org/7.6.4/release-notes.html


FAILURE: Build failed with an exception.

* What went wrong:
Gradle could not start your build.
> Cannot create service of type BuildSessionActionExecutor using method LauncherServices$ToolingBuildSessionScopeServices.createActionExecutor() as there is a problem with parameter #21 of type FileSystemWatchingInformation.
   > Cannot create service of type BuildLifecycleAwareVirtualFileSystem using method VirtualFileSystemServices$GradleUserHomeServices.createVirtualFileSystem() as there is a problem with parameter #7 of type GlobalCacheLocations.
      > Cannot create service of type GlobalCacheLocations using method GradleUserHomeScopeServices.createGlobalCacheLocations() as there is a problem with parameter #1 of type List<GlobalCache>.
         > Could not create service of type FileAccessTimeJournal using GradleUserHomeScopeServices.createFileAccessTimeJournal().
            > java.net.SocketException: Operation not permitted

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 628ms
```

without sandbox:
```
jade@darwin01> nix log /nix/store/cf8qzslqz8v2knby2444zdrcim3llv7p-apksigner-33.0.1.drv | sed -e 's/\x1b\[[0-9;]*m//g'
warning: The interpretation of store paths arguments ending in `.drv` recently changed. If this command is now failing try again with '/nix/store/cf8qzslqz8v2knby2444zdrcim3llv7p-apksigner-33.0.1.drv^*'
@nix { "action": "setPhase", "phase": "unpackPhase" }
Running phase: unpackPhase
unpacking source archive /nix/store/6sxf6k11rvas3n263rshi1s79mpgfkgf-apksigner
source root is apksigner
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "configurePhase" }
Running phase: configurePhase
no configure script, doing nothing
@nix { "action": "setPhase", "phase": "buildPhase" }
Running phase: buildPhase

Welcome to Gradle 7.6.4!

Here are the highlights of this release:
 - Added support for Java 19.
 - Introduced `--rerun` flag for individual task rerun.
 - Improved dependency block for test suites to be strongly typed.
 - Added a pluggable system for Java toolchains provisioning.

For more details see https://docs.gradle.org/7.6.4/release-notes.html


> Task :compileJava
/private/tmp/nix-build-apksigner-33.0.1.drv-0/apksigner/src/main/java/com/android/apksig/internal/asn1/Asn1BerParser.java:642: warning: [removal] Boolean(boolean) in Boolean has been deprecated and marked for removal
                        return (T) new Boolean(result);
                                   ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
1 warning

> Task :compileTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

> Task :processTestResources
Execution optimizations have been disabled for task ':processTestResources' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/private/tmp/nix-build-apksigner-33.0.1.drv-0/apksigner/build/extracted-protos/test'. Reason: Task ':processTestResources' uses this output of task ':extractTestProto' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6.4/userguide/validation_problems.html#implicit_dependency for more details about this problem.

> Task :test

com.android.apksig.AllTests > com.android.apksig.ApkVerifierTest.testV2SignatureDoesNotMatchSignedDataRejected FAILED
    java.lang.AssertionError at ApkVerifierTest.java:1552

com.android.apksig.ApkVerifierTest > testV2SignatureDoesNotMatchSignedDataRejected FAILED
    java.lang.AssertionError at ApkVerifierTest.java:1552

1021 tests completed, 2 failed, 4 skipped

> Task :test FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':test'.
> There were failing tests. See the report at: file:///private/tmp/nix-build-apksigner-33.0.1.drv-0/apksigner/build/reports/tests/test/index.html

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6.4/userguide/command_line_interface.html#sec:command_line_warnings

Execution optimizations have been disabled for 1 invalid unit(s) of work during this build to ensure correctness.
Please consult deprecation warnings for more details.

BUILD FAILED in 23s
12 actionable tasks: 12 executed
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
