### PR TITLE
fermyon-spin: 2.2.0 -> 2.4.2

### DIFF
--- a/pkgs/development/tools/fermyon-spin/default.nix
+++ b/pkgs/development/tools/fermyon-spin/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchzip
+, fetchurl
 , autoPatchelfHook
 , gcc-unwrapped
 , zlib
@@ -17,21 +17,25 @@ let
   }.${system} or (throw "Unsupported system: ${system}");
 
   packageHash = {
-    x86_64-linux = "sha256-Y0Inew0PncpnEpdLWtl/85t93eGSRewKh5mvGnn+yck=";
-    aarch64-linux = "sha256-HEm3TaLeaws8G73CU9BmxeplQdeF9nQbBSnbctaVhqI=";
-    x86_64-darwin = "sha256-mlshpN/4Od4qrXiqIEYo7G84Dtb+tp2nK2VnrRG2rto=";
-    aarch64-darwin = "sha256-aJH/vOidj0vbkttGDgelaAC/dMYguQPLjxl+V3pOVzI=";
+    x86_64-linux = "sha256-LHiLkZ+VN+wPnq6OukXozQWKh7ewNaFor1ndCUlCBtU=";
+    aarch64-linux = "sha256-1+rLGnm+LhbYigYUcmuLICLFXUk3wjOkmxuCuuI+Xqc=";
+    x86_64-darwin = "sha256-mJA3VXfNr6578Q2xw0xOZccloQpeCIsjn3dVdlsnTVs=";
+    aarch64-darwin = "sha256-FNl3UefJWA8yJ2B44GUEK6py7DLikJrygIwsqdIjW9c=";
   }.${system} or (throw "Unsupported system: ${system}");
 
 in stdenv.mkDerivation rec {
   pname = "fermyon-spin";
-  version = "2.2.0";
+  version = "2.4.2";
 
-  src = fetchzip {
+  # Use fetchurl rather than fetchzip as these tarballs are built by the project
+  # and not by GitHub (and thus are stable) - this simplifies the update script
+  # by allowing it to use the output of `nix store prefetch-file`.
+  src = fetchurl {
     url = "https://github.com/fermyon/spin/releases/download/v${version}/spin-v${version}-${platform}.tar.gz";
-    stripRoot = false;
     hash = packageHash;
   };
+
+  sourceRoot = ".";
 
   nativeBuildInputs = lib.optionals stdenv.isLinux [
     autoPatchelfHook
@@ -46,7 +50,7 @@ in stdenv.mkDerivation rec {
     runHook preInstall
 
     mkdir -p $out/bin
-    cp $src/* $out/bin
+    cp ./spin $out/bin
 
     runHook postInstall
   '';

--- a/pkgs/development/tools/fermyon-spin/update.sh
+++ b/pkgs/development/tools/fermyon-spin/update.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p jq
+#shellcheck shell=bash
+
+CURRENT_HASH=""
+
+print_hash() {
+    OS="$1"
+    ARCH="$2"
+    VERSION="$3"
+
+    URL="https://github.com/fermyon/spin/releases/download/v${VERSION}/spin-v${VERSION}-${OS}-${ARCH}.tar.gz"
+    echo
+    CURRENT_HASH=$(nix store prefetch-file "$URL" --json | jq -r '.hash')
+
+    echo "${ARCH}-${OS}: $CURRENT_HASH"
+}
+
+if [[ -z "$VER" && -n "$1" ]]; then
+    VER="$1"
+fi
+
+if [[ -z "$VER" ]]; then
+    echo "No 'VER' environment variable provided, skipping"
+else
+    print_hash "linux"  "amd64"   "$VER"
+    print_hash "linux"  "aarch64" "$VER"
+    print_hash "macos" "amd64"   "$VER"
+    print_hash "macos" "aarch64" "$VER"
+fi
+


### PR DESCRIPTION
## Description of changes

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
