### PR TITLE
fish: remove `python` from dependencies

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -1,9 +1,7 @@
 { stdenv
 , lib
 , fetchurl
-, fetchpatch
 , coreutils
-, which
 , gnused
 , gnugrep
 , groff
@@ -18,9 +16,6 @@
 , cmake
 , fishPlugins
 , procps
-
-# used to generate autocompletions from manpages and for configuration editing in the browser
-, usePython ? true
 
 , runCommand
 , writeText
@@ -270,14 +265,6 @@ let
           -i $out/share/fish/functions/{__fish_print_packages.fish,__fish_print_addresses.fish,__fish_describe_command.fish,__fish_complete_man.fish,__fish_complete_convert_options.fish} \
              $out/share/fish/completions/{cwebp,adb,ezjail-admin,grunt,helm,heroku,lsusb,make,p4,psql,rmmod,vim-addons}.fish
 
-    '' + optionalString usePython ''
-      cat > $out/share/fish/functions/__fish_anypython.fish <<EOF
-      function __fish_anypython
-          echo ${python3.interpreter}
-          return 0
-      end
-      EOF
-
     '' + optionalString stdenv.isLinux ''
       for cur in $out/share/fish/functions/*.fish; do
         sed -e "s|/usr/bin/getent|${getent}/bin/getent|" \
@@ -335,7 +322,7 @@ let
             ) | ${lib.getExe gnugrep} -q 'a href="http://localhost.*Start the Fish Web config'
           '';
           in
-          runCommand "test-web-config" { } ''
+          runCommand "test-web-config" { buildInputs = [ python3 ]; } ''
             HOME=$(mktemp -d)
             ${fish}/bin/fish ${fishScript} && touch $out
           '';


### PR DESCRIPTION
Hello everyone,

Today, while optimizing the closure size of a Home-Manager profile, I discovered that including Python3 significantly increased the size. Specifically, Python3 set the `fish` derivation's size to 220MB.

```
❯ nix path-info --recursive --size --closure-size --human-readable $(nix build --impure --print-out-paths --expr '(import ./. { system = "x86_64-linux";}).fish')
...
/nix/store/rswmlkz46y7svb399kfzvp3gdihml8mg-fish-3.7.1            14.6M  220.8M
...
```

Upon examining the [Fish derivation](https://github.com/NixOS/nixpkgs/blob/90055d5e616bd943795d38808c94dbf0dd35abe8/pkgs/shells/fish/default.nix#L23), I found a parameter `usePython` set to `true` by default. 

When I build Fish with `usePython` set to `false`, its size dropped to 92MB.

```
programs.fish.package = pkgs.fish.override({
  usePython = false;
});
```

```
❯ nix path-info --recursive --size --closure-size --human-readable $(nix build --impure --print-out-paths --expr '(import ./. { system = "x86_64-linux";}).fish.override({ usePython=true; })')
...
/nix/store/mgmn7cyjriy65z27hijfma2habq4779y-fish-3.7.1            14.6M   92.3M
...
```

It appears that Python is primarily used to run `fish_config`, the web-based interface for configuring Fish.

Given this, I opened this thread to discuss whether the `usePython` flag should default to `false` to optimize the closure size for users who do not require the web configuration interface. In this Nix context, Fish is usually configured through Home-Manager and/or custom config files. I guess not so many people are aware of this config interface anyway, but I might be wrong.

This PR is here as a draft for the moment until we find a way to fix this gracefully.

See the related Discourse thread: https://discourse.nixos.org/t/fish-shell-includes-python-by-default/43421/5

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
