### PR TITLE
workflows: add concurrency group to check-by-name workflow

### DIFF
--- a/.github/workflows/check-by-name.yml
+++ b/.github/workflows/check-by-name.yml
@@ -16,6 +16,13 @@ on:
     # so it shouldn't be a problem
     types: [opened, synchronize, reopened, edited]
 
+# Create a check-by-name concurrency group based on the branch name. if a new
+# commit is pushed to the main branch while a previous run is still in progress,
+# the previous run will be cancelled and the new one will start.
+concurrency:
+  group: check-by-name-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   # We need this permission to cancel the workflow run if there's a merge conflict
   actions: write


### PR DESCRIPTION

## Description of changes

Noticed yesterday that multiple runs can happen at the same time.
On event that triggers the workflow for the matching concurrency group, any previous runs of the workflow in the same group will be cancelled.

## Things done

- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
