### PR TITLE
simulide: factor out sources and format with nixfmt (no rebuilds)

### DIFF
--- a/pkgs/applications/science/electronics/simulide/default.nix
+++ b/pkgs/applications/science/electronics/simulide/default.nix
@@ -1,26 +1,28 @@
-{ lib
-, fetchbzr
-, mkDerivation
-, qmake
-, qtserialport
-, qtmultimedia
-, qttools
-, qtscript
+{
+  lib,
+  fetchbzr,
+  mkDerivation,
+  qmake,
+  qtserialport,
+  qtmultimedia,
+  qttools,
+  qtscript,
 }:
 
 let
   generic =
-    { version
-    , release
-    , rev
-    , src
-    , extraPostPatch ? ""
-    , extraBuildInputs ? [ ]
-    , iconPath ? "resources/icons/simulide.png"
-    , installFiles ? ''
+    {
+      version,
+      release,
+      rev,
+      src,
+      extraPostPatch ? "",
+      extraBuildInputs ? [ ],
+      iconPath ? "resources/icons/simulide.png",
+      installFiles ? ''
         cp -r data examples $out/share/simulide
         cp simulide $out/bin/simulide
-      ''
+      '',
     }:
     mkDerivation {
       pname = "simulide";
@@ -46,9 +48,7 @@ let
         cd build_XX
       '';
 
-      nativeBuildInputs = [
-        qmake
-      ];
+      nativeBuildInputs = [ qmake ];
 
       buildInputs = [
         qtserialport
@@ -80,7 +80,10 @@ let
         homepage = "https://simulide.com/";
         license = lib.licenses.gpl3Only;
         mainProgram = "simulide";
-        maintainers = with lib.maintainers; [ carloscraveiro tomasajt ];
+        maintainers = with lib.maintainers; [
+          carloscraveiro
+          tomasajt
+        ];
         platforms = [ "x86_64-linux" ];
       };
     };

--- a/pkgs/applications/science/electronics/simulide/default.nix
+++ b/pkgs/applications/science/electronics/simulide/default.nix
@@ -12,9 +12,8 @@ let
   generic =
     { version
     , release
-    , branch
     , rev
-    , sha256
+    , src
     , extraPostPatch ? ""
     , extraBuildInputs ? [ ]
     , iconPath ? "resources/icons/simulide.png"
@@ -26,11 +25,7 @@ let
     mkDerivation {
       pname = "simulide";
       version = "${version}-${release}";
-
-      src = fetchbzr {
-        url = "https://code.launchpad.net/~arcachofo/simulide/${branch}";
-        inherit rev sha256;
-      };
+      inherit src;
 
       postPatch = ''
         sed -i resources/simulide.desktop \
@@ -91,12 +86,16 @@ let
     };
 in
 {
-  simulide_0_4_15 = generic {
+  simulide_0_4_15 = generic rec {
     version = "0.4.15";
     release = "SR10";
-    branch = "simulide_0.4.14"; # the branch name does not mach the version for some reason
     rev = "291";
-    sha256 = "sha256-BBoZr/S2pif0Jft5wrem8y00dXl08jq3kFiIUtOr3LM=";
+    src = fetchbzr {
+      # the branch name does not mach the version for some reason
+      url = "https://code.launchpad.net/~arcachofo/simulide/simulide_0.4.14";
+      sha256 = "sha256-BBoZr/S2pif0Jft5wrem8y00dXl08jq3kFiIUtOr3LM=";
+      inherit rev;
+    };
     extraPostPatch = ''
       # GCC 13 needs the <cstdint> header explicitly included
       sed -i src/gpsim/value.h -e '1i #include <cstdint>'
@@ -110,20 +109,26 @@ in
     '';
   };
 
-  simulide_1_0_0 = generic {
+  simulide_1_0_0 = generic rec {
     version = "1.0.0";
     release = "SR2";
-    branch = "1.0.0";
     rev = "1449";
-    sha256 = "sha256-rJWZvnjVzaKXU2ktbde1w8LSNvu0jWkDIk4dq2l7t5g=";
+    src = fetchbzr {
+      url = "https://code.launchpad.net/~arcachofo/simulide/1.0.0";
+      sha256 = "sha256-rJWZvnjVzaKXU2ktbde1w8LSNvu0jWkDIk4dq2l7t5g=";
+      inherit rev;
+    };
     extraBuildInputs = [ qtscript ];
   };
 
-  simulide_1_1_0 = generic {
+  simulide_1_1_0 = generic rec {
     version = "1.1.0";
     release = "SR0";
-    branch = "1.1.0";
     rev = "1917";
-    sha256 = "sha256-qNBaGWl89Le9uC1VFK+xYhrLzIvOIWjkQbutnrAmZ2M=";
+    src = fetchbzr {
+      url = "https://code.launchpad.net/~arcachofo/simulide/1.1.0";
+      sha256 = "sha256-qNBaGWl89Le9uC1VFK+xYhrLzIvOIWjkQbutnrAmZ2M=";
+      inherit rev;
+    };
   };
 }


### PR DESCRIPTION
## Description of changes

This PR is done in anticipation of the next release of `simulide` being on GitHub.
This will allow us to take in a non-bzr `src` in the future.

This PR shouldn't cause any package rebuilds.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
