### PR TITLE
spago: 0.20.9 -> 0.21.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1333,9 +1333,6 @@ self: super: {
   # https://github.com/haskell/hoopl/issues/50
   hoopl = dontCheck super.hoopl;
 
-  # Generate shell completion for spago
-  spago = self.generateOptparseApplicativeCompletions [ "spago" ] super.spago;
-
   # https://github.com/DanielG/cabal-helper/pull/123
   cabal-helper = doJailbreak super.cabal-helper;
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -43,7 +43,6 @@ extra-packages:
   - attoparsec == 0.13.*                # 2022-02-23: Needed to compile elm for now
   - base16-bytestring < 1               # required for cabal-install etc.
   - basement < 0.0.15                   # 2022-08-30: last version to support GHC < 8.10
-  - bower-json == 1.0.0.1               # 2022-05-21: Needed for spago 0.20.9
   - brick == 0.70.*                     # 2022-08-13: needed by taskell
   - brittany == 0.13.1.2                # 2022-09-20: needed for hls on ghc 8.8
   - crackNum < 3.0                      # 2021-05-21: 3.0 removed the lib which sbv 7.13 uses
@@ -109,6 +108,8 @@ extra-packages:
   - algebraic-graphs < 0.7              # 2023-08-14: Needed for building weeder < 2.6.0
   - fuzzyset == 0.2.4                   # 2023-12-20: Needed for building postgrest > 10
   - ShellCheck == 0.9.0                 # 2024-03-21: pinned by haskell-ci
+  - versions < 6                        # 2024-04-22: required by spago-0.21
+  - fsnotify < 0.4                      # 2024-04-22: required by spago-0.21
 
 package-maintainers:
   abbradar:

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -849,8 +849,12 @@ self: super: builtins.intersectAttrs super {
         url = "https://github.com/purescript/purescript-docs-search/releases/download/v0.0.11/purescript-docs-search";
         sha256 = "1hjdprm990vyxz86fgq14ajn0lkams7i00h8k2i2g1a0hjdwppq6";
       };
-
-      spagoDocs = overrideCabal (drv: {
+    in
+    lib.pipe (super.spago.override {
+      versions = self.versions_5_0_5;
+      fsnotify = self.fsnotify_0_3_0_1;
+    }) [
+      (overrideCabal (drv: {
         postUnpack = (drv.postUnpack or "") + ''
           # Spago includes the following two files directly into the binary
           # with Template Haskell.  They are fetched at build-time from the
@@ -875,21 +879,14 @@ self: super: builtins.intersectAttrs super {
             "$sourceRoot/templates/docs-search-app-0.0.11.js" \
             "$sourceRoot/templates/purescript-docs-search-0.0.11"
         '';
-      }) super.spago;
-
-      spagoOldAeson = spagoDocs.overrideScope (hfinal: hprev: {
-        # spago is not yet updated for aeson 2.0
-        aeson = hfinal.aeson_1_5_6_0;
-        # bower-json 1.1.0.0 only supports aeson 2.0, so we pull in the older version here.
-        bower-json = hprev.bower-json_1_0_0_1;
-      });
+      }))
 
       # Tests require network access.
-      spagoWithoutChecks = dontCheck spagoOldAeson;
-    in
-    # spago doesn't currently build with ghc92.  Top-level spago is pulled from
-    # ghc90 and explicitly marked unbroken.
-    markBroken spagoWithoutChecks;
+      dontCheck
+
+      # Overly strict upper bound on text
+      doJailbreak
+    ];
 
   # checks SQL statements at compile time, and so requires a running PostgreSQL
   # database to run it's test suite

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -886,6 +886,9 @@ self: super: builtins.intersectAttrs super {
 
       # Overly strict upper bound on text
       doJailbreak
+
+      # Generate shell completion for spago
+      (self.generateOptparseApplicativeCompletions [ "spago" ])
     ];
 
   # checks SQL statements at compile time, and so requires a running PostgreSQL

--- a/pkgs/development/tools/purescript/spago/default.nix
+++ b/pkgs/development/tools/purescript/spago/default.nix
@@ -1,7 +1,9 @@
 { haskell
+, haskellPackages
 , lib
 
 # The following are only needed for the passthru.tests:
+, spago
 , cacert
 , git
 , nodejs
@@ -9,53 +11,47 @@
 , runCommand
 }:
 
-let
-  spago =
-    lib.pipe
-      haskell.packages.ghc90.spago
-      [ haskell.lib.compose.justStaticExecutables
-        (haskell.lib.compose.overrideCabal (oldAttrs: {
-          changelog = "https://github.com/purescript/spago/releases/tag/${oldAttrs.version}";
-        }))
-      ];
-in
+lib.pipe
+  haskellPackages.spago
+  [
+    haskell.lib.compose.justStaticExecutables
 
-spago.overrideAttrs (oldAttrs: {
-  passthru = (oldAttrs.passthru or {}) // {
-    updateScript = ./update.sh;
+    (haskell.lib.compose.overrideCabal (oldAttrs: {
+      changelog = "https://github.com/purescript/spago/releases/tag/${oldAttrs.version}";
 
-    # These tests can be run with the following command.  The tests access the
-    # network, so they cannot be run in the nix sandbox.  sudo is needed in
-    # order to change the sandbox option.
-    #
-    # $ sudo nix-build -A spago.passthru.tests --option sandbox relaxed
-    #
-    tests =
-      runCommand
-        "spago-tests"
-        {
-          __noChroot = true;
-          nativeBuildInputs = [
-            cacert
-            git
-            nodejs
-            purescript
-            spago
-          ];
-        }
-        ''
-          # spago expects HOME to be set because it creates a cache file under
-          # home.
-          HOME=$(pwd)
+      passthru = (oldAttrs.passthru or {}) // {
+        updateScript = ./update.sh;
 
-          spago --verbose init
-          spago --verbose build
-          spago --verbose test
+        # These tests can be run with the following command.  The tests access the
+        # network, so they cannot be run in the nix sandbox.  sudo is needed in
+        # order to change the sandbox option.
+        #
+        # $ sudo nix-build -A spago.passthru.tests --option sandbox relaxed
+        #
+        tests =
+          runCommand
+            "spago-tests"
+            {
+              __noChroot = true;
+              nativeBuildInputs = [
+                cacert
+                git
+                nodejs
+                purescript
+                spago
+              ];
+            }
+            ''
+              # spago expects HOME to be set because it creates a cache file under
+              # home.
+              HOME=$(pwd)
 
-          touch $out
-        '';
-  };
-  meta = (oldAttrs.meta or {}) // {
-    mainProgram = "spago";
-  };
-})
+              spago --verbose init
+              spago --verbose build
+              spago --verbose test
+
+              touch $out
+            '';
+      };
+    }))
+  ]

