### PR TITLE
nixos/prometheus-github-exporter: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -141,6 +141,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [Prometheus DNSSEC Exporter](https://github.com/chrj/prometheus-dnssec-exporter), check for validity and expiration in DNSSEC signatures and expose metrics for Prometheus. Available as [services.prometheus.exporters.dnssec](#opt-services.prometheus.exporters.dnssec.enable).
 
+- [Prometheus Github Exporter](https://github.com/githubexporter/github-exporter), exposes basic metrics for your repositories from the GitHub API, to a Prometheus compatible endpoint. Available as [services.prometheus.exporters.github](#opt-services.prometheus.exporters.github.enable).
+
 - [TigerBeetle](https://tigerbeetle.com/), a distributed financial accounting database designed for mission critical safety and performance. Available as [services.tigerbeetle](#opt-services.tigerbeetle.enable).
 
 - [go-camo](https://github.com/cactus/go-camo), a secure image proxy server. Available as [services.go-camo](#opt-services.go-camo.enable).

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -38,6 +38,7 @@ let
     "flow"
     "fritz"
     "fritzbox"
+    "github"
     "graphite"
     "idrac"
     "imap-mailstat"

--- a/nixos/modules/services/monitoring/prometheus/exporters/github.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/github.nix
@@ -1,0 +1,98 @@
+{ config
+, lib
+, pkgs
+, ...
+}:
+let
+  cfg = config.services.prometheus.exporters.github;
+in
+{
+  port = 9171;
+  extraOpts = {
+    users = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        If supplied, the exporter will enumerate all repositories
+        for that users.
+      '';
+    };
+
+    organizations = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        If supplied, the exporter will enumerate all repositories
+        for that organization.
+      '';
+    };
+
+    repositories = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        If supplied, The repos you wish to monitor, expected in the
+        format "user/repo1". Can be across different Github users/orgs.
+      '';
+    };
+
+    apiUrl = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "https://api.github.com";
+      description = ''
+        Github API URL, shouldn't need to change this.
+      '';
+    };
+
+    tokenPath = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/github-api-token";
+      description = ''
+        If supplied, enables the user to supply a path to a file
+        containing a github authentication token that allows the
+        API to be queried more often. Optional, but recommended.
+
+        See the [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+        for more information.
+
+        ::: {.warning}
+        Please do not store this file in the nix store if you choose to
+        include any credentials here, as it would be world-readable.
+        :::
+      '';
+    };
+
+    telemetryPath = lib.mkOption {
+      type = lib.types.str;
+      default = "/metrics";
+      description = ''
+        Path under which to expose metrics.
+      '';
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.enum [ "critical" "error" "warning" "info" "debug" ];
+      default = "info";
+      description = "The level of logging the exporter will run with.";
+    };
+  };
+
+  serviceOpts = {
+    serviceConfig = {
+      Environment =
+        [
+          "LOG_LEVEL=${cfg.logLevel}"
+          "LISTEN_PORT=${toString cfg.port}"
+          "METRICS_PATH=${cfg.telemetryPath}"
+        ]
+        ++ lib.optionals (cfg.apiUrl != null) [ "API_URL=${cfg.apiUrl}" ]
+        ++ lib.optionals (cfg.tokenPath != null) [ "GITHUB_TOKEN_FILE=${cfg.tokenPath}" ]
+        ++ lib.optionals (cfg.users != [ ]) [ "USERS=${lib.concatStringsSep "," cfg.users}" ]
+        ++ lib.optionals (cfg.repositories != [ ]) [ "REPOS=${lib.concatStringsSep "," cfg.repositories}" ]
+        ++ lib.optionals (cfg.organizations != [ ]) [ "ORGS=${lib.concatStringsSep "," cfg.organizations}" ];
+      ExecStart = lib.getExe pkgs.prometheus-github-exporter;
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -335,6 +335,16 @@ let
       '';
     };
 
+    github = {
+      # Minimal configuration without Github API queries to avoid error scenarios resulting from a possible rate limit.
+      exporterConfig.enable = true;
+      exporterTest = ''
+        wait_for_unit("prometheus-github-exporter.service")
+        wait_for_open_port(9171)
+        succeed("curl -sSf http://localhost:9171/metrics")
+      '';
+    };
+
     graphite = {
       exporterConfig = {
         enable = true;

--- a/pkgs/by-name/pr/prometheus-github-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-github-exporter/package.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub, }:
+buildGoModule rec {
+  pname = "prometheus-github-exporter";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "githubexporter";
+    repo = "github-exporter";
+    rev = "${version}";
+    hash = "sha256-sHmugAVi9wGh0sR6tPDXp0FlRG96WY4/MXMHv2TC50E=";
+  };
+
+  vendorHash = "sha256-ZO9Dq9tuNP+262eEwBzptBMNtGIxkc7y4MCwMnRSTnE=";
+
+  meta = with lib; {
+    homepage = "https://github.com/githubexporter/github-exporter";
+    description = "Github Exporter for Prometheus";
+    license = licenses.mit;
+    mainProgram = "github-exporter";
+    maintainers = with maintainers; [ swendel ];
+  };
+}


### PR DESCRIPTION
Prometheus Github Exporter package, module and test

## Description of changes

This PR introduces the `prometheus-github-exporter` package and its accompanying NixOS module `services.prometheus.exporters.github` to the Nixpkgs collection. The [prometheus-github-exporter](https://github.com/githubexporter/github-exporter) exposes basic metrics for your repositories from the GitHub API, to a Prometheus compatible endpoint.

## Things done

- Added `prometheus-github-exporter` package, allowing users to easily deploy this tool in a Nix environment.
- Created a NixOS module `services.prometheus.exporters.github`, facilitating simple configuration and deployment of the service within NixOS systems.
- Implemented a NixOS test for the `services.prometheus.exporters.github` module to ensure its correct operation and integration within the NixOS ecosystem.

---

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
