### PR TITLE
vscode-extensions.github.copilot: 1.172.758 -> 1.180.827

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1756,8 +1756,8 @@ let
         mktplcRef = {
           publisher = "github";
           name = "copilot";
-          version = "1.172.758";
-          hash = "sha256-sK3IiA4mQ6Hse+UpZ81Zb5iBSREzTrs7ypsfGbJiXm4=";
+          version = "1.180.827";
+          hash = "sha256-HA1na9FoExIiAay+tEjxWKqpG2+wq4Oww77Gl2Bhciw=";
         };
 
         meta = {


### PR DESCRIPTION
## Description of changes

updated vscode-extension-github-copilot and vscode-extension-github-copilot-chat version to make it compatible with vscode 1.88.1 (nixpkgs-unstable).

## Things done

I have identified working versions with nix4vscode and tried the versions localy with extensionsFromVscodeMarketplace  on my local PC.


