### PR TITLE
cmake-language-server: 0.1.9 -> 0.1.10

### DIFF
--- a/pkgs/development/tools/misc/cmake-language-server/default.nix
+++ b/pkgs/development/tools/misc/cmake-language-server/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonApplication rec {
   pname = "cmake-language-server";
-  version = "0.1.9";
+  version = "0.1.10";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -21,7 +21,7 @@ buildPythonApplication rec {
     owner = "regen100";
     repo = "cmake-language-server";
     rev = "refs/tags/v${version}";
-    hash = "sha256-8ypl0YA6ep8/jBL3tsutSgCW13NZTZzaNafaOamcT08=";
+    hash = "sha256-9fnyDJm8rUl+7g4FrdMykPpQOcww2M6IPWH/3qVeJX4=";
   };
 
   patches = [

--- a/pkgs/development/tools/misc/cmake-language-server/disable-test-timeouts.patch
+++ b/pkgs/development/tools/misc/cmake-language-server/disable-test-timeouts.patch
@@ -1,8 +1,8 @@
 diff --git a/tests/test_server.py b/tests/test_server.py
-index f349329..d130a2e 100644
+index e6cfe6e..3a3ee6a 100644
 --- a/tests/test_server.py
 +++ b/tests/test_server.py
-@@ -27,7 +27,7 @@ from pygls.server import LanguageServer
+@@ -31,7 +31,7 @@ from pygls.server import LanguageServer
  
  from cmake_language_server.server import CMakeLanguageServer
  
@@ -11,3 +11,12 @@ index f349329..d130a2e 100644
  
  
  def _init(client: LanguageServer, root: Path) -> None:
+@@ -115,7 +115,7 @@ def test_workspace_did_change_configuration(
+     )
+ 
+     start = time.monotonic()
+-    while server._api is old_api and (time.monotonic() - start) < CALL_TIMEOUT:
++    while server._api is old_api:
+         time.sleep(0.1)
+ 
+     assert server._api is not None


### PR DESCRIPTION
## Description of changes

https://github.com/regen100/cmake-language-server/releases/tag/v0.1.10

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
