### PR TITLE
emacsPackages.acm-terminal: 20230601.1326 -> 20231206.1141

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/acm-terminal/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/acm-terminal/default.nix
@@ -4,21 +4,21 @@
 , acm
 , popon
 , writeText
-, unstableGitUpdater
+, writeScript
 }:
 
 let
-  rev = "0dbbd7f401da1bedd1a9146df6127233d601435b";
+  rev = "1851d8fa2a27d3fd8deeeb29cd21c3002b8351ba";
 in
 melpaBuild {
   pname = "acm-terminal";
-  version = "20230601.1326"; # 13:26 UTC
+  version = "20231206.1141";
 
   src = fetchFromGitHub {
     owner = "twlz0ne";
     repo = "acm-terminal";
     inherit rev;
-    sha256 = "sha256-Opouy9A6z0YUT1zxZq1yHx+r/hwNE93JDwfa1fMWNgc=";
+    sha256 = "sha256-EYhFrOo0j0JSNTdcZCbyM0iLxaymUXi1u6jZy8lTOaY=";
   };
 
   commit = rev;
@@ -32,7 +32,19 @@ melpaBuild {
     (acm-terminal :repo "twlz0ne/acm-terminal" :fetcher github)
   '';
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = writeScript "update.sh" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p common-updater-scripts coreutils git gnused
+    set -eu -o pipefail
+    tmpdir="$(mktemp -d)"
+    git clone --depth=1 https://github.com/twlz0ne/acm-terminal.git "$tmpdir"
+    pushd "$tmpdir"
+    commit=$(git show -s --pretty='format:%H')
+    # Based on: https://github.com/melpa/melpa/blob/2d8716906a0c9e18d6c979d8450bf1d15dd785eb/package-build/package-build.el#L523-L533
+    version=$(TZ=UTC git show -s --pretty='format:%cd' --date='format-local:%Y%m%d.%H%M' | sed 's|\.0*|.|')
+    popd
+    update-source-version emacsPackages.acm-terminal $version --rev="$commit"
+  '';
 
   meta = with lib; {
     description = "Patch for LSP bridge acm on Terminal";


### PR DESCRIPTION
## Description of changes

Update to the latest commit

Also modifies the updater to use a version compatible with `package-build.el`, like what was done for lsp-bridge in #305882.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
