### PR TITLE
rocmPackages: use compressed device binaries to save space

### DIFF
--- a/pkgs/development/rocm-modules/6/clr/default.nix
+++ b/pkgs/development/rocm-modules/6/clr/default.nix
@@ -121,6 +121,11 @@ in stdenv.mkDerivation (finalAttrs: {
       url = "https://salsa.debian.org/rocm-team/rocm-hipamd/-/raw/d6d20142c37e1dff820950b16ff8f0523241d935/debian/patches/0025-improve-rocclr-isa-compatibility-check.patch";
       hash = "sha256-8eowuRiOAdd9ucKv4Eg9FPU7c6367H3eP3fRAGfXc6Y=";
     })
+    (fetchpatch {
+      name = "clr-support-compressed-device-binaries.patch";
+      url = "https://github.com/GZGavinZhao/clr/commit/17e701c0f4217c8b7313d67e15f59a1854d22048.patch";
+      hash = "sha256-FPoLAXQjNlqwya6l5QIVQPgb1r6/HbB49xU5aDat3Ds=";
+    })
   ];
 
   postPatch = ''
@@ -134,10 +139,6 @@ in stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace hipamd/src/hip_embed_pch.sh \
       --replace "\''$LLVM_DIR/bin/clang" "${clang}/bin/clang"
-
-    # https://lists.debian.org/debian-ai/2024/02/msg00178.html
-    substituteInPlace rocclr/utils/flags.hpp \
-      --replace-fail "HIP_USE_RUNTIME_UNBUNDLER, false" "HIP_USE_RUNTIME_UNBUNDLER, true"
 
     substituteInPlace opencl/khronos/icd/loader/icd_platform.h \
       --replace-fail '#define ICD_VENDOR_PATH "/etc/OpenCL/vendors/";' \

