### PR TITLE
maintainers: thehedgeh0g -> pyrox0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16407,6 +16407,16 @@
     githubId = 4579165;
     name = "Danny Bautista";
   };
+  pyrox0 = {
+    name = "Pyrox";
+    email = "pyrox@pyrox.dev";
+    matrix = "@pyrox:pyrox.dev";
+    github = "pyrox0";
+    githubId = 35778371;
+    keys = [{
+      fingerprint = "4CA9 72FB ADC8 1416 0F10  3138 FE1D 8A7D 620C 611F";
+    }];
+  };
   pyxels = {
     email = "pyxels.dev@gmail.com";
     github = "Pyxels";
@@ -20017,16 +20027,6 @@
     matrix = "@thefossguy:matrix.org";
     github = "thefossguy";
     githubId = 44400303;
-  };
-  thehedgeh0g = {
-    name = "The Hedgehog";
-    email = "hedgehog@mrhedgehog.xyz";
-    matrix = "@mrhedgehog:jupiterbroadcasting.com";
-    github = "pyrox0";
-    githubId = 35778371;
-    keys = [{
-      fingerprint = "38A0 29B0 4A7E 4C13 A4BB  86C8 7D51 0786 6B1C 6752";
-    }];
   };
   thekostins = {
     name = "Konstantin";

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -722,5 +722,5 @@ in
       timerConfig.OnCalendar = cfg.dump.interval;
     };
   };
-  meta.maintainers = with lib.maintainers; [ srhb ma27 thehedgeh0g ];
+  meta.maintainers = with lib.maintainers; [ srhb ma27 pyrox0 ];
 }

--- a/pkgs/applications/misc/sway-launcher-desktop/default.nix
+++ b/pkgs/applications/misc/sway-launcher-desktop/default.nix
@@ -37,6 +37,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/Biont/sway-launcher-desktop/releases/tag/v${version}";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = [ maintainers.thehedgeh0g ];
+    maintainers = [ maintainers.pyrox0 ];
   };
 }

--- a/pkgs/applications/office/espanso/default.nix
+++ b/pkgs/applications/office/espanso/default.nix
@@ -148,7 +148,7 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "espanso";
     homepage = "https://espanso.org";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ kimat thehedgeh0g ];
+    maintainers = with maintainers; [ kimat pyrox0 ];
     platforms = platforms.unix;
 
     longDescription = ''

--- a/pkgs/by-name/bl/bluetuith/package.nix
+++ b/pkgs/by-name/bl/bluetuith/package.nix
@@ -41,6 +41,6 @@ buildGoModule rec {
     license = licenses.mit;
     platforms = platforms.linux;
     mainProgram = "bluetuith";
-    maintainers = with maintainers; [ thehedgeh0g katexochen ];
+    maintainers = with maintainers; [ pyrox0 katexochen ];
   };
 }

--- a/pkgs/by-name/xp/xplr/package.nix
+++ b/pkgs/by-name/xp/xplr/package.nix
@@ -43,6 +43,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://xplr.dev";
     changelog = "https://github.com/sayanarijit/xplr/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ sayanarijit suryasr007 thehedgeh0g mimame figsoda ];
+    maintainers = with maintainers; [ sayanarijit suryasr007 pyrox0 mimame figsoda ];
   };
 }

--- a/pkgs/development/tools/goresym/default.nix
+++ b/pkgs/development/tools/goresym/default.nix
@@ -35,6 +35,6 @@ buildGoModule rec {
     homepage = "https://github.com/mandiant/GoReSym";
     changelog = "https://github.com/mandiant/GoReSym/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ thehedgeh0g ];
+    maintainers = with maintainers; [ pyrox0 ];
   };
 }

--- a/pkgs/development/tools/yarn-berry/default.nix
+++ b/pkgs/development/tools/yarn-berry/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://yarnpkg.com/";
     description = "Fast, reliable, and secure dependency management.";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ ryota-ka thehedgeh0g DimitarNestorov ];
+    maintainers = with maintainers; [ ryota-ka pyrox0 DimitarNestorov ];
     platforms = platforms.unix;
     mainProgram = "yarn";
   };

--- a/pkgs/shells/fish/plugins/autopair.nix
+++ b/pkgs/shells/fish/plugins/autopair.nix
@@ -15,6 +15,6 @@ buildFishPlugin rec {
     description = "Auto-complete matching pairs in the Fish command line";
     homepage = "https://github.com/jorgebucaran/autopair.fish";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda kidonng thehedgeh0g ];
+    maintainers = with maintainers; [ figsoda kidonng pyrox0 ];
   };
 }

--- a/pkgs/shells/fish/plugins/hydro.nix
+++ b/pkgs/shells/fish/plugins/hydro.nix
@@ -15,6 +15,6 @@ buildFishPlugin rec {
     description = "Ultra-pure, lag-free prompt with async Git status";
     homepage = "https://github.com/jorgebucaran/hydro";
     license = licenses.mit;
-    maintainers = with maintainers; [ thehedgeh0g ];
+    maintainers = with maintainers; [ pyrox0 ];
   };
 }

--- a/pkgs/tools/misc/mprocs/default.nix
+++ b/pkgs/tools/misc/mprocs/default.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
     description = "A TUI tool to run multiple commands in parallel and show the output of each command separately";
     homepage = "https://github.com/pvolok/mprocs";
     license = licenses.mit;
-    maintainers = with maintainers; [ GaetanLepage thehedgeh0g ];
+    maintainers = with maintainers; [ GaetanLepage pyrox0 ];
     mainProgram = "mprocs";
   };
 }

--- a/pkgs/tools/misc/zellij/default.nix
+++ b/pkgs/tools/misc/zellij/default.nix
@@ -63,7 +63,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://zellij.dev/";
     changelog = "https://github.com/zellij-org/zellij/blob/v${version}/CHANGELOG.md";
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ therealansh _0x4A6F abbe thehedgeh0g ];
+    maintainers = with maintainers; [ therealansh _0x4A6F abbe pyrox0 ];
     mainProgram = "zellij";
   };
 }

--- a/pkgs/tools/networking/asleap/default.nix
+++ b/pkgs/tools/networking/asleap/default.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/zackw/asleap";
     description = "Recovers weak LEAP and PPTP passwords";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ thehedgeh0g ];
+    maintainers = with maintainers; [ pyrox0 ];
   };
 }


### PR DESCRIPTION
Also updates my information and contact info.

I no longer use The Hedgehog as my github username or online presence username, so this fixes that. It also matches my github username, so it should be easier for others to mention me if needed.

Further, for any packages that I am the sole maintainer of, this moves those packages to `pkgs/by-name`. I did not move any packages maintained by multiple people, to reduce the risk of breaking changes and pull request conflicts.
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
