### PR TITLE
pythonCatchConflictsHook: prevent exponential worst-case

### DIFF
--- a/pkgs/development/interpreters/python/catch_conflicts/catch_conflicts.py
+++ b/pkgs/development/interpreters/python/catch_conflicts/catch_conflicts.py
@@ -58,7 +58,7 @@ def find_packages(store_path: Path, site_packages_path: str, parents: List[str])
     # recursively add dependencies
     if propagated_build_inputs.exists():
         with open(propagated_build_inputs, "r") as f:
-            build_inputs: List[str] = f.read().strip().split(" ")
+            build_inputs: List[str] = f.read().split()
             for build_input in build_inputs:
                 find_packages(Path(build_input), site_packages_path, parents + [build_input])
 

--- a/pkgs/development/interpreters/python/catch_conflicts/catch_conflicts.py
+++ b/pkgs/development/interpreters/python/catch_conflicts/catch_conflicts.py
@@ -5,7 +5,7 @@ import sys
 import os
 from typing import Dict, List, Set, Tuple
 do_abort: bool = False
-packages: Dict[str, Dict[str, List[Dict[str, List[str]]]]] = collections.defaultdict(list)
+packages: Dict[str, Dict[str, Dict[str, List[str]]]] = collections.defaultdict(dict)
 found_paths: Set[Path] = set()
 out_path: Path = Path(os.getenv("out"))
 version: Tuple[int, int] = sys.version_info
@@ -32,14 +32,10 @@ def describe_parents(parents: List[str]) -> str:
 
 # inserts an entry into 'packages'
 def add_entry(name: str, version: str, store_path: str, parents: List[str]) -> None:
-    if name not in packages:
-        packages[name] = {}
-    if store_path not in packages[name]:
-        packages[name][store_path] = []
-    packages[name][store_path].append(dict(
+    packages[name][store_path] = dict(
         version=version,
         parents=parents,
-    ))
+    )
 
 
 # transitively discover python dependencies and store them in 'packages'
@@ -64,8 +60,7 @@ def find_packages(store_path: Path, site_packages_path: str, parents: List[str])
         with open(propagated_build_inputs, "r") as f:
             build_inputs: List[str] = f.read().strip().split(" ")
             for build_input in build_inputs:
-                if build_input not in parents:
-                    find_packages(Path(build_input), site_packages_path, parents + [build_input])
+                find_packages(Path(build_input), site_packages_path, parents + [build_input])
 
 
 find_packages(out_path, site_packages_path, [f"this derivation: {out_path}"])
@@ -75,10 +70,9 @@ for name, store_paths in packages.items():
     if len(store_paths) > 1:
         do_abort = True
         print("Found duplicated packages in closure for dependency '{}': ".format(name))
-        for store_path, candidates in store_paths.items():
-            for candidate in candidates:
-                print(f"  {name} {candidate['version']} ({store_path})")
-                print(describe_parents(candidate['parents']))
+        for store_path, candidate in store_paths.items():
+            print(f"  {name} {candidate['version']} ({store_path})")
+            print(describe_parents(candidate['parents']))
 
 # fail if duplicates were found
 if do_abort:

--- a/pkgs/development/interpreters/python/hooks/python-catch-conflicts-hook-tests.nix
+++ b/pkgs/development/interpreters/python/hooks/python-catch-conflicts-hook-tests.nix
@@ -143,4 +143,46 @@ in {
     };
   in
     expectFailure toplevel "Found duplicated packages in closure for dependency 'leaf'";
+
+  /*
+    Transitive conflict with multiple dependency chains leading to the
+    conflicting package.
+
+    Test sets up this dependency tree:
+
+      toplevel
+      ├── dep1
+      │   └── leaf
+      ├── dep2
+      │   └── leaf
+      └── dep3
+          └── leaf (customized version -> conflicting)
+  */
+  catches-conflict-multiple-chains = let
+    # package depending on dependency1, dependency2 and dependency3
+    toplevel = generatePythonPackage {
+      pname = "catches-conflict-multiple-chains";
+      propagatedBuildInputs = [ dep1 dep2 dep3 ];
+    };
+    # dep1 package depending on leaf
+    dep1 = generatePythonPackage {
+      pname = "dependency1";
+      propagatedBuildInputs = [ leaf ];
+    };
+    # dep2 package depending on leaf
+    dep2 = generatePythonPackage {
+      pname = "dependency2";
+      propagatedBuildInputs = [ leaf ];
+    };
+    # dep3 package depending on conflicting version of leaf
+    dep3 = generatePythonPackage {
+      pname = "dependency3";
+      propagatedBuildInputs = [ (customize leaf) ];
+    };
+    # some leaf package
+    leaf = generatePythonPackage {
+      pname = "leaf";
+    };
+  in
+    expectFailure toplevel "Found duplicated packages in closure for dependency 'leaf'";
 }


### PR DESCRIPTION
## Description of changes

The hook performs a depth first search on the graph defined by `propagatedBuildInputs`. This traverses all paths through the graph, except for any cycles. In the worst case with a highly connected graph, this search can take exponential time. In practice, this means that in cases with long dependency chains and multiple packages depending on the same package, the hook can take several hours to run.

Avoid this problem by keeping track of already visited paths and only visiting each path once. This makes the search complete in linear time.

The visible effect of this change is that, if a conflict is found, only one dependency chain that leads to the conflicting package is printed, rather than all the possible dependency chains.

Now that only one dependency chain will be found for each package, a few other simplifications are possible and are included in a separate commit.

Also, add a test to demonstrate the change in output with multiple dependency chains, and fix a minor bug in parsing `nix-support/propagated-build-inputs`.

The tests pass and I have tested building a few Python packages.

Fixes #305599

cc @DavHau @phaer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
