### PR TITLE
nixos-rebuild: Add missing passed-through options to man page and completion

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -117,6 +117,9 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @raitobezarius @ma27
 /nixos/modules/installer/cd-dvd/            @samueldr
 /nixos/modules/installer/sd-card/           @samueldr
 
+# nixos-rebuild command
+pkgs/os-specific/linux/nixos-rebuild/ @samueldr # Mainly for bash completion
+
 # Updaters
 ## update.nix
 /maintainers/scripts/update.nix   @jtojnar

--- a/pkgs/os-specific/linux/nixos-rebuild/_nixos-rebuild
+++ b/pkgs/os-specific/linux/nixos-rebuild/_nixos-rebuild
@@ -58,6 +58,7 @@ _nixos-rebuild() {
     --no-registries
     --no-update-lock-file
     --no-write-lock-file
+    --accept-flake-config
 
     # Nix-copy options
     --use-substitutes --substitute-on-destination -s
@@ -71,7 +72,14 @@ _nixos-rebuild() {
     --keep-going -k
     --max-jobs -j # number
     --log-format # format
+    --quiet
+    --print-build-logs -L
+    --no-build-output -Q
+    --fallback
+    --refresh
+    --repair
     -I # NIX_PATH
+    --offline # --no-net not suggested, deprecated
   )
 
   local all_subcommands=(
@@ -84,6 +92,7 @@ _nixos-rebuild() {
     edit
     list-generations
     switch
+    repl
     test
   )
 

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
@@ -24,6 +24,13 @@
 .Op Fl -no-flake
 .Op Fl -override-input Ar input-name flake-uri
 .br
+.Op Fl -commit-lock-file
+.Op Fl -recreate-lock-file
+.Op Fl -update-input
+.Op Fl -no-registries
+.Op Fl -no-update-lock-file
+.Op Fl -no-write-lock-file
+.br
 .Op Fl -profile-name | p Ar name
 .Op Fl -specialisation | c Ar name
 .br
@@ -31,14 +38,26 @@
 .Op Fl -target-host Va host
 .Op Fl -use-remote-sudo
 .br
+.Op Fl -use-substitutes | -substitute-on-destination | s
+.br
 .Op Fl -show-trace
 .Op Fl I Va NIX_PATH
+.Op Fl -no-build-output | Q
+.Op Fl L
+.Op Fl -refresh
+.Op Fl -offline
 .Op Fl -verbose | v
 .Op Fl -accept-flake-config
 .Op Fl -impure
+.Op Fl -fallback
+.Op Fl -repair
 .Op Fl -max-jobs | j Va number
 .Op Fl -keep-failed | K
 .Op Fl -keep-going | k
+.Op Fl -option Ar name Ar value
+.Op Fl -quiet
+.Op Fl -print-build-logs | L
+.Op Fl -log-format Ar format
 .
 .
 .
@@ -351,7 +370,7 @@ target host. Hence the
 .Va nixpkgs.crossSystem
 setting has to match the target platform or else activation will fail.
 .
-.It Fl -use-substitutes
+.It Fl -use-substitutes , Fl s
 When set, nixos-rebuild will add
 .Fl -use-substitutes
 to each invocation of nix-copy-closure. This will only affect the behavior of
@@ -394,11 +413,25 @@ accepts various Nix-related flags, including
 .Fl -max-jobs Ns ,
 .Fl j Ns ,
 .Fl I Ns ,
+.Fl L Ns ,
 .Fl -accept-flake-config Ns ,
 .Fl -show-trace Ns ,
 .Fl -keep-failed Ns ,
+.Fl K Ns ,
 .Fl -keep-going Ns ,
+.Fl k Ns ,
 .Fl -impure Ns ,
+.Fl -fallback Ns ,
+.Fl -repair Ns ,
+.Fl -no-build-output Ns ,
+.Fl Q Ns ,
+.Fl -refresh Ns ,
+.Fl -offline Ns ,
+.Fl -option Ns ,
+.Fl -quiet Ns ,
+.Fl -print-build-logs Ns ,
+.Fl L Ns ,
+.Fl -log-format Ns ,
 .Fl -verbose Ns , and
 .Fl v Ns
 \&. See the Nix manual for details.
@@ -423,7 +456,6 @@ nixpkgs=./my-nixpkgs
 Additional options to be passed to
 .Ic ssh
 on the command line.
-.Ed
 .
 .It Ev NIXOS_SWITCH_USE_DIRTY_ENV
 Expose the the current environment variables to post activation scripts. Will

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -81,7 +81,11 @@ while [ "$#" -gt 0 ]; do
         j="$1"; shift 1
         extraBuildFlags+=("$i" "$j")
         ;;
-      --accept-flake-config|-j*|--quiet|--print-build-logs|-L|--no-build-output|-Q| --show-trace|--keep-going|-k|--keep-failed|-K|--fallback|--refresh|--repair|--impure|--offline|--no-net)
+      --accept-flake-config|-j*|--quiet|--print-build-logs|-L|--no-build-output|-Q| --show-trace|--keep-going|-k|--keep-failed|-K|--fallback|--refresh|--repair|--impure|--offline)
+        extraBuildFlags+=("$i")
+        ;;
+      # Deprecated passed-through arguments
+      --no-net) # To be removed when removed from Nix; --offline is the replacement
         extraBuildFlags+=("$i")
         ;;
       --verbose|-v|-vv|-vvv|-vvvv|-vvvvv)


### PR DESCRIPTION
## Description of changes

This is syncing the man page and bash completion with the options. This fixes #16770.

In addition it adds the `repl` command to the bash completion.

I'm also adding myself to CODEOWNERS to ensure the bash completion doesn't drift again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
