### PR TITLE
ustream-ssl: unstable-2023-11-11 -> 0-unstable-2024-03-26

### DIFF
--- a/pkgs/development/libraries/libubox/default.nix
+++ b/pkgs/development/libraries/libubox/default.nix
@@ -22,6 +22,10 @@ stdenv.mkDerivation {
     done
   '';
 
+  env.NIX_CFLAGS_COMPILE = toString (lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
+    "-Wno-error=gnu-folding-constant"
+  ]);
+
   meta = with lib; {
     description = "C utility functions for OpenWrt";
     homepage = "https://git.openwrt.org/?p=project/libubox.git;a=summary";

--- a/pkgs/development/libraries/ubus/default.nix
+++ b/pkgs/development/libraries/ubus/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation {
   buildInputs = [ libubox libjson ];
   nativeBuildInputs = [ cmake ];
 
+  env.NIX_CFLAGS_COMPILE = toString (lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
+    "-Wno-error=gnu-folding-constant"
+  ]);
+
   meta = with lib; {
     description = "OpenWrt system message/RPC bus";
     homepage = "https://git.openwrt.org/?p=project/ubus.git;a=summary";

--- a/pkgs/development/libraries/uclient/default.nix
+++ b/pkgs/development/libraries/uclient/default.nix
@@ -26,5 +26,6 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ mkg20001 ];
     mainProgram = "uclient-fetch";
     platforms = platforms.all;
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/libraries/ustream-ssl/default.nix
+++ b/pkgs/development/libraries/ustream-ssl/default.nix
@@ -10,12 +10,12 @@
 
 stdenv.mkDerivation {
   pname = "ustream-ssl";
-  version = "unstable-2023-11-11";
+  version = "0-unstable-2024-03-26";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/ustream-ssl.git";
-    rev = "263b9a97cf7e1e2467319c23832b705fc01190b5";
-    hash = "sha256-RLHU6swNbS3DL3QbKnwU4BbD0EFGKCrHHp0hbnoSssw=";
+    rev = "7621339d7694abef5da5e5353ac440f2d39dcecb";
+    hash = "sha256-No0Pk8KbkT7W4Rav7W3rMKEJISbp7RRoRx7t6LPMxlk=";
   };
 
   preConfigure = ''

--- a/pkgs/tools/networking/uqmi/default.nix
+++ b/pkgs/tools/networking/uqmi/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation {
     # Needed with GCC 12 but breaks on darwin (with clang) or older gcc
     "-Wno-error=dangling-pointer"
     "-Wno-error=maybe-uninitialized"
+  ] ++ lib.optionals stdenv.cc.isClang [
+    "-Wno-error=sometimes-uninitialized"
   ]);
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20434,7 +20434,10 @@ with pkgs;
 
   ustream-ssl-wolfssl = callPackage ../development/libraries/ustream-ssl { ssl_implementation = wolfssl; additional_buildInputs = [ openssl ]; };
 
-  ustream-ssl-mbedtls = callPackage ../development/libraries/ustream-ssl { ssl_implementation = mbedtls_2; };
+  ustream-ssl-mbedtls = callPackage ../development/libraries/ustream-ssl {
+    ssl_implementation = mbedtls_2;
+    stdenv = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
+  };
 
   uri = callPackage ../development/libraries/uri { };
 


### PR DESCRIPTION
## Description of changes

Diff: https://git.openwrt.org/?p=project/ustream-ssl.git;a=commit;h=7621339d7694abef5da5e5353ac440f2d39dcecb

Should fix build on aarch64-darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
