### PR TITLE
redocly-cli: 1.6.0 -> 1.12.0, rename to redocly

### DIFF
--- a/pkgs/by-name/re/redocly-cli/package.nix
+++ b/pkgs/by-name/re/redocly-cli/package.nix
@@ -5,17 +5,17 @@
 }:
 
 buildNpmPackage rec {
-  pname = "redocly-cli";
-  version = "1.6.0";
+  pname = "redocly";
+  version = "1.12.0";
 
   src = fetchFromGitHub {
     owner = "Redocly";
     repo = "redocly-cli";
     rev = "@redocly/cli@${version}";
-    hash = "sha256-xoehTTpXT/9tlL0VoDQwKbyUnNGeMyH+VBIVLiz69ko=";
+    hash = "sha256-KfNwBRGDFNMsba+yjwUHiiO2BJbIl4pW1b3cvLBe+lk=";
   };
 
-  npmDepsHash = "sha256-9fI9P96iNmHrhjbgjePpRnknFe3yIjkirOoIMkVGkH4=";
+  npmDepsHash = "sha256-I3cxMw9zOZb9sfP8UUoHc1UJ0RpDqVn9D29arSdNob4=";
 
   npmBuildScript = "prepare";
 

--- a/pkgs/by-name/re/redocly/package.nix
+++ b/pkgs/by-name/re/redocly/package.nix
@@ -2,6 +2,8 @@
 , buildNpmPackage
 , fetchFromGitHub
 , makeWrapper
+, redocly
+, testers
 }:
 
 buildNpmPackage rec {
@@ -32,24 +34,25 @@ buildNpmPackage rec {
 
     mkdir $out/bin
     makeWrapper $out/lib/node_modules/@redocly/cli/node_modules/@redocly/cli/bin/cli.js \
-      $out/bin/redocly-cli \
+      $out/bin/redocly \
       --set-default REDOCLY_TELEMETRY off \
       --set-default CI true # Silence update messages
+
+    # Symlink for backwards compatibility. Remove after 24.05.
+    ln -s $out/bin/redocly $out/bin/redocly-cli
   '';
 
-  installCheckPhase = ''
-    runHook preInstallCheck
-    $out/bin/redocly-cli --version
-    runHook postInstallCheck
-  '';
-
-  doInstallCheck = true;
+  passthru = {
+    tests.version = testers.testVersion {
+      package = redocly;
+    };
+  };
 
   meta = {
-    description = "Redocly CLI makes OpenAPI easy. Lint/validate to any standard, generate beautiful docs, and more.";
+    description = "Makes OpenAPI easy. Lint/validate to any standard, generate beautiful docs, and more";
     homepage = "https://github.com/Redocly/redocly-cli";
     license = lib.licenses.mit;
-    mainProgram = "redocly-cli";
+    mainProgram = "redocly";
     maintainers = with lib.maintainers; [ szlend ];
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1066,6 +1066,7 @@ mapAliases ({
   rccl = throw "'rccl' has been replaced with 'rocmPackages.rccl'"; # Added 2023-10-08
   rdc = throw "'rdc' has been replaced with 'rocmPackages.rdc'"; # Added 2023-10-08
   readline63 = throw "'readline63' has been replaced with 'readline'"; # Added 2024-02-10
+  redocly-cli = redocly; # Added 2024-04-14
   redpanda = redpanda-client; # Added 2023-10-14
   restya-board = throw "'restya-board' has been removed from nixpkgs, as it was broken and unmaintained"; # Added 2024-01-22
   retdec-full = throw "'retdec-full' is no longer needed, please use 'retdec'"; # Added 2024-02-05


### PR DESCRIPTION
## Description of changes

- upgrade redocly-cli to v1.12.0 ([diff](https://github.com/Redocly/redocly-cli/compare/%40redocly/cli%401.6.0...%40redocly/openapi-core%401.12.0))
- rename redocly-cli -> redocly

Reasons for renaming:
- it's called redocly in other repos (see repology.org)
  - the naming difference is causing `r-ryantm` to miss updates
- the cli tool upstream is called `redocly` (see [README](https://github.com/Redocly/redocly-cli?tab=readme-ov-file#generate-api-reference-documentation))

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
