### PR TITLE
tlpui: init at 1.6.5

### DIFF
--- a/pkgs/by-name/tl/tlpui/package.nix
+++ b/pkgs/by-name/tl/tlpui/package.nix
@@ -1,0 +1,70 @@
+{
+  cairo,
+  fetchFromGitHub,
+  gobject-introspection,
+  gtk3,
+  lib,
+  pciutils,
+  python3Packages,
+  substituteAll,
+  tlp,
+  usbutils,
+  wrapGAppsHook,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "tlpui";
+  version = "1.6.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "d4nj1";
+    repo = "TLPUI";
+    rev = "refs/tags/tlpui-${version}";
+    hash = "sha256-pgzGhf2WDRNQ2z0hPapUJA5MLTKq92UlgjC+G78T/4s=";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./path.patch;
+      inherit tlp;
+    })
+  ];
+
+  # ignore test/test_tlp_settings.py asit relies on opening a gui which is non-trivial
+  pytestFlagsArray = [ "--ignore=test/test_tlp_settings.py" ];
+  nativeCheckInputs = [
+    gobject-introspection
+    python3Packages.pytestCheckHook
+  ];
+
+  build-system = [
+    wrapGAppsHook
+    python3Packages.poetry-core
+  ];
+
+  buildInputs = [ tlp ];
+
+  dependencies = [
+    gobject-introspection
+    gtk3
+    pciutils
+    python3Packages.pycairo
+    python3Packages.pygobject3
+    python3Packages.pyyaml
+    usbutils
+  ];
+
+  meta = {
+    changelog = "https://github.com/d4nj1/TLPUI/releases/tag/tlpui-${version}";
+    description = "A GTK user interface for TLP written in Python";
+    homepage = "https://github.com/d4nj1/TLPUI";
+    license = lib.licenses.gpl2Only;
+    longDescription = ''
+      The Python scripts in this project generate a GTK-UI to change TLP configuration files easily.
+      It has the aim to protect users from setting bad configuration and to deliver a basic overview of all the valid configuration values.
+    '';
+    platforms = lib.platforms.linux;
+    mainProgram = "tlpui";
+    maintainers = with lib.maintainers; [ grimmauld ];
+  };
+}

--- a/pkgs/by-name/tl/tlpui/path.patch
+++ b/pkgs/by-name/tl/tlpui/path.patch
@@ -1,0 +1,57 @@
+diff --git a/tlpui/file.py b/tlpui/file.py
+index f0f3ecb..a9ad7f8 100644
+--- a/tlpui/file.py
++++ b/tlpui/file.py
+@@ -26,7 +26,7 @@ def get_tlp_config_defaults(tlpversion: str):
+     tlpconfig_defaults = extract_default_tlp_configs(f"{settings.workdir}/defaults/tlp-{tlpversion}.conf")
+ 
+     # update default values with intrinsic ones
+-    intrinsic_defaults_path = f"{settings.FOLDER_PREFIX}/usr/share/tlp/defaults.conf"
++    intrinsic_defaults_path = f"@tlp@/share/tlp/defaults.conf"
+     tlpconfig_defaults.update(extract_default_tlp_configs(intrinsic_defaults_path))
+ 
+     return tlpconfig_defaults
+@@ -124,7 +124,10 @@ def create_tmp_tlp_config_file(changedproperties: dict) -> str:
+     filehandler, tmpfilename = mkstemp(dir=settings.TMP_FOLDER)
+     newfile = open(tmpfilename, mode='w', encoding='utf-8')
+ 
+-    oldfile = open(settings.tlpconfigfile, encoding='utf-8')
++    try:
++        oldfile = open(settings.tlpconfigfile, encoding='utf-8')
++    except FileNotFoundError:
++        oldfile = open("@tlp@/etc/tlp.conf", encoding='utf-8')
+     lines = oldfile.readlines()
+     oldfile.close()
+ 
+diff --git a/tlpui/mainui.py b/tlpui/mainui.py
+index 0242514..da59046 100644
+--- a/tlpui/mainui.py
++++ b/tlpui/mainui.py
+@@ -115,8 +115,12 @@ def changed_items_dialog(window, tmpfilename: str, dialogtitle: str, message: st
+     scrolledwindow.set_hexpand(True)
+     scrolledwindow.set_vexpand(True)
+ 
+-    with open(settings.tlpconfigfile, encoding='utf-8') as fromfile:
+-        fromfilecontent = fromfile.readlines()
++    try:
++        with open(settings.tlpconfigfile, encoding='utf-8') as fromfile:
++            fromfilecontent = fromfile.readlines()
++    except FileNotFoundError:
++        with open("@tlp@/etc/tlp.conf", encoding='utf-8') as fromfile:
++            fromfilecontent = fromfile.readlines()
+     with open(tmpfilename, encoding='utf-8') as tofile:
+         tofilecontent = tofile.readlines()
+     diff = settings.tlpbaseconfigfile + '\n\n'
+diff --git a/tlpui/settingshelper.py b/tlpui/settingshelper.py
+index 69481c0..d769029 100644
+--- a/tlpui/settingshelper.py
++++ b/tlpui/settingshelper.py
+@@ -20,7 +20,7 @@ def exec_command(commands: [str]):
+ 
+ def get_tlp_config_file(prefix: str) -> str:
+     """Select tlp config file by prefix."""
+-    return f"{prefix}/etc/tlp.conf"
++    return f"{prefix}/etc/tlp.d/30-tlpui.conf"
+ 
+ 
+ def check_binaries_exist(flatpak_folder_prefix: str) -> None:


### PR DESCRIPTION
## Description of changes

- ~~link the empty default config of tlp into the legacy config path of tlp to make it work even without explicit config in /etc/tlp.conf~~
- ~~move nixos tlp module to use `/etc/tlp.d/` as to not break the tlp config created imperatively with tlpui in /etc/tlp.conf~~
- init tlpui at 1.6.5

This PR reuses work by @GeorgesAlkhouri in #188278, but with an updated nix package to use pyproj and an updated patchset to use the tlp default config in the tlp store path if the explicit tlp config in /etc/tlp.conf does not yet exist.

I tested this PR on my local system and it works well as far as i can tell.

~~I understand this is a relatively big scale for tlp as a whole, not just a simple package addition, feedback is welcome.~~

Edit: i adjusted this pull request. It no longer needs to modify the tlp nixos module.
Instead, the tlp nixos module is now completely untouched and still applies its config in the global config location of /etc/tlp.conf. tlpui places its config files in /etc/tlp.d/30-tlpui.conf instead.
This approach has a couple interesting quirks but is an overall improvement:

-   currently, it outright crashes if /etc/tlp.d does not yet exist as a directory.
-   the changes made in tlpui do persist even after uninstalling tlpui
-   nix settings for tlp takes precedence over tlpui, which means at least the end result can still be fully determined by nix even with left-over config files.
    Ideally, I'd write a nixos module for tlpui instead, with tlpui writing to a special location and the nixos module symlinking the config result into place ensuring both tlp.d exists and is being properly cleaned up on uninstall.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
