### PR TITLE
coder: add support for mainline channel

### DIFF
--- a/pkgs/development/tools/coder/default.nix
+++ b/pkgs/development/tools/coder/default.nix
@@ -1,4 +1,5 @@
 { lib
+, channel ? "stable"
 , fetchurl
 , installShellFiles
 , makeBinaryWrapper
@@ -9,18 +10,33 @@
 
 let
   inherit (stdenvNoCC.hostPlatform) system;
+
+  channels = {
+    stable = {
+      version = "2.9.3";
+      hash = {
+        x86_64-linux = "sha256-6VS21x2egWBV6eJqRCBGG7mEGPIDFtY9GN6Ry4ilC70=";
+        x86_64-darwin = "sha256-UBUGjA+jUkT6p9714l8IvDDI/qhWNctVFOvcA2S5kQU=";
+        aarch64-linux = "sha256-2QAahqcM2gi3lT+18q2Nm9GNqVsqzX3RajBsTn+KB1c=";
+        aarch64-darwin = "sha256-uEH7Y7c9BcU/Q/jwx/inFMvUrgm2dUruID+FJL+rA6Y=";
+      };
+    };
+    mainline = {
+      version = "2.10.1";
+      hash = {
+        x86_64-linux = "sha256-jNPL30e5xvyajlIqivtEpSb3cRhfgFhLFlC+CaLY2IM=";
+        x86_64-darwin = "sha256-U1eQaYwnm/mdQoZ8YxK/+s3HboVfMIAtdI7aQnCiDM8=";
+        aarch64-linux = "sha256-YtSyKZYG8vdubZUfo2FjEoVwSF82TXzeLJjPpHqgFDk=";
+        aarch64-darwin = "sha256-aQSiXK7voP5/mPFIscfTnSc4Ae5/f+WW8MR6ZtuC/eY=";
+      };
+    };
+  };
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "coder";
-  version = "2.9.1";
-
+  version = channels.${channel}.version;
   src = fetchurl {
-    hash = {
-      x86_64-linux = "sha256-r4+u/s/dOn2GhyhEROu8i03QY3VA/bIyO/Yj7KSqicY=";
-      x86_64-darwin = "sha256-uShCmMvb5OcinqP0CmrlP9QAJkjfG3g1QuHE4JRDOjE=";
-      aarch64-linux = "sha256-tvpzfJ95YYfCY5V4iayjAmY5PDw+1uHUhY5F3pv/2Uk=";
-      aarch64-darwin = "sha256-sP9HnB2DzAU9IvL3+QPmIFLvRkGkoxSoa68uXGQrNkw=";
-    }.${system};
+    hash = (channels.${channel}.hash).${system};
 
     url =
       let

--- a/pkgs/development/tools/coder/update.sh
+++ b/pkgs/development/tools/coder/update.sh
@@ -5,12 +5,13 @@ set -eu -o pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-LATEST_TAG=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} --silent https://api.github.com/repos/coder/coder/releases/latest | jq -r '.tag_name')
-LATEST_VERSION=$(echo ${LATEST_TAG} | sed 's/^v//')
+# Fetch the latest stable version
+LATEST_STABLE_TAG=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} --silent https://api.github.com/repos/coder/coder/releases/latest | jq -r '.tag_name')
+LATEST_STABLE_VERSION=$(echo ${LATEST_STABLE_TAG} | sed 's/^v//')
 
-# change version number
-sed -e "s/version =.*;/version = \"$LATEST_VERSION\";/g" \
-    -i ./default.nix
+# Fetch the latest mainline version
+LATEST_MAINLINE_TAG=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} --silent https://api.github.com/repos/coder/coder/releases | jq -r '.[0].tag_name')
+LATEST_MAINLINE_VERSION=$(echo ${LATEST_MAINLINE_TAG} | sed 's/^v//')
 
 # Define the platforms
 declare -A ARCHS=(["x86_64-linux"]="linux_amd64.tar.gz"
@@ -18,15 +19,33 @@ declare -A ARCHS=(["x86_64-linux"]="linux_amd64.tar.gz"
                   ["x86_64-darwin"]="darwin_amd64.zip"
                   ["aarch64-darwin"]="darwin_arm64.zip")
 
-# Update hashes for each architecture
-for ARCH in "${!ARCHS[@]}"; do
-  URL="https://github.com/coder/coder/releases/download/v${LATEST_VERSION}/coder_${LATEST_VERSION}_${ARCHS[$ARCH]}"
-  echo "Fetching hash for $ARCH..."
+update_version_and_hashes() {
+    local version=$1
+    local channel=$2
 
-  # Fetch the new hash using nix-prefetch-url
-  NEW_HASH=$(nix-prefetch-url --type sha256 $URL)
-  SRI_HASH=$(nix hash to-sri --type sha256 $NEW_HASH)
+    # Update version number, using '#' as delimiter
+    sed -i "/${channel} = {/,/};/{
+        s#^\(\s*\)version = .*#\1version = \"$version\";#
+    }" ./default.nix
 
-  # Update the Nix file with the new hash
-  sed -i "s|${ARCH} = \"sha256-.*\";|${ARCH} = \"${SRI_HASH}\";|" ./default.nix
-done
+    # Update hashes for each architecture
+    for ARCH in "${!ARCHS[@]}"; do
+        local URL="https://github.com/coder/coder/releases/download/v${version}/coder_${version}_${ARCHS[$ARCH]}"
+        echo "Fetching hash for $channel/$ARCH..."
+
+        # Fetch the new hash using nix-prefetch-url
+        local NEW_HASH=$(nix-prefetch-url --type sha256 $URL)
+        local SRI_HASH=$(nix hash to-sri --type sha256 $NEW_HASH)
+
+        # Update the Nix file with the new hash, using '#' as delimiter and preserving indentation
+        sed -i "/${channel} = {/,/};/{
+            s#^\(\s*\)${ARCH} = .*#\1${ARCH} = \"${SRI_HASH}\";#
+        }" ./default.nix
+    done
+}
+
+# Update stable channel
+update_version_and_hashes $LATEST_STABLE_VERSION "stable"
+
+# Update mainline channel
+update_version_and_hashes $LATEST_MAINLINE_VERSION "mainline"


### PR DESCRIPTION
Coder releases with the latest tag for a stable release, and an untagged latest release for mainline.

This change enables the update script to update both release candidates and enables the installation of both as well!

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
