### PR TITLE
[23.11] flatpak: 1.14.4 -> 1.14.6, xdg-desktop-portal: 1.18.1 -> 1.18.4

### DIFF
--- a/nixos/modules/services/desktops/flatpak.nix
+++ b/nixos/modules/services/desktops/flatpak.nix
@@ -35,6 +35,7 @@ in {
     services.dbus.packages = [ pkgs.flatpak ];
 
     systemd.packages = [ pkgs.flatpak ];
+    systemd.tmpfiles.packages = [ pkgs.flatpak ];
 
     environment.profiles = [
       "$HOME/.local/share/flatpak/exports"

--- a/nixos/tests/installed-tests/flatpak.nix
+++ b/nixos/tests/installed-tests/flatpak.nix
@@ -7,6 +7,7 @@ makeInstalledTest {
   testConfig = {
     xdg.portal.enable = true;
     xdg.portal.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
+    xdg.portal.config.common.default = "gtk";
     services.flatpak.enable = true;
     environment.systemPackages = with pkgs; [ gnupg ostree python3 ];
     virtualisation.memorySize = 2047;

--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -54,14 +54,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flatpak";
-  version = "1.14.4";
+  version = "1.14.5";
 
   # TODO: split out lib once we figure out what to do with triggerdir
   outputs = [ "out" "dev" "man" "doc" "devdoc" "installedTests" ];
 
   src = fetchurl {
     url = "https://github.com/flatpak/flatpak/releases/download/${finalAttrs.version}/flatpak-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-ijTb0LZ8Q051mLmOxpCVPQRvDbJuSArq+0bXKuxxZ5k="; # Taken from https://github.com/flatpak/flatpak/releases/
+    sha256 = "sha256-W3DGTOesE04eoIARJW5COuXFTydyl0QVg/d9AT8n/6w="; # Taken from https://github.com/flatpak/flatpak/releases/
   };
 
   patches = [

--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -54,14 +54,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flatpak";
-  version = "1.14.5";
+  version = "1.14.6";
 
   # TODO: split out lib once we figure out what to do with triggerdir
   outputs = [ "out" "dev" "man" "doc" "devdoc" "installedTests" ];
 
   src = fetchurl {
     url = "https://github.com/flatpak/flatpak/releases/download/${finalAttrs.version}/flatpak-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-W3DGTOesE04eoIARJW5COuXFTydyl0QVg/d9AT8n/6w="; # Taken from https://github.com/flatpak/flatpak/releases/
+    sha256 = "sha256-U482ssb4xw7v0S0TrVsa2DCCAQaovTqfa45NnegeSUY="; # Taken from https://github.com/flatpak/flatpak/releases/
   };
 
   patches = [

--- a/pkgs/development/libraries/flatpak/fix-test-paths.patch
+++ b/pkgs/development/libraries/flatpak/fix-test-paths.patch
@@ -63,7 +63,7 @@ index afa11a6b..5b12055f 100755
  flatpak build-finish ${DIR} >&2
  mkdir -p repos
 diff --git a/tests/make-test-runtime.sh b/tests/make-test-runtime.sh
-index 4ba950df..fd50fab3 100755
+index 6345ff58..fd50fab3 100755
 --- a/tests/make-test-runtime.sh
 +++ b/tests/make-test-runtime.sh
 @@ -28,9 +28,10 @@ EOF
@@ -78,7 +78,7 @@ index 4ba950df..fd50fab3 100755
  mkdir -p ${DIR}/usr/bin
  mkdir -p ${DIR}/usr/lib
  ln -s ../lib ${DIR}/usr/lib64
-@@ -40,40 +41,17 @@ if test -f /sbin/ldconfig.real; then
+@@ -40,46 +41,17 @@ if test -f /sbin/ldconfig.real; then
  else
      cp "$(type -P ldconfig)" "${DIR}/usr/bin"
  fi
@@ -88,6 +88,12 @@ index 4ba950df..fd50fab3 100755
 -add_bin() {
 -    local f=$1
 -    shift
+-
+-    # Check if the program is installed
+-    if ! command -v "${f}" &> /dev/null; then
+-        echo "${f} not found"
+-        exit 1
+-    fi
 -
 -    if grep -qFe "${f}" $BINS; then
 -        # Already handled
@@ -129,7 +135,7 @@ index 4ba950df..fd50fab3 100755
  done
  ln -s bash ${DIR}/usr/bin/sh
  
-@@ -84,11 +62,13 @@ echo "Hello world, from a runtime$EXTRA"
+@@ -90,11 +62,13 @@ echo "Hello world, from a runtime$EXTRA"
  EOF
  chmod a+x ${DIR}/usr/bin/runtime_hello.sh
  

--- a/pkgs/development/libraries/flatpak/unset-env-vars.patch
+++ b/pkgs/development/libraries/flatpak/unset-env-vars.patch
@@ -1,11 +1,11 @@
 diff --git a/common/flatpak-run.c b/common/flatpak-run.c
-index 8fa8c0e0..e1cdeba0 100644
+index 6f54a9d0..102d9b90 100644
 --- a/common/flatpak-run.c
 +++ b/common/flatpak-run.c
-@@ -1900,6 +1900,7 @@ static const ExportData default_exports[] = {
-   {"XKB_CONFIG_ROOT", NULL},
-   {"GIO_EXTRA_MODULES", NULL},
+@@ -1902,6 +1902,7 @@ static const ExportData default_exports[] = {
    {"GDK_BACKEND", NULL},
+   {"VK_DRIVER_FILES", NULL},
+   {"VK_ICD_FILENAMES", NULL},
 +  {"GDK_PIXBUF_MODULE_FILE", NULL},
  };
  

--- a/pkgs/development/libraries/xdg-desktop-portal/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal/default.nix
@@ -31,7 +31,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-desktop-portal";
-  version = "1.18.3";
+  version = "1.18.4";
 
   outputs = [ "out" "installedTests" ];
 
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "flatpak";
     repo = "xdg-desktop-portal";
     rev = finalAttrs.version;
-    hash = "sha256-VqIQLUAf/n5m1tHCvnlxi0eaLOuG1R44tMFI/Hc992A=";
+    hash = "sha256-o+aO7uGewDPrtgOgmp/CE2uiqiBLyo07pVCFrtlORFQ=";
   };
 
   patches = [

--- a/pkgs/development/libraries/xdg-desktop-portal/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal/default.nix
@@ -31,7 +31,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-desktop-portal";
-  version = "1.18.2";
+  version = "1.18.3";
 
   outputs = [ "out" "installedTests" ];
 
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "flatpak";
     repo = "xdg-desktop-portal";
     rev = finalAttrs.version;
-    hash = "sha256-Pd5IKrVp/OOE10Ozy4R3XbubVc6iz0znG+YB0Uu+68E=";
+    hash = "sha256-VqIQLUAf/n5m1tHCvnlxi0eaLOuG1R44tMFI/Hc992A=";
   };
 
   patches = [

--- a/pkgs/development/libraries/xdg-desktop-portal/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal/default.nix
@@ -31,7 +31,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-desktop-portal";
-  version = "1.18.1";
+  version = "1.18.2";
 
   outputs = [ "out" "installedTests" ];
 
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "flatpak";
     repo = "xdg-desktop-portal";
     rev = finalAttrs.version;
-    sha256 = "sha256-S4I578gX1ONbixWGcQLY3WqzACoVfAtLuOFBhh36hFY=";
+    hash = "sha256-Pd5IKrVp/OOE10Ozy4R3XbubVc6iz0znG+YB0Uu+68E=";
   };
 
   patches = [


### PR DESCRIPTION
## Description of changes

Includes the fix for CVE-2024-32462 (#305186).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review pr 305737` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>34 packages built:</summary>
  <ul>
    <li>flatpak</li>
    <li>flatpak-builder</li>
    <li>flatpak-builder.doc</li>
    <li>flatpak-builder.installedTests</li>
    <li>flatpak-builder.man</li>
    <li>flatpak.dev</li>
    <li>flatpak.devdoc</li>
    <li>flatpak.doc</li>
    <li>flatpak.installedTests</li>
    <li>flatpak.man</li>
    <li>fractal</li>
    <li>gnome-builder</li>
    <li>gnome-builder.devdoc</li>
    <li>gnome.gnome-software</li>
    <li>libsForQt5.discover</li>
    <li>libsForQt5.flatpak-kcm</li>
    <li>malcontent-ui</li>
    <li>malcontent-ui.dev</li>
    <li>malcontent-ui.lib</li>
    <li>monitor</li>
    <li>pantheon.appcenter</li>
    <li>pantheon.elementary-greeter</li>
    <li>pantheon.elementary-onboarding</li>
    <li>pantheon.sideload</li>
    <li>pantheon.switchboard-plug-applications</li>
    <li>pantheon.switchboard-with-plugs</li>
    <li>pantheon.wingpanel-applications-menu</li>
    <li>pantheon.wingpanel-with-indicators</li>
    <li>vala-language-server</li>
    <li>xdg-desktop-portal</li>
    <li>xdg-desktop-portal-gnome</li>
    <li>xdg-desktop-portal-gtk</li>
    <li>xdg-desktop-portal-xapp</li>
    <li>xdg-desktop-portal.installedTests</li>
  </ul>
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
