### PR TITLE
soundconverter: 4.0.3 -> 4.0.5

### DIFF
--- a/pkgs/by-name/so/soundconverter/package.nix
+++ b/pkgs/by-name/so/soundconverter/package.nix
@@ -7,11 +7,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "soundconverter";
-  version = "4.0.3";
+  version = "4.0.4";
 
   src = fetchurl {
     url = "https://launchpad.net/soundconverter/trunk/${version}/+download/${pname}-${version}.tar.gz";
-    sha256 = "sha256-hzIG/4LD3705erPYvXb7uoRwF9LtKKIKB3jrhpYMsZ0=";
+    hash = "sha256-15TeNxFQzE6pzADuBN8jEzpPPna4pt0x4GXsaxi0gr4=";
   };
 
   buildInputs = [
@@ -56,7 +56,7 @@ python3Packages.buildPythonApplication rec {
     # FIXME: Fails due to weird Gio.file_parse_name() behavior.
     sed -i '49 a\    @unittest.skip("Gio.file_parse_name issues")' tests/testcases/names.py
   '' + lib.optionalString (!faacSupport) ''
-    substituteInPlace tests/testcases/integration.py --replace \
+    substituteInPlace tests/testcases/gui_integration.py --replace \
       "for encoder in ['fdkaacenc', 'faac', 'avenc_aac']:" \
       "for encoder in ['fdkaacenc', 'avenc_aac']:"
   '';
@@ -65,6 +65,10 @@ python3Packages.buildPythonApplication rec {
     runHook preCheck
     xvfb-run python tests/test.py
     runHook postCheck
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/soundconverter --prefix PYTHONPATH : "$PYTHONPATH"
   '';
 
   # Necessary to set GDK_PIXBUF_MODULE_FILE.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13209,8 +13209,6 @@ with pkgs;
 
   sony-headphones-client = callPackage ../applications/audio/sony-headphones-client { };
 
-  soundconverter = callPackage ../applications/audio/soundconverter { };
-
   soundkonverter = libsForQt5.soundkonverter;
 
   soundwireserver = callPackage ../applications/audio/soundwireserver { };


### PR DESCRIPTION
## Description of changes

This upgrades the current soundconverter package to 4.0.5, as well as moves it to pkgs/by-name.
It's originally based on #259343, and the previous commit is there to preserve the work done. I've also tested that the package works, and I see no issues at all.

Per the comments on the original PR, I've removed 2 wrappers and solved the triple wrapper issue that blocked the previous one from being merged. I also added myself as a maintainer.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
There's no formal changelog for the project, but you can see the changes after 4.0.3 at [this link](https://git.launchpad.net/soundconverter/log/?h=4.0.5) at the project's Launchpad repo.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