--- a/pkgs/development/tools/purescript/spago/spago.nix
+++ b/pkgs/development/tools/purescript/spago/spago.nix
@@ -9,16 +9,16 @@
 , optparse-applicative, prettyprinter, process, QuickCheck, retry
 , rio, rio-orphans, safe, semver-range, stm, stringsearch, tar
 , template-haskell, temporary, text, time, transformers, turtle
-, unliftio, unordered-containers, utf8-string, versions, with-utf8
-, zlib
+, unliftio, unordered-containers, uri-encode, utf8-string, versions
+, with-utf8, yaml, zlib
 }:
 mkDerivation {
   pname = "spago";
-  version = "0.20.9";
+  version = "0.21.0";
   src = fetchgit {
     url = "https://github.com/purescript/spago.git";
-    sha256 = "00vdqg7vaw3d9zwh47886lw9fhhlwjagzhaj3aqz4xm92pjavhih";
-    rev = "d16d4914200783fbd820ba89dbdf67270454faf5";
+    sha256 = "1v5y15nhw6smnir0y7y854pa70iv8asxsqph2y8rz1c9lkz5d41g";
+    rev = "c354f4a461f65fcb83aaa843830ea1589f6c7179";
     fetchSubmodules = true;
   };
   isLibrary = true;
@@ -31,7 +31,7 @@ mkDerivation {
     optparse-applicative prettyprinter process retry rio rio-orphans
     safe semver-range stm stringsearch tar template-haskell temporary
     text time transformers turtle unliftio unordered-containers
-    utf8-string versions with-utf8 zlib
+    uri-encode utf8-string versions with-utf8 yaml zlib
   ];
   executableHaskellDepends = [
     ansi-terminal base text turtle with-utf8
@@ -43,4 +43,5 @@ mkDerivation {
   testToolDepends = [ hspec-discover ];
   homepage = "https://github.com/purescript/spago#readme";
   license = lib.licenses.bsd3;
+  mainProgram = "spago";
 }


### PR DESCRIPTION
## Description of changes

Tests fail due to https://github.com/purescript/spago/issues/957, no clue what's going on there. The solution suggested in the thread of running `git init` before `spago` commands does not work.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
