### PR TITLE
nixos-firewall-tool: skip ip6tables when IPv6 is disabled

### DIFF
--- a/pkgs/by-name/ni/nixos-firewall-tool/nixos-firewall-tool.sh
+++ b/pkgs/by-name/ni/nixos-firewall-tool/nixos-firewall-tool.sh
@@ -4,8 +4,10 @@ set -euo pipefail
 
 ip46tables() {
   iptables -w "$@"
-  ip6tables -w "$@"
 
+  if [[ $(< /sys/module/ipv6/parameters/disable) != "1" ]]; then
+    ip6tables -w "$@"
+  fi
 }
 
 show_help() {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

**TLDR:** Updated `nixos-firewall-tool`, so it doesn't fail when it's run on NixOS with disabled IPv6

I faced an issue when I tried to run `nixos-firewall-tool` on my NixOS machine. 

For example this:

```bash
sudo nixos-firewall-tool open tcp 8000
```

Gives the following output:

```
ip6tables v1.8.10 (nf_tables): Chain 'nixos-fw-accept' does not exist
Try `ip6tables -h' or 'ip6tables --help' for more information.
```

My `/etc/nixos/configuration.nix` contains the following lines which disable IPv6:

```nix
networking.enableIPv6 = false;
boot.kernelParams = ["ipv6.disable=1"];
```

I added a simple if statement in `nixos-firewall-tool.sh`, so `ip6tables` is not run for non-IPv6 system. I tested the updated script (with configs with IPv6 disabled and enabled), and it works as intended.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
