### PR TITLE
am2rlauncher: fix error with missing GSettings schemas

### DIFF
--- a/pkgs/by-name/am/am2rlauncher/package.nix
+++ b/pkgs/by-name/am/am2rlauncher/package.nix
@@ -17,6 +17,8 @@
 , fetchFromGitHub
 , buildFHSEnv
 , glib-networking
+, wrapGAppsHook
+, gsettings-desktop-schemas
 }:
 let
   am2r-run = buildFHSEnv {
@@ -69,7 +71,9 @@ buildDotnetModule {
     openssl
   ];
 
-  buildInputs = [ gtk3 ];
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+  buildInputs = [ gtk3 gsettings-desktop-schemas glib-networking ];
 
   patches = [ ./am2r-run-binary.patch ];
 
@@ -78,7 +82,6 @@ buildDotnetModule {
   postFixup = ''
     wrapProgram $out/bin/AM2RLauncher.Gtk \
       --prefix PATH : ${lib.makeBinPath [ am2r-run xdelta file openjdk patchelf ]} \
-      --prefix GIO_EXTRA_MODULES : ${glib-networking}/lib/gio/modules
 
     mkdir -p $out/share/icons
     install -Dm644 $src/AM2RLauncher/distribution/linux/AM2RLauncher.png $out/share/icons/AM2RLauncher.png


### PR DESCRIPTION
## Description of changes

AM2RLauncher relies on GNOME tools heavily: GTK for display, GSettings for fetching settings from `XDG_DATA_DIRS`, and networking via `glib-networking`. For users on non-GTK WMs like KDE Plasma, these services/libraries are not automatically present in the environment and can cause crashes (see https://github.com/NixOS/nixpkgs/issues/304963 and https://github.com/NixOS/nixpkgs/issues/304965).

This PR fixes those issues by using the `wrapGAppsHook` and properly adding `glib-networking` as a `buildInput`, rather than wrapping the binary to include it in the `GIO_EXTRA_MODULES` env var.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
