### PR TITLE
logpipe: init at 0.0.5

### DIFF
--- a/pkgs/by-name/lo/logpipe/package.nix
+++ b/pkgs/by-name/lo/logpipe/package.nix
@@ -1,0 +1,54 @@
+{ lib, buildNpmPackage, fetchFromGitHub }:
+
+let
+  pname = "logpipe";
+  version = "0.0.5";
+
+  packageLock =
+  let
+    name = "@emnudge/logpipe";
+  in
+  {
+    inherit version name;
+    lockfileVersion = 3;
+    requires = true;
+    packages= {
+      "\"\"" = {
+        inherit version name;
+        license = "MIT";
+        bin = {
+          "${pname}" = "index.mjs";
+        };
+      };
+    };
+  };
+in
+buildNpmPackage rec {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "EmNudge";
+    repo = pname;
+    rev = "af21baaca4d4779479c9307e9b844cafdb4507f2";
+    hash = "sha256-0/8um5HaiGfGd0hfproUDZklbCxcxImlPzFQx7VpvzM=";
+  };
+
+  # We have no deps, but no lockfile exists upstream. Fudge an empty one.
+  npmDepsHash = "sha256-1ZRmgKrlPQEGDqmqEq9DEg7fowT8dIIZ4xSHTKHdBGg=";
+  postPatch = ''
+    echo '${builtins.toJSON packageLock}' > package-lock.json
+    mkdir node_modules
+  '';
+  forceEmptyCache = true;
+
+  # dontNpmInstall = true;
+  dontNpmBuild = true;
+
+  meta = with lib; {
+    description = "Inspect your logs";
+    homepage = "https://logpipe.emnudge.dev/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nullishamy ];
+    mainProgram = "logpipe";
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds [logpipe](https://github.com/EmNudge/logpipe), a small utility for viewing logs in a nicer web interface. Similar to `less`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
