### PR TITLE
[23.11] python311Packages.blosc2: add patches for CVE-2024-3203 & CVE-2024-3204

### DIFF
--- a/pkgs/development/python-modules/blosc2/default.nix
+++ b/pkgs/development/python-modules/blosc2/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 
 # build-system
 , cmake
@@ -36,6 +37,23 @@ buildPythonPackage rec {
     fetchSubmodules = true;
     hash = "sha256-5a94Zm6sYl/nSfkcFbKG7PkyXwLB6bAoIvfaq0yVGHo=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2024-3203.CVE-2024-3204.part-1.patch";
+      url = "https://github.com/Blosc/c-blosc2/commit/892f6d9c8ffc6e3c4d571df8fc02114f88c69b52.patch";
+      stripLen = 1;
+      extraPrefix = "blosc2/c-blosc2/";
+      hash = "sha256-sNgDcdT9HFrx41VKohp4GNUEjM1sqLYkIZu4baKRMeI=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-3203.CVE-2024-3204.part-2.patch";
+      url = "https://github.com/Blosc/c-blosc2/commit/9cc79a79373f1b338b2e029e2e489b4e7971cd0c.patch";
+      stripLen = 1;
+      extraPrefix = "blosc2/c-blosc2/";
+      hash = "sha256-J/zcyNrxQr43+ROhDDQFmUJZQSTwo9qDuLwZeLd/ooo=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace requirements-runtime.txt \


### PR DESCRIPTION
## Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2024-3203
https://nvd.nist.gov/vuln/detail/CVE-2024-3204

23.11's `python3Packages.blosc2` still uses the bundled c-blosc2, whereas unstable uses the "system" c-blosc2 (which 23.11 doesn't even have) that has been independently bumped past this problem.

Have only done `nixpkgs-review` up to `sfepy` because life's too short to run `sfepy`'s test suite.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
