### PR TITLE
lib.attrsets.matchAttrTag: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -84,7 +84,7 @@ let
       mapAttrs' mapAttrsToList attrsToList concatMapAttrs mapAttrsRecursive
       mapAttrsRecursiveCond genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
-      recursiveUpdate matchAttrs mergeAttrsList overrideExisting showAttrPath getOutput
+      recursiveUpdate matchAttrs mergeAttrsList overrideExisting showAttrPath matchAttrTag getOutput
       getBin getLib getDev getMan chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProductOfSets
       updateManyAttrsByPath;

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -72,6 +72,7 @@ let
     makeOverridable
     mapAttrs
     matchAttrs
+    matchAttrTag
     mergeAttrs
     meta
     mkOption
@@ -1107,6 +1108,37 @@ runTests {
   testAttrsToListsCanDealWithFunctions = testingEval (
     attrsToList { someFunc= a: a + 1;}
   );
+
+  testMatchAttrTagExample1 = {
+    expr = matchAttrTag "test" { n = 10; } {
+      n = number: "It's the number ${toString number}";
+      s = str: "It's the string ${str}";
+    };
+    expected = "It's the number 10";
+  };
+
+  testMatchAttrTagExample2 = {
+    expr = matchAttrTag "test" { s = "Paul"; } {
+      n = number: "It's the number ${toString number}";
+      s = str: "It's the string ${str}";
+    };
+    expected = "It's the string Paul";
+  };
+
+  testMatchAttrTagExample3 = testingThrow (
+    matchAttrTag "test" { unknown = null; } {
+      n = number: "It's the number ${toString number}";
+      s = str: "It's the string ${str}";
+    }
+  );
+
+  testMatchAttrTagExample4 = testingThrow (
+    matchAttrTag "test" { n = 10; s = "Paul"; } {
+      n = number: "It's the number ${toString number}";
+      s = str: "It's the string ${str}";
+    }
+  );
+
 
 # GENERATORS
 # these tests assume attributes are converted to lists


### PR DESCRIPTION
## Description of changes

As suggested in https://github.com/NixOS/nixpkgs/pull/284551#pullrequestreview-1961816244, this is a useful utility function for working with values from `lib.types.attrTag`:

```
lib.matchAttrTag "my.option" value.my.option {
  tag1 = tagValue: "Tag1: ${tagValue}";
  tag2 = tagValue: "Tag2: ${tagValue}";
}
```

This was written in [Nix Hour 68](https://www.youtube.com/watch?v=Y6epvlDxrCQ&list=PLyzwHTVJlRc8yjlx4VR4LU5A5O44og9in&index=1)

Ping @roberth

## Things done

- [x] Add documentation
- [x] Add tests
- [ ] Update `lib.types.attrTag` docs to mention this function

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
