### PR TITLE
realvnc-vnc-viewer: replace fetchurl by requireFile to fix captcha

### DIFF
--- a/pkgs/tools/admin/realvnc-vnc-viewer/darwin.nix
+++ b/pkgs/tools/admin/realvnc-vnc-viewer/darwin.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenvNoCC
-, fetchurl
+, requireFile
 , undmg
 , pname
 , version
@@ -9,9 +9,17 @@
 stdenvNoCC.mkDerivation (finalAttrs: {
   inherit pname version meta;
 
-  src = fetchurl {
-    url = "https://downloads.realvnc.com/download/file/viewer.files/VNC-Viewer-${finalAttrs.version}-MacOSX-universal.dmg";
-    sha256 = "0k72fdnx1zmyi9z5n3lazc7s70gcddxq0s73akp0al0y9hzq9prh";
+  src = requireFile rec {
+      name = "VNC-Viewer-${finalAttrs.version}-MacOSX-universal.dmg";
+      url = "https://downloads.realvnc.com/download/file/viewer.files/${name}";
+      sha256 = "0k72fdnx1zmyi9z5n3lazc7s70gcddxq0s73akp0al0y9hzq9prh";
+      message= ''
+        vnc-viewer can be downloaded from ${url},
+        but the download link require captcha, thus if you wish to use this application,
+        you need to download it manually and use follow command to add downloaded files into nix-store
+
+        $ nix-prefetch-url --type sha256 file:///path/to/${name}
+      '';
   };
   sourceRoot = ".";
 

--- a/pkgs/tools/admin/realvnc-vnc-viewer/default.nix
+++ b/pkgs/tools/admin/realvnc-vnc-viewer/default.nix
@@ -17,6 +17,7 @@ let
     };
     maintainers = with maintainers; [ emilytrau onedragon ];
     platforms = [ "x86_64-linux" ] ++ platforms.darwin;
+    hydraPlatforms = [];
     mainProgram = "vncviewer";
   };
 in

--- a/pkgs/tools/admin/realvnc-vnc-viewer/linux.nix
+++ b/pkgs/tools/admin/realvnc-vnc-viewer/linux.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchurl
+, requireFile
 , autoPatchelfHook
 , rpmextract
 , libX11
@@ -14,9 +14,17 @@ stdenv.mkDerivation (finalAttrs: {
   inherit pname version;
 
   src = {
-    "x86_64-linux" = fetchurl {
-      url = "https://downloads.realvnc.com/download/file/viewer.files/VNC-Viewer-${finalAttrs.version}-Linux-x64.rpm";
+    "x86_64-linux" = requireFile rec {
+      name = "VNC-Viewer-${finalAttrs.version}-Linux-x64.rpm";
+      url = "https://downloads.realvnc.com/download/file/viewer.files/${name}";
       sha256 = "sha256-Ull9iNi8NxB12YwEThWE0P9k1xOV2LZnebuRrVH/zwI=";
+      message= ''
+        vnc-viewer can be downloaded from ${url},
+        but the download link require captcha, thus if you wish to use this application,
+        you need to download it manually and use follow command to add downloaded files into nix-store
+
+        $ nix-prefetch-url --type sha256 file:///path/to/${name}
+      '';
     };
   }.${stdenv.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 


### PR DESCRIPTION
## Description of changes

Due to changes in platform download rules, when downloading vnc-viewer package from its website will require a captcha.
fix #303675 

<img src="https://github.com/NixOS/nixpkgs/assets/50787361/97de79f0-3eea-4d3c-8e90-1d99a10889cc" width="60%">


## Things done

just simple replace fetchurl with requireFile. 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@NickCao @emilytrau