### PR TITLE
haskell.compiler.ghc{9{6,8},HEAD}: use patched ghcSrc across all involved derivations

### DIFF
--- a/pkgs/development/tools/haskell/hadrian/disable-hyperlinked-source.patch
+++ b/pkgs/development/tools/haskell/hadrian/disable-hyperlinked-source.patch
@@ -1,7 +1,7 @@
 diff --git a/hadrian/src/Settings/Builders/Haddock.hs b/hadrian/src/Settings/Builders/Haddock.hs
 index 902b2f85e2..429a441c3b 100644
---- a/src/Settings/Builders/Haddock.hs
-+++ b/src/Settings/Builders/Haddock.hs
+--- a/hadrian/src/Settings/Builders/Haddock.hs
++++ b/hadrian/src/Settings/Builders/Haddock.hs
 @@ -57,7 +57,6 @@ haddockBuilderArgs = mconcat
              , arg $ "--odir=" ++ takeDirectory output
              , arg $ "--dump-interface=" ++ output

--- a/pkgs/development/tools/haskell/hadrian/hadrian-9.8.1-allow-Cabal-3.10.patch
+++ b/pkgs/development/tools/haskell/hadrian/hadrian-9.8.1-allow-Cabal-3.10.patch
@@ -1,7 +1,7 @@
 diff --git a/hadrian.cabal b/hadrian.cabal
 index 70fded11aa..3893537f05 100644
---- a/hadrian.cabal
-+++ b/hadrian.cabal
+--- a/hadrian/hadrian.cabal
++++ b/hadrian/hadrian.cabal
 @@ -150,7 +150,7 @@ executable hadrian
                         , TypeOperators
      other-extensions:    MultiParamTypeClasses

--- a/pkgs/development/tools/haskell/hadrian/hadrian.nix
+++ b/pkgs/development/tools/haskell/hadrian/hadrian.nix
@@ -11,7 +11,6 @@
 , ghcVersion
   # Customization
 , userSettings ? null
-, enableHyperlinkedSource
 }:
 
 mkDerivation {
@@ -21,13 +20,6 @@ mkDerivation {
   postUnpack = ''
     sourceRoot="$sourceRoot/hadrian"
   '';
-  patches = lib.optionals (!enableHyperlinkedSource) [
-    ./disable-hyperlinked-source.patch
-  ] ++ lib.optionals (lib.elem ghcVersion [ "9.8.1" "9.8.2" ]) [
-    # Incorrect bounds on Cabal
-    # https://gitlab.haskell.org/ghc/ghc/-/issues/24100
-    ./hadrian-9.8.1-allow-Cabal-3.10.patch
-  ];
   # Overwrite UserSettings.hs with a provided custom one
   postPatch = lib.optionalString (userSettings != null) ''
     install -m644 "${writeText "UserSettings.hs" userSettings}" src/UserSettings.hs

--- a/pkgs/development/tools/haskell/hadrian/make-hadrian.nix
+++ b/pkgs/development/tools/haskell/hadrian/make-hadrian.nix
@@ -32,10 +32,6 @@
   # Contents of a non-default UserSettings.hs to use when building hadrian, if any.
   # Should be a string or null.
 , userSettings ? null
-  # Whether to pass --hyperlinked-source to haddock or not. This is a custom
-  # workaround as we wait for this to be configurable via userSettings or similar.
-  # https://gitlab.haskell.org/ghc/ghc/-/issues/23625
-, enableHyperlinkedSource ? false
 }:
 
 let
@@ -50,7 +46,7 @@ let
 in
 
 callPackage' ./hadrian.nix ({
-  inherit userSettings enableHyperlinkedSource;
+  inherit userSettings;
 } // lib.optionalAttrs (lib.versionAtLeast ghcVersion "9.9") {
   # Starting with GHC 9.9 development, additional in tree packages are required
   # to build hadrian. (Hackage-released conditional dependencies are handled


### PR DESCRIPTION
## Description of changes

I think this is the way to untangle this mess. It allows for the use case that motivated #283364, but without making everything even more complicated (e.g. #283364 would have required threading the `patches` argument to two extra places now).

Extra details in the commit messages.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
