### PR TITLE
podman-compose: 1.0.6 -> 1.1.0

### DIFF
--- a/pkgs/applications/virtualization/podman-compose/default.nix
+++ b/pkgs/applications/virtualization/podman-compose/default.nix
@@ -1,17 +1,24 @@
-{ lib, buildPythonApplication, fetchFromGitHub, python-dotenv, pyyaml }:
+{ lib, buildPythonApplication, fetchFromGitHub, python-dotenv, pyyaml, setuptools, pipBuildHook, pypaBuildHook }:
 
 buildPythonApplication rec {
-  version = "1.0.6";
+  version = "1.1.0";
   pname = "podman-compose";
+  pyproject = true;
 
   src = fetchFromGitHub {
     repo = "podman-compose";
     owner = "containers";
     rev = "v${version}";
-    sha256 = "sha256-TsNM5xORqwWge+UCijKptwbAcIz1uZFN9BuIOl28vIU=";
+    sha256 = "sha256-uNgzdLrnDIABtt0L2pvsil14esRzl0XcWohgf7Oksr8=";
   };
 
-  propagatedBuildInputs = [ pyyaml python-dotenv ];
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [ python-dotenv pyyaml ];
+  propagatedBuildInputs = [ pypaBuildHook ];
 
   meta = {
     description = "An implementation of docker-compose with podman backend";


### PR DESCRIPTION
## Description of changes

After a period of not being maintained the new maintainer release a new version: https://github.com/containers/podman-compose/issues/825

Release: https://github.com/containers/podman-compose/releases/tag/v1.1.0

I tried to fix build issues/deprecation as possible, one I couldn't fix (but not breaking build):

```
python3.11-python-dotenv> /nix/store/4718wmk03wr3554kmf09vy80vkdjvq56-python3.11-setuptools-69.1.1/lib/python3.11/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
python3.11-python-dotenv> !!
python3.11-python-dotenv>         ********************************************************************************
python3.11-python-dotenv>         Please avoid running ``setup.py`` directly.
python3.11-python-dotenv>         Instead, use pypa/build, pypa/installer or other
python3.11-python-dotenv>         standards-based tools.
python3.11-python-dotenv>         See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
python3.11-python-dotenv>         ********************************************************************************
python3.11-python-dotenv> !!
```

So would appreciate input if there is something that can be done :v:

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
