### PR TITLE
hyprland-activewindow: init at 1.0.1

### DIFF
--- a/pkgs/by-name/hy/hyprland-activewindow/package.nix
+++ b/pkgs/by-name/hy/hyprland-activewindow/package.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "hyprland-activewindow";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "FieldOfClay";
+    repo = "hyprland-activewindow";
+    rev = "v${version}";
+    hash = "sha256-8pzm8uIyvlz4nHbxtmbMblFIj38M2VsenaKzJ9di1Do=";
+  };
+
+  cargoHash = "sha256-wIF0qa1dyZlcsLPL2TflFQFPm4Pe9TWHe1F2L1YccZ8=";
+
+  meta = with lib; {
+    description = "A multi-monitor-aware Hyprland workspace widget helper";
+    homepage = "https://github.com/FieldofClay/hyprland-activewindow";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kiike donovanglover ];
+    mainProgram = "hyprland-activewindow";
+  };
+}


### PR DESCRIPTION
## Description of changes

This package introduces a helper application for Hyprland users. It consists of a program that connects to the Hyprland IPC to monitor active window changes. Then, thanks to `hyprland-activewindow`'s output, custom widgets such as waybar's or eww's can be updated with the current active window.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
