### PR TITLE
treewide: improve usage of `lib.optional` and `lib.optionals`

### DIFF
--- a/nixos/modules/config/xdg/portal.nix
+++ b/nixos/modules/config/xdg/portal.nix
@@ -121,7 +121,8 @@ in
       packages = [ pkgs.xdg-desktop-portal ] ++ cfg.extraPortals;
     in
     mkIf cfg.enable {
-      warnings = lib.optional (cfg.configPackages == [ ] && cfg.config == { }) ''
+      warnings = lib.optionals (cfg.configPackages == [ ] && cfg.config == { }) [
+        ''
         xdg-desktop-portal 1.17 reworked how portal implementations are loaded, you
         should either set `xdg.portal.config` or `xdg.portal.configPackages`
         to specify which portal backend to use for the requested interface.
@@ -132,7 +133,8 @@ in
         portal implementation found in lexicographical order, use the following:
 
         xdg.portal.config.common.default = "*";
-      '';
+      ''
+      ];
 
       assertions = [
         {

--- a/nixos/modules/services/monitoring/certspotter.nix
+++ b/nixos/modules/services/monitoring/certspotter.nix
@@ -11,18 +11,18 @@ let
       name = "watchlist";
       path = pkgs.writeText "certspotter-watchlist" (builtins.concatStringsSep "\n" cfg.watchlist);
     }
-    ++ lib.optional (cfg.emailRecipients != [ ]) {
+    ++ lib.optionals (cfg.emailRecipients != [ ]) [{
       name = "email_recipients";
       path = pkgs.writeText "certspotter-email_recipients" (builtins.concatStringsSep "\n" cfg.emailRecipients);
-    }
+    }]
     # always generate hooks dir when no emails are provided to allow running cert spotter with no hooks/emails
-    ++ lib.optional (cfg.emailRecipients == [ ] || cfg.hooks != [ ]) {
+    ++ lib.optionals (cfg.emailRecipients == [ ] || cfg.hooks != [ ]) [{
       name = "hooks.d";
       path = pkgs.linkFarm "certspotter-hooks" (lib.imap1 (i: path: {
         inherit path;
         name = "hook${toString i}";
       }) cfg.hooks);
-    });
+    }]);
 in
 {
   options.services.certspotter = {

--- a/nixos/modules/services/monitoring/telegraf.nix
+++ b/nixos/modules/services/monitoring/telegraf.nix
@@ -64,11 +64,12 @@ in {
       path = lib.optional (config.services.telegraf.extraConfig.inputs ? procstat) pkgs.procps;
       serviceConfig = {
         EnvironmentFile = config.services.telegraf.environmentFiles;
-        ExecStartPre = lib.optional (config.services.telegraf.environmentFiles != [])
+        ExecStartPre = lib.optionals (config.services.telegraf.environmentFiles != []) [
           (pkgs.writeShellScript "pre-start" ''
             umask 077
             ${pkgs.envsubst}/bin/envsubst -i "${configFile}" > /var/run/telegraf/config.toml
-          '');
+          '')
+        ];
         ExecStart="${cfg.package}/bin/telegraf -config ${finalConfigFile}";
         ExecReload="${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         RuntimeDirectory = "telegraf";

--- a/nixos/modules/services/networking/mycelium.nix
+++ b/nixos/modules/services/networking/mycelium.nix
@@ -97,9 +97,9 @@ in
           "--tun-name"
           "mycelium"
           "${utils.escapeSystemdExecArgs cfg.extraArgs}"
-        ] ++
-        (lib.optional (cfg.addHostedPublicNodes || cfg.peers != [ ]) "--peers")
-        ++ cfg.peers ++ (lib.optionals cfg.addHostedPublicNodes [
+        ] ++ lib.optionals (cfg.addHostedPublicNodes || cfg.peers != [ ]) [
+          "--peers"
+        ] ++ cfg.peers ++ (lib.optionals cfg.addHostedPublicNodes [
           "tcp://188.40.132.242:9651" # DE 01
           "tcp://[2a01:4f8:221:1e0b::2]:9651"
           "quic://188.40.132.242:9651"

--- a/nixos/modules/services/networking/quicktun.nix
+++ b/nixos/modules/services/networking/quicktun.nix
@@ -137,13 +137,13 @@ in
       (lib.mapAttrsToList (name: value: if value.privateKey != null then name else null))
       (builtins.filter (n: n != null))
       (map (n: "  - services.quicktun.${n}.privateKey"))
-      (services: lib.optional (services != [ ]) ''
+      (services: lib.optionals (services != [ ]) [''
         `services.quicktun.<name>.privateKey` is deprecated.
         Please use `services.quicktun.<name>.privateKeyFile` instead.
 
         Offending options:
         ${lib.concatStringsSep "\n" services}
-      '')
+      ''])
     ];
 
     systemd.services = lib.mkMerge (

--- a/nixos/modules/services/system/cachix-watch-store.nix
+++ b/nixos/modules/services/system/cachix-watch-store.nix
@@ -83,10 +83,24 @@ in
       };
       script =
         let
-          command = [ "${cfg.package}/bin/cachix" ]
-            ++ (lib.optional cfg.verbose "--verbose") ++ (lib.optionals (cfg.host != null) [ "--host" cfg.host ])
-            ++ [ "watch-store" ] ++ (lib.optionals (cfg.compressionLevel != null) [ "--compression-level" (toString cfg.compressionLevel) ])
-            ++ (lib.optionals (cfg.jobs != null) [ "--jobs" (toString cfg.jobs) ]) ++ [ cfg.cacheName ];
+          command = [
+            "${cfg.package}/bin/cachix"
+          ] ++ lib.optionals cfg.verbose [
+            "--verbose"
+          ] ++ lib.optionals (cfg.host != null) [
+            "--host"
+            cfg.host
+          ] ++ [
+            "watch-store"
+          ] ++ lib.optionals (cfg.compressionLevel != null) [
+            "--compression-level"
+            (toString cfg.compressionLevel)
+          ] ++ lib.optionals (cfg.jobs != null) [
+            "--jobs"
+            (toString cfg.jobs)
+          ] ++ [
+            cfg.cacheName
+          ];
         in
         ''
           export CACHIX_AUTH_TOKEN="$(<"$CREDENTIALS_DIRECTORY/cachix-token")"

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -599,7 +599,7 @@ in
       defaultListenAddresses = mkOption {
         type = types.listOf types.str;
         default = [ "0.0.0.0" ] ++ optional enableIPv6 "[::0]";
-        defaultText = literalExpression ''[ "0.0.0.0" ] ++ lib.optional config.networking.enableIPv6 "[::0]"'';
+        defaultText = literalExpression ''[ "0.0.0.0" ] ++ lib.optionals config.networking.enableIPv6 [ "[::0]" ]'';
         example = literalExpression ''[ "10.0.0.12" "[2002:a00:1::]" ]'';
         description = ''
           If vhosts do not specify listenAddresses, use these addresses by default.
@@ -1207,7 +1207,7 @@ in
     services.nginx.virtualHosts.localhost = mkIf cfg.statusPage {
       listenAddresses = lib.mkDefault ([
         "0.0.0.0"
-      ] ++ lib.optional enableIPv6 "[::]");
+      ] ++ lib.optionals enableIPv6 [ "[::]" ]);
       locations."/nginx_status" = {
         extraConfig = ''
           stub_status on;

--- a/nixos/modules/services/web-servers/stargazer.nix
+++ b/nixos/modules/services/web-servers/stargazer.nix
@@ -38,8 +38,8 @@ in
 
     listen = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = [ "0.0.0.0" ] ++ lib.optional config.networking.enableIPv6 "[::0]";
-      defaultText = lib.literalExpression ''[ "0.0.0.0" ] ++ lib.optional config.networking.enableIPv6 "[::0]"'';
+      default = [ "0.0.0.0" ] ++ lib.optionals config.networking.enableIPv6 [ "[::0]" ];
+      defaultText = lib.literalExpression ''[ "0.0.0.0" ] ++ lib.optionals config.networking.enableIPv6 [ "[::0]" ]'';
       example = lib.literalExpression ''[ "10.0.0.12" "[2002:a00:1::]" ]'';
       description = ''
         Address and port to listen on.

--- a/nixos/modules/services/web-servers/traefik.nix
+++ b/nixos/modules/services/web-servers/traefik.nix
@@ -151,11 +151,12 @@ in {
       startLimitBurst = 5;
       serviceConfig = {
         EnvironmentFile = cfg.environmentFiles;
-        ExecStartPre = lib.optional (cfg.environmentFiles != [])
+        ExecStartPre = lib.optionals (cfg.environmentFiles != []) [
           (pkgs.writeShellScript "pre-start" ''
             umask 077
             ${pkgs.envsubst}/bin/envsubst -i "${staticConfigFile}" > "${finalStaticConfigFile}"
-          '');
+          '')
+        ];
         ExecStart = "${cfg.package}/bin/traefik --configfile=${finalStaticConfigFile}";
         Type = "simple";
         User = "traefik";

--- a/nixos/modules/virtualisation/digital-ocean-init.nix
+++ b/nixos/modules/virtualisation/digital-ocean-init.nix
@@ -5,7 +5,7 @@ let
   defaultConfigFile = pkgs.writeText "digitalocean-configuration.nix" ''
     { modulesPath, lib, ... }:
     {
-      imports = lib.optional (builtins.pathExists ./do-userdata.nix) ./do-userdata.nix ++ [
+      imports = lib.optionals (builtins.pathExists ./do-userdata.nix) [ ./do-userdata.nix ] ++ [
         (modulesPath + "/virtualisation/digital-ocean-config.nix")
       ];
     }

--- a/pkgs/applications/editors/textadept/default.nix
+++ b/pkgs/applications/editors/textadept/default.nix
@@ -21,9 +21,12 @@ stdenv.mkDerivation rec {
      lib.optionals withQt [ qtbase ]
   ++ lib.optionals withCurses ncurses;
 
-  cmakeFlags =
-     lib.optional withQt [ "-DQT=ON" ]
-  ++ lib.optional withCurses [ "-DCURSES=ON" "-DQT=OFF"];
+  cmakeFlags = lib.optionals withQt [
+    "-DQT=ON"
+  ] ++ lib.optionals withCurses [
+    "-DCURSES=ON"
+    "-DQT=OFF"
+  ];
 
   preConfigure = ''
     mkdir -p $PWD/build/_deps

--- a/pkgs/applications/editors/vim/plugins/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/vim-utils.nix
@@ -199,7 +199,7 @@ let
         ln -s ${python3Env}/${python3Env.sitePackages} $out/pack/${packageName}/start/__python3_dependencies/python3
       '';
     in
-      [ packdirStart packdirOpt ] ++ lib.optional (allPython3Dependencies python3.pkgs != []) python3link;
+      [ packdirStart packdirOpt ] ++ lib.optionals (allPython3Dependencies python3.pkgs != []) [ python3link ];
   in
     buildEnv {
       name = "vim-pack-dir";
@@ -266,12 +266,16 @@ let
 
       entries = [
         beforePlugins
-      ]
-      ++ lib.optional (vam != null) (lib.warn "'vam' attribute is deprecated. Use 'packages' instead in your vim configuration" vamImpl)
-      ++ lib.optional (packages != null && packages != []) (nativeImpl packages)
-      ++ lib.optional (pathogen != null) (throw "pathogen is now unsupported, replace `pathogen = {}` with `packages.home = { start = []; }`")
-      ++ lib.optional (plug != null) plugImpl
-      ++ [ customRC ];
+        customRC
+      ] ++ lib.optionals (vam != null) [
+        (lib.warn "'vam' attribute is deprecated. Use 'packages' instead in your vim configuration" vamImpl)
+      ] ++ lib.optionals (packages != null && packages != []) [
+        (nativeImpl packages)
+      ] ++ lib.optionals (pathogen != null) [
+        (throw "pathogen is now unsupported, replace `pathogen = {}` with `packages.home = { start = []; }`")
+      ] ++ lib.optionals (plug != null) [
+        plugImpl
+      ];
 
     in
       lib.concatStringsSep "\n" (lib.filter (x: x != null && x != "") entries);

--- a/pkgs/applications/emulators/retroarch/default.nix
+++ b/pkgs/applications/emulators/retroarch/default.nix
@@ -56,9 +56,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
   };
 
-  nativeBuildInputs = [ pkg-config wrapQtAppsHook ] ++
-    lib.optional withWayland wayland ++
-    lib.optional (runtimeLibs != [ ]) makeWrapper;
+  nativeBuildInputs = [
+    pkg-config
+    wrapQtAppsHook
+  ] ++ lib.optionals withWayland [
+    wayland
+  ] ++ lib.optionals (runtimeLibs != [ ]) [
+    makeWrapper
+  ];
 
   buildInputs = [
     ffmpeg_4

--- a/pkgs/applications/networking/libcoap/default.nix
+++ b/pkgs/applications/networking/libcoap/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     which
     libtool
     pkg-config
-  ] ++ lib.optional withTLS gnutls ++ lib.optionals withDocs [ doxygen asciidoc ] ;
+  ] ++ lib.optionals withTLS [ gnutls ] ++ lib.optionals withDocs [ doxygen asciidoc ] ;
   preConfigure = "./autogen.sh";
   configureFlags = [ "--disable-shared" ]
     ++ lib.optional (!withDocs) "--disable-documentation"

--- a/pkgs/applications/radio/pat/default.nix
+++ b/pkgs/applications/radio/pat/default.nix
@@ -25,7 +25,9 @@ buildGoModule rec {
     installShellFiles
   ];
 
-  buildInputs = lib.optional stdenv.isLinux [ libax25 ];
+  buildInputs = lib.optionals stdenv.isLinux [
+    libax25
+  ];
 
   # Needed by wl2k-go go module for libax25 to include support for Linux' AX.25 stack by linking against libax25.
   # ref: https://github.com/la5nta/wl2k-go/blob/abe3ae5bf6a2eec670a21672d461d1c3e1d4c2f3/transport/ax25/ax25.go#L11-L17

--- a/pkgs/applications/science/biology/bowtie2/default.nix
+++ b/pkgs/applications/science/biology/bowtie2/default.nix
@@ -34,7 +34,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ tbb zlib python3 perl ];
 
-  cmakeFlags = lib.optional (!stdenv.hostPlatform.isx86) ["-DCMAKE_CXX_FLAGS=-I${finalAttrs.src}/third_party"];
+  cmakeFlags = lib.optionals (!stdenv.hostPlatform.isx86) [
+    "-DCMAKE_CXX_FLAGS=-I${finalAttrs.src}/third_party"
+  ];
 
   # ctest fails because of missing dependencies between tests
   doCheck = false;

--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -10,7 +10,7 @@ lib.makeOverridable (
 } @ args:
 
 let
-  slug = lib.concatStringsSep "/" ((lib.optional (group != null) group) ++ [ owner repo ]);
+  slug = lib.concatStringsSep "/" ([ owner repo ] ++ lib.optionals (group != null) [ group ]);
   escapedSlug = lib.replaceStrings [ "." "/" ] [ "%2E" "%2F" ] slug;
   escapedRev = lib.replaceStrings [ "+" "%" "/" ] [ "%2B" "%25" "%2F" ] rev;
   passthruAttrs = removeAttrs args [ "protocol" "domain" "owner" "group" "repo" "rev" "fetchSubmodules" "forceFetchGit" "leaveDotGit" "deepClone" ];

--- a/pkgs/by-name/c2/c2patool/package.nix
+++ b/pkgs/by-name/c2/c2patool/package.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage rec {
   ];
   buildInputs = [
     openssl
-  ] ++ lib.optional stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     libiconv
     darwin.apple_sdk.frameworks.CoreServices
     darwin.apple_sdk.frameworks.Carbon

--- a/pkgs/by-name/fr/frankenphp/package.nix
+++ b/pkgs/by-name/fr/frankenphp/package.nix
@@ -54,7 +54,9 @@ in buildGoModule rec {
     "-w"
     "-X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP ${version} PHP ${phpUnwrapped.version} Caddy'"
     # pie mode is only available with pkgsMusl, it also automaticaly add -buildmode=pie to $GOFLAGS
-  ]  ++ (lib.optional pieBuild [ "-static-pie" ]);
+  ] ++ lib.optionals pieBuild [
+    "-static-pie"
+  ];
 
   preBuild = ''
     export CGO_CFLAGS="$(${phpConfig} --includes)"

--- a/pkgs/by-name/kt/ktls-utils/package.nix
+++ b/pkgs/by-name/kt/ktls-utils/package.nix
@@ -37,9 +37,9 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "man" ];
 
-  configureFlags = lib.optional withSystemd [ "--with-systemd" ];
+  configureFlags = lib.optionals withSystemd [ "--with-systemd" ];
 
-  makeFlags = lib.optional withSystemd [ "unitdir=$(out)/lib/systemd/system" ];
+  makeFlags = lib.optionals withSystemd [ "unitdir=$(out)/lib/systemd/system" ];
 
   doCheck = true;
 

--- a/pkgs/by-name/ni/nix-unit/package.nix
+++ b/pkgs/by-name/ni/nix-unit/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     # nlohmann_json can be only discovered via cmake files
     cmake
-  ] ++ lib.optional stdenv.cc.isClang [ clang-tools ];
+  ] ++ lib.optionals stdenv.cc.isClang [ clang-tools ];
 
   postInstall = ''
     wrapProgram "$out/bin/nix-unit" --prefix PATH : ${difftastic}/bin

--- a/pkgs/by-name/no/novops/package.nix
+++ b/pkgs/by-name/no/novops/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [
     openssl # required for openssl-sys
-  ] ++ lib.optional stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     libiconv
     darwin.apple_sdk.frameworks.SystemConfiguration
   ];

