### PR TITLE
split-monitor-workspaces: init at 1.1.0

### DIFF
--- a/pkgs/by-name/sp/split-monitor-workspaces/package.nix
+++ b/pkgs/by-name/sp/split-monitor-workspaces/package.nix
@@ -1,0 +1,41 @@
+{ lib
+, gcc13Stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, hyprland
+, pango
+, cairo
+,
+}:
+gcc13Stdenv.mkDerivation rec {
+  pname = "split-monitor-workspaces";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Duckonaut";
+    repo = pname;
+    rev = "b0ee3953eaeba70f3fba7c4368987d727779826a";
+    hash = "sha256-M9nGSYBieZNg/OgLqL7bX0S9Khlh4MFca0euGKwbuG4=";
+  };
+
+  BUILT_WITH_NOXWAYLAND = false;
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs =
+    [
+      hyprland
+      pango
+      cairo
+    ]
+    ++ hyprland.buildInputs;
+
+  meta = {
+    homepage = "https://github.com/Duckonaut/split-monitor-workspaces";
+    description = "Small Hyprland plugin to provide awesome-like workspace behavior";
+    license = lib.licenses.bsd3;
+    platforms = hyprland.meta.platforms;
+    maintainers = with lib.maintainers; [ yunfachi ];
+  };
+}


### PR DESCRIPTION
## Description of changes
https://github.com/Duckonaut/split-monitor-workspaces
A small plugin to provide awesome/dwm-like behavior with workspaces: split them between monitors and provide independent numbering

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
