### PR TITLE
clang-uml: init at 0.5.1

### DIFF
--- a/pkgs/by-name/cl/clang-uml/package.nix
+++ b/pkgs/by-name/cl/clang-uml/package.nix
@@ -1,0 +1,79 @@
+{ lib
+, fetchFromGitHub
+, stdenv
+, cmake
+, pkg-config
+, installShellFiles
+, libclang
+, clang
+, llvmPackages
+, libllvm
+, yaml-cpp
+, elfutils
+, libunwind
+, enableLibcxx ? false
+, debug ? false
+,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "clang-uml";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "bkryza";
+    repo = "clang-uml";
+    rev = finalAttrs.version;
+    hash = "sha256-ZVaMLsI1FK05xFfMmlLBPop7DR3fDstnfgjdBmsjNBA=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    installShellFiles
+  ] ++ (if debug then [
+    elfutils
+    libunwind
+  ] else [ ]);
+
+  buildInputs = [
+    clang
+    libclang
+    libllvm
+    yaml-cpp
+  ];
+
+  cmakeFlags = if debug then [ "-DCMAKE_BUILD_TYPE=Debug" ] else [ ];
+
+  clang = if enableLibcxx then llvmPackages.libcxxClang else llvmPackages.clang;
+
+  postInstall = ''
+    cp $out/bin/clang-uml $out/bin/clang-uml-unwrapped
+    rm $out/bin/clang-uml
+    export unwrapped_clang_uml="$out/bin/clang-uml-unwrapped"
+
+    # inject clang and unwrapp_clang_uml variables into wrapper
+    substituteAll ${./wrapper} $out/bin/clang-uml
+    chmod +x $out/bin/clang-uml
+
+    installShellCompletion --cmd clang-uml \
+      --bash $src/packaging/autocomplete/clang-uml \
+      --zsh $src/packaging/autocomplete/_clang-uml
+  '';
+
+  dontFixup = debug;
+  dontStrip = debug;
+
+  meta = with lib; {
+    description = "Customizable automatic UML diagram generator for C++ based on Clang.";
+    longDescription = ''
+      clang-uml is an automatic C++ to UML class, sequence, package and include diagram generator, driven by YAML configuration files.
+      The main idea behind the project is to easily maintain up-to-date diagrams within a code-base or document legacy code.
+      The configuration file or files for clang-uml define the types and contents of each generated diagram.
+      The diagrams can be generated in PlantUML, MermaidJS and JSON formats.
+    '';
+    maintainers = with maintainers; [ eymeric ];
+    homepage = "https://clang-uml.github.io/";
+    license = licenses.asl20;
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/by-name/cl/clang-uml/wrapper
+++ b/pkgs/by-name/cl/clang-uml/wrapper
@@ -1,0 +1,31 @@
+#!/bin/sh
+# This file is copied from https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/clang-tools/wrapper
+# The clang-tools wrapper is commonly used together with the clang package on
+# nix, because without the wrapper, clang tools fail to find stdlib includes on
+# nix.
+
+buildcpath() {
+  local path after
+  while (( $# )); do
+    case $1 in
+        -isystem)
+            shift
+            path=$path${path:+':'}$1
+            ;;
+        -idirafter)
+            shift
+            after=$after${after:+':'}$1
+            ;;
+    esac
+    shift
+  done
+  echo $path${after:+':'}$after
+}
+
+export CPATH=${CPATH}${CPATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
+                                               $(<@clang@/nix-support/libc-cflags)):@clang@/resource-root/include
+export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}${CPLUS_INCLUDE_PATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
+                                                                                      $(<@clang@/nix-support/libcxx-cxxflags) \
+                                                                                      $(<@clang@/nix-support/libc-cflags)):@clang@/resource-root/include
+
+exec @unwrapped_clang_uml@ "$@"


### PR DESCRIPTION
## Description of changes

Add the package clang-uml

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
