### PR TITLE
kodi: make overrideAttrs and withPackages composable

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -518,6 +518,7 @@ with lib.maintainers; {
       cpages
       dschrempf
       edwtjo
+      kazenyuk
       minijackson
       peterhoeg
       sephalon

--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -1,14 +1,18 @@
 { callPackage, ... } @ args:
 let
   unwrapped = callPackage ./unwrapped.nix (removeAttrs args [ "callPackage" ]);
-  kodiPackages = callPackage ../../../top-level/kodi-packages.nix { kodi = unwrapped; };
 in
   unwrapped.overrideAttrs (oldAttrs: {
-    passthru = oldAttrs.passthru // {
-      packages = kodiPackages;
-      withPackages = func: callPackage ./wrapper.nix {
-        kodi = unwrapped;
-        addons = kodiPackages.requiredKodiAddons (func kodiPackages);
-      };
-    };
+    passthru =
+      let
+        finalKodi = oldAttrs.passthru.kodi;
+        kodiPackages = callPackage ../../../top-level/kodi-packages.nix { kodi = finalKodi; };
+      in
+        oldAttrs.passthru // {
+          packages = kodiPackages;
+          withPackages = func: callPackage ./wrapper.nix {
+            kodi = finalKodi;
+            addons = kodiPackages.requiredKodiAddons (func kodiPackages);
+          };
+        };
   })

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -26,7 +26,7 @@ let
   self = {
     addonDir = "/share/kodi/addons";
 
-    rel = "Omega";
+    rel = kodi.kodiReleaseName;
 
     inherit callPackage kodi hasKodiAddon requiredKodiAddons;
 


### PR DESCRIPTION
## Description of changes

This work is an up-to-date version of #209580 which has been stale for a long time already. Last time it was postponed due to an upcoming Kodi release, hopefully, we could merge it this time.
I've been using those changes and supporting them for about 2 years in my Nixos configuration with zero problems.
I've also improved it in a couple of places regarding the ability to override, and consistent handling of existing configuration parameters (`opticalSupport`, `vdpauSupport`).

- introduction of `finalAttrs` pattern
When using a kodi derivation modified with overrideAttrs and adding extensions to it with withPackages the changes were discarded and the original unmodified kodi derivation was wrapped together with the extensions.
Fix this by switching kodi to use the mkDerivation with finalAttrs pattern (described in https://github.com/NixOS/nixpkgs/pull/119942 and https://nixos.org/manual/nixpkgs/stable/#mkderivation-recursive-attributes).

This will make customizing Kodi for other platforms (e.g. Raspberry Pi, which require custom `ffmpeg`, `libcec` and other optimizations) much easier when all of `overrideAttrs`, `override`, and `withPackages` are needed at the same time.

Could be tested with something along these lines: (there is also test flake example in the original PR)
```nix
with import <nixpkgs> { system = "aarch64-linux"; };

let
  kodi-rpi = ((kodi.overrideAttrs (old: {
    pname = "kodi-rpi";

    ffmpeg = pkgs.ffmpeg_4 {
      withDav1 = true;
      withVaapi = false;
      withVdpau = false;
    };
  })).override {
    libcec = libcec.override {
      withLibraspberrypi = true;
    };
    vdpauSupport = false;
    dav1dSupport = true;
    gbmSupport = true;
  });
in kodi-rpi.withPackages (pkgs: with pkgs; [
    inputstream-adaptive
    inputstream-ffmpegdirect
    inputstream-rtmp
    joystick
    libretro
    libretro-2048
    libretro-fuse
    libretro-genplus
    libretro-mgba
    libretro-nestopia
    libretro-snes9x
    pvr-iptvsimple
    vfs-libarchive
    vfs-rar
])

```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
