### PR TITLE
shelldap: fix on darwin using shortenPerlShebang

### DIFF
--- a/pkgs/tools/misc/shelldap/default.nix
+++ b/pkgs/tools/misc/shelldap/default.nix
@@ -1,6 +1,8 @@
 { lib
+, stdenv
 , fetchFromGitHub
 , perlPackages
+, shortenPerlShebang
 }:
 
 perlPackages.buildPerlPackage rec {
@@ -26,6 +28,8 @@ perlPackages.buildPerlPackage rec {
     YAMLSyck
   ];
 
+  nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
+
   prePatch = ''
     touch Makefile.PL
   '';
@@ -33,7 +37,11 @@ perlPackages.buildPerlPackage rec {
   installPhase = ''
     runHook preInstall
     install -Dm555 -t $out/bin shelldap
-    runHook preInstall
+    runHook postInstall
+  '';
+
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    shortenPerlShebang $out/bin/shelldap
   '';
 
   # no make target 'test', not tests provided by source


### PR DESCRIPTION
## Description of changes

Found that trying to use `shelldap` on macOS, it spammed the following error:

`/etc/profiles/per-user/joris/bin/Shelldap: line 31: =head1: command not found`

After a bit a looking, it seems that the shebang is too long, and found all the work had been done ([here](https://nixos.org/manual/nixpkgs/stable/#ssec-perl-packaging)) so this PR only applies it to this package.

It also fixes what I believe was a typo in the `installPhase` (`runHook preInstall` -> `runHook postInstall`).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
