### PR TITLE
jupyter related packages updates 2024-04-19

### DIFF
--- a/pkgs/development/python-modules/anywidget/default.nix
+++ b/pkgs/development/python-modules/anywidget/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "anywidget";
-  version = "0.9.6";
+  version = "0.9.7";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-nhDPAXwcsxwrTBG1kEBj77bDXMb3j/Xckk3FENjCS5E=";
+    hash = "sha256-mepiQbJVtIHgzEhnjy8MjBOEMYLvlpLJ/wzMSm3+2bE=";
   };
 
   # We do not need the jupyterlab build dependency, because we do not need to

--- a/pkgs/development/python-modules/ipyniivue/default.nix
+++ b/pkgs/development/python-modules/ipyniivue/default.nix
@@ -4,37 +4,32 @@
 , pythonOlder
 , hatchling
 , hatch-jupyter-builder
-, ipywidgets
-, jupyter-ui-poll
+, anywidget
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "ipyniivue";
-  version = "1.1.0";
-  format = "pyproject";
+  version = "2.0.0";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-kym7949VI6C+62p3IOQ2QIzWnuSBcrmySb83oqUwhjI=";
+    hash = "sha256-CvMSUvPyXxPexs0/0sa/xt65RFWtvmYZwGSMIQGvLkc=";
   };
 
-  # We do not need the jupyterlab build dependency, because we do not need to
+  # We do not need the build hooks, because we do not need to
   # build any JS components; these are present already in the PyPI artifact.
-  #
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace '"jupyterlab==3.*",' ""
-  '';
+  env.HATCH_BUILD_NO_HOOKS = true;
 
-  nativeBuildInputs = [
+  build-system = [
     hatchling
     hatch-jupyter-builder
   ];
 
-  propagatedBuildInputs = [ ipywidgets jupyter-ui-poll ];
+  dependencies = [ anywidget ];
 
   nativeCheckImports = [ pytestCheckHook ];
   pythonImportsCheck = [ "ipyniivue" ];

--- a/pkgs/development/python-modules/jupyter-collaboration/default.nix
+++ b/pkgs/development/python-modules/jupyter-collaboration/default.nix
@@ -64,6 +64,10 @@ buildPythonPackage rec {
     export HOME=$TEMP
   '';
 
+  pytestFlagsArray = [
+    "-Wignore::DeprecationWarning"
+  ];
+
   disabledTests = [
     # ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
     "test_dirty"

--- a/pkgs/development/python-modules/jupyter-lsp/default.nix
+++ b/pkgs/development/python-modules/jupyter-lsp/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "jupyter-lsp";
-  version = "2.2.4";
+  version = "2.2.5";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-XlADMUk0QGU0jmiGCPPG1lTvBtmFa2dlW9e2usnuLVk=";
+    hash = "sha256-eTFHoFrURvgJ/VPvHNGan1JW/Qota3zpQ6mCy09UUAE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/jupyter-server/default.nix
+++ b/pkgs/development/python-modules/jupyter-server/default.nix
@@ -34,14 +34,14 @@
 
 buildPythonPackage rec {
   pname = "jupyter-server";
-  version = "2.13.0";
+  version = "2.14.0";
   pyproject = true;
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     pname = "jupyter_server";
     inherit version;
-    hash = "sha256-yAv7BJ6iAFPD2WQcKt1ISLOAc7958XKc6h+u0y/Bx44=";
+    hash = "sha256-ZZFUzqUSCDQ0/XyTt/4Il696L9C53UdJKCtC6qxK5nc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/notebook/default.nix
+++ b/pkgs/development/python-modules/notebook/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "notebook";
-  version = "7.1.2";
+  version = "7.1.3";
   disabled = pythonOlder "3.8";
 
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-78LIAEOQng+qF/zp6bN8BZwDrw7Jmk1NuEyyHZ0uk2o=";
+    hash = "sha256-Qfzr/0TPe7k3cYCAi8uuBmYptV2MdyLx6751ykT5z8E=";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Update jupyter-related packages at once to avoid building hundreds of packages over and over again.

This PR is based on the commits generated by the following command.

```
nix search nixpkgs#python311Packages 'ipython|jupyter|notebook' --json | jq -r 'keys | .[]' | cut -d . -f 3,4 | xargs -n 1 nix-update --commit
```

closes #303778
closes #304178
closes #304851
closes #304474
closes #303870
closes #303460

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
