### PR TITLE
all-packages: Add firstAvailableOnHost function

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15497,6 +15497,7 @@ with pkgs;
 
   fasmg = callPackage ../development/compilers/fasmg { };
 
+  # candidate
   fbc = if stdenv.hostPlatform.isDarwin then
     callPackage ../development/compilers/fbc/mac-bin.nix { }
   else
@@ -18084,11 +18085,23 @@ with pkgs;
     electron_29-bin
     electron_30-bin;
 
+  # Use the first package available on the current host platform
+  # and merge all meta.platforms in the resulting derivation.
+  firstAvailableOnHost = packages:
+    let platforms = lib.unique (lib.concatMap (p: p.meta.platforms) packages);
+    in let firstAvailable =
+         lib.findFirst (lib.meta.availableOn stdenv.hostPlatform)
+                       (let p = lib.head packages;
+                            name = p.pname or p.name;
+                        in (throw "${name} not supported on ${stdenv.hostPlatform.system}"))
+                       packages;
+       in lib.recursiveUpdate firstAvailable { meta.platforms = platforms; };
+
   electron_24 = electron_24-bin;
-  electron_27 = if lib.meta.availableOn stdenv.hostPlatform electron-source.electron_27 then electron-source.electron_27 else electron_27-bin;
-  electron_28 = if lib.meta.availableOn stdenv.hostPlatform electron-source.electron_28 then electron-source.electron_28 else electron_28-bin;
-  electron_29 = if lib.meta.availableOn stdenv.hostPlatform electron-source.electron_29 then electron-source.electron_29 else electron_29-bin;
-  electron_30 = if lib.meta.availableOn stdenv.hostPlatform electron-source.electron_30 then electron-source.electron_30 else electron_30-bin;
+  electron_27 = firstAvailableOnHost [ electron-source.electron_27 electron_27-bin ];
+  electron_28 = firstAvailableOnHost [ electron-source.electron_28 electron_28-bin ];
+  electron_29 = firstAvailableOnHost [ electron-source.electron_29 electron_29-bin ];
+  electron_30 = firstAvailableOnHost [ electron-source.electron_30 electron_30-bin ];
   electron = electron_29;
   electron-bin = electron_29-bin;
 
@@ -21622,6 +21635,7 @@ with pkgs;
 
   ip2location-c = callPackage ../development/libraries/ip2location-c { };
 
+  # candidate
   irrlicht = if !stdenv.isDarwin then
     callPackage ../development/libraries/irrlicht { }
   else callPackage ../development/libraries/irrlicht/mac.nix {


### PR DESCRIPTION
## Description of changes

This is a preliminary PR to propose an idea. I don't know if it's a good idea, I don't know where the function should live, and I am seeking feedback.

The `firstAvailableOnHost` function aids in producing top-level derivations where not all host platforms are supported by the same derivation within `nixpkgs`. In practice, the derivations are the same, but they must be built differently depending on the host.

It is conceptually the same as a top-level if-statement choosing between two derivations, but it supports any number of possible variants of the derivation and it merges the platforms together. This is a key advantage -- no matter what host the derivation is evaluated on, the list of platforms supported will be complete.

My desire for this function in part comes from the frustration that currently any nixpkgs derivation that depends on `electron` and uses `electron.meta.platforms` as its own `meta.platforms` will look like it supports different platforms depending on where the derivation is evaluated. Evaluate on a Darwin machine and it works, but evaluate it on a Linux machine and it looks like Darwin is not even supported. This latter situation happens to cause `ofBorg` to think such packages should not be built for Darwin.

I've marked a couple of other top-level packages as "candidates" but I noted a handful of additional locations where this would not immediately work because the derivations being chosen between all stated that they supported all platforms, but I suspect that the more robust solution would be to refactor those to use a function like this as well and let the individual derivations being chosen between state if they support a given architecture instead of that information only living in a conditional in the top-level file.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
