### PR TITLE
arc-browser: init at 1.38.0-48670

### DIFF
--- a/pkgs/by-name/ar/arc-browser/package.nix
+++ b/pkgs/by-name/ar/arc-browser/package.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, undmg
+, writeShellApplication
+, curl
+, common-updater-scripts
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "arc-browser";
+  version = "1.38.0-48670";
+
+  src = fetchurl {
+    url = "https://releases.arc.net/release/Arc-${finalAttrs.version}.dmg";
+    hash = "sha256-6LJEIkr1NA8HHxbLWtd/OTlPPErh05UTjVhjuZVcmTg=";
+  };
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = "Arc.app";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications/Arc.app
+    cp -R . $out/Applications/Arc.app
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "arc-browser-update-script";
+    runtimeInputs = [ curl common-updater-scripts ];
+    text = ''
+      set -euo pipefail
+      redirect_url="$(curl -s -L -f "https://releases.arc.net/release/Arc-latest.dmg" -o /dev/null -w '%{url_effective}')"
+      # The url scheme is: https://releases.arc.net/release/Arc-1.23.4-56789.dmg
+      # We strip everything before 'Arc-' and after '.dmg'
+      version="''${redirect_url##*/Arc-}"
+      version="''${version%.dmg}"
+      update-source-version arc-browser "$version" --file=./pkgs/by-name/ar/arc-browser/package.nix
+    '';
+  });
+
+  meta = {
+    description = "Arc from The Browser Company";
+    homepage = "https://arc.net/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ donteatoreo ];
+    platforms = [ "aarch64-darwin" "x86_64-darwin" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc