### PR TITLE
nixVersions.unstable: build from master, re-init at 2.22.0.pre20240321_6fd2f42c

### DIFF
--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -2,7 +2,7 @@
   # Don't test properties of pkgs.lib, but rather the lib in the parent directory
   pkgs ? import ../.. {} // { lib = throw "pkgs.lib accessed, but the lib tests should use nixpkgs' lib path directly!"; },
   nix ? pkgs-nixVersions.stable,
-  nixVersions ? [ pkgs-nixVersions.minimum nix pkgs-nixVersions.unstable ],
+  nixVersions ? [ pkgs-nixVersions.minimum nix pkgs-nixVersions.latest ],
   pkgs-nixVersions ? import ./nix-for-tests.nix { inherit pkgs; },
 }:
 

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -30,6 +30,10 @@ In addition to numerous new and upgraded packages, this release has the followin
 
   To disable this, set [nixpkgs.flake.setNixPath](#opt-nixpkgs.flake.setNixPath) and [nixpkgs.flake.setFlakeRegistry](#opt-nixpkgs.flake.setFlakeRegistry) to false.
 
+- `nixVersions.unstable` was removed. Instead the following attributes are provided:
+  - `nixVersions.git` which tracks the latest Nix master and is roughly updated once a week. This is intended to enable people to easily test unreleased changes of Nix to catch regressions earlier.
+  - `nixVersions.latest` which points to the latest Nix version packaged in nixpkgs.
+
 - Julia environments can now be built with arbitrary packages from the ecosystem using the `.withPackages` function. For example: `julia.withPackages ["Plots"]`.
 
 - The PipeWire and WirePlumber modules have removed support for using

--- a/pkgs/development/tools/language-servers/nil/default.nix
+++ b/pkgs/development/tools/language-servers/nil/default.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-lyKPmzuZB9rCBI9JxhxlyDtNHLia8FXGnSgV+D/dwgo=";
 
   nativeBuildInputs = [
-    (lib.getBin nixVersions.unstable)
+    (lib.getBin nixVersions.latest)
   ];
 
   env.CFG_RELEASE = version;

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -179,6 +179,19 @@ in lib.makeExtensible (self: ({
     hash = "sha256-Ugcc+lSq8nJP+mddMlGFnoG4Ix1lRFHWOal3299bqR8=";
   };
 
+  git = common rec {
+    version = "2.22.0";
+    suffix = "pre20240421_${lib.substring 0 8 src.rev}";
+    src = fetchFromGitHub {
+      owner = "NixOS";
+      repo = "nix";
+      rev = "6fd2f42c2defd210e17ec95653110fc58858dba9";
+      hash = "sha256-DjkxYMcG52APiADdEtXL1FNVSxNXRBw78LYctly93j0=";
+    };
+  };
+
+  latest = self.nix_2_21;
+
   # The minimum Nix version supported by Nixpkgs
   # Note that some functionality *might* have been backported into this Nix version,
   # making this package an inaccurate representation of what features are available
@@ -197,8 +210,6 @@ in lib.makeExtensible (self: ({
       nix;
 
   stable = addFallbackPathsCheck self.nix_2_18;
-
-  unstable = self.nix_2_22;
 } // lib.optionalAttrs config.allowAliases (
   lib.listToAttrs (map (
     minor:
@@ -207,4 +218,7 @@ in lib.makeExtensible (self: ({
     in
     lib.nameValuePair attr (throw "${attr} has been removed")
   ) (lib.range 4 17))
+  // {
+    unstable = throw "nixVersions.unstable has been removed. For bleeding edge (Nix master, roughly weekly updated) use nixVersions.git, otherwise use nixVersions.latest.";
+  }
 )))

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -180,13 +180,13 @@ in lib.makeExtensible (self: ({
   };
 
   git = common rec {
-    version = "2.22.0";
-    suffix = "pre20240421_${lib.substring 0 8 src.rev}";
+    version = "2.23.0";
+    suffix = "pre20240426_${lib.substring 0 8 src.rev}";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
-      rev = "6fd2f42c2defd210e17ec95653110fc58858dba9";
-      hash = "sha256-DjkxYMcG52APiADdEtXL1FNVSxNXRBw78LYctly93j0=";
+      rev = "2f678331d59451dd6f1d9512cb6d92e4ecb9750f";
+      hash = "sha256-4AwaLB/gTRgvZG4FmFY6OY52yeLAnj0a6rtJCz7TRXA=";
     };
   };
 

--- a/pkgs/tools/package-management/nix/nix-perl.nix
+++ b/pkgs/tools/package-management/nix/nix-perl.nix
@@ -9,35 +9,75 @@
 , autoreconfHook
 , autoconf-archive
 , nlohmann_json
+, xz
 , Security
+, meson
+, ninja
+, bzip2
 }:
 
-stdenv.mkDerivation {
+let
+  atLeast223 = lib.versionAtLeast nix.version "2.23";
+
+  mkConfigureOption = { mesonOption, autoconfOption, value }:
+    let
+      setFlagTo = if atLeast223
+        then lib.mesonOption mesonOption
+        else lib.withFeatureAs true autoconfOption;
+    in
+    setFlagTo value;
+in stdenv.mkDerivation (finalAttrs: {
   pname = "nix-perl";
   inherit (nix) version src;
 
   postUnpack = "sourceRoot=$sourceRoot/perl";
 
-  buildInputs = lib.optional (stdenv.isDarwin) Security;
-
-  # This is not cross-compile safe, don't have time to fix right now
-  # but noting for future travellers.
-  nativeBuildInputs = [
-    autoconf-archive
-    autoreconfHook
+  buildInputs = [
     boost
+    bzip2
     curl
     libsodium
     nix
-    nlohmann_json
     perl
+    xz
+  ] ++ lib.optional (stdenv.isDarwin) Security;
+
+  # Not cross-safe since Nix checks for curl/perl via
+  # NEED_PROG/find_program, but both seem to be needed at runtime
+  # as well.
+  nativeBuildInputs = [
     pkg-config
+    perl
+    curl
+  ] ++ (if atLeast223 then [
+    meson
+    ninja
+  ] else [
+    autoconf-archive
+    autoreconfHook
+  ]);
+
+  # `perlPackages.Test2Harness` is marked broken for Darwin
+  doCheck = !stdenv.isDarwin;
+
+  nativeCheckInputs = [
+    perl.pkgs.Test2Harness
   ];
 
-  configureFlags = [
-    "--with-dbi=${perl.pkgs.DBI}/${perl.libPrefix}"
-    "--with-dbd-sqlite=${perl.pkgs.DBDSQLite}/${perl.libPrefix}"
+  ${if atLeast223 then "mesonFlags" else "configureFlags"} = [
+    (mkConfigureOption {
+      mesonOption = "dbi_path";
+      autoconfOption = "dbi";
+      value = "${perl.pkgs.DBI}/${perl.libPrefix}";
+    })
+    (mkConfigureOption {
+      mesonOption = "dbd_sqlite_path";
+      autoconfOption = "dbd-sqlite";
+      value = "${perl.pkgs.DBDSQLite}/${perl.libPrefix}";
+    })
+  ] ++ lib.optionals atLeast223 [
+    (lib.mesonEnable "tests" finalAttrs.doCheck)
   ];
 
   preConfigure = "export NIX_STATE_DIR=$TMPDIR";
-}
+})


### PR DESCRIPTION
## Description of changes

Things to discuss first:
* [x] Should we use a different attribute, e.g. `nixVersions.git`? OTOH unstable Nix is already insufficiently stable for nixpkgs, so I'm not sure if that even makes a different currently :shrug: 
* [x] For that attribute, breaking backports are OK to me. Otherwise, we'll need to remove this from every stable nixpkgs.

---

The idea behind that is to enable users and developers of downstream tools such as home-manager to test Nix master for several reasons:

* Nix is currently trying to have a `master` branch that's always releasable[1]. We're still on Nix 2.18 in nixpkgs due to too many notable regressions. Enabling people to test latest master may help on that end.

* This uses the most bleeding-edge Nix, but our packaging, so we can identify issues with our packaging early.

* From what I've seen, most people are using the packages from nixpkgs anyways instead of the upstream flake, this is far more convenient anyways.

My plan is to update this once a week. Right now we rely on the `installCheckPhase` here, but as soon as we have proper regression testing[2], we may want to add `nixUnstable` there as well (however with failures being allowed probably).

[1] https://discourse.nixos.org/t/nix-release-schedule-and-roadmap/14204
[2] https://github.com/NixOS/nixpkgs/pull/304332

---

cc @RaitoBezarius @lovesegfault @Artturin 
cc @rycee @Enzime (for hm/nix-darwin as downstream projects that might be interested in that).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
