### PR TITLE
trenchbroom: 2023.1 -> 2024.1

### DIFF
--- a/pkgs/applications/misc/trenchbroom/default.nix
+++ b/pkgs/applications/misc/trenchbroom/default.nix
@@ -2,19 +2,19 @@
 , cmake, ninja, curl, git, pandoc, pkg-config, unzip, zip
 , libGL, libGLU, freeimage, freetype, assimp
 , catch2, fmt, glew, miniz, tinyxml-2, xorg
-, qtbase, wrapQtAppsHook
+, qtbase, qtwayland, wrapQtAppsHook
 , copyDesktopItems, makeDesktopItem
 }:
 
 stdenv.mkDerivation rec {
   pname = "TrenchBroom";
-  version = "2023.1";
+  version = "2024.1";
 
   src = fetchFromGitHub {
     owner = "TrenchBroom";
     repo = "TrenchBroom";
     rev = "v${version}";
-    sha256 = "sha256-62xcFKSqxPS+J54+kLo/hewM+Wu/rVBGD8oiECDCJpA=";
+    hash = "sha256-HNK/gLbew7MKN6GVStxDb2tyMgyw2l1+dhPr6fSaZ4A=";
     fetchSubmodules = true;
   };
   # Manually simulate a vcpkg installation so that it can link the libraries
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ninja curl git pandoc wrapQtAppsHook copyDesktopItems pkg-config unzip zip ];
   buildInputs = [
     libGL libGLU xorg.libXxf86vm xorg.libSM
-    freeimage freetype qtbase catch2 fmt
+    freeimage freetype qtbase qtwayland catch2 fmt
     glew miniz tinyxml-2 assimp
   ];
   QT_PLUGIN_PATH = "${qtbase}/${qtbase.qtPluginPrefix}";


### PR DESCRIPTION
## Description of changes

- Update trenchbroom: 2023.1 -> 2024.1
- Changelog: https://github.com/TrenchBroom/TrenchBroom/compare/v2023.1...v2024.1
- Closes https://github.com/NixOS/nixpkgs/issues/304342

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
