### PR TITLE
dotnet: fix --self-contained builds

### DIFF
--- a/pkgs/applications/audio/galaxy-buds-client/default.nix
+++ b/pkgs/applications/audio/galaxy-buds-client/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , buildDotnetModule
 , fetchFromGitHub
-, autoPatchelfHook
 , fontconfig
 , xorg
 , libglvnd
@@ -27,7 +26,6 @@ buildDotnetModule rec {
   dotnetFlags = [ "-p:Runtimeidentifier=linux-x64" ];
 
   nativeBuildInputs = [
-    autoPatchelfHook
     copyDesktopItems
     graphicsmagick
   ];

--- a/pkgs/applications/blockchains/wasabibackend/default.nix
+++ b/pkgs/applications/blockchains/wasabibackend/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   buildDotnetModule,
   dotnetCorePackages,
-  autoPatchelfHook,
   zlib,
   openssl,
 }:
@@ -25,7 +24,6 @@ buildDotnetModule rec {
   dotnet-sdk = dotnetCorePackages.sdk_7_0;
   dotnet-runtime = dotnetCorePackages.aspnetcore_7_0;
 
-  nativeBuildInputs = [autoPatchelfHook];
   buildInputs = [stdenv.cc.cc.lib zlib];
 
   runtimeDeps = [openssl zlib];

--- a/pkgs/applications/misc/avalonia-ilspy/default.nix
+++ b/pkgs/applications/misc/avalonia-ilspy/default.nix
@@ -15,7 +15,6 @@
 , makeDesktopItem
 , copyDesktopItems
 , icoutils
-, autoPatchelfHook
 , bintools
 , fixDarwinDylibNames
 , autoSignDarwinBinariesHook
@@ -40,8 +39,7 @@ buildDotnetModule rec {
   nativeBuildInputs = [
     copyDesktopItems
     icoutils
-  ] ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ bintools fixDarwinDylibNames ]
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ bintools fixDarwinDylibNames ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [ autoSignDarwinBinariesHook ];
 
   buildInputs = [

--- a/pkgs/development/compilers/dotnet/build-dotnet.nix
+++ b/pkgs/development/compilers/dotnet/build-dotnet.nix
@@ -25,6 +25,7 @@ assert if type == "sdk" then packages != null else true;
 , writeShellScript
 , mkNugetDeps
 , callPackage
+, dotnetCorePackages
 }:
 
 let
@@ -43,6 +44,8 @@ let
   };
 
   mkCommon = callPackage ./common.nix {};
