### PR TITLE
tinymist: 0.11.3 -> 0.11.4

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3275,8 +3275,8 @@ let
           publisher = "myriad-dreamin";
           # Please update the corresponding binary (tinymist) when updating
           # this extension.
-          version = "0.11.3";
-          hash = "sha256-b5aD4gz4j+QAEPmYaNnaputbYTPoFxVFih76HmznUP8=";
+          version = "0.11.4";
+          hash = "sha256-VR+vl6mctwq9oSIgnfutvPFwfGUdEco8fCOjzMvPtII=";
         };
 
         nativeBuildInputs = [ jq moreutils ];

--- a/pkgs/by-name/ti/tinymist/Cargo.lock
+++ b/pkgs/by-name/ti/tinymist/Cargo.lock
@@ -3595,7 +3595,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "insta",
  "lsp-server",
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-query"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "comemo 0.4.0",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-render"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "base64 0.22.0",
  "log",
@@ -4370,9 +4370,9 @@ dependencies = [
 
 [[package]]
 name = "typstyle"
-version = "0.11.11"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8556b6c8261a6d205674be583443714a9887911a392df630ea95c2900caf2710"
+checksum = "38f04e5495bff9deed2a9155dca07889ec0fe1c79f48eb2d9ea99fc272459499"
 dependencies = [
  "anyhow",
  "clap",

--- a/pkgs/by-name/ti/tinymist/package.nix
+++ b/pkgs/by-name/ti/tinymist/package.nix
@@ -13,13 +13,13 @@ rustPlatform.buildRustPackage rec {
   pname = "tinymist";
   # Please update the corresponding vscode extension when updating
   # this derivation.
-  version = "0.11.3";
+  version = "0.11.4";
 
   src = fetchFromGitHub {
     owner = "Myriad-Dreamin";
     repo = "tinymist";
     rev = "v${version}";
-    hash = "sha256-0wVCOFWA6PX1UHe3rGWbCW4zSJHvGrW9OiFcH2wvayA=";
+    hash = "sha256-zMwyM4Y+nn/u/UXGlOxGB/JApgmYQW4qAek40uJO0Fc=";
   };
 
   cargoLock = {


### PR DESCRIPTION
Diff: https://github.com/Myriad-Dreamin/tinymist/compare/v0.11.3...v0.11.4

Changelog: https://github.com/Myriad-Dreamin/tinymist/blob/v0.11.4/CHANGELOG.md

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
