### PR TITLE
sshuttle: 1.1.1 → 1.1.2

### DIFF
--- a/pkgs/tools/security/sshuttle/default.nix
+++ b/pkgs/tools/security/sshuttle/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , python3Packages
-, fetchPypi
+, fetchFromGitHub
 , installShellFiles
 , makeWrapper
 , sphinx
@@ -14,11 +14,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "sshuttle";
-  version = "1.1.1";
+  version = "1.1.2";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-9aPtHlqxITx6bfhgr0HxqQOrLK+/73Hzcazc/yHmnuY=";
+  src = fetchFromGitHub {
+    owner = "sshuttle";
+    repo = "sshuttle";
+    rev = "v${version}";
+    hash = "sha256-7jiDTjtL4FiQ4GimSPtUDKPUA29l22a7XILN/s4/DQY=";
   };
 
   patches = [ ./sudo.patch ];

--- a/pkgs/tools/security/sshuttle/sudo.patch
+++ b/pkgs/tools/security/sshuttle/sudo.patch
@@ -1,11 +1,11 @@
-diff --git a/sshuttle/client.py b/sshuttle/client.py
-index cab5b1c..e89f8a6 100644
---- a/sshuttle/client.py
-+++ b/sshuttle/client.py
-@@ -192,7 +192,7 @@ class FirewallClient:
- 
+diff --git i/sshuttle/client.py w/sshuttle/client.py
+index 29c3dfa..da813ed 100644
+--- i/sshuttle/client.py
++++ w/sshuttle/client.py
+@@ -209,7 +209,7 @@ class FirewallClient:
+     def __init__(self, method_name, sudo_pythonpath):
          self.auto_nets = []
-
+ 
 -        argvbase = ([sys.executable, sys.argv[0]] +
 +        argvbase = ([sys.argv[0]] +
                      ['-v'] * (helpers.verbose or 0) +


### PR DESCRIPTION
## Description of changes
https://github.com/sshuttle/sshuttle/releases/tag/v1.1.2

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
