### PR TITLE
tilt: 0.33.10 -> 0.33.12

### DIFF
--- a/pkgs/applications/networking/cluster/tilt/default.nix
+++ b/pkgs/applications/networking/cluster/tilt/default.nix
@@ -5,13 +5,13 @@ let args = rec {
       /* Do not use "dev" as a version. If you do, Tilt will consider itself
         running in development environment and try to serve assets from the
         source tree, which is not there once build completes.  */
-      version = "0.33.10";
+      version = "0.33.12";
 
       src = fetchFromGitHub {
         owner = "tilt-dev";
         repo = "tilt";
         rev = "v${version}";
-        hash = "sha256-LPb2tC3xIGhjiLYkTU+NBIUoqiicO2ORM6Nt1eTnwQs=";
+        hash = "sha256-gZD99wu8RxqWOdIDz3L/OEFvYIS0r2xIpecB4sTRzqg=";
       };
     };
 

--- a/pkgs/applications/networking/cluster/tilt/yarn.nix
+++ b/pkgs/applications/networking/cluster/tilt/yarn.nix
@@ -1,0 +1,41 @@
+/*
+Introduced as a temporary hack until 'fetchYarnDeps' is fixed to
+accommodate yarn berry lockfiles:
+https://github.com/NixOS/nixpkgs/issues/254369
+*/
+{
+  stdenvNoCC,
+  yarn-berry,
+  cacert,
+  src,
+  hash,
+}:
+stdenvNoCC.mkDerivation {
+  name = "yarn-deps";
+  nativeBuildInputs = [yarn-berry cacert];
+  inherit src;
+
+  dontInstall = true;
+
+  NODE_EXTRA_CA_CERTS = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  buildPhase = ''
+    cd web
+    mkdir -p $out
+
+    export HOME=$(mktemp -d)
+    echo $HOME
+
+    export YARN_ENABLE_TELEMETRY=0
+    export YARN_COMPRESSION_LEVEL=mixed
+
+    cache="$(yarn config get cacheFolder)"
+    yarn install --immutable --mode skip-build
+
+    cp -r $cache/* $out/
+  '';
+
+  outputHashAlgo = "sha256";
+  outputHash = hash;
+  outputHashMode = "recursive";
+}


### PR DESCRIPTION
## Description of changes

Updates [Tilt](https://tilt.dev/) from version [0.33.10](https://github.com/tilt-dev/tilt/releases/tag/v0.33.10) to [0.33.12](https://github.com/tilt-dev/tilt/releases/tag/v0.33.12).

This PR also introduces an alternative to `fetchYarnDeps` to build the yarn offline cache. This is required because of the issue at https://github.com/NixOS/nixpkgs/issues/254369 and the fix introduced was inspired by the approach in the comment at https://github.com/NixOS/nixpkgs/issues/277697#issuecomment-1922445558 by @Eisfunke 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
