### PR TITLE
rocmPackages: use CMake 3.9.2 when building clr

### DIFF
--- a/pkgs/development/rocm-modules/5/clr/default.nix
+++ b/pkgs/development/rocm-modules/5/clr/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , callPackage
 , fetchFromGitHub
+, fetchurl
 , rocmUpdateScript
 , makeWrapper
 , cmake
@@ -33,6 +34,16 @@ let
     "--set HSA_PATH ${rocm-runtime}"
     "--set ROCM_PATH $out"
   ];
+
+  # https://github.com/NixOS/nixpkgs/issues/305641
+  # Not needed when 3.29.2 is in unstable
+  cmake' = cmake.overrideAttrs(old: rec {
+    version = "3.29.2";
+    src = fetchurl {
+      url = "https://cmake.org/files/v${lib.versions.majorMinor version}/cmake-${version}.tar.gz";
+      hash = "sha256-NttLaSaqt0G6bksuotmckZMiITIwi03IJNQSPLcwNS4=";
+    };
+  });
 in stdenv.mkDerivation (finalAttrs: {
   pname = "clr";
   version = "5.7.1";
@@ -51,7 +62,7 @@ in stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     makeWrapper
-    cmake
+    cmake'
     perl
     python3Packages.python
     python3Packages.cppheaderparser

--- a/pkgs/development/rocm-modules/6/clr/default.nix
+++ b/pkgs/development/rocm-modules/6/clr/default.nix
@@ -3,6 +3,7 @@
 , callPackage
 , fetchFromGitHub
 , fetchpatch
+, fetchurl
 , rocmUpdateScript
 , makeWrapper
 , cmake
@@ -34,6 +35,16 @@ let
     "--set HSA_PATH ${rocm-runtime}"
     "--set ROCM_PATH $out"
   ];
+
+  # https://github.com/NixOS/nixpkgs/issues/305641
+  # Not needed when 3.29.2 is in unstable
+  cmake' = cmake.overrideAttrs(old: rec {
+    version = "3.29.2";
+    src = fetchurl {
+      url = "https://cmake.org/files/v${lib.versions.majorMinor version}/cmake-${version}.tar.gz";
+      hash = "sha256-NttLaSaqt0G6bksuotmckZMiITIwi03IJNQSPLcwNS4=";
+    };
+  });
 in stdenv.mkDerivation (finalAttrs: {
   pname = "clr";
   version = "6.0.2";
@@ -52,7 +63,7 @@ in stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     makeWrapper
-    cmake
+    cmake'
     perl
     python3Packages.python
     python3Packages.cppheaderparser


### PR DESCRIPTION
Fixes #305641.

## Description of changes

Ensure CMake 3.9.2 is used to build clr, both for ROCm 5 and 6. The changes can be reverted once CMake 3.9.2 lands in unstable, if desired.

I have tested that `rocsparse` (5 and 6), `rocfft` (6), and `composable_kernel` (6) all build.

See #305641 for more details.

cc @mschwaig

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
