### PR TITLE
mwprocapture: fix incorrect hash

### DIFF
--- a/pkgs/os-specific/linux/mwprocapture/default.nix
+++ b/pkgs/os-specific/linux/mwprocapture/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://www.magewell.com/files/drivers/ProCaptureForLinux_${subVersion}.tar.gz";
-    sha256 = "sha256-HOVAR9auc8ulENPLoI0scdCMZoSbDYkTaCLgZoFG7eU=";
+    sha256 = "sha256-a2cU7PYQh1KR5eeMhMNx2Sc3HHd7QvCG9+BoJyVPp1Y=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;


### PR DESCRIPTION
## Description of changes

The mwprocapture 1.3.0.4390 driver has been republished by Magewell without a version change. Tested with Linux 6.6 and 6.8 using Pro Capture Dual HDMI (11080).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>19 packages built:</summary>
  <ul>
    <li>linuxKernel.packages.linux_4_19.mwprocapture</li>
    <li>linuxKernel.packages.linux_4_19_hardened.mwprocapture</li>
    <li>linuxKernel.packages.linux_5_10.mwprocapture</li>
    <li>linuxKernel.packages.linux_5_10_hardened.mwprocapture</li>
    <li>linuxKernel.packages.linux_5_15.mwprocapture</li>
    <li>linuxKernel.packages.linux_5_15_hardened.mwprocapture</li>
    <li>linuxKernel.packages.linux_5_4.mwprocapture</li>
    <li>linuxKernel.packages.linux_5_4_hardened.mwprocapture</li>
    <li>linuxKernel.packages.linux_6_1.mwprocapture</li>
    <li>linuxKernel.packages.linux_6_1_hardened.mwprocapture</li>
    <li>linuxKernel.packages.linux_6_6.mwprocapture</li>
    <li>linuxKernel.packages.linux_hardened.mwprocapture (linuxKernel.packages.linux_6_6_hardened.mwprocapture)</li>
    <li>linuxKernel.packages.linux_6_8.mwprocapture</li>
    <li>linuxKernel.packages.linux_latest_libre.mwprocapture</li>
    <li>linuxKernel.packages.linux_libre.mwprocapture</li>
    <li>linuxKernel.packages.linux_lqx.mwprocapture</li>
    <li>linuxKernel.packages.linux_xanmod.mwprocapture</li>
    <li>linuxKernel.packages.linux_xanmod_latest.mwprocapture (linuxKernel.packages.linux_xanmod_stable.mwprocapture)</li>
    <li>linuxKernel.packages.linux_zen.mwprocapture</li>
  </ul>
</details>


