### PR TITLE
uhd: fix for python module failing to install

### DIFF
--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -8,12 +8,6 @@
 , boost
 , ncurses
 , enableCApi ? true
-# Although we handle the Python API's dependencies in pythonEnvArg, this
-# feature is currently disabled as upstream attempts to run `python setup.py
-# install` by itself, and it fails because the Python's environment's prefix is
-# not a writable directly. Adding support for this feature would require using
-# python's pypa/build nad pypa/install hooks directly, and currently it is hard
-# to do that because it all happens after a long buildPhase of the C API.
 , enablePythonApi ? false
 , python3
 , buildPackages
@@ -138,6 +132,8 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Disable tests that fail in the sandbox
     ./no-adapter-tests.patch
+    # Fix for python module failing to install
+    ./python-api.patch
   ];
 
   postPhases = [ "installFirmware" "removeInstalledTests" ]

--- a/pkgs/applications/radio/uhd/python-api.patch
+++ b/pkgs/applications/radio/uhd/python-api.patch
@@ -1,0 +1,20 @@
+diff --git a/host/python/CMakeLists.txt b/host/python/CMakeLists.txt
+index fdf612747..a67631bc0 100644
+--- a/host/python/CMakeLists.txt
++++ b/host/python/CMakeLists.txt
+@@ -174,6 +174,7 @@ add_custom_command(OUTPUT ${TIMESTAMP_FILE}
+   DEPENDS ${PYUHD_FILES})
+ 
+ add_custom_target(pyuhd_library ALL DEPENDS ${TIMESTAMP_FILE} pyuhd)
++set(HAVE_PYTHON_VIRTUALENV FALSE)
+ if(HAVE_PYTHON_VIRTUALENV)
+   message(STATUS "Python virtual environment detected -- Ignoring UHD_PYTHON_DIR.")
+     # In virtualenvs, let setuptools do its thing
+@@ -192,6 +193,7 @@ else()
+             OUTPUT_VARIABLE UHD_PYTHON_DIR OUTPUT_STRIP_TRAILING_WHITESPACE
+         )
+     endif(NOT DEFINED UHD_PYTHON_DIR)
++    string(REGEX REPLACE "^\\.\\./[^/]+/" "" UHD_PYTHON_DIR ${UHD_PYTHON_DIR})
+     file(TO_CMAKE_PATH ${UHD_PYTHON_DIR} UHD_PYTHON_DIR)
+ 
+     message(STATUS "Utilizing the python install directory: ${CMAKE_INSTALL_PREFIX}/${UHD_PYTHON_DIR}")


### PR DESCRIPTION
## Description of changes

This PR fixes the python module failing to install by patching the upstream build process.

I kept the enablePythonApi flag off however, to respect established uhd package default options.

Detail of this fix:
- It avoids upstreams build process to use pythons setuptools directly by omitting the virtual-env check.
- It rewrites upstreams derived installation path for the python module (/nix/store/<hash>-uhd/../<hash>-python-3.XY-env/lib/python-3.XY/site-packages -> /nix/store/<hash>-uhd/lib/python-3.XY/site-packages) to avoid permission problems.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Only tested on x86_64-linux
- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
