### PR TITLE
[23.11] gitea: backport CSP patch in markdown renderer

### DIFF
--- a/pkgs/applications/version-management/gitea/csp-early-1.21.11.patch
+++ b/pkgs/applications/version-management/gitea/csp-early-1.21.11.patch
@@ -1,0 +1,20 @@
+diff --git a/routers/web/repo/render.go b/routers/web/repo/render.go
+index f07b4e8c11..1fcaa83c4f 100644
+--- a/routers/web/repo/render.go
++++ b/routers/web/repo/render.go
+@@ -44,6 +44,7 @@ func RenderFile(ctx *context.Context) {
+ 	isTextFile := st.IsText()
+ 
+ 	rd := charset.ToUTF8WithFallbackReader(io.MultiReader(bytes.NewReader(buf), dataRc))
++	ctx.Resp.Header().Add("Content-Security-Policy", "frame-src 'self'; sandbox allow-scripts")
+ 
+ 	if markupType := markup.Type(blob.Name()); markupType == "" {
+ 		if isTextFile {
+@@ -62,7 +63,6 @@ func RenderFile(ctx *context.Context) {
+ 		treeLink += "/" + util.PathEscapeSegments(ctx.Repo.TreePath)
+ 	}
+ 
+-	ctx.Resp.Header().Add("Content-Security-Policy", "frame-src 'self'; sandbox allow-scripts")
+ 	err = markup.Render(&markup.RenderContext{
+ 		Ctx:              ctx,
+ 		RelativePath:     ctx.Repo.TreePath,

--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -39,6 +39,9 @@ buildGoModule rec {
       hash = "sha256-cThW3EnHR695thajbnmfNziVB/iBP9OPeDgWbszYIeg=";
     })
     ./XSS-vulnerabilities-1.21.6.patch
+
+    # Derived from https://github.com/go-gitea/gitea/pull/30136
+    ./csp-early-1.21.11.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/304494#issuecomment-2059284122

__Note:__ please await a review from @techknowlogick 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
