### PR TITLE
cups-brother-hl3170cdw: init at 1.1.4-0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11932,6 +11932,12 @@
     githubId = 26020062;
     name = "lumi";
   };
+  luna_1024 = {
+    email = "contact@luna.computer";
+    github = "luna-1024";
+    githubId = 7243615;
+    name = "Luna";
+  };
   lunarequest = {
     email = "nullarequest@vivlaid.net";
     github = "Lunarequest";

--- a/pkgs/by-name/cu/cups-brother-hl3170cdw/package.nix
+++ b/pkgs/by-name/cu/cups-brother-hl3170cdw/package.nix
@@ -1,0 +1,111 @@
+{lib, stdenv, fetchurl, dpkg, makeWrapper, gnused, coreutils, psutils, gnugrep, ghostscript, file, a2ps, gawk, which, pkgsi686Linux }:
+
+stdenv.mkDerivation rec {
+  pname = "cups-brother-${model}";
+  version = "1.1.4-0";
+  lprVersion = "1.1.2-1";
+
+  model = "hl3170cdw";
+  cupsFileNo = "006743";
+  lprFileNo = "007056";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf${cupsFileNo}/${model}_cupswrapper_GPL_source_${version}.tar.gz";
+    hash = "sha256-E3GSwiMRkuiCIJYkDozoYUPfOqvopPqPPQt1uaMDEAU=";
+  };
+
+  lprdeb = fetchurl {
+    url = "https://download.brother.com/welcome/dlf${lprFileNo}/${model}lpr-${lprVersion}.i386.deb";
+    hash = "sha256-N1GjQHth5k4qhbfWLInzub9DcNsee4gKc3EW2WIfrko=";
+  };
+
+  nativeBuildInputs = [ makeWrapper dpkg ];
+
+  preUnpack = ''
+    dpkg-deb -x ${lprdeb} $out
+  '';
+
+  prePatch = ''
+    substituteInPlace brcupsconfig/brcups_commands.h \
+      --replace-fail "brprintconf[30]=\"" "brprintconf[130]=\"$out/usr/bin/"
+
+    substituteInPlace brcupsconfig/brcupsconfig.c \
+      --replace-fail "exec[300]" "exec[400]"
+  '';
+
+  makeFlags = [ "-C brcupsconfig" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # cups install
+    dir=$out/opt/brother/Printers/${model}
+
+    # Extract the true brother_lpdwrapper_MODEL filter embedded in cupswrapperMODEL by
+    # slicing out the relevant parts for the writing the embedded file, then running that.
+    sed -n -e '/tmp_filter=/c\tmp_filter=lpdwrapper'  -e ' 1,/device_model=/p ; /<<!ENDOFWFILTER/,/!ENDOFWFILTER/p ; ' \
+      cupswrapper/cupswrapper${model} > lpdwrapperbuilder
+    sh lpdwrapperbuilder
+    chmod +x lpdwrapper
+    mkdir -p $out/lib/cups/filter
+    cp lpdwrapper $out/lib/cups/filter/brother_lpdwrapper_${model}
+
+    mkdir -p $out/share/cups/model/Brother
+    cp PPD/brother_${model}_printer_en.ppd $out/share/cups/model/Brother/brother_${model}_printer_en.ppd
+
+    mkdir -p $dir/cupswrapper/
+    cp brcupsconfig/brcupsconfpt1 $dir/cupswrapper/
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    # lpr fixup
+    interpreter=${pkgsi686Linux.glibc.out}/lib/ld-linux.so.2
+
+    substituteInPlace $dir/lpd/filter${model} \
+      --replace-fail /opt "$out/opt"
+    substituteInPlace $dir/inf/setupPrintcapij \
+      --replace-fail /opt "$out/opt" \
+      --replace-fail printcap.local printcap
+
+    wrapProgram $dir/lpd/filter${model} \
+      --prefix PATH ":" ${ lib.makeBinPath [ ghostscript a2ps file gnused coreutils ] }
+
+    wrapProgram $dir/inf/setupPrintcapij \
+      --prefix PATH ":" ${ lib.makeBinPath [ coreutils gnused ] }
+
+    wrapProgram $dir/lpd/psconvertij2 \
+      --prefix PATH ":" ${ lib.makeBinPath [ ghostscript gnused coreutils gawk which ] }
+
+    patchelf --set-interpreter "$interpreter" "$dir/lpd/br${model}filter"
+    patchelf --set-interpreter "$interpreter" "$out/usr/bin/brprintconf_${model}"
+
+    wrapProgram $dir/lpd/br${model}filter \
+      --set LD_PRELOAD "${pkgsi686Linux.libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS "/opt=$out/opt"
+
+    wrapProgram $out/usr/bin/brprintconf_${model} \
+      --set LD_PRELOAD "${pkgsi686Linux.libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS "/opt=$out/opt"
+
+    # cups fixup
+    substituteInPlace $out/lib/cups/filter/brother_lpdwrapper_${model} \
+      --replace-fail /opt/brother/Printers/${model} "$dir" \
+      --replace-fail /usr/bin/psnup "${psutils}/bin/psnup" \
+      --replace-fail /usr/share/cups/model/Brother "$out/share/cups/model/Brother"
+
+    wrapProgram $out/lib/cups/filter/brother_lpdwrapper_${model} \
+      --prefix PATH ":" ${ lib.makeBinPath [ coreutils psutils gnused gnugrep ] }
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.brother.com/";
+    description = "Brother ${model} printer driver";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode fromSource ];
+    license = with licenses; [ unfree gpl2Plus ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=us&lang=en&prod=${model}_all&os=128";
+    maintainers = with maintainers; [ luna_1024 ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Add proprietary driver (PPD + CUPS filter) for Brother HL-3170CDW printer.

### Binary functionality testing method
I have tested these packages by incorporating my nixpkgs development repository as an input into my system configuration flake and `cups-brother-hl3170cdw` into the `services.printing.drivers` list as a user would incorporate the package. Then I successfully printed documents with it.

### This package compared to existing Brother printer drivers
I have identified many other Brother printer drivers in nixpkgs, including the for the most similar printers [HL-3140CW](https://github.com/NixOS/nixpkgs/blob/748be90edf46d00a8f7d60470a993bb529965c76/pkgs/misc/cups/drivers/hl3140cw/default.nix), [MFC-9140CDN](https://github.com/NixOS/nixpkgs/blob/748be90edf46d00a8f7d60470a993bb529965c76/pkgs/misc/cups/drivers/mfc9140cdncupswrapper/default.nix), and [DCP-9020CDW](https://github.com/NixOS/nixpkgs/blob/748be90edf46d00a8f7d60470a993bb529965c76/pkgs/misc/cups/drivers/brother/dcp9020cdw/default.nix), and referred to the most recently added brother printer package [MFC-J880DW](https://github.com/NixOS/nixpkgs/pull/279265).

I thus based my implementation on these packages, but found that there is a lot of copy pasting of existing code into each new brother printer package. So I wrote this package with careful consideration of each line. After troubleshooting my own code, I suspect that many existing Brother drivers have an issue of dropping print settings before they get to the printer. This package handles print settings properly.

#### Package Naming
Brother has HL, MFC, and DCP types of laser printer models. I notice that MFC and DCP drivers are implemented as 2 packages `MODEL{lpr,cupswrapper}`, one for each upstream package from Brother. HL printers are have a single `cups-brother-MODEL` package which composites 2 the packages from brother into one Nix package. This is an arbitrary distinction, since all 3 types have [very similar package contents](https://gist.github.com/luna-1024/9cdc219040aee48b76feb9f2d1a0d56a). 

I have decided to follow the existing convention here, since this is probably not the place to resolve that inconsistency. Though I will say that there is sense for a single package: It is clearer for the user the package to use, and just installing the LPR package would be of no use in NixOS unless the user procures a Line Printer Daemon (nixpkgs seems to have no package).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
