### PR TITLE
isolate: Add additional outputs included in v2

### DIFF
--- a/pkgs/tools/security/isolate/default.nix
+++ b/pkgs/tools/security/isolate/default.nix
@@ -3,6 +3,8 @@
 , fetchFromGitHub
 , asciidoc
 , libcap
+, systemdLibs
+, pkg-config
 , installShellFiles
 }:
 
@@ -20,21 +22,21 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     asciidoc
     installShellFiles
+    pkg-config
   ];
 
   buildInputs = [
     libcap.dev
-  ];
-
-  buildFlags = [
-    "isolate"
-    "isolate.1"
+    systemdLibs.dev
   ];
 
   installPhase = ''
     runHook preInstall
 
     install -Dm755 ./isolate $out/bin/isolate
+    install -Dm755 ./isolate-cg-keeper $out/bin/isolate-cg-keeper
+    install -Dm755 ./isolate-check-environment $out/bin/isolate-check-environment
+    install -Dm644 ./systemd/* -t $out/lib/systemd/system/
     installManPage isolate.1
 
     runHook postInstall


### PR DESCRIPTION
## Description of changes

- Since v2, isolate comes with `isolate-cg-keeper`, which is supposed to run as a systemd daemon.
  - This requires `libsystemd`, so it was included. (with `systemdLibs`, since sd_notify is the only function called)
  - Relevant systemd service files are also installed
- Also include `isolate-check-environment` script.

Changelog: https://github.com/ioi/isolate/blob/v2.0/NEWS

The package was previously automatically updated in #294390 without build changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
