### PR TITLE
ayatana-indicator-keyboard: init at 24.7.0-unstable-2024-11-09

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -63,6 +63,7 @@ in
           with pkgs;
           [
             ayatana-indicator-datetime # Clock
+            ayatana-indicator-keyboard # Ability to change keyboard layout
             ayatana-indicator-session # Controls for shutting down etc
           ]
         );

--- a/nixos/tests/ayatana-indicators.nix
+++ b/nixos/tests/ayatana-indicators.nix
@@ -36,6 +36,7 @@ in
             ayatana-indicator-bluetooth
             ayatana-indicator-datetime
             ayatana-indicator-display
+            ayatana-indicator-keyboard
             ayatana-indicator-messages
             ayatana-indicator-power
             ayatana-indicator-session

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -611,11 +611,19 @@ in
           # There's a test app we could use that also displays their contents, but it's abit inconsistent.
           with subtest("ayatana indicators work"):
               mouse_click(735, 0) # the cog in the top-right, for the session indicator
-              wait_for_text(r"(Notifications|Rotation|Battery|Sound|Time|Date|System)")
+              wait_for_text(r"(Notifications|Rotation|Battery|Sound|Time|Date|System|Keyboard)")
               machine.screenshot("indicators_open")
 
               # Indicator order within the menus *should* be fixed based on per-indicator order setting
-              # Session is the one we clicked, but the last we should test (logout). Go as far left as we can test.
+              # Keyboard is the one we clicked, the last one we should test is to the left of it (logout).
+
+              with subtest("ayatana indicator keyboard works"):
+                  # We start on this, don't go right
+                  wait_for_text("English")
+                  machine.screenshot("indicators_keyboard")
+
+              # Now go as far left as we can test.
+              machine.send_key("left")
               machine.send_key("left")
               machine.send_key("left")
               machine.send_key("left")

--- a/pkgs/by-name/ay/ayatana-indicator-keyboard/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-keyboard/package.nix
@@ -1,0 +1,96 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  nixosTests,
+  accountsservice,
+  cmake,
+  glib,
+  intltool,
+  libayatana-common,
+  libX11,
+  libxkbcommon,
+  libxklavier,
+  lomiri,
+  pkg-config,
+  systemd,
+  wrapGAppsHook3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ayatana-indicator-keyboard";
+  version = "24.7.0";
+
+  src = fetchFromGitHub {
+    owner = "AyatanaIndicators";
+    repo = "ayatana-indicator-keyboard";
+    rev = finalAttrs.version;
+    hash = "sha256-W7AvSU2k1vCz6drnm7MDTUNC1irljXjgnFsprYxKAg0=";
+  };
+
+  postPatch = ''
+    substituteInPlace data/CMakeLists.txt \
+      --replace-fail 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir)' 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir DEFINE_VARIABLES prefix=''${CMAKE_INSTALL_PREFIX})' \
+      --replace-fail 'XDG_AUTOSTART_DIR "/etc' 'XDG_AUTOSTART_DIR "''${CMAKE_INSTALL_FULL_SYSCONFDIR}'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    intltool
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    accountsservice
+    lomiri.cmake-extras
+    glib
+    libayatana-common
+    libX11
+    libxkbcommon
+    libxklavier
+    systemd
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "GSETTINGS_LOCALINSTALL" true)
+    (lib.cmakeBool "GSETTINGS_COMPILE" true)
+  ];
+
+  # dlopens different libraries for DE-specific behaviour
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : "$out/lib"
+    )
+  '';
+
+  passthru = {
+    ayatana-indicators = {
+      ayatana-indicator-keyboard = [
+        "ayatana"
+        "lomiri"
+      ];
+    };
+    tests.vm = nixosTests.ayatana-indicators;
+    updateScript = gitUpdater { };
+  };
+
+  meta = {
+    description = "Ayatana Indicator Keyboard Applet";
+    longDescription = ''
+      A keyboard indicator, which should show as an
+      icon in the top panel of indicator-aware desktop environments.
+
+      It can be used to switch key layouts or languages, and helps the user
+      identifying which layouts are currently in use.
+    '';
+    homepage = "https://github.com/AyatanaIndicators/ayatana-indicator-keyboard";
+    changelog = "https://github.com/AyatanaIndicators/ayatana-indicator-keyboard/blob/${finalAttrs.version}/ChangeLog";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/ay/ayatana-indicator-keyboard/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-keyboard/package.nix
@@ -2,7 +2,8 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  fetchpatch,
+  unstableGitUpdater,
   nixosTests,
   accountsservice,
   cmake,
@@ -20,14 +21,22 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ayatana-indicator-keyboard";
-  version = "24.7.0";
+  version = "24.7.0-unstable-2024-11-09";
 
   src = fetchFromGitHub {
     owner = "AyatanaIndicators";
     repo = "ayatana-indicator-keyboard";
-    rev = finalAttrs.version;
-    hash = "sha256-W7AvSU2k1vCz6drnm7MDTUNC1irljXjgnFsprYxKAg0=";
+    rev = "270798fbb77775a01fa339622a16c365acb57d67";
+    hash = "sha256-3mjOvjtF9a3NK/IawWGwqiw/dkRkW6MISMDyoSlYylc=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "0001-ayatana-indicator-keyboard-Never-crash-when-getting-system-layouts.patch";
+      url = "https://github.com/AyatanaIndicators/ayatana-indicator-keyboard/commit/f4aba7e7e809b6c72971142a63aac233df5e1391.patch";
+      hash = "sha256-ypiIn8vpxWjOqt6RoUnyW4LR2R0fsfP+qip991iSSu8=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace data/CMakeLists.txt \
@@ -75,7 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
       ];
     };
     tests.vm = nixosTests.ayatana-indicators;
-    updateScript = gitUpdater { };
+    updateScript = unstableGitUpdater { };
   };
 
   meta = {


### PR DESCRIPTION
## Description of changes

WIP

##### Greeter:
- Indicator not synced to actual keymap used by Lomiri (presumably, indicator only shows a generic keyboard icon)
- Has all the keymaps configured via `services.xserver.xkb.layout`, because it parses `/etc/X11/xorg.conf.d/00-keyboard.conf`
- Attempts to shell out to `setxkbmap -layout ... -variant ...` to set keymap on switch, not sure if that works for Wayland?

##### Session:
- Indicator not synced to actual keymap used by Lomiri (stuck at English, even if keybind to change Lomiri keymap is pressed)
- Only has English, presumably because it checks the GSetting `org.gnome.desktop.input-sources` for the keymaps that are in use
- Haven't tried to add a different keymap via settings app, Lomiri is painful to navigate in our VM setup

This might need some stronger patching to be useful.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
