### PR TITLE
wrapCC, wrapBintools: correctly cross-compile if buildPlatform != hostPlatform

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -8,7 +8,8 @@
 { name ? ""
 , lib
 , stdenvNoCC
-, bintools ? null, libc ? null, coreutils ? null, shell ? stdenvNoCC.shell, gnugrep ? null
+, runtimeShell
+, bintools ? null, libc ? null, coreutils ? null, gnugrep ? null
 , netbsd ? null, netbsdCross ? null
 , sharedLibraryLoader ?
   if libc == null then
@@ -419,7 +420,8 @@ stdenvNoCC.mkDerivation {
   env = {
     # for substitution in utils.bash
     expandResponseParams = "${expand-response-params}/bin/expand-response-params";
-    shell = getBin shell + shell.shellPath or "";
+    # TODO(@sternenseemann): rename env var via stdenv rebuild
+    shell = (getBin runtimeShell + runtimeShell.shellPath or "");
     gnugrep_bin = optionalString (!nativeTools) gnugrep;
     wrapperName = "BINTOOLS_WRAPPER";
     inherit dynamicLinker targetPrefix suffixSalt coreutils_bin;

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -29,7 +29,7 @@
 , isGNU ? bintools.isGNU or false
 , isLLVM ? bintools.isLLVM or false
 , isCCTools ? bintools.isCCTools or false
-, buildPackages ? {}
+, expand-response-params
 , targetPackages ? {}
 , useMacosReexportHack ? false
 , wrapGas ? false
@@ -131,10 +131,6 @@ let
     else if targetPlatform.isFreeBSD                  then "/libexec/ld-elf.so.1"
     else if hasSuffix "pc-gnu" targetPlatform.config then "ld.so.1"
     else "";
-
-  expand-response-params =
-    optionalString (buildPackages ? stdenv && buildPackages.stdenv.hasCC && buildPackages.stdenv.cc != "/dev/null")
-    (import ../expand-response-params { inherit (buildPackages) stdenv; });
 
 in
 
@@ -419,6 +415,7 @@ stdenvNoCC.mkDerivation {
 
   env = {
     # for substitution in utils.bash
+    # TODO(@sternenseemann): invent something cleaner than passing in "" in case of absence
     expandResponseParams = "${expand-response-params}/bin/expand-response-params";
     # TODO(@sternenseemann): rename env var via stdenv rebuild
     shell = (getBin runtimeShell + runtimeShell.shellPath or "");

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -8,7 +8,8 @@
 { name ? ""
 , lib
 , stdenvNoCC
-, cc ? null, libc ? null, bintools, coreutils ? null, shell ? stdenvNoCC.shell
+, runtimeShell
+, cc ? null, libc ? null, bintools, coreutils ? null
 , zlib ? null
 , nativeTools, noLibc ? false, nativeLibc, nativePrefix ? ""
 , propagateDoc ? cc != null && cc ? man
@@ -739,7 +740,8 @@ stdenvNoCC.mkDerivation {
 
     # for substitution in utils.bash
     expandResponseParams = "${expand-response-params}/bin/expand-response-params";
-    shell = getBin shell + shell.shellPath or "";
+    # TODO(@sternenseemann): rename env var via stdenv rebuild
+    shell = getBin runtimeShell + runtimeShell.shellPath or "";
     gnugrep_bin = optionalString (!nativeTools) gnugrep;
     # stdenv.cc.cc should not be null and we have nothing better for now.
     # if the native impure bootstrap is gotten rid of this can become `inherit cc;` again.

--- a/pkgs/build-support/expand-response-params/default.nix
+++ b/pkgs/build-support/expand-response-params/default.nix
@@ -1,4 +1,4 @@
-{ stdenv }:
+{ stdenv, lib }:
 
 # A "response file" is a sequence of arguments that is passed via a
 # file, rather than via argv[].
@@ -25,4 +25,18 @@ stdenv.mkDerivation {
     mkdir -p $prefix/bin
     mv expand-response-params $prefix/bin/
   '';
+
+  meta = {
+    description = "Internal tool used by the nixpkgs wrapper scripts for processing response files";
+    longDescription = ''
+      expand-response-params is a tool that allows for obtaining a full list of all
+      arguments passed in a given compiler command line including those passed via
+      so-called response files. The nixpkgs wrapper scripts for bintools and C
+      compilers use it for processing compiler flags. As it is developed in
+      conjunction with the nixpkgs wrapper scripts, it should be considered as
+      unstable and subject to change.
+    '';
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+  };
 }

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -117,6 +117,7 @@ let
         inherit (prevStage) coreutils gnugrep;
 
         stdenvNoCC = prevStage.ccWrapperStdenv;
+        runtimeShell = prevStage.ccWrapperStdenv.shell;
       };
 
       bash = prevStage.bash or bootstrapTools;
@@ -258,6 +259,7 @@ in
 
           inherit lib;
           inherit (self) stdenvNoCC coreutils gnugrep;
+          runtimeShell = self.stdenvNoCC.shell;
 
           bintools = selfDarwin.binutils-unwrapped;
 
@@ -457,6 +459,8 @@ in
 
           bintools = selfDarwin.binutils-unwrapped;
           libc = selfDarwin.Libsystem;
+          # TODO(@sternenseemann): can this be removed?
+          runtimeShell = "${bootstrapTools}/bin/bash";
         };
 
         binutils-unwrapped = superDarwin.binutils-unwrapped.override {
@@ -1044,8 +1048,6 @@ in
         };
 
         binutils = superDarwin.binutils.override {
-          shell = self.bash + "/bin/bash";
-
           buildPackages = {
             inherit (prevStage) stdenv;
           };
@@ -1124,9 +1126,7 @@ in
               inherit (self.llvmPackages) libcxx;
 
               inherit lib;
-              inherit (self) stdenvNoCC coreutils gnugrep;
-
-              shell = self.bash + "/bin/bash";
+              inherit (self) stdenvNoCC coreutils gnugrep runtimeShell;
             };
           });
           libraries = super.llvmPackages.libraries.extend (_: _:{

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -76,9 +76,9 @@ let
         nativeTools = false;
         nativeLibc = false;
 
-        buildPackages = lib.optionalAttrs (prevStage ? stdenv) {
-          inherit (prevStage) stdenv;
-        };
+        expand-response-params = lib.optionalString
+          (prevStage.stdenv.hasCC or false && prevStage.stdenv.cc != "/dev/null")
+          prevStage.expand-response-params;
 
         extraPackages = [
           prevStage.llvmPackages.compiler-rt
@@ -254,7 +254,7 @@ in
           nativeTools = false;
           nativeLibc = false;
 
-          buildPackages = { };
+          expand-response-params = "";
           libc = selfDarwin.Libsystem;
 
           inherit lib;
@@ -841,9 +841,7 @@ in
 
         # Rewrap binutils so it uses the rebuilt Libsystem.
         binutils = superDarwin.binutils.override {
-          buildPackages = {
-            inherit (prevStage) stdenv;
-          };
+          inherit (prevStage) expand-response-params;
           libc = selfDarwin.Libsystem;
         } // {
           passthru = { inherit (prevStage.bintools.passthru) isFromBootstrapFiles; };
@@ -1048,9 +1046,7 @@ in
         };
 
         binutils = superDarwin.binutils.override {
-          buildPackages = {
-            inherit (prevStage) stdenv;
-          };
+          inherit (prevStage) expand-response-params;
 
           bintools = selfDarwin.binutils-unwrapped;
           libc = selfDarwin.Libsystem;
@@ -1087,9 +1083,7 @@ in
               nativeTools = false;
               nativeLibc = false;
 
-              buildPackages = {
-                inherit (prevStage) stdenv;
-              };
+              inherit (prevStage) expand-response-params;
 
               extraPackages = [
                 self.llvmPackages.compiler-rt

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -196,6 +196,7 @@ let
           inherit (prevStage) coreutils gnugrep;
           stdenvNoCC = prevStage.ccWrapperStdenv;
           fortify-headers = prevStage.fortify-headers;
+          runtimeShell = prevStage.ccWrapperStdenv.shell;
         }).overrideAttrs(a: lib.optionalAttrs (prevStage.gcc-unwrapped.passthru.isXgcc or false) {
           # This affects only `xgcc` (the compiler which compiles the final compiler).
           postFixup = (a.postFixup or "") + ''
@@ -265,6 +266,7 @@ in
         inherit lib;
         inherit (self) stdenvNoCC coreutils gnugrep;
         bintools = bootstrapTools;
+        runtimeShell = "${bootstrapTools}/bin/bash";
       };
       coreutils = bootstrapTools;
       gnugrep = bootstrapTools;
@@ -332,6 +334,14 @@ in
         inherit (prevStage) ccWrapperStdenv coreutils gnugrep gettext bison texinfo zlib gnum4 perl patchelf;
         ${localSystem.libc} = getLibc prevStage;
         gmp = super.gmp.override { cxx = false; };
+        # This stage also rebuilds binutils which will of course be used only in the next stage.
+        # We inherit this until stage3, in stage4 it will be rebuilt using the adjacent bash/runtimeShell pkg.
+        # TODO(@sternenseemann): Can we already build the wrapper with the actual runtimeShell here?
+        # Historically, the wrapper didn't use runtimeShell, so the used shell had to be changed explicitly
+        # (or stdenvNoCC.shell would be used) which happened in stage4.
+        binutils = super.binutils.override {
+          runtimeShell = "${bootstrapTools}/bin/bash";
+        };
         gcc-unwrapped =
           (super.gcc-unwrapped.override (commonGccOverrides // {
             # The most logical name for this package would be something like
@@ -544,9 +554,8 @@ in
       # other purposes (binutils and top-level pkgs) too.
       inherit (prevStage) gettext gnum4 bison perl texinfo zlib linuxHeaders libidn2 libunistring;
       ${localSystem.libc} = getLibc prevStage;
+      # Since this is the first fresh build of binutils since stage2, our own runtimeShell will be used.
       binutils = super.binutils.override {
-        # Don't use stdenv's shell but our own
-        shell = self.bash + "/bin/bash";
         # Build expand-response-params with last stage like below
         buildPackages = {
           inherit (prevStage) stdenv;
@@ -568,8 +577,7 @@ in
         bintools = self.binutils;
         libc = getLibc self;
         inherit lib;
-        inherit (self) stdenvNoCC coreutils gnugrep;
-        shell = self.bash + "/bin/bash";
+        inherit (self) stdenvNoCC coreutils gnugrep runtimeShell;
         fortify-headers = self.fortify-headers;
       };
     };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -656,6 +656,8 @@ with pkgs;
 
   evhz = callPackage ../tools/misc/evhz { };
 
+  expand-response-params = callPackage ../build-support/expand-response-params { };
+
   expressvpn = callPackage ../applications/networking/expressvpn { };
 
   faq = callPackage ../development/tools/faq { };


### PR DESCRIPTION
## Description of changes

The wrapper scripts have two main dependencies (aside from `cc` and `bintools` which are a given):

- The shell used for executing the scripts, known as `shell` thus far.
- `expand-response-params`, a small C program which requires a *wrapped* compiler to be built.

Previously, these programs would be essentially taken from/built with the package set used to build the package set that the wrapper itself is a part of (usually `buildPackages`). This is incorrect, as it only “works” if `hostPlatform == buildPlatform` (relative to the wrapper) or it will be impossible to execute the dependencies.

This has the consequence that if you e.g. build `pkgsCross.aarch64-multiplatform.gcc`, it will be impossible to execute the resulting (wrapped) compiler due to exec format errors.

This weird situation stems from the stdenv bootstrapping process where we have the concrete problem that building a shell and C program requires a wrapped C compiler, but we also require these to build the wrapper. The solution is to either do without the dependencies or take them from the previous bootstrapping stage and, ultimately, `bootstrapTools`. These is sound in this situation since during (initial) stdenv bootstrapping `buildPlatform == hostPlatform == targetPlatform`. It is, however, incorrect to have this leak into the main package set where cross compilation may happen.

The solution to this problem is to make the wrappers behave correctly in the main package set (taking cross into account) and worry about bootstrapping later. This is exactly what I've done:

- Instead of `shell` which defaults to `stdenvNoCC.shell` (which is usually equivalent to `buildPackages.runtimeShell`), we use `runtimeShell` which is an attribute that exposes the default shell we use on the host platform.
- Instead of ad hoc building `expand-response-params` inline in the wrapper derivation by trying to pull a `stdenv` out of `buildPackages` (so that we are effectively using `buildPackages.buildPackages.gcc/clang`), we just take it as an ordinary input (which works perfectly in the main package set) and let the caller worry about bootstrapping.

In a second step I've reflected these changes in the darwin and linux stdenvs, making sure that no derivation hash changes by inserting extra bootstrapping instructions where necessary (the single rebuild is caused by the newly added `expand-response-params` attribute). Some of these may actually be unnecessary (i.e. we may be able to build a proper `runtimeShell` earlier etc.), but this will have to be investigated separately as that would cause a stdenv rebuild.

This change is best reviewed commit by commit.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
