### PR TITLE
apacheHttpd: add utils output

### DIFF
--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   };
 
   # FIXME: -dev depends on -doc
-  outputs = [ "out" "dev" "man" "doc" ];
+  outputs = [ "out" "dev" "man" "doc" "utils" ];
   setOutputFlags = false; # it would move $out/modules, etc.
 
   nativeBuildInputs = [ which ];
@@ -81,6 +81,8 @@ stdenv.mkDerivation rec {
     mv $out/manual $doc/share/doc/httpd
     mkdir -p $dev/bin
     mv $out/bin/apxs $dev/bin/apxs
+    mkdir -p $utils/bin
+    cp $out/bin/{ab,checkgid,fcgistarter,htcacheclean,htdbm,htdigest,htpasswd,logresolve,rotatelogs} $utils/bin/
   '';
 
   passthru = {


### PR DESCRIPTION
Added the new output apacheHttpd.utils. This is about size optimization - no need for whole server when you just require one tool. There are lots of use-cases when you only need one of the utils, for example htpasswd is most used elsewhere.

The utils, I simply checked what Ubuntu package has: https://packages.ubuntu.com/mantic/amd64/apache2-utils/filelist

I could not find the executables from sbin anywhere, but anyway this is a good start already, maybe later someone can add some compile time flags for other binaries.

pkgs.apacheHttpd.out size:
```
864K	/nix/store/brnn5kd5hy290p02khr2awn6gz8z1765-apache-httpd-2.4.59/bin
72K	/nix/store/brnn5kd5hy290p02khr2awn6gz8z1765-apache-httpd-2.4.59/conf/extra
72K	/nix/store/brnn5kd5hy290p02khr2awn6gz8z1765-apache-httpd-2.4.59/conf/original/extra
96K	/nix/store/brnn5kd5hy290p02khr2awn6gz8z1765-apache-httpd-2.4.59/conf/original
268K	/nix/store/brnn5kd5hy290p02khr2awn6gz8z1765-apache-httpd-2.4.59/conf
4.4M	/nix/store/brnn5kd5hy290p02khr2awn6gz8z1765-apache-httpd-2.4.59/modules
260K	/nix/store/brnn5kd5hy290p02khr2awn6gz8z1765-apache-httpd-2.4.59/icons/small
1.3M	/nix/store/brnn5kd5hy290p02khr2awn6gz8z1765-apache-httpd-2.4.59/icons
4.0K	/nix/store/brnn5kd5hy290p02khr2awn6gz8z1765-apache-httpd-2.4.59/logs
20K	/nix/store/brnn5kd5hy290p02khr2awn6gz8z1765-apache-httpd-2.4.59/cgi-bin
16K	/nix/store/brnn5kd5hy290p02khr2awn6gz8z1765-apache-httpd-2.4.59/error/include
260K	/nix/store/brnn5kd5hy290p02khr2awn6gz8z1765-apache-httpd-2.4.59/error
8.0K	/nix/store/brnn5kd5hy290p02khr2awn6gz8z1765-apache-httpd-2.4.59/htdocs
7.1M	/nix/store/brnn5kd5hy290p02khr2awn6gz8z1765-apache-httpd-2.4.59
7.1M	total
```

while pkgs.apacheHttpd.utils size:
```
288K	/nix/store/9d0aqnny2240xh4ncy5c411r285x3lj7-apache-httpd-2.4.59-utils/bin
292K	/nix/store/9d0aqnny2240xh4ncy5c411r285x3lj7-apache-httpd-2.4.59-utils
292K	total
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc