### PR TITLE
snapcraft: init at 8.2.0

### DIFF
--- a/pkgs/by-name/sn/snapcraft/lxd-socket-path.patch
+++ b/pkgs/by-name/sn/snapcraft/lxd-socket-path.patch
@@ -1,0 +1,13 @@
+diff --git a/snapcraft_legacy/internal/build_providers/_lxd/_lxd.py b/snapcraft_legacy/internal/build_providers/_lxd/_lxd.py
+index 5fa4f898..41264ebb 100644
+--- a/snapcraft_legacy/internal/build_providers/_lxd/_lxd.py
++++ b/snapcraft_legacy/internal/build_providers/_lxd/_lxd.py
+@@ -142,7 +142,7 @@ class LXD(Provider):
+             build_provider_flags=build_provider_flags,
+         )
+         # This endpoint is hardcoded everywhere lxc/lxd-pkg-snap#33
+-        lxd_socket_path = "/var/snap/lxd/common/lxd/unix.socket"
++        lxd_socket_path = "/var/lib/lxd/unix.socket"
+         endpoint = "http+unix://{}".format(urllib.parse.quote(lxd_socket_path, safe=""))
+         try:
+             self._lxd_client: pylxd.Client = pylxd.Client(endpoint=endpoint)

--- a/pkgs/by-name/sn/snapcraft/os-platform.patch
+++ b/pkgs/by-name/sn/snapcraft/os-platform.patch
@@ -1,0 +1,21 @@
+diff --git a/snapcraft/utils.py b/snapcraft/utils.py
+index 511effe2..4af5a029 100644
+--- a/snapcraft/utils.py
++++ b/snapcraft/utils.py
+@@ -15,6 +15,7 @@
+ # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ """Utilities for snapcraft."""
++
+ import multiprocessing
+ import os
+ import pathlib
+@@ -91,7 +92,7 @@ def get_os_platform(
+     release = platform.release()
+     machine = platform.machine()
+ 
+-    if system == "Linux":
++    if system == "Linux" and "NixOS" not in platform.version():
+         try:
+             with filepath.open("rt", encoding="utf-8") as release_file:
+                 lines = release_file.readlines()

--- a/pkgs/by-name/sn/snapcraft/package.nix
+++ b/pkgs/by-name/sn/snapcraft/package.nix
@@ -1,0 +1,188 @@
+{
+  fetchFromGitHub,
+  git,
+  glibc,
+  lib,
+  makeWrapper,
+  nix-update-script,
+  python3Packages,
+  squashfsTools,
+  stdenv,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "snapcraft";
+  version = "8.2.0";
+
+  pyproject = true;
+
+  # Somewhere deep in the dependency tree is 'versioningit', which depends
+  # on pydantic 2. Snapcraft will soon migrate to pydantic 2, and disabling
+  # this doesn't seem to affect the functionality of the application.
+  catchConflicts = false;
+
+  src = fetchFromGitHub {
+    owner = "canonical";
+    repo = "snapcraft";
+    rev = "refs/tags/${version}";
+    hash = "sha256-uRapRL+492FOju83o3OBsYK52hwOOG6b4EbdMVpAlBs=";
+  };
+
+  patches = [
+    # Snapcraft is only officially distributed as a snap, as is LXD. The socket
+    # path for LXD must be adjusted so that it's at the correct location for LXD
+    # on NixOS. This patch will likely never be accepted upstream.
+    ./lxd-socket-path.patch
+    # In certain places, Snapcraft expects an /etc/os-release file to determine
+    # host info which doesn't exist in our test environment. This is a
+    # relatively naive patch which helps the test suite pass - without it *many*
+    # of the tests fail. This patch will likely never be accepted upstream.
+    ./os-platform.patch
+    # Snapcraft will try to inject itself as a snap *from the host system* into
+    # the build system. This patch short-circuits that logic and ensures that
+    # Snapcraft is installed on the build system from the snap store - because
+    # there is no snapd on NixOS hosts that can be used for the injection. This
+    # patch will likely never be accepted upstream.
+    ./set-channel-for-nix.patch
+    # Certain paths (for extensions, schemas) are packaged in the snap by the
+    # upstream, so the paths are well-known, except here where Snapcraft is
+    # *not* in a snap, so this patch changes those paths to point to the correct
+    # place in the Nix store. This patch will likely never be accepted upstream.
+    ./snapcraft-data-dirs.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail 'version=determine_version()' 'version="${version}"' \
+      --replace-fail 'gnupg' 'python-gnupg'
+
+    substituteInPlace requirements.txt \
+      --replace-fail 'gnupg==2.3.1' 'python-gnupg'
+
+    substituteInPlace snapcraft/__init__.py \
+      --replace-fail '__version__ = _get_version()' '__version__ = "${version}"'
+
+    substituteInPlace snapcraft_legacy/__init__.py \
+      --replace-fail '__version__ = _get_version()' '__version__ = "${version}"'
+
+    substituteInPlace snapcraft/elf/elf_utils.py \
+      --replace-fail 'arch_linker_path = Path(arch_config.dynamic_linker)' \
+      'return str(Path("${glibc}/lib/ld-linux-x86-64.so.2"))'
+  '';
+
+  buildInputs = [ makeWrapper ];
+
+  propagatedBuildInputs = with python3Packages; [
+    attrs
+    catkin-pkg
+    click
+    craft-application
+    craft-archives
+    craft-cli
+    craft-grammar
+    craft-parts
+    craft-providers
+    craft-store
+    debian
+    docutils
+    jsonschema
+    launchpadlib
+    lazr-restfulclient
+    lxml
+    macaroonbakery
+    mypy-extensions
+    progressbar
+    pyelftools
+    pygit2
+    pylxd
+    python-apt
+    python-gnupg
+    raven
+    requests-toolbelt
+    simplejson
+    snap-helpers
+    tabulate
+    tinydb
+  ];
+
+  nativeBuildInputs = with python3Packages; [
+    pythonRelaxDepsHook
+    setuptools
+  ];
+
+  pythonRelaxDeps = [
+    "docutils"
+    "jsonschema"
+    "pygit2"
+    "urllib3"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/snapcraft --prefix PATH : ${squashfsTools}/bin
+  '';
+
+  nativeCheckInputs = with python3Packages; [
+    pytest-check
+    pytest-cov
+    pytest-mock
+    pytest-subprocess
+    pytestCheckHook
+    responses
+  ] ++ [
+    git
+    squashfsTools
+  ];
+
+  preCheck = ''
+    mkdir -p check-phase
+    export HOME="$(pwd)/check-phase"
+  '';
+
+  pytestFlagsArray = [ "tests/unit" ];
+
+  disabledTests = [
+    "test_bin_echo"
+    "test_classic_linter_filter"
+    "test_classic_linter"
+    "test_complex_snap_yaml"
+    "test_get_base_configuration_snap_channel"
+    "test_get_base_configuration_snap_instance_name_default"
+    "test_get_base_configuration_snap_instance_name_not_running_as_snap"
+    "test_get_extensions_data_dir"
+    "test_get_os_platform_alternative_formats"
+    "test_get_os_platform_linux"
+    "test_get_os_platform_windows"
+    "test_lifecycle_pack_components_with_output"
+    "test_lifecycle_pack_components"
+    "test_lifecycle_write_component_metadata"
+    "test_parse_info_integrated"
+    "test_patch_elf"
+    "test_remote_builder_init"
+    "test_setup_assets_remote_icon"
+    "test_snap_command_fallback"
+    "test_validate_architectures_supported"
+    "test_validate_architectures_unsupported"
+  ] ++ lib.optionals stdenv.isAarch64 [
+    "test_load_project"
+  ];
+
+  disabledTestPaths = [
+    "tests/unit/commands/test_remote.py"
+    "tests/unit/elf"
+    "tests/unit/linters/test_classic_linter.py"
+    "tests/unit/linters/test_library_linter.py"
+    "tests/unit/parts/test_parts.py"
+    "tests/unit/services"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "snapcraft";
+    description = "Build and publish Snap packages";
+    homepage = "https://github.com/canonical/snapcraft";
+    changelog = "https://github.com/canonical/snapcraft/releases/tag/${version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/sn/snapcraft/set-channel-for-nix.patch
+++ b/pkgs/by-name/sn/snapcraft/set-channel-for-nix.patch
@@ -1,0 +1,30 @@
+diff --git a/snapcraft/providers.py b/snapcraft/providers.py
+index a999537a..dcd290a7 100644
+--- a/snapcraft/providers.py
++++ b/snapcraft/providers.py
+@@ -21,6 +21,7 @@ import sys
+ from pathlib import Path
+ from textwrap import dedent
+ from typing import Dict, Optional
++import platform
+ 
+ from craft_cli import emit
+ from craft_providers import Provider, ProviderError, bases, executor
+@@ -178,14 +179,14 @@ def get_base_configuration(
+     # injecting a snap on a non-linux system is not supported, so default to
+     # install snapcraft from the store's stable channel
+     snap_channel = get_managed_environment_snap_channel()
+-    if sys.platform != "linux" and not snap_channel:
++    if snap_channel is None and (sys.platform != "linux" or "NixOS" in platform.version()):
+         emit.progress(
+-            "Using snapcraft from snap store channel 'latest/stable' in instance "
++            "Using snapcraft from snap store channel 'latest/beta' in instance "
+             "because snap injection is only supported on Linux hosts.",
+             permanent=True,
+         )
+         snap_name = "snapcraft"
+-        snap_channel = "stable"
++        snap_channel = "beta"
+     elif is_snapcraft_running_from_snap():
+         # Use SNAP_INSTANCE_NAME for snapcraft's snap name, as it may not be
+         # 'snapcraft' if the '--name' parameter was used to install snapcraft.

--- a/pkgs/by-name/sn/snapcraft/snapcraft-data-dirs.patch
+++ b/pkgs/by-name/sn/snapcraft/snapcraft-data-dirs.patch
@@ -1,0 +1,26 @@
+diff --git a/snapcraft_legacy/internal/common.py b/snapcraft_legacy/internal/common.py
+index 6017b405..aacd99a5 100644
+--- a/snapcraft_legacy/internal/common.py
++++ b/snapcraft_legacy/internal/common.py
+@@ -34,14 +34,17 @@ from snaphelpers import SnapConfigOptions, SnapCtlError
+ 
+ from snapcraft_legacy.internal import errors
+ 
++# Get the path to the Nix store entry for Snapcraft at runtime
++drv = os.path.realpath(__file__).split("/")[3]
++
+ SNAPCRAFT_FILES = ["parts", "stage", "prime"]
+-_DEFAULT_PLUGINDIR = os.path.join(sys.prefix, "share", "snapcraft", "plugins")
++_DEFAULT_PLUGINDIR = os.path.join(os.sep, "nix", "store", drv, "share", "snapcraft", "plugins")
+ _plugindir = _DEFAULT_PLUGINDIR
+-_DEFAULT_SCHEMADIR = os.path.join(sys.prefix, "share", "snapcraft", "schema")
++_DEFAULT_SCHEMADIR = os.path.join(os.sep, "nix", "store", drv, "share", "snapcraft", "schema")
+ _schemadir = _DEFAULT_SCHEMADIR
+-_DEFAULT_EXTENSIONSDIR = os.path.join(sys.prefix, "share", "snapcraft", "extensions")
++_DEFAULT_EXTENSIONSDIR = os.path.join(os.sep, "nix", "store", drv, "share", "snapcraft", "extensions")
+ _extensionsdir = _DEFAULT_EXTENSIONSDIR
+-_DEFAULT_KEYRINGSDIR = os.path.join(sys.prefix, "share", "snapcraft", "keyrings")
++_DEFAULT_KEYRINGSDIR = os.path.join(os.sep, "nix", "store", drv, "share", "snapcraft", "keyrings")
+ _keyringsdir = _DEFAULT_KEYRINGSDIR
+ 
+ _DOCKERENV_FILE = "/.dockerenv"

--- a/pkgs/development/python-modules/catkin-pkg/default.nix
+++ b/pkgs/development/python-modules/catkin-pkg/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  docutils,
+  pyparsing,
+  python-dateutil,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "catkin-pkg";
+  version = "0.5.2";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ros-infrastructure";
+    repo = "catkin_pkg";
+    rev = version;
+    hash = "sha256-DjaPpLDsLpYOZukf5tYe6ZetSNTe/DJ2lS9BUsehZ8k=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [
+    docutils
+    pyparsing
+    python-dateutil
+  ];
+
+  pythonImportsCheck = [ "catkin_pkg" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [ "test/test_flake8.py" ];
+
+  meta = {
+    description = "Library for retrieving information about catkin packages.";
+    homepage = "http://wiki.ros.org/catkin_pkg";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+  };
+}

--- a/pkgs/development/python-modules/craft-application/default.nix
+++ b/pkgs/development/python-modules/craft-application/default.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  git,
+  craft-archives,
+  craft-cli,
+  craft-grammar,
+  craft-parts,
+  craft-providers,
+  pydantic-yaml-0,
+  pyyaml,
+  setuptools,
+  setuptools-scm,
+  snap-helpers,
+  stdenv,
+  pygit2,
+  pyfakefs,
+  pytestCheckHook,
+  pytest-check,
+  pytest-mock,
+  responses,
+  hypothesis,
+}:
+
+buildPythonPackage rec {
+  pname = "craft-application";
+  version = "2.5.0";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "canonical";
+    repo = "craft-application";
+    rev = "refs/tags/${version}";
+    hash = "sha256-66Ldo88DJ6v0+ekvDl++eDzhdn95yxq0SMdzQxTGl5k=";
+  };
+
+  postPatch = ''
+    substituteInPlace craft_application/__init__.py \
+      --replace-fail "dev" "${version}"
+
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools==69.4.0" "setuptools"
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    craft-archives
+    craft-cli
+    craft-grammar
+    craft-parts
+    craft-providers
+    pydantic-yaml-0
+    pygit2
+    pyyaml
+    snap-helpers
+  ];
+
+  pythonImportsCheck = [ "craft_application" ];
+
+  nativeCheckInputs = [
+    git
+    hypothesis
+    pyfakefs
+    pytest-check
+    pytest-mock
+    pytestCheckHook
+    responses
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+
+    # Tests require access to /etc/os-release, which isn't accessible in
+    # the test environment, so create a fake file, and modify the code
+    # to look for it.
+    echo 'ID=nixos' > $HOME/os-release
+    echo 'NAME=NixOS' >> $HOME/os-release
+    echo 'VERSION_ID="24.05"' >> $HOME/os-release
+
+    substituteInPlace craft_application/util/platforms.py \
+      --replace-fail "os_utils.OsRelease()" "os_utils.OsRelease(os_release_file='$HOME/os-release')"
+  '';
+
+  pytestFlagsArray = [ "tests/unit" ];
+
+  disabledTests = [
+    "test_to_yaml_file"
+    # Tests expecting pytest-time
+    "test_monitor_builds_success"
+  ] ++ lib.optionals stdenv.isAarch64 [
+    # These tests have hardcoded "amd64" strings which fail on aarch64
+    "test_process_grammar_build_for"
+    "test_process_grammar_platform"
+    "test_process_grammar_default"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "The basis for Canonical craft applications";
+    homepage = "https://github.com/canonical/craft-application";
+    changelog = "https://github.com/canonical/craft-application/releases/tag/${version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/craft-providers/default.nix
+++ b/pkgs/development/python-modules/craft-providers/default.nix
@@ -33,6 +33,11 @@ buildPythonPackage rec {
   };
 
   patches = [
+    # This lib will try to inject snaps *from the host system* into the build
+    # system. This patch short-circuits that logic and ensures that snaps are
+    # installed on the build system from the snap store - because there is no
+    # snapd on NixOS hosts that can be used for the injection. This patch will
+    # likely never be accepted upstream.
     ./inject-snaps.patch
   ];
 

--- a/pkgs/development/python-modules/craft-providers/inject-snaps.patch
+++ b/pkgs/development/python-modules/craft-providers/inject-snaps.patch
@@ -38,7 +38,7 @@ index 3c914a2..d9c2cf9 100644
 -                        details=error.details,
 -                    ) from error
 +            try:
-+                channel = "latest/edge" if snap.name == "rockcraft" else "latest/stable"
++                channel = "latest/beta"
 +                snap_installer.install_from_store(
 +                    executor=executor,
 +                    snap_name=snap.name,

--- a/pkgs/development/python-modules/python-apt/default.nix
+++ b/pkgs/development/python-modules/python-apt/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  apt,
+  buildPythonPackage,
+  fetchgit,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "apt";
+  version = "2.7.6";
+
+  pyproject = true;
+
+  src = fetchgit {
+    url = "https://git.launchpad.net/python-apt";
+    rev = "refs/tags/${version}";
+    hash = "sha256-1jTe8ncMKV78+cfSZ6p6qdjxs0plZLB4VwVtPLtDlAc=";
+  };
+
+  buildInputs = [ apt.dev ];
+
+  nativeBuildInputs = [ setuptools ];
+
+  # Ensure the version is set properly without trying to invoke
+  # dpkg-parsechangelog
+  env.DEBVER = "${version}";
+
+  pythonImportsCheck = [ "apt_pkg" ];
+
+  meta = {
+    description = "Python bindings for APT";
+    homepage = "https://launchpad.net/python-apt";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2486,6 +2486,8 @@ self: super: with self; {
 
   craft-application-1 = callPackage ../development/python-modules/craft-application-1 { };
 
+  craft-application = callPackage ../development/python-modules/craft-application { };
+
   craft-archives = callPackage ../development/python-modules/craft-archives { };
 
   craft-cli = callPackage ../development/python-modules/craft-cli { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1932,6 +1932,8 @@ self: super: with self; {
     };
   };
 
+  catkin-pkg = callPackage ../development/python-modules/catkin-pkg { };
+
   catppuccin = callPackage ../development/python-modules/catppuccin { };
 
   cattrs = callPackage ../development/python-modules/cattrs { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12184,6 +12184,8 @@ self: super: with self; {
 
   python3-openid = callPackage ../development/python-modules/python3-openid { };
 
+  python-apt = callPackage ../development/python-modules/python-apt { };
+
   python-arango = callPackage ../development/python-modules/python-arango { };
 
   python-awair = callPackage ../development/python-modules/python-awair { };


### PR DESCRIPTION
## Description of changes

Adds `snapcraft`, starting at version `8.2.0`, which is the latest version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
