### PR TITLE
nix.tests.compareEval

### DIFF
--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -17,12 +17,13 @@
 
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-testEqualContents
   # or doc/builders/testers.chapter.md
-  testEqualContents = {
+  testEqualContents = args@{
     assertion,
     actual,
     expected,
   }: runCommand "equal-contents-${lib.strings.toLower assertion}" {
     inherit assertion actual expected;
+    pos = builtins.unsafeGetAttrPos "assertion" args;
   } ''
     echo "Checking:"
     echo "$assertion"

--- a/pkgs/test/eval/all-attributes-eval-shard.nix
+++ b/pkgs/test/eval/all-attributes-eval-shard.nix
@@ -47,7 +47,10 @@ let
         else
           # This could be extended, but make sure to avoid infinite structures
           # and use deepSeq so that the whole structure is covered by tryEval.
-          rawValue.outPath;
+          rawValue.drvPath or
+            # TODO: A derivation path would be preferable for diffing
+            #       https://github.com/NixOS/nixpkgs/pull/281536
+            rawValue.outPath;
     in
       if attempt.success
       then attempt.value

--- a/pkgs/test/eval/all-attributes-eval-shard.nix
+++ b/pkgs/test/eval/all-attributes-eval-shard.nix
@@ -1,0 +1,56 @@
+# Runs in sandbox for all-attributes.nix's derivations.
+# Evaluate an interval of Nixpkgs attribute paths, returning the out paths
+{ attrPaths, path, shardCount, shardIndex }:
+
+let
+  pkgs = import path {
+    system = "x86_64-linux";
+
+    # Just evaluate as much as possible.
+    config = {
+      allowUnfree = true;
+      allowInsecure = true;
+      allowBroken = true;
+    };
+  };
+
+  lib = pkgs.lib;
+
+  inherit (lib) sublist splitString;
+
+  numAttrs = builtins.length attrPaths;
+
+  firstAttr = (numAttrs * shardIndex) / shardCount;
+
+  lastAttr = (numAttrs * (shardIndex + 1)) / shardCount;
+
+  shardAttrPaths = sublist firstAttr (lastAttr - firstAttr) attrPaths;
+
+  result =
+    lib.genAttrs
+      # What we're returning as attributes represent paths into pkgs.
+      shardAttrPaths
+      tryEvalAttrPath;
+
+  tryEvalAttrPath = attrPath:
+    let
+      attempt = builtins.tryEval value;
+      attrPathElements = splitString "." attrPath;
+      rawValue = lib.attrByPath attrPathElements { error = "MISSING"; } pkgs;
+      value =
+        if lib.head attrPathElements == "vmTools"
+        then { error = "EXCLUDED"; }
+        else if ! lib.isDerivation rawValue
+        then { error = "NOT A DERIVATION"; }
+        else if rawValue.meta.available or true == false
+        then { error = "NOT AVAILABLE"; }
+        else
+          # This could be extended, but make sure to avoid infinite structures
+          # and use deepSeq so that the whole structure is covered by tryEval.
+          rawValue.outPath;
+    in
+      if attempt.success
+      then attempt.value
+      else { error = "EXCEPTION"; };
+in
+  result

--- a/pkgs/test/eval/all-attributes.nix
+++ b/pkgs/test/eval/all-attributes.nix
@@ -8,7 +8,7 @@ let
       # or a fixed version, to cache evals when hacking
       # builtins.fetchGit {
       #   url = ../../..;
-      #   rev = "f70a4f73be98c64f4ea930f61bcc80df0f7487d7";
+      #   rev = ".....";
       # }
     else ../../..;
 in
@@ -74,13 +74,6 @@ let
 
     nix-store --init
 
-    # cp -r ${pkgs-path}/lib lib
-    # cp -r ${pkgs-path}/pkgs pkgs
-    # cp -r ${pkgs-path}/default.nix default.nix
-    # cp -r ${pkgs-path}/nixos nixos
-    # cp -r ${pkgs-path}/maintainers maintainers
-    # cp -r ${pkgs-path}/.version .version
-    # cp -r ${pkgs-path}/doc doc
     mkdir $out
     nix-instantiate --eval --strict --json ${./all-attributes-eval-shard.nix} \
         --arg shardIndex ${toString shardIndex} \

--- a/pkgs/test/eval/all-attributes.nix
+++ b/pkgs/test/eval/all-attributes.nix
@@ -1,0 +1,111 @@
+# This is an entrypoint, invoked by the NixOS/nix CI and pkgs.nix.tests
+let
+  defaultPath =
+    if builtins.pathExists ../../../.git
+    then
+      # worktree
+      builtins.fetchGit ../../..
+      # or a fixed version, to cache evals when hacking
+      # builtins.fetchGit {
+      #   url = ../../..;
+      #   rev = "f70a4f73be98c64f4ea930f61bcc80df0f7487d7";
+      # }
+    else ../../..;
+in
+{ pkgs-path ? defaultPath
+, pkgs ? import pkgs-path {}
+, lib ? pkgs.lib
+, nix ? pkgs.nix
+  # shardCount = max-jobs may be most time efficient, but consumes a lot of memory.
+  # Using more shards reduces memory usage because of reachable objects that go unused.
+  # Using more shards tends to increase the time spent re-evaluating shared values.
+  # Anecdata:
+  # on a 12-core, max-jobs = 12, mem = 64G machine,
+  # 50 shards adds a 10% time overhead compared to 12
+  # Est. peak memory at 12 shards: 20 GB
+  #                     50 shards: 13 GB
+  # These memory measurements were quick and dirty by looking at memory usage
+  # graphs on a desktop system, which are noisy, especially because some swap was used.
+, shardCount ? 50
+, mask ? {}
+}:
+
+let
+  label = "by-${nix.pname}-${nix.version}";
+
+  attrPaths = import ./all-attrpaths.nix { inherit pkgs-path pkgs lib nix; writePaths = true; };
+
+  # This evaluates all the attribute paths in the Nixpkgs tree, and returns
+  # information about them.
+  combinedShards = pkgs.runCommand "all-attribute-values-${label}.json" {
+    shards = map (shard: shard + "/attrs.json") allShards;
+    nativeBuildInputs = [ pkgs.jq ];
+    knownIssues = builtins.toJSON mask;
+  } ''
+    jq -s 'reduce .[] as $item ({}; . * $item)
+      + $knownIssues' \
+      --argjson knownIssues "$knownIssues" \
+      $shards >$out
+  '';
+
+  allShards = lib.genList shard shardCount;
+
+  shard = shardIndex:
+    pkgs.runCommand "attr-values-shard-${shardIndexToString shardIndex}-of-${toString shardCount}-${label}" {
+    nativeBuildInputs = [
+      nix
+      pkgs.gitMinimal
+      pkgs.jq
+    ] ++ lib.optional pkgs.stdenv.isLinux pkgs.inotify-tools;
+    strictDeps = true;
+  }
+  ''
+    datadir="${nix}/share"
+    export TEST_ROOT=$(pwd)/test-tmp
+    export HOME=$(mktemp -d)
+    export NIX_BUILD_HOOK=
+    export NIX_CONF_DIR=$TEST_ROOT/etc
+    export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
+    export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
+    export NIX_STATE_DIR=$TEST_ROOT/var/nix
+    export NIX_STORE_DIR=/nix/store
+    export PAGER=cat
+    cacheDir=$TEST_ROOT/binary-cache
+
+    nix-store --init
+
+    # cp -r ${pkgs-path}/lib lib
+    # cp -r ${pkgs-path}/pkgs pkgs
+    # cp -r ${pkgs-path}/default.nix default.nix
+    # cp -r ${pkgs-path}/nixos nixos
+    # cp -r ${pkgs-path}/maintainers maintainers
+    # cp -r ${pkgs-path}/.version .version
+    # cp -r ${pkgs-path}/doc doc
+    mkdir $out
+    nix-instantiate --eval --strict --json ${./all-attributes-eval-shard.nix} \
+        --arg shardIndex ${toString shardIndex} \
+        --arg shardCount ${toString shardCount} \
+        --arg attrPaths 'builtins.fromJSON (builtins.readFile ${attrPaths}/paths.json)' \
+        --arg path ${pkgs-path} \
+        > $out/attrs.json
+  '';
+
+  # Padding is worth the effort because Nix usually schedules in order of name,
+  # giving a nice indication of progress.
+
+  toStringPad = size: int:
+    let
+      s = toString int;
+      padding = size - (lib.stringLength s);
+    in
+      if padding > 0
+      then lib.strings.replicate padding "0" + s
+      else s;
+
+  shardCountPad = lib.stringLength (toString shardCount);
+
+  # Note that progress counting starts at 1, not 0. E.g. number 50 out of 50.
+  shardIndexToString = shardIndex: toStringPad shardCountPad (shardIndex + 1);
+
+in
+  combinedShards

--- a/pkgs/test/eval/all-attrpaths.nix
+++ b/pkgs/test/eval/all-attrpaths.nix
@@ -1,0 +1,46 @@
+# Adapted from lib/tests/release.nix
+{ pkgs-path ? ../../..
+, pkgs ? import pkgs-path {}
+, lib ? pkgs.lib
+, nix ? pkgs.nix
+}:
+
+#
+# This verifies that release-attrpaths-superset.nix does not encounter
+# infinite recursion or non-tryEval-able failures.
+#
+pkgs.runCommand "all-attrs-eval-under-tryEval" {
+  nativeBuildInputs = [
+    nix
+    pkgs.gitMinimal
+  ] ++ lib.optional pkgs.stdenv.isLinux pkgs.inotify-tools;
+  strictDeps = true;
+}
+''
+  datadir="${nix}/share"
+  export TEST_ROOT=$(pwd)/test-tmp
+  export HOME=$(mktemp -d)
+  export NIX_BUILD_HOOK=
+  export NIX_CONF_DIR=$TEST_ROOT/etc
+  export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
+  export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
+  export NIX_STATE_DIR=$TEST_ROOT/var/nix
+  export NIX_STORE_DIR=$TEST_ROOT/store
+  export PAGER=cat
+  cacheDir=$TEST_ROOT/binary-cache
+
+  nix-store --init
+
+  cp -r ${pkgs-path}/lib lib
+  cp -r ${pkgs-path}/pkgs pkgs
+  cp -r ${pkgs-path}/default.nix default.nix
+  cp -r ${pkgs-path}/nixos nixos
+  cp -r ${pkgs-path}/maintainers maintainers
+  cp -r ${pkgs-path}/.version .version
+  cp -r ${pkgs-path}/doc doc
+  echo "Running pkgs/top-level/release-attrpaths-superset.nix"
+  nix-instantiate --eval --strict --json pkgs/top-level/release-attrpaths-superset.nix -A names > /dev/null
+
+  mkdir $out
+  echo success > $out/${nix.version}
+''

--- a/pkgs/test/eval/all-attrpaths.nix
+++ b/pkgs/test/eval/all-attrpaths.nix
@@ -1,8 +1,10 @@
-# Adapted from lib/tests/release.nix
 { pkgs-path ? ../../..
 , pkgs ? import pkgs-path {}
 , lib ? pkgs.lib
 , nix ? pkgs.nix
+  # Normally we don't need the actual list, because we're just checking that
+  # evaluation works. So let's generate less garbage.
+, writePaths ? false
 }:
 
 #
@@ -39,8 +41,13 @@ pkgs.runCommand "all-attrs-eval-under-tryEval" {
   cp -r ${pkgs-path}/.version .version
   cp -r ${pkgs-path}/doc doc
   echo "Running pkgs/top-level/release-attrpaths-superset.nix"
-  nix-instantiate --eval --strict --json pkgs/top-level/release-attrpaths-superset.nix -A names > /dev/null
+  nix-instantiate --eval --strict --json pkgs/top-level/release-attrpaths-superset.nix -A names \
+    ${if writePaths then "> paths.json" else "> /dev/null"}
 
   mkdir $out
-  echo success > $out/${nix.version}
+  ${if writePaths then
+    "mv paths.json $out"
+    else
+    "echo success > $out/${nix.version}"
+  }
 ''

--- a/pkgs/test/release/default.nix
+++ b/pkgs/test/release/default.nix
@@ -1,46 +1,9 @@
-# Adapted from lib/tests/release.nix
-{ pkgs-path ? ../../..
+# Entrypoint for Nixpkgs release tests
+args@{ pkgs-path ? ../../..
 , pkgs ? import pkgs-path {}
 , lib ? pkgs.lib
 , nix ? pkgs.nix
 }:
 
-#
-# This verifies that release-attrpaths-superset.nix does not encounter
-# infinite recursion or non-tryEval-able failures.
-#
-pkgs.runCommand "all-attrs-eval-under-tryEval" {
-  nativeBuildInputs = [
-    nix
-    pkgs.gitMinimal
-  ] ++ lib.optional pkgs.stdenv.isLinux pkgs.inotify-tools;
-  strictDeps = true;
-}
-''
-  datadir="${nix}/share"
-  export TEST_ROOT=$(pwd)/test-tmp
-  export HOME=$(mktemp -d)
-  export NIX_BUILD_HOOK=
-  export NIX_CONF_DIR=$TEST_ROOT/etc
-  export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
-  export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
-  export NIX_STATE_DIR=$TEST_ROOT/var/nix
-  export NIX_STORE_DIR=$TEST_ROOT/store
-  export PAGER=cat
-  cacheDir=$TEST_ROOT/binary-cache
-
-  nix-store --init
-
-  cp -r ${pkgs-path}/lib lib
-  cp -r ${pkgs-path}/pkgs pkgs
-  cp -r ${pkgs-path}/default.nix default.nix
-  cp -r ${pkgs-path}/nixos nixos
-  cp -r ${pkgs-path}/maintainers maintainers
-  cp -r ${pkgs-path}/.version .version
-  cp -r ${pkgs-path}/doc doc
-  echo "Running pkgs/top-level/release-attrpaths-superset.nix"
-  nix-instantiate --eval --strict --json pkgs/top-level/release-attrpaths-superset.nix -A names > /dev/null
-
-  mkdir $out
-  echo success > $out/${nix.version}
-''
+# This could be extended with more tests in the future
+import ../eval/all-attrpaths.nix { inherit pkgs-path pkgs lib nix; }

--- a/pkgs/tools/package-management/nix/common.nix
+++ b/pkgs/tools/package-management/nix/common.nix
@@ -81,6 +81,7 @@ in
 
   # passthru tests
 , pkgsi686Linux
+
 }: let
 self = stdenv.mkDerivation {
   pname = "nix";
@@ -250,6 +251,7 @@ self = stdenv.mkDerivation {
 
     tests = {
       nixi686 = pkgsi686Linux.nixVersions.${"nix_${lib.versions.major version}_${lib.versions.minor version}"};
+      compareEval = callPackage ./tests/compareEval.nix { nix = self; };
     };
   };
 

--- a/pkgs/tools/package-management/nix/tests/compareEval-reinstantiate.nix
+++ b/pkgs/tools/package-management/nix/tests/compareEval-reinstantiate.nix
@@ -1,0 +1,88 @@
+{
+  expected,
+  actual,
+  path,
+}:
+
+let
+  pkgs = import path {
+    system = "x86_64-linux";
+
+    # Just evaluate as much as possible.
+    config = {
+      allowUnfree = true;
+      allowInsecure = true;
+      allowBroken = true;
+    };
+  };
+
+  inherit (pkgs) lib;
+
+  show = lib.generators.toPretty { multiline = false; };
+
+  allAttrPaths = expected // actual;
+
+  differences =
+    lib.concatMapAttrs
+      (attrPath: _v: lib.optionalAttrs (expected.${attrPath} or null != actual.${attrPath} or null) {
+        ${attrPath} = {
+          expected = expected.${attrPath} or "NOT RECURSED INTO";
+          actual = actual.${attrPath} or "NOT RECURSED INTO";
+        };
+      })
+      allAttrPaths;
+
+  report = lib.concatStringsSep "\n"
+    (lib.mapAttrsToList
+      (attrPath: { expected, actual }: ''
+        ${"    "}${attrPath}:
+                expected: ${show expected}
+                actual:   ${show actual}''
+      )
+      differences
+    );
+
+  commands =
+    lib.concatStringsSep
+      "\n"
+      (lib.mapAttrsToList
+        (attrPath: { expected, actual }:
+          if lib.strings.hasPrefix "/" expected && lib.strings.hasPrefix "/" actual
+          then
+          # We instantiate the derivations again. Storing them would be
+          # inefficient, because most of the time we don't need them, and many
+          # would be duplicated because of the sharding.
+          ''
+            expected=$($nix_expected/bin/nix-instantiate \
+              $path \
+              --attr '${attrPath}' \
+              --argstr system x86_64-linux \
+              --arg config '{ allowUnfree = true; allowInsecure = true; allowBroken = true; }')
+            actual=$($nix_actual/bin/nix-instantiate \
+              $path \
+              --attr '${attrPath}' \
+              --argstr system x86_64-linux \
+              --arg config '{ allowUnfree = true; allowInsecure = true; allowBroken = true; }')
+            nix-diff --color=always $actual $expected | tee $out/diffs/'${attrPath}.diff.color'
+            nix-diff $actual $expected > $out/diffs/'${attrPath}.diff'
+            touch $out/failed
+          ''
+          else ''
+            cat | tee $out/diffs/'${attrPath}' <<EOF
+            ${attrPath}:
+                expected: ${show expected}
+                actual: ${show actual}
+            EOF
+            touch $out/failed
+          ''
+        )
+        differences
+      );
+
+
+in
+{
+  inherit commands;
+  report = if report == "" then "OK" else report;
+}
+

--- a/pkgs/tools/package-management/nix/tests/compareEval.nix
+++ b/pkgs/tools/package-management/nix/tests/compareEval.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  nix,
+  nixVersions,
+  pkgs,
+  testers,
+}:
+
+let
+  knownIssues = {
+    "tests.pkgs-lib" = "KNOWN-UNREPRODUCIBLE";
+    "nixos-install-tools" = "KNOWN-UNREPRODUCIBLE";
+    "tests.nixos-functions.nixos-test" = "KNOWN-UNREPRODUCIBLE";
+  };
+
+  evalAllAttributes = nix: mask: import ../../../../test/eval/all-attributes.nix { inherit pkgs nix mask; };
+
+  referenceNix = nixVersions.nix_2_13;
+
+  otherNix =
+    if nix.version != referenceNix.version
+    then referenceNix
+    else nixVersions.stable;
+
+  testEvalAllAttributes =
+    let
+      hasKnownIssues = ! lib.versionAtLeast nix.version referenceNix.version; # Not sure which version; could be older
+      mask = lib.optionalAttrs hasKnownIssues knownIssues;
+    in
+      # TODO: Perform the comparison in jq, so that we get the diff in structured form,
+      #       and then if both are paths, re-eval and call nix-diff on it.
+      testers.testEqualContents {
+        assertion = "The attributes should match.";
+        expected = evalAllAttributes otherNix mask;
+        actual = evalAllAttributes nix mask;
+      };
+in
+  testEvalAllAttributes

--- a/pkgs/tools/package-management/nix/tests/compareEval.nix
+++ b/pkgs/tools/package-management/nix/tests/compareEval.nix
@@ -1,38 +1,140 @@
 {
+  fetchFromGitHub,
+  jq,
   lib,
   nix,
   nixVersions,
+  nix-diff,
   pkgs,
-  testers,
+  pkgs-path ? builtins.fetchGit ../../../../..,
+  runCommand,
 }:
 
 let
   knownIssues = {
+    # pkgs-lib-formats-tests.drv has floats with different number of digits compared to Nix 2.3
     "tests.pkgs-lib" = "KNOWN-UNREPRODUCIBLE";
+    # options.json, used in the docs, also a float rendered to string
     "nixos-install-tools" = "KNOWN-UNREPRODUCIBLE";
+    # same options.json
     "tests.nixos-functions.nixos-test" = "KNOWN-UNREPRODUCIBLE";
   };
 
   evalAllAttributes = nix: mask: import ../../../../test/eval/all-attributes.nix { inherit pkgs nix mask; };
 
-  referenceNix = nixVersions.nix_2_13;
+  # This is the Nix package to all others are compared against.
+  #
+  # We didn't pick Nix 2.3 because it had different logic for printing floats,
+  # and it's the only currently packaged Nix that has the old behavior.
+  # By making 2.13 the reference version, we can check all attributes without
+  # making any exceptions (knownIssues above). Updates of 2.3 will be tested
+  # against 2.13, and vice versa.
+  # Thus equivalence to 2.3, the minimum version currently supported by Nixpkgs,
+  # is inferred by transitivity; not directly.
+  referenceNix = nixVersions.nix_2_13.overrideAttrs (o: {
+    # This runs in the sandbox, without network access, so we don't need to
+    # care about vulnerabilities. The host Nix is responsible for security;
+    # not this one.
+    meta = o.meta // { knownVulnerabilities = []; };
+  });
 
   otherNix =
     if nix.version != referenceNix.version
     then referenceNix
     else nixVersions.stable;
 
-  testEvalAllAttributes =
+  # TODO (nix-diff > 1.0.20): Remove this override
+  nix-diff_master = nix-diff.overrideAttrs (o: {
+    patches = [];
+    version = "1.0.21pre-f31e0c1";
+    src = fetchFromGitHub {
+      owner = "Gabriella439";
+      repo = "nix-diff";
+      rev = "f31e0c1b5cc21b21e266d823ddca4ab2bce15967";
+      hash = "sha256-36eiphOwAivbfCHKgfUTu7SKpeXii4/2DgAhAG1ifxQ=";
+    };
+    prePatch = "";
+  });
+
+  evalAndCompareAllAttributes =
     let
-      hasKnownIssues = ! lib.versionAtLeast nix.version referenceNix.version; # Not sure which version; could be older
+      hasKnownIssues = ! lib.versionAtLeast nix.version "2.13"; # Not sure which version; could be older than 2.13
       mask = lib.optionalAttrs hasKnownIssues knownIssues;
     in
-      # TODO: Perform the comparison in jq, so that we get the diff in structured form,
-      #       and then if both are paths, re-eval and call nix-diff on it.
-      testers.testEqualContents {
-        assertion = "The attributes should match.";
+      runCommand "compare-attributes-nix-${nix.version}-vs-${otherNix.version}" {
         expected = evalAllAttributes otherNix mask;
+        nix_expected = otherNix;
         actual = evalAllAttributes nix mask;
-      };
+        nix_actual = nix;
+        path = pkgs-path;
+        nativeBuildInputs = [
+          nix
+          pkgs.gitMinimal
+          jq
+          nix-diff_master
+        ];
+        strictDeps = true;
+      }
+      ''
+        export TEST_ROOT=$(pwd)/test-tmp
+        export HOME=$(mktemp -d)
+        export NIX_BUILD_HOOK=
+        export NIX_CONF_DIR=$TEST_ROOT/etc
+        export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
+        export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
+        export NIX_STATE_DIR=$TEST_ROOT/var/nix
+        export NIX_REMOTE=$TEST_ROOT/store
+        export NIX_STORE_DIR=/nix/store
+        export PAGER=cat
+        cacheDir=$TEST_ROOT/binary-cache
+
+        nix-store --init
+
+        mkdir -p $out/diffs
+        nix-instantiate --eval --strict --json ${./compareEval-reinstantiate.nix} \
+            --arg expected "builtins.fromJSON (builtins.readFile $expected)" \
+            --arg actual "builtins.fromJSON (builtins.readFile $actual)" \
+            --arg path $path \
+            --show-trace \
+            > $out/comparison.json
+        (
+          # echo script:
+          # jq -r .commands $out/comparison.json | cat -n
+          eval "set -euo pipefail; $(jq -r .commands $out/comparison.json)"
+        )
+        cp -r $NIX_REMOTE $out/store
+        (
+          # This configures your shell environment so that Nix uses the store
+          # containing the instantiated derivations.
+          echo "export NIX_STORE_DIR='$NIX_STORE_DIR'"
+          echo "export NIX_REMOTE='$out/store?read-only=true'"
+        ) >$out/env.sh
+
+        cat <<<"$out/store?read-only=true" >$out/store-uri
+      '';
+
+  testEvalAllAttributes =
+    runCommand "check-${evalAndCompareAllAttributes.name}" {
+      comparison = evalAndCompareAllAttributes;
+      nativeBuildInputs = [ jq ];
+    } ''
+      if [[ -e $comparison/failed ]]; then
+        echo "Found differences:"
+        jq -r .report $comparison/comparison.json
+        echo "Diffs are available in:"
+        echo "    ls $comparison/diffs"
+        echo "Store files can be manually inspected at:"
+        echo "    $comparison/store"
+        echo "Load store environment:"
+        echo "    source $comparison/env.sh"
+        echo "Use store URI:"
+        echo "    nix --store $(cat $comparison/store-uri) --extra-experimental-features read-only-local-store"
+        echo "nix-diff:"
+        echo "    NIX_REMOTE=$(sed -e 's/?.*//' < $comparison/store-uri) ${nix-diff_master}/bin/nix-diff"
+        exit 1;
+      else
+        mkdir $out
+      fi
+    '';
 in
   testEvalAllAttributes


### PR DESCRIPTION
## Description of changes

Instantiate all of Nixpkgs when Nix is updated.
Succeed only when the resulting derivations are the same as Nix 2.13.

This test will also be used in upstream CI.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
