### PR TITLE
opensplat: init at 1.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9121,6 +9121,12 @@
     github = "joshua-cooper";
     githubId = 35612334;
   };
+  jcaesar = {
+    name = "Julius Michaelis";
+    matrix = "@julius:mtx.liftm.de";
+    github = "jcaesar";
+    githubId = 1753388;
+  };
   jceb = {
     name = "Jan Christoph Ebersbach";
     email = "jceb@e-jc.de";

--- a/pkgs/by-name/op/opensplat/package.nix
+++ b/pkgs/by-name/op/opensplat/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  ninja,
+  fetchFromGitHub,
+  fetchpatch,
+  python3,
+  opencv,
+  nlohmann_json,
+  nanoflann,
+  glm,
+  cxxopts,
+  config,
+  # Upstream has rocm/hip support, too. anyone?
+  cudaSupport ? config.cudaSupport,
+  cudaPackages,
+  autoAddDriverRunpath,
+}:
+let
+  version = "1.1.2";
+  torch = python3.pkgs.torch.override { inherit cudaSupport; };
+  # Using a normal stdenv with cuda torch gives
+  # ld: /nix/store/k1l7y96gv0nc685cg7i3g43i4icmddzk-python3.11-torch-2.2.1-lib/lib/libc10.so: undefined reference to `std::ios_base_library_init()@GLIBCXX_3.4.32'
+  stdenv' = if cudaSupport then cudaPackages.backendStdenv else stdenv;
+in
+stdenv'.mkDerivation {
+  pname = "opensplat";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "pierotofy";
+    repo = "OpenSplat";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-3tk62b5fSf6wzuc5TwkdfAKgUMrw3ZxetCJa2RVMS/s=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "install-executables.patch";
+      url = "https://github.com/pierotofy/OpenSplat/commit/b4c4176819b508978583b7ebf66306171807a8e6.patch";
+      hash = "sha256-BUgPMcO3lt3ZEzv24u36k3aTEIoloOhxrCGi1KQ5Epk=";
+    })
+  ];
+
+  postPatch = ''
+    # the two vendored gsplats are so heavily modified they may be considered a fork
+    find vendor ! -name 'gsplat*' -maxdepth 1 -mindepth 1 -exec rm -rf {} +
+    mkdir vendor/{nanoflann,glm}
+    ln -s ${glm}/include/glm vendor/glm/glm
+    ln -s ${nanoflann}/include/nanoflann.hpp vendor/nanoflann/nanoflann.hpp
+    ln -s ${nlohmann_json}/include/nlohmann vendor/json
+    ln -s ${cxxopts}/include/cxxopts.hpp vendor/cxxopts.hpp
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ] ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_nvcc
+    autoAddDriverRunpath
+  ];
+
+  buildInputs = [
+    nlohmann_json
+    torch.cxxdev
+    torch
+    opencv
+  ] ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_cudart
+  ];
+
+  env.TORCH_CUDA_ARCH_LIST = "${lib.concatStringsSep ";" python3.pkgs.torch.cudaCapabilities}";
+
+  cmakeFlags = [
+    (lib.cmakeBool "CMAKE_SKIP_RPATH" true)
+  ] ++ lib.optionals cudaSupport [
+    (lib.cmakeFeature "GPU_RUNTIME" "CUDA")
+    (lib.cmakeFeature "CUDA_TOOLKIT_ROOT_DIR" "${cudaPackages.cudatoolkit}/")
+  ];
+
+  meta = {
+    description = "Production-grade 3D gaussian splatting";
+    homepage = "https://github.com/pierotofy/OpenSplat/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jcaesar ];
+    platforms = lib.platforms.linux ++ lib.optionals (!cudaSupport) lib.platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15374,6 +15374,8 @@ with pkgs;
   colmap = libsForQt5.callPackage ../applications/science/misc/colmap { inherit (config) cudaSupport; };
   colmapWithCuda = colmap.override { cudaSupport = true; };
 
+  opensplatWithCuda = opensplat.override { cudaSupport = true; };
+
   chickenPackages_4 = recurseIntoAttrs (callPackage ../development/compilers/chicken/4 { });
   chickenPackages_5 = recurseIntoAttrs (callPackage ../development/compilers/chicken/5 { });
   chickenPackages = dontRecurseIntoAttrs chickenPackages_5;


### PR DESCRIPTION
## Description of changes

This PR adds OpenSplat, "A free and open source implementation of 3D [gaussian splatting](https://www.youtube.com/watch?v=HVv_IQKlafQ) written in C++, focused on being portable, lean and fast.": https://github.com/pierotofy/opensplat

Notes for this PR:
 * To check basic functionality:
   ```bash
   nix shell nixpkgs#python311Packages.opensfm github:NixOS/nixpkgs/pull/305300/head#opensplatWithCuda
   git clone https://github.com/mapillary/OpenSfM/ opensfm
   cd opensfm
   git checkout 5e854bb43f046ac9277dcfc7a891bab8587f070f
   cd data/berlin # this is example data for structure from motion, not gaussian splatting, so the result will be pretty bad, i.e. only viewable from a narrow angle
   opensfm_run_all .
   ls images/* | save -f image_list.txt
   opensplat .
   # open https://antimatter15.com/splat/?url=https://splat.uav4geo.com/banana.splat and drag and drop the resulting splat.ply file onto it (sorry, I don't know a better way). rotate around to find a good angle

 * There's also a rocm/hip backend (and there will be a metals backend in the next release, it seems), but I don't have hardware, experience, or examples (there isn't a single package in nixpkgs uses cmake+hip+torch) to work with for that.
 * I [have contributed the patch upstream](https://github.com/pierotofy/OpenSplat/pull/82)
 * This is my second PR, the first hasn't been accepted yet. If there's a general issue with style, please do tell

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
