### PR TITLE
drbd driver: 9.2.7 -> 9.2.8

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -616,7 +616,7 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 - QtMultimedia has changed its default backend to `QT_MEDIA_BACKEND=ffmpeg` (previously `gstreamer` on Linux or `darwin` on MacOS).
   The previous native backends remain available but are now minimally maintained. Refer to [upstream documentation](https://doc.qt.io/qt-6/qtmultimedia-index.html#ffmpeg-as-the-default-backend) for further details about each platform.
 
-- The `drbd` out-of-tree Linux kernel driver has been added in version `9.2.7`. With it the DRBD 9.x features can be used instead of the 8.x features provided by the `8.4.11` in-tree driver.
+- The `drbd` out-of-tree Linux kernel driver has been added in version `9.2`. With it the DRBD 9.x features can be used instead of the 8.x features provided by the `8.4.11` in-tree driver.
 
 - The oil shell's c++ version is now available as `oils-for-unix`. The python version is still available as `oil`
 

--- a/pkgs/os-specific/linux/drbd/driver.nix
+++ b/pkgs/os-specific/linux/drbd/driver.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "drbd-${version}-${kernel.version}";
-  version = "9.2.7";
+  version = "9.2.8";
 
   src = fetchurl {
     url = "https://pkg.linbit.com//downloads/drbd/9/drbd-${version}.tar.gz";
-    sha256 = "1355ns10z0fjgqsdpf09qfy01j8lg2n7zy4kclmar3s798n3mh56";
+    hash = "sha256-LqK1lPucab7wKvcB4VKGdvBIq+K9XtuO2m0DP5XtK3M=";
   };
 
   hardeningDisable = [ "pic" ];
@@ -41,6 +41,12 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace 'SHELL=/bin/bash' 'SHELL=${builtins.getEnv "SHELL"}'
   '';
 
+  postFixup = ''
+    for ko in $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd/*.ko; do
+      xz --compress -6 --threads=0 $ko
+    done
+  '';
+
   enableParallelBuilding = true;
 
   meta = with lib; {
@@ -53,5 +59,6 @@ stdenv.mkDerivation rec {
        DRBD is a software-based, shared-nothing, replicated storage solution
        mirroring the content of block devices (hard disks, partitions, logical volumes, and so on) between hosts.
     '';
+    broken = lib.versionAtLeast kernel.version "6.8"; # wait until next DRBD release for 6.8 support https://github.com/LINBIT/drbd/issues/87#issuecomment-2059323084
   };
 }


### PR DESCRIPTION
## Description of changes

- DRBD [out-of-tree kernel driver](https://github.com/LINBIT/drbd) updated from `9.2.7` to `9.2.8`
- xz compression for module files enabled
- no support for Kernel 6.8 or newer until the [next DRBD driver release](https://github.com/LINBIT/drbd/issues/87#issuecomment-2059323084)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - `nix-build ${NIXPKGS} --attr pkgs.drbd.passthru.tests`
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
    - `nix-build --attr nixosTests.drbd`
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] `nix-build pkgs/top-level/release.nix -A tarball.nixpkgs-basic-release-checks --arg supportedSystems '[ "aarch64-linux" "x86_64-linux" ]'` 
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
