### PR TITLE
kdePackages/kweather: add `python` to `extraBuildInputs`

### DIFF
--- a/pkgs/kde/gear/kweather/default.nix
+++ b/pkgs/kde/gear/kweather/default.nix
@@ -4,10 +4,11 @@
   qtcharts,
   qqc2-desktop-style,
   kholidays,
+  python3,
 }:
 mkKdeDerivation {
   pname = "kweather";
 
-  extraBuildInputs = [qtsvg qtcharts qqc2-desktop-style kholidays];
+  extraBuildInputs = [qtsvg qtcharts qqc2-desktop-style kholidays python3];
   meta.mainProgram = "kweather";
 }

--- a/pkgs/kde/gear/kweather/default.nix
+++ b/pkgs/kde/gear/kweather/default.nix
@@ -1,14 +1,14 @@
-{
-  mkKdeDerivation,
-  qtsvg,
-  qtcharts,
-  qqc2-desktop-style,
-  kholidays,
-  python3,
+{ mkKdeDerivation
+, qtsvg
+, qtcharts
+, qqc2-desktop-style
+, kholidays
+, python3
+,
 }:
 mkKdeDerivation {
   pname = "kweather";
 
-  extraBuildInputs = [qtsvg qtcharts qqc2-desktop-style kholidays python3];
+  extraBuildInputs = [ qtsvg qtcharts qqc2-desktop-style kholidays python3 ];
   meta.mainProgram = "kweather";
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

KWeather now needs Python3 available during the build process. Currently, the build fails.

See: https://invent.kde.org/utilities/kweather/-/commit/2c24376979649b913501f705039c67674e1b0874#9a2aa4db38d3115ed60da621e012c0efc0172aae_43_43

See: https://invent.kde.org/frameworks/extra-cmake-modules/-/blob/v6.1.0/modules/ECMAddAndroidApk.cmake?ref_type=tags#L57

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
