### PR TITLE
mcontrolcenter: init at 0.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20484,6 +20484,12 @@
     email = "tomaszierl@outlook.com";
     name = "Tomkoid";
   };
+  Tommimon = {
+    name = "Tommaso Montanari";
+    email = "sefymw7q8@mozmail.com";
+    github = "Tommimon";
+    githubId = 37435103;
+  };
   tomodachi94 = {
     email = "tomodachi94+nixpkgs@protonmail.com";
     matrix = "@tomodachi94:matrix.org";

--- a/pkgs/by-name/mc/mcontrolcenter/package.nix
+++ b/pkgs/by-name/mc/mcontrolcenter/package.nix
@@ -1,0 +1,62 @@
+{ lib, stdenv, libsForQt5, makeDesktopItem, copyDesktopItems, fetchFromGitHub, cmake, kmod }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mcontrolcenter";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "dmitry-s93";
+    repo = "MControlCenter";
+    rev = finalAttrs.version;
+    hash = "sha256-SV78OVRGzy2zFLT3xqeUtbjlh81Z97PVao18P3h/8dI=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/helper/helper.cpp \
+      --replace-fail "/usr/sbin/modprobe" "${kmod}/bin/modprobe"
+    substituteInPlace src/helper/mcontrolcenter.helper.service \
+      --replace-fail "/usr" "$out"
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "MControlCenter";
+      exec = "mcontrolcenter";
+      icon = "mcontrolcenter";
+      comment = finalAttrs.meta.description;
+      desktopName = "MControlCenter";
+      categories = [ "System" ];
+    })
+  ];
+
+  nativeBuildInputs = [
+    libsForQt5.wrapQtAppsHook
+    libsForQt5.qttools
+    copyDesktopItems
+    cmake
+  ];
+
+  buildInputs = [
+    libsForQt5.qtbase
+    kmod
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 mcontrolcenter $out/bin/mcontrolcenter
+    install -Dm755 helper/mcontrolcenter-helper $out/libexec/mcontrolcenter-helper
+    install -Dm644 ../resources/mcontrolcenter.svg $out/share/icons/hicolor/scalable/apps/mcontrolcenter.svg
+    install -Dm644 ../src/helper/mcontrolcenter-helper.conf $out/share/dbus-1/system.d/mcontrolcenter-helper.conf
+    install -Dm644 ../src/helper/mcontrolcenter.helper.service $out/share/dbus-1/system-services/mcontrolcenter.helper.service
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/dmitry-s93/MControlCenter";
+    description = "Tool to change the settings of MSI laptops running Linux";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.Tommimon ];
+    mainProgram = "mcontrolcenter";
+  };
+})


### PR DESCRIPTION
MControlCenter provides a relatively full-featured control panel for MSI laptops, written in Qt. It allows users to control MSI laptop power plans, fan speed, battery charging limits, keyboard backlight settings, USB power sharing and more.

The application comes with strong desktop integration: shortcuts, taskbar item, etc. etc. -- [screenshots here](https://github.com/dmitry-s93/MControlCenter/blob/main/README.md)

The package comes with a patch that corrects MControlCenter's path to the `modprobe` binary, allowing it to automatically load the `ec_sys` kernel module (included with NixOS by default) with the right settings when launched.

This package has been previous requested by the NixOS community (https://github.com/NixOS/nixpkgs/issues/244881). Another pull request (https://github.com/NixOS/nixpkgs/pull/251816) was submitted for this same package. The pull request has been reviewed but I contacted the author personally and he is not interested in completing it any more. For this reason I'm opening a new pull request incorporating all the changes suggested in the review. 

This NixOS package has been tested on a NixOS Plasma5 and GNOME 45 desktops.

fixes:  #244881

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Description of changes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
