### PR TITLE
Patch RPATH for pre-built node modules in vesktop, terra-station, standardnotes, and logseq

### DIFF
--- a/pkgs/applications/blockchains/terra-station/default.nix
+++ b/pkgs/applications/blockchains/terra-station/default.nix
@@ -5,6 +5,7 @@
 , bash
 , makeWrapper
 , electron
+, asar
 }:
 
 let
@@ -31,7 +32,7 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper asar ];
 
   dontConfigure = true;
   dontBuild = true;
@@ -47,6 +48,13 @@ stdenv.mkDerivation rec {
 
     cp -a usr/share/* $out/share
     cp -a "opt/Terra Station/"{locales,resources} $out/share/${pname}
+
+    # patch pre-built node modules
+    asar e $out/share/${pname}/resources/app.asar asar-unpacked
+    find asar-unpacked -name '*.node' -exec patchelf \
+      --add-rpath "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}" \
+      {} \;
+    asar p asar-unpacked $out/share/${pname}/resources/app.asar
 
     substituteInPlace $out/share/applications/station-electron.desktop \
       --replace "/opt/Terra Station/station-electron" ${pname}

--- a/pkgs/applications/misc/logseq/default.nix
+++ b/pkgs/applications/misc/logseq/default.nix
@@ -5,6 +5,7 @@
 , makeWrapper
 # graphs will not sync without matching upstream's major electron version
 , electron_27
+, autoPatchelfHook
 , git
 , nix-update-script
 }:
@@ -30,7 +31,8 @@ in {
   dontConfigure = true;
   dontBuild = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
+  buildInputs = [ stdenv.cc.cc.lib ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -13,6 +13,9 @@
 , moreutils
 , cacert
 , nodePackages
+, pipewire
+, libpulseaudio
+, autoPatchelfHook
 , withTTS ? true
   # Enables the use of vencord from nixpkgs instead of
   # letting vesktop manage it's own version
@@ -81,6 +84,13 @@ stdenv.mkDerivation (finalAttrs: {
     nodePackages.pnpm
     nodePackages.nodejs
     makeWrapper
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    pipewire
+    libpulseaudio
+    stdenv.cc.cc.lib
   ];
 
   patches = [
@@ -106,6 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
     # using `pnpm exec` here apparently makes it ignore ELECTRON_SKIP_BINARY_DOWNLOAD
     ./node_modules/.bin/electron-builder \
       --dir \
+      -c.asarUnpack="**/*.node" \
       -c.electronDist=${electron}/libexec/electron \
       -c.electronVersion=${electron.version}
   '';
@@ -115,8 +126,8 @@ stdenv.mkDerivation (finalAttrs: {
     ''
       runHook preInstall
 
-      mkdir -p $out/opt/Vesktop/resources
-      cp dist/linux-*unpacked/resources/app.asar $out/opt/Vesktop/resources
+      mkdir -p $out/opt/Vesktop
+      cp -r dist/linux-*unpacked/resources $out/opt/Vesktop/
 
       pushd build
       ${libicns}/bin/icns2png -x icon.icns


### PR DESCRIPTION
## Description of changes

#303590 removed several `LD_LIBRARY_PATH` overrides for `electron` applications. While this works for libraries that are loaded using `dlopen(3)`, several of the affected applications ship pre-compiled native node modules, which also need their `RPATH` adjusted.

Fixes #306374.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>logseq</li>
    <li>standardnotes</li>
    <li>terra-station</li>
    <li>vesktop</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
