### PR TITLE
cbmc-viewer: init at 3.8

### DIFF
--- a/pkgs/by-name/cb/cbmc-viewer/package.nix
+++ b/pkgs/by-name/cb/cbmc-viewer/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "cbmc-viewer";
+  version = "3.8";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-JFL06z7lJWZxTALovDBVwNJWenWPUQV9J0qZz3Ek6gI=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    setuptools
+    jinja2
+    voluptuous
+  ];
+
+  meta = {
+    description = "Produces browsable summary of CBMC model checker output";
+    homepage = "https://github.com/model-checking/cbmc-viewer";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jacg ];
+    mainProgram = "cbmc-viewer";
+  };
+}


### PR DESCRIPTION
## Description of changes

Added [`cbmc-viewer`](https://github.com/model-checking/cbmc-viewer) which is an auxiliary utility for viewing the results produced by the [`cbmc`](https://diffblue.github.io/cbmc/)  model checker, which is already present in `nixpkgs`.

(My motivation for adding this package is that it is a dependency of [The Kani Rust Verifier](https://model-checking.github.io/kani/), which is what I really want to add to `nixpkgs`, and aim to do in a subsequent PR.)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
