### PR TITLE
workflows: force CLI color when running nixpkgs-check-by-name

### DIFF
--- a/.github/workflows/check-by-name.yml
+++ b/.github/workflows/check-by-name.yml
@@ -107,6 +107,10 @@ jobs:
           # Adds a result symlink as a GC root
           nix-store --realise "$toolPath" --add-root result
       - name: Running nixpkgs-check-by-name
+        env:
+          # Force terminal colors to be enabled. The library that
+          # nixpkgs-check-by-name uses respects: https://bixense.com/clicolors/
+          CLICOLOR_FORCE: 1
         run: |
           if result/bin/nixpkgs-check-by-name --base "$base" .; then
             exit 0


### PR DESCRIPTION
## Description of changes

Currently something about the environment in which GH action is running, the [colored](https://crates.io/crates/colored) library does not think ANSI colors are supported, but GH actions support them.

I have done some testing in this repo:

https://github.com/willbush/throwaway-miette-gh-action-test/actions/runs/8777029939/job/24081383467

And I'm fairly certain env var `CLICOLOR_FORCE: 1` should fix colors.

[Here](https://github.com/NixOS/nixpkgs/actions/runs/8776849759/job/24080950111#step:7:15) is an example of it currently *not* working when [it should be](https://github.com/willbush/nixpkgs-check-by-name/blob/b82b53e6c596c040076300f81e7bfbff7c4b9ba1/src/main.rs#L130).

## Things done

- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
