### PR TITLE
mathemagix: init at 11126

### DIFF
--- a/pkgs/by-name/ma/mathemagix/package.nix
+++ b/pkgs/by-name/ma/mathemagix/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
   configureFlags = [ "--prefix=${placeholder "out"}" ];
 
   meta = {
-    description = "Mathemagix is a free computer algebra and analysis system. It consists of a high level language with a compiler and a series of mathematical libraries, some of which are written in C++.";
+    description = "A free computer algebra and analysis system consisting of a high level language with a compiler and a series of mathematical libraries";
     homepage = "http://www.mathemagix.org/";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ drupol ];

--- a/pkgs/by-name/ma/mathemagix/package.nix
+++ b/pkgs/by-name/ma/mathemagix/package.nix
@@ -23,15 +23,15 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   buildInputs = [
-    readline
-    ncurses
+    gmp
     libtool
+    mpfr
+    ncurses
+    readline
   ];
 
   nativeBuildInputs = [
     bison
-    gmp
-    mpfr
   ];
 
   preConfigure = ''

--- a/pkgs/by-name/ma/mathemagix/package.nix
+++ b/pkgs/by-name/ma/mathemagix/package.nix
@@ -22,11 +22,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  nativeBuildInputs = [
+  buildInputs = [
     readline
     ncurses
-    bison
     libtool
+  ];
+
+  nativeBuildInputs = [
+    bison
     gmp
     mpfr
   ];
@@ -34,8 +37,6 @@ stdenv.mkDerivation (finalAttrs: {
   preConfigure = ''
     export HOME="$PWD"
   '';
-
-  configureFlags = [ "--prefix=${placeholder "out"}" ];
 
   meta = {
     description = "A free computer algebra and analysis system consisting of a high level language with a compiler and a series of mathematical libraries";

--- a/pkgs/by-name/ma/mathemagix/package.nix
+++ b/pkgs/by-name/ma/mathemagix/package.nix
@@ -1,0 +1,45 @@
+{
+  stdenv,
+  lib,
+  fetchsvn,
+  readline,
+  ncurses,
+  bison,
+  libtool,
+  gmp,
+  mpfr,
+}:
+
+stdenv.mkDerivation {
+  pname = "mathemagix";
+  version = "11126";
+
+  src = fetchsvn {
+    url = "https://subversion.renater.fr/anonscm/svn/mmx/";
+    rev = 11126;
+    hash = "sha256-AFnYd5oFg/wgaHPjfZmqXNljEpoFW4h6f3UG+KZauEs=";
+  };
+
+  nativeBuildInputs = [
+    readline
+    ncurses
+    bison
+    libtool
+    gmp
+    mpfr
+  ];
+
+  preConfigure = ''
+    export HOME="$PWD"
+  '';
+
+  configureFlags = [ "--prefix=${placeholder "out"}" ];
+
+  meta = {
+    description = "Mathemagix is a free computer algebra and analysis system. It consists of a high level language with a compiler and a series of mathematical libraries, some of which are written in C++.";
+    homepage = "http://www.mathemagix.org/";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ drupol ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/ma/mathemagix/package.nix
+++ b/pkgs/by-name/ma/mathemagix/package.nix
@@ -10,15 +10,17 @@
   mpfr,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mathemagix";
   version = "11126";
 
   src = fetchsvn {
     url = "https://subversion.renater.fr/anonscm/svn/mmx/";
-    rev = 11126;
+    rev = finalAttrs.version;
     hash = "sha256-AFnYd5oFg/wgaHPjfZmqXNljEpoFW4h6f3UG+KZauEs=";
   };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     readline
@@ -42,4 +44,4 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [ drupol ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
TODO:

- [x] ~~Currently broken because it tries to write in the user directory at the end of compilation... investigation ongoing.~~ Fixed
- [x] Add supported platforms (linux only)
- [x] Fix https://discourse.nixos.org/t/building-mathemagix/43846/4
- [ ] Licencing (I wrote the author on the 22 April in the morning... no news so far)

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
