### PR TITLE
lib.trivial: rename NIX_ABORT_ON_WARN to NIXPKGS_ABORT_ON_WARN

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -19,11 +19,15 @@ let
   # uses of this variable would immediately result in an unrecoverable
   # error where there should be a deprecation warning.
   printDeprecationWarning =
-    if builtins.getEnv "NIX_ABORT_ON_WARN" != "" then
+    if 2405 <= oldestSupportedRelease && builtins.getEnv "NIX_ABORT_ON_WARN" != "" then
       builtins.trace
         "[1;31mwarning: NIX_ABORT_ON_WARN has been renamed to NIXPKGS_ABORT_ON_WARN. NIX_ABORT_ON_WARN is still honored, but deprecated and will be removed from nixpkgs after the 24.11 release.[0m"
     else
       a: a;
+
+  # Temporarily moved here to prevent lib.trivial from referencing itself.
+  # See the `inherit oldestSupportedRelease' further down.
+  oldestSupportedRelease = 2311;
 
 in printDeprecationWarning {
 
@@ -390,9 +394,8 @@ in printDeprecationWarning {
     This release number allows deprecation warnings to be implemented such that
     they take effect as soon as the oldest release reaches end of life.
   */
-  oldestSupportedRelease =
     # Update on master only. Do not backport.
-    2311;
+  inherit oldestSupportedRelease;
 
   /**
     Whether a feature is supported in all supported releases (at the time of

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -101,7 +101,7 @@ let
           libPath = filter (pkgs.path + "/lib");
           pkgsLibPath = filter (pkgs.path + "/pkgs/pkgs-lib");
           nixosPath = filter (pkgs.path + "/nixos");
-          NIX_ABORT_ON_WARN = warningsAreErrors;
+          NIXPKGS_ABORT_ON_WARN = warningsAreErrors;
           modules =
             "[ "
             + concatMapStringsSep " " (p: ''"${removePrefix "${modulesPath}/" (toString p)}"'') docModules.lazy

--- a/pkgs/top-level/nixpkgs-basic-release-checks.nix
+++ b/pkgs/top-level/nixpkgs-basic-release-checks.nix
@@ -42,7 +42,7 @@ pkgs.runCommand "nixpkgs-release-checks"
 
         # To get a call trace; see https://nixos.org/manual/nixpkgs/stable/#function-library-lib.trivial.warn
         # Relies on impure eval
-        export NIX_ABORT_ON_WARN=true
+        export NIXPKGS_ABORT_ON_WARN=true
 
         set +e
         (
@@ -79,7 +79,7 @@ pkgs.runCommand "nixpkgs-release-checks"
             exit 1
         fi
 
-        # Catch any trace calls not caught by NIX_ABORT_ON_WARN (lib.warn)
+        # Catch any trace calls not caught by NIXPKGS_ABORT_ON_WARN (lib.warn)
         if [ -s eval-warnings.log ]; then
             echo "Nixpkgs on $platform evaluated with warnings, aborting"
             exit 1


### PR DESCRIPTION
## Description of changes

Renames the `NIX_ABORT_ON_WARN` environment variable to `NIXPKGS_ABORT_ON_WARN`to make it consistent with other environment variables read by nixpkgs to configure its behaviour (e.g. `NIXPKGS_ALLOW_INSECURE` etc.). The previous naming appeared to suggest that the variable is read by Nix itself, which it is not. This is especially a source of confusion when used together with Nix's pure evaluation mode, in which case setting the variable has no effect.

The old `NIX_ABORT_ON_WARN` is still honoured, but produces a deprecation warning. This warning's check is added as a wrapper to the entire lib.trivial attrset, as it should be checked (and, if necessary, printed) regardless of whether or not a use of `lib.warn` is encountered, but whenever the `lib.warn` function is available (i.e. whenever `lib` itself is evaluated), so that users of `NIX_ABORT_ON_WARN` will see it even if their code does not currently produce any warnings. Likewise, this means that the warning does not actually abort evaluation, as otherwise downstream users of `NIX_ABORT_ON_WARN` would be immediately presented with an unrecoverable error.

This deprecation warning and honouring of the older behaviour can then be removed in a future release.

## Downsides

For reasons which remain mysterious to me, the deprecation warning is printed eight times if `nixpkgs` is imported as a flake:

~~~
$ NIX_ABORT_ON_WARN=1 nix build .#hello --impure
trace: warning: NIX_ABORT_ON_WARN has been renamed to NIXPKGS_ABORT_ON_WARN. NIX_ABORT_ON_WARN is still honored, but deprecated and will be removed from nixpkgs after the 24.11 release.
trace: warning: NIX_ABORT_ON_WARN has been renamed to NIXPKGS_ABORT_ON_WARN. NIX_ABORT_ON_WARN is still honored, but deprecated and will be removed from nixpkgs after the 24.11 release.
trace: warning: NIX_ABORT_ON_WARN has been renamed to NIXPKGS_ABORT_ON_WARN. NIX_ABORT_ON_WARN is still honored, but deprecated and will be removed from nixpkgs after the 24.11 release.
trace: warning: NIX_ABORT_ON_WARN has been renamed to NIXPKGS_ABORT_ON_WARN. NIX_ABORT_ON_WARN is still honored, but deprecated and will be removed from nixpkgs after the 24.11 release.
trace: warning: NIX_ABORT_ON_WARN has been renamed to NIXPKGS_ABORT_ON_WARN. NIX_ABORT_ON_WARN is still honored, but deprecated and will be removed from nixpkgs after the 24.11 release.
trace: warning: NIX_ABORT_ON_WARN has been renamed to NIXPKGS_ABORT_ON_WARN. NIX_ABORT_ON_WARN is still honored, but deprecated and will be removed from nixpkgs after the 24.11 release.
trace: warning: NIX_ABORT_ON_WARN has been renamed to NIXPKGS_ABORT_ON_WARN. NIX_ABORT_ON_WARN is still honored, but deprecated and will be removed from nixpkgs after the 24.11 release.
trace: warning: NIX_ABORT_ON_WARN has been renamed to NIXPKGS_ABORT_ON_WARN. NIX_ABORT_ON_WARN is still honored, but deprecated and will be removed from nixpkgs after the 24.11 release.
~~~

but only once if imported in the traditional way:

~~~
$ NIX_ABORT_ON_WARN=1 nix build -f . hello
trace: warning: NIX_ABORT_ON_WARN has been renamed to NIXPKGS_ABORT_ON_WARN. NIX_ABORT_ON_WARN is still honored, but deprecated and will be removed from nixpkgs after the 24.11 release.
~~~

This is only a minor annoyance, but does perhaps (?) point to an unrelated issue with how the nixpkgs flake handles importing `lib`.

## Alternatives

There are a few possible placements for the deprecation warning & its check in the code:
 - inside `lib.warn` itself: seems the most logical place to put it, but it would then only be shown if a warning is actually produced. As (presumably) most users of `NIX_ABORT_ON_WARN` will strive to keep their code free of warnings, this could lead to them never seeing the deprecation message.
 - outside of `lib/`, e.g. in `pkgs/top-level/impure.nix`: i am very hesitant to touch that file, since even slight mistakes would possibly have large consequences. However, it is the only place i could find where, if placed there, the warning is only ever printed once even when using nixpkgs as a flake.

## Question

Should this change be mentioned in the release notes? I was unable to find any clear guidelines on what (if any) changes to `lib` should get an entry there.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
