### PR TITLE
world-wall-clock: init at 0.1.4

### DIFF
--- a/pkgs/by-name/wo/world-wall-clock/package.nix
+++ b/pkgs/by-name/wo/world-wall-clock/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "world-wall-clock";
+  version = "0.1.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ddelabru";
+    repo = "world-wall-clock";
+    tag = "v${version}";
+    hash = "sha256-OTBYSStCFBrZ8JutrhyyJpi7vRvBAUK0EKTtjvbi13I=";
+  };
+
+  build-system = with python3.pkgs; [ poetry-core ];
+
+  dependencies = with python3.pkgs; [
+    tzdata
+    urwid
+    xdg-base-dirs
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [ pytestCheckHook ];
+
+  pytestFlagsArray = [ "tests/*" ];
+
+  meta = {
+    description = "TUI application that provides a multi-timezone graphical clock in a terminal environment.";
+    homepage = "https://github.com/ddelabru/world-wall-clock";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ ddelabru ];
+    mainProgram = "wwclock";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

[world-wall-clock](https://github.com/ddelabru/world-wall-clock) is an urwid-based TUI application that provides a multi-timezone graphical clock in a terminal environment.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I have pytest running unit tests during the build, and the output at `./result/bin/wwclock` runs as expected.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
