### PR TITLE
swhkd: add package and module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1301,6 +1301,7 @@
   ./services/video/unifi-video.nix
   ./services/video/v4l2-relayd.nix
   ./services/wayland/cage.nix
+  ./services/wayland/swhkd.nix
   ./services/web-apps/akkoma.nix
   ./services/web-apps/alps.nix
   ./services/web-apps/anuko-time-tracker.nix

--- a/nixos/modules/services/wayland/swhkd.nix
+++ b/nixos/modules/services/wayland/swhkd.nix
@@ -5,23 +5,17 @@ let
   cfg = config.services.swhkd;
 in {
   options.services.swhkd = {
-    enable = mkEnableOption (lib.mdDoc "simple wayland hotkey daemon");
+    enable = mkEnableOption "simple wayland hotkey daemon";
     package = mkPackageOption pkgs "swhkd" {};
-    installManpages = mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = "install swhkd manual pages";
-    };
     swhkdrc = mkOption {
-      type = lib.types.str;
+      type = lib.types.lines;
       default = "";
-      description = "contents of the system-wide swhkdrc file";
+      description = "contents of the system-wide swhkdrc file. See {manpage}`swhkd(5) for more details on the config format.";
     };
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages =
-      [ cfg.package.bin cfg.package.out ] ++ optional cfg.installManpages cfg.package.man;
+    environment.systemPackages = [ cfg.package ];
     environment.etc."swhkd/swhkdrc".text = cfg.swhkdrc;
     security.polkit.enable = true;
   };

--- a/nixos/modules/services/wayland/swhkd.nix
+++ b/nixos/modules/services/wayland/swhkd.nix
@@ -15,7 +15,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages = [ cfg.package ] ++ [ cfg.package.out ];
     environment.etc."swhkd/swhkdrc".text = cfg.swhkdrc;
     security.polkit.enable = true;
   };

