### PR TITLE
glfw-wayland-minecraft: update to glfw 3.4

### DIFF
--- a/pkgs/development/libraries/glfw/0009-Defer-setting-cursor-position-until-the-cursor-is-lo.patch
+++ b/pkgs/development/libraries/glfw/0009-Defer-setting-cursor-position-until-the-cursor-is-lo.patch
@@ -1,0 +1,59 @@
+From 9997ae55a47de469ea26f8437c30b51483abda5f Mon Sep 17 00:00:00 2001
+From: Dan Klishch <danilklishch@gmail.com>
+Date: Sat, 30 Sep 2023 23:38:05 -0400
+Subject: Defer setting cursor position until the cursor is locked
+
+---
+ src/wl_platform.h |  3 +++
+ src/wl_window.c   | 14 ++++++++++++--
+ 2 files changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/src/wl_platform.h b/src/wl_platform.h
+index ca34f66e..cd1f227f 100644
+--- a/src/wl_platform.h
++++ b/src/wl_platform.h
+@@ -403,6 +403,9 @@ typedef struct _GLFWwindowWayland
+     int                         scaleSize;
+     int                         compositorPreferredScale;
+ 
++    double                      askedCursorPosX, askedCursorPosY;
++    GLFWbool                    didAskForSetCursorPos;
++
+     struct zwp_relative_pointer_v1* relativePointer;
+     struct zwp_locked_pointer_v1*   lockedPointer;
+     struct zwp_confined_pointer_v1* confinedPointer;
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 1de26558..0df16747 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -2586,8 +2586,9 @@ void _glfwGetCursorPosWayland(_GLFWwindow* window, double* xpos, double* ypos)
+ 
+ void _glfwSetCursorPosWayland(_GLFWwindow* window, double x, double y)
+ {
+-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
+-                    "Wayland: The platform does not support setting the cursor position");
++    window->wl.didAskForSetCursorPos = true;
++    window->wl.askedCursorPosX = x;
++    window->wl.askedCursorPosY = y;
+ }
+ 
+ void _glfwSetCursorModeWayland(_GLFWwindow* window, int mode)
+@@ -2819,6 +2820,15 @@ static const struct zwp_relative_pointer_v1_listener relativePointerListener =
+ static void lockedPointerHandleLocked(void* userData,
+                                       struct zwp_locked_pointer_v1* lockedPointer)
+ {
++    _GLFWwindow* window = userData;
++
++    if (window->wl.didAskForSetCursorPos)
++    {
++        window->wl.didAskForSetCursorPos = false;
++        zwp_locked_pointer_v1_set_cursor_position_hint(window->wl.lockedPointer,
++                                                       wl_fixed_from_double(window->wl.askedCursorPosX),
++                                                       wl_fixed_from_double(window->wl.askedCursorPosY));
++    }
+ }
+ 
+ static void lockedPointerHandleUnlocked(void* userData,
+-- 
+2.42.0
+

--- a/pkgs/development/libraries/glfw/3.x-wayland-minecraft.nix
+++ b/pkgs/development/libraries/glfw/3.x-wayland-minecraft.nix
@@ -1,64 +1,8 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch2, cmake, extra-cmake-modules
-, libGL, wayland, wayland-protocols, libxkbcommon, libdecor
-}:
-
-stdenv.mkDerivation {
-  version = "unstable-2023-06-01";
+{ glfw }:
+glfw.overrideAttrs (old: {
   pname = "glfw-wayland-minecraft";
 
-  src = fetchFromGitHub {
-    owner = "glfw";
-    repo = "GLFW";
-    rev = "3eaf1255b29fdf5c2895856c7be7d7185ef2b241";
-    sha256 = "sha256-UnwuE/3q6I4dS5syagpnqrDEVDK9XSVdyOg7KNkdUUA=";
-  };
-
-  patches = [
-    (fetchpatch2 {
-      url = "https://raw.githubusercontent.com/Admicos/minecraft-wayland/15f88a515c63a9716cfdf4090fab8e16543f4ebd/0003-Don-t-crash-on-calls-to-focus-or-icon.patch";
-      hash = "sha256-NZbKh16h+tWXXnz13QcFBFaeGXMNxZKGQb9xJEahFnE=";
-    })
-    (fetchpatch2 {
-      url = "https://raw.githubusercontent.com/Admicos/minecraft-wayland/15f88a515c63a9716cfdf4090fab8e16543f4ebd/0005-Add-warning-about-being-an-unofficial-patch.patch";
-      hash = "sha256-QMUNlnlCeFz5gIVdbM+YXPsrmiOl9cMwuVRSOvlw+T0=";
-    })
+  patches = old.patches or [] ++ [
+    ./0009-Defer-setting-cursor-position-until-the-cursor-is-lo.patch
   ];
-
-  propagatedBuildInputs = [ libGL ];
-
-  nativeBuildInputs = [ cmake extra-cmake-modules ];
-
-  buildInputs = [ wayland wayland-protocols libxkbcommon ];
-
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DGLFW_BUILD_WAYLAND=ON"
-    "-DGLFW_BUILD_X11=OFF"
-    "-DCMAKE_C_FLAGS=-D_GLFW_EGL_LIBRARY='\"${lib.getLib libGL}/lib/libEGL.so.1\"'"
-  ];
-
-  postPatch = ''
-    substituteInPlace src/wl_init.c \
-      --replace "libxkbcommon.so.0" "${lib.getLib libxkbcommon}/lib/libxkbcommon.so.0"
-
-    substituteInPlace src/wl_init.c \
-      --replace "libdecor-0.so.0" "${lib.getLib libdecor}/lib/libdecor-0.so.0"
-
-    substituteInPlace src/wl_init.c \
-      --replace "libwayland-client.so.0" "${lib.getLib wayland}/lib/libwayland-client.so.0"
-
-    substituteInPlace src/wl_init.c \
-      --replace "libwayland-cursor.so.0" "${lib.getLib wayland}/lib/libwayland-cursor.so.0"
-
-    substituteInPlace src/wl_init.c \
-      --replace "libwayland-egl.so.1" "${lib.getLib wayland}/lib/libwayland-egl.so.1"
-  '';
-
-  meta = with lib; {
-    description = "Multi-platform library for creating OpenGL contexts and managing input, including keyboard, mouse, joystick and time - with patches to support Minecraft on Wayland";
-    homepage = "https://www.glfw.org/";
-    license = licenses.zlib;
-    maintainers = with maintainers; [ Scrumplex ];
-    platforms = platforms.linux;
-  };
-}
+})

