### PR TITLE
lldap-cli: init at 0-unstable-2024-05-15

### DIFF
--- a/pkgs/by-name/ll/lldap-cli/package.nix
+++ b/pkgs/by-name/ll/lldap-cli/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  resholve,
+
+  bash,
+  coreutils,
+  curl,
+  gnugrep,
+  gnused,
+  jq,
+  lldap,
+  util-linux,
+}:
+
+resholve.mkDerivation {
+  pname = "lldap-cli";
+  version = "0-unstable-2024-05-15";
+
+  src = fetchFromGitHub {
+    owner = "ibizaman";
+    repo = "lldap-cli";
+    rev = "65c4102ab0b314593d69c02a803a11ba1853978f";
+    hash = "sha256-Ip1FkDrIsphi0GjP805Y8Gii16x7v/fsHtDUOzxie0w=";
+  };
+
+  solutions = {
+    default = {
+      scripts = [ "bin/lldap-cli" ];
+      interpreter = lib.getExe bash;
+      inputs = [
+        coreutils
+        curl
+        gnugrep
+        gnused
+        jq
+        lldap
+        util-linux
+      ];
+      keep = {
+        "$value" = true;
+      };
+    };
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm555 $src/lldap-cli $out/bin/lldap-cli
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Command line interface for LLDAP";
+    homepage = "https://github.com/ibizaman/lldap-cli";
+    license = lib.licenses.gpl3;
+    mainProgram = "lldap-cli";
+    maintainers = with lib.maintainers; [ ibizaman ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

New package https://github.com/Zepmann/lldap-cli

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
