### PR TITLE
teamspeak_client: add ts3Plugins support, ts3-crosstalk: init at 1.6.3.111601-unstable-2024-04-22

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
@@ -1,6 +1,8 @@
 { lib, stdenv, fetchurl, makeWrapper, makeDesktopItem, zlib, glib, libpng, freetype, openssl
 , xorg, fontconfig, qtbase, qtwebengine, qtwebchannel, qtsvg, qtwebsockets, xkeyboard_config
 , alsa-lib, libpulseaudio ? null, libredirect, quazip, which, unzip, perl, llvmPackages
+, symlinkJoin
+, ts3Plugins ? [ ]
 }:
 
 let
@@ -24,6 +26,11 @@ let
     desktopName = "TeamSpeak";
     genericName = "TeamSpeak";
     categories = [ "Network" ];
+  };
+
+  plugins = symlinkJoin {
+    name = "ts3-plugins";
+    paths = map (p: p.ts3_plugin or (throw "plugin ${p} must have a `ts3_plugin` output!.")) ts3Plugins;
   };
 in
 
@@ -90,6 +97,12 @@ stdenv.mkDerivation rec {
       cp pluginsdk/docs/client_html/images/logo.png $out/share/icons/hicolor/64x64/apps/teamspeak.png
       cp ${desktopItem}/share/applications/* $out/share/applications/
 
+    ''
+    + lib.optionalString (ts3Plugins != [ ]) ''
+      mkdir -p $out/lib/teamspeak/
+      ln -s ${plugins} $out/lib/teamspeak/plugins
+    ''
+    + ''
       mkdir -p $out/bin/
       makeWrapper $out/lib/teamspeak/ts3client $out/bin/ts3client \
         --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \

--- a/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
@@ -90,11 +90,8 @@ stdenv.mkDerivation rec {
       cp pluginsdk/docs/client_html/images/logo.png $out/share/icons/hicolor/64x64/apps/teamspeak.png
       cp ${desktopItem}/share/applications/* $out/share/applications/
 
-      # Make a symlink to the binary from bin.
       mkdir -p $out/bin/
-      ln -s $out/lib/teamspeak/ts3client $out/bin/ts3client
-
-      wrapProgram $out/bin/ts3client \
+      makeWrapper $out/lib/teamspeak/ts3client $out/bin/ts3client \
         --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
         --set QT_PLUGIN_PATH "${qtbase}/${qtbase.qtPluginPrefix}" \
     '' /* wayland is currently broken, remove when TS3 fixes that */ + ''

--- a/pkgs/by-name/te/teamspeak-pluginsdk/package.nix
+++ b/pkgs/by-name/te/teamspeak-pluginsdk/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  teamspeak_client,
+
+  version ? "26",
+  hash ? "sha256-oXyOqje4x79ymkG3YoS4zb25R2+HaYiUDwpZnUErag4=",
+}:
+
+let
+  pname = "ts3client-pluginsdk";
+in
+
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "teamspeak";
+    repo = pname;
+    rev = version;
+    inherit hash;
+  };
+
+  outputs = [ "dev" "ts3_plugin" "out" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $dev $out
+    cp -a $src/include/ $dev/include/
+
+    # This is a test plugin built to verify that the SDK works
+    install ts3_plugin.so -Dt $test_plugin/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "TeamSpeak 3 Client Plugin SDK and example plugin (available in the `ts3_plugin` output)";
+    license = lib.licenses.unfree; # Copyright © TeamSpeak Systems GmbH. All rights reserved.
+    inherit (teamspeak_client.meta) platforms; # Doesn't make sense to use anywhere else.
+    maintainers = with lib.maintainers; [ atemu ];
+  };
+}

--- a/pkgs/by-name/ts/ts3-crosstalk/package.nix
+++ b/pkgs/by-name/ts/ts3-crosstalk/package.nix
@@ -1,0 +1,53 @@
+{ lib
+, gcc13Stdenv
+, fetchFromGitHub
+, cmake
+, qt5
+}:
+
+# Barely compiles with GCC 13; might compile with newer ones with a little effort.
+gcc13Stdenv.mkDerivation {
+  pname = "ts3-crosstalk";
+  version = "1.6.3.111601-unstable-2024-04-22";
+
+  src = fetchFromGitHub {
+    # Upstream is unresponsive, so until # https://github.com/thorwe/CrossTalk/pull/60
+    # is merged, point at my(@Atemu) fork
+    owner = "Atemu";
+    repo = "CrossTalk";
+    rev = "75b9194d2ad19b7bc38a61562db0fa9d9fc0f011";
+    hash = "sha256-PVOsyeaG2FCp5DbgK+LOuPSeMwDdnXYSegJR4/tE+IA=";
+    fetchSubmodules = true;
+  };
+
+  outputs = [ "ts3_plugin" "out" ];
+
+  env.NIX_CFLAGS_COMPILE = "-fpermissive";
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [ qt5.qtbase ];
+
+  installPhase = ''
+    runHook preInstall
+
+    echo "Use `teamspeak_client.override { ts3Plugins = [ pkgs.ts3-crosstalk ]; }`" > $out
+
+    install libCrossTalk.so -Dt $ts3_plugin/
+
+    runHook postInstall
+  '';
+
+  dontWrapQtApps = true;
+
+  meta = {
+    description = "A Teamspeak 3 plugin that enhances the general audio experience and provides advanced features for commanders";
+    homepage = "https://github.com/thorwe/CrossTalk";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ atemu ];
+    mainProgram = "ts3-crosstalk";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

Allows the user to install plugins packaged via Nix:

    teamspeak_client.override {
      ts3Plugins = [ teamspeak-pluginsdk.test_plugin ];
    }

Closes https://github.com/NixOS/nixpkgs/issues/146932

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
