### PR TITLE
quick-serve: init at 0.2.0

### DIFF
--- a/pkgs/by-name/qu/quick-serve/package.nix
+++ b/pkgs/by-name/qu/quick-serve/package.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  makeBinaryWrapper,
+  copyDesktopItems,
+  makeDesktopItem,
+  libxkbcommon,
+  vulkan-loader,
+  zstd,
+  stdenv,
+  darwin,
+  wayland,
+  gtk3,
+  libGL,
+  wget,
+  tftp-hpa,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "quick-serve";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "joaofl";
+    repo = "quick-serve";
+    rev = "v${version}";
+    hash = "sha256-yO2D3w+aURLX8caFuadzRPdQDlI37ZB4CFzvO4J/zq8=";
+  };
+
+  cargoHash = "sha256-Cogt3eS97CM0Ym0k1C74NfIzNeC3ajIWdTsvwZtRL0U=";
+
+  patches = [ ./remove-e2e-test-path.patch ];
+
+  nativeBuildInputs = [
+    pkg-config
+    makeBinaryWrapper
+    copyDesktopItems
+  ];
+
+  nativeCheckInputs = [
+    wget
+    tftp-hpa
+  ];
+
+  buildInputs =
+    [
+      libxkbcommon
+      vulkan-loader
+      zstd
+      gtk3
+      libGL
+    ]
+    ++ lib.optionals stdenv.isDarwin (
+      with darwin.apple_sdk.frameworks;
+      [
+        CoreGraphics
+        Foundation
+        Metal
+        QuartzCore
+        Security
+      ]
+    )
+    ++ lib.optionals stdenv.isLinux [ wayland ];
+
+  runtimeDependencies = [
+    libxkbcommon
+    libGL
+  ] ++ lib.optionals stdenv.isLinux [ wayland ];
+
+  env = {
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+  };
+
+  postInstall = ''
+    wrapProgram $out/bin/quick-serve \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeDependencies}"
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Quick Serve";
+      exec = "quick-serve";
+      desktopName = "Quick Serve";
+      comment = "Standalone server for a prompt file serving";
+      categories = [
+        "Network"
+        "Utility"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "Zero-config, multi-platform, multi-protocol standalone server for a prompt file serving";
+    homepage = "https://github.com/joaofl/quick-serve";
+    changelog = "https://github.com/joaofl/quick-serve/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vinnymeller ];
+    mainProgram = "quick-serve";
+  };
+}

--- a/pkgs/by-name/qu/quick-serve/remove-e2e-test-path.patch
+++ b/pkgs/by-name/qu/quick-serve/remove-e2e-test-path.patch
@@ -1,0 +1,11 @@
+--- a/src/tests/common.rs
++++ b/src/tests/common.rs
+@@ -74,7 +74,6 @@ pub mod tests {
+             cmd.timeout(Duration::from_secs(3));
+             cmd.arg("-c");
+             cmd.arg(&dl_cmd);
+-            cmd.env("PATH", "/bin");
+             cmd.unwrap()
+         });
+
+


### PR DESCRIPTION
## Description of changes

Adds the [quick-serve](https://github.com/joaofl/quick-serve) application

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
