### PR TITLE
jetbrains: 2024.1 -> 2024.1.2

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -3,34 +3,34 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
-      "version": "2024.1",
-      "sha256": "a753369d74832d15fcf082587291921e8a90be04529c05b8e9d64a3afb24120c",
-      "url": "https://download.jetbrains.com/cpp/CLion-2024.1.tar.gz",
-      "build_number": "241.14494.288"
+      "version": "2024.1.1",
+      "sha256": "299ff2eb9c91282df074c58c0ecf73ecf59c7d077bc309f085229eaa32fbd46d",
+      "url": "https://download.jetbrains.com/cpp/CLion-2024.1.1.tar.gz",
+      "build_number": "241.15989.121"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.tar.gz",
-      "version": "2024.1.1",
-      "sha256": "05c1f910126b8499d26ab52d333307d3b6df6a3fa06b5e0b1a79ff15caf40e0a",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2024.1.1.tar.gz",
-      "build_number": "241.14494.283"
+      "version": "2024.1.2",
+      "sha256": "449ca450179bda3a342f92ff0fe44e52b51c11adcda4d2836a215282ffc0fc95",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2024.1.2.tar.gz",
+      "build_number": "241.15989.49"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}.tar.gz",
-      "version": "2024.1",
-      "sha256": "4f73d514dcbf5dce769e7ee4e0a81a1d8dc970f6553c246e3016963b9f077dca",
-      "url": "https://download.jetbrains.com/python/dataspell-2024.1.tar.gz",
-      "build_number": "241.14494.247"
+      "version": "2024.1.1",
+      "sha256": "0913a4938c7df68796b4d29cf0cf8d836da270aa34239fc7d756138f21e1a895",
+      "url": "https://download.jetbrains.com/python/dataspell-2024.1.1.tar.gz",
+      "build_number": "241.15989.62"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.tar.gz",
-      "version": "2024.1",
-      "sha256": "d777e88a3098790e19a93cb14fe4a21c740553958514e2b55fa2ba588f5c2c78",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2024.1.tar.gz",
-      "build_number": "241.14494.255"
+      "version": "2024.1.1",
+      "sha256": "2fd861d6fc91815466fc1f3b2bbd2177e55f1ea2c086fa10cf979de773d9cc06",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2024.1.1.tar.gz",
+      "build_number": "241.15989.74"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
@@ -67,10 +67,10 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.tar.gz",
-      "version": "2024.1",
-      "sha256": "11c6862954f87b89d081cc0382e54b105d8b0c933dae78fd952cd2a3604889b2",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.1.tar.gz",
-      "build_number": "241.14494.237",
+      "version": "2024.1.1",
+      "sha256": "bb3d10d5ce7419f5123937bcd40f1584fca4b844a2f83b6850fec57cd1f44282",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.1.1.tar.gz",
+      "build_number": "241.15989.102",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
@@ -92,76 +92,76 @@
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.tar.gz",
-      "version": "2024.1",
-      "sha256": "194096b0b550e1e320fc72aaf0510faeebf8737d05f6e02eecd72efe6f7cd757",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.1.tar.gz",
-      "build_number": "241.14494.307"
+      "version": "2024.1.1",
+      "sha256": "390967705d8e13f39754cbf39a9bec2bb33c6d0f8eeffcdb3d68a5c9ced696ea",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.1.1.tar.gz",
+      "build_number": "241.14494.325"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.tar.gz",
-      "version": "2024.1",
-      "sha256": "4fd9dcf83a1d1f6b7513c18383938bd65b2479fdb39c0421e2237a1e340c3912",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.1.tar.gz",
-      "build_number": "241.14494.234"
+      "version": "2024.1.1",
+      "sha256": "32e324e976c63e6f5897b392469240382baf5ab94c700b7f75c4a575a1f5d1dc",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.1.1.tar.gz",
+      "build_number": "241.15989.113"
     },
     "rust-rover": {
       "update-channel": "RustRover EAP",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.tar.gz",
-      "version": "2023.3 EAP",
-      "sha256": "a7176fb06c18ce50f8f901ecde9fa75e968ddf27e3366e70bffd7ad1208fdde9",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-233.15026.24.tar.gz",
-      "build_number": "233.15026.24"
+      "version": "2024.1 EAP",
+      "sha256": "10a904c833990c4621f919a36d31744dd1700dce42ff3addbc909937b6f6329d",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-241.15989.101.tar.gz",
+      "build_number": "241.15989.101"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
-      "version": "2024.1",
-      "sha256": "d4c7cb7f1462c2b2bd9042b4714ab9de66c455ab9752c87698dc3902f0d49a2a",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.1.tar.gz",
-      "build_number": "241.14494.235"
+      "version": "2024.1.2",
+      "sha256": "10110ac54ab7db1ca4560f83fdb921ca6217437dba1ad4ceb1c6cf0887ec5f29",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.1.2.tar.gz",
+      "build_number": "241.15989.105"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
       "url-template": "https://download.jetbrains.com/writerside/writerside-{version}.tar.gz",
-      "version": "2023.3 EAP",
-      "sha256": "8eae1c965c1b5dae17c580cd3ed9b2a6182a3b54a54f8e6152472815118ae2c2",
-      "url": "https://download.jetbrains.com/writerside/writerside-233.14938.tar.gz",
-      "build_number": "233.14938"
+      "version": "2024.1 EAP",
+      "sha256": "24da41b0eb4ca23652d05ecbccc5d2c792c3d49a964d8b6eb765ccd9cbcc7c3d",
+      "url": "https://download.jetbrains.com/writerside/writerside-241.15989.11.tar.gz",
+      "build_number": "241.15989.11"
     }
   },
   "aarch64-linux": {
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.tar.gz",
-      "version": "2024.1",
-      "sha256": "f937b263bd697595427e3e1d04513f9b6a786d56214ce34fe7a038efa2e949cf",
-      "url": "https://download.jetbrains.com/cpp/CLion-2024.1-aarch64.tar.gz",
-      "build_number": "241.14494.288"
+      "version": "2024.1.1",
+      "sha256": "2323f3b64f690b0b099cdcb14ef6b80440abafda1c0113a6b96df9656167e638",
+      "url": "https://download.jetbrains.com/cpp/CLion-2024.1.1-aarch64.tar.gz",
+      "build_number": "241.15989.121"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.tar.gz",
-      "version": "2024.1.1",
-      "sha256": "d269bfe10fb97572e785dce6e387d09f429396db002e12ecb9a44cced915c032",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2024.1.1-aarch64.tar.gz",
-      "build_number": "241.14494.283"
+      "version": "2024.1.2",
+      "sha256": "98b9a89ba49fa16376dbdec01412893635465a67ee482c80f9c48e10dcf0bead",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2024.1.2-aarch64.tar.gz",
+      "build_number": "241.15989.49"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}-aarch64.tar.gz",
-      "version": "2024.1",
-      "sha256": "f1adfe94bd6482a4f15db02611afc7487d59c47f8ee120e925feeb23c980cd9f",
-      "url": "https://download.jetbrains.com/python/dataspell-2024.1-aarch64.tar.gz",
-      "build_number": "241.14494.247"
+      "version": "2024.1.1",
+      "sha256": "3ee14b5d19d15ef652c6ca7ff8026d438980de5c28ce0375e8418a32fe8fed62",
+      "url": "https://download.jetbrains.com/python/dataspell-2024.1.1-aarch64.tar.gz",
+      "build_number": "241.15989.62"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.tar.gz",
-      "version": "2024.1",
-      "sha256": "3b6ffb21148d3327e9a5558c5657c22f7076c6208e8a10836f155d8f0200fb36",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2024.1-aarch64.tar.gz",
-      "build_number": "241.14494.255"
+      "version": "2024.1.1",
+      "sha256": "f500422ce9f2c7edb6515b3e7c6336df94000f0c2c454fe207a295489dcf3a0d",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2024.1.1-aarch64.tar.gz",
+      "build_number": "241.15989.74"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
@@ -198,10 +198,10 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.tar.gz",
-      "version": "2024.1",
-      "sha256": "0c5debd888359b37c9c95176c09a16e94f2412fb88f98b928e64ed2466f88ec1",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.1-aarch64.tar.gz",
-      "build_number": "241.14494.237",
+      "version": "2024.1.1",
+      "sha256": "c1ff0b85679cee8c17ee3ea4b19ccb3278540821c7162354bee900d95cbc52a4",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.1.1-aarch64.tar.gz",
+      "build_number": "241.15989.102",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
@@ -223,76 +223,76 @@
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.tar.gz",
-      "version": "2024.1",
-      "sha256": "e196c8e70d7eb6f56a08df809f5de430bf5e61509abb13de8b301c036c4f446e",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.1-aarch64.tar.gz",
-      "build_number": "241.14494.307"
+      "version": "2024.1.1",
+      "sha256": "9f079193067cf1e4595a5142bb2341187e8730f3551b4583c940f2822d9c5be2",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.1.1-aarch64.tar.gz",
+      "build_number": "241.14494.325"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.tar.gz",
-      "version": "2024.1",
-      "sha256": "690f90bd8a974585414e499aa2cb46d68dbc8145906e98d7f3b4ad1f3bf49040",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.1-aarch64.tar.gz",
-      "build_number": "241.14494.234"
+      "version": "2024.1.1",
+      "sha256": "87c7c6f86cc0337311eea595ee0754bcce3f4e88579c1f022abca19037ba7c51",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.1.1-aarch64.tar.gz",
+      "build_number": "241.15989.113"
     },
     "rust-rover": {
       "update-channel": "RustRover EAP",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.tar.gz",
-      "version": "2023.3 EAP",
-      "sha256": "4e03720aae12b32f91d4ddf4e01cfb454311b8a0b901dcee733d62579aa4cc0c",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-233.15026.24-aarch64.tar.gz",
-      "build_number": "233.15026.24"
+      "version": "2024.1 EAP",
+      "sha256": "6ee90aee367cd9ecc8db99020133e17299113c1e016b3344a4762eb8b954317a",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-241.15989.101-aarch64.tar.gz",
+      "build_number": "241.15989.101"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.tar.gz",
-      "version": "2024.1",
-      "sha256": "6691e4855fd4ecf3da9b63b78a11afc3441fb2139cdc7e7aaa5d78aa92a88c12",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.1-aarch64.tar.gz",
-      "build_number": "241.14494.235"
+      "version": "2024.1.2",
+      "sha256": "de1443570d2769e5dae11da2c3a8049c438f6f16b598a214ab000a300c148476",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.1.2-aarch64.tar.gz",
+      "build_number": "241.15989.105"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
       "url-template": "https://download.jetbrains.com/writerside/writerside-{version}-aarch64.tar.gz",
-      "version": "2023.3 EAP",
-      "sha256": "b09dac04217d5d523501bdb1e9026fd17fb6370dff2610502472bbf6a48323d8",
-      "url": "https://download.jetbrains.com/writerside/writerside-233.14938-aarch64.tar.gz",
-      "build_number": "233.14938"
+      "version": "2024.1 EAP",
+      "sha256": "9b72a2422f2cb1f2bb2034ef4eaf130ee7a9062cf99ba53b8df62cc4e1c76c42",
+      "url": "https://download.jetbrains.com/writerside/writerside-241.15989.11-aarch64.tar.gz",
+      "build_number": "241.15989.11"
     }
   },
   "x86_64-darwin": {
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.dmg",
-      "version": "2024.1",
-      "sha256": "373c78ff045a17fdcae44cc9b76b41862d4bee9c8476813e518c7cc1de88b6a1",
-      "url": "https://download.jetbrains.com/cpp/CLion-2024.1.dmg",
-      "build_number": "241.14494.288"
+      "version": "2024.1.1",
+      "sha256": "43a765102080acd6dc1fa5a26e0c5efcc3d2e7a22a0bf054a3b9ba4714a9c43e",
+      "url": "https://download.jetbrains.com/cpp/CLion-2024.1.1.dmg",
+      "build_number": "241.15989.121"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.dmg",
-      "version": "2024.1.1",
-      "sha256": "232582204a6f810bcbd2387ba2cef824f0f81c3a7e022f7f2bebf643d32f866d",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2024.1.1.dmg",
-      "build_number": "241.14494.283"
+      "version": "2024.1.2",
+      "sha256": "41a4dabdd2ad97387d806742c41b34e5a1544860c159f5d71c09b00a1e605356",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2024.1.2.dmg",
+      "build_number": "241.15989.49"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}.dmg",
-      "version": "2024.1",
-      "sha256": "a48036f55ef8301d6f77f726c68d7415c0056ddb4143ca3eed2698306f2c021f",
-      "url": "https://download.jetbrains.com/python/dataspell-2024.1.dmg",
-      "build_number": "241.14494.247"
+      "version": "2024.1.1",
+      "sha256": "dfbe160a8a1676dad81b5d5ca35d8d02258a5684c3a140bbb415edae575a058b",
+      "url": "https://download.jetbrains.com/python/dataspell-2024.1.1.dmg",
+      "build_number": "241.15989.62"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.dmg",
-      "version": "2024.1",
-      "sha256": "fb37fe7ba94f151f9613134b232b79f44524c126152f70eeb31421cee89b514d",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2024.1.dmg",
-      "build_number": "241.14494.255"
+      "version": "2024.1.1",
+      "sha256": "4513e26abf40f69a6eecd7f52d20a0f20e82a87722d4e8a4bd71718a4cba51b0",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2024.1.1.dmg",
+      "build_number": "241.15989.74"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
@@ -329,10 +329,10 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.dmg",
-      "version": "2024.1",
-      "sha256": "75699ce909f07de35a6e89745c652f08afba5096b7930fdc51683989967fcc62",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.1.dmg",
-      "build_number": "241.14494.237",
+      "version": "2024.1.1",
+      "sha256": "0232f3e562698bbacf8c72446fc868d50d2b308ce17b6a0655fe351b46370fa4",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.1.1.dmg",
+      "build_number": "241.15989.102",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
@@ -354,76 +354,76 @@
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.dmg",
-      "version": "2024.1",
-      "sha256": "12155c779c7f11dd71b3573af266c0221960eaea8a442fda4faaec8ca6eefa95",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.1.dmg",
-      "build_number": "241.14494.307"
+      "version": "2024.1.1",
+      "sha256": "1c6f52b9629f77ca6a2f903fbadaae9dc80237b061dfeb94638d029a43bdf0c5",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.1.1.dmg",
+      "build_number": "241.14494.325"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.dmg",
-      "version": "2024.1",
-      "sha256": "47ff2d04362beb2acb3421780f9c5f3dd5ef02aa2cdd9cef2c64a10c6ce2c062",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.1.dmg",
-      "build_number": "241.14494.234"
+      "version": "2024.1.1",
+      "sha256": "839fe79e93a293a514e8abdaec60ca9a79cddb889fe4fe1287e2b74540a9ec57",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.1.1.dmg",
+      "build_number": "241.15989.113"
     },
     "rust-rover": {
       "update-channel": "RustRover EAP",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.dmg",
-      "version": "2023.3 EAP",
-      "sha256": "b59ff55e4ba22df41acc9870f88b7f957f31af179e482ccaa4320b1f1ffff346",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-233.15026.24.dmg",
-      "build_number": "233.15026.24"
+      "version": "2024.1 EAP",
+      "sha256": "c0b5885e7d85cc89d79110b4a56c3a08784c43b03e42686ec91cd4679bf9f469",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-241.15989.101.dmg",
+      "build_number": "241.15989.101"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.dmg",
-      "version": "2024.1",
-      "sha256": "b3b41e5e8559e36e0bd4121dee61d39a8ba5b5ce8193e7b026c5bc261e973df5",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.1.dmg",
-      "build_number": "241.14494.235"
+      "version": "2024.1.2",
+      "sha256": "a5b79c530596bcef503847ea38a11263c871a9f8267d2e4fe4ef025c166d144f",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.1.2.dmg",
+      "build_number": "241.15989.105"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
       "url-template": "https://download.jetbrains.com/writerside/writerside-{version}.dmg",
-      "version": "2023.3 EAP",
-      "sha256": "53c7ad5a8808776b60eb82b3155c6f3a2a0dfad43ba8d9238a0db1752d503b09",
-      "url": "https://download.jetbrains.com/writerside/writerside-233.14938.dmg",
-      "build_number": "233.14938"
+      "version": "2024.1 EAP",
+      "sha256": "36ec40a47989be9ab263f4b9f182fcc5b155f3fd068174e7539adc55f892b230",
+      "url": "https://download.jetbrains.com/writerside/writerside-241.15989.11.dmg",
+      "build_number": "241.15989.11"
     }
   },
   "aarch64-darwin": {
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.dmg",
-      "version": "2024.1",
-      "sha256": "b1044fdbf9e3f93aaf8ca8ad2b7bc2eae165f86bc5cae6910f2ad0ee92c198a5",
-      "url": "https://download.jetbrains.com/cpp/CLion-2024.1-aarch64.dmg",
-      "build_number": "241.14494.288"
+      "version": "2024.1.1",
+      "sha256": "08dab457cf1cb07e4489653f22a12e2997dea2b788ab0a5494de40a86b39f104",
+      "url": "https://download.jetbrains.com/cpp/CLion-2024.1.1-aarch64.dmg",
+      "build_number": "241.15989.121"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.dmg",
-      "version": "2024.1.1",
-      "sha256": "c2545df9784fa1f8f9234dd93d1c513ed691c797f26471cb545188ce7f495864",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2024.1.1-aarch64.dmg",
-      "build_number": "241.14494.283"
+      "version": "2024.1.2",
+      "sha256": "583c32f39918681673028a20cb911a41fc4495cf44c151c0790594042ec9e160",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2024.1.2-aarch64.dmg",
+      "build_number": "241.15989.49"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}-aarch64.dmg",
-      "version": "2024.1",
-      "sha256": "4a8abf8cf816f98502cf58cd3de07c28d496d4fe20d338cee0ac714196b8a612",
-      "url": "https://download.jetbrains.com/python/dataspell-2024.1-aarch64.dmg",
-      "build_number": "241.14494.247"
+      "version": "2024.1.1",
+      "sha256": "eb345888f6e926439a1142614e10b36123b40fbd876d31060856c7e532b53f64",
+      "url": "https://download.jetbrains.com/python/dataspell-2024.1.1-aarch64.dmg",
+      "build_number": "241.15989.62"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.dmg",
-      "version": "2024.1",
-      "sha256": "c82392faec283b2a6ab25dd0cbd8c3733ea046799d9d95ba4b5d6086767f7715",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2024.1-aarch64.dmg",
-      "build_number": "241.14494.255"
+      "version": "2024.1.1",
+      "sha256": "840eb4ae9d2de9bbe353007798a6337f307f177e907754382ce7bef8be060e01",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2024.1.1-aarch64.dmg",
+      "build_number": "241.15989.74"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
@@ -460,10 +460,10 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.dmg",
-      "version": "2024.1",
-      "sha256": "02bcb551de99cf070e90b2131b41f0b3e93aa776615bcfba1508e4c4d1bb9378",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.1-aarch64.dmg",
-      "build_number": "241.14494.237",
+      "version": "2024.1.1",
+      "sha256": "b6b2b6181c724c320a491cea013c620f662e3fbc3a2f62718354d9e88c9d210d",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.1.1-aarch64.dmg",
+      "build_number": "241.15989.102",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
@@ -485,42 +485,42 @@
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.dmg",
-      "version": "2024.1",
-      "sha256": "c2e0dadc6c7f924e849e87d1c04aeaa02d6a14d5868294dd36481a70cbd508cb",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.1-aarch64.dmg",
-      "build_number": "241.14494.307"
+      "version": "2024.1.1",
+      "sha256": "d197249cc5cb8fb3ec30f3ed5468dd6d7782e97adb1e48a0509d2415b48f7a1b",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2024.1.1-aarch64.dmg",
+      "build_number": "241.14494.325"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.dmg",
-      "version": "2024.1",
-      "sha256": "7e085580ebc8aadb9342e7362e3078b988e38fe8b5bfe8c4825a1744ad53c33f",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.1-aarch64.dmg",
-      "build_number": "241.14494.234"
+      "version": "2024.1.1",
+      "sha256": "5e6bd929f2b74145aa763ca277ade3c3512342b38a5a21a605c0b319f487b49e",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.1.1-aarch64.dmg",
+      "build_number": "241.15989.113"
     },
     "rust-rover": {
       "update-channel": "RustRover EAP",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.dmg",
-      "version": "2023.3 EAP",
-      "sha256": "03e7c1e3c029cd72ddc9422cc1dc54ed581356b278127dc8d2b2f9e53d357054",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-233.15026.24-aarch64.dmg",
-      "build_number": "233.15026.24"
+      "version": "2024.1 EAP",
+      "sha256": "1d63faf3d687508b976989768ee44ac3632017d55fce0557591dff2eae37d6a2",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-241.15989.101-aarch64.dmg",
+      "build_number": "241.15989.101"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.dmg",
-      "version": "2024.1",
-      "sha256": "95dd3a397fe063583c5e3ba4fefafdfcad740c18447c1a70c0f03cb004436496",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.1-aarch64.dmg",
-      "build_number": "241.14494.235"
+      "version": "2024.1.2",
+      "sha256": "b3ce2aabba5bc3afef95d768aa721bb245d2fce0ec8d69d61d011c2b23087d97",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.1.2-aarch64.dmg",
+      "build_number": "241.15989.105"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
       "url-template": "https://download.jetbrains.com/writerside/writerside-{version}-aarch64.dmg",
-      "version": "2023.3 EAP",
-      "sha256": "2a78fbcabcdd5b7c906d933dd91ac927bde22ae3bba988dad7450184fd90457a",
-      "url": "https://download.jetbrains.com/writerside/writerside-233.14938-aarch64.dmg",
-      "build_number": "233.14938"
+      "version": "2024.1 EAP",
+      "sha256": "624f9f2fb0ed7c7d42484e42c16b9b0ec0c542ad8187d81b11ef1d38576c589d",
+      "url": "https://download.jetbrains.com/writerside/writerside-241.15989.11-aarch64.dmg",
+      "build_number": "241.15989.11"
     }
   }
 }

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -18,16 +18,16 @@
       ],
       "builds": {
         "233.13135.979": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip",
-        "233.15026.24": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip",
-        "241.14494.234": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip",
-        "241.14494.235": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip",
-        "241.14494.237": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip",
         "241.14494.238": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip",
         "241.14494.240": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip",
         "241.14494.241": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip",
-        "241.14494.283": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip",
-        "241.14494.288": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip",
-        "241.14494.307": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip"
+        "241.14494.325": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip",
+        "241.15989.101": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip",
+        "241.15989.102": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip",
+        "241.15989.105": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip",
+        "241.15989.113": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip",
+        "241.15989.121": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip",
+        "241.15989.49": "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip"
       },
       "name": "ideavim"
     },