--- a/pkgs/by-name/sp/spla/package.nix
+++ b/pkgs/by-name/sp/spla/package.nix
@@ -43,13 +43,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     blas
-  ]
-  ++ lib.optional (gpuBackend == "cuda") cudaPackages.cudatoolkit
-  ++ lib.optionals (gpuBackend == "rocm") [
+  ] ++ lib.optionals (gpuBackend == "cuda") [
+    cudaPackages.cudatoolkit
+  ] ++ lib.optionals (gpuBackend == "rocm") [
     rocmPackages.clr
     rocmPackages.rocblas
-  ] ++ lib.optional stdenv.isDarwin llvmPackages.openmp
-  ;
+  ] ++ lib.optionals stdenv.isDarwin [
+    llvmPackages.openmp
+  ];
 
   propagatedBuildInputs = [ mpi ];
 
@@ -60,10 +61,11 @@ stdenv.mkDerivation rec {
     # Required due to broken CMake files
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
-  ]
-  ++ lib.optional (gpuBackend == "cuda") "-DSPLA_GPU_BACKEND=CUDA"
-  ++ lib.optional (gpuBackend == "rocm") [ "-DSPLA_GPU_BACKEND=ROCM" ]
-  ;
+  ] ++ lib.optionals (gpuBackend == "cuda") [
+    "-DSPLA_GPU_BACKEND=CUDA"
+  ] ++ lib.optionals (gpuBackend == "rocm") [
+    "-DSPLA_GPU_BACKEND=ROCM"
+  ];
 
   meta = with lib; {
     description = "Specialized Parallel Linear Algebra, providing distributed GEMM functionality for specific matrix distributions with optional GPU acceleration";

--- a/pkgs/by-name/wh/where-is-my-sddm-theme/package.nix
+++ b/pkgs/by-name/wh/where-is-my-sddm-theme/package.nix
@@ -42,16 +42,16 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-o9SpzSmHygHix3BUaMQRwLvgy2BdDsBXmiLDU+9u/6Q=";
   };
 
