### PR TITLE
haskellPackages.mkDerivation: Replace testTarget with testTargets

### DIFF
--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -297,8 +297,8 @@ Defaults to `false`.
 : Whether to build (HTML) documentation using [haddock][haddock].
 Defaults to `true` if supported.
 
-`testTarget`
-: Name of the test suite to build and run. If unset, all test suites will be executed.
+`testTargets`
+: Names of the test suites to build and run. If unset, all test suites will be executed.
 
 `preCompileBuildDriver`
 : Shell code to run before compiling `Setup.hs`.

--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -37,3 +37,7 @@
 - `functor.wrapped` is now deprecated for some types and using it will give a warning with migration instructions. It is deprecated for these types:
     - `lib.types.attrsWith`
     - `lib.types.listOf`
+
+- The `testTarget` argument of `haskellPackages.mkDerivation` has been deprecated in favour of `testTargets`.
+  `testTarget` took a space separated string of targets, whereas the new `testTargets` argument takes a list of targets.
+  For instance, `testTarget = "foo bar baz"` should become `testTargets = [ "foo" "bar" "baz" ]`.

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -149,7 +149,7 @@ self: super: {
     # Too strict bounds on doctest which isn't used, but is part of the configuration
     jailbreak = true;
     # vector-doctest seems to be broken when executed via ./Setup test
-    testTarget = lib.concatStringsSep " " [
+    testTargets = [
       "vector-tests-O0"
       "vector-tests-O2"
     ];
@@ -890,7 +890,7 @@ self: super: {
   CHXHtml = dontDistribute super.CHXHtml;
 
   # https://github.com/NixOS/nixpkgs/issues/6350
-  paypal-adaptive-hoops = overrideCabal (drv: { testTarget = "local"; }) super.paypal-adaptive-hoops;
+  paypal-adaptive-hoops = overrideCabal (drv: { testTargets = [ "local" ]; }) super.paypal-adaptive-hoops;
 
   # Avoid "QuickCheck >=2.3 && <2.10" dependency we cannot fulfill in lts-11.x.
   test-framework = dontCheck super.test-framework;
@@ -2507,7 +2507,7 @@ self: super: {
       rm Setup.hs
     '';
     # doctest suite uses doctest-parallel which still doesn't work in nixpkgs
-    testTarget = "tests";
+    testTargets = [ "tests" ];
   }) super.conduit-aeson;
 
   hermes-json = overrideCabal (drv: {
@@ -2543,7 +2543,7 @@ self: super: {
 
   # Disabling doctests.
   regex-tdfa = overrideCabal {
-    testTarget = "regex-tdfa-unittest";
+    testTargets = [ "regex-tdfa-unittest" ];
   } super.regex-tdfa;
 
   # Missing test files https://github.com/kephas/xdg-basedir-compliant/issues/1

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -75,7 +75,7 @@ self: super: builtins.intersectAttrs super {
       chmod +x "$out/bin/haskell-language-server"
       '';
     testToolDepends = [ self.cabal-install pkgs.git ];
-    testTarget = "func-test"; # wrapper test accesses internet
+    testTargets = [ "func-test" ]; # wrapper test accesses internet
     preCheck = ''
       export PATH=$PATH:$PWD/dist/build/haskell-language-server:$PWD/dist/build/haskell-language-server-wrapper
       export HOME=$TMPDIR
@@ -334,7 +334,7 @@ self: super: builtins.intersectAttrs super {
   digitalocean-kzs = dontCheck super.digitalocean-kzs;  # https://github.com/KazumaSATO/digitalocean-kzs/issues/1
   github-types = dontCheck super.github-types;          # http://hydra.cryp.to/build/1114046/nixlog/1/raw
   hadoop-rpc = dontCheck super.hadoop-rpc;              # http://hydra.cryp.to/build/527461/nixlog/2/raw
-  hjsonschema = overrideCabal (drv: { testTarget = "local"; }) super.hjsonschema;
+  hjsonschema = overrideCabal (drv: { testTargets = [ "local" ]; }) super.hjsonschema;
   marmalade-upload = dontCheck super.marmalade-upload;  # http://hydra.cryp.to/build/501904/nixlog/1/raw
   mongoDB = dontCheck super.mongoDB;
   network-transport-tcp = dontCheck super.network-transport-tcp;
@@ -701,7 +701,7 @@ self: super: builtins.intersectAttrs super {
 
   # Not running the "example" test because it requires a binary from lsps test
   # suite which is not part of the output of lsp.
-  lsp-test = overrideCabal (old: { testTarget = "tests func-test"; }) super.lsp-test;
+  lsp-test = overrideCabal (old: { testTargets = [ "tests" "func-test" ]; }) super.lsp-test;
 
   # the test suite attempts to run the binaries built in this package
   # through $PATH but they aren't in $PATH
@@ -1275,7 +1275,7 @@ self: super: builtins.intersectAttrs super {
       "-p" "!/oeis/"
     ];
     # disco-examples needs network access
-    testTarget = "disco-tests";
+    testTargets = [ "disco-tests" ];
   }) super.disco;
 
   # Apply a patch which hardcodes the store path of graphviz instead of using

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -83,7 +83,9 @@ in
 , pkg-configDepends ? [], libraryPkgconfigDepends ? [], executablePkgconfigDepends ? [], testPkgconfigDepends ? [], benchmarkPkgconfigDepends ? []
 , testDepends ? [], testHaskellDepends ? [], testSystemDepends ? [], testFrameworkDepends ? []
 , benchmarkDepends ? [], benchmarkHaskellDepends ? [], benchmarkSystemDepends ? [], benchmarkFrameworkDepends ? []
-, testTarget ? "", testFlags ? []
+, # testTarget is deprecated. Use testTargets instead.
+  testTarget ? ""
+, testTargets ? lib.strings.splitString " " testTarget, testFlags ? []
 , broken ? false
 , preCompileBuildDriver ? null, postCompileBuildDriver ? null
 , preUnpack ? null, postUnpack ? null
@@ -408,6 +410,10 @@ let
       exec "$@"
     '';
 
+  testTargetsString =
+    lib.warnIf (testTarget != "") "haskellPackages.mkDerivation: testTarget is deprecated. Use testTargets instead"
+    (lib.concatStringsSep " " testTargets);
+
 in lib.fix (drv:
 
 stdenv.mkDerivation ({
@@ -616,7 +622,7 @@ stdenv.mkDerivation ({
       ${lib.escapeShellArgs (builtins.map (opt: "--test-option=${opt}") testFlags)}
     )
     export NIX_GHC_PACKAGE_PATH_FOR_TEST="''${NIX_GHC_PACKAGE_PATH_FOR_TEST:-$packageConfDir:}"
-    ${setupCommand} test ${testTarget} $checkFlags ''${checkFlagsArray:+"''${checkFlagsArray[@]}"}
+    ${setupCommand} test ${testTargetsString} $checkFlags ''${checkFlagsArray:+"''${checkFlagsArray[@]}"}
     runHook postCheck
   '';
 

--- a/pkgs/tools/nix/nix-output-monitor/default.nix
+++ b/pkgs/tools/nix/nix-output-monitor/default.nix
@@ -12,7 +12,7 @@ let
 
     # nom has unit-tests and golden-tests
     # golden-tests call nix and thus can’t be run in a nix build.
-    testTarget = "unit-tests";
+    testTargets = [ "unit-tests" ];
 
     buildTools = [ installShellFiles ];
     postInstall = ''


### PR DESCRIPTION


## Description of changes

testTarget takes a space separated list of test suites to run. We introduce a new testTargets argument that instead takes a list, and add a backwards compatibility shim.

cc @sternenseemann  you mentioned you were interested in a change like this.

I've tested building a couple of packages and it seems to evaluate to the same thing. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
