### PR TITLE
python311Packages.ocrmypdf: 16.1.2 -> 16.2.0

### DIFF
--- a/pkgs/development/python-modules/ocrmypdf/default.nix
+++ b/pkgs/development/python-modules/ocrmypdf/default.nix
@@ -9,6 +9,7 @@
 , jbig2enc
 , packaging
 , pdfminer-six
+, pillow-heif
 , pikepdf
 , pillow
 , pluggy
@@ -18,19 +19,17 @@
 , pythonOlder
 , rich
 , reportlab
-, setuptools
 , setuptools-scm
 , substituteAll
 , tesseract
 , tqdm
-, typing-extensions
 , unpaper
 , installShellFiles
 }:
 
 buildPythonPackage rec {
   pname = "ocrmypdf";
-  version = "16.1.2";
+  version = "16.2.0";
 
   disabled = pythonOlder "3.10";
 
@@ -46,10 +45,11 @@ buildPythonPackage rec {
     postFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    hash = "sha256-nZvfkfO5u3iuN0g/KITWbhYCRAJngEOKCW48z6IEPMI=";
+    hash = "sha256-sqhuQ+no6UymxbVtDtWiYQK8kKpO1y37NxLDmRT1LEQ=";
   };
 
   patches = [
+    ./use-pillow-heif.patch
     (substituteAll {
       src = ./paths.patch;
       gs = lib.getExe ghostscript;
@@ -60,30 +60,31 @@ buildPythonPackage rec {
     })
   ];
 
-  nativeBuildInputs = [
-    setuptools
+  build-system = [
     setuptools-scm
+  ];
+
+  nativeBuildInputs = [
     installShellFiles
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     deprecation
     img2pdf
     packaging
     pdfminer-six
+    pillow-heif
     pikepdf
     pillow
     pluggy
-    reportlab
     rich
-  ] ++ lib.optionals (pythonOlder "3.10") [
-    typing-extensions
   ];
 
   nativeCheckInputs = [
     hypothesis
     pytest-xdist
     pytestCheckHook
+    reportlab
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/ocrmypdf/use-pillow-heif.patch
+++ b/pkgs/development/python-modules/ocrmypdf/use-pillow-heif.patch
@@ -1,0 +1,26 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index d045458f..efa9161d 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -16,7 +16,7 @@ dependencies = [
+   "img2pdf>=0.5",
+   "packaging>=20",
+   "pdfminer.six>=20220319",
+-  "pi-heif",                # Heif image format - maintainers: if this is removed, it will NOT break
++  "pillow-heif",                # Heif image format - maintainers: if this is removed, it will NOT break
+   "pikepdf>=8.10.1",
+   "Pillow>=10.0.1",
+   "pluggy>=1",
+diff --git a/src/ocrmypdf/_pipeline.py b/src/ocrmypdf/_pipeline.py
+index 043a78a0..522197b1 100644
+--- a/src/ocrmypdf/_pipeline.py
++++ b/src/ocrmypdf/_pipeline.py
+@@ -42,7 +42,7 @@ from ocrmypdf.pdfinfo import Colorspace, Encoding, PageInfo, PdfInfo
+ from ocrmypdf.pluginspec import OrientationConfidence
+ 
+ try:
+-    from pi_heif import register_heif_opener
++    from pillow_heif import register_heif_opener
+ except ImportError:
+ 
+     def register_heif_opener():

--- a/pkgs/development/python-modules/pillow-heif/default.nix
+++ b/pkgs/development/python-modules/pillow-heif/default.nix
@@ -57,8 +57,12 @@ buildPythonPackage rec {
     x265
   ];
 
-  # clang-16: error: argument unused during compilation: '-fno-strict-overflow' [-Werror,-Wunused-command-line-argument]
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-unused-command-line-argument";
+  env = {
+    # clang-16: error: argument unused during compilation: '-fno-strict-overflow'
+    NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-unused-command-line-argument";
+
+    RELEASE_FULL_FLAG = 1;
+  };
 
   propagatedBuildInputs = [
     pillow


### PR DESCRIPTION
Should I patch OCRmyPDF to use pillow-heif rather than adding pi-heif as a package?

## Description of changes
Diff: https://github.com/ocrmypdf/OCRmyPDF/compare/v16.1.2...v16.2.0

Changelog: https://github.com/ocrmypdf/OCRmyPDF/blob/v16.2.0/docs/release_notes.rst
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
