### PR TITLE
[Backport release-23.11] vscode-utils: allow `hash` to be used in mktplcRef

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/mktplcExtRefToFetchArgs.nix
+++ b/pkgs/applications/editors/vscode/extensions/mktplcExtRefToFetchArgs.nix
@@ -1,10 +1,10 @@
-{ publisher, name, version, arch ? "", sha256 ? "" }:
+{ publisher, name, version, arch ? "", sha256 ? "", hash ? "" }:
 let
   archurl = (if arch == "" then "" else "?targetPlatform=${arch}");
 in
 {
   url = "https://${publisher}.gallery.vsassets.io/_apis/public/gallery/publisher/${publisher}/extension/${name}/${version}/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage${archurl}";
-  sha256 = sha256;
+  inherit sha256 hash;
   # The `*.vsix` file is in the end a simple zip file. Change the extension
   # so that existing `unzip` hooks takes care of the unpacking.
   name = "${publisher}-${name}.zip";

--- a/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
@@ -78,6 +78,7 @@ let
     "publisher"
     "version"
     "sha256"
+    "hash"
     "arch"
   ];
 


### PR DESCRIPTION
[Backport release-23.11] vscode-utils: allow `hash` to be used in mktplcRef

Cherry-picked `d9d0e40aeb44274d9a6faa44d5aceb49a31ad9bc` from: #301936

CC @datafoo @deviant