### PR TITLE
autopsy: init at 4.21.0

### DIFF
--- a/pkgs/by-name/au/autopsy/package.nix
+++ b/pkgs/by-name/au/autopsy/package.nix
@@ -1,0 +1,49 @@
+{ stdenv, lib, makeWrapper, fetchzip, testdisk, imagemagick, jdk, findutils, sleuthkit, ... }:
+let
+  jdkWithJfx = jdk.override (lib.optionalAttrs stdenv.isLinux {
+    enableJavaFX = true;
+  });
+in
+stdenv.mkDerivation rec {
+  pname = "autopsy";
+  version = "4.21.0";
+
+  src = fetchzip {
+    url = "https://github.com/sleuthkit/autopsy/releases/download/autopsy-${version}/autopsy-${version}.zip";
+    sha256 = "32iOQA3+ykltCYW/MpqCVxyhh3mm6eYzY+t0smAsWRw=";
+  };
+
+  nativeBuildInputs = [ makeWrapper findutils ];
+  buildInputs = [ testdisk imagemagick jdkWithJfx ];
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r . $out
+
+    # Run the provided setup script to make files executable and copy sleuthkit
+    TSK_JAVA_LIB_PATH="${sleuthkit}/share/java" bash $out/unix_setup.sh -j '${jdkWithJfx}' -n autopsy
+
+    substituteInPlace $out/bin/autopsy \
+      --replace-warn 'APPNAME=`basename "$PRG"`' 'APPNAME=autopsy'
+    wrapProgram $out/bin/autopsy \
+      --run 'export SOLR_LOGS_DIR="$HOME/.autopsy/dev/var/log"' \
+      --run 'export SOLR_PID_DIR="$HOME/.autopsy/dev"' \
+      --prefix PATH : "${lib.makeBinPath [ testdisk imagemagick jdkWithJfx ]}"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Graphical interface to The Sleuth Kit and other open source digital forensics tools";
+    homepage = "https://www.sleuthkit.org/autopsy";
+    changelog = "https://github.com/sleuthkit/autopsy/releases/tag/autopsy-${version}";
+    # Autopsy brings a lot of vendored dependencies
+    license = with lib.licenses; [ asl20 ipl10 lgpl3Only lgpl21Only zlib wtfpl bsd3 cc-by-30 mit gpl2Only ];
+    maintainers = with lib.maintainers; [ zebreus ];
+    mainProgram = "autopsy";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    # Autopsy theoretically also supports darwin
+    platforms = lib.platforms.x86_64;
+  };
+}


### PR DESCRIPTION
## Description of changes

This PR adds [autopsy](https://github.com/sleuthkit/autopsy), a digital forensics platform and graphical interface to [The Sleuth Kit](https://github.com/sleuthkit/sleuthkit) and other digital forensics tools. It can be used to investigate what happened on a computer. You can even use it to recover photos from your camera's memory card.

fixes: #173227
related to: #81418

This package was originally based on the autopsy package from [nix-security](https://github.com/juliosueiras-nix/nix-security). That one builds openjfx and sleuthkit from scratch, they were not in nixpkgs at the time. However, the latest version of autopsy is compatible with sleuthkit and openjfx from nixpkgs.

This package is built from the github release of autopsy. Autopsy contains a lot of vendored java dependencies, getting rid of them seems unfeasible.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested with [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
