### PR TITLE
dub-to-nix,buildDubPackage: allow git-type dependencies

### DIFF
--- a/pkgs/build-support/dlang/dub-to-nix/default.nix
+++ b/pkgs/build-support/dlang/dub-to-nix/default.nix
@@ -4,8 +4,15 @@
   makeWrapper,
   python3,
   nix,
+  nix-prefetch-git,
 }:
 
+let
+  binPath = lib.makeBinPath [
+    nix
+    nix-prefetch-git
+  ];
+in
 runCommand "dub-to-nix"
   {
     nativeBuildInputs = [ makeWrapper ];
@@ -15,5 +22,5 @@ runCommand "dub-to-nix"
     install -Dm755 ${./dub-to-nix.py} "$out/bin/dub-to-nix"
     patchShebangs "$out/bin/dub-to-nix"
     wrapProgram "$out/bin/dub-to-nix" \
-        --prefix PATH : ${lib.makeBinPath [ nix ]}
+        --prefix PATH : ${binPath}
   ''

--- a/pkgs/build-support/dlang/dub-to-nix/dub-to-nix.py
+++ b/pkgs/build-support/dlang/dub-to-nix/dub-to-nix.py
@@ -4,9 +4,12 @@ import sys
 import json
 import os
 import subprocess
+import string
+
 
 def eprint(text: str):
     print(text, file=sys.stderr)
+
 
 if not os.path.exists("dub.selections.json"):
     eprint("The file `dub.selections.json` does not exist in the current working directory")
@@ -16,24 +19,53 @@ if not os.path.exists("dub.selections.json"):
 with open("dub.selections.json") as f:
     selectionsJson = json.load(f)
 
-versionDict: dict[str, str] = selectionsJson["versions"]
+depsDict: dict = selectionsJson["versions"]
 
-for pname in versionDict:
-    version = versionDict[pname]
+# For each dependency expand non-expanded version into a dict with a "version" key
+depsDict = {pname: (versionOrDepDict if isinstance(versionOrDepDict, dict) else {"version": versionOrDepDict}) for (pname, versionOrDepDict) in depsDict.items()}
+
+# Don't process path-type selections
+depsDict = {pname: depDict for (pname, depDict) in depsDict.items() if "path" not in depDict}
+
+# Pre-validate selections before trying to fetch
+for pname in depsDict:
+    depDict = depsDict[pname]
+    version = depDict["version"]
     if version.startswith("~"):
-        eprint(f'Package "{pname}" has a branch-type version "{version}", which doesn\'t point to a fixed version')
-        eprint("You can resolve it by manually changing the required version to a fixed one inside `dub.selections.json`")
-        eprint("When packaging, you might need to create a patch for `dub.sdl` or `dub.json` to accept the changed version")
+        eprint(f'Expected version of "{pname}" to be non-branch type')
+        eprint(f'Found: "{version}"')
+        eprint("Please specify a non-branch version inside `dub.selections.json`")
+        eprint("When packaging, you might also need to patch the version value in the appropriate places (`dub.selections.json`, dub.sdl`, `dub.json`)")
         sys.exit(1)
+    if "repository" in depDict:
+        repository = depDict["repository"]
+        if not repository.startswith("git+"):
+            eprint(f'Expected repository field of "{pname}" to begin with "git+"')
+            eprint(f'Found: "{repository}"')
+            sys.exit(1)
+        if (len(version) < 7 or len(version) > 40 or not all(c in string.hexdigits for c in version)):
+            eprint(f'Expected version field of "{pname}" to begin be a valid git revision')
+            eprint(f'Found: "{version}"')
+            sys.exit(1)
 
-lockedDependenciesDict: dict[str, dict[str, str]] = {}
+lockedDepsDict: dict[str, dict[str, str]] = {}
 
-for pname in versionDict:
-    version = versionDict[pname]
-    eprint(f"Fetching {pname}@{version}")
-    url = f"https://code.dlang.org/packages/{pname}/{version}.zip"
-    command = ["nix-prefetch-url", "--type", "sha256", url]
-    sha256 = subprocess.run(command, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL).stdout.rstrip()
-    lockedDependenciesDict[pname] = {"version": version, "sha256": sha256}
+for pname in depsDict:
+    depDict = depsDict[pname]
+    version = depDict["version"]
+    if "repository" in depDict:
+        repository = depDict["repository"]
+        strippedRepo = repository[4:]
+        eprint(f"Fetching {pname}@{version} ({strippedRepo})")
+        command = ["nix-prefetch-git", strippedRepo, version]
+        rawRes = subprocess.run(command, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL).stdout
+        sha256 = json.loads(rawRes)["sha256"]
+        lockedDepsDict[pname] = {"version": version, "repository": repository, "sha256": sha256}
+    else:
+        eprint(f"Fetching {pname}@{version}")
+        url = f"https://code.dlang.org/packages/{pname}/{version}.zip"
+        command = ["nix-prefetch-url", "--type", "sha256", url]
+        sha256 = subprocess.run(command, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL).stdout.rstrip()
+        lockedDepsDict[pname] = {"version": version, "sha256": sha256}
 
-print(json.dumps({"dependencies": lockedDependenciesDict}, indent=2))
+print(json.dumps({"dependencies": lockedDepsDict}, indent=2))


### PR DESCRIPTION
## Description of changes

Closes: https://github.com/NixOS/nixpkgs/issues/305440

This PR adds support to `dub-to-nix` for processing other types of entries in `dub.selections.json`.


It will now be able to parse and prefetch git-type dependencies and it will filter out `path` type dependencies.
The custom lockfile format is only extended, so no breaking changes for previously generated lockfiles.

I also added the relevant logic to `buildDubPackage` that copies the directory fetched by `fetchgit` to the appropriate location.

---

The PR only causes rebuilds for other packages because of comment/whitespace differences in buildDubPackage. Other than this, other packages should be unaffected.

---

~I temporarily added the `sideloader` package's derivation to the PR to show that it works.~

Edit: I've removed it.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