@@ -36,7 +36,7 @@
         "idea-ultimate"
       ],
       "builds": {
-        "241.14494.240": "https://plugins.jetbrains.com/files/631/513581/python-241.14494.240.zip"
+        "241.14494.240": "https://plugins.jetbrains.com/files/631/521307/python-241.14494.314.zip"
       },
       "name": "python"
     },
@@ -58,16 +58,16 @@
       ],
       "builds": {
         "233.13135.979": null,
-        "233.15026.24": null,
-        "241.14494.234": null,
-        "241.14494.235": null,
-        "241.14494.237": null,
         "241.14494.238": null,
         "241.14494.240": null,
         "241.14494.241": null,
-        "241.14494.283": null,
-        "241.14494.288": null,
-        "241.14494.307": null
+        "241.14494.325": null,
+        "241.15989.101": null,
+        "241.15989.102": null,
+        "241.15989.105": null,
+        "241.15989.113": null,
+        "241.15989.121": null,
+        "241.15989.49": null
       },
       "name": "kotlin"
     },
@@ -89,16 +89,16 @@
       ],
       "builds": {
         "233.13135.979": null,
-        "233.15026.24": "https://plugins.jetbrains.com/files/6981/509027/ini-233.15026.15.zip",
-        "241.14494.234": "https://plugins.jetbrains.com/files/6981/513562/ini-241.14494.240.zip",
-        "241.14494.235": "https://plugins.jetbrains.com/files/6981/513562/ini-241.14494.240.zip",
-        "241.14494.237": "https://plugins.jetbrains.com/files/6981/513562/ini-241.14494.240.zip",
         "241.14494.238": "https://plugins.jetbrains.com/files/6981/513562/ini-241.14494.240.zip",
         "241.14494.240": "https://plugins.jetbrains.com/files/6981/513562/ini-241.14494.240.zip",
         "241.14494.241": "https://plugins.jetbrains.com/files/6981/513562/ini-241.14494.240.zip",
-        "241.14494.283": "https://plugins.jetbrains.com/files/6981/513562/ini-241.14494.240.zip",
-        "241.14494.288": "https://plugins.jetbrains.com/files/6981/513562/ini-241.14494.240.zip",
-        "241.14494.307": "https://plugins.jetbrains.com/files/6981/513562/ini-241.14494.240.zip"
+        "241.14494.325": "https://plugins.jetbrains.com/files/6981/513562/ini-241.14494.240.zip",
+        "241.15989.101": "https://plugins.jetbrains.com/files/6981/527916/ini-241.15989.113.zip",
+        "241.15989.102": "https://plugins.jetbrains.com/files/6981/527916/ini-241.15989.113.zip",
+        "241.15989.105": "https://plugins.jetbrains.com/files/6981/527916/ini-241.15989.113.zip",
+        "241.15989.113": "https://plugins.jetbrains.com/files/6981/527916/ini-241.15989.113.zip",
+        "241.15989.121": "https://plugins.jetbrains.com/files/6981/527916/ini-241.15989.113.zip",
+        "241.15989.49": "https://plugins.jetbrains.com/files/6981/527916/ini-241.15989.113.zip"
       },
       "name": "ini"
     },
