### PR TITLE
firefoxpwa: fix libEGL detection

### DIFF
--- a/pkgs/by-name/fi/firefoxpwa/package.nix
+++ b/pkgs/by-name/fi/firefoxpwa/package.nix
@@ -10,6 +10,7 @@
   cups,
   firefox-unwrapped,
   libcanberra-gtk3,
+  libglvnd,
   libnotify,
   libva,
   mesa,
@@ -67,6 +68,7 @@ rustPlatform.buildRustPackage rec {
       libs =
         lib.optionals stdenv.isLinux [
           cups
+          libglvnd
           libnotify
           libva
           mesa

--- a/pkgs/by-name/fi/firefoxpwa/package.nix
+++ b/pkgs/by-name/fi/firefoxpwa/package.nix
@@ -150,6 +150,7 @@ rustPlatform.buildRustPackage rec {
     license = licenses.mpl20;
     platforms = platforms.unix;
     maintainers = with maintainers; [
+      adamcstephens
       camillemndn
       pasqui23
     ];

--- a/pkgs/by-name/fi/firefoxpwa/package.nix
+++ b/pkgs/by-name/fi/firefoxpwa/package.nix
@@ -1,22 +1,25 @@
-{ lib
-, rustPlatform
-, fetchFromGitHub
-, makeWrapper
-, pkg-config
-, installShellFiles
-, firefox-unwrapped
-, openssl
-, stdenv
-, udev
-, libva
-, mesa
-, libnotify
-, xorg
-, cups
-, pciutils
-, libcanberra-gtk3
-, extraLibs ? [ ]
-, nixosTests
+{
+  extraLibs ? [ ],
+
+  lib,
+  fetchFromGitHub,
+  installShellFiles,
+  makeWrapper,
+  rustPlatform,
+
+  cups,
+  firefox-unwrapped,
+  libcanberra-gtk3,
+  libnotify,
+  libva,
+  mesa,
+  nixosTests,
+  openssl,
+  pciutils,
+  pkg-config,
+  stdenv,
+  udev,
+  xorg,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -47,7 +50,11 @@ rustPlatform.buildRustPackage rec {
     sed -i $'s;DISTRIBUTION_VERSION = \'0.0.0\';DISTRIBUTION_VERSION = \'${version}\';' userchrome/profile/chrome/pwa/chrome.jsm
   '';
 
-  nativeBuildInputs = [ makeWrapper pkg-config installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+    pkg-config
+  ];
   buildInputs = [ openssl ];
 
   FFPWA_EXECUTABLES = ""; # .desktop entries generated without any store path references
@@ -55,7 +62,22 @@ rustPlatform.buildRustPackage rec {
   completions = "target/${stdenv.targetPlatform.config}/release/completions";
 
   gtk_modules = map (x: x + x.gtkModule) [ libcanberra-gtk3 ];
-  libs = let libs = lib.optionals stdenv.isLinux [ udev libva mesa libnotify xorg.libXScrnSaver cups pciutils ] ++ gtk_modules ++ extraLibs; in lib.makeLibraryPath libs + ":" + lib.makeSearchPathOutput "lib" "lib64" libs;
+  libs =
+    let
+      libs =
+        lib.optionals stdenv.isLinux [
+          cups
+          libnotify
+          libva
+          mesa
+          pciutils
+          udev
+          xorg.libXScrnSaver
+        ]
+        ++ gtk_modules
+        ++ extraLibs;
+    in
+    lib.makeLibraryPath libs + ":" + lib.makeSearchPathOutput "lib" "lib64" libs;
 
   postInstall = ''
     # Runtime
@@ -127,7 +149,10 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/filips123/PWAsForFirefox/releases/tag/v${version}";
     license = licenses.mpl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ camillemndn pasqui23 ];
+    maintainers = with maintainers; [
+      camillemndn
+      pasqui23
+    ];
     mainProgram = "firefoxpwa";
   };
 }


### PR DESCRIPTION
## Description of changes

Fixes libEGL detection, ensuring hardware acceleration.

Previously:
```
[GFX1-]: glxtest: libEGL missing
[GFX1-]: glxtest: EGL test failed
[GFX1-]: No GPUs detected via PCI
```

Also added myself as a maintainer, and applied formatting. I'm willing to remove the formatting if requested.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
