### PR TITLE
dogedns: init at 0.2.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -790,6 +790,12 @@
     githubId = 20405311;
     name = "Aksh Gupta";
   };
+  aktaboot = {
+    email = "akhtaboo@protonmail.com";
+    github = "aktaboot";
+    githubId = 120214979;
+    name = "aktaboot";
+  };
   al3xtjames = {
     email = "nix@alextjam.es";
     github = "al3xtjames";

--- a/pkgs/by-name/do/dogedns/package.nix
+++ b/pkgs/by-name/do/dogedns/package.nix
@@ -43,5 +43,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Dj-Codeman/doge";
     license = licenses.eupl12;
     mainProgram = "doge";
+    maintainers = with maintainers; [ aktaboot ];
   };
 }

--- a/pkgs/by-name/do/dogedns/package.nix
+++ b/pkgs/by-name/do/dogedns/package.nix
@@ -1,0 +1,47 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, installShellFiles
+, stdenv
+, pkg-config
+, openssl
+, pandoc
+, darwin
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "dogedns";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "Dj-Codeman";
+    repo = "doge";
+    rev = "6dd0383f31c096bfe2b6918c36b6e2c48414e753";
+    hash = "sha256-cvqDSTHFf/le2jItGTSkAGURj64WRvOmMRI+vFH0/50=";
+  };
+
+  cargoHash = "sha256-v9AuX7FZfy18yu4P9ovHsL5AQIYhPa8NEsMziEeHCJ8=";
+
+  patches = [
+    # remove date info to make the build reproducible
+    # remove commit hash to avoid dependency on git and the need to keep `.git`
+    ./remove-date-info.patch
+  ];
+
+  nativeBuildInputs = [ installShellFiles pandoc ]
+    ++ lib.optionals stdenv.isLinux [ pkg-config ];
+  buildInputs = lib.optionals stdenv.isLinux [ openssl ]
+    ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
+
+ postInstall = ''
+    installShellCompletion completions/doge.{bash,fish,zsh}
+    installManPage ./target/man/*.1
+  '';
+
+  meta = with lib; {
+    description = "Reviving A command-line DNS client";
+    homepage = "https://github.com/Dj-Codeman/doge";
+    license = licenses.eupl12;
+    mainProgram = "doge";
+  };
+}

--- a/pkgs/by-name/do/dogedns/remove-date-info.patch
+++ b/pkgs/by-name/do/dogedns/remove-date-info.patch
@@ -1,0 +1,11 @@
+--- a/build.rs
++++ b/build.rs
+@@ -34,7 +34,7 @@ fn main() -> io::Result<()> {
+             format!("{}\nv{} \\1;31m(beta debug build!)\\0m\n\\1;4;34m{}\\0m", tagline, version_string(), url)
+         }
+         else if is_development_version() {
+-            format!("{}\nv{} [{}] built on {} \\1;31m(beta-release!)\\0m\n\\1;4;34m{}\\0m", tagline, version_string(), git_hash(), build_date(), url)
++            format!("{}\nv{} [nixpkgs] \\1;31m(beta-release!)\\0m\n\\1;4;34m{}\\0m", tagline, version_string(),  url)
+         }
+         else {
+             format!("{}\nv{}\n\\1;4;34m{}\\0m", tagline, version_string(), url)


### PR DESCRIPTION
## Description of changes

Adds [doge](https://github.com/Dj-Codeman/doge), a cli DNS client forked from [dog](https://github.com/ogham/dog) which is no longer maintained!

@figsoda should dogdns be dropped in favor of this ? #141368

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