@@ -108,8 +108,8 @@
         "phpstorm"
       ],
       "builds": {
-        "241.14494.237": "https://plugins.jetbrains.com/files/7219/518876/Symfony_Plugin-2023.1.268.zip",
-        "241.14494.240": "https://plugins.jetbrains.com/files/7219/518876/Symfony_Plugin-2023.1.268.zip"
+        "241.14494.240": "https://plugins.jetbrains.com/files/7219/525744/Symfony_Plugin-2023.1.270.zip",
+        "241.15989.102": "https://plugins.jetbrains.com/files/7219/525744/Symfony_Plugin-2023.1.270.zip"
       },
       "name": "symfony-support"
     },
@@ -119,8 +119,8 @@
         "phpstorm"
       ],
       "builds": {
-        "241.14494.237": "https://plugins.jetbrains.com/files/7320/507957/PHP_Annotations-10.0.0.zip",
-        "241.14494.240": "https://plugins.jetbrains.com/files/7320/507957/PHP_Annotations-10.0.0.zip"
+        "241.14494.240": "https://plugins.jetbrains.com/files/7320/507957/PHP_Annotations-10.0.0.zip",
+        "241.15989.102": "https://plugins.jetbrains.com/files/7320/507957/PHP_Annotations-10.0.0.zip"
       },
       "name": "php-annotations"
     },
