### PR TITLE
yabai: pkgs/os-specific -> pkgs/by-name

### DIFF
--- a/pkgs/by-name/ya/yabai/package.nix
+++ b/pkgs/by-name/ya/yabai/package.nix
@@ -1,42 +1,51 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, fetchzip
-, installShellFiles
-, testers
-, writeShellScript
-, common-updater-scripts
-, curl
-, jq
-, xcodebuild
-, xxd
-, yabai
-, Carbon
-, Cocoa
-, ScriptingBridge
-, SkyLight
+{
+  lib,
+  stdenv,
+  overrideSDK,
+  fetchFromGitHub,
+  fetchzip,
+  installShellFiles,
+  testers,
+  writeShellScript,
+  common-updater-scripts,
+  curl,
+  darwin,
+  jq,
+  xcodebuild,
+  xxd,
+  yabai,
 }:
+let
+  inherit (darwin.apple_sdk_11_0.frameworks)
+    Carbon
+    Cocoa
+    ScriptingBridge
+    SkyLight
+    ;
 
-stdenv.mkDerivation (finalAttrs: {
+  stdenv' = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
+in
+stdenv'.mkDerivation (finalAttrs: {
   pname = "yabai";
   version = "7.1.0";
 
-  src = finalAttrs.passthru.sources.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  src =
+    finalAttrs.passthru.sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   env = {
     # silence service.h error
     NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration";
   };
 
-  nativeBuildInputs = [
-    installShellFiles
-  ]
-  ++ lib.optionals stdenv.isx86_64 [
-    xcodebuild
-    xxd
-  ];
+  nativeBuildInputs =
+    [ installShellFiles ]
+    ++ lib.optionals stdenv.isx86_64 [
+      xcodebuild
+      xxd
+    ];
 
-  buildInputs = [ ] ++ lib.optionals stdenv.isx86_64 [
+  buildInputs = lib.optionals stdenv.isx86_64 [
     Carbon
     Cocoa
     ScriptingBridge
@@ -59,20 +68,22 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  postPatch = lib.optionalString stdenv.isx86_64 /* bash */ ''
-    # aarch64 code is compiled on all targets, which causes our Apple SDK headers to error out.
-    # Since multilib doesnt work on darwin i dont know of a better way of handling this.
-    substituteInPlace makefile \
-    --replace "-arch arm64e" "" \
-    --replace "-arch arm64" "" \
-    --replace "clang" "${stdenv.cc.targetPrefix}clang"
+  postPatch =
+    lib.optionalString stdenv.isx86_64 # bash
+      ''
+        # aarch64 code is compiled on all targets, which causes our Apple SDK headers to error out.
+        # Since multilib doesn't work on darwin i dont know of a better way of handling this.
+        substituteInPlace makefile \
+        --replace "-arch arm64e" "" \
+        --replace "-arch arm64" "" \
+        --replace "clang" "${stdenv.cc.targetPrefix}clang"
 
-    # `NSScreen::safeAreaInsets` is only available on macOS 12.0 and above, which frameworks arent packaged.
-    # When a lower OS version is detected upstream just returns 0, so we can hardcode that at compiletime.
-    # https://github.com/koekeishiya/yabai/blob/v4.0.2/src/workspace.m#L109
-    substituteInPlace src/workspace.m \
-    --replace 'return screen.safeAreaInsets.top;' 'return 0;'
-  '';
+        # `NSScreen::safeAreaInsets` is only available on macOS 12.0 and above, which frameworks aren't packaged.
+        # When a lower OS version is detected upstream just returns 0, so we can hardcode that at compile time.
+        # https://github.com/koekeishiya/yabai/blob/v4.0.2/src/workspace.m#L109
+        substituteInPlace src/workspace.m \
+        --replace 'return screen.safeAreaInsets.top;' 'return 0;'
+      '';
 
   passthru = {
     tests.version = testers.testVersion {
@@ -87,18 +98,23 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://github.com/koekeishiya/yabai/releases/download/v${finalAttrs.version}/yabai-v${finalAttrs.version}.tar.gz";
         hash = "sha256-88Sh2nizAQ0a0cnlnrkhb5x3VjHa372HhjHlmNjGdQ4=";
       };
-      "x86_64-darwin" = fetchFromGitHub
-        {
-          owner = "koekeishiya";
-          repo = "yabai";
-          rev = "v${finalAttrs.version}";
-          hash = "sha256-5iC1U6tyUYFLjOfnIxCrjCjj2deUZ/rvsJN4jlrr2Tc=";
-        };
+      "x86_64-darwin" = fetchFromGitHub {
+        owner = "koekeishiya";
+        repo = "yabai";
+        rev = "v${finalAttrs.version}";
+        hash = "sha256-5iC1U6tyUYFLjOfnIxCrjCjj2deUZ/rvsJN4jlrr2Tc=";
+      };
     };
 
     updateScript = writeShellScript "update-yabai" ''
       set -o errexit
-      export PATH="${lib.makeBinPath [ curl jq common-updater-scripts ]}"
+      export PATH="${
+        lib.makeBinPath [
+          curl
+          jq
+          common-updater-scripts
+        ]
+      }"
       NEW_VERSION=$(curl --silent https://api.github.com/repos/koekeishiya/yabai/releases/latest | jq '.tag_name | ltrimstr("v")' --raw-output)
       if [[ "${finalAttrs.version}" = "$NEW_VERSION" ]]; then
           echo "The new version same as the old version."
@@ -130,12 +146,8 @@ stdenv.mkDerivation (finalAttrs: {
       ivar
       khaneliman
     ];
-    sourceProvenance = with lib.sourceTypes; [ ]
-      ++ lib.optionals stdenv.isx86_64 [
-      fromSource
-    ] ++ lib.optionals stdenv.isAarch64 [
-      binaryNativeCode
-    ];
+    sourceProvenance =
+      with lib.sourceTypes;
+      lib.optionals stdenv.isx86_64 [ fromSource ] ++ lib.optionals stdenv.isAarch64 [ binaryNativeCode ];
   };
 })
-

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40745,10 +40745,6 @@ with pkgs;
 
   xzoom = callPackage ../tools/X11/xzoom { };
 
-  yabai = darwin.apple_sdk_11_0.callPackage ../os-specific/darwin/yabai {
-    inherit (darwin.apple_sdk_11_0.frameworks) SkyLight Cocoa Carbon ScriptingBridge;
-  };
-
   yacreader = libsForQt5.callPackage ../applications/graphics/yacreader { };
 
   yadm = callPackage ../applications/version-management/yadm { };


### PR DESCRIPTION
## Description of changes
Looking to take advantage of nixpkgs-merge-bot for some of the packages I maintain. Moving these to by-name.
Splitting off https://github.com/NixOS/nixpkgs/pull/303961
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
