### PR TITLE
libproxy: 0.5.3 → 0.5.6

### DIFF
--- a/pkgs/development/libraries/libproxy/default.nix
+++ b/pkgs/development/libraries/libproxy/default.nix
@@ -4,7 +4,6 @@
 , darwin
 , duktape
 , fetchFromGitHub
-, fetchpatch
 , gi-docgen
 , gitUpdater
 , glib
@@ -21,7 +20,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libproxy";
-  version = "0.5.3";
+  version = "0.5.6";
 
   outputs = [ "out" "dev" "devdoc" ];
 
@@ -29,18 +28,10 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "libproxy";
     repo = "libproxy";
     rev = finalAttrs.version;
-    hash = "sha256-qdYB6HJkgboS8kkTvTqLy6Z3JYY5SOJsRl6nZM0iuvw=";
+    hash = "sha256-2uDlKjxzrKlyZKV0BSUDzmLSo2voJKDerbZZkamgNYk=";
   };
 
   patches = [
-    # Minor refactoring. Allows the following patches to apply without rebasing.
-    (fetchpatch {
-      url = "https://github.com/libproxy/libproxy/commit/397f4dc72607cc1bb3b584ffd3de49f8ba80491a.patch";
-      hash = "sha256-iUMBMpcVOLG+NxEj8Nd7JtKZFmoGXn0t6A2r2ayiteg=";
-      includes = [
-        "src/backend/plugins/config-gnome/config-gnome.c"
-      ];
-    })
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     # Disable schema presence detection, it would fail because it cannot be autopatched,
@@ -74,19 +65,15 @@ stdenv.mkDerivation (finalAttrs: {
     gsettings-desktop-schemas
   ]);
 
-  mesonFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+  mesonFlags = [
+    # Prevent installing commit hook.
+    "-Drelease=true"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "-Dconfig-gnome=false"
   ];
 
   doCheck = !stdenv.hostPlatform.isDarwin;
-
-  postPatch = ''
-    # Fix running script that will try to install git hooks.
-    # Though it will not do anything since we do not keep .git/ directory.
-    # https://github.com/libproxy/libproxy/issues/262
-    chmod +x data/install-git-hook.sh
-    patchShebangs data/install-git-hook.sh
-  '';
 
   postFixup = ''
     # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.


### PR DESCRIPTION
## Description of changes

https://github.com/libproxy/libproxy/releases/tag/0.5.4
https://github.com/libproxy/libproxy/releases/tag/0.5.5
https://github.com/libproxy/libproxy/releases/tag/0.5.6

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
