### PR TITLE
gitui: 0.25.2 → 0.26.1

### DIFF
--- a/pkgs/applications/version-management/gitui/default.nix
+++ b/pkgs/applications/version-management/gitui/default.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "gitui";
-  version = "0.25.2";
+  version = "0.26.1";
 
   src = fetchFromGitHub {
     owner = "extrawurst";
-    repo = pname;
+    repo = "gitui";
     rev = "v${version}";
-    hash = "sha256-1sBuyY6lpxb/Vlpy6pi7YP69HZID6D97ZkVLbPEZ4Qw=";
+    hash = "sha256-JqxZbxjZrrdsXWhpYu0E9F18gMldtOLrAYd+uiY8IcQ=";
   };
 
-  cargoHash = "sha256-S8Oy5DII05430nkRJmMgZsb4fUIks2zliDea9RycH3E=";
+  cargoHash = "sha256-zEoNyIiHQT6HBNSe+H7pz229K4eD0WMhp3I/6zJQHuU=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -29,27 +29,32 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optional stdenv.isLinux xclip
     ++ lib.optionals stdenv.isDarwin [ libiconv Security AppKit ];
 
+  postPatch = ''
+    # The cargo config overrides linkers for some targets, breaking the build
+    # on e.g. `aarch64-linux`. These overrides are not required in the Nix
+    # environment: delete them.
+    rm .cargo/config
+
+    # build script tries to get version information from git
+    rm build.rs
+    substituteInPlace Cargo.toml --replace-fail 'build = "build.rs"' ""
+  '';
+
+  GITUI_BUILD_NAME = version;
   # Needed to get openssl-sys to use pkg-config.
   OPENSSL_NO_VENDOR = 1;
-
-  # The cargo config overrides linkers for some targets, breaking the build
-  # on e.g. `aarch64-linux`. These overrides are not required in the Nix
-  # environment: delete them.
-  postPatch = "rm .cargo/config";
-
 
   # Getting app_config_path fails with a permission denied
   checkFlags = [
     "--skip=keys::key_config::tests::test_symbolic_links"
   ];
 
-
-  meta = with lib; {
+  meta = {
     description = "Blazing fast terminal-ui for Git written in Rust";
     homepage = "https://github.com/extrawurst/gitui";
     changelog = "https://github.com/extrawurst/gitui/blob/v${version}/CHANGELOG.md";
     mainProgram = "gitui";
-    license = licenses.mit;
-    maintainers = with maintainers; [ Br1ght0ne yanganto mfrw ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Br1ght0ne yanganto mfrw ];
   };
 }

--- a/pkgs/by-name/gi/gitui/package.nix
+++ b/pkgs/by-name/gi/gitui/package.nix
@@ -6,8 +6,7 @@
 , openssl
 , pkg-config
 , xclip
-, AppKit
-, Security
+, darwin
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -27,7 +26,11 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ openssl ]
     ++ lib.optional stdenv.isLinux xclip
-    ++ lib.optionals stdenv.isDarwin [ libiconv Security AppKit ];
+    ++ lib.optionals stdenv.isDarwin [
+         libiconv
+         darwin.apple_sdk.frameworks.Security
+         darwin.apple_sdk.frameworks.AppKit
+       ];
 
   postPatch = ''
     # The cargo config overrides linkers for some targets, breaking the build

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2528,10 +2528,6 @@ with pkgs;
 
   gittyup = libsForQt5.callPackage ../applications/version-management/gittyup { };
 
-  gitui = callPackage ../applications/version-management/gitui {
-    inherit (darwin.apple_sdk.frameworks) Security AppKit;
-  };
-
   gitweb = callPackage ../applications/version-management/gitweb { };
 
   glab = callPackage ../applications/version-management/glab { };


### PR DESCRIPTION
## Description of changes
https://github.com/extrawurst/gitui/releases

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
