### PR TITLE
zig: fix build on darwin (WIP)

### DIFF
--- a/pkgs/development/compilers/zig/0.10.nix
+++ b/pkgs/development/compilers/zig/0.10.nix
@@ -4,6 +4,7 @@
 , cmake
 , llvmPackages
 , libxml2
+, xcbuild
 , zlib
 , coreutils
 , callPackage

--- a/pkgs/development/compilers/zig/0.11.nix
+++ b/pkgs/development/compilers/zig/0.11.nix
@@ -3,7 +3,13 @@
 , fetchFromGitHub
 , cmake
 , llvmPackages
+, libcxx
+, CoreServices
+, CoreFoundation
+, Foundation
+, Libsystem
 , libxml2
+, xcbuild
 , zlib
 , coreutils
 , callPackage

--- a/pkgs/development/compilers/zig/0.9.nix
+++ b/pkgs/development/compilers/zig/0.9.nix
@@ -4,6 +4,7 @@
 , cmake
 , llvmPackages
 , libxml2
+, xcbuild
 , zlib
 , coreutils
 , callPackage

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25261,6 +25261,12 @@ with pkgs;
   # requires a newer Apple SDK
   zig_0_11 = darwin.apple_sdk_11_0.callPackage ../development/compilers/zig/0.11.nix {
     llvmPackages = llvmPackages_16;
+    inherit (darwin.apple_sdk_11_0) Libsystem;
+    inherit (darwin.apple_sdk_11_0.frameworks)
+      Foundation
+      CoreServices
+      CoreFoundation
+    ;
   };
   zig = zig_0_11;
 


### PR DESCRIPTION
## Description of changes

I'm trying to fix #299091, and I've fixed the basic issue, but I'm not quite there yet.

The first two bootstrap stages build fine, though I'm already seeing a suspicious warning indicating an ABI incompatibility (emitted 44 times in different lines):

```
/tmp/nix-build-zig-0.11.0.drv-0/source/build/zig2.c:271367:23: warning: incompatible pointer types passing 'uintptr_t *' (aka 'unsigned long *') to parameter of type 'uint64_t *' (aka 'unsigned long long *') [-Wincompatible-pointer-types]
```

Maybe that's ok, though. However, the build breaks completely in stage3:

```
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_dup2'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_pthread_attr_destroy'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
[...]
```

<details>
<summary>Click to expand full list of linker errors</summary>

```
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_dup2'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_pthread_attr_destroy'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_getenv'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_writev'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_getcontext'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_abort'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '__dyld_image_count'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '__exit'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_exit'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_pthread_attr_init'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '___ulock_wait2'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_fstat'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_fstatat'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_faccessat'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_mkdirat'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_openat'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_unlinkat'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_symlinkat'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_renameat'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_futimens'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '___error'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_fchdir'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_chdir'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '__dyld_get_image_header'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_pthread_threadid_np'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '__tlv_bootstrap'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_munmap'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_mmap'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_bzero'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_environ'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_sigaction'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_pthread_join'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_posix_memalign'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_open'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_fcntl'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_poll'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '___stack_chk_fail'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_fork'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_lseek'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_os_unfair_lock_trylock'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_os_unfair_lock_unlock'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_flock'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_os_unfair_lock_lock'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_arc4random_buf'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_pthread_attr_setstacksize'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_pthread_attr_setguardsize'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_malloc_size'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_execve'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_pwrite'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_write'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_pthread_create'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_ftruncate'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_pipe'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_clock_gettime'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_sysctlbyname'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '__dyld_get_image_name'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_sendfile'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '___ulock_wake'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_free'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '__dyld_get_image_vmaddr_slide'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_getcwd'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '___stack_chk_guard'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_setreuid'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_waitpid'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_setregid'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_pread'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_read'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_msync'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_close$NOCANCEL'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '_wait4'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '___getdirentries64'
error(link):   first referenced in '/private/tmp/nix-build-zig-0.11.0.drv-0/source/zig-cache/o/7960b35761de5022e22d150339659c1e/build.o'
error(link): undefined reference to symbol '__availability_version_check'
```

</details>

As far as I understand, these dependencies should be provided by some of the apple SDK frameworks, but I don't know which. I threw different ones at the wall to see if any stick, but didn't manage to make them work.

This is probably super simple, so I'm posting this as a draft for more experienced maintainers to look at.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