@@ -133,11 +133,11 @@
         "rust-rover"
       ],
       "builds": {
-        "233.15026.24": "https://plugins.jetbrains.com/files/7322/502153/python-ce-233.14808.12.zip",
         "241.14494.238": "https://plugins.jetbrains.com/files/7322/513587/python-ce-241.14494.240.zip",
         "241.14494.240": "https://plugins.jetbrains.com/files/7322/513587/python-ce-241.14494.240.zip",
-        "241.14494.283": "https://plugins.jetbrains.com/files/7322/513587/python-ce-241.14494.240.zip",
-        "241.14494.307": "https://plugins.jetbrains.com/files/7322/513587/python-ce-241.14494.240.zip"
+        "241.14494.325": "https://plugins.jetbrains.com/files/7322/513587/python-ce-241.14494.240.zip",
+        "241.15989.101": "https://plugins.jetbrains.com/files/7322/524818/python-ce-241.15989.69.zip",
+        "241.15989.49": "https://plugins.jetbrains.com/files/7322/524818/python-ce-241.15989.69.zip"
       },
       "name": "python-community-edition"
     },
@@ -158,15 +158,15 @@
       ],
       "builds": {
         "233.13135.979": "https://plugins.jetbrains.com/files/8182/466854/intellij-rust-233.15445.zip",
-        "241.14494.234": null,
-        "241.14494.235": null,
-        "241.14494.237": null,
         "241.14494.238": null,
         "241.14494.240": null,
         "241.14494.241": null,
-        "241.14494.283": null,
-        "241.14494.288": null,
-        "241.14494.307": null
+        "241.14494.325": null,
+        "241.15989.102": null,
+        "241.15989.105": null,
+        "241.15989.113": null,
+        "241.15989.121": null,
+        "241.15989.49": null
       },
       "name": "-deprecated-rust"
     },
