### PR TITLE
[23.11] qdrant: add patch for CVE-2024-3078

### DIFF
--- a/pkgs/servers/search/qdrant/1.6.1-CVE-2024-3078.patch
+++ b/pkgs/servers/search/qdrant/1.6.1-CVE-2024-3078.patch
@@ -1,0 +1,141 @@
+Based on upstream 3ab5172e9c8f14fa1f7b24e7147eac74e2412b62 with minor
+adjustments to apply to 1.6.1
+
+diff --git a/lib/collection/src/collection/snapshots.rs b/lib/collection/src/collection/snapshots.rs
+index 76c8ba98..193261de 100644
+--- a/lib/collection/src/collection/snapshots.rs
++++ b/lib/collection/src/collection/snapshots.rs
+@@ -193,35 +193,35 @@ impl Collection {
+             .await
+     }
+ 
++    /// Get full file path for a collection snapshot by name
++    ///
++    /// This enforces the file to be inside the snapshots directory
+     pub async fn get_snapshot_path(&self, snapshot_name: &str) -> CollectionResult<PathBuf> {
+-        let snapshot_path = self.snapshots_path.join(snapshot_name);
+-
+-        let absolute_snapshot_path =
+-            snapshot_path
+-                .canonicalize()
+-                .map_err(|_| CollectionError::NotFound {
+-                    what: format!("Snapshot {snapshot_name}"),
+-                })?;
++        let absolute_snapshot_dir = self.snapshots_path.canonicalize().map_err(|_| {
++            CollectionError::not_found(format!(
++                "Snapshot directory: {}",
++                self.snapshots_path.display()
++            ))
++        })?;
+ 
+-        let absolute_snapshot_dir =
+-            self.snapshots_path
+-                .canonicalize()
+-                .map_err(|_| CollectionError::NotFound {
+-                    what: format!("Snapshot directory: {}", self.snapshots_path.display()),
+-                })?;
++        let absolute_snapshot_path = absolute_snapshot_dir
++            .join(snapshot_name)
++            .canonicalize()
++            .map_err(|_| CollectionError::not_found(format!("Snapshot {snapshot_name}")))?;
+ 
+         if !absolute_snapshot_path.starts_with(absolute_snapshot_dir) {
+-            return Err(CollectionError::NotFound {
+-                what: format!("Snapshot {snapshot_name}"),
+-            });
++            return Err(CollectionError::not_found(format!(
++                "Snapshot {snapshot_name}"
++            )));
+         }
+ 
+-        if !snapshot_path.exists() {
+-            return Err(CollectionError::NotFound {
+-                what: format!("Snapshot {snapshot_name}"),
+-            });
++        if !absolute_snapshot_path.exists() {
++            return Err(CollectionError::not_found(format!(
++                "Snapshot {snapshot_name}"
++            )));
+         }
+-        Ok(snapshot_path)
++
++        Ok(absolute_snapshot_path)
+     }
+ 
+     pub async fn list_shard_snapshots(
+diff --git a/lib/collection/src/operations/types.rs b/lib/collection/src/operations/types.rs
+index 9846e713..112f9b6a 100644
+--- a/lib/collection/src/operations/types.rs
++++ b/lib/collection/src/operations/types.rs
+@@ -638,6 +638,10 @@ impl CollectionError {
+         CollectionError::BadInput { description }
+     }
+ 
++    pub fn not_found(what: impl Into<String>) -> CollectionError {
++        CollectionError::NotFound { what: what.into() }
++    }
++
+     pub fn bad_request(description: String) -> CollectionError {
+         CollectionError::BadRequest { description }
+     }
+diff --git a/lib/storage/src/content_manager/errors.rs b/lib/storage/src/content_manager/errors.rs
+index 2d2a224e..3258ce7b 100644
+--- a/lib/storage/src/content_manager/errors.rs
++++ b/lib/storage/src/content_manager/errors.rs
+@@ -46,6 +46,12 @@ impl StorageError {
+         }
+     }
+ 
++    pub fn not_found(description: impl Into<String>) -> StorageError {
++        StorageError::NotFound {
++            description: description.into(),
++        }
++    }
++
+     /// Used to override the `description` field of the resulting `StorageError`
+     pub fn from_inconsistent_shard_failure(
+         err: CollectionError,
+diff --git a/lib/storage/src/content_manager/snapshots/mod.rs b/lib/storage/src/content_manager/snapshots/mod.rs
+index 8a417377..9965006a 100644
+--- a/lib/storage/src/content_manager/snapshots/mod.rs
++++ b/lib/storage/src/content_manager/snapshots/mod.rs
+@@ -24,17 +24,33 @@ pub struct SnapshotConfig {
+     pub collections_aliases: HashMap<String, String>,
+ }
+ 
++/// Get full file path for a full snapshot by name
++///
++/// This enforces the file to be inside the snapshots directory
+ pub async fn get_full_snapshot_path(
+     toc: &TableOfContent,
+     snapshot_name: &str,
+ ) -> Result<PathBuf, StorageError> {
+-    let snapshot_path = Path::new(toc.snapshots_path()).join(snapshot_name);
+-    if !snapshot_path.exists() {
+-        return Err(StorageError::NotFound {
+-            description: format!("Full storage snapshot {snapshot_name} not found"),
+-        });
++    let snapshots_path = toc.snapshots_path();
++
++    let absolute_snapshot_dir = Path::new(snapshots_path)
++        .canonicalize()
++        .map_err(|_| StorageError::not_found(format!("Snapshot directory: {snapshots_path}")))?;
++
++    let absolute_snapshot_path = absolute_snapshot_dir
++        .join(snapshot_name)
++        .canonicalize()
++        .map_err(|_| StorageError::not_found(format!("Snapshot {snapshot_name}")))?;
++
++    if !absolute_snapshot_path.starts_with(absolute_snapshot_dir) {
++        return Err(StorageError::not_found(format!("Snapshot {snapshot_name}")));
+     }
+-    Ok(snapshot_path)
++
++    if !absolute_snapshot_path.exists() {
++        return Err(StorageError::not_found(format!("Snapshot {snapshot_name}")));
++    }
++
++    Ok(absolute_snapshot_path)
+ }
+ 
+ pub async fn do_delete_full_snapshot(

--- a/pkgs/servers/search/qdrant/default.nix
+++ b/pkgs/servers/search/qdrant/default.nix
@@ -21,6 +21,10 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-G9nA0F3KKl6mLgcpuMW1uikOyBcBsJ1qd2IlMhW4vhg=";
   };
 
+  patches = [
+    ./1.6.1-CVE-2024-3078.patch
+  ];
+
   cargoLock = {
     lockFile = ./Cargo.lock;
     outputHashes = {


### PR DESCRIPTION
## Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2024-3078

I'm still fighting with #183344 to get unstable bumped to >=1.8.3. Failing that I might raise a PR to patch that too as a stopgap.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
