### PR TITLE
neverest: init at 1.0.0-beta

### DIFF
--- a/pkgs/by-name/ne/neverest/package.nix
+++ b/pkgs/by-name/ne/neverest/package.nix
@@ -1,0 +1,63 @@
+{ lib
+, rustPlatform
+, fetchFromSourcehut
+, stdenv
+, pkg-config
+, darwin
+, installShellFiles
+, installShellCompletions ? stdenv.hostPlatform == stdenv.buildPlatform
+, installManPages ? stdenv.hostPlatform == stdenv.buildPlatform
+, notmuch
+, buildNoDefaultFeatures ? false
+, buildFeatures ? []
+}:
+
+rustPlatform.buildRustPackage rec {
+  # Learn more about available cargo features at:
+  #  - <https://pimalaya.org/neverest/cli/latest/installation.html#cargo>
+  #  - <https://git.sr.ht/~soywod/neverest-cli/tree/master/item/Cargo.toml#L18>
+  inherit buildNoDefaultFeatures buildFeatures;
+
+  pname = "neverest";
+  version = "1.0.0-beta";
+
+  src = fetchFromSourcehut {
+    owner = "~soywod";
+    repo = "${pname}-cli";
+    rev = "v${version}";
+    hash = "sha256-3PSJyhxrOCiuHUeVHO77+NecnI5fN5EZfPhYizuYvtE=";
+  };
+
+  cargoSha256 = "i5or8oBtjGqOfTfwB7dYXn/OPgr5WEWNEvC0WdCCG+c=";
+
+  nativeBuildInputs = [ pkg-config ]
+    ++ lib.optional (installManPages || installShellCompletions) installShellFiles;
+
+  buildInputs = [ ]
+    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ AppKit Cocoa Security ])
+    ++ lib.optional (builtins.elem "notmuch" buildFeatures) notmuch;
+
+  # TODO: unit tests temporarily broken, remove this line for the next
+  # beta.2 release
+  doCheck = false;
+
+  postInstall = lib.optionalString installManPages ''
+    mkdir -p $out/man
+    $out/bin/neverest man $out/man
+    installManPage $out/man/*
+  '' + lib.optionalString installShellCompletions ''
+    installShellCompletion --cmd neverest \
+      --bash <($out/bin/neverest completion bash) \
+      --fish <($out/bin/neverest completion fish) \
+      --zsh <($out/bin/neverest completion zsh)
+  '';
+
+  meta = with lib; {
+    description = "CLI to synchronize, backup and restore emails";
+    mainProgram = "neverest";
+    homepage = "https://pimalaya.org/neverest/cli/v${version}/";
+    changelog = "https://git.sr.ht/~soywod/neverest-cli/tree/v${version}/item/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ soywod ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Neverest CLI is a CLI to synchronize, backup and restore emails.

Website: https://pimalaya.org/neverest/cli/latest/
Sources: https://git.sr.ht/~soywod/neverest-cli

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