@@ -187,15 +187,15 @@
       ],
       "builds": {
         "233.13135.979": null,
-        "241.14494.234": null,
-        "241.14494.235": null,
-        "241.14494.237": null,
         "241.14494.238": null,
         "241.14494.240": null,
         "241.14494.241": null,
-        "241.14494.283": null,
-        "241.14494.288": null,
-        "241.14494.307": null
+        "241.14494.325": null,
+        "241.15989.102": null,
+        "241.15989.105": null,
+        "241.15989.113": null,
+        "241.15989.121": null,
+        "241.15989.49": null
       },
       "name": "-deprecated-rust-beta"
     },
@@ -209,10 +209,10 @@
         "ruby-mine"
       ],
       "builds": {
-        "241.14494.234": "https://plugins.jetbrains.com/files/8554/508289/featuresTrainer-241.14494.150.zip",
         "241.14494.238": "https://plugins.jetbrains.com/files/8554/508289/featuresTrainer-241.14494.150.zip",
         "241.14494.240": "https://plugins.jetbrains.com/files/8554/508289/featuresTrainer-241.14494.150.zip",
-        "241.14494.241": "https://plugins.jetbrains.com/files/8554/508289/featuresTrainer-241.14494.150.zip"
+        "241.14494.241": "https://plugins.jetbrains.com/files/8554/508289/featuresTrainer-241.14494.150.zip",
+        "241.15989.113": "https://plugins.jetbrains.com/files/8554/508289/featuresTrainer-241.14494.150.zip"
       },
       "name": "ide-features-trainer"
     },
