### PR TITLE
nixos/networkd: add [Bridge] section to netdev conf

### DIFF
--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -148,6 +148,10 @@ in rec {
     optional (attr ? ${name} && !(min <= attr.${name} && max >= attr.${name}))
       "Systemd ${group} field `${name}' is outside the range [${toString min},${toString max}]";
 
+  assertRangeOrOneOf = name: min: max: values: group: attr:
+    optional (attr ? ${name} && !((min <= attr.${name} && max >= attr.${name}) || elem attr.${name} values))
+      "Systemd ${group} field `${name}' is not a value in range [${toString min},${toString max}], or one of ${toString values}";
+
   assertMinimum = name: min: group: attr:
     optional (attr ? ${name} && attr.${name} < min)
       "Systemd ${group} field `${name}' must be greater than or equal to ${toString min}";

--- a/nixos/lib/systemd-network-units.nix
+++ b/nixos/lib/systemd-network-units.nix
@@ -25,6 +25,9 @@ in {
     commonMatchText def + ''
       [NetDev]
       ${attrsToSection def.netdevConfig}
+    '' + optionalString (def.bridgeConfig != { }) ''
+      [Bridge]
+      ${attrsToSection def.bridgeConfig}
     '' + optionalString (def.vlanConfig != { }) ''
       [VLAN]
       ${attrsToSection def.vlanConfig}

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -186,6 +186,37 @@ let
         (assertNetdevMacAddress "MACAddress")
       ];
 
+      sectionBridge = checkUnitConfig "Bridge" [
+        (assertOnlyFields [
+          "HelloTimeSec"
+          "MaxAgeSec"
+          "ForwardDelaySec"
+          "AgeingTimeSec"
+          "Priority"
+          "GroupForwardMask"
+          "DefaultPVID"
+          "MulticastQuerier"
+          "MulticastSnooping"
+          "VLANFiltering"
+          "VLANProtocol"
+          "STP"
+          "MulticastIGMPVersion"
+        ])
+        (assertInt "HelloTimeSec")
+        (assertInt "MaxAgeSec")
+        (assertInt "ForwardDelaySec")
+        (assertInt "AgeingTimeSec")
+        (assertRange "Priority" 0 65535)
+        (assertRange "GroupForwardMask" 0 65535)
+        (assertRangeOrOneOf "DefaultPVID" 0 4094 ["none"])
+        (assertValueOneOf "MulticastQuerier" boolValues)
+        (assertValueOneOf "MulticastSnooping" boolValues)
+        (assertValueOneOf "VLANFiltering" boolValues)
+        (assertValueOneOf "VLANProtocol" ["802.1q" "802.ad"])
+        (assertValueOneOf "STP" boolValues)
+        (assertValueOneOf "MulticastIGMPVersion" [2 3])
+      ];
+
       sectionVLAN = checkUnitConfig "VLAN" [
         (assertOnlyFields [
           "Id"
@@ -1631,6 +1662,17 @@ let
       description = ''
         Each attribute in this set specifies an option in the
         `[Netdev]` section of the unit.  See
+        {manpage}`systemd.netdev(5)` for details.
+      '';
+    };
+
+    bridgeConfig = mkOption {
+      default = {};
+      example = { STP = true; };
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionBridge;
+      description = ''
+        Each attribute in this set specifies an option in the
+        `[Bridge]` section of the unit.  See
         {manpage}`systemd.netdev(5)` for details.
       '';
     };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -899,6 +899,7 @@ in {
   systemd-lock-handler = runTestOn ["aarch64-linux" "x86_64-linux"] ./systemd-lock-handler.nix;
   systemd-machinectl = handleTest ./systemd-machinectl.nix {};
   systemd-networkd = handleTest ./systemd-networkd.nix {};
+  systemd-networkd-bridge = handleTest ./systemd-networkd-bridge.nix {};
   systemd-networkd-dhcpserver = handleTest ./systemd-networkd-dhcpserver.nix {};
   systemd-networkd-dhcpserver-static-leases = handleTest ./systemd-networkd-dhcpserver-static-leases.nix {};
   systemd-networkd-ipv6-prefix-delegation = handleTest ./systemd-networkd-ipv6-prefix-delegation.nix {};

--- a/nixos/tests/systemd-networkd-bridge.nix
+++ b/nixos/tests/systemd-networkd-bridge.nix
@@ -1,0 +1,103 @@
+/* This test ensures that we can configure spanning-tree protocol
+   across bridges using systemd-networkd.
+
+   Test topology:
+
+              1       2       3
+       node1 --- sw1 --- sw2 --- node2
+                   \     /
+                  4 \   / 5
+                     sw3
+                      |
+                    6 |
+                      |
+                    node3
+
+   where switches 1, 2, and 3 bridge their links and use STP,
+   and each link is labeled with the VLAN we are assigning it in
+   virtualisation.vlans.
+*/
+with builtins;
+let
+  commonConf = {
+    systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+    networking.useNetworkd = true;
+    networking.useDHCP = false;
+    networking.firewall.enable = false;
+  };
+
+  generateNodeConf = { octet, vlan }:
+    { lib, pkgs, config, ... }: {
+      imports = [ common/user-account.nix commonConf ];
+      virtualisation.vlans = [ vlan ];
+      systemd.network = {
+        enable = true;
+        networks = {
+          "30-eth" = {
+            matchConfig.Name = "eth1";
+            address = [ "10.0.0.${toString octet}/24" ];
+          };
+        };
+      };
+    };
+
+  generateSwitchConf = vlans:
+    { lib, pkgs, config, ... }: {
+      imports = [ common/user-account.nix commonConf ];
+      virtualisation.vlans = vlans;
+      systemd.network = {
+        enable = true;
+        netdevs = {
+          "40-br0" = {
+            netdevConfig = {
+              Kind = "bridge";
+              Name = "br0";
+            };
+            bridgeConfig.STP = "yes";
+          };
+        };
+        networks = {
+          "30-eth" = {
+            matchConfig.Name = "eth*";
+            networkConfig.Bridge = "br0";
+          };
+          "40-br0" = { matchConfig.Name = "br0"; };
+        };
+      };
+    };
+in import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "networkd";
+  meta = with pkgs.lib.maintainers; { maintainers = [ picnoir ]; };
+  nodes = {
+    node1 = generateNodeConf {
+      octet = 1;
+      vlan = 1;
+    };
+    node2 = generateNodeConf {
+      octet = 2;
+      vlan = 3;
+    };
+    node3 = generateNodeConf {
+      octet = 3;
+      vlan = 6;
+    };
+    sw1 = generateSwitchConf [ 1 2 4 ];
+    sw2 = generateSwitchConf [ 2 3 5 ];
+    sw3 = generateSwitchConf [ 4 5 6 ];
+  };
+  testScript = ''
+    network_nodes = [node1, node2, node3]
+    network_switches = [sw1, sw2, sw3]
+    start_all()
+
+    for n in network_nodes + network_switches:
+        n.wait_for_unit("systemd-networkd-wait-online.service")
+
+    node1.succeed("ping 10.0.0.2 -w 10 -c 1")
+    node1.succeed("ping 10.0.0.3 -w 10 -c 1")
+    node2.succeed("ping 10.0.0.1 -w 10 -c 1")
+    node2.succeed("ping 10.0.0.3 -w 10 -c 1")
+    node3.succeed("ping 10.0.0.1 -w 10 -c 1")
+    node3.succeed("ping 10.0.0.2 -w 10 -c 1")
+  '';
+})


### PR DESCRIPTION
## Description of changes

This setting was missing from netdev. These parameters are derived from [the systemd-networkd manpages](https://www.freedesktop.org/software/systemd/man/latest/systemd.netdev.html#%5BBridge%5D%20Section%20Options).

This commit additionally adds a test that incorporates [Bridge] parameters (ensuring that STP can be enabled, and works correctly).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [x] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) -- see `nixos/tests/systemd-networkd-bridge.nix`
  - ~~and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)~~
  - ~~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~~
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
