### PR TITLE
Update ayatana datetime & some OTA-less Lomiri things

### DIFF
--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
@@ -44,13 +44,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-system-settings-unwrapped";
-  version = "1.0.2";
+  version = "1.1.0";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-system-settings";
     rev = finalAttrs.version;
-    hash = "sha256-gi6ZujIs0AEDLsqcTNlRNSS8SyqEU6q0+xaDf55XwuM=";
+    hash = "sha256-Po5eArO7zyaGatTf6kqci3DdzFDJSZakeglbiMx9kR8=";
   };
 
   outputs = [
@@ -73,34 +73,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-lSKAhtE3oSSv7USvDbbcfBZWAtWMmuKneWawKQABIiM=";
     })
 
-    # Remove when version > 1.0.2
+    # Fixes tests with very-recent python-dbusmock
+    # Remove when version > 1.1.0
     (fetchpatch {
-      name = "0003-lomiri-system-settings-Use-GSettings-for-DT2W-value.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/commit/29e2533efcac23e41b083b11c540c9221b71de7e.patch";
-      hash = "sha256-d52d/b1ZdafaqhOljCg5E3I12XWtFAfG4rmn8CYngB4=";
-    })
-  ] ++ lib.optionals (lib.strings.versionOlder python3.pkgs.python-dbusmock.version "0.30.1") [
-    # Makes tests work with newer dbusmock, but breaks with much-newer dbusmock
-    # See for details:
-    # - https://gitlab.com/ubports/development/core/lomiri-system-settings/-/merge_requests/354
-    # - https://gitlab.com/ubports/development/core/lomiri-system-settings/-/merge_requests/426
-    # Remove/adjust based on merges & next LSS release, and packaged version of dbusmock
-    (fetchpatch {
-      name = "0101-lomiri-system-settings-Pass-missing-parameters-to-dbusmock.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/commit/b9aacd88e3789dbb7578f32b31ad5b239db227a2.patch";
-      hash = "sha256-jf+jMc+6QxONavlX5C9UZyX23jb6fZnYV8mWFyQGGbU=";
-    })
-    (fetchpatch {
-      name = "0102-lomiri-system-settings-Fix-BT-plugin-testIsPaired.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/commit/e39b9728e18635413f07f9c9f6ddc73208260b2a.patch";
-      hash = "sha256-YUtdlQ2XcanXzsxD40SbML7fSxG75yMKz/XnaQN9YP8=";
-    })
-    (fetchpatch {
-      name = "0103-lomiri-system-settings-Fix-BT-plugin-testGet-IconName-Type.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/commit/9ad5d9324945f06f764d3a963dbfc7bccefe574b.patch";
-      # Merge conflict, relevant change handled further down
-      excludes = [ "CMakeLists.txt" ];
-      hash = "sha256-QCgkVos9Q9/8jd25rqzdEKdnBw0Re47X7B9nLH8QOQU=";
+      name = "0003-lomiri-system-settings-Revert-Pass-missing-parameter-to-dbusmock-bluez-PairDevice-function.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/commit/67d9e28ebab8bdb9473d5bf8da2b7573e6848fa2.patch";
+      hash = "sha256-pFWNne2UH3R5Fz9ayHvIpDXDQbXPs0k4b/oRg0fzi+s=";
     })
   ] ++ [
 

--- a/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/2001-Mark-problematic-tests.patch
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/2001-Mark-problematic-tests.patch
@@ -1,20 +1,18 @@
-From 243477a2bd6e315c77ebaf5b2ed4a9c9c4e1e22a Mon Sep 17 00:00:00 2001
-From: OPNA2608 <christoph.neidahl@gmail.com>
-Date: Sat, 25 Nov 2023 10:49:32 +0100
+From c71d5fed4ef1f0b6d56400cddf02d8ac438168c8 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Wed, 17 Apr 2024 16:18:23 +0200
 Subject: [PATCH] Mark problematic tests
 
 - ShapeMaterial requires a Qt OpenGL context, doesn't work in our sandbox
 - SignalSpy on QML shaders compilers don't see changes
-- Scaling value from environment not picked up properly since Qt 5.15.11
-  https://gitlab.com/ubports/development/core/lomiri-ui-toolkit/-/issues/34
 - TypeError on some properties with Qt 5.15
   https://gitlab.com/ubports/development/core/lomiri-ui-toolkit/-/issues/9
 ---
- tests/checkresults.sh | 89 ++++++++++++++++++++++++++++++++++++++++---
- 1 file changed, 83 insertions(+), 6 deletions(-)
+ tests/checkresults.sh | 88 ++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 82 insertions(+), 6 deletions(-)
 
 diff --git a/tests/checkresults.sh b/tests/checkresults.sh
-index fc498985e..730b9d406 100755
+index fc498985e..b5d204d0d 100755
 --- a/tests/checkresults.sh
 +++ b/tests/checkresults.sh
 @@ -22,6 +22,7 @@ ERRORS_PATTERN='<failure'
@@ -25,7 +23,7 @@ index fc498985e..730b9d406 100755
  EXCEPTED=0
  for _XML in $*; do
      _TESTNAME=$(basename $_XML | sed -r 's@(.+)\.xml@\1@' -)
-@@ -31,7 +32,72 @@ for _XML in $*; do
+@@ -31,7 +32,71 @@ for _XML in $*; do
        exit 1
      fi
  
@@ -91,7 +89,6 @@ index fc498985e..730b9d406 100755
 +                swipearea \
 +                tst_icon.11.qml \
 +                tst_icon.13.qml \
-+                dpr1 \
 +                '
 +
 +    EXCEPTIONS='\
@@ -99,7 +96,7 @@ index fc498985e..730b9d406 100755
                  tst_tabbar.11.qml \
                  tst_datepicker.bug1567840.SEGFAULT.12.qml \
                  tst_datepicker.bug1567840.SEGFAULT.13.qml \
-@@ -49,22 +115,28 @@ for _XML in $*; do
+@@ -49,22 +114,28 @@ for _XML in $*; do
                  inversemousearea \
                  tst_listitem_focus_bug.13.qml \
                  tst_shortcuts.13.qml \
@@ -132,7 +129,7 @@ index fc498985e..730b9d406 100755
        WOOT_FILES="${WOOT_FILES}  ${_TESTNAME}\n"
      fi
  done
-@@ -82,6 +154,11 @@ if [ -n "$FATAL_WARNINGS_FILES" ]; then
+@@ -82,6 +153,11 @@ if [ -n "$FATAL_WARNINGS_FILES" ]; then
      echo -e "$FATAL_WARNINGS_FILES"
  fi
  
@@ -144,7 +141,7 @@ index fc498985e..730b9d406 100755
  if [ -n "$EXCEPTED_FILES" ]; then
      echo The following tests issued $EXCEPTED expected warnings:
      echo -e "$EXCEPTED_FILES"
-@@ -89,7 +166,7 @@ fi
+@@ -89,7 +165,7 @@ fi
  
  if [ -n "$WOOT_FILES" ]; then
      echo Woot! Known problematic tests passed!
@@ -154,5 +151,5 @@ index fc498985e..730b9d406 100755
  fi
  
 -- 
-2.40.1
+2.42.0
 

--- a/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitLab
-, fetchpatch
 , gitUpdater
 , substituteAll
 , testers
@@ -35,30 +34,18 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-ui-toolkit";
-  version = "1.3.5012";
+  version = "1.3.5100";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-ui-toolkit";
     rev = finalAttrs.version;
-    hash = "sha256-Azz2IOm/7XRvDbyIKaYxrkR47evSB17ejtssuEJayPc=";
+    hash = "sha256-r+wUCl+ywFcgFYo7BjBoXiulQptd1Zd3LJchXiMtx4I=";
   };
 
   outputs = [ "out" "dev" ];
 
   patches = [
-    # Upstreaming effort for these two patches: https://gitlab.com/ubports/development/core/lomiri-ui-toolkit/-/merge_requests/44
-    (fetchpatch {
-      name = "0001-lomiri-ui-toolkit-fix-tests-on-qt-5.15.4.patch";
-      url = "https://salsa.debian.org/ubports-team/lomiri-ui-toolkit/-/raw/1ad650c326ba9706d549d1dbe8335c70f6b382c8/debian/patches/0001-fix-tests-on-qt-5.15.4.patch";
-      hash = "sha256-Y5HVvulR2760DBzlmYkImbJ/qIeqMISqPpUppbv8xJA=";
-    })
-    (fetchpatch {
-      name = "0002-lomiri-ui-toolkit-fix-tests-on-qt-5.15.5.patch";
-      url = "https://salsa.debian.org/ubports-team/lomiri-ui-toolkit/-/raw/03bcafadd3e4fda34bcb5af23454f4b202cf5517/debian/patches/0002-fix-tests-on-qt-5.15.5.patch";
-      hash = "sha256-x8Zk7+VBSlM16a3V1yxJqIB63796H0lsS+F4dvR/z80=";
-    })
-
     ./2001-Mark-problematic-tests.patch
     (substituteAll {
       src = ./2002-Nixpkgs-versioned-QML-path.patch.in;
@@ -70,18 +57,15 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     patchShebangs documentation/docs.sh tests/
 
-    substituteInPlace tests/tests.pro \
-      --replace "\''$\''$PYTHONDIR" "$dev/${python3.sitePackages}"
-
     for subproject in po app-launch-profiler lomiri-ui-toolkit-launcher; do
       substituteInPlace $subproject/$subproject.pro \
-        --replace "\''$\''$[QT_INSTALL_PREFIX]" "$out" \
-        --replace "\''$\''$[QT_INSTALL_LIBS]" "$out/lib"
+        --replace-fail "\''$\''$[QT_INSTALL_PREFIX]" "$out" \
+        --replace-warn "\''$\''$[QT_INSTALL_LIBS]" "$out/lib"
     done
 
     # Install apicheck tool into bin
     substituteInPlace apicheck/apicheck.pro \
-      --replace "\''$\''$[QT_INSTALL_LIBS]/lomiri-ui-toolkit" "$out/bin"
+      --replace-fail "\''$\''$[QT_INSTALL_LIBS]/lomiri-ui-toolkit" "$out/bin"
 
     # Causes redefinition error with our own fortify hardening
     sed -i '/DEFINES += _FORTIFY_SOURCE/d' features/lomiri_common.prf
@@ -98,19 +82,19 @@ stdenv.mkDerivation (finalAttrs: {
     # Using /run/current-system/sw/share/locale instead of /usr/share/locale isn't a great
     # solution, but at least it should get us working localisations
     substituteInPlace src/LomiriToolkit/i18n.cpp \
-      --replace "/usr" "/run/current-system/sw"
+      --replace-fail "/usr" "/run/current-system/sw"
 
     # The code here overrides the regular QML import variables so the just-built modules are found & used in the tests
     # But we need their QML dependencies too, so put them back in there
     substituteInPlace export_qml_dir.sh \
-      --replace '_IMPORT_PATH=$BUILD_DIR/qml' '_IMPORT_PATH=$BUILD_DIR/qml:${qtQmlPaths}'
+      --replace-fail '_IMPORT_PATH=$BUILD_DIR/qml' '_IMPORT_PATH=$BUILD_DIR/qml:${qtQmlPaths}'
 
     # These tests try to load Suru theme icons, but override XDG_DATA_DIRS / use full paths to load them
     substituteInPlace \
       tests/unit/visual/tst_visual.cpp \
       tests/unit/visual/tst_icon.{11,13}.qml \
       tests/unit/visual/tst_imageprovider.11.qml \
-      --replace '/usr/share' '${suru-icon-theme}/share'
+      --replace-fail '/usr/share' '${suru-icon-theme}/share'
   '';
 
   # With strictDeps, QMake only picks up Qt dependencies from nativeBuildInputs
@@ -190,7 +174,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Qt-generated wrapper script lacks QML paths to dependencies
     for qmlModule in Components PerformanceMetrics Test; do
       substituteInPlace src/imports/$qmlModule/wrapper.sh \
-        --replace 'QML2_IMPORT_PATH=' 'QML2_IMPORT_PATH=${qtQmlPaths}:'
+        --replace-fail 'QML2_IMPORT_PATH=' 'QML2_IMPORT_PATH=${qtQmlPaths}:'
     done
   '';
 
@@ -198,8 +182,8 @@ stdenv.mkDerivation (finalAttrs: {
     # Code loads Qt's qt_module.prf, which force-overrides all QMAKE_PKGCONFIG_* variables except PREFIX for QMake-generated pkg-config files
     for pcFile in Lomiri{Gestures,Metrics,Toolkit}.pc; do
       substituteInPlace $out/lib/pkgconfig/$pcFile \
-        --replace "${lib.getLib qtbase}/lib" "\''${prefix}/lib" \
-        --replace "${lib.getDev qtbase}/include" "\''${prefix}/include"
+        --replace-fail "${lib.getLib qtbase}/lib" "\''${prefix}/lib" \
+        --replace-fail "${lib.getDev qtbase}/include" "\''${prefix}/include"
     done
 
     # These are all dev-related tools, but declaring a bin output also moves around the QML modules


### PR DESCRIPTION
## Description of changes

Some smaller updates not associated with any big OTA release.

- `ayatana-indicator-datetime`: 24.1.0 was still WIP & borked when we merged this, 24.2.0 has now obsoleted the patches.
- `lomiri.lomiri-ui-toolkit`: Translations, addressing some build warnings & failures
- `lomiri.lomiri-system-settings-unwrapped` (and the wrapped version): Translations, a switch to enable the system dark mode (untested)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
