### PR TITLE
fretboard: 5.4 -> 6.1

### DIFF
--- a/pkgs/by-name/fr/fretboard/package.nix
+++ b/pkgs/by-name/fr/fretboard/package.nix
@@ -16,21 +16,21 @@
 , wrapGAppsHook4
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "fretboard";
-  version = "5.4";
+  version = "6.1";
 
   src = fetchFromGitHub {
     owner = "bragefuglseth";
     repo = "fretboard";
-    rev = "v${version}";
-    hash = "sha256-GqnwAB7hmg2QLwSWqrZtTp6+FybK8/v4GZx/lMi0dGY=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Jr7DxoOmggcAxU1y+2jXZvMgAf9SDSA7t5Jr2AYZV7s=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit src;
-    name = "${pname}-${version}";
-    hash = "sha256-sGvb1+HKIqNSgCV9UzkCrkGrpjA34Pe9eq2/w3K/w/E=";
+    src = finalAttrs.src;
+    name = "${finalAttrs.pname}-${finalAttrs.version}";
+    hash = "sha256-P7dafWBaHVrxh30YxKiraKPMjtmGTTNd8qvoJ1M2vKI=";
   };
 
   nativeBuildInputs = [
@@ -58,12 +58,12 @@ stdenv.mkDerivation rec {
   ]);
 
   meta = with lib; {
+    changelog = "https://github.com/bragefuglseth/fretboard/releases/tag/v${finalAttrs.version}";
     description = "Look up guitar chords";
-    homepage = "https://github.com/bragefuglseth/fretboard";
-    changelog = "https://github.com/bragefuglseth/fretboard/releases/tag/v${version}";
+    homepage = "https://apps.gnome.org/Fretboard/";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ michaelgrahamevans ];
     mainProgram = "fretboard";
+    maintainers = with maintainers; [ michaelgrahamevans ];
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

https://github.com/bragefuglseth/fretboard/releases/tag/v6.0
https://github.com/bragefuglseth/fretboard/releases/tag/v6.1
https://github.com/bragefuglseth/fretboard/compare/v5.4...v6.1

Updates to libadwaita v1.5 and adds translations.

In the nix file, I have switched to the `finalAttrs` pattern, updated the homepage link and sorted the meta fields.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
