### PR TITLE
[release-23.11] forgejo: 1.20.6-1-unstable-2024-02-22 -> 1.20.6-1-unstable-2024-04-18

### DIFF
--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -39,18 +39,22 @@ let
 in
 buildGoModule rec {
   pname = "forgejo";
-  version = "1.20.6-1-unstable-2024-02-22";
+  version = "1.20.6-1-unstable-2024-04-18";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "forgejo";
     repo = "forgejo";
-    # latest commit from 1.20.x branch (2024-02-22) with 1.21.6-0's XSS fix backported.
+    # latest commit from 1.20.x branch (2024-04-18) with 1.21.6-0's and
+    # 1.21.11-0's security fixes backported.
     # coordinated with upstream in #forgejo-development:matrix.org :)
+    # https://codeberg.org/forgejo/forgejo/src/branch/v1.20/forgejo
     # https://codeberg.org/forgejo/forgejo/pulls/2443
     # https://codeberg.org/forgejo/forgejo/commit/2fe5f6f73283c2f6935ded62440a1f15ded12dcd
-    rev = "2fe5f6f73283c2f6935ded62440a1f15ded12dcd";
-    hash = "sha256-U80HfHDSOKN+MGOX9Tu85lgN+8KeEzjSjpZXVFGmLKQ=";
+    # https://codeberg.org/forgejo/forgejo/pulls/3319
+    # https://codeberg.org/forgejo/forgejo/commit/0c4a307ee2aeaaf464ed74521b1fdb12114fde60
+    rev = "0c4a307ee2aeaaf464ed74521b1fdb12114fde60";
+    hash = "sha256-S2aRSXJybrjgpN16/1vbV1CUoMc1IvUGBO2DXB1CTYE=";
     # Forgejo has multiple different version strings that need to be provided
     # via ldflags.  main.ForgejoVersion for example is a combination of a
     # hardcoded gitea compatibility version string (in the Makefile) and
@@ -69,7 +73,7 @@ buildGoModule rec {
     '';
   };
 
-  vendorHash = "sha256-HDKirjQI4KvHvzDCqKe9nHvQUv3VNRl5tkr0rO7gcAY=";
+  vendorHash = "sha256-ao2CY6LmiDQIgv/i8okWt+xGa+clHzbCEHYFUrlwox0=";
 
   subPackages = [ "." ];
 


### PR DESCRIPTION
## Description of changes

This bump backports 1.21.11-0's security fixes to 1.20.6-1.

https://codeberg.org/forgejo/forgejo/pulls/3319

Please refer to the "Security fix" section in 1.21.11-0's release notes: https://codeberg.org/forgejo/forgejo/src/branch/forgejo/RELEASE-NOTES.md#1-21-11-0

Ref:
- #290725
- #305143

I also ran this version against our newer nixos-unstable VM test suite, which tests Forgejo Actions as well, using the following patch:

```diff
diff --git a/nixos/tests/forgejo.nix b/nixos/tests/forgejo.nix
index 8b9ee46ff5d3..bacaa7cb30bf 100644
--- a/nixos/tests/forgejo.nix
+++ b/nixos/tests/forgejo.nix
@@ -226,7 +226,7 @@ let
             def poll_workflow_action_status(_) -> bool:
                 output = server.succeed(
                     "curl --fail http://localhost:3000/test/repo/actions | "
-                    + 'htmlq ".flex-item-leading span" --attribute "data-tooltip-content"'
+                    + 'htmlq "span" --attribute "data-tooltip-content"'
                 ).strip()
 
                 # values taken from https://codeberg.org/forgejo/forgejo/src/commit/af47c583b4fb3190fa4c4c414500f9941cc02389/options/locale/locale_en-US.ini#L3649-L3661
``` 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
