### PR TITLE
ayatana-indicator-display: init & add to Lomiri

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -72,6 +72,7 @@ in {
       enable = true;
       packages = (with pkgs; [
         ayatana-indicator-datetime
+        ayatana-indicator-display
         ayatana-indicator-messages
         ayatana-indicator-power
         ayatana-indicator-session

--- a/nixos/tests/ayatana-indicators.nix
+++ b/nixos/tests/ayatana-indicators.nix
@@ -28,6 +28,7 @@ in {
       enable = true;
       packages = with pkgs; [
         ayatana-indicator-datetime
+        ayatana-indicator-display
         ayatana-indicator-messages
         ayatana-indicator-power
         ayatana-indicator-session
@@ -95,7 +96,7 @@ in {
 
     # Now check if all indicators were brought up successfully, and kill them for later
   '' + (runCommandOverAyatanaIndicators (service: let serviceExec = builtins.replaceStrings [ "." ] [ "-" ] service; in ''
-    machine.succeed("pgrep -u ${user} -f ${serviceExec}")
+    machine.wait_until_succeeds("pgrep -u ${user} -f ${serviceExec}")
     machine.succeed("pkill -f ${serviceExec}")
   '')) + ''
 

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -290,7 +290,7 @@ in {
     # There's a test app we could use that also displays their contents, but it's abit inconsistent.
     with subtest("ayatana indicators work"):
         mouse_click(735, 0) # the cog in the top-right, for the session indicator
-        machine.wait_for_text(r"(Notifications|Battery|Sound|Time|Date|System)")
+        machine.wait_for_text(r"(Notifications|Rotation|Battery|Sound|Time|Date|System)")
         machine.screenshot("indicators_open")
 
         # Indicator order within the menus *should* be fixed based on per-indicator order setting
@@ -299,10 +299,16 @@ in {
         machine.send_key("left")
         machine.send_key("left")
         machine.send_key("left")
+        machine.send_key("left")
         # Notifications are usually empty, nothing to check there
 
-        with subtest("lomiri indicator network works"):
+        with subtest("ayatana indicator display works"):
             # We start on this, don't go right
+            machine.wait_for_text("Lock")
+            machine.screenshot("indicators_display")
+
+        with subtest("lomiri indicator network works"):
+            machine.send_key("right")
             machine.wait_for_text(r"(Flight|Wi-Fi)")
             machine.screenshot("indicators_network")
 

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -312,7 +312,7 @@ in {
             machine.wait_for_text(r"(Flight|Wi-Fi)")
             machine.screenshot("indicators_network")
 
-        with subtest("lomiri indicator sound works"):
+        with subtest("ayatana indicator sound works"):
             machine.send_key("right")
             machine.wait_for_text(r"(Silent|Volume)")
             machine.screenshot("indicators_sound")

--- a/pkgs/by-name/ay/ayatana-indicator-display/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-display/package.nix
@@ -1,0 +1,124 @@
+{ stdenv
+, lib
+, gitUpdater
+, fetchFromGitHub
+, nixosTests
+, accountsservice
+, cmake
+, cppcheck
+, dbus
+, geoclue2
+, glib
+, gsettings-desktop-schemas
+, gtest
+, intltool
+, libayatana-common
+, libgudev
+, libqtdbusmock
+, libqtdbustest
+, libsForQt5
+, lomiri
+, mate
+, pkg-config
+, properties-cpp
+, python3
+, systemd
+, wrapGAppsHook3
+, xsct
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ayatana-indicator-display";
+  version = "24.5.0";
+
+  src = fetchFromGitHub {
+    owner = "AyatanaIndicators";
+    repo = "ayatana-indicator-display";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-ZEmJJtVK1dHIrY0C6pqVu1N5PmQtYqX0K5v5LvzNfFA=";
+  };
+
+  postPatch = ''
+    # Replace systemd prefix in pkg-config query, use GNUInstallDirs location for /etc
+    substituteInPlace data/CMakeLists.txt \
+      --replace-fail 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir)' 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir DEFINE_VARIABLES prefix=''${CMAKE_INSTALL_PREFIX})' \
+      --replace-fail 'DESTINATION "/etc' 'DESTINATION "''${CMAKE_INSTALL_FULL_SYSCONFDIR}'
+
+    # Hardcode xsct path
+    substituteInPlace src/service.cpp \
+      --replace-fail 'sCommand = g_strdup_printf ("xsct' 'sCommand = g_strdup_printf ("${lib.getExe xsct}'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    glib # for schema discovery
+    intltool
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  # TODO Can we get around requiring every desktop's schemas just to avoid segfaulting on some systems?
+  buildInputs = [
+    accountsservice
+    geoclue2
+    gsettings-desktop-schemas # gnome schemas
+    glib
+    libayatana-common
+    libgudev
+    libsForQt5.qtbase
+    systemd
+  ] ++ (with lomiri; [
+    cmake-extras
+    lomiri-schemas # lomiri schema
+  ]) ++ (with mate; [
+    mate.marco # marco schema
+    mate.mate-settings-daemon # mate mouse schema
+  ]);
+
+  nativeCheckInputs = [
+    cppcheck
+    dbus
+    (python3.withPackages (ps: with ps; [
+      python-dbusmock
+    ]))
+  ];
+
+  checkInputs = [
+    gtest
+    libqtdbusmock
+    libqtdbustest
+    properties-cpp
+  ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "ENABLE_COLOR_TEMP" true)
+    (lib.cmakeBool "GSETTINGS_LOCALINSTALL" true)
+    (lib.cmakeBool "GSETTINGS_COMPILE" true)
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  passthru = {
+    ayatana-indicators = [ "ayatana-indicator-display" ];
+    tests.vm = nixosTests.ayatana-indicators;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Ayatana Indicator for Display configuration";
+    longDescription = ''
+      This Ayatana Indicator is designed to be placed on the right side of a
+      panel and give the user easy control for changing their display settings.
+    '';
+    homepage = "https://github.com/AyatanaIndicators/ayatana-indicator-display";
+    changelog = "https://github.com/AyatanaIndicators/ayatana-indicator-display/blob/${finalAttrs.version}/ChangeLog";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Inits [ayatana-indicator-display](https://github.com/AyatanaIndicators/ayatana-indicator-display) and adds it to the Lomiri module.

On Lomiri, it only handles screen lock afaict. Not much to show there.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
