### PR TITLE
python311Packages.llama-index-core: fix `pythonImportCheck` failures for dependent packages

### DIFF
--- a/pkgs/development/python-modules/llama-index-core/default.nix
+++ b/pkgs/development/python-modules/llama-index-core/default.nix
@@ -6,6 +6,7 @@
   deprecated,
   dirtyjson,
   fetchFromGitHub,
+  fetchzip,
   fsspec,
   llamaindex-py-client,
   nest-asyncio,
@@ -29,6 +30,18 @@
   typing-inspect,
 }:
 
+let
+  stopwords = fetchzip {
+    url = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages/corpora/stopwords.zip";
+    hash = "sha256-tX1CMxSvFjr0nnLxbbycaX/IBnzHFxljMZceX5zElPY=";
+  };
+
+  punkt = fetchzip {
+    url = "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages/tokenizers/punkt.zip";
+    hash = "sha256-SKZu26K17qMUg7iCFZey0GTECUZ+sTTrF/pqeEgJCos=";
+  };
+in
+
 buildPythonPackage rec {
   pname = "llama-index-core";
   version = "0.10.29";
@@ -44,6 +57,20 @@ buildPythonPackage rec {
   };
 
   sourceRoot = "${src.name}/${pname}";
+
+  # When `llama-index` is imported, it uses `nltk` to look for the following files and tries to
+  # download them if they aren't present.
+  # https://github.com/run-llama/llama_index/blob/6efa53cebd5c8ccf363582c932fffde44d61332e/llama-index-core/llama_index/core/utils.py#L59-L67
+  # Setting `NLTK_DATA` to a writable path can also solve this problem, but it needs to be done in
+  # every package that depends on `llama-index-core` for `pythonImportsCheck` not to fail, so this
+  # solution seems more elegant.
+  patchPhase = ''
+    mkdir -p llama_index/core/_static/nltk_cache/corpora/stopwords/
+    cp -r ${stopwords}/* llama_index/core/_static/nltk_cache/corpora/stopwords/
+
+    mkdir -p llama_index/core/_static/nltk_cache/tokenizers/punkt/
+    cp -r ${punkt}/* llama_index/core/_static/nltk_cache/tokenizers/punkt/
+  '';
 
   build-system = [ poetry-core ];
 


### PR DESCRIPTION
## Description of changes

When `llama-index` is imported, it uses `nltk` to [check](https://github.com/run-llama/llama_index/blob/6efa53cebd5c8ccf363582c932fffde44d61332e/llama-index-core/llama_index/core/utils.py#L59-L67) whether certain files are present and tries to download them if they aren't.

This PR adds those files to the `llama-index-core` package.

Setting the environment variable `NLTK_DATA` to a writable path can also solve this problem, but it needs to be done in every package that depends on `llama-index-core` for `pythonImportsCheck` not to fail, so this solution seems more elegant.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
