### PR TITLE
ayatana-indicator-power: init & add to Lomiri

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -72,6 +72,7 @@ in {
       packages = (with pkgs; [
         ayatana-indicator-datetime
         ayatana-indicator-messages
+        ayatana-indicator-power
         ayatana-indicator-session
       ]) ++ (with pkgs.lomiri; [
         telephony-service

--- a/nixos/tests/ayatana-indicators.nix
+++ b/nixos/tests/ayatana-indicators.nix
@@ -29,6 +29,7 @@ in {
       packages = with pkgs; [
         ayatana-indicator-datetime
         ayatana-indicator-messages
+        ayatana-indicator-power
         ayatana-indicator-session
       ] ++ (with pkgs.lomiri; [
         lomiri-indicator-network

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -290,11 +290,12 @@ in {
     # There's a test app we could use that also displays their contents, but it's abit inconsistent.
     with subtest("ayatana indicators work"):
         mouse_click(735, 0) # the cog in the top-right, for the session indicator
-        machine.wait_for_text(r"(Notifications|Time|Date|System)")
+        machine.wait_for_text(r"(Notifications|Battery|Time|Date|System)")
         machine.screenshot("indicators_open")
 
         # Indicator order within the menus *should* be fixed based on per-indicator order setting
         # Session is the one we clicked, but the last we should test (logout). Go as far left as we can test.
+        machine.send_key("left")
         machine.send_key("left")
         machine.send_key("left")
         # Notifications are usually empty, nothing to check there
@@ -303,6 +304,11 @@ in {
             # We start on this, don't go right
             machine.wait_for_text(r"(Flight|Wi-Fi)")
             machine.screenshot("indicators_network")
+
+        with subtest("ayatana indicator power works"):
+            machine.send_key("right")
+            machine.wait_for_text(r"(Charge|Battery settings)")
+            machine.screenshot("indicators_power")
 
         with subtest("ayatana indicator datetime works"):
             machine.send_key("right")

--- a/pkgs/by-name/ay/ayatana-indicator-power/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-power/package.nix
@@ -1,0 +1,107 @@
+{ stdenv
+, lib
+, gitUpdater
+, fetchFromGitHub
+, nixosTests
+, cmake
+, dbus
+, dbus-test-runner
+, glib
+, gtest
+, intltool
+, libayatana-common
+, libnotify
+, librda
+, lomiri
+, pkg-config
+, python3
+, systemd
+, wrapGAppsHook3
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ayatana-indicator-power";
+  version = "24.1.0";
+
+  src = fetchFromGitHub {
+    owner = "AyatanaIndicators";
+    repo = "ayatana-indicator-power";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-VUDNy6pPOsjioV5UNiKm8dzYb02ZrZ8CiIiJmAoQYaM=";
+  };
+
+  postPatch = ''
+    # Replace systemd prefix in pkg-config query, use GNUInstallDirs location for /etc
+    substituteInPlace data/CMakeLists.txt \
+      --replace-fail 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir)' 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir DEFINE_VARIABLES prefix=''${CMAKE_INSTALL_PREFIX})' \
+      --replace-fail 'XDG_AUTOSTART_DIR "/etc' 'XDG_AUTOSTART_DIR "''${CMAKE_INSTALL_FULL_SYSCONFDIR}'
+
+    # Path needed for build-time codegen
+    substituteInPlace src/CMakeLists.txt \
+      --replace-fail '/usr/share/accountsservice/interfaces/com.lomiri.touch.AccountsService.Sound.xml' '${lomiri.lomiri-schemas}/share/accountsservice/interfaces/com.lomiri.touch.AccountsService.Sound.xml'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    intltool
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    glib
+    libayatana-common
+    libnotify
+    librda
+    systemd
+  ] ++ (with lomiri; [
+    cmake-extras
+    deviceinfo
+    lomiri-schemas
+    lomiri-sounds
+  ]);
+
+  nativeCheckInputs = [
+    dbus
+    (python3.withPackages (ps: with ps; [
+      python-dbusmock
+    ]))
+  ];
+
+  checkInputs = [
+    dbus-test-runner
+    gtest
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "ENABLE_LOMIRI_FEATURES" true)
+    (lib.cmakeBool "ENABLE_DEVICEINFO" true)
+    (lib.cmakeBool "ENABLE_RDA" true)
+    (lib.cmakeBool "GSETTINGS_LOCALINSTALL" true)
+    (lib.cmakeBool "GSETTINGS_COMPILE" true)
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  passthru = {
+    ayatana-indicators = [ "ayatana-indicator-power" ];
+    tests.vm = nixosTests.ayatana-indicators;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Ayatana Indicator showing power state";
+    longDescription = ''
+      This Ayatana Indicator displays current power management information and
+      gives the user a way to access power management preferences.
+    '';
+    homepage = "https://github.com/AyatanaIndicators/ayatana-indicator-power";
+    changelog = "https://github.com/AyatanaIndicators/ayatana-indicator-power/blob/${finalAttrs.version}/ChangeLog";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

An indicator that shows the charge state, and allows to change the screen brightness.

https://github.com/AyatanaIndicators/ayatana-indicator-power

![image](https://github.com/NixOS/nixpkgs/assets/23431373/fdef86f9-8303-4be2-9372-9f9ec6d3aac1)

It integrates heavily with the yet-to-be-packaged [repowerd](https://gitlab.com/ubports/development/core/repowerd) (the slider to change screen brightness only works when repowerd is used, the battery settings page it opens is only supposed to be displayed when repowerd is present) but I'm submitting this now because

1. The battery charge state is useful on its own
2. I've had issues with getting repowerd working properly. It can start if requested, but doesn't seem to register any inputs no matter what I do, so it always goes into dim-the-screen and turn-off-the-screen mode after afew seconds. Which is *very inconvenient* to say the least. I'd prefer to worry about this at a later point.

---

I've also moved some frequently-done calls from the Lomiri indicator tests into functions higher up. There's at least 7 more indicators I can think of that could be added, and I don't wanna keep copy-pasting & adjusting that much code going forward.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
