### PR TITLE
vscode-extensions.github.copilot-chat: 0.13.2024022301 -> 0.14.2024032901

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1773,8 +1773,8 @@ let
         mktplcRef = {
           publisher = "github";
           name = "copilot-chat";
-          version = "0.13.2024022301"; # compatible with vscode >= 1.87
-          hash = "sha256-WdojLEdrg6iqTH/cNPEWb6VEfk+gIHh2M5GHrAURjy8=";
+          version = "0.14.2024032901";  # compatible with vscode 1.88.1
+          hash = "sha256-+6N7IGO5j0wP5Zg8CwapHeKGWiZzc43VM4jCtqJDJIQ=";
         };
         meta = {
           description = "GitHub Copilot Chat is a companion extension to GitHub Copilot that houses experimental chat features";


### PR DESCRIPTION
## Description of changes
update github.copilot-chat from 0.13.2024022301 to 0.14.2024032901

## Things done

I have checked  that the installed packets work with vscode 1.88.1. (with extensionsFromVscodeMarketplace )
