### PR TITLE
vendor-reset: unstable-2021-02-16 -> unstable-2024-04-16

### DIFF
--- a/pkgs/os-specific/linux/vendor-reset/default.nix
+++ b/pkgs/os-specific/linux/vendor-reset/default.nix
@@ -2,23 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "vendor-reset";
-  version = "unstable-2021-02-16-${kernel.version}";
+  version = "unstable-2024-04-16-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "gnif";
     repo = "vendor-reset";
-    rev = "225a49a40941e350899e456366265cf82b87ad25";
-    sha256 = "sha256-xa7P7+mRk4FVgi+YYCcsFLfyNqPmXvy3xhGoTDVqPxw=";
+    rev = "084881c6e9e11bdadaf05798e669568848e698a3";
+    hash = "sha256-Klu2uysbF5tH7SqVl815DwR7W+Vx6PyVDDLwoMZiqBI=";
   };
-
-  patches = [
-    # Fix build with Linux 5.18.
-    # https://github.com/gnif/vendor-reset/pull/58
-    (fetchpatch {
-      url = "https://github.com/gnif/vendor-reset/commit/5bbffcd6fee5348e8808bdbfcb5b21d455b02f55.patch";
-      sha256 = "sha256-L1QxVpcZAVYiaMFCBfL2EJgeMyOR8sDa1UqF1QB3bns=";
-    })
-  ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 


### PR DESCRIPTION
The `vendor-reset` Linux kernel module stopped building as of kernel versions 6.8.1 because `strlcopy` has been removed. An upstream patch fixed this by replacing the only callsite with `strscpy` [^1].

As the patch has already been merged into `master`, I updated the nix package to the latest trunk commit and labeled the version as `unstable-2024-04-16`.

Since the only patch specified in the package has already been merged in late 2022 [^2], we can remove that one as well.

[^1]: https://github.com/gnif/vendor-reset/pull/79
[^2]: https://github.com/gnif/vendor-reset/pull/58

## Description of changes

- Update `vendor-reset` kernel module to v. `unstable-2024-04-16` (i.e. [the current state of `master`](https://github.com/gnif/vendor-reset/commit/084881c6e9e11bdadaf05798e669568848e698a3))
- Remove patch for https://github.com/gnif/vendor-reset/pull/58

A note on my tests:
Since I'm relying on this module myself in my NixOS configuration and building the packages from a local Nixpkgs fork would be rather cumbersome, I only tested the new version through an `overrideAttrs` call in my configuration. I've successfully built the module this way and my AMD Navi 10 card (Radeon RX 5700 XT) successfully resets after shutting down a VM:

```nix
//...
let
  vendor-reset = config.boot.kernelPackages.vendor-reset.overrideAttrs (old: rec {
      version = "unstable-2024-04-16";
  
      src = pkgs.fetchFromGitHub {
        owner = "gnif";
        repo = "vendor-reset";
        rev = "084881c6e9e11bdadaf05798e669568848e698a3";
        hash = "sha256-Klu2uysbF5tH7SqVl815DwR7W+Vx6PyVDDLwoMZiqBI=";
      };
  
      patches = [];
    });

in {
//...
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
