### PR TITLE
insync 3.8.7.50516 -> 3.9.1.60010 | insync-emblem-icons: init at 3.8.7.50516 | insync-nautilus: fixes

### DIFF
--- a/pkgs/by-name/in/insync-emblem-icons/package.nix
+++ b/pkgs/by-name/in/insync-emblem-icons/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "insync-emblem-icons";
+  version = "3.8.7.50516";
+
+  src = fetchurl rec {
+    urls = [
+      "https://cdn.insynchq.com/builds/linux/insync-emblem-icons_${finalAttrs.version}_all.deb"
+      "https://web.archive.org/web/20240409081214/${builtins.elemAt urls 0}"
+    ];
+    hash = "sha256-uALaIxETEEkjDTx331uIsb4VswWk2K0dGuDMYH8v5U8=";
+  };
+
+  nativeBuildInputs = [ dpkg ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    dpkg-deb --fsys-tarfile "$src" | tar -x --no-same-permissions --no-same-owner
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -R usr/* $out/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ hellwolf ];
+    homepage = "https://www.insynchq.com";
+    description = "This package contains the file manager emblem icons for Insync file manager extensions";
+  };
+})

--- a/pkgs/by-name/in/insync-nautilus/package.nix
+++ b/pkgs/by-name/in/insync-nautilus/package.nix
@@ -1,39 +1,39 @@
-{ stdenv,
+{
+  stdenv,
   fetchurl,
   lib,
   dpkg,
   gnome,
-  insync
+  insync-emblem-icons,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "insync-nautilus";
-  version = lib.getVersion insync;
+  version = lib.getVersion insync-emblem-icons;
   pyproject = true;
 
   # Download latest from: https://www.insynchq.com/downloads/linux#nautilus
 
-  src = fetchurl {
+  src = fetchurl rec {
     urls = [
       "https://cdn.insynchq.com/builds/linux/insync-nautilus_${finalAttrs.version}_all.deb"
-      "https://web.archive.org/web/20240409080611/https://cdn.insynchq.com/builds/linux/insync-nautilus_${finalAttrs.version}_all.deb"
+      "https://web.archive.org/web/20240409080611/${builtins.elemAt urls 0}"
     ];
     hash = "sha256-aB1/ZzcQH3T1lviMZO8jXbtdbe4TW20f0TAcv4HDOGI=";
   };
 
-  nativeBuildInputs = [
-    dpkg
-  ];
+  nativeBuildInputs = [ dpkg ];
 
   buildInputs = [
     gnome.nautilus-python
-    insync
+    insync-emblem-icons
   ];
 
   installPhase = ''
     runHook preInstall
     mkdir -p $out
     cp -R usr/share $out/
+    cp -rs "${insync-emblem-icons}"/share/icons $out/share/icons
     runHook postInstall
   '';
 

--- a/pkgs/by-name/in/insync/package.nix
+++ b/pkgs/by-name/in/insync/package.nix
@@ -1,44 +1,34 @@
-{ lib
-, writeShellScript
-, buildFHSEnv
-, stdenvNoCC
-, fetchurl
-, autoPatchelfHook
-, dpkg
-, nss
-, alsa-lib
-, libvorbis
-, libdrm
-, libGL
-, wayland
-, xkeyboard_config
-, libthai
-, libsForQt5
+{
+  lib,
+  writeShellScript,
+  buildFHSEnv,
+  stdenvNoCC,
+  fetchurl,
+  autoPatchelfHook,
+  dpkg,
+  nss,
+  alsa-lib,
+  xkeyboard_config,
+  libthai,
+  libsForQt5,
 }:
 
 let
   pname = "insync";
-  # Find a binary from https://www.insynchq.com/downloads/linux#ubuntu.
-  version = "3.8.7.50516";
-  ubuntu-dist = "mantic_amd64";
-  insyncDeb = (fetchurl {
-    urls = [
-      "https://cdn.insynchq.com/builds/linux/insync_${version}-${ubuntu-dist}.deb"
-      "https://web.archive.org/web/20240409080945/https://cdn.insynchq.com/builds/linux/insync_${version}-${ubuntu-dist}.deb"
-    ];
-    hash = "sha256-U7BcgghbdR7r9WiZpEOka+BzXwnxrzL6p4imGESuB/k=";
-  });
-  insyncEmblemIconsDeb = (fetchurl {
-    urls = [
-      "https://cdn.insynchq.com/builds/linux/insync-emblem-icons_${version}_all.deb"
-      "https://web.archive.org/web/20240409081214/https://cdn.insynchq.com/builds/linux/insync-emblem-icons_${version}_all.deb"
-    ];
-    hash = "sha256-uALaIxETEEkjDTx331uIsb4VswWk2K0dGuDMYH8v5U8=";
-  });
+  # Find a binary from https://www.insynchq.com/downloads/linux
+  version = "3.9.1.60010";
+  ubuntu-dist = "trixie_amd64";
   insync-pkg = stdenvNoCC.mkDerivation {
-    name = "${pname}-pkg-${version}";
+    pname = "${pname}-pkg";
+    inherit version;
 
-    srcs = [ insyncDeb insyncEmblemIconsDeb ];
+    src = fetchurl rec {
+      urls = [
+        "https://cdn.insynchq.com/builds/linux/${version}/insync_${version}-${ubuntu-dist}.deb"
+        "https://web.archive.org/web/20240622110117/${builtins.elemAt urls 0}"
+      ];
+      hash = "sha256-8gT2xLZa/zrM3X3AXTOvHelO0tF2w/3/qOyw2wB98uY=";
+    };
 
     nativeBuildInputs = [
       dpkg
@@ -47,23 +37,24 @@ let
     ];
 
     buildInputs = [
-      nss
       alsa-lib
-      libvorbis
-      libdrm
-      libGL
-      wayland
+      nss
       libthai
-      libsForQt5.qt5.qtvirtualkeyboard
-    ];
+    ] ++ (with libsForQt5; [ qt5.qtvirtualkeyboard ]);
 
     unpackPhase = ''
-      dpkg-deb --fsys-tarfile ${insyncDeb} | tar -x --no-same-permissions --no-same-owner
-      dpkg-deb --fsys-tarfile ${insyncEmblemIconsDeb} | tar -x --no-same-permissions --no-same-owner
+      runHook preUnpack
+
+      dpkg-deb --fsys-tarfile "$src" | tar -x --no-same-permissions --no-same-owner
+
+      runHook postUnpack
     '';
 
     installPhase = ''
       runHook preInstall
+
+      # Remove unused plugins. This is based on missing libraries from the upstream package.
+      rm -rf usr/lib/insync/PySide2/Qt/qml/
 
       mkdir -p $out
       cp -R usr/* $out/
@@ -75,13 +66,15 @@ let
     dontStrip = true;
   };
 
-in buildFHSEnv {
+in
+buildFHSEnv {
   inherit pname version;
 
-  targetPkgs = pkgs: with pkgs; [
-    libudev0-shim
-    insync-pkg
-  ];
+  targetPkgs =
+    pkgs: with pkgs; [
+      libudev0-shim
+      insync-pkg
+    ];
 
   extraInstallCommands = ''
     cp -rsHf "${insync-pkg}"/share $out/
@@ -91,18 +84,21 @@ in buildFHSEnv {
     # xkb configuration needed: https://github.com/NixOS/nixpkgs/issues/236365
     export XKB_CONFIG_ROOT=${xkeyboard_config}/share/X11/xkb/
 
+    # When using Ubuntu deb package, this might be needed for showing system tray icon.
+    # export XDG_CURRENT_DESKTOP=Unity
+
     # For debugging:
     # export QT_DEBUG_PLUGINS=1
 
     exec /usr/lib/insync/insync "$@"
-    '';
+  '';
 
   # As intended by this bubble wrap, share as much namespaces as possible with user.
-  unshareUser   = false;
-  unshareIpc    = false;
-  unsharePid    = false;
-  unshareNet    = false;
-  unshareUts    = false;
+  unshareUser = false;
+  unshareIpc = false;
+  unsharePid = false;
+  unshareNet = false;
+  unshareUts = false;
   unshareCgroup = false;
 
   dieWithParent = true;
@@ -115,16 +111,16 @@ in buildFHSEnv {
     homepage = "https://www.insynchq.com";
     description = "Google Drive sync and backup with multiple account support";
     longDescription = ''
-     Insync is a commercial application that syncs your Drive files to your
-     computer.  It has more advanced features than Google's official client
-     such as multiple account support, Google Doc conversion, symlink support,
-     and built in sharing.
+      Insync is a commercial application that syncs your Drive files to your
+      computer.  It has more advanced features than Google's official client
+      such as multiple account support, Google Doc conversion, symlink support,
+      and built in sharing.
 
-     There is a 15-day free trial, and it is a paid application after that.
+      There is a 15-day free trial, and it is a paid application after that.
 
-     Known bug(s):
+      Known bug(s):
 
-     1) Currently the system try icon does not render correctly.
+      1) Currently the system try icon does not render correctly.
     '';
     mainProgram = "insync";
   };


### PR DESCRIPTION
## Description of changes

- insync: 3.8.7.50516 -> 3.9.0.60000-
- insync-emblem-icons: init at 3.8.7.50516
  - insync-nautilus: use insync-emblem-icons

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
