### PR TITLE
lenovo-legion: 0.0.9 -> 0.0.12

### DIFF
--- a/pkgs/os-specific/linux/lenovo-legion/app.nix
+++ b/pkgs/os-specific/linux/lenovo-legion/app.nix
@@ -2,13 +2,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "lenovo-legion-app";
-  version = "0.0.9";
+  version = "0.0.12";
 
   src = fetchFromGitHub {
     owner = "johnfanv2";
     repo = "LenovoLegionLinux";
     rev = "v${version}-prerelease";
-    hash = "sha256-PQdxfDfW3sn0wWjmsPoAt3HZ43PS3Tyez3/0KEVVZQg=";
+    hash = "sha256-BNrRv9EBmNINQbAw+BzVxKl/XoDgH1tsNZHJxfSpNoU=";
   };
 
   sourceRoot = "${src.name}/python/legion_linux";
@@ -17,6 +17,7 @@ python3.pkgs.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3.pkgs; [
     pyqt5
+    pyqt6
     argcomplete
     pyyaml
     darkdetect
@@ -26,13 +27,13 @@ python3.pkgs.buildPythonApplication rec {
 
   postPatch = ''
     substituteInPlace ./setup.cfg \
-      --replace "_VERSION" "${version}"
+      --replace-fail "_VERSION" "${version}"
     substituteInPlace ../../extra/service/fancurve-set \
-      --replace "FOLDER=/etc/legion_linux/" "FOLDER=$out/share/legion_linux"
+      --replace-fail "FOLDER=/etc/legion_linux/" "FOLDER=$out/share/legion_linux"
     substituteInPlace ./legion_linux/legion.py \
-      --replace "/etc/legion_linux" "$out/share/legion_linux"
-    substituteInPlace ./legion_linux/legion_gui{,_user}.desktop \
-      --replace "Icon=/usr/share/pixmaps/legion_logo.png" "Icon=legion_logo"
+      --replace-fail "/etc/legion_linux" "$out/share/legion_linux"
+    substituteInPlace ./legion_linux/legion_gui.desktop \
+      --replace-fail "Icon=/usr/share/pixmaps/legion_logo.png" "Icon=legion_logo"
   '';
 
   dontWrapQtApps = true;


### PR DESCRIPTION
https://github.com/johnfanv2/LenovoLegionLinux/releases/tag/v0.0.12-prerelease

## Description of changes
added additional new dependencies and resolved deprecated build arguments and fixed a broken path for a .desktop file.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- bumped Lenovo-Legion from version 0.0.9 to 0.0.12;
- added pyqt6 dependency
- rewrote deprecated ```--replace``` to ```--replace-fail``` [maybe ```--replace-warn``` would be better? I am not quite sure]
- updated checksum

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
