### PR TITLE
nixos/wireless: correctly handle secrets containing &

### DIFF
--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -127,8 +127,12 @@ let
         # substitute environment variables
         if [ -f "${configFile}" ]; then
           ${pkgs.gawk}/bin/awk '{
-            for(varname in ENVIRON)
-              gsub("@"varname"@", ENVIRON[varname])
+            for(varname in ENVIRON) {
+              find = "@"varname"@"
+              repl = ENVIRON[varname]
+              if (i = index($0, find))
+                $0 = substr($0, 1, i-1) repl substr($0, i+length(find))
+            }
             print
           }' "${configFile}" > "${finalConfig}"
         else

--- a/nixos/tests/wpa_supplicant.nix
+++ b/nixos/tests/wpa_supplicant.nix
@@ -102,13 +102,15 @@ import ./make-test-python.nix ({ pkgs, lib, ...}:
           test2.psk = "@PSK_SPECIAL@";            # should be replaced
           test3.psk = "@PSK_MISSING@";            # should not be replaced
           test4.psk = "P@ssowrdWithSome@tSymbol"; # should not be replaced
+          test5.psk = "@PSK_AWK_REGEX@";          # should be replaced
         };
 
         # secrets
         environmentFile = pkgs.writeText "wpa-secrets" ''
           PSK_VALID="S0m3BadP4ssw0rd";
           # taken from https://github.com/minimaxir/big-list-of-naughty-strings
-          PSK_SPECIAL=",./;'[]\-= <>?:\"{}|_+ !@#$%^\&*()`~";
+          PSK_SPECIAL=",./;'[]\/\-= <>?:\"{}|_+ !@#$%^&*()`~";
+          PSK_AWK_REGEX="PassowrdWith&symbol";
         '';
       };
     };
@@ -171,6 +173,7 @@ import ./make-test-python.nix ({ pkgs, lib, ...}:
           basic.fail(f"grep -q @PSK_SPECIAL@ {config_file}")
           basic.succeed(f"grep -q @PSK_MISSING@ {config_file}")
           basic.succeed(f"grep -q P@ssowrdWithSome@tSymbol {config_file}")
+          basic.succeed(f"grep -q 'PassowrdWith&symbol' {config_file}")
 
       with subtest("WPA2 fallbacks have been generated"):
           assert int(basic.succeed(f"grep -c sae-only {config_file}")) == 1


### PR DESCRIPTION
## Description of changes

Fix for issue #279803.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested via `nixosTests.wpa_supplicant`
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
