### PR TITLE
symphony: init at 5.7.2 and rPackages.Rsymphony

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2936,6 +2936,12 @@
       fingerprint = "BF4FCB85C69989B4ED95BF938AE74787A4B7C07E";
     }];
   };
+  b-rodrigues = {
+    email = "bruno@brodrigues.co";
+    github = "b-rodrigues";
+    githubId = 2998834;
+    name = "Bruno Rodrigues";
+  };
   broke = {
     email = "broke@in-fucking.space";
     github = "broke";

--- a/pkgs/by-name/sy/symphony/package.nix
+++ b/pkgs/by-name/sy/symphony/package.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, coin-utils
+, CoinMP
+, gfortran
+, libtool
+, glpk
+, osi
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "symphony";
+  version = "5.7.2";
+
+  outputs = [ "out" ];
+
+  src = fetchFromGitHub {
+    owner = "coin-or";
+    repo = "SYMPHONY";
+    rev = "releases/${version}";
+    sha256 = "sha256-OdTUMG3iVhjhw5uKtUnsLCZ4DfMjYHm8+/ozfmw7J6c=";
+  };
+
+  nativeBuildInputs = [ libtool pkg-config glpk gfortran CoinMP osi coin-utils ];
+
+  meta = {
+    description = "SYMPHONY is an open-source solver, callable library, and development framework for mixed-integer linear programs (MILPs) written in C with a number of unique features";
+    homepage = "https://www.coin-or.org/SYMPHONY/index.htm";
+    changelog = "https://github.com/coin-or/SYMPHONY/blob/${version}/CHANGELOG.md";
+    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.epl20;
+    maintainers = with lib.maintainers; [ b-rodrigues ];
+  };
+}

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -525,6 +525,7 @@ let
     Rbwa = [ pkgs.zlib.dev ];
     trackViewer = [ pkgs.zlib.dev ];
     themetagenomics = [ pkgs.zlib.dev ];
+    Rsymphony = [ pkgs.pkg-config ];
     NanoMethViz = [ pkgs.zlib.dev ];
     RcppMeCab = [ pkgs.pkg-config ];
     HilbertVisGUI = with pkgs; [ pkg-config which ];
@@ -604,7 +605,7 @@ let
     mashr = [ pkgs.gsl ];
     hadron = [ pkgs.gsl ];
     AMOUNTAIN = [ pkgs.gsl ];
-    Rsymphony = with pkgs; [ pkg-config doxygen graphviz subversion ];
+    Rsymphony = with pkgs; [ symphony doxygen graphviz subversion cgl clp];
     tcltk2 = with pkgs; [ tcl tk ];
     rswipl = with pkgs; [ ncurses.dev libxcrypt zlib.dev ];
     tikzDevice = with pkgs; [ which texliveMedium ];


### PR DESCRIPTION
## Description of changes

EDIT: 2024-04-20 thanks to the help of @jbedo and @Kupac , this works now! Tested with example from documentation:

```
library(Rsymphony)

obj <- c(2, 4, 3)
mat <- matrix(c(3, 2, 1, 4, 1, 3, 2, 1, 2), nrow = 3)
dir <- c("<=", "<=", "<=")
rhs <- c(60, 40, 80)
max <- TRUE
Rsymphony_solve_LP(obj, mat, dir, rhs, max = max)

```

This PR contains two commits: one that adds the Symphony solver, and another that fixes the build for the R package.

Original message:
Trying to fix `rPackages.Rsymphony`. I've first added the `symphony` software in `pkgs/by-name/sy/symphony/package.nix` and this builds successfully. I'm able to drop in a shell and execute it with:

```
nix-shell -I nixpkgs=. -p symphony
```

When building it, the following message appears:

```
Libraries have been installed in:
   /nix/store/r11wx6bcf8kxfdkigspbbdzgg4mvq6yf-symphony-5.7.2/lib

If you ever happen to want to link against installed libraries
in a given directory, LIBDIR, you must either use libtool, and
specify the full pathname of the library, or use the `-LLIBDIR'
flag during linking and do at least one of the following:
   - add LIBDIR to the `LD_LIBRARY_PATH' environment variable
     during execution
   - add LIBDIR to the `LD_RUN_PATH' environment variable
     during linking
   - use the `-Wl,--rpath -Wl,LIBDIR' linker flag

See any operating system documentation about shared libraries for
more information, such as the ld(1) and ld.so(8) manual pages.
```

Trying to build the R packages, `rPackages.Rsymphony` doesn't succeed, so I tried to add:

```
    Rsymphony = old.Rsymphony.overrideAttrs (attrs: {
      preConfigure = ''
        export LD_RUN_PATH="${lib.getLib pkgs.symphony}/lib/"
      '';
    });
```

but trying to build results in the following error:

```
error: builder for '/nix/store/n310bh4kfhakzdzwrccgygh4b9d5vl3n-r-Rsymphony-0.1-33.drv' failed with exit code 1;
       last 10 log lines:
       > Running phase: buildPhase
       > Running phase: checkPhase
       > Running phase: installPhase
       > * installing *source* package 'Rsymphony' ...
       > ** package 'Rsymphony' successfully unpacked and MD5 sums checked
       > ** using staged installation
       > Cannot find SYMPHONY libraries and headers.
       > See <https://projects.coin-or.org/SYMPHONY>.
       > ERROR: configuration failed for package 'Rsymphony'
       > * removing '/nix/store/hfivzzxh1pw5rgfzc53mzxshra5wixva-r-Rsymphony-0.1-33/library/Rsymphony'
       For full logs, run 'nix log /nix/store/n310bh4kfhakzdzwrccgygh4b9d5vl3n-r-Rsymphony-0.1-33.drv'.

```

Any ideas?

By the way, I don't know if this should be an issue instead of a draft PR, so let me know if I should close this and open it as an issue instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
