### PR TITLE
Make parent dir available in fileset.fileFilter

### DIFF
--- a/lib/fileset/default.nix
+++ b/lib/fileset/default.nix
@@ -668,6 +668,8 @@ in {
 
       - `name` (String): The name of the file
 
+      - `dir` (Path): The path of the directory containing the file.
+
       - `type` (String, one of `"regular"`, `"symlink"` or `"unknown"`): The type of the file.
         This matches result of calling [`builtins.readFileType`](https://nixos.org/manual/nix/stable/language/builtins.html#builtins-readFileType) on the file's path.
 

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -825,11 +825,11 @@ rec {
   _fileFilter = predicate: root:
     let
       # Check the predicate for a single file
-      # Type: String -> String -> filesetTree
-      fromFile = name: type:
+      # Type: Path -> String -> String -> filesetTree
+      fromFile = dir: name: type:
         if
           predicate {
-            inherit name type;
+            inherit dir name type;
             hasExt = ext: hasSuffix ".${ext}" name;
 
             # To ensure forwards compatibility with more arguments being added in the future,
@@ -848,7 +848,7 @@ rec {
           if type == "directory" then
             fromDir (path + "/${name}")
           else
-            fromFile name type
+            fromFile path name type
         ) (readDir path);
 
       rootType = pathType root;


### PR DESCRIPTION
## Description of changes

Currently, fileFilter only allows filtering based based on a files base name + file type.

This is a bit limiting if you want to include files based on the name of the directory they reside in.

I bumped in to this when using fileFilter to make a minimal set of files to make Cargo happy in a Rust workspace - specifically, I needed to pull in any `.rs` file that lived under a `bin/`, `examples/`, or `benches/` folder before Cargo would stop complaining. (Note that I am trying to avoid pulling in all rust files - I'm working in a large Rust workspace but trying to package a single small member of the workspace).

This change allows me to write filters like such as this:

```
file.hasExt "rs" && (pkgs.lib.hasSuffix  "bin" (toString file.path))
```

## Open questions
- should `dir` be a Path (as implemented it is) or should it be converted to stringified path relative to the filter root?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


### Benchmark results
There is a preexisting benchmark script. I ran `./benchmark.sh master` and got the following results:

```
Benchmarking expression toSource { root = ./.; fileset = ./.; }
Mean CPU time 0.179607 (σ = 0.00527474) for 10 runs is 100.03230315958318% (σ = 3.669259422572901%) of the old value 0.179549 (σ = 0.00394593)
Statistic .gc.totalBytes (19776544) is 100.0001% (+32) of the old value 19776512
1 stats differ between the current tree and master

Benchmarking expression toSource { root = ./.; fileset = unions (mapAttrsToList (name: value: ./. + "/${name}") (builtins.readDir ./.)); }
Mean CPU time 0.105958 (σ = 0.00257414) for 10 runs is 101.95621842675006% (σ = 2.7418005135301344%) of the old value 0.103925 (σ = 0.00119843)
0 stats differ between the current tree and master
```

This doesn't seem to have a large impact on performance if not using `dir`
