### PR TITLE
ncspot: Adjust defaults to upstream

### DIFF
--- a/pkgs/applications/audio/ncspot/default.nix
+++ b/pkgs/applications/audio/ncspot/default.nix
@@ -6,12 +6,13 @@
 , ncurses
 , openssl
 , Cocoa
-, withALSA ? true, alsa-lib
+, withALSA ? false, alsa-lib
 , withClipboard ? true, libxcb, python3
 , withCover ? false, ueberzug
-, withPulseAudio ? false, libpulseaudio
+, withPulseAudio ? true, libpulseaudio
 , withPortAudio ? false, portaudio
 , withMPRIS ? true, withNotify ? true, dbus
+, withCross ? true
 , nix-update-script
 , testers
 , ncspot
@@ -54,6 +55,7 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optional withPulseAudio "pulseaudio_backend"
     ++ lib.optional withPortAudio "portaudio_backend"
     ++ lib.optional withMPRIS "mpris"
+    ++ lib.optional withCross "crossterm_backend"
     ++ lib.optional withNotify "notify";
 
   postInstall = ''

--- a/pkgs/applications/audio/ncspot/default.nix
+++ b/pkgs/applications/audio/ncspot/default.nix
@@ -12,7 +12,7 @@
 , withPulseAudio ? true, libpulseaudio
 , withPortAudio ? false, portaudio
 , withMPRIS ? true, withNotify ? true, dbus
-, withCross ? true
+, withCrossterm ? true
 , nix-update-script
 , testers
 , ncspot
@@ -55,7 +55,7 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optional withPulseAudio "pulseaudio_backend"
     ++ lib.optional withPortAudio "portaudio_backend"
     ++ lib.optional withMPRIS "mpris"
-    ++ lib.optional withCross "crossterm_backend"
+    ++ lib.optional withCrossterm "crossterm_backend"
     ++ lib.optional withNotify "notify";
 
   postInstall = ''


### PR DESCRIPTION
## Description of changes

Ncspot uses pulseaudio and crossterm as default features.
I adjusted these accordingly.

resolves: https://github.com/hrkfdn/ncspot/issues/1378 (issue does not occur upstream, tested via cargo install)
## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


