### PR TITLE
testers: add more parameters, add testVersion to my maintained packages

### DIFF
--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -89,6 +89,7 @@ A common usage of the `version` attribute is to specify `version = "v${version}"
 
 By default, the executable name is derived from the package's `meta.mainProgram` or, failing that, `pname` or `name`. It can be explicitly declared using the `executable` parameter.
 The command ran to test the version can be fully customised via the `command` parameter. This voids the effect of `executable` and `parameter`.
+The version check only succeeds if the command ran exits with exit code 0. The `exitCode` parameter can be customised in case the program returns a different exit code when ran with the version parameter.
 
 :::
 

--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -88,7 +88,7 @@ A common usage of the `version` attribute is to specify `version = "v${version}"
 ```
 
 By default, the executable name is derived from the package's `meta.mainProgram` or, failing that, `pname` or `name`. It can be explicitly declared using the `executable` parameter.
-The command ran to test the version can be fully customised via the `command` parameter. This voids the effect of `executable` and `parameter`.
+The command ran to test the version can be fully customised via the `command` parameter, which is incompatible with `executable` and `parameter`.
 The version check only succeeds if the command ran exits with exit code 0. The `exitCode` parameter can be customised in case the program returns a different exit code when ran with the version parameter.
 
 :::

--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -81,11 +81,14 @@ A common usage of the `version` attribute is to specify `version = "v${version}"
 
   passthru.tests.version = testers.testVersion {
     package = leetcode-cli;
-    command = "leetcode -V";
+    parameter = "-V";
     version = "leetcode ${version}";
   };
 }
 ```
+
+By default, the executable name is derived from the package's `meta.mainProgram` or, failing that, `pname` or `name`. It can be explicitly declared using the `executable` parameter.
+The command ran to test the version can be fully customised via the `command` parameter. This voids the effect of `executable` and `parameter`.
 
 :::
 

--- a/pkgs/applications/terminal-emulators/mlterm/default.nix
+++ b/pkgs/applications/terminal-emulators/mlterm/default.nix
@@ -5,6 +5,7 @@
 , autoconf
 , makeDesktopItem
 , nixosTests
+, testers
 , vte
 , harfbuzz # can be replaced with libotf
 , fribidi
@@ -204,7 +205,13 @@ in stdenv.mkDerivation (finalAttrs: {
   };
 
   passthru = {
-    tests.test = nixosTests.terminal-emulators.mlterm;
+    tests = {
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+        exitCode = 1; # it exit(1)s for some reason
+      };
+      test = nixosTests.terminal-emulators.mlterm;
+    };
     inherit
       enableTypeEngines
       enableTools

--- a/pkgs/applications/virtualization/virt-viewer/default.nix
+++ b/pkgs/applications/virtualization/virt-viewer/default.nix
@@ -31,11 +31,12 @@
 , spiceSupport ? true
 , vte
 , wrapGAppsHook3
+, testers
 }:
 
 with lib;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: rec {
   pname = "virt-viewer";
   version = "11.0";
 
@@ -99,6 +100,10 @@ stdenv.mkDerivation rec {
     patchShebangs build-aux/post_install.py
   '';
 
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+  };
+
   meta = {
     description = "A viewer for remote virtual machines";
     maintainers = with maintainers; [ raskin atemu ];
@@ -110,4 +115,4 @@ stdenv.mkDerivation rec {
       downloadPage = "https://virt-manager.org/download.html";
     };
   };
-}
+})

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -57,7 +57,9 @@
   # or doc/builders/testers.chapter.md
   testVersion =
     { package,
-      command ? "${package.meta.mainProgram or package.pname or package.name} --version",
+      parameter ? "--version",
+      executable ? package.meta.mainProgram or package.pname or package.name,
+      command ? "${executable} ${parameter}",
       version ? package.version,
     }: runCommand "${package.name}-test-version" { nativeBuildInputs = [ package ]; meta.timeout = 60; } ''
       if output=$(${command} 2>&1); then

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -64,7 +64,7 @@
     }: runCommand "${package.name}-test-version" { nativeBuildInputs = [ package ]; meta.timeout = 60; } ''
       if output=$(${command} 2>&1); then
         if grep -Fw -- "${version}" - <<< "$output"; then
-          touch $out
+          echo "$output" > $out
         else
           echo "Version string '${version}' not found!" >&2
           echo "The output was:" >&2

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -72,20 +72,17 @@
         exitCode=$?
         set -e
 
-        if [ $exitCode == ${toString exitCode} ]; then
-          if grep -Fw -- "${version}" - <<< "$output"; then
-            echo "$output" > $out
-          else
-            echo "Version string '${version}' not found!" >&2
-            echo "The output was:" >&2
-            echo "$output" >&2
-            exit 1
-          fi
-        else
-          echo -n ${lib.escapeShellArg command} >&2
-          echo " returned a non-zero exit code." >&2
+        if [ $exitCode -ne ${toString exitCode} ]; then
+          echo "${lib.escapeShellArg command} returned a non-zero exit code." >&2
           echo "$output" >&2
           exit 1
+        elif ! grep -Fw -- "${version}" - <<< "$output"; then
+          echo "Version string '${version}' not found!" >&2
+          echo "The output was:" >&2
+          echo "$output" >&2
+          exit 1
+        else
+          echo "$output" > $out
         fi
       '';
 

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -61,8 +61,14 @@
       executable ? package.meta.mainProgram or package.pname or package.name,
       command ? "${executable} ${parameter}",
       version ? package.version,
+      exitCode ? 0,
     }: runCommand "${package.name}-test-version" { nativeBuildInputs = [ package ]; meta.timeout = 60; } ''
-      if output=$(${command} 2>&1); then
+      set +e
+      output=$(${command} 2>&1)
+      exitCode=$?
+      set -e
+
+      if [ $exitCode == ${toString exitCode} ]; then
         if grep -Fw -- "${version}" - <<< "$output"; then
           echo "$output" > $out
         else

--- a/pkgs/build-support/testers/test/default.nix
+++ b/pkgs/build-support/testers/test/default.nix
@@ -210,4 +210,23 @@ lib.recurseIntoAttrs {
         touch $out
       '';
   };
+
+  testVersion = let inherit (testers) testVersion; in {
+    # Test with default arguments
+    hello = testVersion { package = pkgs.hello; };
+
+    # Test non-default arguments
+    cat = testVersion {
+      package = pkgs.coreutils;
+      executable = "cat"; # must pet
+    };
+    ffmpeg = testVersion {
+      package = pkgs.ffmpeg;
+      parameter = "-version";
+    };
+    mlterm = testVersion {
+      package = pkgs.mlterm;
+      exitCode = 1;
+    };
+  };
 }

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -847,7 +847,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  passthru.tests = {
+    pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      parameter = "-version";
+    };
+  };
 
   meta = with lib; {
     description = "A complete, cross-platform solution to record, convert and stream audio and video";

--- a/pkgs/development/python-modules/jc/default.nix
+++ b/pkgs/development/python-modules/jc/default.nix
@@ -10,6 +10,8 @@
   pygments,
   pytestCheckHook,
   pythonOlder,
+  testers,
+  jc,
 }:
 
 buildPythonPackage rec {
@@ -49,6 +51,8 @@ buildPythonPackage rec {
 
   # tests require timezone to set America/Los_Angeles
   doCheck = false;
+
+  passthru.tests.version = testers.testVersion { package = jc; };
 
   meta = with lib; {
     description = "This tool serializes the output of popular command line tools and filetypes to structured JSON output";

--- a/pkgs/tools/networking/dnscrypt-proxy/default.nix
+++ b/pkgs/tools/networking/dnscrypt-proxy/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, testers, dnscrypt-proxy }:
 
 buildGoModule rec {
   pname = "dnscrypt-proxy";
@@ -13,6 +13,10 @@ buildGoModule rec {
     repo = "dnscrypt-proxy";
     rev = version;
     sha256 = "sha256-A9Cu4wcJxrptd9CpgXw4eyMX2nmNAogYBRDeeAjpEZY=";
+  };
+
+  passthru.tests.version = testers.testVersion {
+    package = dnscrypt-proxy;
   };
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

When any aspect of the command to show the version needed to change, the entire
command would have to be declared in full. This allows directly customising
those aspects individually.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
