### PR TITLE
firefoxpwa: add fhs wrapper to run downloaded binaries

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
@@ -108,17 +108,17 @@ let
 
   toExtensionJsonEntry = ext: rec {
     identifier = {
-      id = ext.vscodeExtUniqueId;
+      id = ext.vscodeExtUniqueId or (lib.head (lib.attrNames (builtins.readDir "${ext}/share/vscode/extensions")));
       uuid = "";
     };
 
-    version = ext.version;
+    version = ext.version or (lib.getversion ext.name);
 
     relativeLocation = ext.vscodeExtUniqueId;
 
     location = {
       "$mid" = 1;
-      fsPath = ext.outPath + "/share/vscode/extensions/${ext.vscodeExtUniqueId}";
+      fsPath = "${ext.outPath}/share/vscode/extensions/${identifier.id}";
       path = location.fsPath;
       scheme = "file";
     };
@@ -126,7 +126,7 @@ let
     metadata = {
       id = "";
       publisherId = "";
-      publisherDisplayName = ext.vscodeExtPublisher;
+      publisherDisplayName = ext.vscodeExtPublisher or (lib.head (lib.splitString ''\.'' identifier.id));
       targetPlatform = "undefined";
       isApplicationScoped = false;
       updated = false;

--- a/pkgs/by-name/fi/firefoxpwa/package.nix
+++ b/pkgs/by-name/fi/firefoxpwa/package.nix
@@ -16,84 +16,105 @@
 , pciutils
 , libcanberra-gtk3
 , extraLibs ? [ ]
+, symlinkJoin
 , nixosTests
+, buildFHSUserEnv
 }:
-
-rustPlatform.buildRustPackage rec {
-  pname = "firefoxpwa";
+let
+  name = "firefoxpwa";
   version = "2.11.1";
-
-  src = fetchFromGitHub {
-    owner = "filips123";
-    repo = "PWAsForFirefox";
-    rev = "v${version}";
-    hash = "sha256-ZD/bTziVmHtQVKejzj+fUXVazCm2PaulS2NZjTribSk=";
-  };
-
-  sourceRoot = "${src.name}/native";
-  buildFeatures = [ "immutable-runtime" ];
-
-  cargoLock = {
-    lockFile = ./Cargo.lock;
-    outputHashes = {
-      "mime-0.4.0-a.0" = "sha256-LjM7LH6rL3moCKxVsA+RUL9lfnvY31IrqHa9pDIAZNE=";
-      "web_app_manifest-0.0.0" = "sha256-G+kRN8AEmAY1TxykhLmgoX8TG8y2lrv7SCRJlNy0QzA=";
+  unwrapped = rustPlatform.buildRustPackage rec {
+    inherit version;
+    pname = "${name}-unwrapped";
+    src = fetchFromGitHub {
+      owner = "filips123";
+      repo = "PWAsForFirefox";
+      rev = "v${version}";
+      hash = "sha256-ZD/bTziVmHtQVKejzj+fUXVazCm2PaulS2NZjTribSk=";
     };
+
+    sourceRoot = "${src.name}/native";
+    buildFeatures = [ "immutable-runtime" ];
+
+    cargoLock = {
+      lockFile = ./Cargo.lock;
+      outputHashes = {
+        "mime-0.4.0-a.0" = "sha256-LjM7LH6rL3moCKxVsA+RUL9lfnvY31IrqHa9pDIAZNE=";
+        "web_app_manifest-0.0.0" = "sha256-G+kRN8AEmAY1TxykhLmgoX8TG8y2lrv7SCRJlNy0QzA=";
+      };
+    };
+
+    preConfigure = ''
+      sed -i 's;version = "0.0.0";version = "${version}";' Cargo.toml
+      sed -zi 's;name = "firefoxpwa"\nversion = "0.0.0";name = "firefoxpwa"\nversion = "${version}";' Cargo.lock
+      sed -i $'s;DISTRIBUTION_VERSION = \'0.0.0\';DISTRIBUTION_VERSION = \'${version}\';' userchrome/profile/chrome/pwa/chrome.jsm
+    '';
+
+    nativeBuildInputs = [ makeWrapper pkg-config installShellFiles ];
+    buildInputs = [ openssl ];
+
+    FFPWA_EXECUTABLES = ""; # .desktop entries generated without any store path references
+    FFPWA_SYSDATA = "${placeholder "out"}/share/firefoxpwa";
+    completions = "target/${stdenv.targetPlatform.config}/release/completions";
+
+    gtk_modules = map (x: x + x.gtkModule) [ libcanberra-gtk3 ];
+    libs = let libs = lib.optionals stdenv.isLinux [ udev libva mesa libnotify xorg.libXScrnSaver cups pciutils ] ++ gtk_modules ++ extraLibs; in lib.makeLibraryPath libs + ":" + lib.makeSearchPathOutput "lib" "lib64" libs;
+
+    postInstall = ''
+      # Runtime
+      mkdir -p $out/share/firefoxpwa
+      cp -Lr ${firefox-unwrapped}/lib/firefox $out/share/firefoxpwa/runtime
+      chmod -R +w $out/share/firefoxpwa
+
+      # UserChrome
+      cp -r userchrome $out/share/firefoxpwa
+
+      # Runtime patching
+      FFPWA_USERDATA=$out/share/firefoxpwa $out/bin/firefoxpwa runtime patch
+
+      # Manifest
+      sed -i "s!/usr/libexec!$out/bin!" manifests/linux.json
+      install -Dm644 manifests/linux.json $out/lib/mozilla/native-messaging-hosts/firefoxpwa.json
+
+      installShellCompletion --cmd firefoxpwa \
+        --bash $completions/firefoxpwa.bash \
+        --fish $completions/firefoxpwa.fish \
+        --zsh $completions/_firefoxpwa
+
+      # AppStream Metadata
+      install -Dm644 packages/appstream/si.filips.FirefoxPWA.metainfo.xml $out/share/metainfo/si.filips.FirefoxPWA.metainfo.xml
+      install -Dm644 packages/appstream/si.filips.FirefoxPWA.svg $out/share/icons/hicolor/scalable/apps/si.filips.FirefoxPWA.svg
+
+      wrapProgram $out/bin/firefoxpwa \
+        --prefix FFPWA_SYSDATA : "$out/share/firefoxpwa" \
+        --prefix LD_LIBRARY_PATH : "$libs" \
+        --suffix-each GTK_PATH : "$gtk_modules"
+
+      wrapProgram $out/bin/firefoxpwa-connector \
+        --prefix FFPWA_SYSDATA : "$out/share/firefoxpwa" \
+        --prefix LD_LIBRARY_PATH : "$libs" \
+        --suffix-each GTK_PATH : "$gtk_modules"
+    '';
+
+    postInstallCheck = ''
+      mv $out/bin/firefoxpwa $out/bin/.firefoxpwa-wrapped
+    '';
   };
 
-  preConfigure = ''
-    sed -i 's;version = "0.0.0";version = "${version}";' Cargo.toml
-    sed -zi 's;name = "firefoxpwa"\nversion = "0.0.0";name = "firefoxpwa"\nversion = "${version}";' Cargo.lock
-    sed -i $'s;DISTRIBUTION_VERSION = \'0.0.0\';DISTRIBUTION_VERSION = \'${version}\';' userchrome/profile/chrome/pwa/chrome.jsm
-  '';
-
-  nativeBuildInputs = [ makeWrapper pkg-config installShellFiles ];
-  buildInputs = [ openssl ];
-
-  FFPWA_EXECUTABLES = ""; # .desktop entries generated without any store path references
-  FFPWA_SYSDATA = "${placeholder "out"}/share/firefoxpwa";
-  completions = "target/${stdenv.targetPlatform.config}/release/completions";
-
-  gtk_modules = map (x: x + x.gtkModule) [ libcanberra-gtk3 ];
-  libs = let libs = lib.optionals stdenv.isLinux [ udev libva mesa libnotify xorg.libXScrnSaver cups pciutils ] ++ gtk_modules ++ extraLibs; in lib.makeLibraryPath libs + ":" + lib.makeSearchPathOutput "lib" "lib64" libs;
-
-  postInstall = ''
-    # Runtime
-    mkdir -p $out/share/firefoxpwa
-    cp -Lr ${firefox-unwrapped}/lib/firefox $out/share/firefoxpwa/runtime
-    chmod -R +w $out/share/firefoxpwa
-
-    # UserChrome
-    cp -r userchrome $out/share/firefoxpwa
-
-    # Runtime patching
-    FFPWA_USERDATA=$out/share/firefoxpwa $out/bin/firefoxpwa runtime patch
-
-    # Manifest
-    sed -i "s!/usr/libexec!$out/bin!" manifests/linux.json
-    install -Dm644 manifests/linux.json $out/lib/mozilla/native-messaging-hosts/firefoxpwa.json
-
-    installShellCompletion --cmd firefoxpwa \
-      --bash $completions/firefoxpwa.bash \
-      --fish $completions/firefoxpwa.fish \
-      --zsh $completions/_firefoxpwa
-
-    # AppStream Metadata
-    install -Dm644 packages/appstream/si.filips.FirefoxPWA.metainfo.xml $out/share/metainfo/si.filips.FirefoxPWA.metainfo.xml
-    install -Dm644 packages/appstream/si.filips.FirefoxPWA.svg $out/share/icons/hicolor/scalable/apps/si.filips.FirefoxPWA.svg
-
-    wrapProgram $out/bin/firefoxpwa \
-      --prefix FFPWA_SYSDATA : "$out/share/firefoxpwa" \
-      --prefix LD_LIBRARY_PATH : "$libs" \
-      --suffix-each GTK_PATH : "$gtk_modules"
-
-    wrapProgram $out/bin/firefoxpwa-connector \
-      --prefix FFPWA_SYSDATA : "$out/share/firefoxpwa" \
-      --prefix LD_LIBRARY_PATH : "$libs" \
-      --suffix-each GTK_PATH : "$gtk_modules"
-  '';
-
-  passthru.tests.firefoxpwa = nixosTests.firefoxpwa;
+  # firefoxpwa wants to run binaries downloaded into users' home dir
+  fhs = buildFHSUserEnv {
+    name = "${name}-wrapper-${version}";
+    runScript = "${unwrapped}/bin/.firefoxpwa-wrapped";
+    targetPkgs = _: firefox-unwrapped.buildInputs;
+  };
+in
+(symlinkJoin {
+  name = "${name}-${version}";
+  paths = [ fhs unwrapped ];
+}) // {
+  inherit unwrapped fhs version;
+  pname = name;
+  tests.firefoxpwa = nixosTests.firefoxpwa;
 
   meta = with lib; {
     description = "A tool to install, manage and use Progressive Web Apps (PWAs) in Mozilla Firefox (native component)";


### PR DESCRIPTION
## Description of changes
Fixes https://github.com/NixOS/nixpkgs/issues/302431?notification_referrer_id=NT_kwDOAGnFH7MxMDE2Mzg4NjI2Mzo2OTMxNzQz#issuecomment-2053956619
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
