### PR TITLE
blackmagic-desktop-video,decklink: 12.5a15 -> 12.9a3

### DIFF
--- a/pkgs/os-specific/linux/decklink/default.nix
+++ b/pkgs/os-specific/linux/decklink/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , lib
+, fetchpatch
 , blackmagic-desktop-video
 , kernel
 }:
@@ -17,9 +18,26 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs =  kernel.moduleBuildDependencies;
 
-  postUnpack = ''
-    tar xf Blackmagic_Desktop_Video_Linux_${lib.versions.majorMinor version}/other/${stdenv.hostPlatform.uname.processor}/desktopvideo-${version}-${stdenv.hostPlatform.uname.processor}.tar.gz
+  patches = lib.optionals (lib.versionAtLeast kernel.version "6.8") [
+    (fetchpatch {
+      name = "decklink-addMutex.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/01-addMutex.patch?h=decklink&id=132ce45a76e230cbfec4a3daac237ffe9b8a377a";
+      sha256 = "sha256-YLIjO3wMrMoEZwMX5Fs9W4uRu9Xo8klzsjfhxS2wRfQ=";
+    })
+    (fetchpatch {
+      name = "decklink-changeMaxOrder.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/02-changeMaxOrder.patch?h=decklink&id=132ce45a76e230cbfec4a3daac237ffe9b8a377a";
+      sha256 = "sha256-/erUVYjpTuyaQaCSzSxwKgNocxijc1uNaUjnrJEMa6g=";
+    })
+  ];
+
+
+  postUnpack = let
+    arch = stdenv.hostPlatform.uname.processor;
+  in ''
+    tar xf Blackmagic_Desktop_Video_Linux_${lib.head (lib.splitString "a" version)}/other/${arch}/desktopvideo-${version}-${arch}.tar.gz
     moduleRoot=$NIX_BUILD_TOP/desktopvideo-${version}-${stdenv.hostPlatform.uname.processor}/usr/src
+    sourceRoot=$moduleRoot
   '';
 
 

--- a/pkgs/tools/video/blackmagic-desktop-video/default.nix
+++ b/pkgs/tools/video/blackmagic-desktop-video/default.nix
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation rec {
   pname = "blackmagic-desktop-video";
-  version = "12.5a15";
+  version = "12.9a3";
 
   buildInputs = [
     autoPatchelfHook
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     rec {
       outputHashMode = "recursive";
       outputHashAlgo = "sha256";
-      outputHash = "sha256-ss7Ab5dy7cmXp9LBirFXMeGY4ZbYHvWnXmYvNeBq0RY=";
+      outputHash = "sha256-H7AHD6u8KsJoL+ug3QCqxuPfMP4A0nHtIyKx5IaQkdQ=";
 
       impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 
@@ -36,9 +36,9 @@ stdenv.mkDerivation rec {
       SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
       # from the URL that the POST happens to, see browser console
-      DOWNLOADID = "fecacc0f9b2f4c2e8bf2863e9e26c8e1";
+      DOWNLOADID = "495ebc707969447598c2f1cf0ff8d7d8";
       # from the URL the download page where you click the "only download" button is at
-      REFERID = "052d944af6744608b27da496dfc4396d";
+      REFERID = "6e65a87d97bd49e1915c57f8df255f5c";
       SITEURL = "https://www.blackmagicdesign.com/api/register/us/download/${DOWNLOADID}";
 
       USERAGENT = builtins.concatStringsSep " " [
@@ -72,8 +72,10 @@ stdenv.mkDerivation rec {
       > $out
   '';
 
-  postUnpack = ''
-    tar xf Blackmagic_Desktop_Video_Linux_${lib.versions.majorMinor version}/other/${stdenv.hostPlatform.uname.processor}/desktopvideo-${version}-${stdenv.hostPlatform.uname.processor}.tar.gz
+  postUnpack = let
+    arch = stdenv.hostPlatform.uname.processor;
+  in ''
+    tar xf Blackmagic_Desktop_Video_Linux_${lib.head (lib.splitString "a" version)}/other/${arch}/desktopvideo-${version}-${arch}.tar.gz
     unpacked=$NIX_BUILD_TOP/desktopvideo-${version}-${stdenv.hostPlatform.uname.processor}
   '';
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update of the decklink driver to the latest version. Driver compiles on the latest kernel as found in linuxPackages_latest.

Due to ZFS being broken on that kernel, i have only tested it on the latest stable kernel, but it works, including audio with my DeckLink Mini Recorder.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
