### PR TITLE
Fix services.xserver.displayManager Warnings for VBox Appliance

### DIFF
--- a/nixos/modules/profiles/demo.nix
+++ b/nixos/modules/profiles/demo.nix
@@ -11,7 +11,7 @@
       uid = 1000;
     };
 
-  services.xserver.displayManager = {
+  services.displayManager = {
     autoLogin = {
       enable = true;
       user = "demo";

--- a/nixos/modules/profiles/graphical.nix
+++ b/nixos/modules/profiles/graphical.nix
@@ -6,12 +6,11 @@
 {
   services.xserver = {
     enable = true;
-    displayManager.sddm.enable = true;
-    desktopManager.plasma5 = {
-      enable = true;
-    };
+    desktopManager.plasma5.enable = true;
     libinput.enable = true; # for touchpad support on many laptops
   };
+
+  services.displayManager.sddm.enable = true;
 
   # Enable sound in virtualbox appliances.
   hardware.pulseaudio.enable = true;


### PR DESCRIPTION
## Description of changes

This PR fixes all warnings when building the VirtualBox Appliance:

```shell
$ nix-instantiate ./nixos/release.nix -A ova.x86_64-linux
trace: warning: The option `services.xserver.displayManager.sddm.enable' defined in `/home/julian/src/own/nixpkgs/nixos/modules/profiles/graphical.nix' has been renamed to `services.displayManager.sddm.enable'.
trace: warning: The option `services.xserver.displayManager.sddm.autoLogin.relogin' defined in `/home/julian/src/own/nixpkgs/nixos/modules/profiles/demo.nix' has been renamed to `services.displayManager.sddm.autoLogin.relogin'.
trace: warning: The option `services.xserver.displayManager.autoLogin' defined in `/home/julian/src/own/nixpkgs/nixos/modules/profiles/demo.nix' has been renamed to `services.displayManager.autoLogin'.

Warning: you did not specify '--add-root'; the result might be removed by the garbage collector
/nix/store/lf52ldkiy0dgdxf3kpmqg81qjvnc24fm-nixos-ova-24.05pre130979.gfedcba-x86_64-linux.drv
```

After:

```shell
❯ nix-instantiate ./nixos/release.nix -A ova.x86_64-linux 
warning: you did not specify '--add-root'; the result might be removed by the garbage collector
/nix/store/7j98z3yzjfljxgp3vm8401c244ks95w0-nixos-ova-24.05pre130979.gfedcba-x86_64-linux.drv
```

There are no functional changes here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
