### PR TITLE
 nixos/libinput: move out of xserver 

### DIFF
--- a/nixos/doc/manual/configuration/profiles/graphical.section.md
+++ b/nixos/doc/manual/configuration/profiles/graphical.section.md
@@ -6,5 +6,5 @@ graphical installation CD.
 It sets [](#opt-services.xserver.enable),
 [](#opt-services.displayManager.sddm.enable),
 [](#opt-services.xserver.desktopManager.plasma5.enable),
-and [](#opt-services.xserver.libinput.enable) to true. It also
+and [](#opt-services.libinput.enable) to true. It also
 includes glxinfo and firefox in the system packages list.

--- a/nixos/doc/manual/configuration/x-windows.chapter.md
+++ b/nixos/doc/manual/configuration/x-windows.chapter.md
@@ -207,7 +207,7 @@ Latitude series) can be enabled as follows:
 
 ```nix
 {
-  services.xserver.libinput.enable = true;
+  services.libinput.enable = true;
 }
 ```
 
@@ -216,7 +216,7 @@ For instance, the following disables tap-to-click behavior:
 
 ```nix
 {
-  services.xserver.libinput.touchpad.tapping = false;
+  services.libinput.touchpad.tapping = false;
 }
 ```
 

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -185,7 +185,7 @@ in
         # };
 
         # Enable touchpad support (enabled default in most desktopManager).
-        # services.xserver.libinput.enable = true;
+        # services.libinput.enable = true;
 
         # Define a user account. Don't forget to set a password with ‘passwd’.
         # users.users.alice = {

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -558,6 +558,7 @@
   ./services/hardware/joycond.nix
   ./services/hardware/kanata.nix
   ./services/hardware/lcd.nix
+  ./services/hardware/libinput.nix
   ./services/hardware/lirc.nix
   ./services/hardware/nvidia-container-toolkit-cdi-generator
   ./services/hardware/monado.nix
@@ -1466,7 +1467,6 @@
   ./services/x11/gdk-pixbuf.nix
   ./services/x11/hardware/cmt.nix
   ./services/x11/hardware/digimend.nix
-  ./services/x11/hardware/libinput.nix
   ./services/x11/hardware/synaptics.nix
   ./services/x11/hardware/wacom.nix
   ./services/x11/imwheel.nix

--- a/nixos/modules/profiles/graphical.nix
+++ b/nixos/modules/profiles/graphical.nix
@@ -7,10 +7,12 @@
   services.xserver = {
     enable = true;
     desktopManager.plasma5.enable = true;
-    libinput.enable = true; # for touchpad support on many laptops
   };
 
-  services.displayManager.sddm.enable = true;
+  services = {
+    displayManager.sddm.enable = true;
+    libinput.enable = true; # for touchpad support on many laptops
+  };
 
   # Enable sound in virtualbox appliances.
   hardware.pulseaudio.enable = true;

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -238,7 +238,7 @@ in {
     services.system-config-printer.enable = mkIf config.services.printing.enable (mkDefault true);
     services.udisks2.enable = true;
     services.upower.enable = config.powerManagement.enable;
-    services.xserver.libinput.enable = mkDefault true;
+    services.libinput.enable = mkDefault true;
 
     # Extra UDEV rules used by Solid
     services.udev.packages = [

--- a/nixos/modules/services/display-managers/sddm.nix
+++ b/nixos/modules/services/display-managers/sddm.nix
@@ -111,8 +111,8 @@ let
       let
         westonIni = (pkgs.formats.ini { }).generate "weston.ini" {
           libinput = {
-            enable-tap = xcfg.libinput.mouse.tapping;
-            left-handed = xcfg.libinput.mouse.leftHanded;
+            enable-tap = config.services.libinput.mouse.tapping;
+            left-handed = config.services.libinput.mouse.leftHanded;
           };
           keyboard = {
             keymap_model = xcfg.xkb.model;

--- a/nixos/modules/services/hardware/libinput.nix
+++ b/nixos/modules/services/hardware/libinput.nix
@@ -2,7 +2,7 @@
 
 with lib;
 
-let cfg = config.services.xserver.libinput;
+let cfg = config.services.libinput;
 
     xorgBool = v: if v then "on" else "off";
 
@@ -223,7 +223,7 @@ let cfg = config.services.xserver.libinput;
 in {
 
   imports =
-    (map (option: mkRenamedOptionModule ([ "services" "xserver" "libinput" option ]) [ "services" "xserver" "libinput" "touchpad" option ]) [
+    (map (option: mkRenamedOptionModule ([ "services" "xserver" "libinput" option ]) [ "services" "libinput" "touchpad" option ]) [
       "accelProfile"
       "accelSpeed"
       "buttonMapping"
@@ -242,11 +242,15 @@ in {
       "transformationMatrix"
       "disableWhileTyping"
       "additionalOptions"
-    ]);
+    ]) ++ [
+      (mkRenamedOptionModule [ "services" "xserver" "libinput" "enable" ]   [ "services" "libinput" "enable" ])
+      (mkRenamedOptionModule [ "services" "xserver" "libinput" "mouse" ]    [ "services" "libinput" "mouse" ])
+      (mkRenamedOptionModule [ "services" "xserver" "libinput" "touchpad" ] [ "services" "libinput" "touchpad" ])
+    ];
 
   options = {
 
-    services.xserver.libinput = {
+    services.libinput = {
       enable = mkEnableOption "libinput" // {
         default = config.services.xserver.enable;
         defaultText = lib.literalExpression "config.services.xserver.enable";

--- a/nixos/modules/services/x11/desktop-managers/budgie.nix
+++ b/nixos/modules/services/x11/desktop-managers/budgie.nix
@@ -214,7 +214,7 @@ in {
 
     services.geoclue2.enable = mkDefault true; # for BCC's Privacy > Location Services panel.
     services.upower.enable = config.powerManagement.enable; # for Budgie's Status Indicator and BCC's Power panel.
-    services.xserver.libinput.enable = mkDefault true; # for BCC's Mouse panel.
+    services.libinput.enable = mkDefault true; # for BCC's Mouse panel.
     services.colord.enable = mkDefault true; # for BCC's Color panel.
     services.gnome.at-spi2-core.enable = mkDefault true; # for BCC's A11y panel.
     services.accounts-daemon.enable = mkDefault true; # for BCC's Users panel.

--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -116,7 +116,7 @@ in
       services.touchegg.enable = mkDefault true;
       services.udisks2.enable = true;
       services.upower.enable = mkDefault config.powerManagement.enable;
-      services.xserver.libinput.enable = mkDefault true;
+      services.libinput.enable = mkDefault true;
       services.xserver.updateDbusEnvironment = true;
       networking.networkmanager.enable = mkDefault true;
 

--- a/nixos/modules/services/x11/desktop-managers/deepin.nix
+++ b/nixos/modules/services/x11/desktop-managers/deepin.nix
@@ -61,7 +61,7 @@ in
       services.gnome.gnome-keyring.enable = mkDefault true;
       services.bamf.enable = mkDefault true;
 
-      services.xserver.libinput.enable = mkDefault true;
+      services.libinput.enable = mkDefault true;
       services.udisks2.enable = true;
       services.upower.enable = mkDefault config.powerManagement.enable;
       networking.networkmanager.enable = mkDefault true;

--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -96,7 +96,7 @@ in
 
     services.udisks2.enable = true;
     services.upower.enable = config.powerManagement.enable;
-    services.xserver.libinput.enable = mkDefault true;
+    services.libinput.enable = mkDefault true;
 
     services.dbus.packages = [ e.efl ];
 

--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -339,7 +339,7 @@ in
       # services.packagekit.enable = mkDefault true;
       services.udisks2.enable = true;
       services.upower.enable = config.powerManagement.enable;
-      services.xserver.libinput.enable = mkDefault true; # for controlling touchpad settings via gnome control center
+      services.libinput.enable = mkDefault true; # for controlling touchpad settings via gnome control center
 
       # Explicitly enabled since GNOME will be severely broken without these.
       xdg.mime.enable = true;

--- a/nixos/modules/services/x11/desktop-managers/lxqt.nix
+++ b/nixos/modules/services/x11/desktop-managers/lxqt.nix
@@ -69,7 +69,7 @@ in
 
     services.upower.enable = config.powerManagement.enable;
 
-    services.xserver.libinput.enable = mkDefault true;
+    services.libinput.enable = mkDefault true;
 
     xdg.portal.lxqt.enable = true;
 

--- a/nixos/modules/services/x11/desktop-managers/mate.nix
+++ b/nixos/modules/services/x11/desktop-managers/mate.nix
@@ -88,7 +88,7 @@ in
       services.udev.packages = [ pkgs.mate.mate-settings-daemon ];
       services.gvfs.enable = true;
       services.upower.enable = config.powerManagement.enable;
-      services.xserver.libinput.enable = mkDefault true;
+      services.libinput.enable = mkDefault true;
 
       security.pam.services.mate-screensaver.unixAuth = true;
 

--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -159,7 +159,7 @@ in
       services.gsignond.plugins = with pkgs.gsignondPlugins; [ lastfm mail oauth ];
       services.udisks2.enable = true;
       services.upower.enable = config.powerManagement.enable;
-      services.xserver.libinput.enable = mkDefault true;
+      services.libinput.enable = mkDefault true;
       services.xserver.updateDbusEnvironment = true;
       services.zeitgeist.enable = mkDefault true;
       services.geoclue2.enable = mkDefault true;

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -348,7 +348,7 @@ in
       services.system-config-printer.enable = mkIf config.services.printing.enable (mkDefault true);
       services.udisks2.enable = true;
       services.upower.enable = config.powerManagement.enable;
-      services.xserver.libinput.enable = mkDefault true;
+      services.libinput.enable = mkDefault true;
 
       # Extra UDEV rules used by Solid
       services.udev.packages = [

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -164,7 +164,7 @@ in
     services.gvfs.enable = true;
     services.tumbler.enable = true;
     services.system-config-printer.enable = (mkIf config.services.printing.enable (mkDefault true));
-    services.xserver.libinput.enable = mkDefault true; # used in xfce4-settings-manager
+    services.libinput.enable = mkDefault true; # used in xfce4-settings-manager
 
     # Enable default programs
     programs.dconf.enable = true;

--- a/nixos/modules/services/x11/hardware/cmt.nix
+++ b/nixos/modules/services/x11/hardware/cmt.nix
@@ -46,10 +46,10 @@ in {
 
     assertions = [
       {
-        assertion = !config.services.xserver.libinput.enable;
+        assertion = !config.services.libinput.enable;
         message = ''
           cmt and libinput are incompatible, meaning you cannot enable them both.
-          To use cmt you need to disable libinput with `services.xserver.libinput.enable = false`
+          To use cmt you need to disable libinput with `services.libinput.enable = false`
           If you haven't enabled it in configuration.nix, it's enabled by default on a
           different xserver module.
         '';

--- a/nixos/modules/services/x11/hardware/synaptics.nix
+++ b/nixos/modules/services/x11/hardware/synaptics.nix
@@ -30,7 +30,7 @@ in {
       enable = mkOption {
         type = types.bool;
         default = false;
-        description = "Whether to enable touchpad support. Deprecated: Consider services.xserver.libinput.enable.";
+        description = "Whether to enable touchpad support. Deprecated: Consider services.libinput.enable.";
       };
 
       dev = mkOption {
@@ -207,8 +207,8 @@ in {
 
     assertions = [
       {
-        assertion = !config.services.xserver.libinput.enable;
-        message = "Synaptics and libinput are incompatible, you cannot enable both (in services.xserver).";
+        assertion = !config.services.libinput.enable;
+        message = "Synaptics and libinput are incompatible, you cannot enable both.";
       }
     ];
 

--- a/nixos/tests/libinput.nix
+++ b/nixos/tests/libinput.nix
@@ -12,7 +12,7 @@ import ./make-test-python.nix ({ ... }:
 
       test-support.displayManager.auto.user = "alice";
 
-      services.xserver.libinput = {
+      services.libinput = {
         enable = true;
         mouse = {
           naturalScrolling = true;


### PR DESCRIPTION
## Description of changes

From the maker of "Make SDDM wayland only possible".

I am slowly working torwards removing xserver from my config. This time libinput is being changed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


---

cc @alois31 