### PR TITLE
go-passbolt-cli: init at 0.3.1

### DIFF
--- a/pkgs/by-name/go/go-passbolt-cli/package.nix
+++ b/pkgs/by-name/go/go-passbolt-cli/package.nix
@@ -1,0 +1,52 @@
+{ buildGoModule, fetchFromGitHub, installShellFiles, lib, stdenv }:
+
+buildGoModule rec {
+  pname = "go-passbolt-cli";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "passbolt";
+    repo = "go-passbolt-cli";
+    rev = "v${version}";
+    hash = "sha256-I+niNUowKTFDMa7yOnRToMFPzO/CbnjXHJr5nAhhHcg=";
+  };
+
+  vendorHash = "sha256-XRHGq3Qeq7VWHzw5WWVv4x5orQu740lttGVreiu7qP4=";
+
+  ldflags = [
+    "-X=main.version=${version}"
+    "-X=main.commit=${src.rev}"
+    "-X=main.date=1970-01-01T00:00:00Z"
+  ];
+
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D $GOPATH/bin/go-passbolt-cli $out/bin/passbolt
+    runHook postInstall
+  '';
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd passbolt \
+      --bash <($out/bin/passbolt completion bash) \
+      --fish <($out/bin/passbolt completion fish) \
+      --zsh <($out/bin/passbolt completion zsh)
+
+    export tmpDir=$(mktemp -d)
+    cd $tmpDir && mkdir man && $out/bin/passbolt gendoc --type man && installManPage man/*
+  '';
+
+  meta = with lib; {
+    description = "CLI tool to interact with Passbolt, an open source password manager for teams";
+    homepage = "https://github.com/passbolt/go-passbolt-cli";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pbek ];
+    mainProgram = "passbolt";
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}


### PR DESCRIPTION
## Description of changes

Package for https://github.com/passbolt/go-passbolt-cli, in addition to #227484.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
