### PR TITLE
python311Packages.scipy: fix darwin build

### DIFF
--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -76,6 +76,11 @@ in buildPythonPackage {
         "doc/source/dev/contributor/meson_advanced.rst"
       ];
     })
+    # Fix for https://github.com/scipy/scipy/issues/20300 until 1.13.1, based
+    # on: https://github.com/scipy/scipy/issues/20300 linked from there,
+    # couldn't use fetchpatch because it is a submodule of scipy, and
+    # extraPrefix doesn't fit this purpose.
+    ./pocketfft-aligned_alloc.patch
   ];
 
   # Upstream says in a comment in their pyproject.toml that building against

--- a/pkgs/development/python-modules/scipy/pocketfft-aligned_alloc.patch
+++ b/pkgs/development/python-modules/scipy/pocketfft-aligned_alloc.patch
@@ -1,0 +1,30 @@
+From fbe3c10d117de98d80a86a10f76d4cd74efc55a8 Mon Sep 17 00:00:00 2001
+From: Martin Reinecke <martin@mpa-garching.mpg.de>
+Date: Fri, 22 Mar 2024 10:53:05 +0100
+Subject: [PATCH] unconditionaly disable use of aligned_alloc
+
+---
+ pocketfft_hdronly.h | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/scipy/_lib/pocketfft/pocketfft_hdronly.h b/scipy/_lib/pocketfft/pocketfft_hdronly.h
+index 6c98f2d..66eea06 100644
+--- a/scipy/_lib/pocketfft/pocketfft_hdronly.h
++++ b/scipy/_lib/pocketfft/pocketfft_hdronly.h
+@@ -152,11 +152,11 @@ template<> struct VLEN<double> { static constexpr size_t val=2; };
+ #endif
+ #endif
+ 
+-// the __MINGW32__ part in the conditional below works around the problem that
+-// the standard C++ library on Windows does not provide aligned_alloc() even
+-// though the MinGW compiler and MSVC may advertise C++17 compliance.
+-// aligned_alloc is only supported from MacOS 10.15.
+-#if (__cplusplus >= 201703L) && (!defined(__MINGW32__)) && (!defined(_MSC_VER)) && (__MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15)
++// std::aligned_alloc is a bit cursed ... it doesn't exist on MacOS < 10.15
++// and in musl, and other OSes seem to have even more peculiarities.
++// Let's unconditionally work around it for now.
++# if 0
++//#if (__cplusplus >= 201703L) && (!defined(__MINGW32__)) && (!defined(_MSC_VER)) && (__MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15)
+ inline void *aligned_alloc(size_t align, size_t size)
+   {
+   // aligned_alloc() requires that the requested size is a multiple of "align"


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