--- a/pkgs/development/libraries/glfw/3.x.nix
+++ b/pkgs/development/libraries/glfw/3.x.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   };
 
   # Fix linkage issues on X11 (https://github.com/NixOS/nixpkgs/issues/142583)
-  patches = ./x11.patch;
+  patches = [ ./x11.patch ];
 
   propagatedBuildInputs =
     lib.optionals stdenv.isDarwin [ OpenGL ]


### PR DESCRIPTION

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The set-cursor patch is taken from: <https://github.com/Admicos/minecraft-wayland/pull/56>

And other changes including fractional scaling is already upstreamed in 3.4 thus not needed anymore. I override the patch on the original glfw to de-duplicate the packaging code.

I tested with `prismlauncher.override { withWaylandGLFW = true; }`, Minecraft 1.20.2, Java 17, on KDE 6 wayland session with a 125% scaled display. The game is indeed a native wayland window (checked in KWin debug console), and the cursor setting on opening game GUI (https://github.com/NixOS/nixpkgs/pull/293296#issuecomment-2002562523) is working correctly instead of crashing like the unpatched glfw.

The set-cursor patch itself seems quite reasonable and probably is suitable for upstreaming? CC @DanShaders. Also I'm not sure if it's a good idea to patch unconditionally or conditionally on the glfw package, rather than a separated `glfw-wayland-minecraft`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
