### PR TITLE
cinnamon.pix: Build without webkit2gtk-4.0

### DIFF
--- a/pkgs/desktops/cinnamon/pix/default.nix
+++ b/pkgs/desktops/cinnamon/pix/default.nix
@@ -10,15 +10,12 @@
 , libtiff
 , gst_all_1
 , libraw
-, libsoup
 , libsecret
 , glib
 , gtk3
 , gsettings-desktop-schemas
 , librsvg
 , libwebp
-, json-glib
-, webkitgtk
 , lcms2
 , bison
 , flex
@@ -65,17 +62,14 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-bad
     gst_all_1.gst-plugins-ugly
     gtk3
-    json-glib
     lcms2
     libheif
     libjpeg
     libraw
     librsvg
     libsecret
-    libsoup
     libtiff
     libwebp
-    webkitgtk
     xapp
   ];
 
@@ -88,6 +82,10 @@ stdenv.mkDerivation rec {
       postinstall.py \
       pix/make-authors-tab.py
   '';
+
+  # Avoid direct dependency on webkit2gtk-4.0
+  # https://fedoraproject.org/wiki/Changes/Remove_webkit2gtk-4.0_API_Version
+  mesonFlags = [ "-Dwebservices=false" ];
 
   preFixup = ''
     gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${shared-mime-info}/share")


### PR DESCRIPTION
This removes webkit2gtk-4.0 from cinnamon closure.

ref: https://fedoraproject.org/wiki/Changes/Remove_webkit2gtk-4.0_API_Version
ref: https://salsa.debian.org/debian/gthumb/-/commit/a19d4c2b0a42073d7e4dc743f33d92af0a188836

(I am aware of https://github.com/linuxmint/pix/commit/14682f6249b3b0be351b6b06474512c80bd39dba, but I don't think that actually can make oauth plugin functional, since it [also](https://github.com/linuxmint/pix/blob/14682f6249b3b0be351b6b06474512c80bd39dba/extensions/oauth/meson.build#L18) links with libsoup-2.4, and now I am just looking at the extension [`Hidden=true`](https://github.com/linuxmint/pix/blob/14682f6249b3b0be351b6b06474512c80bd39dba/extensions/oauth/oauth.extension.desktop.in.in#L2) :joy:)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

