### PR TITLE
 nixos/vmagent: use dynamic user and cache directory, cleanup

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -319,6 +319,10 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - `services.vikunja.setupNginx` setting has been removed. Users now need to setup the webserver configuration on their own with a proxy pass to the vikunja service.
 
+- `services.vmagent` module deprecates `dataDir`, `group` and `user` setting in favor of systemd provided CacheDirectory and DynamicUser.
+
+- `services.vmagent.remoteWriteUrl` setting has been renamed to `services.vmagent.remoteWrite.url` and now defaults to `null`.
+
 - `woodpecker-*` packages have been updated to v2 which includes [breaking changes](https://woodpecker-ci.org/docs/next/migrations#200).
 
 - `services.nginx` will no longer advertise HTTP/3 availability automatically. This must now be manually added, preferably to each location block.

--- a/nixos/modules/services/monitoring/vmagent.nix
+++ b/nixos/modules/services/monitoring/vmagent.nix
@@ -4,41 +4,40 @@ let
   cfg = config.services.vmagent;
   settingsFormat = pkgs.formats.json { };
 in {
+  imports = [
+    (lib.mkRemovedOptionModule [ "services" "vmagent" "dataDir" ] "dataDir has been deprecated in favor of systemd provided CacheDirectory")
+    (lib.mkRemovedOptionModule [ "services" "vmagent" "user" ] "user has been deprecated in favor of systemd DynamicUser")
+    (lib.mkRemovedOptionModule [ "services" "vmagent" "group" ] "group has been deprecated in favor of systemd DynamicUser")
+    (lib.mkRenamedOptionModule [ "services" "vmagent" "remoteWriteUrl" ] [ "services" "vmagent" "remoteWrite" "url" ])
+  ];
+
   options.services.vmagent = {
     enable = lib.mkEnableOption "vmagent";
 
-    user = lib.mkOption {
-      default = "vmagent";
-      type = lib.types.str;
-      description = ''
-        User account under which vmagent runs.
-      '';
-    };
-
-    group = lib.mkOption {
-      type = lib.types.str;
-      default = "vmagent";
-      description = ''
-        Group under which vmagent runs.
-      '';
-    };
-
     package = lib.mkPackageOption pkgs "vmagent" { };
 
-    dataDir = lib.mkOption {
-      type = lib.types.str;
-      default = "/var/lib/vmagent";
-      description = ''
-        The directory where vmagent stores its data files.
-      '';
-    };
-
-    remoteWriteUrl = lib.mkOption {
-      default = "http://localhost:8428/api/v1/write";
-      type = lib.types.str;
-      description = ''
-        The storage endpoint such as VictoriaMetrics
-      '';
+    remoteWrite = {
+      url = lib.mkOption {
+        default = null;
+        type = lib.types.nullOr lib.types.str;
+        description = ''
+          Endpoint for prometheus compatible remote_write
+        '';
+      };
+      basicAuthUsername = lib.mkOption {
+        default = null;
+        type = lib.types.nullOr lib.types.str;
+        description = ''
+          Basic Auth username used to connect to remote_write endpoint
+        '';
+      };
+      basicAuthPasswordFile = lib.mkOption {
+        default = null;
+        type = lib.types.nullOr lib.types.str;
+        description = ''
+          File that contains the Basic Auth password used to connect to remote_write endpoint
+        '';
+      };
     };
 
     prometheusConfig = lib.mkOption {
@@ -68,36 +67,35 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    users.groups = lib.mkIf (cfg.group == "vmagent") { vmagent = { }; };
-
-    users.users = lib.mkIf (cfg.user == "vmagent") {
-      vmagent = {
-        group = cfg.group;
-        description = "vmagent daemon user";
-        home = cfg.dataDir;
-        isSystemUser = true;
-      };
-    };
-
     networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ 8429 ];
 
     systemd.services.vmagent = let
       prometheusConfig = settingsFormat.generate "prometheusConfig.yaml" cfg.prometheusConfig;
+      startCommandLine = lib.concatStringsSep " " ([
+        "${cfg.package}/bin/vmagent"
+        "-promscrape.config=${prometheusConfig}"
+      ] ++ cfg.extraArgs
+        ++ lib.optionals (cfg.remoteWrite.url != null) [
+        "-remoteWrite.url=${cfg.remoteWrite.url}"
+        "-remoteWrite.tmpDataPath=%C/vmagent/remote_write_tmp"
+      ] ++ lib.optional (cfg.remoteWrite.basicAuthUsername != null) "-remoteWrite.basicAuth.username=${cfg.remoteWrite.basicAuthUsername}"
+        ++ lib.optional (cfg.remoteWrite.basicAuthPasswordFile != null) "-remoteWrite.basicAuth.passwordFile=\${CREDENTIALS_DIRECTORY}/remote_write_basic_auth_password");
     in {
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       description = "vmagent system service";
       serviceConfig = {
-        User = cfg.user;
-        Group = cfg.group;
+        DynamicUser = true;
+        User = "vmagent";
+        Group = "vmagent";
         Type = "simple";
         Restart = "on-failure";
-        WorkingDirectory = cfg.dataDir;
-        ExecStart = "${cfg.package}/bin/vmagent -remoteWrite.url=${cfg.remoteWriteUrl} -promscrape.config=${prometheusConfig} ${lib.escapeShellArgs cfg.extraArgs}";
+        CacheDirectory = "vmagent";
+        ExecStart = startCommandLine;
+        LoadCredential = lib.optional (cfg.remoteWrite.basicAuthPasswordFile != null) [
+          "remote_write_basic_auth_password:${cfg.remoteWrite.basicAuthPasswordFile}"
+        ];
       };
     };
-
-    systemd.tmpfiles.rules =
-      [ "d '${cfg.dataDir}' 0755 ${cfg.user} ${cfg.group} -" ];
   };
 }

--- a/nixos/modules/services/monitoring/vmagent.nix
+++ b/nixos/modules/services/monitoring/vmagent.nix
@@ -1,63 +1,63 @@
 { config, pkgs, lib, ... }:
-with lib;
+
 let
   cfg = config.services.vmagent;
   settingsFormat = pkgs.formats.json { };
 in {
   options.services.vmagent = {
-    enable = mkEnableOption "vmagent";
+    enable = lib.mkEnableOption "vmagent";
 
-    user = mkOption {
+    user = lib.mkOption {
       default = "vmagent";
-      type = types.str;
+      type = lib.types.str;
       description = ''
         User account under which vmagent runs.
       '';
     };
 
-    group = mkOption {
-      type = types.str;
+    group = lib.mkOption {
+      type = lib.types.str;
       default = "vmagent";
       description = ''
         Group under which vmagent runs.
       '';
     };
 
-    package = mkPackageOption pkgs "vmagent" { };
+    package = lib.mkPackageOption pkgs "vmagent" { };
 
-    dataDir = mkOption {
-      type = types.str;
+    dataDir = lib.mkOption {
+      type = lib.types.str;
       default = "/var/lib/vmagent";
       description = ''
         The directory where vmagent stores its data files.
       '';
     };
 
-    remoteWriteUrl = mkOption {
+    remoteWriteUrl = lib.mkOption {
       default = "http://localhost:8428/api/v1/write";
-      type = types.str;
+      type = lib.types.str;
       description = ''
         The storage endpoint such as VictoriaMetrics
       '';
     };
 
-    prometheusConfig = mkOption {
+    prometheusConfig = lib.mkOption {
       type = lib.types.submodule { freeformType = settingsFormat.type; };
       description = ''
         Config for prometheus style metrics
       '';
     };
 
-    openFirewall = mkOption {
-      type = types.bool;
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Whether to open the firewall for the default ports.
       '';
     };
 
-    extraArgs = mkOption {
-      type = types.listOf types.str;
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
       default = [];
       description = ''
         Extra args to pass to `vmagent`. See the docs:
@@ -67,10 +67,10 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
-    users.groups = mkIf (cfg.group == "vmagent") { vmagent = { }; };
+  config = lib.mkIf cfg.enable {
+    users.groups = lib.mkIf (cfg.group == "vmagent") { vmagent = { }; };
 
-    users.users = mkIf (cfg.user == "vmagent") {
+    users.users = lib.mkIf (cfg.user == "vmagent") {
       vmagent = {
         group = cfg.group;
         description = "vmagent daemon user";
@@ -79,7 +79,7 @@ in {
       };
     };
 
-    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ 8429 ];
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ 8429 ];
 
     systemd.services.vmagent = let
       prometheusConfig = settingsFormat.generate "prometheusConfig.yaml" cfg.prometheusConfig;
@@ -93,7 +93,7 @@ in {
         Type = "simple";
         Restart = "on-failure";
         WorkingDirectory = cfg.dataDir;
-        ExecStart = "${cfg.package}/bin/vmagent -remoteWrite.url=${cfg.remoteWriteUrl} -promscrape.config=${prometheusConfig} ${escapeShellArgs cfg.extraArgs}";
+        ExecStart = "${cfg.package}/bin/vmagent -remoteWrite.url=${cfg.remoteWriteUrl} -promscrape.config=${prometheusConfig} ${lib.escapeShellArgs cfg.extraArgs}";
       };
     };
 

--- a/pkgs/servers/monitoring/vmagent/default.nix
+++ b/pkgs/servers/monitoring/vmagent/default.nix
@@ -22,6 +22,6 @@ buildGoModule rec {
     mainProgram = "vmagent";
     license = licenses.asl20;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ nullx76 ];
+    maintainers = with maintainers; [ nullx76 leona ];
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The vmagent module currently uses a full user instead of dynamic user, which is unnecessary.
Also currently it's not possible to use the module when not using `remote_write`. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
