### PR TITLE
grafana-alloy: init at 1.0.0

### DIFF
--- a/pkgs/by-name/gr/grafana-alloy/package.nix
+++ b/pkgs/by-name/gr/grafana-alloy/package.nix
@@ -1,0 +1,113 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchYarnDeps
+, buildGoModule
+, systemd
+, yarn
+, fixup-yarn-lock
+, nodejs
+, grafana-alloy
+, nix-update-script
+, nixosTests
+, testers
+}:
+
+buildGoModule rec {
+  pname = "grafana-alloy";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "grafana";
+    repo = "alloy";
+    sha256 = "sha256-G+lLxdUnE07QXt2wBcS6K3DVHIS35aKCh0TZCzpNgBE=";
+  };
+
+  vendorHash = "sha256-Dj3K0ynPPl350tNYClZDHNNan54N1iGfnryH60nO1bg=";
+
+  nativeBuildInputs = [ fixup-yarn-lock yarn nodejs ];
+
+  ldflags =
+    let
+      prefix = "github.com/grafana/alloy/internal/build";
+    in
+    [
+      "-s"
+      "-w"
+      # https://github.com/grafana/alloy/blob/3201389252d2c011bee15ace0c9f4cdbcb978f9f/Makefile#L110
+      "-X ${prefix}.Branch=v${version}"
+      "-X ${prefix}.Version=${version}"
+      "-X ${prefix}.Revision=v${version}"
+      "-X ${prefix}.BuildUser=nix"
+      "-X ${prefix}.BuildDate=1980-01-01T00:00:00Z"
+    ];
+
+  tags = [
+    "nonetwork" # disable network tests
+    "nodocker" # disable docker tests
+    "netgo"
+    "builtinassets"
+    "promtail_journal_enabled"
+  ];
+
+  subPackages = [
+    "."
+  ];
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${src}/internal/web/ui/yarn.lock";
+    sha256 = "sha256-WqbIg18qUNcs9O2wh7DAzwXKb60iEuPL8zFCIgScqI0=";
+  };
+
+  preBuild = ''
+    pushd internal/web/ui
+
+    # Yarn wants a real home directory to write cache, config, etc to
+    export HOME=$NIX_BUILD_TOP/fake_home
+
+    fixup-yarn-lock yarn.lock
+    yarn config --offline set yarn-offline-mirror ${yarnOfflineCache}
+    yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
+
+    patchShebangs node_modules/
+
+    yarn --offline build
+
+    popd
+  '';
+
+  # uses go-systemd, which uses libsystemd headers
+  # https://github.com/coreos/go-systemd/issues/351
+  NIX_CFLAGS_COMPILE = lib.optionals stdenv.isLinux [ "-I${lib.getDev systemd}/include" ];
+
+  # go-systemd uses libsystemd under the hood, which does dlopen(libsystemd) at
+  # runtime.
+  # Add to RUNPATH so it can be found.
+  postFixup = lib.optionalString stdenv.isLinux ''
+    patchelf \
+      --set-rpath "${lib.makeLibraryPath [ (lib.getLib systemd) ]}:$(patchelf --print-rpath $out/bin/alloy)" \
+      $out/bin/alloy
+  '';
+
+  passthru = {
+    tests = {
+      inherit (nixosTests) grafana-alloy;
+      version = testers.testVersion {
+        inherit version;
+        command = "${lib.getExe grafana-alloy} --version";
+        package = grafana-alloy;
+      };
+    };
+    updateScript = nix-update-script { };
+    # alias for nix-update to be able to find and update this attribute
+    offlineCache = yarnOfflineCache;
+  };
+
+  meta = with lib; {
+    description = "Open source OpenTelemetry Collector distribution with built-in Prometheus pipelines and support for metrics, logs, traces, and profiles";
+    license = licenses.asl20;
+    homepage = "https://grafana.com/oss/alloy";
+    maintainers = with maintainers; [ flokli emilylange ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adding (grafana-)alloy, a rewrite of grafana-agent.

- https://github.com/grafana/alloy
- https://grafana.com/oss/alloy

Closes #303418 

@flokli @emilylange I added you as maintainers as you already maintain grafana-agent and signaled interest in maintaining alloy as well. I hope that's ok!

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
