### PR TITLE
lib: add `lib.attrsets.mapAttrsRecursiveFunc`

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1175,6 +1175,71 @@ rec {
     in
     recurse [ ] set;
 
+  /**
+    This function recursively searches for attrsets `attrs` that are *not* derivations and
+    where a given function `f` applied to the current path `path` is applicable,
+    and replaces `attrs` by `f path attrs`.
+
+    A function `f` is applicable to an attrset `attrs` at the current path `path` when
+    `builtins.intersectAttrs (builtins.functionArgs (f path)) attrs == attrs`.
+
+    If `f path` does not have formal arguments (see `builtins.functionArgs`):
+    - A new function with formal arguments can be created;
+    - Formal arguments can be set via `lib.trivial.setFunctionArgs` or `lib.trivial.mirrorFunctionArgs`.
+
+    # Inputs
+
+    `f`
+
+    : A function, given the current path and an attrset at this path, returns a value.
+
+    `set`
+    
+    : An attrset.
+
+    # Type
+    ```
+    mapAttrsRecursiveFunc :: ([String] -> AttrSet -> a) -> AttrSet -> AttrSet
+    ```
+
+    :::{#map-attrs-recursive-func-example .example}
+    # Map attrsets to scripts
+    
+    Attrsets are searched for using `builtins.functionArgs pkgs.writeShellApplication`.
+
+    ```nix
+    mapAttrsRecursiveFunc
+      (path: args@{ text, name ? lib.concatStringsSep "-" path, runtimeInputs ? [ pkgs.docker-compose ] }:
+        pkgs.writeShellApplication (args // { inherit name runtimeInputs; }))
+      {
+        service1.start.text = "docker compose up service1";
+        service1.stop.text = "docker compose down service1";
+      }
+    ```
+    :::
+  */
+  mapAttrsRecursiveFunc =
+    f:
+    set:
+    let
+      recurse =
+        path:
+        mapAttrs (
+          name: value:
+          let
+            path' = path ++ [ name ];
+          in
+          if isAttrs value && !(lib.isDerivation value) then
+            if builtins.intersectAttrs (builtins.functionArgs (f path')) value == value then
+              f path' value
+            else
+              recurse path' value
+          else
+            value
+        );
+    in
+    recurse [ ] set;
+
 
   /**
     Generate an attribute set by mapping a function over a list of

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -82,7 +82,7 @@ let
       getAttrFromPath attrVals attrValues getAttrs catAttrs filterAttrs
       filterAttrsRecursive foldlAttrs foldAttrs collect nameValuePair mapAttrs
       mapAttrs' mapAttrsToList attrsToList concatMapAttrs mapAttrsRecursive
-      mapAttrsRecursiveCond genAttrs isDerivation toDerivation optionalAttrs
+      mapAttrsRecursiveCond mapAttrsRecursiveFunc genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs mergeAttrsList overrideExisting showAttrPath getOutput
       getBin getLib getDev getMan chooseDevOutputs zipWithNames zip


### PR DESCRIPTION
## Description of changes

Added a new function `lib.attrsets.mapAttrsRecursiveFunc` that allows to apply a given function `f` to attrsets (not derivations) where `f` is applicable.

## Initial problem

I use `pkgs.writeShellApplication` and create a number of scripts with similar `runtimeInputs`.
I have to write a `pkgs.writeShellApplication`, a  `name`, and `runtimeInputs` for each script.

## Initial solution

Create a custom library of functions and provide there a function that reduces boilerplate.
However, I don't want to use that library in my public projects because of a single function.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

> [!NOTE]
> no packages depend on the new function

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
