### PR TITLE
blender: Switch to fetching source git instead of source tarball

### DIFF
--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -16,7 +16,8 @@
   cudaSupport ? config.cudaSupport,
   dbus,
   embree,
-  fetchurl,
+  fetchFromGitea,
+  fetchgit,
   fetchzip,
   ffmpeg,
   fftw,
@@ -101,10 +102,30 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "blender";
   version = "4.1.0";
 
-  src = fetchurl {
-    url = "https://download.blender.org/source/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
-    hash = "sha256-3AAtguPDQMk4VcZoRzDQGAG2aaKbHMa3XuuZC6aecj8=";
-  };
+  srcs = [
+    (fetchgit {
+      name = "source";
+      url = "https://projects.blender.org/blender/blender.git";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-4LtBOufcaUJP49QxT9/EcFVjNbyvGf/gYFoVtljod1Y=";
+      fetchLFS = true;
+    })
+    (fetchFromGitea {
+      name = "addons";
+      domain = "projects.blender.org";
+      owner = "blender";
+      repo = "blender-addons";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-OHEUtGiubZNf3nsT4LfHuGyOhfVPk2H3osZ1lWJL4jI=";
+    })
+  ];
+
+  sourceRoot = "source";
+
+  prePatch = ''
+    mkdir scripts/addons
+    cp -Rv --no-preserve=all ../addons/* scripts/addons
+  '';
 
   patches = [ ./draco.patch ] ++ lib.optional stdenv.isDarwin ./darwin.patch;
 


### PR DESCRIPTION
## Description of changes

Splitting up #257780, part 1 (I'm probably going to rewrite some of it, now that I know a bit more about nixpkgs)

This switches from building with a source tarball to cloning the repository directly. From what I understand, this is common practice, but it's a lot slower.

This is a much smaller change so *hopefully* it doesn't get stalled like my last attempt.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
