### PR TITLE
Fix cross: appstream, wlroots, wlogout

### DIFF
--- a/pkgs/by-name/wl/wlogout/package.nix
+++ b/pkgs/by-name/wl/wlogout/package.nix
@@ -64,6 +64,16 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace main.c \
       --replace "/etc/wlogout" "$out/etc/wlogout"
+
+    # aarch64 build (cross-compilation) fails with -Werror like this:
+    # aarch64-unknown-linux-gnu-gcc ... -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Werror -std=c11 -Wno-unused-parameter -Wno-unused-result -Wno-missing-braces -MD -MQ wlogout.p/main.c.o -MF wlogout.p/main.c.o.d -o wlogout.p/main.c.o -c ../main.c
+    # ../main.c: In function 'set_fullscreen':
+    # ../main.c:499:17: error: unused variable 'mon' [-Werror=unused-variable]
+    # 499 |     GdkMonitor *mon = gdk_display_get_monitor(gdk_display_get_default(), monitor);
+    #     |                 ^~~
+    # cc1: all warnings being treated as errors
+    substituteInPlace meson.build \
+      --replace-warn "werror=true" "werror=false"
   '';
 
   passthru = {

--- a/pkgs/development/libraries/appstream/default.nix
+++ b/pkgs/development/libraries/appstream/default.nix
@@ -29,6 +29,7 @@
 , pango
 , librsvg
 , systemd
+, appstream
 , nixosTests
 , testers
 , withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd
@@ -79,6 +80,8 @@ stdenv.mkDerivation (finalAttrs: {
     vala
     gperf
   ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    # TODO(Mindavi): Probably should be done for _all_ cross cases?
+    appstream
     mesonEmulatorHook
   ];
 

--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -127,9 +127,11 @@ rec {
   wlroots_0_17 = generic {
     version = "0.17.2";
     hash = "sha256-Of9qykyVnBURc5A2pvCMm7sLbnuuG7OPWLxodQLN2Xg=";
+    extraNativeBuildInputs = [
+      hwdata
+    ];
     extraBuildInputs = [
       ffmpeg
-      hwdata
       libliftoff
       libdisplay-info
     ];


### PR DESCRIPTION
## Description of changes

Some small cross-compilation fixes. Hopefully doesn´t rebuild the world, but I'll retarget if needed.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross-compiled)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
