### PR TITLE
factorio: 1.1.104 -> 1.1.107

### DIFF
--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,56 +2,56 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.104.tar.xz",
+        "name": "factorio_alpha_x64-1.1.107.tar.xz",
         "needsAuth": true,
-        "sha256": "0aizllbfzbn2j0560n4f823jqq7v7qz813an4wlm39rfsfx7b0vq",
+        "sha256": "16hkyfwp02zcijka4yslifz62ry6hrvk0w9960618kqdw3gr7p82",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.104/alpha/linux64",
-        "version": "1.1.104"
+        "url": "https://factorio.com/get-download/1.1.107/alpha/linux64",
+        "version": "1.1.107"
       },
       "stable": {
-        "name": "factorio_alpha_x64-1.1.104.tar.xz",
+        "name": "factorio_alpha_x64-1.1.107.tar.xz",
         "needsAuth": true,
-        "sha256": "0aizllbfzbn2j0560n4f823jqq7v7qz813an4wlm39rfsfx7b0vq",
+        "sha256": "16hkyfwp02zcijka4yslifz62ry6hrvk0w9960618kqdw3gr7p82",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.104/alpha/linux64",
-        "version": "1.1.104"
+        "url": "https://factorio.com/get-download/1.1.107/alpha/linux64",
+        "version": "1.1.107"
       }
     },
     "demo": {
       "experimental": {
-        "name": "factorio_demo_x64-1.1.104.tar.xz",
+        "name": "factorio_demo_x64-1.1.107.tar.xz",
         "needsAuth": false,
-        "sha256": "0x08dy6pagfpqc9c2cl239b1f7pf0p4cghzp7avxmbkmbl1fan2l",
+        "sha256": "0qc36n6h4wcbnj9rnq162bsml4x3ag1dkjmywqz8f4ydaf86gyjw",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.104/demo/linux64",
-        "version": "1.1.104"
+        "url": "https://factorio.com/get-download/1.1.107/demo/linux64",
+        "version": "1.1.107"
       },
       "stable": {
-        "name": "factorio_demo_x64-1.1.104.tar.xz",
+        "name": "factorio_demo_x64-1.1.107.tar.xz",
         "needsAuth": false,
-        "sha256": "0x08dy6pagfpqc9c2cl239b1f7pf0p4cghzp7avxmbkmbl1fan2l",
+        "sha256": "0qc36n6h4wcbnj9rnq162bsml4x3ag1dkjmywqz8f4ydaf86gyjw",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.104/demo/linux64",
-        "version": "1.1.104"
+        "url": "https://factorio.com/get-download/1.1.107/demo/linux64",
+        "version": "1.1.107"
       }
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.104.tar.xz",
+        "name": "factorio_headless_x64-1.1.107.tar.xz",
         "needsAuth": false,
-        "sha256": "10qmq2mw2j97s64skwr3m7hmv21h3m0r8rdhnyfrhmrxn8x3a4wf",
+        "sha256": "10ds1nz9sbx9xz1lyypf16wncc6323vpm7l5p11d6iy4cha85wsw",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.104/headless/linux64",
-        "version": "1.1.104"
+        "url": "https://factorio.com/get-download/1.1.107/headless/linux64",
+        "version": "1.1.107"
       },
       "stable": {
-        "name": "factorio_headless_x64-1.1.104.tar.xz",
+        "name": "factorio_headless_x64-1.1.107.tar.xz",
         "needsAuth": false,
-        "sha256": "10qmq2mw2j97s64skwr3m7hmv21h3m0r8rdhnyfrhmrxn8x3a4wf",
+        "sha256": "10ds1nz9sbx9xz1lyypf16wncc6323vpm7l5p11d6iy4cha85wsw",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.104/headless/linux64",
-        "version": "1.1.104"
+        "url": "https://factorio.com/get-download/1.1.107/headless/linux64",
+        "version": "1.1.107"
       }
     }
   }


### PR DESCRIPTION
## Description of changes
Version bump to 1.1.107. Change log in following link:
https://wiki.factorio.com/Version_history/1.1.0#1.1.107
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Updated versions.json with given python script. Ran headless server with existing save game. Connected to running server with client.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
