### PR TITLE
check-cherry-picks.sh: "pass" commit differences but post check-run with warning

### DIFF
--- a/.github/workflows/check-cherry-picks.yml
+++ b/.github/workflows/check-cherry-picks.yml
@@ -5,7 +5,8 @@ on:
      - 'release-**'
      - 'staging-**'
 
-permissions: {}
+permissions:
+  checks: write
 
 jobs:
   check:
@@ -20,5 +21,8 @@ jobs:
       env:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO_API_URL: https://api.github.com/repos/${{ github.repository }}
+        SELF_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: |
         ./maintainers/scripts/check-cherry-picks.sh "$BASE_SHA" "$HEAD_SHA"

--- a/maintainers/scripts/check-cherry-picks.sh
+++ b/maintainers/scripts/check-cherry-picks.sh
@@ -4,12 +4,38 @@
 set -e
 
 if [ $# != "2" ] ; then
-  echo "usage: check-cherry-picks.sh base_rev head_rev"
+  echo "usage: check-cherry-picks.sh base_rev head_rev" >&2
   exit 2
 fi
 
 PICKABLE_BRANCHES=${PICKABLE_BRANCHES:-master staging release-??.?? staging-??.??}
-problem=0
+has_error=0
+has_warning=0
+
+if [ "$GITHUB_ACTIONS" = 'true' ] ; then
+  if ! type -p jq > /dev/null ; then
+    echo "check-cherry-picks.sh expects 'jq' to be present in GITHUB_ACTIONS mode" >&2
+    exit 2
+  fi
+  if ! type -p curl > /dev/null ; then
+    echo "check-cherry-picks.sh expects 'curl' to be present in GITHUB_ACTIONS mode" >&2
+    exit 2
+  fi
+  if [ -z "$REPO_API_URL" ] ; then
+    echo 'check-cherry-picks.sh expects $REPO_API_URL to be set in GITHUB_ACTIONS mode' >&2
+    exit 2
+  fi
+  if [ -z "$SELF_RUN_URL" ] ; then
+    echo 'check-cherry-picks.sh expects $SELF_RUN_URL to be set in GITHUB_ACTIONS mode' >&2
+    exit 2
+  fi
+  if [ -z "$GITHUB_TOKEN" ] ; then
+    echo 'check-cherry-picks.sh expects $GITHUB_TOKEN to be set in GITHUB_ACTIONS mode' >&2
+    exit 2
+  fi
+
+  WARNINGS_MD=$(mktemp)
+fi
 
 while read new_commit_sha ; do
   if [ -z "$new_commit_sha" ] ; then
@@ -60,9 +86,16 @@ while read new_commit_sha ; do
 
           $range_diff_common --color
 
-          echo "Note this should not necessarily be treated as a hard fail, but a reviewer's attention should" \
-            "be drawn to it and github actions have no way of doing that but to raise a 'failure'"
-          problem=1
+          if [ "$GITHUB_ACTIONS" = 'true' ] ; then
+            cat >> "$WARNINGS_MD" <<EOF
+
+> [!WARNING]
+> Difference between $new_commit_sha and original $original_commit_sha may warrant inspection
+
+EOF
+          fi
+
+          has_warning=1
         else
           echo "  ✔ $original_commit_sha highly similar to $new_commit_sha"
           $range_diff_common --color
@@ -87,11 +120,41 @@ while read new_commit_sha ; do
   fi
   echo "$original_commit_sha not found in any pickable branch"
 
-  problem=1
+  has_error=1
 done <<< "$(
   git rev-list \
     -E -i --grep="cherry.*[0-9a-f]{40}" --reverse \
     "$1..$2"
 )"
 
-exit $problem
+if [ "$has_error" != '0' ] ; then
+  exit $has_error
+fi
+
+if [ "$GITHUB_ACTIONS" = 'true' ] && [ "$has_warning" != '0' ] ; then
+  echo ::group::Setting github check-run for warnings
+  cat >> "$WARNINGS_MD" <<EOF
+
+[See diffs]($SELF_RUN_URL)
+
+EOF
+
+  HEAD_SHA="$2" curl -L \
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $GITHUB_TOKEN" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "$REPO_API_URL/check-runs" \
+    -d "$(jq --raw-input --slurp '{
+      name: "cherry-picks-warrant-inspection",
+      status: "completed",
+      conclusion: "neutral",
+      details_url: env.SELF_RUN_URL,
+      head_sha: env.HEAD_SHA,
+      output: {
+        title: "Cherry-picks may warrant inspection",
+        summary: .,
+      },
+    }' < "$WARNINGS_MD")"
+  echo ::endgroup::
+fi


### PR DESCRIPTION
## Description of changes
"Failing" when commit differences are found is confusing, but "neutral" outcomes are only supported by the check-runs API. so in cases where we just have warnings, post a neutral check-run conclusion.

Check-runs have a markdown-based summary page they can use to show results - while it would be nice to use this to show the diff-diff, it doesn't allow the custom colouring that the git output uses to make it (slightly) more digestible. So that page is just used to list the problem commits and link to the action run from where the annotation links can be followed to see the relevant section of (coloured) terminal output.

See https://github.com/risicle/nixpkgs/pull/11/checks?check_run_id=24057883046 for an example output.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
