### PR TITLE
nixos/ollama: add options to bypass sandboxing

### DIFF
--- a/nixos/modules/services/misc/ollama.nix
+++ b/nixos/modules/services/misc/ollama.nix
@@ -21,6 +21,8 @@ in
         example = "/home/foo";
         description = ''
           The home directory that the ollama service is started in.
+
+          See also `services.ollama.writablePaths` and `services.ollama.sandbox`.
         '';
       };
       models = lib.mkOption {
@@ -29,6 +31,37 @@ in
         example = "/path/to/ollama/models";
         description = ''
           The directory that the ollama service will read models from and download new models to.
+
+          See also `services.ollama.writablePaths` and `services.ollama.sandbox`
+          if downloading models or other mutation of the filesystem is required.
+        '';
+      };
+      sandbox = lib.mkOption {
+        type = types.bool;
+        default = true;
+        example = false;
+        description = ''
+          Whether to enable systemd's sandboxing capabilities.
+
+          This sets [`DynamicUser`](
+          https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#DynamicUser=
+          ), which runs the server as a unique user with read-only access to most of the filesystem.
+
+          See also `services.ollama.writablePaths`.
+        '';
+      };
+      writablePaths = lib.mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "/home/foo" "/mnt/foo" ];
+        description = ''
+          Paths that the server should have write access to.
+
+          This sets [`ReadWritePaths`](
+          https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#ReadWritePaths=
+          ), which allows specified paths to be written to through the default sandboxing.
+
+          See also `services.ollama.sandbox`.
         '';
       };
       listenAddress = lib.mkOption {
@@ -59,8 +92,8 @@ in
         type = types.attrsOf types.str;
         default = { };
         example = {
-          HOME = "/tmp";
           OLLAMA_LLM_LIBRARY = "cpu";
+          HIP_VISIBLE_DEVICES = "0,1";
         };
         description = ''
           Set arbitrary environment variables for the ollama service.
@@ -87,7 +120,8 @@ in
         ExecStart = "${lib.getExe ollamaPackage} serve";
         WorkingDirectory = cfg.home;
         StateDirectory = [ "ollama" ];
-        DynamicUser = true;
+        DynamicUser = cfg.sandbox;
+        ReadWritePaths = cfg.writablePaths;
       };
     };
 


### PR DESCRIPTION
## Description of changes

By default, the service has some sandboxing systemd features enabled, which includes making most of the filesystem read-only. This is usually fine, but in some cases may get in the way. This allows two ways to bypass sanboxing: disabling it entirely, or giving write access to specific paths.

Resolves #304531.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
