### PR TITLE
sequoia-sqv: fix build by updating nettle-sys

### DIFF
--- a/pkgs/tools/security/sequoia-sqv/Cargo.lock.patch
+++ b/pkgs/tools/security/sequoia-sqv/Cargo.lock.patch
@@ -1,0 +1,385 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index e41780e..15db50e 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -119,11 +119,11 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+ 
+ [[package]]
+ name = "bindgen"
+-version = "0.57.0"
++version = "0.68.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fd4865004a46a0aafb2a0a5eb19d3c9fc46ee5f063a6cfc605c69ac9ecf5263d"
++checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+ dependencies = [
+- "bitflags",
++ "bitflags 2.5.0",
+  "cexpr",
+  "clang-sys",
+  "lazy_static",
+@@ -134,6 +134,7 @@ dependencies = [
+  "regex",
+  "rustc-hash",
+  "shlex",
++ "syn 2.0.59",
+ ]
+ 
+ [[package]]
+@@ -157,6 +158,12 @@ version = "1.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+ 
++[[package]]
++name = "bitflags"
++version = "2.5.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
++
+ [[package]]
+ name = "block-buffer"
+ version = "0.9.0"
+@@ -189,9 +196,9 @@ checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+ 
+ [[package]]
+ name = "cexpr"
+-version = "0.4.0"
++version = "0.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
++checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+ dependencies = [
+  "nom",
+ ]
+@@ -243,7 +250,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+ dependencies = [
+  "ansi_term",
+  "atty",
+- "bitflags",
++ "bitflags 1.3.2",
+  "strsim",
+  "term_size",
+  "textwrap",
+@@ -439,6 +446,16 @@ version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "1f4b14e20978669064c33b4c1e0fb4083412e40fe56cbea2eae80fd7591503ee"
+ 
++[[package]]
++name = "errno"
++version = "0.3.8"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
++dependencies = [
++ "libc",
++ "windows-sys",
++]
++
+ [[package]]
+ name = "failure"
+ version = "0.1.8"
+@@ -457,10 +474,16 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 1.0.82",
+  "synstructure",
+ ]
+ 
++[[package]]
++name = "fastrand"
++version = "2.0.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
++
+ [[package]]
+ name = "fixedbitset"
+ version = "0.2.0"
+@@ -609,9 +632,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.109"
++version = "0.2.153"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f98a04dce437184842841303488f70d0188c5f51437d2a834dc097eafa909a01"
++checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+ 
+ [[package]]
+ name = "libloading"
+@@ -629,6 +652,12 @@ version = "0.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+ 
++[[package]]
++name = "linux-raw-sys"
++version = "0.4.13"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
++
+ [[package]]
+ name = "lock_api"
+ version = "0.4.5"
+@@ -665,6 +694,12 @@ version = "0.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "2af4f95d8737f4ffafbd1fb3c703cdc898868a244a59786793cba0520ebdcbdd"
+ 
++[[package]]
++name = "minimal-lexical"
++version = "0.2.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
++
+ [[package]]
+ name = "miniz_oxide"
+ version = "0.4.4"
+@@ -689,12 +724,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "nettle-sys"
+-version = "2.0.8"
++version = "2.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b95aff9e61c8d8132e41dceae74c6e526edcac8d120072c87a300b9ab7e75226"
++checksum = "b495053a10a19a80e3a26bf1212e92e29350797b5f5bdc58268c3f3f818e66ec"
+ dependencies = [
+  "bindgen",
++ "cc",
++ "libc",
+  "pkg-config",
++ "tempfile",
+  "vcpkg",
+ ]
+ 
+@@ -706,12 +744,12 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+ 
+ [[package]]
+ name = "nom"
+-version = "5.1.2"
++version = "7.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
++checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+ dependencies = [
+  "memchr",
+- "version_check",
++ "minimal-lexical",
+ ]
+ 
+ [[package]]
+@@ -851,18 +889,18 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+ 
+ [[package]]
+ name = "proc-macro2"
+-version = "1.0.33"
++version = "1.0.81"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
++checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+ dependencies = [
+- "unicode-xid",
++ "unicode-ident",
+ ]
+ 
+ [[package]]
+ name = "quote"
+-version = "1.0.10"
++version = "1.0.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
++checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+ dependencies = [
+  "proc-macro2",
+ ]
+@@ -909,7 +947,7 @@ version = "0.2.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+ dependencies = [
+- "bitflags",
++ "bitflags 1.3.2",
+ ]
+ 
+ [[package]]
+@@ -951,6 +989,19 @@ version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+ 
++[[package]]
++name = "rustix"
++version = "0.38.32"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
++dependencies = [
++ "bitflags 2.5.0",
++ "errno",
++ "libc",
++ "linux-raw-sys",
++ "windows-sys",
++]
++
+ [[package]]
+ name = "rustversion"
+ version = "1.0.6"
+@@ -1053,9 +1104,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "shlex"
+-version = "0.1.1"
++version = "1.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
++checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+ 
+ [[package]]
+ name = "signature"
+@@ -1117,6 +1168,17 @@ dependencies = [
+  "unicode-xid",
+ ]
+ 
++[[package]]
++name = "syn"
++version = "2.0.59"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "unicode-ident",
++]
++
+ [[package]]
+ name = "synstructure"
+ version = "0.12.6"
+@@ -1125,10 +1187,22 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 1.0.82",
+  "unicode-xid",
+ ]
+ 
++[[package]]
++name = "tempfile"
++version = "3.10.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
++dependencies = [
++ "cfg-if",
++ "fastrand",
++ "rustix",
++ "windows-sys",
++]
++
+ [[package]]
+ name = "term"
+ version = "0.7.0"
+@@ -1177,7 +1251,7 @@ checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 1.0.82",
+ ]
+ 
+ [[package]]
+@@ -1226,6 +1300,12 @@ version = "0.3.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+ 
++[[package]]
++name = "unicode-ident"
++version = "1.0.12"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
++
+ [[package]]
+ name = "unicode-normalization"
+ version = "0.1.19"
+@@ -1306,6 +1386,79 @@ version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+ 
++[[package]]
++name = "windows-sys"
++version = "0.52.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
++dependencies = [
++ "windows-targets",
++]
++
++[[package]]
++name = "windows-targets"
++version = "0.52.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
++dependencies = [
++ "windows_aarch64_gnullvm",
++ "windows_aarch64_msvc",
++ "windows_i686_gnu",
++ "windows_i686_gnullvm",
++ "windows_i686_msvc",
++ "windows_x86_64_gnu",
++ "windows_x86_64_gnullvm",
++ "windows_x86_64_msvc",
++]
++
++[[package]]
++name = "windows_aarch64_gnullvm"
++version = "0.52.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
++
++[[package]]
++name = "windows_aarch64_msvc"
++version = "0.52.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
++
++[[package]]
++name = "windows_i686_gnu"
++version = "0.52.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
++
++[[package]]
++name = "windows_i686_gnullvm"
++version = "0.52.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
++
++[[package]]
++name = "windows_i686_msvc"
++version = "0.52.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
++
++[[package]]
++name = "windows_x86_64_gnu"
++version = "0.52.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
++
++[[package]]
++name = "windows_x86_64_gnullvm"
++version = "0.52.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
++
++[[package]]
++name = "windows_x86_64_msvc"
++version = "0.52.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
++
+ [[package]]
+ name = "xxhash-rust"
+ version = "0.8.2"
+@@ -1329,6 +1482,6 @@ checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 1.0.82",
+  "synstructure",
+ ]

--- a/pkgs/tools/security/sequoia-sqv/default.nix
+++ b/pkgs/tools/security/sequoia-sqv/default.nix
@@ -17,8 +17,9 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     hash = "sha256-KoB9YnPNE2aB5MW5G9r6Bk+1QnANVSKA2dp3ufSJ44M=";
   };
+  cargoPatches = [ ./Cargo.lock.patch ];
 
-  cargoHash = "sha256-uwOU/yyh3eoD10El7Oe9E97F3dvPuXMHQhpnWEJ1gnI=";
+  cargoHash = "sha256-E6tNOc3omg6yLwCP+MdyBF/HmFTBFCiXd5r+jflfs4k=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
## Description of changes
The build was encountering an issue in rust-bindgen, that has been fixed[1], but nettle-sys depends on an old version of rust-bindgen,

Updated nettle-sys, patched Cargo.lock

[1]- https://github.com/rust-lang/rust-bindgen/pull/2316

https://bugs.launchpad.net/ubuntu/+source/rust-bindgen/+bug/2030886



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
