### PR TITLE
termsonic: init at 0-unstable-2024-02-02

### DIFF
--- a/pkgs/by-name/te/termsonic/package.nix
+++ b/pkgs/by-name/te/termsonic/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildGoModule,
+  fetchzip,
+  pkg-config,
+  alsa-lib
+}:
+buildGoModule rec {
+  name = "termsonic";
+  version = "0-unstable-2024-02-02";
+
+  src = fetchzip {
+    url = "https://git.sixfoisneuf.fr/termsonic/snapshot/termsonic-7a3aabee59e1a427aff755fc69759265ad9d0adc.zip";
+    hash = "sha256-C5/4679qw4CAdUt9lXpPIR3yejrPdddvmjgbpLF3SvA=";
+  };
+
+  vendorHash = "sha256-wCtQD9f1mbN/0qUZnamPoVn9p4Ra5dQ34vlT+XjPF3k=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ alsa-lib ];
+
+  strictDeps = true;
+
+  meta = with lib; {
+    homepage = "https://git.sixfoisneuf.fr/termsonic";
+    description = "A Subsonic client running in your terminal";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    mainProgram = "termsonic";
+    maintainers = with maintainers; [ mksafavi ];
+  };
+}


### PR DESCRIPTION
## Description of changes
A Subsonic Tui client that's compatible with navidrome.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
