### PR TITLE
jetbrains.jcef: 675 -> 766

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/jcef.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/jcef.nix
@@ -97,11 +97,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "jcef-jetbrains";
-  rev = "9f8d4fb20b4658db6b2b6bc08e5dd0d8c7340290";
+  rev = "72b2597f4c88fe643b14b5ae619878457b842c74";
   # This is the commit number
   # Currently from the branch: https://github.com/JetBrains/jcef/tree/232
   # Run `git rev-list --count HEAD`
-  version = "675";
+  version = "766";
 
   nativeBuildInputs = [ cmake python3 jdk17 git rsync ant ninja strip-nondeterminism stripJavaArchivesHook ];
   buildInputs = [ libX11 libXdamage nss nspr ];
@@ -110,15 +110,15 @@ stdenv.mkDerivation rec {
     owner = "jetbrains";
     repo = "jcef";
     inherit rev;
-    hash = "sha256-8zsgcWl0lZtC1oud5IlkUdeXxJUlHoRfw8t0FrZUQec=";
+    hash = "sha256-/1OrKd4FhtollYwCV/9mYT018WttkovXV4C3B/N9zpk=";
   };
   cef-bin =
     let
       # `cef_binary_${CEF_VERSION}_linux64_minimal`, where CEF_VERSION is from $src/CMakeLists.txt
-      name = "cef_binary_111.2.1+g870da30+chromium-111.0.5563.64_${platform}_minimal";
+      name = "cef_binary_122.1.9+gd14e051+chromium-122.0.6261.94_${platform}_minimal";
       hash = {
-        "linuxarm64" = "sha256-gCDIfWsysXE8lHn7H+YM3Jag+mdbWwTQpJf0GKdXEVs=";
-        "linux64" = "sha256-r+zXTmDN5s/bYLvbCnHufYdXIqQmCDlbWgs5pdOpLTw=";
+        "linuxarm64" = "sha256-wABtvz0JHitlkkB748I7yr02Oxs5lXvqDfrBAQiKWHU=";
+        "linux64" = "sha256-qlutM0IsE1emcMe/3p7kwMIK7ou1rZGvpUkrSMVPnCc=";
       }.${platform};
       urlName = builtins.replaceStrings [ "+" ] [ "%2B" ] name;
     in
@@ -130,6 +130,10 @@ stdenv.mkDerivation rec {
     url = "https://storage.googleapis.com/chromium-clang-format/dd736afb28430c9782750fc0fd5f0ed497399263";
     hash = "sha256-4H6FVO9jdZtxH40CSfS+4VESAHgYgYxfCBFSMHdT0hE=";
   };
+
+  patches = [
+    ./remove-vcpkgs.patch
+  ];
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/development/compilers/jetbrains-jdk/remove-vcpkgs.patch
+++ b/pkgs/development/compilers/jetbrains-jdk/remove-vcpkgs.patch
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cd5463b..b026aaf 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -117,13 +117,13 @@ cmake_minimum_required(VERSION 3.19)
+ # Only generate Debug and Release configuration types.
+ set(CMAKE_CONFIGURATION_TYPES Debug Release)
+ 
+-include(cmake/vcpkg.cmake)
+-bring_vcpkg()
++# include(cmake/vcpkg.cmake)
++# bring_vcpkg()
+ 
+ # Project name.
+ project(jcef)
+ 
+-vcpkg_install_package(boost-filesystem boost-interprocess thrift)
++# vcpkg_install_package(boost-filesystem boost-interprocess thrift)
+ 
+ # Use folders in the resulting project files.
+ set_property(GLOBAL PROPERTY OS_FOLDERS ON)
+@@ -331,7 +331,7 @@ endif()
+ add_subdirectory(${CEF_LIBCEF_DLL_WRAPPER_PATH} libcef_dll_wrapper)
+ add_subdirectory(native)
+ 
+-add_subdirectory(remote)
++# add_subdirectory(remote)
+ 
+ 
+ #


### PR DESCRIPTION
## Description of changes

Bump JCEF to the required version for the 2024.1 versions (updated in #301635).

I added a patch to disable calling `vcpkg` for some remote dev stuff.
I couldn't get it to work quickly, but someone else is certainly welcome to fix it.

Additionally, the logs show lines like:

```
ERR: Display.cpp:1052 (initialize): ANGLE Display::initialize error 12289: Could not dlopen libGL.so.1: libGL.so.1: cannot open shared object file: No such file or directory
```

I tried a few things (like some changes from our CEF build), but to no avail. Everything I usually check for JCEF (e.g. the markdown preview) seems to work despite these error messages, so perhaps they are not relevant.

Pinging @GenericNerdyUsername, since you have done a lot of work on this in the past.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
