### PR TITLE
gitu: 0.17.1 -> 0.19.1

### DIFF
--- a/pkgs/by-name/gi/gitu/package.nix
+++ b/pkgs/by-name/gi/gitu/package.nix
@@ -12,21 +12,23 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "gitu";
-  version = "0.17.1";
+  version = "0.19.1";
 
   src = fetchFromGitHub {
     owner = "altsem";
     repo = "gitu";
     rev = "v${version}";
-    hash = "sha256-9OY6zBW7UA4lTH+NI61xuil5p2ChQESXrG2zTxdJblE=";
+    hash = "sha256-SQubZazI6ZOQFTAdsfHd/GbdXcCOEX7gvipKduQ5Nr0=";
   };
 
-  cargoHash = "sha256-gVmoKneAtC5dJh5Z+3aXwxCixrPZTRcxQRpoSh4S1e4=";
+  cargoHash = "sha256-RunJw5UIVq/L3cCZIJqe3B4TEhMk3xYkUgvuqyMeJ1g=";
 
   nativeBuildInputs = [
     pkg-config
   ];
 
+  # TODO:
+  #   - unvendor tree-sitter (added in 0.18.0)
   buildInputs = [
     libgit2
     openssl


### PR DESCRIPTION
## Description of changes

Cumulative changelog from 0.17.1:

```md
## [0.19.1] - 2024-04-21

### 🐛 Bug Fixes

- Crash when trying to highlight `.tsx` files

## [0.19.0] - 2024-04-21

### 🚀 Features

- Move to parent section with alt+h
- Move to next/prev sections with alt+j and alt+k
- On MacOS: load `~/.config/gitu/config.toml` instead of `~/Library/Application Support/gitu/config.toml`
- Add Revert commit/abort/continue
- Show revert status

### 🐛 Bug Fixes

- Scala syntax highlighter would not load

## [0.18.4] - 2024-04-20

### 🐛 Bug Fixes

- *(ci)* Release dir would not be created

## [0.18.3] - 2024-04-20

### 🐛 Bug Fixes

- Release to windows

## [0.18.0] - 2024-04-20

### 🚀 Features

- Syntax highlighting with tree-sitter and revamp of diff style config

### 🐛 Bug Fixes

- *(log)* Ignore `prefetch/remotes/` refs
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
