### PR TITLE
nix-inspect: 0.1.0 -> 0.1.1

### DIFF
--- a/pkgs/by-name/ni/nix-inspect/package.nix
+++ b/pkgs/by-name/ni/nix-inspect/package.nix
@@ -50,7 +50,7 @@ in
     '';
 
     meta = with lib; {
-      description = "A Rust package for inspecting Nix expressions";
+      description = "Interactive TUI for inspecting nix configs and other expressions";
       homepage = "https://github.com/bluskript/nix-inspect";
       license = licenses.mit;
       maintainers = with maintainers; [blusk];

--- a/pkgs/by-name/ni/nix-inspect/package.nix
+++ b/pkgs/by-name/ni/nix-inspect/package.nix
@@ -13,7 +13,7 @@
   src = fetchFromGitHub {
     owner = "bluskript";
     repo = "nix-inspect";
-    rev = "3d0fea2bb246130825548fce331093ee9cc9c20b";
+    rev = "74007c580b8282bd336130ddf354e71502b421a6";
     hash = "sha256-JichXRSfTLfy+7fhbTvA89rQLkqsY2eHgEAeAHWbA9s=";
   };
 
@@ -21,7 +21,7 @@
     inherit src;
 
     pname = "nix-inspect-worker";
-    version = "0.1.0";
+    version = "0.1.1";
     sourceRoot = "source/worker";
 
     nativeBuildInputs = [meson ninja pkg-config];
@@ -38,9 +38,9 @@ in
   rustPlatform.buildRustPackage {
     inherit src;
     pname = "nix-inspect";
-    version = "0.1.0";
+    version = "0.1.1";
 
-    cargoHash = "sha256-FdpHdw7bg/nEG4GjYhrdIDB4MJ4n5LoWnW4mTG2Lh5I=";
+    cargoHash = "sha256-l+R7BLgJvK9mQ89GVAdTyQX81VMoV11h5KFlMUqAH30=";
 
     buildInputs = [workerPackage];
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/bluskript/nix-inspect/blob/main/CHANGELOG.md#011

Description was also adjusted because it did not accurately describe what the program did.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
