### PR TITLE
coreutils: fix test failure when using musl

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -39,6 +39,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-zTKO3qyS9qZl3p8yPJO3Eq8YWLwuDYjz9xAEaUcKG4o=";
   };
 
+  patches = lib.optionals stdenv.hostPlatform.isMusl [
+    # https://lists.gnu.org/archive/html/bug-coreutils/2024-03/msg00089.html
+    ./fix-test-failure-musl.patch
+  ];
+
   postPatch = ''
     # The test tends to fail on btrfs, f2fs and maybe other unusual filesystems.
     sed '2i echo Skipping dd sparse test && exit 77' -i ./tests/dd/sparse.sh

--- a/pkgs/tools/misc/coreutils/fix-test-failure-musl.patch
+++ b/pkgs/tools/misc/coreutils/fix-test-failure-musl.patch
@@ -1,0 +1,23 @@
+From 1defda6356c29c7f731bddb9e9231f594e01d9c9
+(adjusted so it can be applied on coreutils to coreutils tarball)
+
+Reported by Adept's Lab via Pádraig Brady at
+<https://lists.gnu.org/archive/html/bug-coreutils/2024-03/msg00086.html>.
+
+diff --git a/gnulib-tests/test-canonicalize.c b/gnulib-tests/test-canonicalize.c
+index 6763a525c9..5d19285c00 100644
+--- a/gnulib-tests/test-canonicalize.c
++++ b/gnulib-tests/test-canonicalize.c
+@@ -394,9 +394,9 @@ main (void)
+     ASSERT (stat ("/", &st1) == 0);
+     ASSERT (stat ("//", &st2) == 0);
+     bool same = psame_inode (&st1, &st2);
+-#if defined __MVS__ || defined MUSL_LIBC
+-    /* On IBM z/OS and musl libc, "/" and "//" both canonicalize to
+-       themselves, yet they both have st_dev == st_ino == 1.  */
++#if defined __MVS__
++    /* On IBM z/OS, "/" and "//" both canonicalize to themselves, yet they both
++       have st_dev == st_ino == 1.  */
+     same = false;
+ #endif
+     if (same)


### PR DESCRIPTION
## Description of changes

https://lists.gnu.org/archive/html/bug-coreutils/2024-03/msg00089.html

Used upstream patch but only kept the part we needed to apply on top of the coreutils tarball.

https://github.com/coreutils/gnulib/commit/1defda6356c29c7f731bddb9e9231f594e01d9c9

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (`pkgsMusl.coreutils`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
