### PR TITLE
release-plz: init at 0.3.72

### DIFF
--- a/pkgs/by-name/re/release-plz/package.nix
+++ b/pkgs/by-name/re/release-plz/package.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, installShellFiles
+, pkg-config
+, perl
+, openssl
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "release-plz";
+  version = "0.3.72";
+
+  src = fetchFromGitHub {
+    owner = "MarcoIeni";
+    repo = "release-plz";
+    rev = "release-plz-v${version}";
+    hash = "sha256-wc/+X/P/FKDpvw0U7ItIgzHbqsEnngHk4wt7Pjzk594=";
+  };
+
+  cargoHash = "sha256-RB+NXuASfpx6tZJfG18Hj7JOfXK9FIqSD7QaDfGUHi4=";
+
+  nativeBuildInputs = [ installShellFiles pkg-config perl ];
+  buildInputs = [ openssl ];
+
+  buildAndTestSubdir = "crates/release_plz";
+
+  # Tests depend on additional infrastructure to be running locally
+  doCheck = false;
+
+  postInstall = ''
+    installShellCompletion --cmd ${meta.mainProgram} \
+      --bash <($out/bin/${meta.mainProgram} generate-completions bash) \
+      --fish <($out/bin/${meta.mainProgram} generate-completions fish) \
+      --zsh <($out/bin/${meta.mainProgram} generate-completions zsh)
+  '';
+
+  meta = {
+    description = "Publish Rust crates from CI with a Release PR";
+    homepage = "https://release-plz.ieni.dev";
+    license = with lib.licenses; [ asl20 mit ];
+    maintainers = with lib.maintainers; [ dannixon ];
+    mainProgram = "release-plz";
+    broken = stdenv.isDarwin;
+  };
+}


### PR DESCRIPTION
## Description of changes

Packages [release-plz](https://github.com/MarcoIeni/release-plz).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
