### PR TITLE
nixos/doc: fix typo in abstractions.section.md

### DIFF
--- a/nixos/doc/manual/configuration/abstractions.section.md
+++ b/nixos/doc/manual/configuration/abstractions.section.md
@@ -35,7 +35,7 @@ in
 {
   services.httpd.virtualHosts =
     { "blog.example.org" = (commonConfig // { documentRoot = "/webroot/blog.example.org"; });
-      "wiki.example.org" = (commonConfig // { documentRoot = "/webroot/wiki.example.com"; });
+      "wiki.example.org" = (commonConfig // { documentRoot = "/webroot/wiki.example.org"; });
     };
 }
 ```


### PR DESCRIPTION
I found this while perusing the manual thinking about whether or not to install NixOS on my new laptop. It threw me for a loop for a second but as best I can tell this meant to be ".org" like the rest of the example, and not ".com"

Please let me know if this isn't the right place for this PR, I don't use GitHub and I couldn't find any instructions telling me otherwise