### PR TITLE
knock: update repo from github to codeberg

### DIFF
--- a/pkgs/tools/networking/knock/package.nix
+++ b/pkgs/tools/networking/knock/package.nix
@@ -1,6 +1,6 @@
 { lib
 , buildGoModule
-, fetchFromGitHub
+, fetchFromGitea
 , installShellFiles
 }:
 
@@ -8,11 +8,12 @@ buildGoModule rec {
   pname = "knock";
   version = "0.0.2";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitea {
+    domain = "codeberg.org";
     owner = "nat-418";
     repo ="knock";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-VXrWphfBDGDNsz4iuUdwwd46oqnmhJ9i3TtzMqHoSJk=";
+    rev = "v${version}";
+    hash = "sha256-K+L4F4bTERQSqISAmfyps/U5GJ2N0FdJ3RmpiUmt4uA=";
   };
 
   vendorHash = "sha256-wkSXdIgfkHbVJYsgm/hLAeKA9geof92U3mzSzt7eJE8=";
@@ -27,9 +28,9 @@ buildGoModule rec {
 
   meta = with lib; {
     description = "A simple CLI network reachability tester";
-    homepage = "https://github.com/nat-418/knock";
+    homepage = "https://codeberg.org/nat-418/knock";
     license = licenses.bsd0;
-    changelog = "https://github.com/nat-418/knock/blob/${version}/CHANGELOG.md";
+    changelog = "https://codeberg.org/nat-418/knock/raw/branch/trunk/CHANGELOG.md";
     maintainers = with maintainers; [ nat-418 ];
   };
 }


### PR DESCRIPTION
Project has moved development from GitHub to Codeberg.