+
+  targetRid = dotnetCorePackages.systemToDotnetRid stdenv.targetPlatform.system;
 
 in
 mkCommon type rec {
@@ -88,21 +91,21 @@ mkCommon type rec {
 
   # Tell autoPatchelf about runtime dependencies.
   # (postFixup phase is run before autoPatchelfHook.)
-  postFixup = lib.optionalString stdenv.isLinux ''
+  postFixup = lib.optionalString stdenv.targetPlatform.isLinux ''
     patchelf \
       --add-needed libicui18n.so \
       --add-needed libicuuc.so \
       $out/shared/Microsoft.NETCore.App/*/libcoreclr.so \
       $out/shared/Microsoft.NETCore.App/*/*System.Globalization.Native.so \
-      $out/packs/Microsoft.NETCore.App.Host.linux-x64/*/runtimes/linux-x64/native/singlefilehost
+      $out/packs/Microsoft.NETCore.App.Host.${targetRid}/*/runtimes/${targetRid}/native/*host
     patchelf \
       --add-needed libgssapi_krb5.so \
       $out/shared/Microsoft.NETCore.App/*/*System.Net.Security.Native.so \
-      $out/packs/Microsoft.NETCore.App.Host.linux-x64/*/runtimes/linux-x64/native/singlefilehost
+      $out/packs/Microsoft.NETCore.App.Host.${targetRid}/*/runtimes/${targetRid}/native/*host
     patchelf \
       --add-needed libssl.so \
       $out/shared/Microsoft.NETCore.App/*/*System.Security.Cryptography.Native.OpenSsl.so \
-      $out/packs/Microsoft.NETCore.App.Host.linux-x64/*/runtimes/linux-x64/native/singlefilehost
+      $out/packs/Microsoft.NETCore.App.Host.${targetRid}/*/runtimes/${targetRid}/native/*host
   '';
 
   passthru = {

--- a/pkgs/development/compilers/dotnet/common.nix
+++ b/pkgs/development/compilers/dotnet/common.nix
@@ -63,7 +63,7 @@
           '' + build);
         in
           if run == null
-            then build
+            then built
           else
             runCommand "${built.name}-run" { src = built; nativeBuildInputs = runInputs; } (
               lib.optionalString (runtime != null) ''

--- a/pkgs/development/compilers/dotnet/common.nix
+++ b/pkgs/development/compilers/dotnet/common.nix
@@ -98,6 +98,15 @@
         run = checkConsoleOutput "$src/test";
       };
 
+      self-contained = mkDotnetTest {
+        name = "self-contained";
+        template = "console";
+        usePackageSource = true;
+        build = "dotnet publish --use-current-runtime --sc -o $out";
+        runtime = null;
+        run = checkConsoleOutput "$src/test";
+      };
+
       single-file = mkDotnetTest {
         name = "single-file";
         template = "console";

--- a/pkgs/development/compilers/dotnet/common.nix
+++ b/pkgs/development/compilers/dotnet/common.nix
@@ -71,8 +71,10 @@
                 export DOTNET_ROOT=${runtime}
               '' + run);
 
+      # Setting LANG to something other than 'C' forces the runtime to search
+      # for ICU, which will be required in most user environments.
       checkConsoleOutput = command: ''
-        output="$(${command})"
+        output="$(LANG=C.UTF-8 ${command})"
         # yes, older SDKs omit the comma
         [[ "$output" =~ Hello,?\ World! ]] && touch "$out"
       '';

--- a/pkgs/development/compilers/inklecate/default.nix
+++ b/pkgs/development/compilers/inklecate/default.nix
@@ -1,6 +1,5 @@
 { lib
 , stdenv
-, autoPatchelfHook
 , buildDotnetModule
 , dotnetCorePackages
 , fetchFromGitHub
@@ -17,7 +16,6 @@ buildDotnetModule rec {
     hash = "sha512-aUjjT5Qf64wrKRn1vkwJadMOBWMkvsXUjtZ7S3/ZWAh1CCDkQNO84mSbtbVc9ny0fKeJEqaDX2tJNwq7pYqAbA==";
   };
 
-  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
   buildInputs = [ stdenv.cc.cc.lib ];
 
   projectFile = "inklecate/inklecate.csproj";

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -1,5 +1,4 @@
-{ autoPatchelfHook
-, autoSignDarwinBinariesHook
+{ autoSignDarwinBinariesHook
 , buildDotnetModule
 , dotnetCorePackages
 , fetchFromGitHub
@@ -114,8 +113,6 @@ buildDotnetModule rec {
   nativeBuildInputs = [
     which
     git
-  ] ++ lib.optionals stdenv.isLinux [
-    autoPatchelfHook
   ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
     autoSignDarwinBinariesHook
   ];

--- a/pkgs/tools/games/opentracker/default.nix
+++ b/pkgs/tools/games/opentracker/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildDotnetModule,
   fetchFromGitHub,
-  autoPatchelfHook,
   wrapGAppsHook,
   dotnetCorePackages,
   fontconfig,
@@ -40,7 +39,6 @@ buildDotnetModule rec {
   ];
 
   nativeBuildInputs = [
-    autoPatchelfHook
     wrapGAppsHook
   ];
 
@@ -63,12 +61,6 @@ buildDotnetModule rec {
       libX11
       libXi
     ]);
-
-  # Attempts to patchelf unneeded SOs
-  autoPatchelfIgnoreMissingDeps = [
-    "libc.musl-x86_64.so.1"
-    "libintl.so.8"
-  ];
 
   meta = with lib; {
     description = "A tracking application for A Link to the Past Randomizer";

--- a/pkgs/tools/networking/mqttmultimeter/default.nix
+++ b/pkgs/tools/networking/mqttmultimeter/default.nix
@@ -4,16 +4,12 @@
 , dotnet-runtime_8
 , buildDotnetModule
 , fetchFromGitHub
-, autoPatchelfHook
 , fontconfig
 , xorg
 , libglvnd
 , makeDesktopItem
 , copyDesktopItems
 }:
-
-# NOTES:
-# 1. we need autoPatchelfHook for quite a number of things in $out/lib
 
 buildDotnetModule rec {
   pname = "mqttmultimeter";
@@ -35,13 +31,11 @@ buildDotnetModule rec {
   executables = [ "mqttMultimeter" ];
 
   nativeBuildInputs = [
-    autoPatchelfHook
     copyDesktopItems
   ];
 
   buildInputs = [ stdenv.cc.cc.lib fontconfig ];
 
-  # don't care about musl and windows versions, as they fail autoPatchelfHook
   postInstall = ''
     rm -rf $out/lib/${lib.toLower pname}/runtimes/{*musl*,win*}
   '';


### PR DESCRIPTION
## Description of changes

Builds using `--self-contained` (but not `PublishSingleFile`) would fail with

> Process terminated. Couldn't find a valid ICU package installed on the system. Please install libicu (or icu-libs) using your package manager and try again. Alternatively you can set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support. Please see https://aka.ms/dotnet-missing-libicu for more information.

This was due to `singlefilehost` being patched, but not `apphost`.

This PR also adds a test for this build configuration, and sets `LANG` in all tests, to force ICU to be loaded.

FYI @NixOS/dotnet 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
