### PR TITLE
haskell-modules/generic-builder.nix: Allow running Haskell tests as passthru.tests 

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -2294,6 +2294,8 @@ builtins.intersectAttrs super {
 
   # Workaround for flaky test: https://github.com/basvandijk/threads/issues/10
   threads = appendPatch ./patches/threads-flaky-test.patch super.threads;
+
+  PSQueue = enableSeparateTestOutput (overrideCabal (drv: {doCheck = true;}) super.PSQueue);
 }
 
 // lib.optionalAttrs pkgs.config.allowAliases (

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -210,6 +210,10 @@ in
   enableSeparateDataOutput ? false,
   enableSeparateDocOutput ? doHaddock,
   enableSeparateIntermediatesOutput ? false,
+  # When enabled test suites are not run in the main deriviation.
+  # Instead they are built, installed in the 'tests' output, and
+  # a passthru.test derivation is created for test suites.
+  enableSeparateTestOutput ? false,
   # Don't fail at configure time if there are multiple versions of the
   # same package in the (recursive) dependencies of the package being
   # built. Will delay failures, if any, to compile time.
@@ -647,7 +651,8 @@ lib.fix (
       ++ (optional enableSeparateDataOutput "data")
       ++ (optional enableSeparateDocOutput "doc")
       ++ (optional enableSeparateBinOutput "bin")
-      ++ (optional enableSeparateIntermediatesOutput "intermediates");
+      ++ (optional enableSeparateIntermediatesOutput "intermediates")
+      ++ (optional enableSeparateTestOutput "test");
 
       setOutputFlags = false;
 
@@ -857,7 +862,7 @@ lib.fix (
       # - If it is empty, it'll be unset during test suite execution.
       # - Otherwise GHC_PACKAGE_PATH will have the package db used for configuring
       #   plus GHC's core packages.
-      checkPhase = ''
+      ${if enableSeparateTestOutput then null else "checkPhase"} = ''
         runHook preCheck
         checkFlagsArray+=(
           "--show-details=streaming"
@@ -934,6 +939,26 @@ lib.fix (
           mkdir -p $doc
         ''}
         ${optionalString enableSeparateDataOutput "mkdir -p $data"}
+        ${optionalString enableSeparateTestOutput (
+          # if no testTargets are specified but this flag is enabled, then we should query Cabal for the list of all test suites and install them
+          if testTargets == [ ] || testTargets == [ "" ] then
+            ''
+              mkdir -p $test/bin
+              # TODO: fix this. This only works with some random versions of Cabal
+              tests="$(${setupCommand} test $buildFlags -v0 --test-wrapper=echo)"
+              for t in $tests; do
+                install $t "$test"/bin/
+              done
+            ''
+          # otherwise just install the test suites specified by testTargets
+          else
+            ''
+              mkdir -p $test/bin
+              for t in ${testTargetsString}; do
+                install dist/build/$t/$t $test/bin/
+              done
+            ''
+        )}
 
         runHook postInstall
       '';
@@ -1002,6 +1027,41 @@ lib.fix (
             benchmarkToolDepends
             ;
         };
+        tests =
+          passthru.tests or { }
+          // lib.optionalAttrs enableSeparateTestOutput {
+            checks = (
+              stdenv.mkDerivation {
+                name = "${pname}-check";
+                inherit
+                  src
+                  preCheck
+                  postCheck
+                  patches
+                  ;
+                inherit (drv) meta LANG buildInputs;
+                phases = [
+                  "unpackPhase"
+                  "patchPhase"
+                  "checkPhase"
+                  "installPhase"
+                ];
+                checkPhase = ''
+                  runHook preCheck
+                  for t in ${drv.test}/bin/*; do
+                   $t $checkFlags ${lib.concatStringsSep " " testFlags} 2> >(tee $(basename $t)-stderr) | tee $(basename $t)-stdout
+                  done
+                  runHook postCheck
+                '';
+                installPhase = ''
+                  mkdir $out
+                  cp *-stderr $out/
+                  cp *-stdout $out/
+                '';
+              }
+              // lib.optionalAttrs (drv ? LOCALE_ARCHIVE) { inherit (drv) LOCALE_ARCHIVE; }
+            );
+          };
 
         # Attributes for the old definition of `shellFor`. Should be removed but
         # this predates the warning at the top of `getCabalDeps`.

--- a/pkgs/development/haskell-modules/lib/compose.nix
+++ b/pkgs/development/haskell-modules/lib/compose.nix
@@ -337,6 +337,10 @@ rec {
     enableSeparateBinOutput = true;
   });
 
+  enableSeparateTestOutput = overrideCabal (drv: {
+    enableSeparateTestOutput = true;
+  });
+
   appendPatch = x: appendPatches [ x ];
   appendPatches =
     xs:

--- a/pkgs/development/haskell-modules/lib/default.nix
+++ b/pkgs/development/haskell-modules/lib/default.nix
@@ -214,6 +214,7 @@ rec {
   disableStaticLibraries = compose.disableStaticLibraries;
 
   enableSeparateBinOutput = compose.enableSeparateBinOutput;
+  enableSeparateTestOutput = compose.enableSeparateTestOutput;
 
   appendPatch = drv: x: compose.appendPatch x drv;
   appendPatches = drv: xs: compose.appendPatches xs drv;


### PR DESCRIPTION
## Description of changes

This adds a flag to the Haskell generic builder to allow running the test suites through a `passthru.tests.checks` derivation.

This is quite helpful for large/complex test suites attached to large libraries. Having these as separate derivations makes it a lot quicker to debug why a test suite is failing. It's also quite nice for end-users cause there's a clearer separation between "this build failed" and "this test-suite failed".

It also means that if *just* the test suite fails then the overall build graph isn't blocked. So you can potentially build more packages and get more information from one feedback cycle. This makes a big difference when building large package graphs.

If a test requires KVM, this is also helpful for just making the test derivation require that.

This is a feature in haskell.nix and I'm taking inspiration from their implementation. (I'll add credit in the commit message once I write up a proper one). For reference here's the equivalent bit of haskell.nix: https://github.com/input-output-hk/haskell.nix/blob/master/lib/check.nix, which has a few more bells and whistles.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
