### PR TITLE
rnnoise: 2021-01-22 -> 0.2

### DIFF
--- a/pkgs/development/libraries/rnnoise/default.nix
+++ b/pkgs/development/libraries/rnnoise/default.nix
@@ -1,12 +1,16 @@
-{ stdenv, lib, fetchurl, fetchzip, autoreconfHook, writeScript }:
+{ stdenv, lib, fetchurl, fetchzip, autoreconfHook, writeScript
+, modelUrl ? "", modelHash ? "" # Allow overriding the model URL and hash
+}:
 
-let 
+let
   modelVersionJSON = lib.importJSON ./model-version.json;
 
-  # Copy from https://gitlab.xiph.org/xiph/rnnoise/-/raw/v${finalAttrs.version}/model_version
+  # Copy from https://gitlab.xiph.org/xiph/rnnoise/-/raw/v${version}/model_version
   default_model_version = modelVersionJSON.version;
-  default_model_url = "https://media.xiph.org/rnnoise/models/rnnoise_data-${default_model_version}.tar.gz";
-  default_model_hash = modelVersionJSON.hash;
+
+  # Either use the default model or the one provided by package override
+  model_url = if (modelUrl == "") then "https://media.xiph.org/rnnoise/models/rnnoise_data-${default_model_version}.tar.gz" else modelUrl;
+  model_hash = if (modelHash == "") then modelVersionJSON.hash else modelHash;
 
 in stdenv.mkDerivation (finalAttrs: {
   pname = "rnnoise";
@@ -21,8 +25,8 @@ in stdenv.mkDerivation (finalAttrs: {
   };
 
   model = fetchurl {
-    url = default_model_url;
-    hash = default_model_hash;
+    url = model_url;
+    hash = model_hash;
   };
 
   postPatch = ''

--- a/pkgs/development/libraries/rnnoise/default.nix
+++ b/pkgs/development/libraries/rnnoise/default.nix
@@ -1,15 +1,27 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook }:
+{ stdenv, lib, fetchFromGitLab, fetchurl, autoreconfHook }:
 
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rnnoise";
-  version = "2021-01-22";
+  version = "0.2";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitLab {
+    domain = "gitlab.xiph.org";
     owner = "xiph";
     repo = "rnnoise";
-    rev = "1cbdbcf1283499bbb2230a6b0f126eb9b236defd";
-    sha256 = "1y0rzgmvy8bf9a431garpm2w177s6ajgf79y5ymw4yb0pik57rwb";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Qaf+0iOprq7ILRWNRkBjsniByctRa/lFVqiU5ZInF/Q=";
   };
+
+  # Copy from https://gitlab.xiph.org/xiph/rnnoise/-/raw/v${finalAttrs.version}/model_version
+  model_version = "0b50c45";
+  model = fetchurl {
+    url = "https://media.xiph.org/rnnoise/models/rnnoise_data-${finalAttrs.model_version}.tar.gz";
+    hash = "sha256-SsgcXAiE7EvVkHAmqq4WIJt7ds2df3GvWCCUovmPS0M=";
+  };
+
+  patchPhase = ''
+    tar xvomf ${finalAttrs.model}
+  '';
 
   nativeBuildInputs = [ autoreconfHook ];
 
@@ -17,12 +29,12 @@ stdenv.mkDerivation (rec {
     install -Dt $out/bin examples/.libs/rnnoise_demo
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Recurrent neural network for audio noise reduction";
     homepage = "https://people.xiph.org/~jm/demo/rnnoise/";
-    license = licenses.bsd3;
-    maintainers = [ maintainers.nh2 ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ nh2 ];
     mainProgram = "rnnoise_demo";
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
   };
 })

--- a/pkgs/development/libraries/rnnoise/default.nix
+++ b/pkgs/development/libraries/rnnoise/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, fetchzip, autoreconfHook, writeScript
+{ stdenv, lib, fetchurl, fetchzip, autoreconfHook, writeScript, fetchpatch
 , modelUrl ? "", modelHash ? "" # Allow overriding the model URL and hash
 }:
 
@@ -23,6 +23,14 @@ in stdenv.mkDerivation (finalAttrs: {
     ];
     hash = "sha256-Qaf+0iOprq7ILRWNRkBjsniByctRa/lFVqiU5ZInF/Q=";
   };
+
+  patches = [
+    # remove when updating
+    (fetchpatch {
+      url = "https://github.com/xiph/rnnoise/commit/372f7b4b76cde4ca1ec4605353dd17898a99de38.patch";
+      hash = "sha256-Dzikb59hjVxd1XIEj/Je4evxtGORkaNcqE+zxOJMSvs=";
+    })
+  ];
 
   model = fetchurl {
     url = model_url;

--- a/pkgs/development/libraries/rnnoise/model-version.json
+++ b/pkgs/development/libraries/rnnoise/model-version.json
@@ -1,0 +1,4 @@
+{
+  "version": "0b50c45",
+  "hash": "sha256-SsgcXAiE7EvVkHAmqq4WIJt7ds2df3GvWCCUovmPS0M="
+}


### PR DESCRIPTION
## Description of changes
- Updates rnnoise: 2021-01-22 -> 0.2
- Adds an update-script for easier upgrade
- Allows overriding the model
- Changelog: https://github.com/xiph/rnnoise/compare/1cbdbcf1283499bbb2230a6b0f126eb9b236defd...v0.2

Closes https://github.com/NixOS/nixpkgs/issues/304433

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---
Pinging maintainer: @nh2

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
