### PR TITLE
nixos/stirling-pdf: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1417,6 +1417,7 @@
   ./services/web-apps/slskd.nix
   ./services/web-apps/snipe-it.nix
   ./services/web-apps/sogo.nix
+  ./services/web-apps/stirling-pdf.nix
   ./services/web-apps/trilium.nix
   ./services/web-apps/tt-rss.nix
   ./services/web-apps/vikunja.nix

--- a/nixos/modules/services/web-apps/stirling-pdf.nix
+++ b/nixos/modules/services/web-apps/stirling-pdf.nix
@@ -1,0 +1,179 @@
+{
+  config,
+  lib,
+  options,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    getExe
+    literalExpression
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkOption
+    mkPackageOption
+    optional
+    ;
+
+  inherit (lib.types)
+    attrsOf
+    either
+    nullOr
+    path
+    port
+    str
+    ;
+
+  cfg = config.services.stirling-pdf;
+in
+
+{
+  meta.maintainers = with lib.maintainers; [ thubrecht ];
+
+  options.services.stirling-pdf = {
+    enable = mkEnableOption "Stirling-PDF, a web application for manipulating PDF files";
+
+    package = mkPackageOption pkgs "stirling-pdf" { };
+
+    port = mkOption {
+      type = port;
+      default = 8080;
+      description = ''
+        Port that Stirling-PDF will listen on.
+      '';
+    };
+
+    environment = mkOption {
+      type = attrsOf (nullOr (either str path));
+      defaultText = ''
+        {
+          SERVER_PORT = cfg.port;
+        }
+      '';
+      description = ''
+        Settings for the stirling-pdf app.
+      '';
+    };
+
+    environmentFile = mkOption {
+      type = nullOr path;
+      default = null;
+      description = ''
+        File containing additional environment variables to pass to Stirling PDF.
+      '';
+    };
+
+    domain = mkOption {
+      type = nullOr str;
+      default = null;
+      description = ''
+        The domain for the application.
+        This is used to set the Nginx options to the correct vhost.
+      '';
+    };
+
+    nginx = mkOption {
+      type = nullOr options.services.nginx.virtualHosts.type.nestedTypes.elemType;
+      default = null;
+      description = ''
+        With this option, you can customize the nginx virtualHost settings.
+      '';
+      example = literalExpression ''
+        {
+          # To enable encryption and let Let's Encrypt take care of certificate
+          forceSSL = true;
+          enableACME = true;
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.nginx != { } -> cfg.domain != null;
+        message = "A domain is required to setup nginx.";
+      }
+    ];
+
+    systemd.services.stirling-pdf = {
+      inherit (cfg) environment;
+
+      path = with pkgs; [
+        calibre
+        ghostscript_headless
+        libreoffice
+        ocrmypdf
+        opencv
+        pngquant
+        tesseract
+        unoconv
+        unpaper
+
+        python3.pkgs.weasyprint
+      ];
+
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        BindReadOnlyPaths = [ "${pkgs.tesseract}/share/tessdata:/usr/share/tessdata" ];
+        CacheDirectory = "stirling-pdf";
+        Environment = [ "HOME=%S/stirling-pdf" ];
+        EnvironmentFile = optional (cfg.environmentFile != null) cfg.environmentFile;
+        ExecStart = getExe cfg.package;
+        RuntimeDirectory = "stirling-pdf";
+        StateDirectory = "stirling-pdf";
+        SuccessExitStatus = 143;
+        User = "stirling-pdf";
+        WorkingDirectory = "/var/lib/stirling-pdf";
+
+        # Hardening
+        CapabilityBoundingSet = "";
+        DynamicUser = true;
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "~@cpu-emulation @debug @keyring @mount @obsolete @privileged @resources @clock @setuid @chown"
+        ];
+        UMask = "0077";
+      };
+    };
+
+    services.stirling-pdf.environment = {
+      # Default values
+      SERVER_PORT = builtins.toString cfg.port;
+      INSTALL_BOOK_AND_ADVANCED_HTML_OPS = "true";
+    };
+
+    services.nginx = mkIf (cfg.nginx != null) {
+      enable = true;
+
+      virtualHosts.${cfg.domain} = mkMerge [
+        cfg.nginx
+        { locations."/".proxyPass = "http://127.0.0.1:${builtins.toString cfg.port}"; }
+      ];
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -857,6 +857,7 @@ in {
   starship = handleTest ./starship.nix {};
   static-web-server = handleTest ./web-servers/static-web-server.nix {};
   step-ca = handleTestOn ["x86_64-linux"] ./step-ca.nix {};
+  stirling-pdf = handleTest ./stirling-pdf.nix {};
   stratis = handleTest ./stratis {};
   strongswan-swanctl = handleTest ./strongswan-swanctl.nix {};
   stub-ld = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./stub-ld.nix {};

--- a/nixos/tests/stirling-pdf.nix
+++ b/nixos/tests/stirling-pdf.nix
@@ -1,0 +1,22 @@
+import ./make-test-python.nix (
+  { lib, ... }:
+
+  {
+    name = "stirling-pdf";
+    meta.maintainers = with lib.maintainers; [ thubrecht ];
+
+    nodes.machine = {
+      services.stirling-pdf = {
+        enable = true;
+        port = 3000;
+      };
+    };
+
+    testScript = ''
+      machine.start()
+      machine.wait_for_unit("stirling-pdf.service")
+      machine.wait_for_open_port(3000)
+      machine.succeed("curl --fail http://localhost:3000/")
+    '';
+  }
+)

--- a/pkgs/by-name/st/stirling-pdf/package.nix
+++ b/pkgs/by-name/st/stirling-pdf/package.nix
@@ -7,6 +7,7 @@
   perl,
   makeWrapper,
   jre,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -101,6 +102,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) stirling-pdf;
+  };
 
   meta = {
     changelog = "https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/${finalAttrs.src.rev}";


### PR DESCRIPTION
## Description of changes

Create a module for Stirling PDF

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
