### PR TITLE
wip: no root for wpa-supplicant

### DIFF
--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -107,6 +107,12 @@ let
       stopIfChanged = false;
 
       path = [ package ];
+      serviceConfig.User = "wpa-supplicant";
+      serviceConfig.Group = "wpa-supplicant";
+      serviceConfig.AmbientCapabilities = [
+        "cap_net_raw"
+        "cap_net_admin"
+      ];
       # if `userControl.enable`, the supplicant automatically changes the permissions
       #  and owning group of the runtime dir; setting `umask` ensures the generated
       #  config file isn't readable (except to root);  see nixpkgs#267693
@@ -456,7 +462,7 @@ in {
 
         group = mkOption {
           type = types.str;
-          default = "wheel";
+          default = "wpa-supplicant";
           example = "network";
           description = "Members of this group can control wpa_supplicant.";
         };
@@ -489,6 +495,11 @@ in {
   };
 
   config = mkIf cfg.enable {
+    users.groups.wpa-supplicant = {};
+    users.users.wpa-supplicant = {
+      isSystemUser = true;
+      group = "wpa-supplicant";
+    };
     assertions = flip mapAttrsToList cfg.networks (name: cfg: {
       assertion = with cfg; count (x: x != null) [ psk pskRaw auth ] <= 1;
       message = ''options networking.wireless."${name}".{psk,pskRaw,auth} are mutually exclusive'';

--- a/nixos/tests/wpa_supplicant.nix
+++ b/nixos/tests/wpa_supplicant.nix
@@ -181,7 +181,7 @@ import ./make-test-python.nix ({ pkgs, lib, ...}:
 
       with subtest("Daemon is running and accepting connections"):
           basic.wait_for_unit("wpa_supplicant-wlan1.service")
-          status = basic.succeed("wpa_cli -i wlan1 status")
+          status = basic.succeed("sudo -u wpa-supplicant wpa_cli -i wlan1 status")
           assert "Failed to connect" not in status, \
                  "Failed to connect to the daemon"
 
@@ -189,22 +189,22 @@ import ./make-test-python.nix ({ pkgs, lib, ...}:
       machineSae.copy_from_vm("/run/hostapd/wlan0.hostapd.conf")
       with subtest("Daemon can connect to the SAE access point using SAE"):
           machineSae.wait_until_succeeds(
-            "wpa_cli -i wlan1 status | grep -q wpa_state=COMPLETED"
+            "sudo -u wpa-supplicant wpa_cli -i wlan1 status | grep -q wpa_state=COMPLETED"
           )
 
       with subtest("Daemon can connect to the SAE and WPA2 mixed access point using SAE"):
           machineMixedUsingSae.wait_until_succeeds(
-            "wpa_cli -i wlan1 status | grep -q wpa_state=COMPLETED"
+            "sudo -u wpa-supplicant wpa_cli -i wlan1 status | grep -q wpa_state=COMPLETED"
           )
 
       with subtest("Daemon can connect to the SAE and WPA2 mixed access point using WPA2"):
           machineMixedUsingWpa2.wait_until_succeeds(
-            "wpa_cli -i wlan1 status | grep -q wpa_state=COMPLETED"
+            "sudo -u wpa-supplicant wpa_cli -i wlan1 status | grep -q wpa_state=COMPLETED"
           )
 
       with subtest("Daemon can connect to the WPA2 access point using WPA2"):
           machineWpa2.wait_until_succeeds(
-            "wpa_cli -i wlan1 status | grep -q wpa_state=COMPLETED"
+            "sudo -u wpa-supplicant wpa_cli -i wlan1 status | grep -q wpa_state=COMPLETED"
           )
     '';
 })

--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    ./unprivileged-dbus.patch
     # Fix a bug when using two config files
     ./Use-unique-IDs-for-networks-and-credentials.patch
   ] ++ lib.optionals readOnlyModeSSIDs [

--- a/pkgs/os-specific/linux/wpa_supplicant/unprivileged-dbus.patch
+++ b/pkgs/os-specific/linux/wpa_supplicant/unprivileged-dbus.patch
@@ -1,0 +1,30 @@
+commit e9a70008582562d9d83cf56ad5f93fe0c98e57b8
+Author: Tom Fitzhenry <tom@tom-fitzhenry.me.uk>
+Date:   Sun Apr 21 21:23:17 2024 +1000
+
+    unprivileged dbus
+
+diff --git a/wpa_supplicant/dbus/dbus-wpa_supplicant.conf b/wpa_supplicant/dbus/dbus-wpa_supplicant.conf
+index e81b495f4..eeea505cc 100644
+--- a/wpa_supplicant/dbus/dbus-wpa_supplicant.conf
++++ b/wpa_supplicant/dbus/dbus-wpa_supplicant.conf
+@@ -2,7 +2,7 @@
+  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+ <busconfig>
+-        <policy user="root">
++        <policy user="wpa-supplicant">
+                 <allow own="fi.w1.wpa_supplicant1"/>
+ 
+                 <allow send_destination="fi.w1.wpa_supplicant1"/>
+diff --git a/wpa_supplicant/dbus/fi.w1.wpa_supplicant1.service.in b/wpa_supplicant/dbus/fi.w1.wpa_supplicant1.service.in
+index d97ff3921..ed6e421f2 100644
+--- a/wpa_supplicant/dbus/fi.w1.wpa_supplicant1.service.in
++++ b/wpa_supplicant/dbus/fi.w1.wpa_supplicant1.service.in
+@@ -1,5 +1,5 @@
+ [D-BUS Service]
+ Name=fi.w1.wpa_supplicant1
+ Exec=@BINDIR@/wpa_supplicant -u
+-User=root
++User=wpa-supplicant
+ SystemdService=wpa_supplicant.service


### PR DESCRIPTION
## Description of changes

WIP running of wpa_supplicant using Linux capabilities rather than as a root process, as documented in https://w1.fi/cgit/hostap/tree/wpa_supplicant/README#n982 . The motivation is to reduce the privilege that this process has, in case it's exploited.

Tests are passing, but there's a few problems:
* the patch is a bit gross
* `wpa_cli` fails when executed as `root`
* Would be nice if this was opt-in for now, if only because wpa_supplicant has all sorts of integrations (e.g. NetworkManager) that this might broken in esoteric hard-to-test ways.

@rnhmjoj thoughts on whether this change is desirable?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
