### PR TITLE
veracrypt: add patch to support sudo-rs

### DIFF
--- a/pkgs/applications/misc/veracrypt/default.nix
+++ b/pkgs/applications/misc/veracrypt/default.nix
@@ -14,6 +14,7 @@
 , btrfs-progs
 , pcsclite
 , wrapGAppsHook
+, withSudoRsPatch ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -35,7 +36,7 @@ stdenv.mkDerivation rec {
       ntfs = "${ntfs3g}/bin/mkfs.ntfs";
       btrfs = "${btrfs-progs}/bin/mkfs.btrfs";
     })
-  ];
+  ] ++ lib.optional withSudoRsPatch (lib.singleton ./sudo-rs.patch);
 
   sourceRoot = "src";
 

--- a/pkgs/applications/misc/veracrypt/sudo-rs.patch
+++ b/pkgs/applications/misc/veracrypt/sudo-rs.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -urN a/Core/Unix/CoreService.cpp b/Core/Unix/CoreService.cpp
+--- a/Core/Unix/CoreService.cpp	2024-04-18 22:51:05.955873091 +0800
++++ b/Core/Unix/CoreService.cpp	2024-04-18 23:04:18.650426107 +0800
+@@ -413,7 +413,7 @@
+ 					if (appPath.empty())
+ 						appPath = "veracrypt";
+ 
+-					const char *args[] = { "sudo", "-S", "-p", "", appPath.c_str(), TC_CORE_SERVICE_CMDLINE_OPTION, nullptr };
++					const char *args[] = { "sudo", "-S", appPath.c_str(), TC_CORE_SERVICE_CMDLINE_OPTION, nullptr };
+ 					execvp (args[0], ((char* const*) args));
+ 					throw SystemException (SRC_POS, args[0]);
+ 				}


### PR DESCRIPTION
## Description of changes

Added patch that removes extra flag `-p` from `sudo` command in veracrypt.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

## Notes
`sudo-rs` has fewer options and doesn't provide `-p` flag.
Because of that, instead of mounting/dismounting app throws a message "Failed to obtain administrator privileges: invalid option provided".

Optional patch was created due to developers response in opened [issue](https://github.com/veracrypt/VeraCrypt/issues/1331)

Defaulted to false as might cause problems for users that us regular `sudo`.

---

## Question

I am not interested in maintaining this package; I just want to apply the patch. Am I required to add myself to the maintainers' list?

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

