### PR TITLE
eepers: init at 1.3

### DIFF
--- a/pkgs/by-name/ee/eepers/package.nix
+++ b/pkgs/by-name/ee/eepers/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gnat,
+  raylib,
+  alsa-lib,
+  wayland,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "eepers";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "tsoding";
+    repo = "eepers";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-KG7ci327qlTtlN4yV54P8Q34ExFLJfTGMTZxN3RtZbc=";
+  };
+
+  postPatch = ''
+    substituteInPlace eepers.adb \
+      --replace-fail "assets/" "$out/assets/"
+  '';
+
+  buildInputs = [
+    gnat
+    raylib
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    gnatmake -f -O3 \
+      -Wall \
+      -Wextra \
+      -gnat2012 \
+      -o eepers-linux eepers.adb \
+      -bargs \
+      -largs -lraylib -lm \
+      -pthread
+
+    runHook postBuild
+  '';
+
+  postFixup = ''
+    patchelf $out/bin/eepers \
+      --add-needed libwayland-client.so \
+      --add-needed libwayland-cursor.so \
+      --add-needed libwayland-egl.so \
+      --add-needed libasound.so \
+      --add-rpath ${
+        lib.makeLibraryPath [
+          alsa-lib
+          wayland
+        ]
+      }
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp ./eepers-linux $out/bin/eepers
+
+    cp -r ./assets $out/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Simple Turn-based Game";
+    homepage = "https://github.com/tsoding/eepers";
+    changelog = "https://github.com/tsoding/eepers/blob/${src.rev}/CHANGELOG.txt";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "eepers";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add the game [eepers](https://github.com/tsoding/eepers).
~~Sound doesn't work for me (on wayland).~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
