### PR TITLE
syncyomi: init at 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6047,6 +6047,13 @@
     githubId = 323436;
     name = "Eric Yen";
   };
+  eriedaberrie = {
+    email = "eriedaberrie@gmail.com";
+    matrix = "@eriedaberrie:matrix.org";
+    github = "eriedaberrie";
+    githubId = 64395218;
+    name = "eriedaberrie";
+  };
   erikarvstedt = {
     email = "erik.arvstedt@gmail.com";
     matrix = "@erikarvstedt:matrix.org";

--- a/pkgs/by-name/sy/syncyomi/package.nix
+++ b/pkgs/by-name/sy/syncyomi/package.nix
@@ -1,0 +1,86 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, buildGoModule
+, nodejs
+, pnpm_9
+, esbuild
+}:
+
+buildGoModule rec {
+  pname = "syncyomi";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "SyncYomi";
+    repo = "SyncYomi";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-90MA62Zm9ouaf+CnYsbOm/njrUui21vW/VrwKYfsCZs=";
+  };
+
+  vendorHash = "sha256-/rpT6SatIZ+GVzmVg6b8Zy32pGybprObotyvEgvdL2w=";
+
+  web = stdenvNoCC.mkDerivation (finalAttrs: {
+    pname = "${pname}-web";
+    inherit src version;
+    sourceRoot = "${finalAttrs.src.name}/web";
+
+    pnpmDeps = pnpm_9.fetchDeps {
+      inherit (finalAttrs) pname version src sourceRoot;
+      hash = "sha256-25Bg8sTeH/w25KdfwgZNoqBXz2d5c1QD5vGb33xpTCA=";
+    };
+
+    nativeBuildInputs = [
+      nodejs
+      pnpm_9.configHook
+    ];
+
+    env.ESBUILD_BINARY_PATH = lib.getExe (esbuild.override {
+      buildGoModule = args: buildGoModule (args // rec {
+        version = "0.17.19";
+        src = fetchFromGitHub {
+          owner = "evanw";
+          repo = "esbuild";
+          rev = "v${version}";
+          hash = "sha256-PLC7OJLSOiDq4OjvrdfCawZPfbfuZix4Waopzrj8qsU=";
+        };
+        vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
+      });
+    });
+
+    buildPhase = ''
+      runHook preBuild
+      pnpm build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      cp -r dist $out
+      runHook postInstall
+    '';
+  });
+
+  preConfigure = ''
+    cp -r $web/* web/dist
+  '';
+
+  ldflags = [
+    "-s" "-w"
+    "-X main.version=v${version}"
+  ];
+
+  postInstall = lib.optionalString (!stdenvNoCC.isDarwin) ''
+    mv $out/bin/SyncYomi $out/bin/syncyomi
+  '';
+
+  meta = {
+    description = "Open-source project to synchronize Tachiyomi manga reading progress and library across multiple devices";
+    homepage = "https://github.com/SyncYomi/SyncYomi";
+    changelog = "https://github.com/SyncYomi/SyncYomi/releases/tag/v${version}";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ eriedaberrie ];
+    mainProgram = "syncyomi";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
## Description of changes

[SyncYomi](https://github.com/SyncYomi/SyncYomi), an open-source project to synchronize Tachiyomi manga reading progress and library across multiple devices.

I've also written a NixOS service module that is working for me so far but will probably need some more polishing before a PR (documentation, hardening, adding postgres support, etc.).

This replaces my previous PR #301155 which needed to fix several build errors and then another upstream release happened in the meantime, so I opted to make a new PR for this (also because I had accidentally based that PR off of my fork's master branch which was slightly inconvenient for me).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
