### PR TITLE
parallel-full: fix missing files

### DIFF
--- a/pkgs/tools/misc/parallel/wrapper.nix
+++ b/pkgs/tools/misc/parallel/wrapper.nix
@@ -3,8 +3,8 @@
 , willCite ? false }:
 
 symlinkJoin {
-  name = "parallel-full";
-  inherit (parallel) outputs;
+  name = "parallel-full-${parallel.version}";
+  inherit (parallel) pname version meta outputs;
   nativeBuildInputs = [ makeWrapper ];
   paths = [ parallel ];
   postBuild = ''

--- a/pkgs/tools/misc/parallel/wrapper.nix
+++ b/pkgs/tools/misc/parallel/wrapper.nix
@@ -1,10 +1,18 @@
-{ lib, runCommand, makeWrapper, parallel, perlPackages
+{ lib, symlinkJoin, makeWrapper, parallel, perlPackages
 , extraPerlPackages ? with perlPackages; [ DBI DBDPg DBDSQLite DBDCSV TextCSV ]
 , willCite ? false }:
 
-runCommand "parallel-full" { nativeBuildInputs = [ makeWrapper ]; } ''
-  mkdir -p $out/bin
-  makeWrapper ${parallel}/bin/parallel $out/bin/parallel \
-    --set PERL5LIB "${perlPackages.makeFullPerlPath extraPerlPackages}" \
-    ${lib.optionalString willCite "--add-flags --will-cite"}
-''
+symlinkJoin {
+  name = "parallel-full";
+  inherit (parallel) outputs;
+  nativeBuildInputs = [ makeWrapper ];
+  paths = [ parallel ];
+  postBuild = ''
+    ${lib.concatMapStringsSep "\n" (output: "ln -s --no-target-directory ${parallel.${output}} \$${output}") (lib.remove "out" parallel.outputs)}
+
+    rm $out/bin/parallel
+    makeWrapper ${parallel}/bin/parallel $out/bin/parallel \
+      --set PERL5LIB "${perlPackages.makeFullPerlPath extraPerlPackages}" \
+      ${lib.optionalString willCite "--add-flags --will-cite"}
+  '';
+}


### PR DESCRIPTION
Previously, this was not usable as a drop-in replacement for `parallel` since it only included the one exe. This changes to additionally symlink all files from $out as well as symlink all other outputs. So no files are missing compared to `parallel`, while being efficiently symlinked.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
