### PR TITLE
python311Packages.stone: 3.3.1 -> 3.3.3

### DIFF
--- a/pkgs/development/python-modules/stone/default.nix
+++ b/pkgs/development/python-modules/stone/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "stone";
-  version = "3.3.1";
+  version = "3.3.3";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -20,15 +20,12 @@ buildPythonPackage rec {
     owner = "dropbox";
     repo = "stone";
     rev = "refs/tags/v${version}";
-    hash = "sha256-0FWdYbv+paVU3Wj6g9OrSNUB0pH8fLwTkhVIBPeFB/U=";
+    hash = "sha256-l86j2fd6x57bKt/TFGiyg+ZFjZFFCo43rE48MoPvXWc=";
   };
 
   postPatch = ''
-    # https://github.com/dropbox/stone/issues/288
-    substituteInPlace stone/frontend/ir_generator.py \
-      --replace-fail "inspect.getargspec" "inspect.getfullargspec"
     substituteInPlace setup.py \
-      --replace-fail "'pytest-runner == 5.2.0'," ""
+      --replace-fail "'pytest-runner == 5.3.2'," ""
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/stone/default.nix
+++ b/pkgs/development/python-modules/stone/default.nix
@@ -1,12 +1,13 @@
-{ lib
-, buildPythonPackage
-, fetchFromGitHub
-, mock
-, ply
-, pytestCheckHook
-, pythonOlder
-, setuptools
-, six
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  mock,
+  ply,
+  pytestCheckHook,
+  pythonOlder,
+  setuptools,
+  six,
 }:
 
 buildPythonPackage rec {
@@ -28,9 +29,7 @@ buildPythonPackage rec {
       --replace-fail "'pytest-runner == 5.3.2'," ""
   '';
 
-  build-system = [
-    setuptools
-  ];
+  build-system = [ setuptools ];
 
   dependencies = [
     ply
@@ -42,13 +41,7 @@ buildPythonPackage rec {
     mock
   ];
 
-  disabledTests = [
-    "test_type_name_with_module"
-  ];
-
-  pythonImportsCheck = [
-    "stone"
-  ];
+  pythonImportsCheck = [ "stone" ];
 
   meta = with lib; {
     description = "Official Api Spec Language for Dropbox";

--- a/pkgs/development/python-modules/stone/default.nix
+++ b/pkgs/development/python-modules/stone/default.nix
@@ -5,6 +5,7 @@
   mock,
   ply,
   pytestCheckHook,
+  pythonAtLeast,
   pythonOlder,
   setuptools,
   six,
@@ -15,7 +16,8 @@ buildPythonPackage rec {
   version = "3.3.3";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  # distutils removal, https://github.com/dropbox/stone/issues/323
+  disabled = pythonOlder "3.7" || pythonAtLeast "3.12";
 
   src = fetchFromGitHub {
     owner = "dropbox";

--- a/pkgs/development/python-modules/stone/default.nix
+++ b/pkgs/development/python-modules/stone/default.nix
@@ -4,20 +4,21 @@
 , mock
 , ply
 , pytestCheckHook
-, six
 , pythonOlder
+, setuptools
+, six
 }:
 
 buildPythonPackage rec {
   pname = "stone";
   version = "3.3.1";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "dropbox";
-    repo = pname;
+    repo = "stone";
     rev = "refs/tags/v${version}";
     hash = "sha256-0FWdYbv+paVU3Wj6g9OrSNUB0pH8fLwTkhVIBPeFB/U=";
   };
@@ -25,12 +26,16 @@ buildPythonPackage rec {
   postPatch = ''
     # https://github.com/dropbox/stone/issues/288
     substituteInPlace stone/frontend/ir_generator.py \
-      --replace "inspect.getargspec" "inspect.getfullargspec"
+      --replace-fail "inspect.getargspec" "inspect.getfullargspec"
     substituteInPlace setup.py \
-      --replace "'pytest-runner == 5.2.0'," ""
+      --replace-fail "'pytest-runner == 5.2.0'," ""
   '';
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     ply
     six
   ];
@@ -50,10 +55,10 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Official Api Spec Language for Dropbox";
-    mainProgram = "stone";
     homepage = "https://github.com/dropbox/stone";
     changelog = "https://github.com/dropbox/stone/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ jonringer ];
+    mainProgram = "stone";
   };
 }


### PR DESCRIPTION
Diff: https://github.com/dropbox/stone/compare/refs/tags/v3.3.1...v3.3.3

Changelog: https://github.com/dropbox/stone/releases/tag/v3.3.3

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
