### PR TITLE
kdePackages.mkKdeDerivation: move Qt Designer plugins out of $dev

### DIFF
--- a/pkgs/applications/video/haruna/default.nix
+++ b/pkgs/applications/video/haruna/default.nix
@@ -1,6 +1,6 @@
 { lib
+, stdenv
 , fetchFromGitLab
-, mkKdeDerivation
 , breeze-icons
 , breeze
 , cmake
@@ -15,7 +15,7 @@
 , kirigami
 , kxmlgui
 , kdoctools
-, mpv
+, mpvqt
 , pkg-config
 , wrapQtAppsHook
 , qqc2-desktop-style
@@ -23,7 +23,7 @@
 , yt-dlp
 }:
 
-mkKdeDerivation rec {
+stdenv.mkDerivation rec {
   pname = "haruna";
   version = "1.0.2";
 
@@ -56,7 +56,7 @@ mkKdeDerivation rec {
     kirigami
     kxmlgui
     kdoctools
-    mpv
+    mpvqt
     qtbase
   ];
 

--- a/pkgs/kde/lib/mk-kde-derivation.nix
+++ b/pkgs/kde/lib/mk-kde-derivation.nix
@@ -91,7 +91,7 @@ in
     defaultArgs = {
       inherit version src;
 
-      outputs = ["out" "dev"];
+      outputs = ["out" "dev" "devtools"];
 
       nativeBuildInputs = [cmake qt6.wrapQtAppsHook moveDevHook] ++ extraNativeBuildInputs;
       buildInputs = [qt6.qtbase] ++ extraBuildInputs;

--- a/pkgs/kde/lib/move-dev-hook.sh
+++ b/pkgs/kde/lib/move-dev-hook.sh
@@ -2,7 +2,10 @@
 # shellcheck disable=SC2154
 
 moveKF6DevTools() {
-    moveToOutput "${qtPluginPrefix}/designer" "${!outputDev}"
+    if [ -n "$devtools" ]; then
+        mkdir -p "$devtools"
+        moveToOutput "${qtPluginPrefix}/designer" "$devtools"
+    fi
 }
 
 postInstallHooks+=('moveKF6DevTools')

--- a/pkgs/kde/misc/mpvqt/default.nix
+++ b/pkgs/kde/misc/mpvqt/default.nix
@@ -17,7 +17,8 @@ mkKdeDerivation rec {
     hash = "sha256-XHiCxH7dJxJamloM2SJbiFHDt8j4rVfv/M9PaBzvgM4=";
   };
 
-  extraBuildInputs = [mpv qtdeclarative];
+  extraBuildInputs = [qtdeclarative];
+  extraPropagatedBuildInputs = [mpv];
 
   meta.license = with lib.licenses; [bsd2 bsd3 cc-by-sa-40 cc0 lgpl21Only lgpl3Only lgpl3Plus mit];
 }

--- a/pkgs/kde/plasma/breeze-grub/default.nix
+++ b/pkgs/kde/plasma/breeze-grub/default.nix
@@ -6,6 +6,8 @@ mkKdeDerivation {
   nativeBuildInputs = [];
   buildInputs = [];
 
+  outputs = ["out"];
+
   installPhase = ''
     runHook preInstall
 


### PR DESCRIPTION
Or they end up picked up by the build hooks. Fixes #305632.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
