### PR TITLE
wrapCC, wrapBintools, stdenv: make Nix code a bit more consistent

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -83,8 +83,7 @@ let
     replaceStrings
     ;
 
-  stdenv = stdenvNoCC;
-  inherit (stdenv) hostPlatform targetPlatform;
+  inherit (stdenvNoCC) hostPlatform targetPlatform;
 
   # Prefix for binaries. Customarily ends with a dash separator.
   #
@@ -138,7 +137,7 @@ let
 
 in
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = targetPrefix
     + (if name != "" then name else "${bintoolsName}-wrapper");
   version = optionalString (bintools != null) bintoolsVersion;
@@ -346,7 +345,7 @@ stdenv.mkDerivation {
       done
     ''
 
-    + optionalString stdenv.targetPlatform.isDarwin ''
+    + optionalString stdenvNoCC.targetPlatform.isDarwin ''
       echo "-arch ${targetPlatform.darwinArch}" >> $out/nix-support/libc-ldflags
     ''
 
@@ -363,7 +362,7 @@ stdenv.mkDerivation {
     ###
     ### Remove certain timestamps from final binaries
     ###
-    + optionalString (stdenv.targetPlatform.isDarwin && !(bintools.isGNU or false)) ''
+    + optionalString (stdenvNoCC.targetPlatform.isDarwin && !(bintools.isGNU or false)) ''
       echo "export ZERO_AR_DATE=1" >> $out/nix-support/setup-hook
     ''
 
@@ -380,9 +379,9 @@ stdenv.mkDerivation {
     ###
     ### Ensure consistent LC_VERSION_MIN_MACOSX
     ###
-    + optionalString stdenv.targetPlatform.isDarwin (
+    + optionalString stdenvNoCC.targetPlatform.isDarwin (
       let
-        inherit (stdenv.targetPlatform)
+        inherit (stdenvNoCC.targetPlatform)
           darwinPlatform darwinSdkVersion
           darwinMinVersion darwinMinVersionVariable;
       in ''

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -345,7 +345,7 @@ stdenvNoCC.mkDerivation {
       done
     ''
 
-    + optionalString stdenvNoCC.targetPlatform.isDarwin ''
+    + optionalString targetPlatform.isDarwin ''
       echo "-arch ${targetPlatform.darwinArch}" >> $out/nix-support/libc-ldflags
     ''
 
@@ -362,7 +362,7 @@ stdenvNoCC.mkDerivation {
     ###
     ### Remove certain timestamps from final binaries
     ###
-    + optionalString (stdenvNoCC.targetPlatform.isDarwin && !(bintools.isGNU or false)) ''
+    + optionalString (targetPlatform.isDarwin && !(bintools.isGNU or false)) ''
       echo "export ZERO_AR_DATE=1" >> $out/nix-support/setup-hook
     ''
 
@@ -379,9 +379,9 @@ stdenvNoCC.mkDerivation {
     ###
     ### Ensure consistent LC_VERSION_MIN_MACOSX
     ###
-    + optionalString stdenvNoCC.targetPlatform.isDarwin (
+    + optionalString targetPlatform.isDarwin (
       let
-        inherit (stdenvNoCC.targetPlatform)
+        inherit (targetPlatform)
           darwinPlatform darwinSdkVersion
           darwinMinVersion darwinMinVersionVariable;
       in ''

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -117,10 +117,10 @@ let
 
   useGccForLibs = useCcForLibs
     && libcxx == null
-    && !stdenvNoCC.targetPlatform.isDarwin
-    && !(stdenvNoCC.targetPlatform.useLLVM or false)
-    && !(stdenvNoCC.targetPlatform.useAndroidPrebuilt or false)
-    && !(stdenvNoCC.targetPlatform.isiOS or false)
+    && !targetPlatform.isDarwin
+    && !(targetPlatform.useLLVM or false)
+    && !(targetPlatform.useAndroidPrebuilt or false)
+    && !(targetPlatform.isiOS or false)
     && gccForLibs != null;
   gccForLibs_solib = getLib gccForLibs
     + optionalString (targetPlatform != hostPlatform) "/${targetPlatform.config}";
@@ -247,17 +247,17 @@ let
     then cc.hardeningUnsupportedFlagsByTargetPlatform targetPlatform
     else (cc.hardeningUnsupportedFlags or []);
 
-  darwinPlatformForCC = optionalString stdenvNoCC.targetPlatform.isDarwin (
+  darwinPlatformForCC = optionalString targetPlatform.isDarwin (
     if (targetPlatform.darwinPlatform == "macos" && isGNU) then "macosx"
     else targetPlatform.darwinPlatform
   );
 
-  darwinMinVersion = optionalString stdenvNoCC.targetPlatform.isDarwin (
-    stdenvNoCC.targetPlatform.darwinMinVersion
+  darwinMinVersion = optionalString targetPlatform.isDarwin (
+    targetPlatform.darwinMinVersion
   );
 
-  darwinMinVersionVariable = optionalString stdenvNoCC.targetPlatform.isDarwin
-    stdenvNoCC.targetPlatform.darwinMinVersionVariable;
+  darwinMinVersionVariable = optionalString targetPlatform.isDarwin
+    targetPlatform.darwinMinVersionVariable;
 in
 
 assert includeFortifyHeaders' -> fortify-headers != null;
@@ -477,8 +477,8 @@ stdenvNoCC.mkDerivation {
     # break `useLLVM` into.)
     + optionalString (isClang
                       && targetPlatform.isLinux
-                      && !(stdenvNoCC.targetPlatform.useAndroidPrebuilt or false)
-                      && !(stdenvNoCC.targetPlatform.useLLVM or false)
+                      && !(targetPlatform.useAndroidPrebuilt or false)
+                      && !(targetPlatform.useLLVM or false)
                       && gccForLibs != null) (''
       echo "--gcc-toolchain=${gccForLibs}" >> $out/nix-support/cc-cflags
 
@@ -687,7 +687,7 @@ stdenvNoCC.mkDerivation {
       done
     ''
 
-    + optionalString stdenvNoCC.targetPlatform.isDarwin ''
+    + optionalString targetPlatform.isDarwin ''
         echo "-arch ${targetPlatform.darwinArch}" >> $out/nix-support/cc-cflags
     ''
 

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -82,9 +82,7 @@ let
     versionAtLeast
     ;
 
-  inherit (stdenv) hostPlatform targetPlatform;
-
-  stdenv = stdenvNoCC;
+  inherit (stdenvNoCC) hostPlatform targetPlatform;
 
   includeFortifyHeaders' = if includeFortifyHeaders != null
     then includeFortifyHeaders
@@ -119,10 +117,10 @@ let
 
   useGccForLibs = useCcForLibs
     && libcxx == null
-    && !stdenv.targetPlatform.isDarwin
-    && !(stdenv.targetPlatform.useLLVM or false)
-    && !(stdenv.targetPlatform.useAndroidPrebuilt or false)
-    && !(stdenv.targetPlatform.isiOS or false)
+    && !stdenvNoCC.targetPlatform.isDarwin
+    && !(stdenvNoCC.targetPlatform.useLLVM or false)
+    && !(stdenvNoCC.targetPlatform.useAndroidPrebuilt or false)
+    && !(stdenvNoCC.targetPlatform.isiOS or false)
     && gccForLibs != null;
   gccForLibs_solib = getLib gccForLibs
     + optionalString (targetPlatform != hostPlatform) "/${targetPlatform.config}";
@@ -249,17 +247,17 @@ let
     then cc.hardeningUnsupportedFlagsByTargetPlatform targetPlatform
     else (cc.hardeningUnsupportedFlags or []);
 
-  darwinPlatformForCC = optionalString stdenv.targetPlatform.isDarwin (
+  darwinPlatformForCC = optionalString stdenvNoCC.targetPlatform.isDarwin (
     if (targetPlatform.darwinPlatform == "macos" && isGNU) then "macosx"
     else targetPlatform.darwinPlatform
   );
 
-  darwinMinVersion = optionalString stdenv.targetPlatform.isDarwin (
-    stdenv.targetPlatform.darwinMinVersion
+  darwinMinVersion = optionalString stdenvNoCC.targetPlatform.isDarwin (
+    stdenvNoCC.targetPlatform.darwinMinVersion
   );
 
-  darwinMinVersionVariable = optionalString stdenv.targetPlatform.isDarwin
-    stdenv.targetPlatform.darwinMinVersionVariable;
+  darwinMinVersionVariable = optionalString stdenvNoCC.targetPlatform.isDarwin
+    stdenvNoCC.targetPlatform.darwinMinVersionVariable;
 in
 
 assert includeFortifyHeaders' -> fortify-headers != null;
@@ -272,7 +270,7 @@ assert nativeTools == bintools.nativeTools;
 assert nativeLibc == bintools.nativeLibc;
 assert nativePrefix == bintools.nativePrefix;
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = targetPrefix
     + (if name != "" then name else "${ccName}-wrapper");
   version = optionalString (cc != null) ccVersion;
@@ -426,7 +424,7 @@ stdenv.mkDerivation {
     ../setup-hooks/role.bash
   ] ++ optional (cc.langC or true) ./setup-hook.sh
     ++ optional (cc.langFortran or false) ./fortran-hook.sh
-    ++ optional (targetPlatform.isWindows) (stdenv.mkDerivation {
+    ++ optional (targetPlatform.isWindows) (stdenvNoCC.mkDerivation {
       name = "win-dll-hook.sh";
       dontUnpack = true;
       installPhase = ''
@@ -479,8 +477,8 @@ stdenv.mkDerivation {
     # break `useLLVM` into.)
     + optionalString (isClang
                       && targetPlatform.isLinux
-                      && !(stdenv.targetPlatform.useAndroidPrebuilt or false)
-                      && !(stdenv.targetPlatform.useLLVM or false)
+                      && !(stdenvNoCC.targetPlatform.useAndroidPrebuilt or false)
+                      && !(stdenvNoCC.targetPlatform.useLLVM or false)
                       && gccForLibs != null) (''
       echo "--gcc-toolchain=${gccForLibs}" >> $out/nix-support/cc-cflags
 
@@ -689,7 +687,7 @@ stdenv.mkDerivation {
       done
     ''
 
-    + optionalString stdenv.targetPlatform.isDarwin ''
+    + optionalString stdenvNoCC.targetPlatform.isDarwin ''
         echo "-arch ${targetPlatform.darwinArch}" >> $out/nix-support/cc-cflags
     ''
 

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -328,12 +328,12 @@ in
     assert isBuiltByBootstrapFilesCompiler prevStage.patchelf;
     stageFun prevStage {
       name = "bootstrap-stage-xgcc";
-      overrides = final: prev: {
+      overrides = self: super: {
         inherit (prevStage) ccWrapperStdenv coreutils gnugrep gettext bison texinfo zlib gnum4 perl patchelf;
         ${localSystem.libc} = getLibc prevStage;
-        gmp      = prev.gmp.override { cxx = false; };
+        gmp = super.gmp.override { cxx = false; };
         gcc-unwrapped =
-          (prev.gcc-unwrapped.override (commonGccOverrides // {
+          (super.gcc-unwrapped.override (commonGccOverrides // {
             # The most logical name for this package would be something like
             # "gcc-stage1".  Unfortunately "stage" is already reserved for the
             # layers of stdenv, so using "stage" in the name of this package
@@ -376,7 +376,7 @@ in
             #
             configureFlags = (a.configureFlags or []) ++ [
               "--with-native-system-header-dir=/include"
-              "--with-build-sysroot=${lib.getDev final.stdenv.cc.libc}"
+              "--with-build-sysroot=${lib.getDev self.stdenv.cc.libc}"
             ];
 
             # This is a separate phase because gcc assembles its phase scripts

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -152,7 +152,7 @@ in
     inherit config overlays;
     stdenv = makeStdenv {
       inherit (prevStage) cc fetchurl;
-      overrides = prev: final: { inherit (prevStage) fetchurl; };
+      overrides = self: super: { inherit (prevStage) fetchurl; };
     } // {
       inherit (prevStage) fetchurl;
     };


### PR DESCRIPTION
## Description of changes

Simple cleanups that aim to make the stdenv/wrapper code more consistent and less confusing. These should be easy to review and uncontroversial. ~~A follow-up change concerning darwin is noted as `FIXME`, but I think that's better reviewed separately.~~ See #304034.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
