### PR TITLE
clatd: init at 1.6

### DIFF
--- a/pkgs/by-name/cl/clatd/package.nix
+++ b/pkgs/by-name/cl/clatd/package.nix
@@ -1,0 +1,63 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, perl
+, perlPackages
+, tayga
+, iproute2
+, iptables
+}:
+
+stdenv.mkDerivation rec {
+  pname = "clatd";
+  version = "1.6";
+
+  src = fetchFromGitHub {
+    owner = "toreanderson";
+    repo = "clatd";
+    rev = "v${version}";
+    hash = "sha256-ZUGWQTXXgATy539NQxkZSvQA7HIWkIPsw1NJrz0xKEg=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    perl # for pod2man
+  ];
+
+  buildInputs = with perlPackages; [
+    perl
+    NetIP
+    NetDNS
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  preBuild = ''
+    mkdir -p $out/{sbin,share/man/man8}
+  '';
+
+  postFixup = ''
+    patchShebangs $out/bin/clatd
+    wrapProgram $out/bin/clatd \
+      --set PERL5LIB $PERL5LIB \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          tayga
+          iproute2
+          iptables
+        ]
+      }
+  '';
+
+  meta = with lib; {
+    description = "A 464XLAT CLAT implementation for Linux";
+    homepage = "https://github.com/toreanderson/clatd";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jmbaur ];
+    mainProgram = "clatd";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION


## Description of changes

[clatd](https://github.com/toreanderson/clatd) implements the CLAT component of the 464XLAT network architecture specified in RFC 6877.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
