### PR TITLE
steamtinkerlaunch: 12.12 -> 12.12-unstable-2024-05-03

### DIFF
--- a/pkgs/tools/games/steamtinkerlaunch/default.nix
+++ b/pkgs/tools/games/steamtinkerlaunch/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     mainProgram = "steamtinkerlaunch";
     homepage = "https://github.com/sonic2kk/steamtinkerlaunch";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ urandom ];
+    maintainers = with maintainers; [ urandom surfaceflinger ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/tools/games/steamtinkerlaunch/default.nix
+++ b/pkgs/tools/games/steamtinkerlaunch/default.nix
@@ -1,11 +1,11 @@
 { bash
+, fetchFromGitHub
 , gawk
 , git
-, gnugrep
-, fetchFromGitHub
 , lib
 , makeWrapper
-, stdenv
+, procps
+, stdenvNoCC
 , unixtools
 , unzip
 , wget
@@ -14,15 +14,15 @@
 , yad
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation {
   pname = "steamtinkerlaunch";
-  version = "12.12";
+  version = "12.12-unstable-2024-05-03";
 
   src = fetchFromGitHub {
     owner = "sonic2kk";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-oigHNfg5rHxRabwUs66ye+chJzivmCIw8mg/GaJLPkg=";
+    repo = "steamtinkerlaunch";
+    rev = "59b421b2f3686120a076909a4a158824cd4ef05e";
+    hash = "sha256-CGtSGAm+52t2zFsPJEsm76w+FEHhbOd9NYuerGa31tc=";
   };
 
   # hardcode PROGCMD because #150841
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
       bash
       gawk
       git
-      gnugrep
+      procps
       unixtools.xxd
       unzip
       wget


### PR DESCRIPTION
## Description of changes

Upstream didn't tag a release for some time and 12.12 doesn't have a workaround for running MO2, as the latest version is broken on wine.
Also worth noting that upstream actually recommends running the latest git commit instead of releases. -> https://github.com/sonic2kk/steamtinkerlaunch/issues/1018#issuecomment-1893036240

> And spread the word for people to STOP using STL v12.12. It really annoys me 😓 Even when v14.0 comes out, if people stick to using it I will lose a lot of hope for this project. There is zero reason to use a "stable" version of a Bash script...

so yeah, let's just switch to the latest commit. Tested it with Cyberpunk 2077 from Steam and it seems to be working fine, including MO2.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
