### PR TITLE
ayatana-indicator-sound: init & add to Lomiri

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -38,6 +38,7 @@ in {
       ]);
     };
 
+    hardware.pulseaudio.enable = lib.mkDefault true;
     networking.networkmanager.enable = lib.mkDefault true;
 
     systemd.packages = with pkgs.lomiri; [
@@ -74,6 +75,8 @@ in {
         ayatana-indicator-messages
         ayatana-indicator-power
         ayatana-indicator-session
+      ] ++ lib.optionals (config.hardware.pulseaudio.enable || config.services.pipewire.pulse.enable) [
+        ayatana-indicator-sound
       ]) ++ (with pkgs.lomiri; [
         telephony-service
       ] ++ lib.optionals config.networking.networkmanager.enable [

--- a/nixos/tests/ayatana-indicators.nix
+++ b/nixos/tests/ayatana-indicators.nix
@@ -31,6 +31,7 @@ in {
         ayatana-indicator-messages
         ayatana-indicator-power
         ayatana-indicator-session
+        ayatana-indicator-sound
       ] ++ (with pkgs.lomiri; [
         lomiri-indicator-network
         telephony-service
@@ -40,6 +41,8 @@ in {
     # Setup needed by some indicators
 
     services.accounts-daemon.enable = true; # messages
+
+    hardware.pulseaudio.enable = true; # sound
 
     # Lomiri-ish setup for Lomiri indicators
     # TODO move into a Lomiri module, once the package set is far enough for the DE to start

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -290,11 +290,12 @@ in {
     # There's a test app we could use that also displays their contents, but it's abit inconsistent.
     with subtest("ayatana indicators work"):
         mouse_click(735, 0) # the cog in the top-right, for the session indicator
-        machine.wait_for_text(r"(Notifications|Battery|Time|Date|System)")
+        machine.wait_for_text(r"(Notifications|Battery|Sound|Time|Date|System)")
         machine.screenshot("indicators_open")
 
         # Indicator order within the menus *should* be fixed based on per-indicator order setting
         # Session is the one we clicked, but the last we should test (logout). Go as far left as we can test.
+        machine.send_key("left")
         machine.send_key("left")
         machine.send_key("left")
         machine.send_key("left")
@@ -304,6 +305,11 @@ in {
             # We start on this, don't go right
             machine.wait_for_text(r"(Flight|Wi-Fi)")
             machine.screenshot("indicators_network")
+
+        with subtest("lomiri indicator sound works"):
+            machine.send_key("right")
+            machine.wait_for_text(r"(Silent|Volume)")
+            machine.screenshot("indicators_sound")
 
         with subtest("ayatana indicator power works"):
             machine.send_key("right")

--- a/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
@@ -1,0 +1,125 @@
+{ stdenv
+, lib
+, gitUpdater
+, fetchFromGitHub
+, nixosTests
+, accountsservice
+, cmake
+, dbus
+, dbus-test-runner
+, glib
+, gobject-introspection
+, gtest
+, intltool
+, libayatana-common
+, libgee
+, libnotify
+, libpulseaudio
+, libqtdbusmock
+, libqtdbustest
+, libsForQt5
+, libxml2
+, lomiri
+, pkg-config
+, python3
+, systemd
+, vala
+, wrapGAppsHook3
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ayatana-indicator-sound";
+  version = "24.4.0";
+
+  src = fetchFromGitHub {
+    owner = "AyatanaIndicators";
+    repo = "ayatana-indicator-sound";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-2B2CFUjDvBpZ8R4fnGDViS3pXO1L0kP1tnJCtqKeLaQ=";
+  };
+
+  postPatch = ''
+    # Replace systemd prefix in pkg-config query, use GNUInstallDirs location for /etc
+    substituteInPlace data/CMakeLists.txt \
+      --replace-fail 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir)' 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir DEFINE_VARIABLES prefix=''${CMAKE_INSTALL_PREFIX})' \
+      --replace-fail 'DESTINATION "/etc' 'DESTINATION "''${CMAKE_INSTALL_FULL_SYSCONFDIR}'
+
+    # Build-time Vala codegen
+    substituteInPlace src/CMakeLists.txt \
+      --replace-fail '/usr/share/gir-1.0/AccountsService-1.0.gir' '${lib.getDev accountsservice}/share/gir-1.0/AccountsService-1.0.gir'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gobject-introspection
+    intltool
+    libpulseaudio # vala files(?)
+    pkg-config
+    vala
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    accountsservice
+    glib
+    gobject-introspection
+    libayatana-common
+    libgee
+    libnotify
+    libpulseaudio
+    libxml2
+    systemd
+  ] ++ (with lomiri; [
+    cmake-extras
+    lomiri-api
+    lomiri-schemas
+  ]);
+
+  nativeCheckInputs = [
+    dbus
+    (python3.withPackages (ps: with ps; [
+      python-dbusmock
+    ]))
+  ];
+
+  checkInputs = [
+    dbus-test-runner
+    gtest
+    libsForQt5.qtbase
+    libqtdbusmock
+    libqtdbustest
+    lomiri.gmenuharness
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "ENABLE_LOMIRI_FEATURES" true)
+    (lib.cmakeBool "GSETTINGS_LOCALINSTALL" true)
+    (lib.cmakeBool "GSETTINGS_COMPILE" true)
+  ];
+
+  dontWrapQtApps = true;
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  passthru = {
+    ayatana-indicators = [ "ayatana-indicator-sound" ];
+    tests.vm = nixosTests.ayatana-indicators;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Ayatana Indicator for managing system sound";
+    longDescription = ''
+      Ayatana Indicator Sound that provides easy control of the PulseAudio
+      sound daemon.
+    '';
+    homepage = "https://github.com/AyatanaIndicators/ayatana-indicator-sound";
+    changelog = "https://github.com/AyatanaIndicators/ayatana-indicator-sound/blob/${finalAttrs.version}/ChangeLog";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

An indicator for sound device control.

https://github.com/AyatanaIndicators/ayatana-indicator-sound

![image](https://github.com/NixOS/nixpkgs/assets/23431373/3de2ff0a-8873-4ec1-898e-857d9727528d)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
