### PR TITLE
 gtklock: 2.1.0 -> 3.0.0; gtk-session-lock: init at 0.2.0

### DIFF
--- a/pkgs/by-name/gt/gtk-session-lock/package.nix
+++ b/pkgs/by-name/gt/gtk-session-lock/package.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, gobject-introspection
+, vala
+, gtk3
+, wayland-scanner
+, wayland
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gtk-session-lock";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "Cu3PO42";
+    repo = "gtk-session-lock";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-SHKAYmdev08oRB/V6UpfSFqYwplF59IaNSOoWcACPig=";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gobject-introspection
+    vala
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    gtk3
+    wayland
+  ];
+
+  # Tests are not fully prepared, but may be enabled in later versions
+  doCheck = false;
+
+  strictDeps = true;
+
+  meta = {
+    description = "A library to use GTK 3 to build screen lockers using ext-session-lock-v1 protocol";
+    homepage = "https://github.com/Cu3PO42/gtk-session-lock";
+    # The author stated "GTK Session Lock is licensed under the GNU General
+    # Public License version 3.0 or any later version approved by me (Cu3PO42)."
+    # Since we don't know if the author will approve later versions, we mark gpl3Only
+    license = with lib.licenses; [ gpl3Only ];
+    maintainers = with lib.maintainers; [ aleksana ];
+    platforms = lib.platforms.unix;
+    badPlatforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/tools/wayland/gtklock/default.nix
+++ b/pkgs/tools/wayland/gtklock/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     ''; # Following  nixpkgs/pkgs/applications/window-managers/sway/lock.nix
     homepage = "https://github.com/jovanlanik/gtklock";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ dit7ya ];
+    maintainers = with maintainers; [ dit7ya aleksana ];
     platforms = platforms.linux;
     mainProgram = "gtklock";
   };

--- a/pkgs/tools/wayland/gtklock/default.nix
+++ b/pkgs/tools/wayland/gtklock/default.nix
@@ -1,44 +1,42 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, wrapGAppsHook
-, pam
+, meson
+, ninja
 , scdoc
-, gtk3
 , pkg-config
-, gtk-layer-shell
-, glib
-, librsvg
-, wayland
-, wayland-scanner
+, wrapGAppsHook
+, gtk3
+, pam
+, gtk-session-lock
 }:
 
 stdenv.mkDerivation rec {
   pname = "gtklock";
-  version = "2.1.0";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "jovanlanik";
-    repo = pname;
+    repo = "gtklock";
     rev = "v${version}";
-    sha256 = "sha256-Jh+BmtKGaLgAcTXc44ydV83dp/W4wzByehUWyeyBoFI=";
+    hash = "sha256-B6pySjiwPBRFb4avE9NHsS1KkWMPW81DAqYro/wtrmQ=";
   };
 
   nativeBuildInputs = [
+    meson
+    ninja
     scdoc
     pkg-config
-    wayland-scanner
-    glib
     wrapGAppsHook
   ];
 
   buildInputs = [
-    wayland
     gtk3
     pam
-    gtk-layer-shell
-    librsvg
+    gtk-session-lock
   ];
+
+  strictDeps = true;
 
   installFlags = [
     "DESTDIR=$(out)"
@@ -51,7 +49,7 @@ stdenv.mkDerivation rec {
       Important note: for gtklock to work you need to set "security.pam.services.gtklock = {};" manually.
     ''; # Following  nixpkgs/pkgs/applications/window-managers/sway/lock.nix
     homepage = "https://github.com/jovanlanik/gtklock";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ dit7ya ];
     platforms = platforms.linux;
     mainProgram = "gtklock";


### PR DESCRIPTION
## Description of changes

This enables ext-session-v1 in gtklock. Tested and works fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
