### PR TITLE
Revert "icu: refactor to avoid runtime dependency on bash"

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -453,8 +453,6 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - The `erlang-ls` package no longer ships the `els_dap` binary as of v0.51.0.
 
-- `icu` no longer includes `install-sh` and `mkinstalldirs` in the shared folder.
-
 ## Other Notable Changes {#sec-release-24.05-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/development/libraries/icu/make-icu.nix
+++ b/pkgs/development/libraries/icu/make-icu.nix
@@ -75,8 +75,6 @@ let
         { from = "\${pkglibdir}/pkgdata.inc"; to = "${placeholder "dev"}/lib/icu/pkgdata.inc"; } # --incpkgdatafile
       ];
     in ''
-      rm $out/share/icu/${version}/install-sh $out/share/icu/${version}/mkinstalldirs # Avoid having a runtime dependency on bash
-
       substituteInPlace "$dev/bin/icu-config" \
         ${lib.concatMapStringsSep " " (r: "--replace '${r.from}' '${r.to}'") replacements}
     '');


### PR DESCRIPTION
Reverts NixOS/nixpkgs#304784 since it causes a mass-rebuild