### PR TITLE
vscode-js-debug: init at 1.90.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23018,6 +23018,16 @@
       fingerprint = "1127 F188 280A E312 3619  3329 87E1 7EEF 9B18 B6C9";
     }];
   };
+  zeorin = {
+    name = "Xandor Schiefer";
+    email = "me@xandor.co.za";
+    matrix = "@zeorin:matrix.org";
+    github = "zeorin";
+    githubId = 1187078;
+    keys = [{
+      fingerprint = "863F 093A CF82 D2C8 6FD7  FB74 5E1C 0971 FE4F 665A";
+    }];
+  };
   zeratax = {
     email = "mail@zera.tax";
     github = "zeratax";

--- a/pkgs/by-name/vs/vscode-js-debug/package.nix
+++ b/pkgs/by-name/vs/vscode-js-debug/package.nix
@@ -1,0 +1,82 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+, jq
+, libsecret
+, pkg-config
+, nodePackages
+, runCommand
+, vscode-js-debug
+, nix-update-script
+}:
+
+buildNpmPackage rec {
+  pname = "vscode-js-debug";
+  version = "1.90.0";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "vscode-js-debug";
+    rev = "v${version}";
+    hash = "sha256-SmWPKO7CEXaOIkuf9Y+825EfGsIz+rWlnCsh1T2UEF0=";
+  };
+
+  npmDepsHash = "sha256-DfeaiqKadTnGzOObK01ctlavwqTMa0tqn59sLZMPvUM=";
+
+  nativeBuildInputs = [ pkg-config nodePackages.node-gyp jq ];
+
+  buildInputs = [ libsecret ];
+
+  postPatch = ''
+    jq '
+      .scripts.postinstall |= empty |             # tries to install playwright, not necessary for build
+      .scripts.build |= "gulp dapDebugServer" |   # there is no build script defined
+      .bin |= "./dist/src/dapDebugServer.js"      # there is no bin output defined
+    ' ${src}/package.json > package.json
+  '';
+
+  makeCacheWritable = true;
+
+  npmInstallFlags = [ "--include=dev" ];
+
+  preBuild = ''
+    export PATH="node_modules/.bin:$PATH"
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex" "v((?!\d{4}\.\d\.\d{3}).*)" ];
+  };
+
+  passthru.tests.test = runCommand "${pname}-test"
+    {
+      nativeBuildInputs = [ vscode-js-debug ];
+      meta.timeout = 60;
+    } ''
+    output=$(js-debug --help 2>&1)
+    if grep -Fw -- "Usage: dapDebugServer.js [port|socket path=8123] [host=localhost]" - <<< "$output"; then
+      touch $out
+    else
+      echo "Expected help output was not found!" >&2
+      echo "The output was:" >&2
+      echo "$output" >&2
+      exit 1
+    fi
+  '';
+
+  meta = with lib; {
+    description = "A DAP-compatible JavaScript debugger";
+    longDescription = ''
+      This is a [DAP](https://microsoft.github.io/debug-adapter-protocol/)-based
+      JavaScript debugger. It debugs Node.js, Chrome, Edge, WebView2, VS Code
+      extensions, and more. It has been the default JavaScript debugger in
+      Visual Studio Code since 1.46, and is gradually rolling out in Visual
+      Studio proper.
+    '';
+    homepage = "https://github.com/microsoft/vscode-js-debug";
+    changelog =
+      "https://github.com/microsoft/vscode-js-debug/blob/v${version}/CHANGELOG.md";
+    mainProgram = "js-debug";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zeorin ];
+  };
+}


### PR DESCRIPTION
## Description of changes

- Add @zeorin as a maintainer
- Init [vscode-js-debug](https://github.com/microsoft/vscode-js-debug) at 1.90.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - ~~[NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - ~~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~~
  - ~~made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages~~
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
