### PR TITLE
committed: init at 1.0.20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15734,6 +15734,12 @@
     githubId = 1179566;
     name = "Nicolas B. Pierron";
   };
+  pigeonf = {
+    email = "fnoegip+nixpkgs@gmail.com";
+    github = "PigeonF";
+    githubId = 7536431;
+    name = "Jonas Fierlings";
+  };
   pimeys = {
     email = "julius@nauk.io";
     github = "pimeys";

--- a/pkgs/by-name/co/committed/package.nix
+++ b/pkgs/by-name/co/committed/package.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, darwin
+, testers
+, nix-update-script
+, committed
+}:
+let
+  version = "1.0.20";
+in
+rustPlatform.buildRustPackage {
+  pname = "committed";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "crate-ci";
+    repo = "committed";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-HqZYxV2YjnK7Q3A7B6yVFXME0oc3DZ4RfMkDGa2IQxA=";
+  };
+  cargoHash = "sha256-AmAEGVWq6KxLtiHDGIFVcoP1Wck8z+P9mnDy0SSSJNM=";
+
+  buildInputs = lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
+
+  passthru = {
+    tests.version = testers.testVersion { package = committed; };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    homepage = "https://github.com/crate-ci/committed";
+    changelog = "https://github.com/crate-ci/committed/blob/v${version}/CHANGELOG.md";
+    description = "Nitpicking commit history since beabf39";
+    mainProgram = "committed";
+    license = [
+      lib.licenses.asl20 # or
+      lib.licenses.mit
+    ];
+    maintainers = [ lib.maintainers.pigeonf ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds [crate-ci/committed](https://github.com/crate-ci/committed), a tool for enforcing commit standards.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

While I ran `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`, the output indicates that the build was successful, but the command fails because of a missing build log? I am not sure what is going on there.

<details>

<summary>Error log of <code>nixpkgs-review rev b171ecfe9750ffa1</code></summary>

```text
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
$ git worktree add /home/pigeon/.cache/nixpkgs-review/rev-b171ecfe9750ffa13ac297be48c6842f0e140848-2/nixpkgs 164c9f87931e3e9b05895d302e8b351798a25e05
Preparing worktree (detached HEAD 164c9f87931e3e9b)
Updating files: 100% (40984/40984), done.
HEAD is now at 164c9f87931e3e9b Merge pull request #304576 from rster2002/publish-myxer
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/pigeon/.cache/nixpkgs-review/rev-b171ecfe9750ffa13ac297be48c6842f0e140848-2/nixpkgs nixpkgs-overlays=/run/user/1000/tmpzayl23w0 -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
$ git merge --no-commit --no-ff b171ecfe9750ffa13ac297be48c6842f0e140848
Auto-merging maintainers/maintainer-list.nix
Automatic merge went well; stopped before committing as requested
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/pigeon/.cache/nixpkgs-review/rev-b171ecfe9750ffa13ac297be48c6842f0e140848-2/nixpkgs nixpkgs-overlays=/run/user/1000/tmpzayl23w0 -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
1 package added:
committed (init at 1.0.20)

$ nom build --file /nix/store/fhkw3f0yq2cbp9cg5564gfwj1q9rwjha-nixpkgs-review-2.10.4/lib/python3.11/site-packages/nixpkgs_review/nix/review-shell.nix --nix-path nixpkgs=/home/pigeon/.cache/nixpkgs-review/rev-b171ecfe9750ffa13ac297be48c6842f0e140848-2/nixpkgs nixpkgs-overlays=/run/user/1000/tmpzayl23w0 --extra-experimental-features nix-command no-url-literals --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed --argstr system x86_64-linux --argstr nixpkgs-path /home/pigeon/.cache/nixpkgs-review/rev-b171ecfe9750ffa13ac297be48c6842f0e140848-2/nixpkgs --argstr nixpkgs-config-path /run/user/1000/tmphqcrcbn7.nix --argstr attrs-path /home/pigeon/.cache/nixpkgs-review/rev-b171ecfe9750ffa13ac297be48c6842f0e140848-2/attrs.nix
Finished at 13:50:28 after 0s
1 package built:
committed

error: build log of '/nix/store/ydqjk53jn51ks58a7x059zdwx67l497w-committed-1.0.20.drv^*' is not available
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
