### PR TITLE
[23.11] python311Packages.pillow: add patch for CVE-2024-28219

### DIFF
--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -2,7 +2,9 @@
 , stdenv
 , buildPythonPackage
 , pythonOlder
+, fetchpatch
 , fetchPypi
+, fetchurl
 , isPyPy
 , defusedxml, olefile, freetype, libjpeg, zlib, libtiff, libwebp, libxcrypt, tcl, lcms2, tk, libX11
 , libxcb, openjpeg, libimagequant, pyroma, numpy, pytestCheckHook, setuptools
@@ -22,6 +24,34 @@ import ./generic.nix (rec {
     inherit version;
     hash = "sha256-6H8LLHgVfhLXaGsn1jwHD9ZdmU6N2ubzKODc9KDNAH4=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2024-28219.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/2a93aba5cfcf6e241ab4f9392c13e3b74032c061.patch";
+      hash = "sha256-djbVjbWWAAr+QMErT+lFhj2HF7uGn8oI68tC+i1PHys=";
+    })
+  ];
+
+  # patching mechanism doesn't work with binary files, but the commits contain
+  # example images needed for the accompanying tests, so invent our own mechanism
+  # to put these in place
+  extraPostPatch = lib.concatMapStrings ({commit, hash, path}: let
+      src = fetchurl {
+        inherit hash;
+        url = "https://github.com/python-pillow/Pillow/raw/${commit}/${path}";
+      };
+      dest = path;
+    in ''
+      cp ${src} ${dest}
+    ''
+  ) [
+    { # needed by CVE-2024-28219.patch
+      commit = "2a93aba5cfcf6e241ab4f9392c13e3b74032c061";
+      hash = "sha256-rCgFueB7b6O6dAaqSOhNhwQQl9pmIgzCo4Xhe7KJPME=";
+      path = "Tests/icc/sGrey-v2-nano.icc";
+    }
+  ];
 
   passthru.tests = {
     inherit imageio matplotlib pilkit pydicom reportlab;

--- a/pkgs/development/python-modules/pillow/generic.nix
+++ b/pkgs/development/python-modules/pillow/generic.nix
@@ -3,6 +3,7 @@
 , disabled
 , src
 , patches ? []
+, extraPostPatch ? ""
 , meta
 , passthru ? {}
 , ...
@@ -17,7 +18,7 @@ buildPythonPackage rec {
   # https://github.com/python-pillow/Pillow/issues/1259
   postPatch = ''
     rm Tests/test_imagefont.py
-  '';
+  '' + extraPostPatch;
 
   disabledTests = [
     # Code quality mismathch 9 vs 10


### PR DESCRIPTION
## Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2024-28219

Reintroduce mechanism from a3713143cc79e038634780745a2edb598f51fe0a (release-20.09 branch) to fetch required binary files for patches.

Unstable addressed by #300677

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
