### PR TITLE
chromium: 123.0.6312.122 -> 124.0.6367.60, fix M124+ build by using the vendored libwebp

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -102,7 +102,14 @@ let
     "flac"
     "libjpeg"
     "libpng"
+  ] ++ lib.optionals (!chromiumVersionAtLeast "124") [
+    # Use the vendored libwebp for M124+ until we figure out how to solve:
+    # Running phase: configurePhase
+    # ERROR Unresolved dependencies.
+    # //third_party/libavif:libavif_enc(//build/toolchain/linux/unbundle:default)
+    #   needs //third_party/libwebp:libwebp_sharpyuv(//build/toolchain/linux/unbundle:default)
     "libwebp"
+  ] ++ [
     "libxslt"
     # "opus"
   ];

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -248,6 +248,15 @@ let
       # Partial revert of https://github.com/chromium/chromium/commit/3687976b0c6d36cf4157419a24a39f6770098d61
       # allowing us to use our rustc and our clang.
       ./patches/chromium-121-rust.patch
+    ] ++ lib.optionals (chromiumVersionAtLeast "124" && !chromiumVersionAtLeast "125") [
+      # M124 shipped with broken --ozone-platform-hint flag handling, which we rely on
+      # for our NIXOS_OZONE_WL (wayland) environment variable.
+      # See <https://issues.chromium.org/issues/329678163>.
+      # This is the commit for the fix that landed in M125, which applies clean on M124.
+      (githubPatch {
+        commit = "c7f4c58f896a651eba80ad805ebdb49d19ebdbd4";
+        hash = "sha256-6nYWT2zN+j73xAIXLdGYT2eC71vGnGfiLCB0OwT0CAI=";
+      })
     ];
 
     postPatch = ''

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -9,15 +9,15 @@
     };
     deps = {
       gn = {
-        hash = "sha256-JvilCnnb4laqwq69fay+IdAujYC1EHD7uWpkF/C8tBw=";
-        rev = "d4f94f9a6c25497b2ce0356bb99a8d202c8c1d32";
+        hash = "sha256-aEL1kIhgPAFqdb174dG093HoLhCJ07O1Kpqfu7r14wQ=";
+        rev = "22581fb46c0c0c9530caa67149ee4dd8811063cf";
         url = "https://gn.googlesource.com/gn";
-        version = "2024-02-19";
+        version = "2024-03-14";
       };
     };
-    hash = "sha256-7H7h621AHPyhFYbaVFO892TtS+SP3Qu7cYUVk3ICL14=";
-    hash_deb_amd64 = "sha256-tNkO1mPZg1xltBfoWeNhLekITtZV/WNgu//i2DJb17c=";
-    version = "123.0.6312.122";
+    hash = "sha256-apEniFKhIxPo4nhp9gCU+WpiV/EB40qif4RfE7Uniog=";
+    hash_deb_amd64 = "sha256-rSbigG5/xbL32d1ntOn6gnZyxSpgrg1h7lb/RD4YROI=";
+    version = "124.0.6367.60";
   };
   ungoogled-chromium = {
     deps = {


### PR DESCRIPTION
## Description of changes

https://chromereleases.googleblog.com/2024/04/stable-channel-update-for-desktop_16.html

This update includes 23 security fixes.

CVEs:
CVE-2024-3832 CVE-2024-3833 CVE-2024-3914 CVE-2024-3834 CVE-2024-3837
CVE-2024-3838 CVE-2024-3839 CVE-2024-3840 CVE-2024-3841 CVE-2024-3843
CVE-2024-3844 CVE-2024-3845 CVE-2024-3846 CVE-2024-3847

Building with our libwebp runs into the following error:

~~~
Running phase: configurePhase
ERROR Unresolved dependencies.
//third_party/libavif:libavif_enc(//build/toolchain/linux/unbundle:default)
  needs //third_party/libwebp:libwebp_sharpyuv(//build/toolchain/linux/unbundle:default)
~~~ 

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
