### PR TITLE
moneydance: 2023.3_5064 -> 2024.1_5118

### DIFF
--- a/pkgs/by-name/mo/moneydance/package.nix
+++ b/pkgs/by-name/mo/moneydance/package.nix
@@ -1,16 +1,22 @@
-{ lib, stdenv, fetchzip, makeWrapper, openjdk21, openjfx21, jvmFlags ? [ ] }:
-let jdk = openjdk21.override { enableJavaFX = true; };
-in stdenv.mkDerivation (finalAttrs: {
+{ lib, stdenv, fetchzip, makeWrapper, openjdk22, openjfx22, jvmFlags ? [ ] }:
+let
+  openjfx = openjfx22;
+  jdk = openjdk22.override {
+    enableJavaFX = true;
+    inherit openjfx;
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "moneydance";
-  version = "2023.3_5064";
+  version = "2024.1_5118";
 
   src = fetchzip {
-    url = "https://infinitekind.com/stabledl/${finalAttrs.version}/moneydance-linux.tar.gz";
-    hash = "sha256-jHr1V/gV1seenw2Q0/G405lTiabEYEsOS8p/XyByrtM=";
+    url = "https://infinitekind.com/stabledl/2024_5118/moneydance-linux.tar.gz";
+    hash = "sha256-wwSb3CuhuXB4I9jq+TpLPbd1k9UzqQbAaZkGKgi+nns=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jdk openjfx21 ];
+  buildInputs = [ jdk openjfx ];
 
   # Note the double escaping in the call to makeWrapper. The escapeShellArgs
   # call quotes each element of the flags list as a word[1] and returns a
@@ -43,6 +49,7 @@ in stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://infinitekind.com/moneydance";
+    changelog = "https://infinitekind.com/stabledl/2024_5118/changelog.txt";
     description = "An easy to use and full-featured personal finance app that doesn't compromise your privacy";
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
     license = lib.licenses.unfree;


### PR DESCRIPTION
## Description of changes

Changelog: https://infinitekind.com/stabledl/2024_5118/changelog.txt

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).