-  propagatedUserEnvPkgs =
-    [ ]
-    ++ lib.optional (lib.elem "qt5" variants) [ libsForQt5.qtgraphicaleffects ]
-    ++ lib.optional (lib.elem "qt6" variants) [
-      qt6.qt5compat
-      qt6.qtsvg
-    ];
+  propagatedUserEnvPkgs = lib.optionals (lib.elem "qt5" variants) [
+    libsForQt5.qtgraphicaleffects
+  ] ++ lib.optionals (lib.elem "qt6" variants) [
+    qt6.qt5compat
+    qt6.qtsvg
+  ];
 
   installPhase =
     ''
+      runHook preInstall
       mkdir -p $out/share/sddm/themes/
     ''
     + lib.optionalString (lib.elem "qt6" variants) (
@@ -69,7 +69,9 @@ stdenvNoCC.mkDerivation rec {
       + lib.optionalString (lib.isAttrs themeConfig) ''
         ln -sf ${user-cfg} $out/share/sddm/themes/where_is_my_sddm_theme_qt5/theme.conf.user
       ''
-    );
+    ) + ''
+      runHook postInstall
+    '';
 
   meta = with lib; {
     description = "The most minimalistic SDDM theme among all themes";

--- a/pkgs/data/fonts/openmoji/default.nix
+++ b/pkgs/data/fonts/openmoji/default.nix
@@ -48,10 +48,14 @@ stdenvNoCC.mkDerivation rec {
 
   methods_black = builtins.filter (m: builtins.elem m fontFormats) methods.black;
   methods_color = builtins.filter (m: builtins.elem m fontFormats) methods.color;
-  saturations = lib.optional (methods_black != [ ]) "black" ++ lib.optional (methods_color != [ ]) "color";
+  saturations = lib.optionals (methods_black != [ ]) [
+    "black"
+  ] ++ lib.optionals (methods_color != [ ]) [
+    "color"
+  ];
   maximumColorVersions = lib.optionals (buildMaximumColorFonts != "none") (
-    lib.optional (builtins.elem "glyf_colr_0" fontFormats) "0"
-    ++ lib.optional (builtins.elem "glyf_colr_1" fontFormats) "1"
+    lib.optionals (builtins.elem "glyf_colr_0" fontFormats) [ "0" ]
+    ++ lib.optionals (builtins.elem "glyf_colr_1" fontFormats) [ "1" ]
   );
 
   postPatch = lib.optionalString (buildMaximumColorFonts == "bitmap") ''

--- a/pkgs/data/icons/papirus-icon-theme/default.nix
+++ b/pkgs/data/icons/papirus-icon-theme/default.nix
@@ -30,7 +30,7 @@ stdenvNoCC.mkDerivation rec {
   propagatedBuildInputs = [
     breeze-icons
     hicolor-icon-theme
-  ] ++ lib.optional withElementary [
+  ] ++ lib.optionals withElementary [
     elementary-icon-theme
   ];
 

--- a/pkgs/development/embedded/arduino/arduino-core/default.nix
+++ b/pkgs/development/embedded/arduino/arduino-core/default.nix
@@ -39,12 +39,15 @@ let
     inherit (stdenv.hostPlatform) system;
   };
   # Some .so-files are later copied from .jar-s to $HOME, so patch them beforehand
-  patchelfInJars =
-    lib.optional (stdenv.hostPlatform.system == "aarch64-linux") { jar = "share/arduino/lib/jssc-2.8.0-arduino4.jar"; file = "libs/linux/libjSSC-2.8_aarch64.so"; }
-    ++ lib.optional (builtins.match "armv[67]l-linux" stdenv.hostPlatform.system != null) { jar = "share/arduino/lib/jssc-2.8.0-arduino4.jar"; file = "libs/linux/libjSSC-2.8_armhf.so"; }
-    ++ lib.optional (stdenv.hostPlatform.system == "x86_64-linux") { jar = "share/arduino/lib/jssc-2.8.0-arduino4.jar"; file = "libs/linux/libjSSC-2.8_x86_64.so"; }
-    ++ lib.optional (stdenv.hostPlatform.system == "i686-linux") { jar = "share/arduino/lib/jssc-2.8.0-arduino4.jar"; file = "libs/linux/libjSSC-2.8_x86.so"; }
-  ;
+  patchelfInJars = lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
+    { jar = "share/arduino/lib/jssc-2.8.0-arduino4.jar"; file = "libs/linux/libjSSC-2.8_aarch64.so"; }
+  ] ++ lib.optionals (builtins.match "armv[67]l-linux" stdenv.hostPlatform.system != null) [
+    { jar = "share/arduino/lib/jssc-2.8.0-arduino4.jar"; file = "libs/linux/libjSSC-2.8_armhf.so"; }
+  ] ++ lib.optionals (stdenv.hostPlatform.system == "x86_64-linux") [
+    { jar = "share/arduino/lib/jssc-2.8.0-arduino4.jar"; file = "libs/linux/libjSSC-2.8_x86_64.so"; }
+  ] ++ lib.optionals (stdenv.hostPlatform.system == "i686-linux") [
+    { jar = "share/arduino/lib/jssc-2.8.0-arduino4.jar"; file = "libs/linux/libjSSC-2.8_x86.so"; }
+  ];
   # abiVersion 6 is default, but we need 5 for `avrdude_bin` executable
   ncurses5 = ncurses.override { abiVersion = "5"; };
   teensy_libpath = lib.makeLibraryPath [

--- a/pkgs/development/interpreters/perl/interpreter.nix
+++ b/pkgs/development/interpreters/perl/interpreter.nix
@@ -95,26 +95,33 @@ stdenv.mkDerivation (rec {
   # $out/lib/perl5 - this is the general default, but because $out
   # contains the string "perl", Configure would select $out/lib.
   # Miniperl needs -lm. perl needs -lrt.
-  configureFlags =
-    (if crossCompiling
-    then [ "-Dlibpth=\"\"" "-Dglibpth=\"\"" "-Ddefault_inc_excludes_dot" ]
-    else [ "-de" "-Dcc=cc" ])
-    ++ [
+  configureFlags = [
       "-Uinstallusrbinperl"
       "-Dinstallstyle=lib/perl5"
-    ] ++ lib.optional (!crossCompiling) "-Duseshrplib" ++ [
       "-Dlocincpth=${libcInc}/include"
       "-Dloclibpth=${libcLib}/lib"
-    ]
-    ++ lib.optionals ((builtins.match ''5\.[0-9]*[13579]\..+'' version) != null) [ "-Dusedevel" "-Uversiononly" ]
-    ++ lib.optional stdenv.isSunOS "-Dcc=gcc"
-    ++ lib.optional enableThreading "-Dusethreads"
-    ++ lib.optional (!enableCrypt) "-A clear:d_crypt_r"
-    ++ lib.optional stdenv.hostPlatform.isStatic "--all-static"
-    ++ lib.optionals (!crossCompiling) [
+    ] ++ lib.optionals crossCompiling [
+      "-Dlibpth=\"\""
+      "-Dglibpth=\"\""
+      "-Ddefault_inc_excludes_dot"
+    ] ++ lib.optionals (!crossCompiling) [
+      "-de"
+      "-Dcc=cc"
+      "-Duseshrplib"
       "-Dprefix=${placeholder "out"}"
       "-Dman1dir=${placeholder "out"}/share/man/man1"
       "-Dman3dir=${placeholder "out"}/share/man/man3"
+    ] ++ lib.optionals ((builtins.match ''5\.[0-9]*[13579]\..+'' version) != null) [
+      "-Dusedevel"
+      "-Uversiononly"
+    ] ++ lib.optionals stdenv.isSunOS [
+      "-Dcc=gcc"
+    ] ++ lib.optionals enableThreading [
+      "-Dusethreads"
+    ] ++ lib.optionals (!enableCrypt) [
+      "-A clear:d_crypt_r"
+    ] ++ lib.optionals stdenv.hostPlatform.isStatic [
+      "--all-static"
     ];
 
   configureScript = lib.optionalString (!crossCompiling) "${stdenv.shell} ./Configure";

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -232,38 +232,64 @@ let
           CXXFLAGS = lib.optionalString stdenv.cc.isClang "-std=c++11";
           SKIP_PERF_SENSITIVE = 1;
 
-          configureFlags =
+          configureFlags = [
             # Disable all extensions
-            [ "--disable-all" ]
+            "--disable-all"
+            ]
 
             # PCRE
-            ++ [ "--with-external-pcre=${pcre2.dev}" ]
+            ++ [
+              "--with-external-pcre=${pcre2.dev}"
+            ]
 
             # Enable sapis
-            ++ lib.optional (!cgiSupport) "--disable-cgi"
-            ++ lib.optional (!cliSupport) "--disable-cli"
-            ++ lib.optional fpmSupport "--enable-fpm"
-            ++ lib.optionals pearSupport [ "--with-pear" "--enable-xml" "--with-libxml" ]
-            ++ lib.optional pharSupport "--enable-phar"
-            ++ lib.optional (!phpdbgSupport) "--disable-phpdbg"
+            ++ lib.optional (!cgiSupport) [
+                "--disable-cgi"
+            ] ++ lib.optionals (!cliSupport) [
+                "--disable-cli"
+            ] ++ lib.optionals fpmSupport [
+              "--enable-fpm"
+            ]
 
+            ++ lib.optionals pearSupport [
+              "--with-pear"
+              "--enable-xml"
+              "--with-libxml"
+            ] ++ lib.optionals pharSupport [
+              "--enable-phar"
+            ] ++ lib.optionals (!phpdbgSupport) [
+              "--disable-phpdbg"
+            ]
 
             # Misc flags
-            ++ lib.optional apxs2Support "--with-apxs2=${apacheHttpd.dev}/bin/apxs"
-            ++ lib.optional argon2Support "--with-password-argon2=${libargon2}"
-            ++ lib.optional cgotoSupport "--enable-re2c-cgoto"
-            ++ lib.optional embedSupport "--enable-embed${lib.optionalString staticSupport "=static"}"
-            ++ lib.optional (!ipv6Support) "--disable-ipv6"
-            ++ lib.optional systemdSupport "--with-fpm-systemd"
-            ++ lib.optional valgrindSupport "--with-valgrind=${valgrind.dev}"
-            ++ lib.optional ztsSupport "--enable-zts"
-            ++ lib.optional staticSupport "--enable-static"
-            ++ lib.optional (!zendSignalsSupport) ["--disable-zend-signals"]
-            ++ lib.optional zendMaxExecutionTimersSupport "--enable-zend-max-execution-timers"
-
+            ++ lib.optionals apxs2Support [
+              "--with-apxs2=${apacheHttpd.dev}/bin/apxs"
+            ] ++ lib.optionals argon2Support [
+              "--with-password-argon2=${libargon2}"
+            ] ++ lib.optionals cgotoSupport [
+              "--enable-re2c-cgoto"
+            ] ++ lib.optionals embedSupport [
+              "--enable-embed${lib.optionalString staticSupport "=static"}"
+            ] ++ lib.optionals (!ipv6Support) [
+              "--disable-ipv6"
+            ] ++ lib.optionals systemdSupport [
+              "--with-fpm-systemd"
+            ] ++ lib.optionals valgrindSupport [
+              "--with-valgrind=${valgrind.dev}"
+            ] ++ lib.optionals ztsSupport [
+              "--enable-zts"
+            ] ++ lib.optionals staticSupport [
+              "--enable-static"
+            ] ++ lib.optionals (!zendSignalsSupport) [
+              "--disable-zend-signals"
+            ] ++ lib.optionals zendMaxExecutionTimersSupport [
+              "--enable-zend-max-execution-timers"
+            ]
 
             # Sendmail
-            ++ [ "PROG_SENDMAIL=${system-sendmail}/bin/sendmail" ]
+            ++ [
+              "PROG_SENDMAIL=${system-sendmail}/bin/sendmail"
+            ]
           ;
 
           hardeningDisable = [ "bindnow" ];

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -153,7 +153,8 @@ let
           # ruby enables -O3 for gcc, however our compiler hardening wrapper
           # overrides that by enabling `-O2` which is the minimum optimization
           # needed for `_FORTIFY_SOURCE`.
-        ] ++ lib.optional stdenv.cc.isGNU "CFLAGS=-O3" ++ [
+        ] ++ lib.optionals stdenv.cc.isGNU [
+          "CFLAGS=-O3"
         ] ++ ops stdenv.isDarwin [
           # on darwin, we have /usr/include/tk.h -- so the configure script detects
           # that tk is installed

--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -81,14 +81,16 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_DEPS=OFF"
-  ] ++ lib.optional (!customMemoryManagement) "-DCUSTOM_MEMORY_MANAGEMENT=0"
-  ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  ] ++ lib.optionals (!customMemoryManagement) [
+    "-DCUSTOM_MEMORY_MANAGEMENT=0"
+  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     "-DENABLE_TESTING=OFF"
     "-DCURL_HAS_H2=1"
     "-DCURL_HAS_TLS_PROXY=1"
     "-DTARGET_ARCH=${host_os}"
-  ] ++ lib.optional (apis != ["*"])
-    "-DBUILD_ONLY=${lib.concatStringsSep ";" apis}";
+  ] ++ lib.optionals (apis != ["*"]) [
+    "-DBUILD_ONLY=${lib.concatStringsSep ";" apis}"
+  ];
 
   env.NIX_CFLAGS_COMPILE = toString [
     # openssl 3 generates several deprecation warnings

--- a/pkgs/development/libraries/folly/default.nix
+++ b/pkgs/development/libraries/folly/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
     # see https://github.com/NixOS/nixpkgs/issues/144170
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
     "-DCMAKE_INSTALL_LIBDIR=lib"
-  ] ++ lib.optional (stdenv.isDarwin && stdenv.isx86_64) [
+  ] ++ lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
     "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13"
   ];
 

--- a/pkgs/development/libraries/kde-frameworks/kauth/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kauth/default.nix
@@ -7,7 +7,11 @@
 mkDerivation {
   pname = "kauth";
   nativeBuildInputs = [ extra-cmake-modules ];
-  buildInputs = lib.optional enablePolkit polkit-qt ++ [ qttools ];
+  buildInputs = [
+    qttools
+  ] ++ lib.optionals enablePolkit [
+    polkit-qt
+  ];
   propagatedBuildInputs = [ kcoreaddons ];
   patches = [
     ./cmake-install-paths.patch

--- a/pkgs/development/libraries/leveldb/default.nix
+++ b/pkgs/development/libraries/leveldb/default.nix
@@ -27,7 +27,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ snappy ];
 
-  nativeBuildInputs = lib.optional stdenv.isDarwin fixDarwinDylibNames ++ [ cmake ];
+  nativeBuildInputs = [
+    cmake
+  ] ++ lib.optionals stdenv.isDarwin [
+    fixDarwinDylibNames
+  ];
 
   doCheck = true;
 

--- a/pkgs/development/libraries/libass/default.nix
+++ b/pkgs/development/libraries/libass/default.nix
@@ -28,14 +28,18 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config yasm ];
 
-  buildInputs = [ freetype fribidi harfbuzz ]
-    ++ lib.optional fontconfigSupport fontconfig
-    ++ lib.optional stdenv.isDarwin [
-      libiconv
-      darwin.apple_sdk.frameworks.ApplicationServices
-      darwin.apple_sdk.frameworks.CoreFoundation
-      darwin.apple_sdk.frameworks.CoreText
-    ];
+  buildInputs = [
+    freetype
+    fribidi
+    harfbuzz
+  ] ++ lib.optionals fontconfigSupport [
+    fontconfig
+  ] ++ lib.optionals stdenv.isDarwin [
+    libiconv
+    darwin.apple_sdk.frameworks.ApplicationServices
+    darwin.apple_sdk.frameworks.CoreFoundation
+    darwin.apple_sdk.frameworks.CoreText
+  ];
 
   meta = with lib; {
     description = "Portable ASS/SSA subtitle renderer";

--- a/pkgs/development/libraries/lief/default.nix
+++ b/pkgs/development/libraries/lief/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     python
   ];
 
-  env.CXXFLAGS = toString (lib.optional stdenv.isDarwin [ "-faligned-allocation" "-fno-aligned-new" "-fvisibility=hidden" ]);
+  env.CXXFLAGS = toString (lib.optionals stdenv.isDarwin [ "-faligned-allocation" "-fno-aligned-new" "-fvisibility=hidden" ]);
 
   postBuild = ''
     pushd ../api/python

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -228,13 +228,15 @@ self = stdenv.mkDerivation {
     # Rusticl, new OpenCL frontend
     "-Dgallium-rusticl=true"
     "-Dclang-libdir=${llvmPackages.clang-unwrapped.lib}/lib"
-  ]  ++ lib.optionals (!withValgrind) [
+  ] ++ lib.optionals (!withValgrind) [
     "-Dvalgrind=disabled"
-  ]  ++ lib.optionals (!withLibunwind) [
+  ] ++ lib.optionals (!withLibunwind) [
     "-Dlibunwind=disabled"
-  ] ++ lib.optional enablePatentEncumberedCodecs
+  ] ++ lib.optionals enablePatentEncumberedCodecs [
     "-Dvideo-codecs=all"
-  ++ lib.optional (vulkanLayers != []) "-D vulkan-layers=${builtins.concatStringsSep "," vulkanLayers}";
+  ] ++ lib.optionals (vulkanLayers != []) [
+    "-D vulkan-layers=${builtins.concatStringsSep "," vulkanLayers}"
+  ];
 
   strictDeps = true;
 

