### PR TITLE
pynitrokey: unpin cryptography, nitrokey-app2: 2.1.5 -> 2.2.2, fix qt somewhat

### DIFF
--- a/pkgs/by-name/py/pynitrokey/package.nix
+++ b/pkgs/by-name/py/pynitrokey/package.nix
@@ -1,28 +1,3 @@
-{ python3
-, fetchPypi
-, rustPlatform
-}:
+{ python3 }:
 
-let
-  python = python3.override {
-    packageOverrides = self: super: {
-      # https://github.com/nxp-mcuxpresso/spsdk/issues/64
-      cryptography = super.cryptography.overridePythonAttrs (old: rec {
-        version = "41.0.7";
-        src = fetchPypi {
-          inherit (old) pname;
-          inherit version;
-          hash = "sha256-E/k86b6oAWwlOzSvxr1qdZk+XEBnLtVAWpyDLw1KALw=";
-        };
-        cargoDeps = rustPlatform.fetchCargoTarball {
-          inherit src;
-          sourceRoot = "${old.pname}-${version}/${old.cargoRoot}";
-          name = "${old.pname}-${version}";
-          hash = "sha256-VeZhKisCPDRvmSjGNwCgJJeVj65BZ0Ge+yvXbZw86Rw=";
-        };
-        patches = [ ];
-        doCheck = false; # would require overriding cryptography-vectors
-      });
-    };
-  };
-in with python.pkgs; toPythonApplication pynitrokey
+with python3.pkgs; toPythonApplication pynitrokey

--- a/pkgs/development/python-modules/spsdk/default.nix
+++ b/pkgs/development/python-modules/spsdk/default.nix
@@ -107,7 +107,6 @@ buildPythonPackage rec {
   passthru.tests.version = testers.testVersion { package = spsdk; };
 
   meta = with lib; {
-    broken = versionAtLeast cryptography.version "41.1";
     changelog = "https://github.com/nxp-mcuxpresso/spsdk/blob/${src.rev}/docs/release_notes.rst";
     description = "NXP Secure Provisioning SDK";
     homepage = "https://github.com/nxp-mcuxpresso/spsdk";

--- a/pkgs/tools/security/nitrokey-app2/default.nix
+++ b/pkgs/tools/security/nitrokey-app2/default.nix
@@ -1,7 +1,11 @@
 { lib
+, stdenv
 , python3
 , fetchPypi
 , fetchFromGitHub
+, wrapQtAppsHook
+, qtbase
+, qtwayland
 }:
 
 let
@@ -19,7 +23,7 @@ let
   };
 in python.pkgs.buildPythonApplication rec {
   pname = "nitrokey-app2";
-  version = "2.1.5";
+  version = "2.2.2";
   pyproject = true;
 
   disabled = python.pythonOlder "3.9";
@@ -28,7 +32,7 @@ in python.pkgs.buildPythonApplication rec {
     owner = "Nitrokey";
     repo = "nitrokey-app2";
     rev = "v${version}";
-    hash = "sha256-mR13zUgCdNS09EnpGLrnOnoIn3p6ZM/0fHKg0OUMWj4=";
+    hash = "sha256-MiyfmsrKZRoe7YMEjR1LHPesfJh6+dcSydoEAgrALJ8=";
   };
 
   # https://github.com/Nitrokey/nitrokey-app2/issues/152
@@ -41,6 +45,11 @@ in python.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python.pkgs; [
     poetry-core
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [ qtbase ] ++ lib.optionals stdenv.isLinux [
+    qtwayland
   ];
 
   propagatedBuildInputs = with python.pkgs; [

--- a/pkgs/tools/security/nitrokey-app2/default.nix
+++ b/pkgs/tools/security/nitrokey-app2/default.nix
@@ -1,29 +1,19 @@
 { lib
 , python3
 , fetchPypi
-, rustPlatform
 , fetchFromGitHub
 }:
 
 let
   python = python3.override {
     packageOverrides = self: super: {
-      # https://github.com/nxp-mcuxpresso/spsdk/issues/64
-      cryptography = super.cryptography.overridePythonAttrs (old: rec {
-        version = "41.0.7";
+      pynitrokey = super.pynitrokey.overridePythonAttrs (old: rec {
+        version = "0.4.45";
         src = fetchPypi {
           inherit (old) pname;
           inherit version;
-          hash = "sha256-E/k86b6oAWwlOzSvxr1qdZk+XEBnLtVAWpyDLw1KALw=";
+          hash = "sha256-iY4ThrmXP7pEjTYYU4lePVAbuJGTdHX3iKswXzuf7W8=";
         };
-        cargoDeps = rustPlatform.fetchCargoTarball {
-          inherit src;
-          sourceRoot = "${old.pname}-${version}/${old.cargoRoot}";
-          name = "${old.pname}-${version}";
-          hash = "sha256-VeZhKisCPDRvmSjGNwCgJJeVj65BZ0Ge+yvXbZw86Rw=";
-        };
-        patches = [ ];
-        doCheck = false; # would require overriding cryptography-vectors
       });
     };
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40935,7 +40935,7 @@ with pkgs;
 
   nitrokey-app = libsForQt5.callPackage ../tools/security/nitrokey-app { };
 
-  nitrokey-app2 = callPackage ../tools/security/nitrokey-app2 { };
+  nitrokey-app2 = qt6Packages.callPackage ../tools/security/nitrokey-app2 { };
 
   fpm2 = callPackage ../tools/security/fpm2 { };
 


### PR DESCRIPTION
## Description of changes

This removes the `meta.broken` attribute from `python3Packages.spsdk` as the update to 2.1.1 enabled using cryptography 42 (see https://github.com/nxp-mcuxpresso/spsdk/blob/2.1.1/requirements.txt#L10) to allow unpinning the `cryptography` dependency in `pynitrokey` and `nitrokey-app2`.
`nitrokey-app2` is also correctly wrapped with the `wrapQtAppsHook` for qt6 and updated to 2.2.2, superseding #287238.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

CC @panicgh @dotlambda @RaitoBezarius 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
