### PR TITLE
Revert "workflows: add concurrency group to check-by-name workflow"

### DIFF
--- a/.github/workflows/check-by-name.yml
+++ b/.github/workflows/check-by-name.yml
@@ -16,13 +16,6 @@ on:
     # so it shouldn't be a problem
     types: [opened, synchronize, reopened, edited]
 
-# Create a check-by-name concurrency group based on the branch name. if a new
-# commit is pushed to the main branch while a previous run is still in progress,
-# the previous run will be cancelled and the new one will start.
-concurrency:
-  group: check-by-name-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   # We need this permission to cancel the workflow run if there's a merge conflict
   actions: write


### PR DESCRIPTION
This reverts commit 75600cde6bb25b0e04d2a10d0fb9aaf975e1da81.

## Description of changes

@infinisil I don't think it's working as expected.

- https://github.com/NixOS/nixpkgs/pull/306427
- https://github.com/NixOS/nixpkgs/pull/306418

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