@@ -234,16 +234,16 @@
       ],
       "builds": {
         "233.13135.979": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip",
-        "233.15026.24": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip",
-        "241.14494.234": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip",
-        "241.14494.235": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip",
-        "241.14494.237": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip",
         "241.14494.238": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip",
         "241.14494.240": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip",
         "241.14494.241": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip",
-        "241.14494.283": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip",
-        "241.14494.288": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip",
-        "241.14494.307": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip"
+        "241.14494.325": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip",
+        "241.15989.101": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip",
+        "241.15989.102": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip",
+        "241.15989.105": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip",
+        "241.15989.113": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip",
+        "241.15989.121": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip",
+        "241.15989.49": "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip"
       },
       "name": "nixidea"
     },
@@ -276,16 +276,16 @@
       ],
       "builds": {
         "233.13135.979": "https://plugins.jetbrains.com/files/10037/493012/CSVEditor-3.3.0-233.zip",
-        "233.15026.24": "https://plugins.jetbrains.com/files/10037/493012/CSVEditor-3.3.0-233.zip",
-        "241.14494.234": "https://plugins.jetbrains.com/files/10037/493010/CSVEditor-3.3.0-241.zip",
-        "241.14494.235": "https://plugins.jetbrains.com/files/10037/493010/CSVEditor-3.3.0-241.zip",
-        "241.14494.237": "https://plugins.jetbrains.com/files/10037/493010/CSVEditor-3.3.0-241.zip",
         "241.14494.238": "https://plugins.jetbrains.com/files/10037/493010/CSVEditor-3.3.0-241.zip",
         "241.14494.240": "https://plugins.jetbrains.com/files/10037/493010/CSVEditor-3.3.0-241.zip",
         "241.14494.241": "https://plugins.jetbrains.com/files/10037/493010/CSVEditor-3.3.0-241.zip",
-        "241.14494.283": "https://plugins.jetbrains.com/files/10037/493010/CSVEditor-3.3.0-241.zip",
-        "241.14494.288": "https://plugins.jetbrains.com/files/10037/493010/CSVEditor-3.3.0-241.zip",
-        "241.14494.307": "https://plugins.jetbrains.com/files/10037/493010/CSVEditor-3.3.0-241.zip"
+        "241.14494.325": "https://plugins.jetbrains.com/files/10037/493010/CSVEditor-3.3.0-241.zip",
+        "241.15989.101": "https://plugins.jetbrains.com/files/10037/493010/CSVEditor-3.3.0-241.zip",
+        "241.15989.102": "https://plugins.jetbrains.com/files/10037/493010/CSVEditor-3.3.0-241.zip",
+        "241.15989.105": "https://plugins.jetbrains.com/files/10037/493010/CSVEditor-3.3.0-241.zip",
+        "241.15989.113": "https://plugins.jetbrains.com/files/10037/493010/CSVEditor-3.3.0-241.zip",
+        "241.15989.121": "https://plugins.jetbrains.com/files/10037/493010/CSVEditor-3.3.0-241.zip",
+        "241.15989.49": "https://plugins.jetbrains.com/files/10037/493010/CSVEditor-3.3.0-241.zip"
       },
       "name": "csv-editor"
     },
