### PR TITLE
githooks: init at 3.0.1

### DIFF
--- a/pkgs/by-name/gi/githooks/package.nix
+++ b/pkgs/by-name/gi/githooks/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  git,
+  testers,
+  makeWrapper,
+}:
+buildGoModule rec {
+  pname = "githooks";
+  version = "3.0.1";
+
+  src = fetchFromGitHub {
+    owner = "gabyx";
+    repo = "githooks";
+    rev = "v${version}";
+    hash = "sha256-qv0nl3EEYVo/s79r+yK3ZQCGPXM2bzGdWatPY24aOZg=";
+  };
+
+  modRoot = "./githooks";
+  vendorHash = "sha256-ZcDD4Z/thtyCvXg6GzzKC/FSbh700QEaqXU8FaZaZc4=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ git ];
+
+  strictDeps = true;
+
+  ldflags = [
+    "-s" # Disable symbole table.
+    "-w" # Disable DWARF generation.
+  ];
+
+  # We need to disable updates and other features:
+  # That is done with tag `package_manager_enabled`.
+  tags = [ "package_manager_enabled" ];
+
+  checkFlags =
+    let
+      skippedTests = [
+        "TestGithooksCompliesWithGit" # Needs internet to download all hooks documentation.
+        "TestUpdateImages" # Needs docker/podman.
+      ];
+    in
+    [
+      "-v"
+      "-skip"
+      "(${builtins.concatStringsSep "|" skippedTests})"
+    ];
+
+  doCheck = true;
+
+  # We need to generate some build files before building.
+  postConfigure = ''
+    GH_BUILD_VERSION="${version}" \
+      GH_BUILD_TAG="v${version}" \
+      go generate -mod=vendor ./...
+  '';
+
+  postInstall = ''
+    # Rename executable to proper names.
+    mv $out/bin/cli $out/bin/githooks-cli
+    mv $out/bin/runner $out/bin/githooks-runner
+    mv $out/bin/dialog $out/bin/githooks-dialog
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/githooks-cli" --prefix PATH : ${lib.makeBinPath [ git ]}
+    wrapProgram "$out/bin/githooks-runner" --prefix PATH : ${lib.makeBinPath [ git ]}
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = "githooks-cli";
+    command = "githooks-cli --version";
+    inherit version;
+  };
+
+  meta = with lib; {
+    description = "A Git hooks manager with per-repo and shared Git hooks including version control";
+    homepage = "https://github.com/gabyx/Githooks";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ gabyx ];
+    mainProgram = "githooks-cli";
+  };
+}


### PR DESCRIPTION
## Description of changes

This adds [Githooks](https://github.com/gabyx/Githooks) at version 3.0.1 which is a platform-independent Git hooks manager.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
