### PR TITLE
nixos/dnscrypt-proxy2: fix cross-compiling

### DIFF
--- a/nixos/modules/services/networking/dnscrypt-proxy2.nix
+++ b/nixos/modules/services/networking/dnscrypt-proxy2.nix
@@ -49,12 +49,12 @@ in
         passAsFile = [ "json" ];
       } ''
         ${if cfg.upstreamDefaults then ''
-          ${pkgs.remarshal}/bin/toml2json ${pkgs.dnscrypt-proxy.src}/dnscrypt-proxy/example-dnscrypt-proxy.toml > example.json
-          ${pkgs.jq}/bin/jq --slurp add example.json $jsonPath > config.json # merges the two
+          ${pkgs.buildPackages.remarshal}/bin/toml2json ${pkgs.dnscrypt-proxy.src}/dnscrypt-proxy/example-dnscrypt-proxy.toml > example.json
+          ${pkgs.buildPackages.jq}/bin/jq --slurp add example.json $jsonPath > config.json # merges the two
         '' else ''
           cp $jsonPath config.json
         ''}
-        ${pkgs.remarshal}/bin/json2toml < config.json > $out
+        ${pkgs.buildPackages.remarshal}/bin/json2toml < config.json > $out
       '';
       defaultText = literalMD "TOML file generated from {option}`services.dnscrypt-proxy2.settings`";
     };


### PR DESCRIPTION
## Description of changes
- [X] Use `pkgs.buildPackages` instead of `pkgs` when setting up the `configFile` of `dnscrypt-proxy2.service` to support cross-compiling. Eg.:
```nix
{
nixpkgs.buildPlatform = { system = "x86_64-linux"; config = "x86_64-unknown-linux-gnu"; };
nixpkgs.hostPlatform = { system = "armv7l-linux"; config = "armv7l-unknown-linux-gnueabihf"; };
}
```
Without this fix the error is:

> /nix/store/8mxrdhszs3fd2hbr9b6qjp2iway4yyg1-python3.11-remarshal-0.17.1-armv7l-unknown-linux-gnueabihf/bin/.toml2json-wrapped: /nix/store/8mxrdhszs3fd2hbr9b6qjp2iway4yyg1-python3.11-remarshal-0.17.1-armv7l-unknown-linux-gnueabihf/bin/toml2json: line 3: syntax error near unexpected token \`lambda'
> /nix/store/8mxrdhszs3fd2hbr9b6qjp2iway4yyg1-python3.11-remarshal-0.17.1-armv7l-unknown-linux-gnueabihf/bin/.toml2json-wrapped: /nix/store/8mxrdhszs3fd2hbr9b6qjp2iway4yyg1-python3.11-remarshal-0.17.1-armv7l-unknown-linux-gnueabihf/bin/toml2json: line 3: `import sys;import site;import functools;sys.argv[0] = '/nix/store/8mxrdhszs3fd2hbr9b6qjp2iway4yyg1-python3.11-remarshal-0.17.1-armv7l-unknown-linux-gnueabihf/bin/toml2json';functools.reduce(lambda k, p: site.addsitedir(p, k), ['/nix/store/8mxrdhszs3fd2hbr9b6qjp2iway4yyg1-python3.11-remarshal-0.17.1-armv7l-unknown-linux-gnueabihf/lib/python3.11/site-packages','/nix/store/avj9mvfc75hq4s3ky6wc6b2fg31fcapr-python3.11-cbor2-5.4.6-armv7l-unknown-linux-gnueabihf/lib/python3.11/site-packages','/nix/store/s8dsr8x0lc9idgfs5d9i7dhcbmibavxk-python3.11-python-dateutil-2.8.2-armv7l-unknown-linux-gnueabihf/lib/python3.11/site-packages','/nix/store/i7a16jhgak1hsf5fp6scf6fwvwawxbmn-python3.11-six-1.16.0-armv7l-unknown-linux-gnueabihf/lib/python3.11/site-packages','/nix/store/r40z5gfflfmbplipv0rcw0w0awfcccar-python3.11-pyyaml-6.0.1-armv7l-unknown-linux-gnueabihf/lib/python3.11/site-packages','/nix/store/jcchdacpbrqi9p9dwbhl8i845m2gpdkf-python3.11-tomlkit-0.12.1-armv7l-unknown-linux-gnueabihf/lib/python3.11/site-packages','/nix/store/93fh3ppiid0kq1icnmm0v16q8zfrv9z5-python3.11-u-msgpack-python-2.8.0-armv7l-unknown-linux-gnueabihf/lib/python3.11/site-packages'], site._init_pathinfo());'

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