@@ -307,16 +307,16 @@
       ],
       "builds": {
         "233.13135.979": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
-        "233.15026.24": "https://plugins.jetbrains.com/files/12062/445740/keymap-vscode-233.11799.188.zip",
-        "241.14494.234": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip",
-        "241.14494.235": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip",
-        "241.14494.237": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip",
         "241.14494.238": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip",
         "241.14494.240": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip",
         "241.14494.241": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip",
-        "241.14494.283": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip",
-        "241.14494.288": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip",
-        "241.14494.307": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip"
+        "241.14494.325": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip",
+        "241.15989.101": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip",
+        "241.15989.102": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip",
+        "241.15989.105": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip",
+        "241.15989.113": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip",
+        "241.15989.121": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip",
+        "241.15989.49": "https://plugins.jetbrains.com/files/12062/508223/keymap-vscode-241.14494.150.zip"
       },
       "name": "vscode-keymap"
     },
@@ -338,16 +338,16 @@
       ],
       "builds": {
         "233.13135.979": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
-        "233.15026.24": "https://plugins.jetbrains.com/files/12559/445772/keymap-eclipse-233.11799.165.zip",
-        "241.14494.234": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
-        "241.14494.235": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
-        "241.14494.237": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
         "241.14494.238": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
         "241.14494.240": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
         "241.14494.241": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
-        "241.14494.283": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
-        "241.14494.288": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
-        "241.14494.307": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip"
+        "241.14494.325": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
+        "241.15989.101": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
+        "241.15989.102": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
+        "241.15989.105": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
+        "241.15989.113": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
+        "241.15989.121": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
+        "241.15989.49": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip"
       },
       "name": "eclipse-keymap"
     },
@@ -369,16 +369,16 @@
       ],
       "builds": {
         "233.13135.979": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
-        "233.15026.24": "https://plugins.jetbrains.com/files/13017/445774/keymap-visualStudio-233.11799.165.zip",
-        "241.14494.234": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip",
-        "241.14494.235": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip",
-        "241.14494.237": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip",
         "241.14494.238": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip",
         "241.14494.240": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip",
         "241.14494.241": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip",
-        "241.14494.283": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip",
-        "241.14494.288": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip",
-        "241.14494.307": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip"
+        "241.14494.325": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip",
+        "241.15989.101": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip",
+        "241.15989.102": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip",
+        "241.15989.105": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip",
+        "241.15989.113": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip",
+        "241.15989.121": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip",
+        "241.15989.49": "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip"
       },
       "name": "visual-studio-keymap"
     },
@@ -400,16 +400,16 @@
       ],
       "builds": {
         "233.13135.979": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "233.15026.24": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "241.14494.234": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "241.14494.235": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "241.14494.237": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "241.14494.238": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "241.14494.240": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "241.14494.241": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "241.14494.283": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "241.14494.288": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "241.14494.307": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
+        "241.14494.325": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "241.15989.101": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "241.15989.102": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "241.15989.105": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "241.15989.113": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "241.15989.121": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "241.15989.49": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
       },
       "name": "darcula-pitch-black"
     },
@@ -431,16 +431,16 @@
       ],
       "builds": {
         "233.13135.979": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip",
-        "233.15026.24": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip",
-        "241.14494.234": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip",
-        "241.14494.235": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip",
-        "241.14494.237": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip",
         "241.14494.238": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip",
         "241.14494.240": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip",
         "241.14494.241": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip",
-        "241.14494.283": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip",
-        "241.14494.288": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip",
-        "241.14494.307": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip"
+        "241.14494.325": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip",
+        "241.15989.101": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip",
+        "241.15989.102": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip",
+        "241.15989.105": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip",
+        "241.15989.113": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip",
+        "241.15989.121": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip",
+        "241.15989.49": "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip"
       },
       "name": "github-copilot"
     },
@@ -462,16 +462,16 @@
       ],
       "builds": {
         "233.13135.979": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "233.15026.24": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "241.14494.234": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "241.14494.235": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "241.14494.237": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "241.14494.238": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "241.14494.240": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "241.14494.241": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "241.14494.283": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "241.14494.288": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "241.14494.307": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
+        "241.14494.325": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "241.15989.101": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "241.15989.102": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "241.15989.105": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "241.15989.113": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "241.15989.121": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "241.15989.49": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
     },