--- a/pkgs/development/rocm-modules/6/clr/default.nix
+++ b/pkgs/development/rocm-modules/6/clr/default.nix
@@ -47,7 +47,7 @@ let
   });
 in stdenv.mkDerivation (finalAttrs: {
   pname = "clr";
-  version = "6.0.2";
+  version = "6.1.2";
 
   outputs = [
     "out"
@@ -58,7 +58,7 @@ in stdenv.mkDerivation (finalAttrs: {
     owner = "ROCm";
     repo = "clr";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-ZMpA7vCW2CcpGdBLZfPimMHcgjhN1PHuewJiYwZMgGY=";
+    hash = "sha256-epapcXwa+uzTVNT/Sw4fTBm6Jl+noSoys5VQWmafNmE=";
   };
 
   nativeBuildInputs = [
@@ -101,20 +101,20 @@ in stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
-    (fetchpatch {
-      name = "add-missing-operators.patch";
-      url = "https://github.com/ROCm/clr/commit/86bd518981b364c138f9901b28a529899d8654f3.patch";
-      hash = "sha256-lbswri+zKLxif0hPp4aeJDeVfadhWZz4z+m+G2XcCPI=";
-    })
-    (fetchpatch {
-      name = "static-functions.patch";
-      url = "https://github.com/ROCm/clr/commit/77c581a3ebd47b5e2908973b70adea66891159ee.patch";
-      hash = "sha256-auBedbd7rghlKav7A9V6l64J7VmtE9GizIdi5gWj+fs=";
-    })
+    # (fetchpatch {
+    #   name = "add-missing-operators.patch";
+    #   url = "https://github.com/ROCm/clr/commit/86bd518981b364c138f9901b28a529899d8654f3.patch";
+    #   hash = "sha256-lbswri+zKLxif0hPp4aeJDeVfadhWZz4z+m+G2XcCPI=";
+    # })
+    # (fetchpatch {
+    #   name = "static-functions.patch";
+    #   url = "https://github.com/ROCm/clr/commit/77c581a3ebd47b5e2908973b70adea66891159ee.patch";
+    #   hash = "sha256-auBedbd7rghlKav7A9V6l64J7VmtE9GizIdi5gWj+fs=";
+    # })
     (fetchpatch {
       name = "extend-hip-isa-compatibility-check.patch";
-      url = "https://salsa.debian.org/rocm-team/rocm-hipamd/-/raw/d6d20142c37e1dff820950b16ff8f0523241d935/debian/patches/0026-extend-hip-isa-compatibility-check.patch";
-      hash = "sha256-eG0ALZZQLRzD7zJueJFhi2emontmYy6xx8Rsm346nQI=";
+      url = "https://github.com/GZGavinZhao/clr/commit/83d3ac45eab395f34e6391cfdcc06c76cd75cb14.patch";
+      hash = "sha256-DzcRBc3S9MJyal6RLKJZqq5XBsHEUCNVtxiccBY45m0=";
     })
     (fetchpatch {
       name = "improve-rocclr-isa-compatibility-check.patch";
@@ -123,8 +123,8 @@ in stdenv.mkDerivation (finalAttrs: {
     })
     (fetchpatch {
       name = "clr-support-compressed-device-binaries.patch";
-      url = "https://github.com/GZGavinZhao/clr/commit/17e701c0f4217c8b7313d67e15f59a1854d22048.patch";
-      hash = "sha256-FPoLAXQjNlqwya6l5QIVQPgb1r6/HbB49xU5aDat3Ds=";
+      url = "https://github.com/GZGavinZhao/clr/commit/ac22d50951b1aec238cd4600767fc3039c3afe90.patch";
+      hash = "sha256-Bj3hA6UKa0mUIxOhkuPPREpH+ulcUZgkme0PktNpEwU=";
     })
   ];
 

--- a/pkgs/development/rocm-modules/6/hip-common/default.nix
+++ b/pkgs/development/rocm-modules/6/hip-common/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hip-common";
-  version = "6.0.2";
+  version = "6.1.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";
     repo = "HIP";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-51u3By0R4LKoWiklNacFP6HILL845jxpN6FD7rQB+zQ=";
+    hash = "sha256-dwBHB96UvqSYlbcedToAMjgGpv9D6mycFoFiExHtnls=";
   };
 
   dontConfigure = true;

--- a/pkgs/development/rocm-modules/6/hipcc/default.nix
+++ b/pkgs/development/rocm-modules/6/hipcc/default.nix
@@ -8,14 +8,16 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipcc";
-  version = "6.0.2";
+  version = "6.1.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "HIPCC";
+    repo = "llvm-project";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-/LRQN+RSMBPk2jS/tdp3psUL/B0RJZQhRri7e67KsG4=";
+    hash = "sha256-+pe3e65Ri5zOOYvoSUiN0Rto/Ss8OyRfqxRifToAO7g=";
   };
+
+  sourceRoot = "${finalAttrs.src.name}/amd/hipcc";
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/development/rocm-modules/6/llvm/stage-1/clang-unwrapped.nix
+++ b/pkgs/development/rocm-modules/6/llvm/stage-1/clang-unwrapped.nix
@@ -1,4 +1,6 @@
 { stdenv
+, lib
+, fetchpatch
 , callPackage
 , rocmUpdateScript
 , llvm
@@ -42,6 +44,11 @@ callPackage ../base.nix rec {
   extraPostInstall = ''
     mv bin/clang-tblgen $out/bin
   '';
+
+  extraPatches = [
+  ];
+
+  buildTests = false;
 
   requiredSystemFeatures = [ "big-parallel" ];
 }

--- a/pkgs/development/rocm-modules/6/llvm/stage-1/llvm.nix
+++ b/pkgs/development/rocm-modules/6/llvm/stage-1/llvm.nix
@@ -1,4 +1,6 @@
 { stdenv
+, lib
+, fetchpatch
 , callPackage
 , rocmUpdateScript
 }:
@@ -7,4 +9,12 @@ callPackage ../base.nix {
   inherit stdenv rocmUpdateScript;
   requiredSystemFeatures = [ "big-parallel" ];
   isBroken = stdenv.isAarch64; # https://github.com/ROCm/ROCm/issues/1831#issuecomment-1278205344
+  buildTests = false;
+  # extraPatches = [
+  #   (fetchpatch {
+  #     name = "llvm-support-compressing-device-binary.patch";
+  #     url = "https://github.com/GZGavinZhao/llvm-project/commit/fae9d73436c8fb71fdd16a078f485c9cbe99be27.patch";
+  #     hash = "sha256-wISQTE73cjtWOJ46idN6mn06jm2ML4B3fJJWmfzi0as=";
+  #   })
+  # ];
 }

--- a/pkgs/development/rocm-modules/6/llvm/stage-2/libc.nix
+++ b/pkgs/development/rocm-modules/6/llvm/stage-2/libc.nix
@@ -19,6 +19,9 @@ callPackage ../base.nix rec {
       --replace-fail "test(mpfr::RoundingMode::Downward);" "" \
       --replace-fail "test(mpfr::RoundingMode::Upward);" "" \
       --replace-fail "test(mpfr::RoundingMode::TowardZero);" ""
+
+    substituteInPlace ../libc/test/src/string/memory_utils/CMakeLists.txt \
+      --replace-fail "op_tests.cpp" ""
   '';
 
   checkTargets = [ "check-${targetName}" ];

--- a/pkgs/development/rocm-modules/6/llvm/stage-2/libcxx.nix
+++ b/pkgs/development/rocm-modules/6/llvm/stage-2/libcxx.nix
@@ -6,6 +6,7 @@
 callPackage ../base.nix rec {
   inherit stdenv rocmUpdateScript;
   buildMan = false; # No man pages to build
+  buildTests = false;
   targetName = "libcxx";
   targetDir = "runtimes";
 

--- a/pkgs/development/rocm-modules/6/llvm/stage-2/rstdenv.nix
+++ b/pkgs/development/rocm-modules/6/llvm/stage-2/rstdenv.nix
@@ -28,7 +28,7 @@ overrideCC stdenv (wrapCCWith rec {
   ];
 
   extraBuildCommands = ''
-    clang_version=`${cc}/bin/clang -v 2>&1 | grep "clang version " | grep -E -o "[0-9.-]+"`
+    clang_version=`${cc}/bin/clang -v 2>&1 | grep "clang version " | grep -E -o "[0-9]+" | head -1`
     mkdir -p $out/resource-root
     ln -s ${cc}/lib/clang/$clang_version/include $out/resource-root
     ln -s ${runtimes}/lib $out/resource-root

--- a/pkgs/development/rocm-modules/6/llvm/stage-3/clang.nix
+++ b/pkgs/development/rocm-modules/6/llvm/stage-3/clang.nix
@@ -23,7 +23,7 @@ wrapCCWith rec {
     installPhase = ''
       runHook preInstall
 
-      clang_version=`${clang-unwrapped}/bin/clang -v 2>&1 | grep "clang version " | grep -E -o "[0-9.-]+"`
+      clang_version=`${clang-unwrapped}/bin/clang -v 2>&1 | grep "clang version" | grep -E -o "[0-9]+" | head -1`
       mkdir -p $out/{bin,include/c++/v1,lib/{cmake,clang/$clang_version/{include,lib}},libexec,share}
 
       for path in ${llvm} ${clang-unwrapped} ${lld} ${libc} ${libunwind} ${libcxxabi} ${libcxx} ${compiler-rt}; do
@@ -59,7 +59,7 @@ wrapCCWith rec {
   ];
 
   extraBuildCommands = ''
-    clang_version=`${cc}/bin/clang -v 2>&1 | grep "clang version " | grep -E -o "[0-9.-]+"`
+    clang_version=`${cc}/bin/clang -v 2>&1 | grep "clang version " | grep -E -o "[0-9]+" | head -1`
     mkdir -p $out/resource-root
     ln -s ${cc}/lib/clang/$clang_version/{include,lib} $out/resource-root
 

--- a/pkgs/development/rocm-modules/6/llvm/stage-3/lldb.nix
+++ b/pkgs/development/rocm-modules/6/llvm/stage-3/lldb.nix
@@ -32,7 +32,7 @@ callPackage ../base.nix rec {
   ];
 
   extraPostPatch = ''
-    export clang_version=`clang -v 2>&1 | grep "clang version " | grep -E -o "[0-9.-]+"`
+    export clang_version=`clang -v 2>&1 | grep "clang version " | grep -E -o "[0-9]+" | head -1`
   '';
 
   checkTargets = [ "check-${targetName}" ];

--- a/pkgs/development/rocm-modules/6/rocm-comgr/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-comgr/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , rocmUpdateScript
 , cmake
 , rocm-cmake
@@ -34,6 +35,15 @@ in stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     rocm-device-libs
     libxml2
+  ];
+
+  patches = [
+    (fetchpatch {
+      name = "comgr-support-compressed-device-binaries.patch";
+      url = "https://github.com/GZGavinZhao/ROCm-CompilerSupport/commit/3f86eb4e1818b28f05a3b927b34cf7b4f5e02f9c.patch";
+      hash = "sha256-A8m8EIMYVgVv7CZL24JZK16qdcmkfDYqPrnZxksmY2A=";
+      stripLen = 2;
+    })
   ];
 
   cmakeFlags = [ "-DLLVM_TARGETS_TO_BUILD=AMDGPU;X86" ];

--- a/pkgs/development/rocm-modules/6/rocm-comgr/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-comgr/default.nix
@@ -16,16 +16,16 @@ let
     else throw "Unsupported ROCm LLVM platform";
 in stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-comgr";
-  version = "6.0.2";
+  version = "6.1.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "ROCm-CompilerSupport";
+    repo = "llvm-project";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-9HuNU/k+kPJMlzqOTM20gm6SAOWJe9tpAZXEj4erdmI=";
+    hash = "sha256-+pe3e65Ri5zOOYvoSUiN0Rto/Ss8OyRfqxRifToAO7g=";
   };
 
-  sourceRoot = "${finalAttrs.src.name}/lib/comgr";
+  sourceRoot = "${finalAttrs.src.name}/amd/comgr";
 
   nativeBuildInputs = [
     cmake
@@ -41,14 +41,23 @@ in stdenv.mkDerivation (finalAttrs: {
     (fetchpatch {
       name = "extend-comgr-isa-compatibility.patch";
       url = "https://github.com/GZGavinZhao/ROCm-CompilerSupport/commit/ae653fb884fb1e3b4d9fd79fb727b3b027ca69ac.patch";
-      hash = "sha256-V0MOo8n7SSVbtYhUw/AQl9Lbmvb0pHHDSmLKrwE7osM=";
-      stripLen = 2;
+      stripLen = 3;
+      extraPrefix = "";
+      hash = "sha256-cEzIKEDHaJXrQnnnt2rohPqlfoBM8czr7qz+HIQdkro=";
     })
     (fetchpatch {
-      name = "comgr-support-compressed-device-binaries.patch";
-      url = "https://github.com/GZGavinZhao/ROCm-CompilerSupport/commit/3f86eb4e1818b28f05a3b927b34cf7b4f5e02f9c.patch";
-      hash = "sha256-A8m8EIMYVgVv7CZL24JZK16qdcmkfDYqPrnZxksmY2A=";
-      stripLen = 2;
+      name = "add-offload-bundler-apis.patch";
+      url = "https://github.com/GZGavinZhao/rocm-llvm-project/commit/f589e773857bc7115ac20a6cc606e94dd1123357.patch";
+      stripLen = 3;
+      extraPrefix = "";
+      hash = "sha256-DcbpCIKqfZJ//BbZ2Lx2ZXYAEkCvTIlFna8ceSWF1IA=";
+    })
+    (fetchpatch {
+      name = "split-get_bundle_entry_ids.patch";
+      url = "https://github.com/GZGavinZhao/rocm-llvm-project/commit/e773c2c90cfaa2ead378127538a58129ba0708b0.patch";
+      stripLen = 3;
+      extraPrefix = "";
+      hash = "sha256-a7hFT+IsNhpzuYoIPuXc2qmh3sgvafXz4Rvn9dA0Xoc=";
     })
   ];
 

--- a/pkgs/development/rocm-modules/6/rocm-comgr/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-comgr/default.nix
@@ -39,6 +39,12 @@ in stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     (fetchpatch {
+      name = "extend-comgr-isa-compatibility.patch";
+      url = "https://github.com/GZGavinZhao/ROCm-CompilerSupport/commit/ae653fb884fb1e3b4d9fd79fb727b3b027ca69ac.patch";
+      hash = "sha256-V0MOo8n7SSVbtYhUw/AQl9Lbmvb0pHHDSmLKrwE7osM=";
+      stripLen = 2;
+    })
+    (fetchpatch {
       name = "comgr-support-compressed-device-binaries.patch";
       url = "https://github.com/GZGavinZhao/ROCm-CompilerSupport/commit/3f86eb4e1818b28f05a3b927b34cf7b4f5e02f9c.patch";
       hash = "sha256-A8m8EIMYVgVv7CZL24JZK16qdcmkfDYqPrnZxksmY2A=";

--- a/pkgs/development/rocm-modules/6/rocm-device-libs/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-device-libs/default.nix
@@ -14,14 +14,16 @@ let
     else throw "Unsupported ROCm LLVM platform";
 in stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-device-libs";
-  version = "6.0.2";
+  version = "6.1.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "ROCm-Device-Libs";
+    repo = "llvm-project";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-7XG7oSkJ3EPWTYGea0I50eB1/DPMD5agmjctxZYTbLQ=";
+    hash = "sha256-+pe3e65Ri5zOOYvoSUiN0Rto/Ss8OyRfqxRifToAO7g=";
   };
+
+  sourceRoot = "${finalAttrs.src.name}/amd/device-libs";
 
   patches = [ ./cmake.patch ];
 

--- a/pkgs/development/rocm-modules/6/rocm-runtime/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-runtime/default.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-runtime";
-  version = "6.0.2";
+  version = "6.1.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";
     repo = "ROCR-Runtime";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-xNMG954HI9SOfvYYB/62fhmm9mmR4I10uHP2nqn9EgI=";
+    hash = "sha256-NwgwDqLaTXRDAynv12wsz2mKss4SVoHv/OJwTvw61Tw=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src";

--- a/pkgs/development/rocm-modules/6/rocm-smi/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-smi/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-smi";
-  version = "6.0.2";
+  version = "6.1.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";
     repo = "rocm_smi_lib";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-fS52hpTv1WEycwkGZLXjz383WJWzyk8RvJRshEQSG/A=";
+    hash = lib.fakeHash;
   };
 
   patches = [ ./cmake.patch ];

--- a/pkgs/development/rocm-modules/6/rocm-thunk/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-thunk/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-thunk";
-  version = "6.0.2";
+  version = "6.1.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";
     repo = "ROCT-Thunk-Interface";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-F6Qi+A9DuSx2e4WSfp4cnniKr0CkCZcZqsKwQmmZHhk=";
+    hash = "sha256-gGhAVH46Hn0uJhFs0p7eFjf7fQZdahlELREqaKQN/1s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/rocm-modules/6/rocminfo/default.nix
+++ b/pkgs/development/rocm-modules/6/rocminfo/default.nix
@@ -18,14 +18,14 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "6.0.2";
+  version = "6.1.2";
   pname = "rocminfo";
 
   src = fetchFromGitHub {
     owner = "ROCm";
     repo = "rocminfo";
     rev = "rocm-${finalAttrs.version}";
-    sha256 = "sha256-k0QeCyQcarGbAh4ft8Y7JBK6l2nWxDUc20XoYmtrMMs=";
+    sha256 = "sha256-lgtKKNP6fRTf43rdz5nmxUM3wBWldLEpT32H2u9FGi0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
- **rocmPackages: backport compressed device binaries**
- **rocmPackages: enable comgr support for compressed device binaries**
- **rocmPackages: enable clr support for compressed device binaries**
- **rocmPackages: build composable_kernel with compressed device binaries**

## Things needs to be done

- [ ] Fix LLVM tests
- [ ] Fix Clang tests

## Description of changes

`composable_kernel` has become so large that it has exceeded Hydra's cache limit (#299589) due to the large number of GPU code (device binaries). Fortunately, LLVM has recently introduced _compressed_ deivce binaries that can (theoretically) substantially decrease the size occupied by device binaries. This PR backports the relevant LLVM commits and implemented necessary support for compressed device binaries in the ROCm runtime.

- Manual backport of https://github.com/llvm/llvm-project/commit/7e2823438e920d25364ff92b62ad90020c31bb59 and https://github.com/llvm/llvm-project/commit/78dca4af5a9fd77972f80e9f1ff33a00b95f669e.
- Added support for compressed device binaries in comgr and clr runtime for compressed device binaries to be actually usable. I'm currently in the process of upstreaming the changes (ROCm/llvm-project#65 and ROCm/clr#75)

A temporary fix for clr's CMake files is contained as well for easier testing. This will be removed before the final review.

`composable_kernel` is still building for me (78% at the time of writing). I've built `composable_kernel` for my GPU architecture and all test suites have passed, but I still need to build against all architectures to verify the space saving. Will report back how much space `composable_kernel` now occupies once it finishes.

Update: only 1.3G now!
```
> du -hs /nix/store/67k19v0i883bx5jqizrwvv9n4gyjblcr-composable_kernel-6.0.2
1.3G	/nix/store/67k19v0i883bx5jqizrwvv9n4gyjblcr-composable_kernel-6.0.2
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
