### PR TITLE
ocamlPackages.phylogenetics: unstable-2022-05-06 → 0.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/binning/default.nix
+++ b/pkgs/development/ocaml-modules/binning/default.nix
@@ -1,0 +1,23 @@
+{ lib
+, buildDunePackage
+, fetchurl
+}:
+
+buildDunePackage rec {
+  pname = "binning";
+  version = "0.0.0";
+
+  minimalOCamlVersion = "4.08";
+
+  src = fetchurl {
+    url = "https://github.com/pveber/binning/releases/download/v${version}/binning-v${version}.tbz";
+    hash = "sha256-eG+xctsbc7lQ5pFOUtJ8rjNW/06gygwLADq7yc8Yf/c=";
+  };
+
+  meta = {
+    description = "A datastructure to accumulate values in bins";
+    license = lib.licenses.cecill-b;
+    homepage = "https://github.com/pveber/binning/";
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/biotk/default.nix
+++ b/pkgs/development/ocaml-modules/biotk/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, angstrom-unix
+, binning
+, ocaml-crunch
+, camlzip
+, core_kernel
+, core_unix
+, csvfields
+, fmt
+, gsl
+, ppx_csv_conv
+, ppx_deriving
+, rresult
+, tyxml
+, uri
+, vg
+}:
+
+buildDunePackage rec {
+  pname = "biotk";
+  version = "0.2.0";
+
+  minimalOCamlVersion = "4.13";
+
+  src = fetchurl {
+    url = "https://github.com/pveber/biotk/releases/download/v${version}/biotk-${version}.tbz";
+    hash = "sha256-FQvbVj5MmraSN6AmOckKgJ/LB14E/pCsPvPvNppcv7A=";
+  };
+
+  nativeBuildInputs = [ ocaml-crunch ];
+
+  buildInputs = [ ppx_csv_conv ];
+
+  propagatedBuildInputs = [
+    angstrom-unix
+    binning
+    camlzip
+    core_kernel
+    core_unix
+    csvfields
+    fmt
+    gsl
+    ppx_deriving
+    rresult
+    tyxml
+    uri
+    vg
+  ];
+
+  meta = {
+    description = "Toolkit for bioinformatics in OCaml";
+    license = lib.licenses.cecill-c;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -582,6 +582,13 @@ with self;
     propagatedBuildInputs = [ ppxlib base ];
   };
 
+  ppx_conv_func = janePackage {
+    pname = "ppx_conv_func";
+    hash = "sha256-61jX8yHZYOnMx1Jlqaq9zSOz25HLOa0Wv/iG6Hu82zI=";
+    meta.description = "Part of the Jane Street's PPX rewriters collection";
+    propagatedBuildInputs = [ ppxlib base ];
+  };
+
   ppx_custom_printf = janePackage {
     pname = "ppx_custom_printf";
     hash = "1k8nmq6kwqz2wpkm9ymq749dz1vd8lxrjc711knp1wyz5935hnsv";
@@ -595,6 +602,13 @@ with self;
     hash = "09dpmj3f3m3z1ji9hq775iqr3cfmv5gh7q9zlblizj4wx4y0ibyi";
     meta.description = "A ppx that takes in css strings and produces a module for accessing the unique names defined within";
     propagatedBuildInputs = [ core_kernel ppxlib js_of_ocaml js_of_ocaml-ppx sedlex ];
+  };
+
+  ppx_csv_conv = janePackage {
+    pname = "ppx_csv_conv";
+    hash = "sha256-ctwgUs1buBZiNqac4760LhWd2/PMZRuxx8SE5T7yZ+g=";
+    meta.description = "Generate functions to read/write records in csv format";
+    propagatedBuildInputs = [ csvfields ppx_conv_func ];
   };
 
   ppx_disable_unused_warnings = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/0.16.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.16.nix
@@ -698,6 +698,13 @@ with self;
     propagatedBuildInputs = [ ppxlib base ];
   };
 
+  ppx_conv_func = janePackage {
+    pname = "ppx_conv_func";
+    hash = "sha256-HPHSZHdR9ll+7EbWc36shTdRPFYB0lkApidk+XL3clI=";
+    meta.description = "Part of the Jane Street's PPX rewriters collection";
+    propagatedBuildInputs = [ ppxlib base ];
+  };
+
   ppx_custom_printf = janePackage {
     pname = "ppx_custom_printf";
     hash = "sha256-V30ijRgcma/rwysPxNAFnuJIb7XFrfi7mfjJxN+rSak=";
@@ -710,6 +717,13 @@ with self;
     hash = "sha256-spT/dJW8YJtG4pOku9r6VVlBAMwGakTrr1euiABeqsU=";
     meta.description = "A ppx that takes in css strings and produces a module for accessing the unique names defined within";
     propagatedBuildInputs = [ async async_unix core_kernel core_unix ppxlib js_of_ocaml js_of_ocaml-ppx sedlex virtual_dom ];
+  };
+
+  ppx_csv_conv = janePackage {
+    pname = "ppx_csv_conv";
+    hash = "sha256-RdPcDPLzoSf45Zeon3f4HcEvlwB6Q6sAINX3LHmjmj8=";
+    meta.description = "Generate functions to read/write records in csv format";
+    propagatedBuildInputs = [ csvfields ppx_conv_func ];
   };
 
   ppx_demo = janePackage {

--- a/pkgs/development/ocaml-modules/phylogenetics/default.nix
+++ b/pkgs/development/ocaml-modules/phylogenetics/default.nix
@@ -1,32 +1,27 @@
 { lib
-, ocaml
 , buildDunePackage
-, fetchFromGitHub
+, fetchurl
 , ppx_deriving
 , bppsuite
 , alcotest
 , angstrom-unix
-, biocaml
+, biotk
 , core
 , gsl
 , lacaml
 , menhir
 , menhirLib
 , printbox-text
+, yojson
 }:
-
-lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
-  "phylogenetics is not compatible with OCaml ${ocaml.version}"
 
 buildDunePackage rec {
   pname = "phylogenetics";
-  version = "unstable-2022-05-06";
+  version = "0.2.0";
 
-  src = fetchFromGitHub {
-    owner = "biocaml";
-    repo = pname;
-    rev = "cd7c624d0f98e31b02933ca4511b9809b26d35b5";
-    sha256 = "sha256:0w0xyah3hj05hxg1rsa40hhma3dm1cyq0zvnjrihhf22laxap7ga";
+  src = fetchurl {
+    url = "https://github.com/biocaml/phylogenetics/releases/download/v${version}/phylogenetics-${version}.tbz";
+    hash = "sha256-JFpYp3pyW7PrBjqCwwDZxkJPA84dp6Qs8rOPvHPY92o=";
   };
 
   minimalOCamlVersion = "4.08";
@@ -36,13 +31,14 @@ buildDunePackage rec {
   nativeBuildInputs = [ menhir ];
   propagatedBuildInputs = [
     angstrom-unix
-    biocaml
+    biotk
     core
     gsl
     lacaml
     menhirLib
     ppx_deriving
     printbox-text
+    yojson
   ];
 
   checkPhase = ''

--- a/pkgs/development/ocaml-modules/streaming/default.nix
+++ b/pkgs/development/ocaml-modules/streaming/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, stdlib-shims
+}:
+
+buildDunePackage rec {
+  pname = "streaming";
+  version = "0.8.0";
+
+  minimalOCamlVersion = "4.08";
+
+  src = fetchurl {
+    url = "https://github.com/odis-labs/streaming/releases/download/${version}/streaming-${version}.tbz";
+    hash = "sha256-W+3GYZpsLj1SnQhuSmjXdi/85fMajWpz4b7x5W0bnJs=";
+  };
+
+  propagatedBuildInputs = [ stdlib-shims ];
+
+  meta = {
+    homepage = "https://odis-labs.github.io/streaming";
+    license = lib.licenses.isc;
+    description = "Fast, safe and composable streaming abstractions";
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1715,6 +1715,8 @@ let
     stog_asy = callPackage ../applications/misc/stog/asy.nix { };
     stog_markdown = callPackage ../applications/misc/stog/markdown.nix { };
 
+    streaming = callPackage ../development/ocaml-modules/streaming { };
+
     stringext = callPackage ../development/ocaml-modules/stringext { };
 
     syslog = callPackage ../development/ocaml-modules/syslog { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -835,7 +835,6 @@ let
       phylogenetics = let
         angstrom = self.angstrom.override { inherit ppx_let; };
       in callPackage ../development/ocaml-modules/phylogenetics {
-        inherit biocaml;
         ppx_deriving = self.ppx_deriving.override { inherit (jsDeps) ppxlib; };
         angstrom-unix = self.angstrom-unix.override { inherit angstrom; };
       };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -88,6 +88,8 @@ let
 
     biniou = callPackage ../development/ocaml-modules/biniou { };
 
+    binning = callPackage ../development/ocaml-modules/binning { };
+
     biocaml = janeStreet_0_15.biocaml;
 
     bisect_ppx = callPackage ../development/ocaml-modules/bisect_ppx { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -92,6 +92,8 @@ let
 
     biocaml = janeStreet_0_15.biocaml;
 
+    biotk = janeStreet_0_15.biotk;
+
     bisect_ppx = callPackage ../development/ocaml-modules/bisect_ppx { };
 
     bistro = callPackage ../development/ocaml-modules/bistro { };
@@ -819,6 +821,15 @@ let
       in callPackage ../development/ocaml-modules/biocaml {
         uri = self.uri.override { inherit angstrom; };
         cfstream = self.cfstream.override { inherit core_kernel; };
+      };
+
+      biotk = let
+        angstrom = self.angstrom.override { inherit ppx_let; };
+      in callPackage ../development/ocaml-modules/biotk {
+        angstrom-unix = self.angstrom-unix.override { inherit angstrom; };
+        ppx_deriving = self.ppx_deriving.override { inherit (jsDeps) ppxlib; };
+        uri = self.uri.override { inherit angstrom; };
+        vg = self.vg.override { htmlcBackend = false; };
       };
 
       phylogenetics = let


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/biocaml/phylogenetics/v0.2.0/Changes

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
