### PR TITLE
python3Packages.rasterio: 1.3.9 -> 1.3.10

### DIFF
--- a/pkgs/development/python-modules/rasterio/default.nix
+++ b/pkgs/development/python-modules/rasterio/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , pytestCheckHook
 , pythonOlder
 , stdenv
@@ -33,7 +32,7 @@
 
 buildPythonPackage rec {
   pname = "rasterio";
-  version = "1.3.9";
+  version = "1.3.10";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -42,25 +41,17 @@ buildPythonPackage rec {
     owner = "rasterio";
     repo = "rasterio";
     rev = "refs/tags/${version}";
-    hash = "sha256-Tp6BSU33FaszrIXQgU0Asb7IMue0C939o/atAKz+3Q4=";
+    hash = "sha256-FidUaSpbTR8X1/Cqy/IwApkOOl2RRtPqYJaSISRPThI=";
   };
-
-  patches = [
-    # fix tests failing with GDAL 3.8.0
-    (fetchpatch {
-      url = "https://github.com/rasterio/rasterio/commit/54ec554a6d9ee52207ad17dee42cbc51c613f709.diff";
-      hash = "sha256-Vjt9HRYNAWyj0myMdtSUENbcLjACfzegEClzZb4BxY8=";
-    })
-    (fetchpatch {
-      url = "https://github.com/rasterio/rasterio/commit/5a72613c58d1482bf297d08cbacf27992f52b2c4.diff";
-      hash = "sha256-bV6rh3GBmeqq9+Jff2b8/1wOuyF3Iqducu2eN4CT3lM=";
-    })
-  ];
 
   postPatch = ''
     # remove useless import statement requiring distutils to be present at the runtime
     substituteInPlace rasterio/rio/calc.py \
       --replace-fail "from distutils.version import LooseVersion" ""
+
+    # relax dependency on yet non-packaged, RC version of numpy
+    substituteInPlace pyproject.toml \
+      --replace-fail "numpy==2.0.0rc1" "numpy"
     '';
 
   nativeBuildInputs = [
@@ -104,12 +95,6 @@ buildPythonPackage rec {
     shapely
   ];
 
-  # rio has runtime dependency on setuptools
-  setuptoolsPythonPath = [ setuptools ];
-  postInstall = ''
-    wrapPythonProgramsIn "$out/bin" "$out $setuptoolsPythonPath"
-  '';
-
   doCheck = true;
 
   preCheck = ''
@@ -118,9 +103,6 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [
     "-m 'not network'"
-
-    # pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
-    "-W ignore::pytest.PytestRemovedIn8Warning"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/rasterio/default.nix
+++ b/pkgs/development/python-modules/rasterio/default.nix
@@ -19,7 +19,6 @@
 , ipython
 , matplotlib
 , numpy
-, oldest-supported-numpy
 , packaging
 , pytest-randomly
 , setuptools
@@ -58,7 +57,6 @@ buildPythonPackage rec {
     cython_3
     gdal
     numpy
-    oldest-supported-numpy
     setuptools
     wheel
   ];


### PR DESCRIPTION
## Description of changes

Update rasterio to the latest version.
List of changes: https://github.com/rasterio/rasterio/releases/tag/1.3.10

- python3Packages.rasterio: 1.3.9 -> 1.3.10
- python3Packages.rasterio: drop dependency on oldest-supported-numpy

According
https://github.com/scipy/oldest-supported-numpy/blob/main/README.rst ,
oldest-supported-numpy should not be needed since numpy 1.25.0.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
