### PR TITLE
stdenv: make checkDependencyList tolerate null deps

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -318,7 +318,7 @@ let
   checkDependencyList' = positions: name: deps:
     imap1
       (index: dep:
-        if isDerivation dep || dep == null || builtins.isString dep || builtins.isPath dep then dep
+        if dep == null || isDerivation dep || builtins.isString dep || builtins.isPath dep then dep
         else if isList dep then checkDependencyList' ([index] ++ positions) name dep
         else throw "Dependency is not of a valid type: ${concatMapStrings (ix: "element ${toString ix} of ") ([index] ++ positions)}${name} for ${attrs.name or attrs.pname}")
       deps;


### PR DESCRIPTION
Hi,

Looks like a bug or deadcode i.e.
The null check should got first must be dropped at all because `isDerivation` is not null safe.