### PR TITLE
pantheon.elementary-photos: Build without webkit2gtk-4.0

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , meson
 , ninja
@@ -11,19 +12,15 @@
 , libexif
 , libgee
 , libhandy
-, geocode-glib
+, geocode-glib_2
 , gexiv2
 , libgphoto2
 , granite
 , gst_all_1
 , libgudev
-, json-glib
 , libraw
-, librest
-, libsoup
 , sqlite
 , python3
-, webkitgtk
 , libwebp
 , appstream
 , wrapGAppsHook
@@ -40,6 +37,32 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-VhJggQMy1vk21zNA5pR4uAPGCwnIxLUHVO58AZs+h6s=";
   };
 
+  patches = [
+    # The following 5 patches allow building this without webkit2gtk-4.0.
+    # https://github.com/elementary/photos/pull/743, https://github.com/elementary/photos/pull/746
+    (fetchpatch {
+      url = "https://github.com/elementary/photos/commit/c48f49869bbf44aa37e64c0c1e25aff887783a02.patch";
+      hash = "sha256-CeKRONVevJqVEIchgxyPqnM16Y2zUJ1+wnL2jLdJqec=";
+    })
+    (fetchpatch {
+      url = "https://github.com/elementary/photos/commit/d7a8265ecb562e439d003b61b0823de8348fb10d.patch";
+      hash = "sha256-6M3t0l8BUhoaowUSfaiz6xjQBHliO13i+qi5cgfEY04=";
+    })
+    (fetchpatch {
+      url = "https://github.com/elementary/photos/commit/d8e13e8e803ed7ab1bd23527866567d998744f57.patch";
+      hash = "sha256-BGBDIHR5iYtd+rJG9sur1oWa4FK/lF0vLdjyPbyNbdU=";
+    })
+    (fetchpatch {
+      url = "https://github.com/elementary/photos/commit/075f983a65e9c6d4e80ee07f0c05309badef526a.patch";
+      excludes = [ ".github/workflows/ci.yml" ];
+      hash = "sha256-QOtssVwwHxFdtfhcVyaN33LMZdOkg/DoAC+UAbrkmDk=";
+    })
+    (fetchpatch {
+      url = "https://github.com/elementary/photos/commit/ea11cf23db6945df6cc3495fd698456054389371.patch";
+      hash = "sha256-4a/CRx7Dmyyda6SUr0QF++R73v7FBzjXfyxvspynnG0=";
+    })
+  ];
+
   nativeBuildInputs = [
     appstream
     desktop-file-utils
@@ -52,22 +75,18 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    geocode-glib
+    geocode-glib_2
     gexiv2
     granite
     gtk3
-    json-glib
     libexif
     libgee
     libgphoto2
     libgudev
     libhandy
     libraw
-    librest
-    libsoup
     libwebp
     sqlite
-    webkitgtk
   ] ++ (with gst_all_1; [
     gst-plugins-bad
     gst-plugins-base
@@ -75,10 +94,6 @@ stdenv.mkDerivation rec {
     gst-plugins-ugly
     gstreamer
   ]);
-
-  mesonFlags = [
-    "-Dplugins=false"
-  ];
 
   postPatch = ''
     chmod +x meson/post_install.py


### PR DESCRIPTION
By fully removing publishing plugins (we are not enabling plugins before already).

https://fedoraproject.org/wiki/Changes/Remove_webkit2gtk-4.0_API_Version

*I think with this change webkitgtk (webkit2gtk-4.0) will no longer block [nixos:trunk-combined](https://hydra.nixos.org/job/nixos/trunk-combined/tested#tabs-constituents), anything am I missing?*

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
