### PR TITLE
mdbook-cmdrun: unstable-2023-01-10 -> 0.6.0-unstable-2024-04-15

### DIFF
--- a/pkgs/tools/text/mdbook-cmdrun/default.nix
+++ b/pkgs/tools/text/mdbook-cmdrun/default.nix
@@ -1,21 +1,31 @@
-{ lib, rustPlatform, fetchFromGitHub }:
+{ lib
+, mdbook
+, nodePackages
+, python3
+, util-linux
+, rustPlatform
+, fetchFromGitHub
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "mdbook-cmdrun";
-  version = "unstable-2023-01-10";
+  version = "0.6.0-unstable-2024-04-15";
 
   src = fetchFromGitHub {
     owner = "FauconFan";
     repo = pname;
-    rev = "3f6d243cd9de5659f166a5642eb46b2a6d8384e7";
-    hash = "sha256-JuKMAb3vwGTju9U1vaS9I39gObTz0JQQV4uol9SmsfM=";
+    rev = "d1fef67f100563c2a433b1f5dd5a71810db6b90d";
+    hash = "sha256-Q2h64XCyDxLmmCNC3wTw81pBotaMEUjY5y0Oq6q20cQ=";
   };
 
-  # Tests are outdated currently, application works fine
-  # See for more info: https://github.com/FauconFan/mdbook-cmdrun/issues/2
-  doCheck = false;
+  nativeCheckInputs = [
+    mdbook # used by tests/book.rs
+    nodePackages.nodejs # used by tests/regression/inline_call/input.md
+    python3 # used by tests/regression/py_*
+    util-linux # used by tests/regression/shell/input.md
+  ];
 
-  cargoHash = "sha256-h3xCnx6byToZx83uWNLz05F3VIDR0D1NVtSOKPuYeG4=";
+  cargoHash = "sha256-gT3DyQRJWn1HuR6fXeqk8aUPb+jmC+V1McdDN2JGXuI=";
 
   meta = with lib; {
     description = "mdbook preprocessor to run arbitrary commands";


### PR DESCRIPTION
## Description of changes

Bump rev from 0.4.0 to [0.6.0](https://github.com/FauconFan/mdbook-cmdrun/commit/d1fef67f100563c2a433b1f5dd5a71810db6b90d).

The upstream is releasing with proper version numbers, but for some reason does not tag the release, so I hope I'm understanding [our naming scheme](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-naming) correctly here.

I also fixed the `checkPhase` since it was simply missing dependencies. We now have clear conclusion for FauconFan/mdbook-cmdrun#2.

I ran `nixpkgs-fmt` on this file and now my comments are not aligned :/

Tested with `<!-- cmdrun seq 1 10 -->` in `mdbook serve`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
