### PR TITLE
jetbrains.writerside: init at 2023.3 EAP

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22393,6 +22393,12 @@
     githubId = 1108325;
     name = "Théo Zimmermann";
   };
+  zlepper = {
+    name = "Rasmus Hansen";
+    github = "zlepper";
+    githubId = 1499810;
+    email = "hansen13579@gmail.com";
+  };
   zmitchell = {
     name = "Zach Mitchell";
     email = "zmitchell@fastmail.com";

--- a/pkgs/applications/editors/jetbrains/bin/ides.json
+++ b/pkgs/applications/editors/jetbrains/bin/ides.json
@@ -168,5 +168,16 @@
       "longDescription": "WebStorm provides an editor for HTML, JavaScript (incl. Node.js), and CSS with on-the-fly code analysis, error prevention and automated refactorings for JavaScript code.",
       "homepage": "https://www.jetbrains.com/webstorm/"
     }
+  },
+  "writerside": {
+    "product": "Writerside",
+    "wmClass": "jetbrains-writerside",
+    "meta": {
+      "isOpenSource": false,
+      "description": "Documentation IDE from JetBrains",
+      "maintainers": [ "zlepper"],
+      "longDescription": "The most powerful development environment – now adapted for writing documentation.",
+      "homepage": "https://www.jetbrains.com/writerside/"
+    }
   }
 }

--- a/pkgs/applications/editors/jetbrains/bin/update_bin.py
+++ b/pkgs/applications/editors/jetbrains/bin/update_bin.py
@@ -68,7 +68,11 @@ def update_product(name, product):
         try:
             build = latest_build(channel)
             new_version = build["@version"]
-            new_build_number = build["@fullNumber"]
+            new_build_number = ""
+            if "@fullNumber" not in build:
+                new_build_number = build["@number"]
+            else:
+                new_build_number = build["@fullNumber"]
             if "EAP" not in channel["@name"]:
                 version_or_build_number = new_version
             else:

--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -120,6 +120,14 @@
       "sha256": "d4c7cb7f1462c2b2bd9042b4714ab9de66c455ab9752c87698dc3902f0d49a2a",
       "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.1.tar.gz",
       "build_number": "241.14494.235"
+    },
+    "writerside": {
+      "update-channel": "Writerside EAP",
+      "url-template": "https://download.jetbrains.com/writerside/writerside-{version}.tar.gz",
+      "version": "2023.3 EAP",
+      "sha256": "8eae1c965c1b5dae17c580cd3ed9b2a6182a3b54a54f8e6152472815118ae2c2",
+      "url": "https://download.jetbrains.com/writerside/writerside-233.14938.tar.gz",
+      "build_number": "233.14938"
     }
   },
   "aarch64-linux": {
@@ -243,6 +251,14 @@
       "sha256": "6691e4855fd4ecf3da9b63b78a11afc3441fb2139cdc7e7aaa5d78aa92a88c12",
       "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.1-aarch64.tar.gz",
       "build_number": "241.14494.235"
+    },
+    "writerside": {
+      "update-channel": "Writerside EAP",
+      "url-template": "https://download.jetbrains.com/writerside/writerside-{version}-aarch64.tar.gz",
+      "version": "2023.3 EAP",
+      "sha256": "b09dac04217d5d523501bdb1e9026fd17fb6370dff2610502472bbf6a48323d8",
+      "url": "https://download.jetbrains.com/writerside/writerside-233.14938-aarch64.tar.gz",
+      "build_number": "233.14938"
     }
   },
   "x86_64-darwin": {
@@ -366,6 +382,14 @@
       "sha256": "b3b41e5e8559e36e0bd4121dee61d39a8ba5b5ce8193e7b026c5bc261e973df5",
       "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.1.dmg",
       "build_number": "241.14494.235"
+    },
+    "writerside": {
+      "update-channel": "Writerside EAP",
+      "url-template": "https://download.jetbrains.com/writerside/writerside-{version}.dmg",
+      "version": "2023.3 EAP",
+      "sha256": "53c7ad5a8808776b60eb82b3155c6f3a2a0dfad43ba8d9238a0db1752d503b09",
+      "url": "https://download.jetbrains.com/writerside/writerside-233.14938.dmg",
+      "build_number": "233.14938"
     }
   },
   "aarch64-darwin": {
@@ -489,6 +513,14 @@
       "sha256": "95dd3a397fe063583c5e3ba4fefafdfcad740c18447c1a70c0f03cb004436496",
       "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.1-aarch64.dmg",
       "build_number": "241.14494.235"
+    },
+    "writerside": {
+      "update-channel": "Writerside EAP",
+      "url-template": "https://download.jetbrains.com/writerside/writerside-{version}-aarch64.dmg",
+      "version": "2023.3 EAP",
+      "sha256": "2a78fbcabcdd5b7c906d933dd91ac927bde22ae3bba988dad7450184fd90457a",
+      "url": "https://download.jetbrains.com/writerside/writerside-233.14938-aarch64.dmg",
+      "build_number": "233.14938"
     }
   }
 }

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -257,6 +257,8 @@ rec {
 
   webstorm = mkJetBrainsProduct { pname = "webstorm"; extraBuildInputs = [ stdenv.cc.cc musl ]; };
 
+  writerside = mkJetBrainsProduct { pname = "writerside"; extraBuildInputs = [ stdenv.cc.cc musl ]; };
+
   plugins = callPackage ./plugins { } // { __attrsFailEvaluation = true; };
 
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://www.jetbrains.com/writerside/ 

Based on description in readme.md file in Jetbrains directory.

This is an alternative to and closes https://github.com/NixOS/nixpkgs/pull/265628 which has pretty bad merge conflicts due to change in structure for how the jetbrains tools are done in nixpkgs. 

As the updates.xml here https://www.jetbrains.com/updates/updates.xml doesn't contain a fullNumber for writerside i had to change the python script slightly to fallback to just using the number if the fullnumber is not available. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
