### PR TITLE
godot_4: 4.2.1-stable -> 4.2.2-stable

### DIFF
--- a/pkgs/by-name/go/godot_4-export-templates/package.nix
+++ b/pkgs/by-name/go/godot_4-export-templates/package.nix
@@ -1,0 +1,13 @@
+# Export templates is necessary for setting up Godot engine, it's used when exporting projects.
+# Godot applications/games packages needs to reference export templates.
+# Export templates version should be kept in sync with Godot version.
+# https://docs.godotengine.org/en/stable/tutorials/export/exporting_projects.html#export-templates
+
+{ fetchzip, godot_4, ... }:
+
+fetchzip {
+  pname = "export_templates";
+  extension = "zip";
+  url = "https://github.com/godotengine/godot/releases/download/${godot_4.version}/Godot_v${godot_4.version}_export_templates.tpz";
+  hash = "sha256-eomGLH9lbZhl7VtHTWjJ5mxVt0Yg8LfnAnpqoCksPgs=";
+}

--- a/pkgs/development/tools/godot/4/default.nix
+++ b/pkgs/development/tools/godot/4/default.nix
@@ -22,6 +22,7 @@
 , speechd
 , fontconfig
 , udev
+, withDebug ? false
 , withPlatform ? "linuxbsd"
 , withTarget ? "editor"
 , withPrecision ? "single"
@@ -115,6 +116,7 @@ stdenv.mkDerivation rec {
     platform = withPlatform;
     target = withTarget;
     precision = withPrecision; # Floating-point precision level
+    debug_symbols = withDebug;
 
     # Options from 'platform/linuxbsd/detect.py'
     pulseaudio = withPulseaudio; # Use PulseAudio
@@ -124,6 +126,8 @@ stdenv.mkDerivation rec {
     udev = withUdev; # Use udev for gamepad connection callbacks
     touch = withTouch; # Enable touch events
   };
+
+  dontStrip = withDebug;
 
   outputs = [ "out" "man" ];
 

--- a/pkgs/development/tools/godot/4/default.nix
+++ b/pkgs/development/tools/godot/4/default.nix
@@ -151,7 +151,7 @@ stdenv.mkDerivation rec {
     description = "Free and Open Source 2D and 3D game engine";
     license = lib.licenses.mit;
     platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" ];
-    maintainers = with lib.maintainers; [ shiryel ];
+    maintainers = with lib.maintainers; [ shiryel superherointj ];
     mainProgram = "godot4";
   };
 }

--- a/pkgs/development/tools/godot/4/default.nix
+++ b/pkgs/development/tools/godot/4/default.nix
@@ -43,14 +43,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "godot4";
-  version = "4.2.1-stable";
-  commitHash = "b09f793f564a6c95dc76acc654b390e68441bd01";
+  version = "4.2.2-stable";
+  commitHash = "15073afe3856abd2aa1622492fe50026c7d63dc1";
 
   src = fetchFromGitHub {
     owner = "godotengine";
     repo = "godot";
     rev = commitHash;
-    hash = "sha256-Q6Og1H4H2ygOryMPyjm6kzUB6Su6T9mJIp0alNAxvjQ=";
+    hash = "sha256-anJgPEeHIW2qIALMfPduBVgbYYyz1PWCmPsZZxS9oHI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/godot/4/default.nix
+++ b/pkgs/development/tools/godot/4/default.nix
@@ -146,12 +146,12 @@ stdenv.mkDerivation rec {
     cp icon.png "$out/share/icons/godot.png"
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://godotengine.org";
     description = "Free and Open Source 2D and 3D game engine";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" ];
-    maintainers = with maintainers; [ shiryel ];
+    maintainers = with lib.maintainers; [ shiryel ];
     mainProgram = "godot4";
   };
 }


### PR DESCRIPTION
godot_4: 4.2.1-stable -> 4.2.2-stable

Release: https://github.com/godotengine/godot-builds/releases/tag/4.2.2-stable

godot_4-export-templates: init 4.2.2-stable

On `pkgs/by-name` check, I found weird to move this to `pkgs/by-name` because I was expecting this to exist at Godot 4 directory. Which also matches Godot 3 structure that already exists.