### PR TITLE
home-assistant-custom-components: Add smartir/xiaomi_miot/xiaomi_gateway3

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -42,5 +42,7 @@
 
   waste_collection_schedule = callPackage ./waste_collection_schedule {};
 
+  xiaomi_miot = callPackage ./xiaomi_miot {};
+
   yassi = callPackage ./yassi {};
 }

--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -44,6 +44,8 @@
 
   waste_collection_schedule = callPackage ./waste_collection_schedule {};
 
+  xiaomi_gateway3 = callPackage ./xiaomi_gateway3 {};
+
   xiaomi_miot = callPackage ./xiaomi_miot {};
 
   yassi = callPackage ./yassi {};

--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -38,6 +38,8 @@
 
   sensi = callPackage ./sensi {};
 
+  smartir = callPackage ./smartir {};
+
   smartthinq-sensors = callPackage ./smartthinq-sensors {};
 
   waste_collection_schedule = callPackage ./waste_collection_schedule {};

--- a/pkgs/servers/home-assistant/custom-components/smartir/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/smartir/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildHomeAssistantComponent
+, fetchFromGitHub
+, aiofiles
+, broadlink
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "smartHomeHub";
+  domain = "smartir";
+  version = "1.17.9";
+
+  src = fetchFromGitHub {
+    owner = "smartHomeHub";
+    repo = "SmartIR";
+    rev = version;
+    hash = "sha256-E6TM761cuaeQzlbjA+oZ+wt5HTJAfkF2J3i4P1Wbuic=";
+  };
+
+  propagatedBuildInputs = [
+    aiofiles
+    broadlink
+  ];
+
+  dontBuild = true;
+
+  postInstall = ''
+    cp -r codes $out/custom_components/smartir/
+  '';
+
+  meta = with lib; {
+    changelog = "https://github.com/smartHomeHub/SmartIR/releases/tag/v${version}";
+    description = "Integration for Home Assistant to control climate, TV and fan devices via IR/RF controllers (Broadlink, Xiaomi, MQTT, LOOKin, ESPHome)";
+    homepage = "https://github.com/smartHomeHub/SmartIR";
+    maintainers = with maintainers; [ azuwis ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/xiaomi_gateway3/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/xiaomi_gateway3/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildHomeAssistantComponent
+, fetchFromGitHub
+, zigpy
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "AlexxIT";
+  domain = "xiaomi_gateway3";
+  version = "4.0.3";
+
+  src = fetchFromGitHub {
+    owner = "AlexxIT";
+    repo = "XiaomiGateway3";
+    rev = "v${version}";
+    hash = "sha256-YGaVQaz3A0yM8AIC02CvMKWMJ3tW3OADYgKY8ViIt5U=";
+  };
+
+  propagatedBuildInputs = [
+    zigpy
+  ];
+
+  dontBuild = true;
+
+  meta = with lib; {
+    changelog = "https://github.com/AlexxIT/XiaomiGateway3/releases/tag/v{version}";
+    description = "Home Assistant custom component for control Xiaomi Multimode Gateway (aka Gateway 3), Xiaomi Multimode Gateway 2, Aqara Hub E1 on default firmwares over LAN";
+    homepage = "https://github.com/AlexxIT/XiaomiGateway3";
+    maintainers = with maintainers; [ azuwis ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/xiaomi_miot/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/xiaomi_miot/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildHomeAssistantComponent
+, fetchFromGitHub
+, hap-python
+, micloud
+, pyqrcode
+, python-miio
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "al-one";
+  domain = "xiaomi_miot";
+  version = "0.7.17";
+
+  src = fetchFromGitHub {
+    owner = "al-one";
+    repo = "hass-xiaomi-miot";
+    rev = "v${version}";
+    hash = "sha256-IpL4e2mKCdtNu8NtI+xpx4FPW/uj1M5Rk6DswXmSJBk=";
+  };
+
+  propagatedBuildInputs = [
+    hap-python
+    micloud
+    pyqrcode
+    python-miio
+  ];
+
+  dontBuild = true;
+
+  meta = with lib; {
+    changelog = "https://github.com/al-one/hass-xiaomi-miot/releases/tag/${version}";
+    description = "Automatic integrate all Xiaomi devices to HomeAssistant via miot-spec, support Wi-Fi, BLE, ZigBee devices.";
+    homepage = "https://github.com/al-one/hass-xiaomi-miot";
+    maintainers = with maintainers; [ azuwis ];
+    license = licenses.asl20;
+  };
+}


### PR DESCRIPTION
## Description of changes

smartir: https://github.com/smartHomeHub/SmartIR
Integration for Home Assistant to control climate, TV and fan devices via IR/RF controllers (Broadlink, Xiaomi, MQTT, LOOKin, ESPHome)

xiaomi_gateway3: https://github.com/AlexxIT/XiaomiGateway3
Home Assistant custom component for control Xiaomi Multimode Gateway (aka Gateway 3), Xiaomi Multimode Gateway 2, Aqara Hub E1 on default firmwares over LAN

xiaomi_miot: https://github.com/al-one/hass-xiaomi-miot
Automatic integrate all Xiaomi devices to HomeAssistant via miot-spec, support Wi-Fi, BLE, ZigBee devices.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
