### PR TITLE
x3270: 4.0ga9 -> 4.3ga8 

### DIFF
--- a/pkgs/applications/terminal-emulators/x3270/default.nix
+++ b/pkgs/applications/terminal-emulators/x3270/default.nix
@@ -1,39 +1,72 @@
-{ lib, stdenv, fetchurl, m4, expat
-, libX11, libXt, libXaw, libXmu, bdftopcf, mkfontdir
-, fontadobe100dpi, fontadobeutopia100dpi, fontbh100dpi
-, fontbhlucidatypewriter100dpi, fontbitstream100dpi
+{ stdenv
+, darwin
+, lib
+, libiconv
+, fetchurl
+, m4
+, expat
+, libX11
+, libXt
+, libXaw
+, libXmu
+, bdftopcf
+, mkfontdir
+, fontadobe100dpi
+, fontadobeutopia100dpi
+, fontbh100dpi
+, fontbhlucidatypewriter100dpi
+, fontbitstream100dpi
 , tcl
-, ncurses }:
-
+, ncurses
+}:
 let
   majorVersion = "4";
-  minorVersion = "0";
-  versionSuffix = "ga9";
-in stdenv.mkDerivation rec {
+  minorVersion = "3";
+  versionSuffix = "ga8";
+in
+stdenv.mkDerivation rec {
   pname = "x3270";
   version = "${majorVersion}.${minorVersion}${versionSuffix}";
 
   src = fetchurl {
-    url = "http://x3270.bgp.nu/download/0${majorVersion}.0${minorVersion}/suite3270-${version}-src.tgz";
-    sha256 = "0km24rgll0s4ji6iz8lvy5ra76ds162s95y33w5px6697cwqkp9j";
+    url =
+      "http://x3270.bgp.nu/download/0${majorVersion}.0${minorVersion}/suite3270-${version}-src.tgz";
+    sha256 = "sha256-gcC6REfZentIPEDhGznUSYu8mvVfpPeMz/Bks+N43Fk=";
   };
 
-  buildFlags = [ "unix" ];
+  buildFlags = lib.optional stdenv.isLinux "unix";
 
-  postConfigure = ''
-    pushd c3270 ; ./configure ; popd
+  configureFlags = lib.optionals stdenv.isDarwin [
+    "--enable-c3270"
+    "--enable-pr3270"
+    "--enable-s3270"
+    "--enable-tcl3270"
+  ];
+
+  postBuild = ''
+    make install.man
   '';
+
+  pathsToLink = [ "/share/man" ];
 
   nativeBuildInputs = [ m4 ];
   buildInputs = [
     expat
-    libX11 libXt libXaw libXmu bdftopcf mkfontdir
-    fontadobe100dpi fontadobeutopia100dpi fontbh100dpi
-    fontbhlucidatypewriter100dpi fontbitstream100dpi
+    libX11
+    libXt
+    libXaw
+    libXmu
+    bdftopcf
+    mkfontdir
+    fontadobe100dpi
+    fontadobeutopia100dpi
+    fontbh100dpi
+    fontbhlucidatypewriter100dpi
+    fontbitstream100dpi
     tcl
     ncurses
     expat
-  ];
+  ] ++ lib.optionals stdenv.isDarwin [ libiconv darwin.apple_sdk.frameworks.Security ];
 
   meta = with lib; {
     description = "IBM 3270 terminal emulator for the X Window System";


### PR DESCRIPTION
## Description of changes

* upgrade to latest release [4.3ga8 changelog](https://x3270.miraheze.org/wiki/Release_Notes/suite3270/4.3ga8)
* fixes broken darwin build by adding dependencies - fixes #304984 
* disables x11 build for darwin
* adds man page installation

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
