### PR TITLE
frr: 9.1 -> 10.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -435,6 +435,8 @@ Use `services.pipewire.extraConfig` or `services.pipewire.configPackages` for Pi
 - `services.archisteamfarm` no longer uses the abbreviation `asf` for its state directory (`/var/lib/asf`), user and group (both `asf`). Instead the long name `archisteamfarm` is used.
   Configurations with `system.stateVersion` 23.11 or earlier, default to the old stateDirectory until the 24.11 release and must either set the option explicitly or move the data to the new directory.
 
+- `frr` was updated to 10.0, which introduces the default of `enforce-first-as` for BGP. Please disable again if needed.
+
 - `services.aria2.rpcSecret` has been replaced with `services.aria2.rpcSecretFile`.
   This was done so that secrets aren't stored in the world-readable nix store.
   To migrate, you will have to create a file with the same exact string, and change

--- a/pkgs/servers/frr/default.nix
+++ b/pkgs/servers/frr/default.nix
@@ -86,23 +86,14 @@ lib.warnIf (!(stdenv.buildPlatform.canExecute stdenv.hostPlatform))
 
 stdenv.mkDerivation rec {
   pname = "frr";
-  version = "9.1";
+  version = "10.0";
 
   src = fetchFromGitHub {
     owner = "FRRouting";
     repo = pname;
     rev = "${pname}-${version}";
-    hash = "sha256-oDPr51vI+tlT1IiUPufmZh/UE0TNKWrn4RqpnGoGxNo=";
+    hash = "sha256-vvh9z2hmjvAA7OXgrUmlcrrTE5MRedZzfmhX5FEDKwE=";
   };
-
-  patches = [
-    # fixes crash in OSPF TE parsing
-    (fetchpatch {
-      name = "CVE-2024-27913.patch";
-      url = "https://github.com/FRRouting/frr/commit/541503eecd302d2cc8456167d130014cd2cf1134.patch";
-      hash = "sha256-7NxPlQK/6lbLs/NqNi4OZ2uBWfXw99SiXDR6okNvJlg=";
-    })
-  ];
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
## Description of changes

Release notes: https://github.com/FRRouting/frr/releases/tag/frr-10.0

Breaking changes:

- per-daemon config files no longer supported -> only when writing, not possible with configs in read-only store paths
- noprefixroute flag for interface prefixes with NetworkManager -> routes with noprefixroute set no longer inserted into advertised set, should be no real issue
- -n is required for mgmtd -> currently netns-based VRFs are not supported in the module. I'd ignore this until someone needs it explicitely.
- Enable enforce-first-as by default for BGP -> likely breaks Route Reflector/Route Server Setups -> mention in release notes?
- Deprecate ConfD -> confd is deprecated by its developing company tail-f

Currently WIP, opened for possible discussion.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
