### PR TITLE
ffado: Remove Qt dependency

### DIFF
--- a/pkgs/os-specific/linux/ffado/default.nix
+++ b/pkgs/os-specific/linux/ffado/default.nix
@@ -7,7 +7,6 @@
   dbus_cplusplus,
   desktop-file-utils,
   fetchurl,
-  fetchpatch,
   glibmm,
   libavc1394,
   libconfig,
@@ -31,7 +30,7 @@ let
 in
 mkDerivation rec {
   pname = "ffado";
-  version = "2.4.8";
+  version = "2.4.9";
 
   outputs = [
     "out"
@@ -41,7 +40,7 @@ mkDerivation rec {
 
   src = fetchurl {
     url = "http://www.ffado.org/files/libffado-${version}.tgz";
-    hash = "sha256-0iFXYyGctOoHCdc232Ud80/wV81tiS7ItiS0uLKyq2Y=";
+    hash = "sha256-xELFL60Ryv1VE7tOhGyFHxAchIT4karFRe0ZDo/U0Q8=";
   };
 
   prePatch = ''
@@ -49,20 +48,7 @@ mkDerivation rec {
       --replace /lib/modules/ "/run/booted-system/kernel-modules/lib/modules/"
   '';
 
-  patches = [
-    # fix installing metainfo file
-    ./fix-build.patch
-
-    (fetchpatch {
-      name = "musl.patch";
-      url = "http://subversion.ffado.org/changeset?format=diff&new=2846&old=2845";
-      stripLen = 2;
-      hash = "sha256-iWeYnb5J69Uvo1lftc7MWg7WrLa+CGZyOwJPOe8/PKg=";
-    })
-  ];
-
   nativeBuildInputs = [
-    desktop-file-utils
     (scons.override { python3Packages = python311.pkgs; })
     pkg-config
     which
@@ -76,7 +62,6 @@ mkDerivation rec {
     "DEBUG=False"
     "ENABLE_ALL=True"
     "BUILD_TESTS=True"
-    "WILL_DEAL_WITH_XDG_MYSELF=True"
     "BUILD_MIXER=True"
     "UDEVDIR=${placeholder "out"}/lib/udev/rules.d"
     "PYPKGDIR=${placeholder "out"}/${python.sitePackages}"
@@ -105,13 +90,6 @@ mkDerivation rec {
   dontWrapQtApps = true;
 
   postInstall = ''
-    desktop="$bin/share/applications/ffado-mixer.desktop"
-    install -DT -m 444 support/xdg/ffado.org-ffadomixer.desktop $desktop
-    substituteInPlace "$desktop" \
-      --replace Exec=ffado-mixer "Exec=$bin/bin/ffado-mixer" \
-      --replace hi64-apps-ffado ffado-mixer
-    install -DT -m 444 support/xdg/hi64-apps-ffado.png "$bin/share/icons/hicolor/64x64/apps/ffado-mixer.png"
-
     # prevent build tools from leaking into closure
     echo 'See `nix-store --query --tree ${placeholder "out"}`.' > $out/lib/libffado/static_info.txt
   '';

--- a/pkgs/os-specific/linux/ffado/default.nix
+++ b/pkgs/os-specific/linux/ffado/default.nix
@@ -55,7 +55,10 @@ mkDerivation rec {
 
   nativeBuildInputs =
     [
-      (scons.override { python3Packages = python311.pkgs; })
+      (scons.override {
+        # SConstruct script depends on distutils removed in Python 3.12
+        python3Packages = python311.pkgs;
+      })
       pkg-config
       which
     ]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26850,6 +26850,7 @@ with pkgs;
   fatrace = callPackage ../os-specific/linux/fatrace { };
 
   ffado = libsForQt5.callPackage ../os-specific/linux/ffado { };
+  ffado-mixer = libsForQt5.callPackage ../os-specific/linux/ffado { withMixer = true; };
   libffado = ffado;
 
   fbterm = callPackage ../os-specific/linux/fbterm { };


### PR DESCRIPTION
## Description of changes

This slims up `pipewire` build closure.

The full package is available as `ffado-mixer`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
