### PR TITLE
home-assistant: 2024.4.2 -> 2024.4.3

### DIFF
--- a/pkgs/development/python-modules/aranet4/default.nix
+++ b/pkgs/development/python-modules/aranet4/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "aranet4";
-  version = "2.2.3";
+  version = "2.3.3";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "Anrijs";
     repo = "Aranet4-Python";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Jd7yuddxwRrO7XFQsVGy5vRQxwIUZdwFSjiZZHdkE3g=";
+    hash = "sha256-j53d2Ki9xVWGHWkAu1wkjYE56Xq7kfMmqQrQiKrBg2I=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2024.4.2";
+  version = "2024.4.3";
   components = {
     "3_day_blinds" = ps: with ps; [
     ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -526,7 +526,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2024.4.2";
+  hassVersion = "2024.4.3";
 
 in python.pkgs.buildPythonApplication rec {
   pname = "homeassistant";
@@ -544,13 +544,13 @@ in python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = "refs/tags/${version}";
-    hash = "sha256-V6qvpPrhfSLINH99hYkAjvG8pfIN8AXGO3HuwiKgMPo=";
+    hash = "sha256-jHt4cWi1JxUs2XKf0N9gqsYj5XZK7TXwgj7WPZ7dmEA=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-ZtTlLRDSXKUz+ZA+UctFL+d3wdKrcPdeROIUhS35qWU=";
+    hash = "sha256-sj3usdXUl/wNElO3OgGx6dsBqn9+h9zq/AC3Zdn379M=";
   };
 
   nativeBuildInputs = with python.pkgs; [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -566,6 +566,7 @@ in python.pkgs.buildPythonApplication rec {
     "hass-nabucasa"
     "httpx"
     "orjson"
+    "pillow"
     "pyopenssl"
     "typing-extensions"
     "urllib3"

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,7 +4,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20240404.1";
+  version = "20240404.2";
   format = "wheel";
 
   src = fetchPypi {
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-Vuk/e+wn8Cbko7tbjLIbclhdj3R+BdHzu4OSsBUAOcU=";
+    hash = "sha256-xCpQHzfXXt9aOWWVGYtt9NYws//ZPjI/owXBQafb31k=";
   };
 
   # there is nothing to strip in this package


### PR DESCRIPTION
## Description of changes

https://github.com/home-assistant/core/releases/tag/2024.4.3

Targeting `staging` because it was broken in `staging` by the Python updates:

```
adding 'homeassistant-2024.4.2.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Successfully built homeassistant-2024.4.2-py3-none-any.whl
Finished creating a wheel...
/build/source/dist /build/source
Unpacking to: unpacked/homeassistant-2024.4.2...OK
Repacking wheel as ./homeassistant-2024.4.2-py3-none-any.whl...OK
/build/source
Finished executing pypaBuildPhase
Running phase: pythonRuntimeDepsCheckHook
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for homeassistant-2024.4.2-py3-none-any.whl
  - aiohttp==3.9.3 not satisfied by version 3.9.4
  - pillow==10.2.0 not satisfied by version 10.3.0
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested my Home Assistant server with this PR and it seems to be working fine.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
