### PR TITLE
crystfel: 0.10.2 -> 0.11.0

### DIFF
--- a/pkgs/applications/science/physics/crystfel/default.nix
+++ b/pkgs/applications/science/physics/crystfel/default.nix
@@ -6,15 +6,16 @@
 , fetchzip
 , cmake
 , lz4
+, gfortran
 , bzip2
-, m4
 , hdf5
 , gsl
 , unzip
 , makeWrapper
+, zlib
 , meson
-, git
 , ninja
+, pandoc
 , eigen
 , pkg-config
 , wrapGAppsHook
@@ -40,7 +41,7 @@ let
     pname = "libccp4";
     version = "8.0.0";
     src = fetchurl {
-      url = "https://ftp.ccp4.ac.uk/opensource/${pname}-${version}.tar.gz";
+      url = "https://ftp.ccp4.ac.uk/opensource/libccp4-${version}.tar.gz";
       hash = "sha256-y4E66GYSoIZjKd6rfO6W6sVz2BvlskA0HUD5rVMi/y0=";
     };
     nativeBuildInputs = [ meson ninja ];
@@ -87,7 +88,7 @@ let
           };
       mosflmBinary = if stdenv.isDarwin then "bin/mosflm" else "mosflm-linux-64-noX11";
     in
-    stdenv.mkDerivation rec {
+    stdenv.mkDerivation {
       pname = "mosflm";
 
       inherit version src;
@@ -111,7 +112,7 @@ let
     pname = "xgandalf";
     version = "c6c5003ff1086e8c0fb5313660b4f02f3a3aab7b";
     src = fetchurl {
-      url = "https://gitlab.desy.de/thomas.white/${pname}/-/archive/${version}/${pname}-${version}.tar.gz";
+      url = "https://gitlab.desy.de/thomas.white/xgandalf/-/archive/${version}/xgandalf-${version}.tar.gz";
       hash = "sha256-/uZlBwAINSoYqgLQFTMz8rS1Rpadu79JkO6Bu/+Nx9E=";
     };
 
@@ -121,10 +122,10 @@ let
 
   pinkIndexer = stdenv.mkDerivation rec {
     pname = "pinkindexer";
-    version = "5d4e016941eb2a9e50a10df96ded7ff1e2464503";
+    version = "15caa21191e27e989b750b29566e4379bc5cd21a";
     src = fetchurl {
       url = "https://gitlab.desy.de/thomas.white/${pname}/-/archive/${version}/${pname}-${version}.tar.gz";
-      hash = "sha256-VnJOJJ247dNoBlos4Fu3GQBlAnTk9el+yZDRiicJtu0=";
+      hash = "sha256-v/SCJiHAV05Lc905y/dE8uBXlW+lLX9wau4XORYdbQg=";
     };
 
     nativeBuildInputs = [ meson pkg-config ninja ];
@@ -169,13 +170,27 @@ let
       "-DENABLE_BZIP2_PLUGIN=yes"
     ];
   };
+
+  millepede-ii = stdenv.mkDerivation rec {
+    pname = "millepede-ii";
+    version = "04-13-06";
+    src = fetchurl {
+      url = "https://gitlab.desy.de/claus.kleinwort/millepede-ii/-/archive/V${version}/millepede-ii-V${version}.tar.gz";
+      hash = "sha256-aFoo8AGBsUEN2u3AmnSpTqJ6JeNV6j9vkAFTZ34I+sI=";
+    };
+
+    nativeBuildInputs = [ gfortran ];
+    buildInputs = [ zlib ];
+
+    makeFlags = [ "PREFIX=$(out)" ];
+  };
 in
 stdenv.mkDerivation rec {
   pname = "crystfel";
-  version = "0.10.2";
+  version = "0.11.0";
   src = fetchurl {
-    url = "https://www.desy.de/~twhite/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-nCO9ndDKS54bVN9IhFBiCVNzqk7BsCljXFrOmlx+sP4=";
+    url = "https://www.desy.de/~twhite/crystfel/crystfel-${version}.tar.gz";
+    sha256 = "sha256-ogNHWYfbxRmB5TdK8K0JpcCnYOOyXapQGSPh8mfp+Tc=";
   };
   nativeBuildInputs = [ meson pkg-config ninja flex bison doxygen opencl-headers makeWrapper ]
     ++ lib.optionals withGui [ wrapGAppsHook ];
@@ -192,6 +207,7 @@ stdenv.mkDerivation rec {
     mosflm
     pinkIndexer
     xgandalf
+    pandoc
   ] ++ lib.optionals withGui [ gtk3 gdk-pixbuf ]
   ++ lib.optionals stdenv.isDarwin [
     argp-standalone
@@ -201,12 +217,12 @@ stdenv.mkDerivation rec {
   ++ lib.optionals withBitshuffle [ hdf5-external-filter-plugins ];
 
   patches = [
+    # on darwin at least, we need to link to a separate argp library;
+    # this patch adds a test for this and the necessary linker options
     ./link-to-argp-standalone-if-needed.patch
-    ./disable-fmemopen-on-aarch64-darwin.patch
-    (fetchpatch {
-      url = "https://gitlab.desy.de/thomas.white/crystfel/-/commit/3c54d59e1c13aaae716845fed2585770c3ca9d14.diff";
-      hash = "sha256-oaJNBQQn0c+z4p1pnW4osRJA2KdKiz4hWu7uzoKY7wc=";
-    })
+    # hotfix for an issue that occurs (at least) on NixOS:
+    # if the temporary path is too long, we get a segfault
+    ./gui-path-issue.patch
   ];
 
   # CrystFEL calls mosflm by searching PATH for it. We could've create a wrapper script that sets the PATH, but
@@ -218,7 +234,9 @@ stdenv.mkDerivation rec {
 
   postInstall = lib.optionalString withBitshuffle ''
     for file in $out/bin/*; do
-      wrapProgram $file --set HDF5_PLUGIN_PATH ${hdf5-external-filter-plugins}/lib/plugins
+      wrapProgram $file \
+        --set HDF5_PLUGIN_PATH ${hdf5-external-filter-plugins}/lib/plugins \
+        --prefix PATH ":" ${lib.makeBinPath [ millepede-ii ]}
     done
   '';
 

--- a/pkgs/applications/science/physics/crystfel/gui-path-issue.patch
+++ b/pkgs/applications/science/physics/crystfel/gui-path-issue.patch
@@ -1,0 +1,27 @@
+diff --git a/src/gui_index.c b/src/gui_index.c
+index 2cc8e8db..13be77d5 100644
+--- a/src/gui_index.c
++++ b/src/gui_index.c
+@@ -540,6 +540,7 @@ static void delete_gui_tempdir(char *tmpdir)
+ {
+ 	char *path;
+ 	int i;
++	size_t pathlen;
+ 
+ 	/* List of files which it's safe to delete */
+ 	char *files[] = {"gmon.out", "mosflm.lp", "SUMMARY", "XDS.INP",
+@@ -552,11 +553,12 @@ static void delete_gui_tempdir(char *tmpdir)
+ 
+ 	if ( tmpdir == NULL ) return;
+ 
+-	path = calloc(strlen(tmpdir)+64, 1);
++	pathlen = strlen(tmpdir)+64;
++	path = calloc(pathlen, 1);
+ 	if ( path == NULL ) return;
+ 
+ 	for ( i=0; i<n_files; i++ ) {
+-		snprintf(path, 127, "%s/%s", tmpdir, files[i]);
++		snprintf(path, pathlen, "%s/%s", tmpdir, files[i]);
+ 		unlink(path);
+ 	}
+ 

--- a/pkgs/applications/science/physics/crystfel/link-to-argp-standalone-if-needed.patch
+++ b/pkgs/applications/science/physics/crystfel/link-to-argp-standalone-if-needed.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 59bbcfb7..dd75d4e2 100644
+index 4717bb2a..38d8693f 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -80,6 +80,12 @@ if cc.has_function('clock_gettime', prefix: '#include <time.h>')
+@@ -70,6 +70,12 @@ if cc.has_function('clock_gettime', prefix: '#include <time.h>')
    conf_data.set10('HAVE_CLOCK_GETTIME', true)
  endif
  
@@ -12,15 +12,15 @@ index 59bbcfb7..dd75d4e2 100644
 +    argpdep = dependency('', required : false)
 +endif
 +
- # ************************ libcrystfel (subdir) ************************
- 
- subdir('libcrystfel')
-@@ -180,7 +186,7 @@ endif
+ if cc.has_function('sched_setaffinity',
+                    prefix: '#include <sched.h>',
+                    args: '-D_GNU_SOURCE')
+@@ -186,7 +192,7 @@ endif
  
  indexamajig = executable('indexamajig', indexamajig_sources,
                           dependencies: [mdep, libcrystfeldep, gsldep,
--                                        pthreaddep, zmqdep, asapodep],
-+                                        pthreaddep, zmqdep, asapodep, argpdep],
+-                                        pthreaddep, zmqdep, asapodep, asapoproddep],
++                                        pthreaddep, zmqdep, asapodep, asapoproddep, argpdep],
                           install: true,
-                          install_rpath: '$ORIGIN/../lib64/:$ORIGIN/../lib')
+                          install_rpath: crystfel_rpath)
  


### PR DESCRIPTION
## Description of changes

CrystFEL 0.11.0 was released recently. I'm working at the same institution and took up maintenance of the NixOS package. Things of note:

- There is a new dependency, millepede-ii (see [here](https://gitlab.desy.de/claus.kleinwort/millepede-ii/-/tree/V04-13-06?ref_type=tags), also developed at DESY, LGPL-licensed), which is used in CrystFEL in a simple system call, so I added the path to this dependency to `PATH` for all CrystFEL binaries.
- One of the patches (OSX-related) had to be updated, it didn't apply anymore, other patches have been mainlined.
- This includes a small bugfix (see the new patch).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
