### PR TITLE
pymol: 2.5.0 -> 3.0.0

### DIFF
--- a/pkgs/applications/science/chemistry/pymol/default.nix
+++ b/pkgs/applications/science/chemistry/pymol/default.nix
@@ -60,7 +60,6 @@ python3Packages.buildPythonApplication rec {
   nativeBuildInputs = [ qt5.wrapQtAppsHook ];
   buildInputs = [ python3Packages.numpy python3Packages.pyqt5 glew glm libpng libxml2 freetype msgpack netcdf ];
   env.NIX_CFLAGS_COMPILE = "-I ${libxml2.dev}/include/libxml2";
-  hardeningDisable = [ "format" ];
 
   postInstall = with python3Packages; ''
     wrapProgram $out/bin/pymol \

--- a/pkgs/applications/science/chemistry/pymol/default.nix
+++ b/pkgs/applications/science/chemistry/pymol/default.nix
@@ -117,6 +117,6 @@ python3Packages.buildPythonApplication rec {
     mainProgram = "pymol";
     homepage = "https://www.pymol.org/";
     license = licenses.mit;
-    maintainers = with maintainers; [ samlich ];
+    maintainers = with maintainers; [ natsukium samlich ];
   };
 }

--- a/pkgs/applications/science/chemistry/pymol/default.nix
+++ b/pkgs/applications/science/chemistry/pymol/default.nix
@@ -72,6 +72,42 @@ python3Packages.buildPythonApplication rec {
     cp -r "${desktopItem}/share/applications/" "$out/share/"
   '';
 
+  pythonImportsCheck = [
+    "pymol"
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    python3Packages.msgpack
+    pillow
+    pytestCheckHook
+  ];
+
+  # some tests hang for some reason
+  doCheck = !(stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);
+
+  disabledTestPaths = [
+    # require biopython which is broken as of 2024-04-20
+    "tests/api/seqalign.py"
+  ];
+
+  disabledTests = [
+    # the output image does not exactly match
+    "test_commands"
+    # touch the network
+    "testFetch"
+    # requires collada2gltf which is not included in nixpkgs
+    "testglTF"
+    # require mmtf-cpp which does not support darwin
+    "testMMTF"
+    "testSave_symmetry__mmtf"
+  ];
+
+  preCheck = ''
+    cd testing
+  '';
+
+  __darwinAllowLocalNetworking = true;
+
   preFixup = ''
     wrapQtApp "$out/bin/pymol"
   '';

--- a/pkgs/applications/science/chemistry/pymol/default.nix
+++ b/pkgs/applications/science/chemistry/pymol/default.nix
@@ -38,12 +38,12 @@ let
 in
 python3Packages.buildPythonApplication rec {
   inherit pname;
-  version = "2.5.0";
+  version = "3.0.0";
   src = fetchFromGitHub {
     owner = "schrodinger";
     repo = "pymol-open-source";
     rev = "v${version}";
-    sha256 = "sha256-JdsgcVF1w1xFPZxVcyS+GcWg4a1Bd4SvxFOuSdlz9SM=";
+    hash = "sha256-GhTHxacjGN7XklZ6gileBMRZAGq4Pp4JknNL+qGqrVE=";
   };
 
   nativeBuildInputs = [ qt5.wrapQtAppsHook ];

--- a/pkgs/applications/science/chemistry/pymol/default.nix
+++ b/pkgs/applications/science/chemistry/pymol/default.nix
@@ -39,6 +39,8 @@ in
 python3Packages.buildPythonApplication rec {
   inherit pname;
   version = "3.0.0";
+  pyproject = true;
+
   src = fetchFromGitHub {
     owner = "schrodinger";
     repo = "pymol-open-source";
@@ -46,22 +48,27 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-GhTHxacjGN7XklZ6gileBMRZAGq4Pp4JknNL+qGqrVE=";
   };
 
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "self.install_libbase" '"${placeholder "out"}/${python3.sitePackages}"'
+  '';
+
+  build-system = [
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [ qt5.wrapQtAppsHook ];
   buildInputs = [ python3Packages.numpy python3Packages.pyqt5 glew glm libpng libxml2 freetype msgpack netcdf ];
   env.NIX_CFLAGS_COMPILE = "-I ${libxml2.dev}/include/libxml2";
   hardeningDisable = [ "format" ];
-
-  installPhase = ''
-    python setup.py install --home="$out"
-    runHook postInstall
-  '';
 
   postInstall = with python3Packages; ''
     wrapProgram $out/bin/pymol \
       --prefix PYTHONPATH : ${lib.makeSearchPathOutput "lib" python3.sitePackages [ pyqt5 pyqt5.pyqt5-sip ]}
 
     mkdir -p "$out/share/icons/"
-    ln -s ../../lib/python/pymol/pymol_path/data/pymol/icons/icon2.svg "$out/share/icons/pymol.svg"
+    ln -s $out/${python3.sitePackages}/pymol/pymol_path/data/pymol/icons/icon2.svg "$out/share/icons/pymol.svg"
+  '' + lib.optionalString stdenv.hostPlatform.isLinux ''
     cp -r "${desktopItem}/share/applications/" "$out/share/"
   '';
 


### PR DESCRIPTION
## Description of changes

- update 2.5.0 -> 3.0.0
Diff: https://github.com/schrodinger/pymol-open-source/compare/v2.5.0...v3.0.0
- refactor
- enable tests

I would like to get rid of PYTHON_PATH and wrapQt, but it's a bit difficult.
I don't want to bring the bug into 24.05, so I'll leave it as is for now.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