--- a/nixos/modules/services/wayland/swhkd.nix
+++ b/nixos/modules/services/wayland/swhkd.nix
@@ -1,0 +1,28 @@
+{ config, pkgs, lib, ... }:
+
+let
+  inherit (lib) mkIf mkOption mkEnableOption mkPackageOption optional;
+  cfg = config.services.swhkd;
+in {
+  options.services.swhkd = {
+    enable = mkEnableOption (lib.mdDoc "simple wayland hotkey daemon");
+    package = mkPackageOption pkgs "swhkd" {};
+    installManpages = mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "install swhkd manual pages";
+    };
+    swhkdrc = mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "contents of the system-wide swhkdrc file";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages =
+      [ cfg.package.bin cfg.package.out ] ++ optional cfg.installManpages cfg.package.man;
+    environment.etc."swhkd/swhkdrc".text = cfg.swhkdrc;
+    security.polkit.enable = true;
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -856,6 +856,7 @@ in {
   swap-partition = handleTest ./swap-partition.nix {};
   swap-random-encryption = handleTest ./swap-random-encryption.nix {};
   sway = handleTest ./sway.nix {};
+  swhkd = runTest ./swhkd.nix;
   switchTest = handleTest ./switch-test.nix {};
   sympa = handleTest ./sympa.nix {};
   syncthing = handleTest ./syncthing.nix {};

--- a/nixos/tests/swhkd.nix
+++ b/nixos/tests/swhkd.nix
@@ -1,0 +1,30 @@
+{ config, lib, ... }:
+{
+  name = "swhkd";
+  skipTypeCheck = true;
+  skipLint = true;
+  nodes.machine = { config, pkgs, ... }: {
+    services.getty.autologinUser = "root";
+    services.swhkd.enable = true;
+    services.swhkd.swhkdrc = ''
+escape
+  touch /tmp/escape-pressed
+'';
+    programs.bash.loginShellInit = ''
+echo login script run as $USER
+swhks &
+pkexec swhkd &
+'';
+  };
+
+  testScript = ''
+    import time
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_until_succeeds("pgrep swhkd", timeout=12)
+    time.sleep(4)
+    machine.send_key("esc")
+    machine.wait_for_file("/tmp/escape-pressed")
+    machine.shutdown()
+  '';
+}

--- a/pkgs/by-name/sw/swhkd/package.nix
+++ b/pkgs/by-name/sw/swhkd/package.nix
@@ -1,0 +1,68 @@
+{ lib
+, rustPlatform
+, fetchurl
+, fetchFromGitHub
+, pkg-config
+, scdoc
+, libgcc
+, systemd
+}:
+rustPlatform.buildRustPackage rec {
+    pname = "swhkd";
+    version = "1.2.1-unstable-2024-04-06";
+
+    # split-output derivation, since there's a fair amount of associated data for
+    # pkexec and such.
+    outputs = [ "bin" "man" "out" ];
+
+    src = fetchFromGitHub {
+        owner = "waycrate";
+        repo = "swhkd";
+        # build from master, since the 1.2.1 makefile is unsutible for packaging
+        rev = "f8519a54900d72492a6c036b32e472c108d44dbf";
+        hash = "sha256-zyGyZOG8gAtsRkzSRH1M777fPv1wudbVsBrSTJ5CBnY=";
+      };
+
+    nativeBuildInputs = [
+      scdoc
+      pkg-config
+    ];
+
+    # the makefile tries to set the ownership of a file to root.
+    # this will fail, but files are owned by root anyways.
+    postPatch = "sed -ie 's/-o root//' Makefile";
+
+    buildPhase = ''
+      runHook preBuild
+      make build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out $bin $man/share
+      make DESTDIR=$out MAN1_DIR=/share/man/man1 MAN5_DIR=/share/man/man5 TARGET_DIR=/bin install
+      mv $out/bin $bin/bin
+      mv $out/share/man $man/share/man
+      mv $out/usr/share/polkit-1 $out/share/polkit-1
+      rm -r $out/etc $out/usr
+
+      runHook postInstall
+    '';
+
+    cargoHash = "sha256-d/61hdyooYuqfOSTUcxVUJVhG98uexgPk7h6N1ptIgQ=";
+
+    buildInputs = [
+      systemd
+      libgcc
+    ];
+
+    meta = with lib; {
+        description = "A drop-in replacement for sxhkd that works with wayland";
+        homepage = "https://github.com/waycrate/swhkd";
+        changelog = "https://github.com/waycrate/swhkd/blob/${src.rev}/CHANGELOG.md";
+        license = licenses.bsd2;
+        maintainers = with maintainers; [ binarycat ];
+      };
+  }

--- a/pkgs/by-name/sw/swhkd/package.nix
+++ b/pkgs/by-name/sw/swhkd/package.nix
@@ -16,12 +16,12 @@ rustPlatform.buildRustPackage rec {
     outputs = [ "bin" "man" "out" ];
 
     src = fetchFromGitHub {
-        owner = "waycrate";
-        repo = "swhkd";
-        # build from master, since the 1.2.1 makefile is unsutible for packaging
-        rev = "f8519a54900d72492a6c036b32e472c108d44dbf";
-        hash = "sha256-zyGyZOG8gAtsRkzSRH1M777fPv1wudbVsBrSTJ5CBnY=";
-      };
+      owner = "waycrate";
+      repo = "swhkd";
+      # build from master, since the 1.2.1 makefile is unsutible for packaging
+      rev = "f8519a54900d72492a6c036b32e472c108d44dbf";
+      hash = "sha256-zyGyZOG8gAtsRkzSRH1M777fPv1wudbVsBrSTJ5CBnY=";
+    };
 
     nativeBuildInputs = [
       scdoc
@@ -30,7 +30,9 @@ rustPlatform.buildRustPackage rec {
 
     # the makefile tries to set the ownership of a file to root.
     # this will fail, but files are owned by root anyways.
-    postPatch = "sed -ie 's/-o root//' Makefile";
+    postPatch = ''
+      sed -ie 's/-o root//' Makefile
+    '';
 
     buildPhase = ''
       runHook preBuild
@@ -59,10 +61,10 @@ rustPlatform.buildRustPackage rec {
     ];
 
     meta = with lib; {
-        description = "A drop-in replacement for sxhkd that works with wayland";
-        homepage = "https://github.com/waycrate/swhkd";
-        changelog = "https://github.com/waycrate/swhkd/blob/${src.rev}/CHANGELOG.md";
-        license = licenses.bsd2;
-        maintainers = with maintainers; [ binarycat ];
-      };
+      description = "A drop-in replacement for sxhkd that works with wayland";
+      homepage = "https://github.com/waycrate/swhkd";
+      changelog = "https://github.com/waycrate/swhkd/blob/${src.rev}/CHANGELOG.md";
+      license = licenses.bsd2;
+      maintainers = with maintainers; [ binarycat ];
+    };
   }


### PR DESCRIPTION
## Description of changes
yet another attempt at adding swhkd to nixpkgs, since all the previous attempts seem to have stagnated.

additionally, there's a few things this PR has over the others i've seen:
1. properly install manpages and polkit policy
2. split-output derivation 
3. nixos module

currently the nixos module doesn't do much besides writing to swhkdrc (although that is quite important, as swhkd will fail to start if the global config file doesn't exist).  users will have to manually launch swhkd via pkexec, or put something in their shell login script.  if someone who understands the nixos security model can tell me the right way to autostart it, that would be appreciated.

the package is built from the main branch, as the Makefile for the latest stable release is not good enough for nix.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
