### PR TITLE
apksigner: 33.0.1 -> 34.0.5-unstable-2024-03-06

### DIFF
--- a/pkgs/development/tools/apksigner/default.nix
+++ b/pkgs/development/tools/apksigner/default.nix
@@ -1,24 +1,22 @@
 { lib
 , stdenv
 , fetchgit
-, openjdk17_headless
-, gradle_7
+, jdk_headless
+, gradle
 , perl
 , makeWrapper
 }:
-let
-  gradle = gradle_7;
-in
+
 stdenv.mkDerivation rec {
   pname = "apksigner";
-  version = "33.0.1";
+  version = "34.0.5-unstable-2024-03-06";
 
   src = fetchgit {
     # use pname here because the final jar uses this as the filename
     name = pname;
     url = "https://android.googlesource.com/platform/tools/apksig";
-    rev = "platform-tools-${version}";
-    hash = "sha256-CKvwB9Bb12QvkL/HBOwT6DhA1PI45+QnTNfwnvReGUQ=";
+    rev = "ac5cbb07d87cc342fcf07715857a812305d69888";
+    hash = "sha256-sLAs7XEkhNkQjB/nhBODxI3QzxFvLWM1SBKDuXp6gvw=";
   };
 
   postPatch = ''
@@ -36,6 +34,7 @@ stdenv.mkDerivation rec {
             include 'com/android/apksigner/*.txt'
         }
     }
+    tasks.named("processTestResources") { dependsOn("extractTestProto") }
     EOF
     sed -i -e '/conscrypt/s/testImplementation/implementation/' build.gradle
   '';
@@ -80,9 +79,11 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     install -Dm444 build/libs/apksigner.jar -t $out/lib
-    makeWrapper "${openjdk17_headless}/bin/java" "$out/bin/apksigner" \
+    makeWrapper "${jdk_headless}/bin/java" "$out/bin/apksigner" \
       --add-flags "-jar $out/lib/apksigner.jar"
   '';
+
+  __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
     description = "Command line tool to sign and verify Android APKs";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
