### PR TITLE
cppitertools: init at 2.1

### DIFF
--- a/pkgs/by-name/cp/cppitertools/package.nix
+++ b/pkgs/by-name/cp/cppitertools/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  boost,
+  catch2,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cppitertools";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner = "ryanhaining";
+    repo = "cppitertools";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-mii4xjxF1YC3H/TuO/o4cEz8bx2ko6U0eufqNVw5LNA=";
+  };
+
+  __structuredAttrs = true;
+
+  # cppitertools has support files for three buildsystems in its repo:
+  # Scons, Bazel, and CMake. The first two only have definitions for running
+  # tests. The CMake system defines tests and install targets, including a
+  # cppitertools-config.cmake, which is really helpful for downstream consumers
+  # to detect this package since it has no pkg-config.
+  # However the CMake system also specifies the entire source repo as an install
+  # target, including support files, the build directory, etc.
+  # We can't simply take cppitertools-config.cmake for ourselves because before
+  # install it's placed in non-specific private CMake subdirectory of the build
+  # directory.
+  # Therefore, we instead simply patch CMakeLists.txt to make the target that
+  # installs the entire directory non-default, and then install the headers manually.
+
+  strictDeps = true;
+
+  doCheck = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ boost ];
+
+  nativeCheckInputs = [ catch2 ];
+
+  # Required on case-sensitive filesystems to not conflict with the Bazel BUILD
+  # files that are also in that repo.
+  cmakeBuildDir = "cmake-build";
+
+  includeInstallDir = "${builtins.placeholder "out"}/include/cppitertools";
+  cmakeInstallDir = "${builtins.placeholder "out"}/share/cmake";
+
+  # This version of cppitertools considers itself as having used the default value,
+  # and issues warning, unless -Dcppitertools_INSTALL_CMAKE_DIR is present as an
+  # *environment* variable. It doesn't actually use the value from this environment
+  # variable at all though, so we still need to pass it in cmakeFlags.
+  env.cppitertools_INSTALL_CMAKE_DIR = finalAttrs.cmakeInstallDir;
+
+  cmakeFlags = [ "-Dcppitertools_INSTALL_CMAKE_DIR=${finalAttrs.cmakeInstallDir}" ];
+
+  prePatch =
+    ''
+      # Mark the `.` install target as non-default.
+      substituteInPlace CMakeLists.txt \
+        --replace-fail "  DIRECTORY ." "  DIRECTORY . EXCLUDE_FROM_ALL"
+    ''
+    + lib.optionalString finalAttrs.doCheck ''
+      # Required for tests.
+      cp ${lib.getDev catch2}/include/catch2/catch.hpp test/
+    '';
+
+  checkPhase = ''
+    runHook preCheck
+    cmake -B build-test -S ../test
+    cmake --build build-test -j$NIX_BUILD_CORES
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    # Install the -config.cmake files.
+    cmake --install . "--prefix=$out"
+    # Install the headers.
+    mkdir -p "$includeInstallDir"
+    cp -r ../*.hpp ../internal "$includeInstallDir"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Implementation of Python itertools and builtin iteration functions for C++17";
+    longDescription = ''
+      Range-based for loop add-ons inspired by the Python builtins and itertools library
+      for C++17, using lazy evaluation wherever possible.
+    '';
+    homepage = "https://github.com/ryanhaining/cppitertools";
+    maintainers = with lib.maintainers; [ qyriad ];
+    license = with lib.licenses; bsd2;
+  };
+})


### PR DESCRIPTION
## Description of changes

This PR packages [CPPItertools](https://github.com/ryanhaining/cppitertools), a port of Python's `itertools` module a builtin functions like `enumerate()`, to C++17.

I've added myself as a maintainer.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
