### PR TITLE
bitcoin: do not build with bdb legacy wallet support

### DIFF
--- a/pkgs/applications/blockchains/bitcoin/default.nix
+++ b/pkgs/applications/blockchains/bitcoin/default.nix
@@ -13,7 +13,6 @@
 , miniupnpc
 , zeromq
 , zlib
-, db48
 , sqlite
 , qrencode
 , qtbase ? null
@@ -51,7 +50,7 @@ stdenv.mkDerivation rec {
     ++ lib.optionals withGui [ wrapQtAppsHook ];
 
   buildInputs = [ boost libevent miniupnpc zeromq zlib ]
-    ++ lib.optionals withWallet [ db48 sqlite ]
+    ++ lib.optionals withWallet [ sqlite ]
     ++ lib.optionals withGui [ qrencode qtbase qttools ];
 
   postInstall = ''


### PR DESCRIPTION
BerkeleyDB support is deprecated and has been for some time.

Let's not build it - it helps with strange issues like https://github.com/NixOS/nixpkgs/issues/305909 for example