### PR TITLE
labelle: init at 1.1.0

### DIFF
--- a/pkgs/by-name/la/labelle/package.nix
+++ b/pkgs/by-name/la/labelle/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  qt6,
+  makeDesktopItem,
+  copyDesktopItems,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "labelle";
+  version = "1.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "labelle-org";
+    repo = "labelle";
+    rev = "v${version}";
+    hash = "sha256-JnV5A3/toTCHCEb0dygouR9MZfk2kdmsKVscwYI2y/Y=";
+  };
+
+  postPatch = ''
+    sed -i 's/hatch-vcs >=0.3.0,<0.4/hatch-vcs >=0.3.0/' pyproject.toml
+  '';
+
+  buildInputs = [ qt6.qtwayland ];
+
+  nativeBuildInputs = [
+    qt6.wrapQtAppsHook
+    python3Packages.hatchling
+    python3Packages.hatch-vcs
+    copyDesktopItems
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    darkdetect
+    pillow
+    platformdirs
+    pyqrcode
+    pyqt6
+    python-barcode
+    pyusb
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "labelle GUI";
+      exec = "labelle-gui";
+      desktopName = "labelle GUI";
+    })
+  ];
+
+  meta = {
+    changelog = "https://github.com/labelle-org/labelle/releases/tag/${src.rev}";
+    description = "Print labels with LabelManager PnP from Dymo";
+    homepage = "https://github.com/labelle-org/labelle";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fabianrig ];
+    mainProgram = "labelle";
+  };
+}


### PR DESCRIPTION
## Description of changes

labelle is a label printer software (https://github.com/labelle-org/labelle). It is the successor to dymoprint for which I had opened a PR (https://github.com/NixOS/nixpkgs/pull/294845).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