--- a/pkgs/development/libraries/opensubdiv/default.nix
+++ b/pkgs/development/libraries/opensubdiv/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-  ] ++ lib.optional cudaSupport [
+  ] ++ lib.optionals cudaSupport [
     cudaPackages.cuda_nvcc
   ];
   buildInputs =

--- a/pkgs/development/libraries/pcre/default.nix
+++ b/pkgs/development/libraries/pcre/default.nix
@@ -19,11 +19,14 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" "doc" "man" ];
 
   # Disable jit on Apple Silicon, https://github.com/zherczeg/sljit/issues/51
-  configureFlags = lib.optional (!(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)) "--enable-jit=auto" ++ [
+  configureFlags = [
     "--enable-unicode-properties"
     "--disable-cpp"
-  ]
-    ++ lib.optional (variant != null) "--enable-${variant}";
+  ] ++ lib.optionals (!(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)) [
+    "--enable-jit=auto"
+  ] ++ lib.optionals (variant != null) [
+    "--enable-${variant}"
+  ];
 
   # https://bugs.exim.org/show_bug.cgi?id=2173
   patches = [ ./stacksize-detection.patch ];

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -351,7 +351,7 @@ stdenv.mkDerivation (finalAttrs: ({
     ] ++ lib.optionals (mysqlSupport) [
       "-L" "${libmysqlclient}/lib"
       "-I" "${libmysqlclient}/include"
-    ] ++ lib.optional (withQttranslation && (qttranslations != null)) [
+    ] ++ lib.optionals (withQttranslation && (qttranslations != null)) [
       # depends on x11
       "-translationdir" "${qttranslations}/translations"
     ]

--- a/pkgs/development/libraries/science/astronomy/indilib/default.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DUDEVRULES_INSTALL_DIR=lib/udev/rules.d"
-  ] ++ lib.optional finalAttrs.finalPackage.doCheck [
+  ] ++ lib.optionals finalAttrs.finalPackage.doCheck [
     "-DINDI_BUILD_UNITTESTS=ON"
     "-DINDI_BUILD_INTEGTESTS=ON"
   ];

--- a/pkgs/development/ocaml-modules/ppx_deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving/default.nix
@@ -38,10 +38,11 @@ buildDunePackage rec {
 
   nativeBuildInputs = [ cppo ];
   buildInputs = [ findlib ppxlib ];
-  propagatedBuildInputs =
-    lib.optional (lib.versionOlder version "5.2") ocaml-migrate-parsetree ++ [
+  propagatedBuildInputs = [
     ppx_derivers
     result
+  ] ++ lib.optionals (lib.versionOlder version "5.2") [
+    ocaml-migrate-parsetree
   ];
 
   doCheck = lib.versionAtLeast ocaml.version "4.08"

--- a/pkgs/development/perl-modules/Po4a/default.nix
+++ b/pkgs/development/perl-modules/Po4a/default.nix
@@ -29,7 +29,15 @@ buildPerlPackage rec {
       ''[[ $1 = "article.cls" ]] && echo /dev/null'';
     in
     [ gettext libxslt docbook_xsl docbook_xsl_ns ModuleBuild docbook_xml_dtd_412 docbook_sgml_dtd_41 opensp kpsewhich-stub glibcLocales ];
-  propagatedBuildInputs = lib.optional (!stdenv.hostPlatform.isMusl) TextWrapI18N ++ [ LocaleGettext SGMLSpm UnicodeLineBreak PodParser YAMLTiny ];
+  propagatedBuildInputs = [
+    LocaleGettext
+    SGMLSpm
+    UnicodeLineBreak
+    PodParser
+    YAMLTiny
+  ] ++ lib.optionals (!stdenv.hostPlatform.isMusl) [
+    TextWrapI18N
+  ];
   # TODO: TermReadKey was temporarily removed from propagatedBuildInputs to unfreeze the build
   buildInputs = [ bash ];
   LC_ALL = "en_US.UTF-8";

--- a/pkgs/development/python-modules/dnf4/wrapper.nix
+++ b/pkgs/development/python-modules/dnf4/wrapper.nix
@@ -27,7 +27,10 @@ stdenv.mkDerivation {
     dnf4-unwrapped
   ] ++ plugins;
 
-  makeWrapperArgs = lib.optional (plugins != [ ]) ''--add-flags "--setopt=pluginpath=${lib.concatStringsSep "," pluginPaths}"'';
+  makeWrapperArgs = lib.optionals (plugins != [ ]) [
+    "--add-flags"
+    "--setopt=pluginpath=${lib.concatStringsSep "," pluginPaths}"
+  ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/development/python-modules/e3-core/default.nix
+++ b/pkgs/development/python-modules/e3-core/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     requests-toolbelt
     tqdm
     stevedore
-  ] ++ lib.optional stdenv.isLinux [
+  ] ++ lib.optionals stdenv.isLinux [
     # See setup.py:24. These are required only on Linux. Darwin has its own set
     # of requirements.
     psutil

--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -227,7 +227,7 @@ let pandas = buildPythonPackage rec {
     "test_binops"
     # These tests are unreliable on aarch64-darwin. See https://github.com/pandas-dev/pandas/issues/38921.
     "test_rolling"
-  ] ++ lib.optional stdenv.is32bit [
+  ] ++ lib.optionals stdenv.is32bit [
     # https://github.com/pandas-dev/pandas/issues/37398
     "test_rolling_var_numerical_issues"
   ];

--- a/pkgs/development/python-modules/pendulum/default.nix
+++ b/pkgs/development/python-modules/pendulum/default.nix
@@ -66,7 +66,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     python-dateutil
     tzdata
-  ] ++ lib.optional (!isPyPy) [
+  ] ++ lib.optionals (!isPyPy) [
     time-machine
   ] ++ lib.optionals (pythonOlder "3.9") [
     backports-zoneinfo

--- a/pkgs/development/python-modules/uqbar/default.nix
+++ b/pkgs/development/python-modules/uqbar/default.nix
@@ -50,10 +50,10 @@ buildPythonPackage rec {
     # assert not ["\x1b[91mWARNING: dot command 'dot' cannot be run (needed for
     # graphviz output), check the graphviz_dot setting\x1b[39;49;00m"]
     "test_sphinx_style_latex"
-  ] ++ lib.optional (pythonAtLeast "3.11") [
+  ] ++ lib.optionals (pythonAtLeast "3.11") [
     # assert not '\x1b[91m/build/uqbar-0.7.0/tests/fake_package/enums.py:docstring
     "test_sphinx_style"
-  ] ++ lib.optional (pythonAtLeast "3.12") [
+  ] ++ lib.optionals (pythonAtLeast "3.12") [
     # https://github.com/josiah-wolf-oberholtzer/uqbar/issues/93
     "objects.get_vars"
   ];

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
   '';
   configureScript = "../configure";
 
-  configureFlags = with lib; [
+  configureFlags = [
     # Set the program prefix to the current targetPrefix.
     # This ensures that the prefix always conforms to
     # nixpkgs' expectations instead of relying on the build
@@ -97,7 +97,6 @@ stdenv.mkDerivation rec {
     "--program-prefix=${targetPrefix}"
 
     "--disable-werror"
-  ] ++ lib.optional (!hostCpuOnly) "--enable-targets=all" ++ [
     "--enable-64-bit-bfd"
     "--disable-install-libbfd"
     "--disable-shared" "--enable-static"
@@ -109,13 +108,22 @@ stdenv.mkDerivation rec {
 
     "--with-gmp=${gmp.dev}"
     "--with-mpfr=${mpfr.dev}"
-    "--with-expat" "--with-libexpat-prefix=${expat.dev}"
+    "--with-expat"
+    "--with-libexpat-prefix=${expat.dev}"
     "--with-auto-load-safe-path=${builtins.concatStringsSep ":" safePaths}"
-  ] ++ lib.optional (!pythonSupport) "--without-python"
-    ++ lib.optional stdenv.hostPlatform.isMusl "--disable-nls"
-    ++ lib.optional stdenv.hostPlatform.isStatic "--disable-inprocess-agent"
-    ++ lib.optional enableDebuginfod "--with-debuginfod=yes"
-    ++ lib.optional (!enableSim) "--disable-sim";
+  ] ++ lib.optionals (!hostCpuOnly) [
+    "--enable-targets=all"
+  ] ++ lib.optionals (!pythonSupport) [
+    "--without-python"
+  ] ++ lib.optionals stdenv.hostPlatform.isMusl [
+    "--disable-nls"
+  ] ++ lib.optionals stdenv.hostPlatform.isStatic [
+    "--disable-inprocess-agent"
+  ] ++ lib.optionals enableDebuginfod [
+    "--with-debuginfod=yes"
+  ] ++ lib.optionals (!enableSim) [
+    "--disable-sim"
+  ];
 
   postInstall =
     '' # Remove Info files already provided by Binutils and other packages.

--- a/pkgs/games/mudlet/default.nix
+++ b/pkgs/games/mudlet/default.nix
@@ -97,7 +97,7 @@ stdenv.mkDerivation rec {
     qtmultimedia
     yajl
     discord-rpc
-  ] ++ lib.optional stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     AppKit
   ];
 

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -60,8 +60,8 @@ stdenv.mkDerivation rec {
     "-Ddeveloper_mode=disabled"
   ]
   ++ [(if shared then "-Ddefault_library=shared" else "-Ddefault_library=static")]
-  ++ lib.optional (machine != null) "-Dmachine=${machine}"
-  ++ lib.optional (withExamples != []) "-Dexamples=${builtins.concatStringsSep "," withExamples}";
+  ++ lib.optionals (machine != null) [ "-Dmachine=${machine}" ]
+  ++ lib.optionals (withExamples != []) [ "-Dexamples=${builtins.concatStringsSep "," withExamples}" ];
 
   postInstall = ''
     # Remove Sphinx cache files. Not only are they not useful, but they also
@@ -75,9 +75,12 @@ stdenv.mkDerivation rec {
     find examples -type f -executable -exec install {} $examples/bin \;
   '';
 
-  outputs =
-    [ "out" "doc" ]
-    ++ lib.optional (withExamples != []) "examples";
+  outputs = [
+    "out"
+    "doc"
+  ] ++ lib.optionals (withExamples != []) [
+    "examples"
+  ];
 
   meta = with lib; {
     description = "Set of libraries and drivers for fast packet processing";

--- a/pkgs/os-specific/linux/kvmfr/default.nix
+++ b/pkgs/os-specific/linux/kvmfr/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
 
   src = looking-glass-client.src;
   sourceRoot = "${looking-glass-client.src.name}/module";
-  patches = lib.optional (kernel.kernelAtLeast "6.4") [
+  patches = lib.optionals (kernel.kernelAtLeast "6.4") [
     ./linux-6-4-compat.patch
   ];
   hardeningDisable = [ "pic" "format" ];

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -227,9 +227,9 @@ stdenv.mkDerivation (finalAttrs: {
     ./0015-tpm2_context_init-fix-driver-name-checking.patch
     ./0016-systemctl-edit-suggest-systemdctl-edit-runtime-on-sy.patch
     ./0017-meson.build-do-not-create-systemdstatedir.patch
-  ] ++ lib.optional (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isGnu) [
+  ] ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isGnu) [
     ./0018-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch
-  ] ++ lib.optional (stdenv.hostPlatform.isPower || stdenv.hostPlatform.isRiscV || stdenv.hostPlatform.isMips) [
+  ] ++ lib.optionals (stdenv.hostPlatform.isPower || stdenv.hostPlatform.isRiscV || stdenv.hostPlatform.isMips) [
     # Fixed upstream and included in the main and stable branches. Can be dropped
     # when bumping to >= v255.5.
     # https://github.com/systemd/systemd/issues/30448
@@ -461,28 +461,28 @@ stdenv.mkDerivation (finalAttrs: {
     ]
 
     ++ lib.optionals wantGcrypt [ libgcrypt libgpg-error ]
-    ++ lib.optional withTests glib
-    ++ lib.optional withAcl acl
-    ++ lib.optional withApparmor libapparmor
-    ++ lib.optional withAudit audit
-    ++ lib.optional wantCurl (lib.getDev curl)
+    ++ lib.optionals withTests [ glib ]
+    ++ lib.optionals withAcl [ acl ]
+    ++ lib.optionals withApparmor [ libapparmor ]
+    ++ lib.optionals withAudit [ audit ]
+    ++ lib.optionals wantCurl [ (lib.getDev curl) ]
     ++ lib.optionals withCompression [ zlib bzip2 lz4 xz zstd ]
-    ++ lib.optional withCoredump elfutils
-    ++ lib.optional withCryptsetup (lib.getDev cryptsetup.dev)
-    ++ lib.optional withKexectools kexec-tools
-    ++ lib.optional withKmod kmod
-    ++ lib.optional withLibidn2 libidn2
-    ++ lib.optional withLibseccomp libseccomp
-    ++ lib.optional withIptables iptables
-    ++ lib.optional withPam pam
-    ++ lib.optional withPCRE2 pcre2
-    ++ lib.optional withSelinux libselinux
+    ++ lib.optionals withCoredump [ elfutils ]
+    ++ lib.optionals withCryptsetup [ (lib.getDev cryptsetup.dev) ]
+    ++ lib.optionals withKexectools [ kexec-tools ]
+    ++ lib.optionals withKmod [ kmod ]
+    ++ lib.optionals withLibidn2 [ libidn2 ]
+    ++ lib.optionals withLibseccomp [ libseccomp ]
+    ++ lib.optionals withIptables [ iptables ]
+    ++ lib.optionals withPam [ pam ]
+    ++ lib.optionals withPCRE2 [ pcre2 ]
+    ++ lib.optionals withSelinux [ libselinux ]
     ++ lib.optionals withRemote [ libmicrohttpd gnutls ]
     ++ lib.optionals (withHomed || withCryptsetup) [ p11-kit ]
     ++ lib.optionals (withHomed || withCryptsetup) [ libfido2 ]
     ++ lib.optionals withLibBPF [ libbpf ]
-    ++ lib.optional withTpm2Tss tpm2-tss
-    ++ lib.optional withUkify (python3Packages.python.withPackages (ps: with ps; [ pefile ]))
+    ++ lib.optionals withTpm2Tss [ tpm2-tss ]
+    ++ lib.optionals withUkify [ (python3Packages.python.withPackages (ps: with ps; [ pefile ])) ]
     ++ lib.optionals withPasswordQuality [ libpwquality ]
     ++ lib.optionals withQrencode [ qrencode ]
   ;

--- a/pkgs/os-specific/linux/v4l-utils/default.nix
+++ b/pkgs/os-specific/linux/v4l-utils/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
     hash = "sha256-y7f+imMH9c5TOgXN7XC7k8O6BjlaubbQB+tTt12AX1s=";
   };
 
-  outputs = [ "out" ] ++ lib.optional withUtils "lib" ++ [ "dev" ];
+  outputs = [ "out" "dev" ] ++ lib.optionals withUtils [ "lib" ];
 
   configureFlags = (if withUtils then [
     "--with-localedir=${placeholder "lib"}/share/locale"

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -39,9 +39,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ perl pkg-config ];
   buildInputs = [ libidn2 libtool libxml2 openssl libuv nghttp2 jemalloc ]
-    ++ lib.optional stdenv.isLinux libcap
-    ++ lib.optional enableGSSAPI libkrb5
-    ++ lib.optional enablePython (python3.withPackages (ps: with ps; [ ply ]));
+    ++ lib.optionals stdenv.isLinux [ libcap ]
+    ++ lib.optionals enableGSSAPI [ libkrb5 ]
+    ++ lib.optionals enablePython [ (python3.withPackages (ps: with ps; [ ply ])) ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 

--- a/pkgs/servers/http/angie/default.nix
+++ b/pkgs/servers/http/angie/default.nix
@@ -17,7 +17,7 @@ callPackage ../nginx/generic.nix args rec {
     hash = "sha256-g6PyuyulnltnZJWiZ01iYG1k6Lz5nO+gneb8M4q3WHo=";
   };
 
-  configureFlags = lib.optional withQuic [
+  configureFlags = lib.optionals withQuic [
     "--with-http_v3_module"
   ];
 

--- a/pkgs/servers/search/groonga/default.nix
+++ b/pkgs/servers/search/groonga/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     msgpack-c
   ] ++ lib.optionals lz4Support [
     lz4
-  ] ++ lib.optional zlibSupport [
+  ] ++ lib.optionals zlibSupport [
     zlib
   ] ++ lib.optionals suggestSupport [
     zeromq

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -1316,7 +1316,7 @@ in
         locale
         apple_sdk.sdkRoot
       ]
-      ++ lib.optional useAppleSDKLibs [ objc4 ]
+      ++ lib.optionals useAppleSDKLibs [ objc4 ]
       ++ lib.optionals doSign [ postLinkSignHook sigtool signingUtils ]);
 
       __stdenvImpureHostDeps = commonImpureHostDeps;

--- a/pkgs/tools/filesystems/garage/default.nix
+++ b/pkgs/tools/filesystems/garage/default.nix
@@ -49,13 +49,14 @@ let
     buildFeatures = [
       "kubernetes-discovery"
       "bundled-libs"
-    ] ++ lib.optional (lib.versionOlder version "1.0") "sled" ++ [
       "metrics"
       "k2v"
       "telemetry-otlp"
       "lmdb"
       "sqlite"
       "consul-discovery"
+    ] ++ lib.optionals (lib.versionOlder version "1.0") [
+      "sled"
     ];
 
     # To make integration tests pass, we include the optional k2v feature here,
@@ -65,9 +66,10 @@ let
       "k2v"
       "kubernetes-discovery"
       "bundled-libs"
-    ] ++ lib.optional (lib.versionOlder version "1.0") "sled" ++ [
       "lmdb"
       "sqlite"
+    ] ++ lib.optionals (lib.versionOlder version "1.0") [
+      "sled"
     ];
 
     disabledTests = [

--- a/pkgs/tools/misc/lesspipe/default.nix
+++ b/pkgs/tools/misc/lesspipe/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
           "mdcat" "pandoc" "docx2txt" "libreoffice" "pptx2md" "mdcat" "xlscat" "odt2txt" "wvText" "antiword" "catdoc"
           "broken_catppt" "sxw2txt" "groff" "mandoc" "unrtf" "dvi2tty" "pod2text" "perldoc" "h5dump" "ncdump" "matdump"
           "djvutxt" "openssl" "gpg" "plistutil" "plutil" "id3v2" "csvlook" "jq" "zlib-flate" "lessfilter"
-        ] ++ lib.optional stdenv.isDarwin [
+        ] ++ lib.optionals stdenv.isDarwin [
           # resholve only identifies this on darwin
           # call site is gaurded by || so it's safe to leave dynamic
           "locale"

--- a/pkgs/tools/networking/tcpdump/default.nix
+++ b/pkgs/tools/networking/tcpdump/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     patchShebangs tests
   '';
 
-  nativeBuildInputs = lib.optional (stdenv.hostPlatform.isStatic) [ pkg-config ];
+  nativeBuildInputs = lib.optionals (stdenv.hostPlatform.isStatic) [ pkg-config ];
 
   nativeCheckInputs = [ perl ];
 

--- a/pkgs/tools/nix/npins/default.nix
+++ b/pkgs/tools/nix/npins/default.nix
@@ -21,7 +21,7 @@ in rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-eySVpmCVWBJfyAkTQv+LqojWMO/3r6kBYP1a4z+FYHY=";
 
-  buildInputs = lib.optional stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Security ]);
+  buildInputs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Security ]);
   nativeBuildInputs = [ makeWrapper ];
 
   # (Almost) all tests require internet

--- a/pkgs/tools/virtualization/mkosi/default.nix
+++ b/pkgs/tools/virtualization/mkosi/default.nix
@@ -96,7 +96,7 @@ buildPythonApplication rec {
     kmod
     systemdForMkosi
     util-linux
-  ] ++ lib.optional withQemu [
+  ] ++ lib.optionals withQemu [
     qemu
   ];
 


### PR DESCRIPTION
This PR updates `nixpkgs` by replacing instances of `lib.optional` with `lib.optionals` where appropriate. This change aims to standardize our usage of these functions and make the codebase more intuitive, especially for new contributors.

The `lib.optional` function generates a list containing the value if the condition is true, and an empty list if false. The `lib.optionals` function, on the other hand, doesn't wrap values by default. Here is a quick reminder of how both functions behave:

```nix
nix-repl> lib.optionals true "foo"
"foo"
nix-repl> lib.optionals false "foo"
[]
nix-repl> lib.optional true "foo"
[ "foo" ]
nix-repl> lib.optional false "foo"
[]
nix-repl> lib.optional true [ "foo" ]
[ [ ... ] ]
nix-repl> lib.optional false [ "foo" ]
[ ]
```

During code reviews, I have frequently noticed incorrect usage of `lib.optional` and `lib.optionals`. By consistently adopting `lib.optionals`, we can avoid common errors such as unintentionally nested lists when a flat list is expected. This function's explicit need for bracketed output also improves readability and reduces ambiguity, lowering the barrier for new contributors and ensuring alignment with common Nix naming patterns.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