@@ -482,9 +482,9 @@
         "rust-rover"
       ],
       "builds": {
-        "233.15026.24": "https://plugins.jetbrains.com/files/22407/515371/intellij-rust-233.25026.24.zip",
-        "241.14494.240": "https://plugins.jetbrains.com/files/22407/515370/intellij-rust-241.25026.24.zip",
-        "241.14494.288": "https://plugins.jetbrains.com/files/22407/515370/intellij-rust-241.25026.24.zip"
+        "241.14494.240": "https://plugins.jetbrains.com/files/22407/526873/intellij-rust-241.25989.101.zip",
+        "241.15989.101": "https://plugins.jetbrains.com/files/22407/526873/intellij-rust-241.25989.101.zip",
+        "241.15989.121": "https://plugins.jetbrains.com/files/22407/526873/intellij-rust-241.25989.101.zip"
       },
       "name": "rust"
     }
@@ -502,15 +502,14 @@
     "https://plugins.jetbrains.com/files/164/515255/IdeaVim-2.10.2-signed.zip": "sha256-FP6th8J3ymfTrwvJ3Ms7fsNPh3f9ab5ZVg5yPpKV/rY=",
     "https://plugins.jetbrains.com/files/17718/517133/github-copilot-intellij-1.5.2.5345.zip": "sha256-BaBYXN8eulaJtJSKrz9bZ2Yn8029goSAUvjYU+BaiIU=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
-    "https://plugins.jetbrains.com/files/22407/515370/intellij-rust-241.25026.24.zip": "sha256-tBPoO2EkPaWFZ/Gu3UAkZPy4opssWJQEVlz9GZUkNtQ=",
-    "https://plugins.jetbrains.com/files/22407/515371/intellij-rust-233.25026.24.zip": "sha256-j4b4To8jY4orP87GpphHPtLKeAPDNXcLNSUlIXDDy2Q=",
-    "https://plugins.jetbrains.com/files/631/513581/python-241.14494.240.zip": "sha256-pQP1LF/6uImQpBOpxUGE8KmmFh26kiC4YaYLAHnEc3o=",
-    "https://plugins.jetbrains.com/files/6981/509027/ini-233.15026.15.zip": "sha256-6sTD+OFO/yA7m5o0XqoJKLcQ4zAFro7Iy7WNPfA49xM=",
+    "https://plugins.jetbrains.com/files/22407/526873/intellij-rust-241.25989.101.zip": "sha256-v1r14zx591Vr8JmQxfysQ/aO8HDYCorwnnOEKDIfx+Y=",
+    "https://plugins.jetbrains.com/files/631/521307/python-241.14494.314.zip": "sha256-LFPN3bURT4gauDdoOgs+Rnq90RZ68/mrpw7/hfsq7VI=",
     "https://plugins.jetbrains.com/files/6981/513562/ini-241.14494.240.zip": "sha256-QC42nC7mEE3X1cmKj8jkwzpDJzX7ZoOPEd9y6i8IuvM=",
-    "https://plugins.jetbrains.com/files/7219/518876/Symfony_Plugin-2023.1.268.zip": "sha256-mYEuFdSaxw9Lc8yNgPB0ty6mfxjKaAa/jY6v4E2Qo0Q=",
+    "https://plugins.jetbrains.com/files/6981/527916/ini-241.15989.113.zip": "sha256-JgFoDqeMxdg3E9ZWHVsJGSygKAifFCEa9S+RdLFkLBI=",
+    "https://plugins.jetbrains.com/files/7219/525744/Symfony_Plugin-2023.1.270.zip": "sha256-JSMTavSX9dzcOjbeuI7HBThtztwkyUqGOtCXNbCsfio=",
     "https://plugins.jetbrains.com/files/7320/507957/PHP_Annotations-10.0.0.zip": "sha256-JIZ6Iq3sOcAm8fBXnjRrG9dqCZuD/WajyVmn1JjYMBA=",
-    "https://plugins.jetbrains.com/files/7322/502153/python-ce-233.14808.12.zip": "sha256-PUBR9krJ26QrL2jTus0b+uhzkEkT+lGnBKy1f4i/U+w=",
     "https://plugins.jetbrains.com/files/7322/513587/python-ce-241.14494.240.zip": "sha256-6YC/aoiTRLAh87C2v3k24BLBH/tsdTWuDK/CBv8y1QI=",
+    "https://plugins.jetbrains.com/files/7322/524818/python-ce-241.15989.69.zip": "sha256-RG4pXcX8KpN1es6qvuU/YL+2LUuOCyzkxy09tJ/XAIE=",
     "https://plugins.jetbrains.com/files/8182/466854/intellij-rust-233.15445.zip": "sha256-+Lc/avYBLpyIV63DlbhAJtieHDv4HdggqdGFDw9iqN0=",
     "https://plugins.jetbrains.com/files/8554/508289/featuresTrainer-241.14494.150.zip": "sha256-D2gF9bLAEFd1+6vZskiM2Eyl5e8hmyh/VHrmW2NociE=",
     "https://plugins.jetbrains.com/files/8607/519418/NixIDEA-0.4.0.12.zip": "sha256-D2HFG2tQy719+baHjUyizoq67tv6lDZrX3s6HDlBRA0=",


### PR DESCRIPTION
## Description of changes


Ran the `update_bin.py` script

```
jetbrains.clion: 2024.1 -> 2024.1.1
jetbrains.datagrip: 2024.1.1 -> 2024.1.2
jetbrains.dataspell: 2024.1 -> 2024.1.1
jetbrains.gateway: 2024.1 -> 2024.1.1
jetbrains.phpstorm: 2024.1 -> 2024.1.1
jetbrains.rider: 2024.1 -> 2024.1.1
jetbrains.ruby-mine: 2024.1 -> 2024.1.1
jetbrains.rust-rover: 2023.3 EAP -> 2024.1 EAP
jetbrains.webstorm: 2024.1 -> 2024.1.1
jetbrains.writerside: 2023.3 EAP -> 2024.1 EAP
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
