### PR TITLE
structurizr-lite: init at v2024.03.03

### DIFF
--- a/pkgs/tools/graphics/structurizr-lite/default.nix
+++ b/pkgs/tools/graphics/structurizr-lite/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, fetchurl
+, lib
+, makeWrapper
+, jre
+, graphviz
+}:
+stdenv.mkDerivation rec {
+  pname = "structurizr-lite";
+  version = "2024.03.03";
+
+  src = fetchurl {
+    url = "https://github.com/structurizr/lite/releases/download/v${version}/${pname}.war";
+    hash = "sha256-rLqMj+tYPxYE86Wp07w2/QTSTn2XrwGT73MKrGiHE+o=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+  
+    mkdir -p $out/bin
+
+    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+        --prefix PATH : ${lib.makeBinPath [ graphviz ]} \
+        --add-flags "-Djdk.util.jar.enableMultiRelease=false" \
+        --add-flags "-jar $src"
+        
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Structurizr builds upon “diagrams as code”, allowing you to create multiple software architecture diagrams, in a variety of rendering tools, from a single model.";
+    homepage = "https://github.com/structurizr/lite";
+    license = licenses.mit;
+    maintainers = with maintainers; [ deemp ];
+    mainProgram = pname;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17640,6 +17640,8 @@ with pkgs;
 
   pypi-mirror = callPackage ../development/tools/pypi-mirror { };
 
+  structurizr-lite = callPackage ../tools/graphics/structurizr-lite { };
+
   svg2tikz = with python3.pkgs; toPythonApplication svg2tikz;
 
   svg2pdf = callPackage ../tools/graphics/svg2pdf { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add `structurizr-lite`, a tool for modelling the architecture of software systems.

Homepage: https://github.com/structurizr/lite

`structurizr-lite` accepts a path to a workspace, similarly to the command in the README ([link](https://github.com/structurizr/lite#building-from-source)):

```
java -Djdk.util.jar.enableMultiRelease=false -jar build/libs/structurizr-lite.war /path/to/workspace
```

Original Nix expression  - https://github.com/craiggwilson/nix-config/blob/e4d6fb7b4e10659010b0d2edbb493478808673fb/packages/structurizr-lite/default.nix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
