### PR TITLE
phpPackages.composer: 2.7.2 -> 2.7.3

### DIFF
--- a/pkgs/development/php-packages/composer/default.nix
+++ b/pkgs/development/php-packages/composer/default.nix
@@ -16,7 +16,7 @@ php.buildComposerProject (finalAttrs: {
   # use together with the version from this package to keep the
   # bootstrap phar file up-to-date together with the end user composer
   # package.
-  passthru.pharHash = "sha256-BJuODtnyZNdwoFEIWM/7w1QBUQdZ7cmnhLOlxuAgvKw=";
+  passthru.pharHash = "sha256-/MAv8ES1oE++z/AVjLYEHCXo94rElAmHNv7NK7TzgeQ=";
 
   composer = callPackage ../../../build-support/php/pkgs/composer-phar.nix {
     inherit (finalAttrs) version;
@@ -24,13 +24,13 @@ php.buildComposerProject (finalAttrs: {
   };
 
   pname = "composer";
-  version = "2.7.2";
+  version = "2.7.3";
 
   src = fetchFromGitHub {
     owner = "composer";
     repo = "composer";
     rev = finalAttrs.version;
-    hash = "sha256-Rev3OW1G+LVgJmHLwuV5u0s7F7lKrvtI43eS7y9SAYA=";
+    hash = "sha256-4cQ/p6lC8qgba/GSKuP2rFc0mZrUc+HuwvBMXnVERoU=";
   };
 
   nativeBuildInputs = [ makeBinaryWrapper ];
@@ -40,7 +40,7 @@ php.buildComposerProject (finalAttrs: {
       --prefix PATH : ${lib.makeBinPath [ _7zz cacert curl git unzip xz ]}
   '';
 
-  vendorHash = "sha256-JLMhjOradyo64mPNos0qtM5bTnAYTRvSWnFUQrLQNjw=";
+  vendorHash = "sha256-dNNV9fTyGyRoGeDV/vBjn0aMgkaUMsrKQv5AOoiYokQ=";
 
   meta = {
     changelog = "https://github.com/composer/composer/releases/tag/${finalAttrs.version}";


### PR DESCRIPTION
## Description of changes

Changes:
https://github.com/composer/composer/releases/tag/2.7.3
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

No new failures.
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>php81Packages.phpinsights</li>
  </ul>
</details>
<details>
  <summary>66 packages built:</summary>
  <ul>
    <li>adminer</li>
    <li>bookstack</li>
    <li>composer-require-checker</li>
    <li>davis</li>
    <li>firefly-iii</li>
    <li>librenms</li>
    <li>movim</li>
    <li>n98-magerun</li>
    <li>n98-magerun2</li>
    <li>paratest</li>
    <li>pdepend</li>
    <li>pest</li>
    <li>phel</li>
    <li>php81Packages.box (php82Packages.box ,php83Packages.box)</li>
    <li>php81Packages.castor</li>
    <li>php81Packages.composer</li>
    <li>php81Packages.deployer</li>
    <li>php81Packages.grumphp</li>
    <li>php81Packages.phan</li>
    <li>php81Packages.phing</li>
    <li>php81Packages.phive</li>
    <li>php81Packages.php-codesniffer</li>
    <li>php81Packages.php-cs-fixer</li>
    <li>php81Packages.php-parallel-lint</li>
    <li>php81Packages.phpmd</li>
    <li>php81Packages.phpstan</li>
    <li>php81Packages.psalm</li>
    <li>php81Packages.psysh</li>
    <li>php82Packages.castor</li>
    <li>php82Packages.composer</li>
    <li>php82Packages.deployer</li>
    <li>php82Packages.grumphp</li>
    <li>php82Packages.phan</li>
    <li>php82Packages.phing</li>
    <li>php82Packages.phive</li>
    <li>php82Packages.php-codesniffer</li>
    <li>php82Packages.php-cs-fixer</li>
    <li>php82Packages.php-parallel-lint</li>
    <li>php82Packages.phpinsights</li>
    <li>php82Packages.phpmd</li>
    <li>php82Packages.phpstan</li>
    <li>php82Packages.psalm</li>
    <li>php82Packages.psysh</li>
    <li>php83Packages.castor</li>
    <li>php83Packages.composer</li>
    <li>php83Packages.deployer</li>
    <li>php83Packages.grumphp</li>
    <li>php83Packages.phan</li>
    <li>php83Packages.phing</li>
    <li>php83Packages.phive</li>
    <li>php83Packages.php-codesniffer</li>
    <li>php83Packages.php-cs-fixer</li>
    <li>php83Packages.php-parallel-lint</li>
    <li>php83Packages.phpinsights</li>
    <li>php83Packages.phpmd</li>
    <li>php83Packages.phpstan</li>
    <li>php83Packages.psalm</li>
    <li>php83Packages.psysh</li>
    <li>phpactor</li>
    <li>phpdocumentor</li>
    <li>phpunit</li>
    <li>pixelfed</li>
    <li>platformsh</li>
    <li>robo</li>
    <li>snipe-it</li>
    <li>vimPlugins.phpactor</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
