### PR TITLE
plasmusic-toolbar: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3326,6 +3326,12 @@
       fingerprint = "1127 A432 6524 BF02 737B  544E 0704 CD9E 550A 6BCD";
     }];
   };
+  ccatterina = {
+    email = "ccatterina@proton.me";
+    github = "ccatterina";
+    githubId = 9085116;
+    name = "Claudio Catterina";
+  };
   ccellado = {
     email = "annplague@gmail.com";
     github = "ccellado";

--- a/pkgs/by-name/pl/plasmusic-toolbar/package.nix
+++ b/pkgs/by-name/pl/plasmusic-toolbar/package.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchFromGitHub, kdePackages }:
+
+stdenv.mkDerivation rec {
+  pname = "plasmusic-toolbar";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ccatterina";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-BSVVEtodPKvtX7HGpgxAIq03BHhj5NmLZGDMqMQLjR8=";
+  };
+
+  dontBuild = true;
+  nativeBuildInputs = [ kdePackages.kpackage ];
+
+  installPhase = ''
+    runHook preInstall
+
+    kpackagetool6 -i src -p $out/share/plasma/plasmoids/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "KDE Plasma widget that shows currently playing song information and provide playback controls";
+    homepage = "https://github.com/ccatterina/plasmusic-toolbar";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ ccatterina ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes
Hi,
this PR adds [plasmusic-toolbar](https://github.com/ccatterina/plasmusic-toolbar), a widget for kde that shows currently playing song information and provide playback controls.

I have some questions about where to place the pkg.
Starting from the v1.0.0, the widget works only on plasma6 but I couldn't find a directory for plasma6 third-party addons, so I placed it in `pkgs/desktops/plasma-5/3rdparty/addons/`. Is it the right position?
What if I wanted to add also a plasma5 compatible version of the widget?

This is my first contribution to nixpkgs, I hope I didn't make any big mistakes  :slightly_smiling_face:

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---
Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
