### PR TITLE
git-co-author: init at 0.2.0

### DIFF
--- a/pkgs/by-name/gi/git-co-author/package.nix
+++ b/pkgs/by-name/gi/git-co-author/package.nix
@@ -1,0 +1,38 @@
+{ bash
+, lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, pkgs
+, pkg-config
+,
+}:
+stdenv.mkDerivation rec {
+  pname = "git-co-author";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "jamesjoshuahill";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-IdVpWVLfS3Xa2+pSwIKz6qeqETnu1Au+bCFaeyepC94=";
+  };
+
+  buidInputs = [ bash ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp git-co-author $out/bin
+    wrapProgram $out/bin/git-co-author \
+      --prefix PATH : ${lib.makeBinPath [bash]}
+  '';
+
+  meta = with lib; {
+    description = "Easily use 'Co-authored-by' trailers in the commit template";
+    homepage = "https://github.com/jamesjoshuahill/git-co-author";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ sentientmonkey ];
+    mainProgram = "git-co-author";
+  };
+}


### PR DESCRIPTION
## Description of changes

Adding git-co-author, which easily uses 'Co-authored-by' trailers in the commit template.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).