### PR TITLE
lomiri.lomiri-network-indicator: Make it work, add it to Lomiri module

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -38,6 +38,8 @@ in {
       ]);
     };
 
+    networking.networkmanager.enable = lib.mkDefault true;
+
     systemd.packages = with pkgs.lomiri; [
       hfd-service
       lomiri-download-manager
@@ -73,6 +75,8 @@ in {
         ayatana-indicator-session
       ]) ++ (with pkgs.lomiri; [
         telephony-service
+      ] ++ lib.optionals config.networking.networkmanager.enable [
+        lomiri-indicator-network
       ]);
     };
 
@@ -111,6 +115,8 @@ in {
       "/share/lomiri-app-launch"
       # TODO Try to get maliit stuff working
       "/share/maliit/plugins"
+      # At least the network indicator is still under the unity name, due to leftover Unity-isms
+      "/share/unity"
       # Data
       "/share/locale" # TODO LUITK hardcoded default locale path, fix individual apps to not rely on it
       "/share/sounds"

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -253,22 +253,35 @@ in {
     with subtest("ayatana indicators work"):
         open_starter()
         machine.send_chars("Indicators\n")
-        machine.wait_for_text(r"(Indicators|Client|List|datetime|session)")
+        machine.wait_for_text(r"(Indicators|Client|List|network|datetime|session)")
         machine.screenshot("indicators_open")
 
         # Element tab order within the indicator menus is not fully deterministic
         # Only check that the indicators are listed & their items load
 
+        with subtest("lomiri indicator network works"):
+            # Select indicator-network
+            machine.send_key("tab")
+            # Don't go further down, first entry
+            machine.send_key("ret")
+            machine.wait_for_text(r"(Flight|Wi-Fi)")
+            machine.screenshot("indicators_network")
+
+        machine.send_key("shift-tab")
+        machine.send_key("ret")
+        machine.wait_for_text(r"(Indicators|Client|List|network|datetime|session)")
+
         with subtest("ayatana indicator datetime works"):
             # Select ayatana-indicator-datetime
             machine.send_key("tab")
+            machine.send_key("down")
             machine.send_key("ret")
             machine.wait_for_text("Time and Date Settings")
             machine.screenshot("indicators_timedate")
 
         machine.send_key("shift-tab")
         machine.send_key("ret")
-        machine.wait_for_text(r"(Indicators|Client|List|datetime|session)")
+        machine.wait_for_text(r"(Indicators|Client|List|network|datetime|session)")
 
         with subtest("ayatana indicator session works"):
             # Select ayatana-indicator-session

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
@@ -47,11 +47,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    # Queried via pkg-config, would need to override a prefix variable
-    # Needs CMake 3.28 or higher to do as part of the call, https://github.com/NixOS/nixpkgs/pull/275284
+    # Override original prefixes
     substituteInPlace data/CMakeLists.txt \
-      --replace 'pkg_get_variable(DBUS_SESSION_BUS_SERVICES_DIR dbus-1 session_bus_services_dir)' 'set(DBUS_SESSION_BUS_SERVICES_DIR "''${CMAKE_INSTALL_SYSCONFDIR}/dbus-1/services")' \
-      --replace 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir)' 'set(SYSTEMD_USER_DIR "''${CMAKE_INSTALL_PREFIX}/lib/systemd/user")'
+      --replace-fail 'pkg_get_variable(DBUS_SESSION_BUS_SERVICES_DIR dbus-1 session_bus_services_dir)' 'pkg_get_variable(DBUS_SESSION_BUS_SERVICES_DIR dbus-1 session_bus_services_dir DEFINE_VARIABLES datadir=''${CMAKE_INSTALL_FULL_SYSCONFDIR})' \
+      --replace-fail 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir)' 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir DEFINE_VARIABLES prefix=''${CMAKE_INSTALL_PREFIX})'
   '';
 
   strictDeps = true;


### PR DESCRIPTION
## Description of changes

Visually informing us about the network state & allowing new connections to be established.

![image](https://github.com/NixOS/nixpkgs/assets/23431373/948783bb-755d-48fa-b18f-2ed7a2173741)

When using a wired connection (like in the VM), it only displays a :gear: instead of a concrete connection-specific icon. Afaict, must be some upstream issue about identifying a suitable icon for that specific connection state?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
