### PR TITLE
ananicy-rules-cachyos: unstable-2024-04-10 -> unstable-2024-04-16

### DIFF
--- a/pkgs/misc/ananicy-rules-cachyos/default.nix
+++ b/pkgs/misc/ananicy-rules-cachyos/default.nix
@@ -1,14 +1,14 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "ananicy-rules-cachyos";
-  version = "unstable-2024-04-10";
+  version = "unstable-2024-04-16";
 
   src = fetchFromGitHub {
     owner = "CachyOS";
     repo = "ananicy-rules";
-    rev = "de55e2f55e6adf559bf4990aa433f5c202dc073d";
-    sha256 = "sha256-TWaOMVEeTLI67eG5BPyb+OSnz31QvTueQD2yfEEbTEo=";
+    rev = "7abaddd5cac23d9fd7a0f0aeccb7a0287456802b";
+    hash = "sha256-06q9dYLdg+AhT8L2OeoDsG7hHlmx/uf/RIwblODiSnE=";
   };
 
   dontConfigure = true;
@@ -16,15 +16,15 @@ stdenv.mkDerivation {
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out
-    cp -r * $out
-    rm $out/README.md
+    mkdir -p $out/etc/ananicy.d
+    rm README.md LICENSE
+    cp -r * $out/etc/ananicy.d
     runHook postInstall
   '';
 
   meta = with lib; {
     homepage = "https://github.com/CachyOS/ananicy-rules";
-    description = "ananicy-cpp-rules for CachyOS ";
+    description = "CachyOS' ananicy-rules meant to be used with ananicy-cpp";
     license = licenses.gpl3Only;
     platforms = platforms.linux;
     maintainers = with maintainers; [ artturin johnrtitor diniamo ];


### PR DESCRIPTION
## Description of changes
- Bump to https://github.com/CachyOS/ananicy-rules/commit/7abaddd5cac23d9fd7a0f0aeccb7a0287456802b commit, which includes fixes for Hyprland, Sway, Waybar process names in NixOS.

- Changelog: https://github.com/CachyOS/ananicy-rules/compare/de55e2f55e6adf559bf4990aa433f5c202dc073d...7abaddd5cac23d9fd7a0f0aeccb7a0287456802b
- Cleanup

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Pinging maintainers: @Artturin @diniamo

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
