### PR TITLE
feishin: fix darwin builds

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9479,6 +9479,12 @@
       fingerprint = "B768 6CD7 451A 650D 9C54  4204 6710 CF0C 1CBD 7762";
     }];
   };
+  jlbribeiro = {
+    email = "nix@jlbribeiro.com";
+    github = "jlbribeiro";
+    githubId = 1015816;
+    name = "José Ribeiro";
+  };
   jleightcap = {
     email = "jack@leightcap.com";
     github = "jleightcap";

--- a/pkgs/applications/audio/feishin/default.nix
+++ b/pkgs/applications/audio/feishin/default.nix
@@ -153,6 +153,9 @@ buildNpmPackage {
     license = licenses.gpl3Plus;
     platforms = platforms.unix;
     mainProgram = "feishin";
-    maintainers = with maintainers; [ onny ];
+    maintainers = with maintainers; [
+      onny
+      jlbribeiro
+    ];
   };
 }

--- a/pkgs/applications/audio/feishin/default.nix
+++ b/pkgs/applications/audio/feishin/default.nix
@@ -1,8 +1,10 @@
 {
   lib,
+  stdenv,
   buildNpmPackage,
   fetchFromGitHub,
   electron_27,
+  darwin,
   copyDesktopItems,
   makeDesktopItem,
   ...
@@ -21,8 +23,7 @@ let
   electron = electron_27;
 in
 buildNpmPackage {
-  pname = "feishin";
-  inherit version;
+  inherit pname version;
 
   inherit src;
   npmDepsHash = "sha256-+pr9fWg/9kxkYMmthtqhjgF6MOomSQxVCO5V8tHHRdE=";
@@ -32,17 +33,25 @@ buildNpmPackage {
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
-  nativeBuildInputs = [ copyDesktopItems ];
+  nativeBuildInputs =
+    lib.optionals (stdenv.isLinux) [ copyDesktopItems ]
+    ++ lib.optionals stdenv.isDarwin [ darwin.autoSignDarwinBinariesHook ];
 
-  postPatch = ''
-    # release/app dependencies are installed on preConfigure
-    substituteInPlace package.json \
-      --replace-fail "electron-builder install-app-deps &&" ""
+  postPatch =
+    ''
+      # release/app dependencies are installed on preConfigure
+      substituteInPlace package.json \
+        --replace-fail "electron-builder install-app-deps &&" ""
 
-    # https://github.com/electron/electron/issues/31121
-    substituteInPlace src/main/main.ts \
-      --replace-fail "process.resourcesPath" "'$out/share/feishin/resources'"
-  '';
+      # Don't check for updates.
+      substituteInPlace src/main/main.ts \
+        --replace-fail "autoUpdater.checkForUpdatesAndNotify();" ""
+    ''
+    + lib.optionalString stdenv.isLinux ''
+      # https://github.com/electron/electron/issues/31121
+      substituteInPlace src/main/main.ts \
+        --replace-fail "process.resourcesPath" "'$out/share/feishin/resources'"
+    '';
 
   preConfigure =
     let
@@ -67,40 +76,59 @@ buildNpmPackage {
       done
     '';
 
-  postBuild = ''
-    npm exec electron-builder -- \
-      --dir \
-      -c.electronDist=${electron}/libexec/electron \
-      -c.electronVersion=${electron.version} \
-      -c.npmRebuild=false
-  '';
+  postBuild =
+    lib.optionalString stdenv.isDarwin ''
+      # electron-builder appears to build directly on top of Electron.app, by overwriting the files in the bundle.
+      cp -r ${electron}/Applications/Electron.app ./
+      find ./Electron.app -name 'Info.plist' | xargs -d '\n' chmod +rw
 
-  installPhase = ''
-    runHook preInstall
+      # Disable code signing during build on macOS.
+      # https://github.com/electron-userland/electron-builder/blob/fa6fc16/docs/code-signing.md#how-to-disable-code-signing-during-the-build-process-on-macos
+      export CSC_IDENTITY_AUTO_DISCOVERY=false
+      sed -i "/afterSign/d" package.json
+    ''
+    + ''
+      npm exec electron-builder -- \
+        --dir \
+        -c.electronDist=${if stdenv.isDarwin then "./" else "${electron}/libexec/electron"} \
+        -c.electronVersion=${electron.version} \
+        -c.npmRebuild=false
+    '';
 
-    mkdir -p $out/share/feishin
-    pushd release/build/*/
-    cp -r locales resources{,.pak} $out/share/feishin
-    popd
+  installPhase =
+    ''
+      runHook preInstall
+    ''
+    + lib.optionalString stdenv.isDarwin ''
+      mkdir -p $out/{Applications,bin}
+      cp -r release/build/**/Feishin.app $out/Applications/
+      makeWrapper $out/Applications/Feishin.app/Contents/MacOS/Feishin $out/bin/feishin
+    ''
+    + lib.optionalString stdenv.isLinux ''
+      mkdir -p $out/share/feishin
+      pushd release/build/*/
+      cp -r locales resources{,.pak} $out/share/feishin
+      popd
 
-    # Code relies on checking app.isPackaged, which returns false if the executable is electron.
-    # Set ELECTRON_FORCE_IS_PACKAGED=1.
-    # https://github.com/electron/electron/issues/35153#issuecomment-1202718531
-    makeWrapper ${lib.getExe electron} $out/bin/feishin \
-      --add-flags $out/share/feishin/resources/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
-      --set ELECTRON_FORCE_IS_PACKAGED=1 \
-      --inherit-argv0
+      # Code relies on checking app.isPackaged, which returns false if the executable is electron.
+      # Set ELECTRON_FORCE_IS_PACKAGED=1.
+      # https://github.com/electron/electron/issues/35153#issuecomment-1202718531
+      makeWrapper ${lib.getExe electron} $out/bin/feishin \
+        --add-flags $out/share/feishin/resources/app.asar \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+        --set ELECTRON_FORCE_IS_PACKAGED=1 \
+        --inherit-argv0
 
-    for size in 32 64 128 256 512 1024; do
-      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-      ln -s \
-        $out/share/feishin/resources/assets/icons/"$size"x"$size".png \
-        $out/share/icons/hicolor/"$size"x"$size"/apps/${pname}.png
-    done
-
-    runHook postInstall
-  '';
+      for size in 32 64 128 256 512 1024; do
+        mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+        ln -s \
+          $out/share/feishin/resources/assets/icons/"$size"x"$size".png \
+          $out/share/icons/hicolor/"$size"x"$size"/apps/${pname}.png
+      done
+    ''
+    + ''
+      runHook postInstall
+    '';
 
   desktopItems = [
     (makeDesktopItem {


### PR DESCRIPTION
## Description of changes

* Fix Feishin's `darwin` builds, broken after #303638 (Electron "from source" packaging), as mentioned [here](https://github.com/NixOS/nixpkgs/pull/303638#issuecomment-2052463043). This takes an approach similar to #262081 and #280825.
* Disable update checks, as macOS builds didn't generate an `app-update.yml` after disabling code signing (and "direct" updates wouldn't be possible in any platform anyway).
* Added myself to the package's maintainers.

@lunik1, I kindly ask you to test this and see if it works on your `darwin` system now :) (including whether it plays any sound)

I tested it on a macOS Sonoma `x86_64-darwin` VM. The app only shows in Launchpad (but not on Applications nor Spotlight); I understand there are a couple of open issues in `nix-darwin` regarding _similar_ behavior, so I'm not 100% sure whether this is a packaging issue or just a Nix-on-macOS issue. I used `nix-darwin` with a very basic (i.e. no post-activation scripts + no Home Manager) config to install it. (Installed [`bruno`](https://search.nixos.org/packages?channel=unstable&type=packages&query=bruno) and it had the same issues.)

Maintainer: @onny

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
