### PR TITLE
dunst: 1.10.0 -> 1.11.0

### DIFF
--- a/pkgs/by-name/du/dunst/package.nix
+++ b/pkgs/by-name/du/dunst/package.nix
@@ -1,10 +1,31 @@
-{ stdenv, lib, fetchFromGitHub, makeWrapper
-, pkg-config, which, perl, jq, libXrandr, coreutils
-, cairo, dbus, systemd, gdk-pixbuf, glib, libX11, libXScrnSaver
-, wayland, wayland-protocols
-, libXinerama, libnotify, pango, xorgproto, librsvg
-, testers, dunst
-, withX11 ? true, withWayland ? true
+{ stdenv
+, lib
+, fetchFromGitHub
+, makeWrapper
+, pkg-config
+, which
+, perl
+, jq
+, libXrandr
+, coreutils
+, cairo
+, dbus
+, systemd
+, gdk-pixbuf
+, glib
+, libX11
+, libXScrnSaver
+, wayland
+, wayland-protocols
+, libXinerama
+, libnotify
+, pango
+, xorgproto
+, librsvg
+, testers
+, dunst
+, withX11 ? true
+, withWayland ? true
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -18,14 +39,32 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-eiFvvavXGNcHZnEGwlTLxRqFNdkvEZMwNIkVyDn1V6o=";
   };
 
-  nativeBuildInputs = [ perl pkg-config which systemd makeWrapper ];
+  nativeBuildInputs = [
+    perl
+    pkg-config
+    which
+    systemd
+    makeWrapper
+  ];
 
   buildInputs = [
-    cairo dbus gdk-pixbuf glib
-    libnotify pango librsvg
-  ]
-  ++ lib.optionals withX11 [ libX11 libXScrnSaver libXinerama xorgproto libXrandr]
-  ++ lib.optionals withWayland [ wayland wayland-protocols ];
+    cairo
+    dbus
+    gdk-pixbuf
+    glib
+    libnotify
+    pango
+    librsvg
+  ] ++ lib.optionals withX11 [
+    libX11
+    libXScrnSaver
+    libXinerama
+    xorgproto
+    libXrandr
+  ] ++ lib.optionals withWayland [
+    wayland
+    wayland-protocols
+  ];
 
   outputs = [ "out" "man" ];
 

--- a/pkgs/by-name/du/dunst/package.nix
+++ b/pkgs/by-name/du/dunst/package.nix
@@ -4,6 +4,7 @@
 , wayland, wayland-protocols
 , libXinerama, libnotify, pango, xorgproto, librsvg
 , testers, dunst
+, withX11 ? true, withWayland ? true
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -20,10 +21,11 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ perl pkg-config which systemd makeWrapper ];
 
   buildInputs = [
-    cairo dbus gdk-pixbuf glib libX11 libXScrnSaver
-    libXinerama libnotify pango xorgproto librsvg libXrandr
-    wayland wayland-protocols
-  ];
+    cairo dbus gdk-pixbuf glib
+    libnotify pango librsvg
+  ]
+  ++ lib.optionals withX11 [ libX11 libXScrnSaver libXinerama xorgproto libXrandr]
+  ++ lib.optionals withWayland [ wayland wayland-protocols ];
 
   outputs = [ "out" "man" ];
 
@@ -33,7 +35,9 @@ stdenv.mkDerivation (finalAttrs: {
     "SYSCONFDIR=$(out)/etc"
     "SERVICEDIR_DBUS=$(out)/share/dbus-1/services"
     "SERVICEDIR_SYSTEMD=$(out)/lib/systemd/user"
-  ];
+  ]
+  ++ lib.optional (!withX11) "X11=0"
+  ++ lib.optional (!withWayland) "WAYLAND=0";
 
   postInstall = ''
     wrapProgram $out/bin/dunst \

--- a/pkgs/by-name/du/dunst/package.nix
+++ b/pkgs/by-name/du/dunst/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dunst";
-  version = "1.10.0";
+  version = "1.11.0";
 
   src = fetchFromGitHub {
     owner = "dunst-project";
     repo = "dunst";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-6smFUdWqOuYB0btsDgHtIpDBfHhkpIQfjyZ8wtRg1bQ=";
+    hash = "sha256-eiFvvavXGNcHZnEGwlTLxRqFNdkvEZMwNIkVyDn1V6o=";
   };
 
   nativeBuildInputs = [ perl pkg-config which systemd makeWrapper ];
@@ -42,10 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
     wrapProgram $out/bin/dunstctl \
       --prefix PATH : "${lib.makeBinPath [ coreutils dbus ]}"
 
-    install -D contrib/_dunst.zshcomp $out/share/zsh/site-functions/_dunst
-    install -D contrib/_dunstctl.zshcomp $out/share/zsh/site-functions/_dunstctl
-    substituteInPlace $out/share/zsh/site-functions/_dunstctl \
-      --replace "jq -M" "${jq}/bin/jq -M"
+    substituteInPlace $out/share/zsh/site-functions/_dunstctl $out/share/fish/vendor_completions.d/{dunstctl,dunstify} \
+      --replace-fail "jq" "${lib.getExe jq}"
   '';
 
   passthru.tests.version = testers.testVersion { package = dunst; };

--- a/pkgs/by-name/du/dunst/package.nix
+++ b/pkgs/by-name/du/dunst/package.nix
@@ -97,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.bsd3;
     # NOTE: 'unix' or even 'all' COULD work too, I'm not sure
     platforms = platforms.linux;
-    maintainers = with maintainers; [ domenkozar ];
+    maintainers = with maintainers; [ domenkozar gepbird ];
     mainProgram = "dunst";
   };
 })


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/dunst-project/dunst/releases/tag/v1.11.0
Shell completions are now officially supported and installed using make, including zsh, bash and fish. @vincentbernat can you test them?
Since upstream allows building without X11 or Wayland, I added options for those.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files **only on X11** (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Result of `nixpkgs-review pr 305398` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>betterlockscreen</li>
    <li>dunst</li>
    <li>dunst.man</li>
  </ul>
</details>


Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
