### PR TITLE
[staging-next] gst_all_1.*,python3Packages.gst-python: follow-up for 1.22.9 -> 1.24.2 bump

### DIFF
--- a/pkgs/development/compilers/orc/default.nix
+++ b/pkgs/development/compilers/orc/default.nix
@@ -60,6 +60,6 @@ in stdenv.mkDerivation rec {
     # under the 3-clause BSD license. The rest is 2-clause BSD license.
     license = with licenses; [ bsd3 bsd2 ];
     platforms = platforms.unix;
-    maintainers = [ ];
+    maintainers = with maintainers; [ lilyinstarlight ];
   };
 }

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -45,6 +45,7 @@
 , flite
 , gsm
 , json-glib
+, libajantv2
 , libaom
 , libdc1394
 , libde265
@@ -152,7 +153,7 @@ stdenv.mkDerivation rec {
     liblc3
     libass
     libkate
-    webrtc-audio-processing_1 # required by isac
+    webrtc-audio-processing_1
     libbs2b
     libmodplug
     openjpeg
@@ -220,6 +221,7 @@ stdenv.mkDerivation rec {
 
     chromaprint
     flite
+    libajantv2
     libdrm
     libgudev
     sbc
@@ -263,7 +265,7 @@ stdenv.mkDerivation rec {
     "-Damfcodec=disabled" # Windows-only
     "-Davtp=disabled"
     "-Ddirectshow=disabled" # Windows-only
-    "-Dqt6d3d11=disabled"
+    "-Dqt6d3d11=disabled" # Windows-only
     "-Ddts=disabled" # required `libdca` library not packaged in nixpkgs as of writing, and marked as "BIG FAT WARNING: libdca is still in early development"
     "-Dzbar=${if enableZbar then "enabled" else "disabled"}"
     "-Dfaac=${if faacSupport then "enabled" else "disabled"}"
@@ -283,7 +285,6 @@ stdenv.mkDerivation rec {
     "-Dmusepack=disabled"
     "-Dopenni2=disabled" # not packaged in nixpkgs as of writing
     "-Dopensles=disabled" # not packaged in nixpkgs as of writing
-    "-Dsvtav1=disabled" # not packaged in nixpkgs as of writing
     "-Dsvthevcenc=disabled" # required `SvtHevcEnc` library not packaged in nixpkgs as of writing
     "-Dteletext=disabled" # required `zvbi` library not packaged in nixpkgs as of writing
     "-Dtinyalsa=disabled" # not packaged in nixpkgs as of writing
@@ -307,8 +308,8 @@ stdenv.mkDerivation rec {
     "-Dva=disabled" # see comment on `libva` in `buildInputs`
   ] ++ lib.optionals (!stdenv.isLinux || !guiSupport) [
     "-Ddirectfb=disabled"
-  ]
-  ++ lib.optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
+    "-Daja=disabled"
     "-Dchromaprint=disabled"
     "-Dflite=disabled"
     "-Dkms=disabled" # renders to libdrm output
@@ -317,6 +318,7 @@ stdenv.mkDerivation rec {
     "-Dspandsp=disabled"
     "-Ddvb=disabled"
     "-Dfbdev=disabled"
+    "-Duvcgadget=disabled" # requires gudev
     "-Duvch264=disabled" # requires gudev
     "-Dv4l2codecs=disabled" # requires gudev
     "-Dladspa=disabled" # requires lrdf
@@ -324,7 +326,7 @@ stdenv.mkDerivation rec {
     "-Dqsv=disabled" # Linux (and Windows) x86 only
   ] ++ lib.optionals (!gst-plugins-base.glEnabled) [
     "-Dgl=disabled"
-  ] ++ lib.optionals (!gst-plugins-base.waylandEnabled) [
+  ] ++ lib.optionals (!gst-plugins-base.waylandEnabled || !guiSupport) [
     "-Dgtk3=disabled" # Wayland-based GTK sink
     "-Dwayland=disabled"
   ] ++ lib.optionals (!gst-plugins-base.glEnabled) [

--- a/pkgs/development/libraries/gstreamer/bad/fix-paths.patch
+++ b/pkgs/development/libraries/gstreamer/bad/fix-paths.patch
@@ -7,7 +7,7 @@ index 11718b8..d4144c1 100644
  
    module = g_module_open (filename, G_MODULE_BIND_LAZY);
 +
-+  if (module == NULL) {
++  if (module == nullptr) {
 +    module = g_module_open ("@driverLink@/lib/" CUDA_LIBNAME, G_MODULE_BIND_LAZY);
 +  }
 +

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -126,6 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional (!enableAlsa) "-Dalsa=disabled"
   ++ lib.optional (!enableCdparanoia) "-Dcdparanoia=disabled"
   ++ lib.optionals stdenv.isDarwin [
+    "-Ddrm=disabled"
     "-Dlibvisual=disabled"
   ];
 

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -106,7 +106,6 @@ stdenv.mkDerivation rec {
     bzip2
     libdv
     libvpx
-    libdrm
     speex
     opencore-amr
     flac
@@ -148,6 +147,7 @@ stdenv.mkDerivation rec {
   ]) ++ lib.optionals stdenv.isDarwin [
     Cocoa
   ] ++ lib.optionals stdenv.isLinux [
+    libdrm
     libGL
     libv4l
     libpulseaudio

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -15,7 +15,6 @@
 , x264
 , libintl
 , lib
-, opencore-amr
 , IOKit
 , CoreFoundation
 , DiskArbitration
@@ -49,7 +48,6 @@ stdenv.mkDerivation rec {
     gst-plugins-base
     orc
     libintl
-    opencore-amr
   ] ++ lib.optionals enableGplPlugins [
     a52dec
     libcdio

--- a/pkgs/development/libraries/libajantv2/default.nix
+++ b/pkgs/development/libraries/libajantv2/default.nix
@@ -28,6 +28,21 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
+  postInstall = ''
+    mkdir -p "$out/lib/pkgconfig"
+    cat >"$out/lib/pkgconfig/libajantv2.pc" <<EOF
+    prefix=$out
+    libdir=\''${prefix}/lib
+    includedir=\''${prefix}/include/ajalibraries
+
+    Name: libajantv2
+    Description: Library for controlling AJA NTV2 video devices
+    Version: ${version}
+    Libs: -L\''${libdir} -lajantv2
+    Cflags: -I\''${includedir} -I\''${includedir}/ajantv2/includes
+    EOF
+  '';
+
   meta = with lib; {
     description = "AJA NTV2 Open Source Static Libs and Headers for building applications that only wish to statically link against";
     homepage = "https://github.com/aja-video/ntv2";

--- a/pkgs/development/libraries/liblc3/default.nix
+++ b/pkgs/development/libraries/liblc3/default.nix
@@ -27,11 +27,14 @@ stdenv.mkDerivation {
     ninja
   ];
 
+  # LTO does not work on Darwin: https://github.com/NixOS/nixpkgs/issues/19098
+  mesonFlags = lib.optionals stdenv.isDarwin [ "-Db_lto=false" ];
+
   meta = with lib; {
     description = "LC3 (Low Complexity Communication Codec) is an efficient low latency audio codec";
     homepage = "https://github.com/google/liblc3";
     license = licenses.asl20;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ jansol ];
   };
 }

--- a/pkgs/development/python-modules/wheezy-template/default.nix
+++ b/pkgs/development/python-modules/wheezy-template/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "wheezy.template";
-  version = "3.1.0";
+  version = "3.2.2";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-4RAHysczaNzhKZjjS2bEdgFrtGFHH/weTVboQALslg8=";
+    hash = "sha256-hknPXHGPPNjRAr0TYVosPaTntsjwQjOKZBCU+qFlIHw=";
   };
 
   pythonImportsCheck = [ "wheezy.template" ];

--- a/pkgs/development/tools/hotdoc/default.nix
+++ b/pkgs/development/tools/hotdoc/default.nix
@@ -1,9 +1,9 @@
 { lib
 , stdenv
 , buildPythonApplication
-, fetchpatch
 , fetchPypi
 , pytestCheckHook
+, python
 , pkg-config
 , cmake
 , flex
@@ -28,21 +28,13 @@
 
 buildPythonApplication rec {
   pname = "hotdoc";
-  version = "0.15";
+  version = "0.16";
   format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-sfQ/iBd1Z+YqnaOg8j32rC2iucdiiK3Tff9NfYFnQyc=";
+    hash = "sha256-rxhW1U+d0j4FOKfcRCO2nSndf1Sk/m40hEYGq1Gj6rM=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-test-hotdoc.patch";
-      url = "https://github.com/hotdoc/hotdoc/commit/d2415a520e960a7b540742a0695b699be9189540.patch";
-      hash = "sha256-9ORZ91c+/oRqEp2EKXjKkz7u8mLnWCq3uPsc3G4NB9E=";
-    })
-  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -86,7 +78,7 @@ buildPythonApplication rec {
   ];
 
   # Run the tests by package instead of current dir
-  pytestFlagsArray = [ "--pyargs" "hotdoc" ];
+  pytestFlagsArray = [ "${builtins.placeholder "out"}/${python.sitePackages}" "--pyargs" "hotdoc" ];
 
   disabledTests = [
     # Test does not correctly handle path normalization for test comparison
@@ -99,10 +91,11 @@ buildPythonApplication rec {
   # Hardcode libclang paths
   postPatch = ''
     substituteInPlace hotdoc/extensions/c/c_extension.py \
-      --replace "shutil.which('llvm-config')" 'True' \
-      --replace "subprocess.check_output(['llvm-config', '--version']).strip().decode()" '"${lib.versions.major llvmPackages.libclang.version}"' \
-      --replace "subprocess.check_output(['llvm-config', '--prefix']).strip().decode()" '"${llvmPackages.libclang.lib}"' \
-      --replace "subprocess.check_output(['llvm-config', '--libdir']).strip().decode()" '"${llvmPackages.libclang.lib}/lib"'
+      --replace-fail "shutil.which('llvm-config')" 'True' \
+      --replace-fail "$(echo -e "subprocess.check_output(\n            ['clang', '--print-resource-dir']).strip().decode()")" '""' \
+      --replace-fail "$(echo -e "subprocess.check_output(\n        ['llvm-config', '--version']).strip().decode()")" '"${lib.versions.major llvmPackages.libclang.version}"' \
+      --replace-fail "$(echo -e "subprocess.check_output(\n        ['llvm-config', '--prefix']).strip().decode()")" '"${llvmPackages.libclang.lib}"' \
+      --replace-fail "subprocess.check_output(['llvm-config', '--libdir']).strip().decode()" '"${llvmPackages.libclang.lib}/lib"'
   '';
 
   # Make pytest run from a temp dir to have it pick up installed package for cmark


### PR DESCRIPTION
## Description of changes

Major GStreamer bump (<https://gstreamer.freedesktop.org/releases/1.24/>)

Fixes #287253

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
  - [ ] x86_64-linux -> aarch64-linux (cross) (in-progress)
  - [x] x86_64-linux (with `qt5Support` override via `nheko`)
  - [x] x86_64-linux (with `gtkSupport` override via `pitivi`)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc