### PR TITLE
lib.warn: Use or behave like builtins.warn

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -711,7 +711,7 @@ in {
           assert isString msg;
           if mustAbort
           then builtins.trace "[1;31mevaluation warning: ${msg}[0m" (abort "NIX_ABORT_ON_WARN=true; warnings are treated as unrecoverable errors.")
-          else builtins.trace "[1;31mevaluation warning: ${msg}[0m" v
+          else builtins.trace "[1;35mevaluation warning: ${msg}[0m" v
     );
 
   /**

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -710,8 +710,8 @@ in {
           # `builtins.warn` requires a string message, so we enforce that in our implementation, so that callers aren't accidentally incompatible with newer Nix versions.
           assert isString msg;
           if mustAbort
-          then builtins.trace "[1;31mwarning: ${msg}[0m" (abort "NIX_ABORT_ON_WARN=true; warnings are treated as unrecoverable errors.")
-          else builtins.trace "[1;31mwarning: ${msg}[0m" v
+          then builtins.trace "[1;31mevaluation warning: ${msg}[0m" (abort "NIX_ABORT_ON_WARN=true; warnings are treated as unrecoverable errors.")
+          else builtins.trace "[1;31mevaluation warning: ${msg}[0m" v
     );
 
   /**

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -661,47 +661,33 @@ in {
   importTOML = path:
     builtins.fromTOML (builtins.readFile path);
 
-  ## Warnings
-
-  # See https://github.com/NixOS/nix/issues/749. Eventually we'd like these
-  # to expand to Nix builtins that carry metadata so that Nix can filter out
-  # the INFO messages without parsing the message string.
-  #
-  # Usage:
-  # {
-  #   foo = lib.warn "foo is deprecated" oldFoo;
-  #   bar = lib.warnIf (bar == "") "Empty bar is deprecated" bar;
-  # }
-  #
-  # TODO: figure out a clever way to integrate location information from
-  # something like __unsafeGetAttrPos.
-
   /**
-    Print a warning before returning the second argument. This function behaves
-    like `builtins.trace`, but requires a string message and formats it as a
-    warning, including the `warning: ` prefix.
 
-    To get a call stack trace and abort evaluation, set the environment variable
-    `NIX_ABORT_ON_WARN=true` and set the Nix options `--option pure-eval false --show-trace`
+    `warn` *`message`* *`value`*
+
+    Print a warning before returning the second argument.
+
+    See [`builtins.warn`](https://nix.dev/manual/nix/latest/language/builtins.html#builtins-warn) (Nix >= 2.23).
+    On older versions, the Nix 2.23 behavior is emulated with [`builtins.trace`](https://nix.dev/manual/nix/latest/language/builtins.html#builtins-warn), including the [`NIX_ABORT_ON_WARN`](https://nix.dev/manual/nix/latest/command-ref/conf-file#conf-abort-on-warn) behavior, but not the `nix.conf` setting or command line option.
 
     # Inputs
 
-    `msg`
+    *`message`* (String)
 
-    : Warning message to print.
+    : Warning message to print before evaluating *`value`*.
 
-    `val`
+    *`value`* (any value)
 
     : Value to return as-is.
 
     # Type
 
     ```
-    string -> a -> a
+    String -> a -> a
     ```
   */
   warn =
-    # Since https://github.com/NixOS/nix/pull/10592
+    # Since Nix 2.23, https://github.com/NixOS/nix/pull/10592
     builtins.warn or (
       let mustAbort = lib.elem (builtins.getEnv "NIX_ABORT_ON_WARN") ["1" "true" "yes"];
       in
@@ -715,53 +701,57 @@ in {
     );
 
   /**
-    Like warn, but only warn when the first argument is `true`.
 
+    `warnIf` *`condition`* *`message`* *`value`*
+
+    Like `warn`, but only warn when the first argument is `true`.
 
     # Inputs
 
-    `cond`
+    *`condition`* (Boolean)
 
-    : 1\. Function argument
+    : `true` to trigger the warning before continuing with *`value`*.
 
-    `msg`
+    *`message`* (String)
 
-    : 2\. Function argument
+    : Warning message to print before evaluating
 
-    `val`
+    *`value`* (any value)
 
     : Value to return as-is.
 
     # Type
 
     ```
-    bool -> string -> a -> a
+    Bool -> String -> a -> a
     ```
   */
   warnIf = cond: msg: if cond then warn msg else x: x;
 
   /**
-    Like warnIf, but negated (warn if the first argument is `false`).
 
+    `warnIfNot` *`condition`* *`message`* *`value`*
+
+    Like `warnIf`, but negated: warn if the first argument is `false`.
 
     # Inputs
 
-    `cond`
+    *`condition`*
 
-    : 1\. Function argument
+    : `false` to trigger the warning before continuing with `val`.
 
-    `msg`
+    *`message`*
 
-    : 2\. Function argument
+    : Warning message to print before evaluating *`value`*.
 
-    `val`
+    *`value`*
 
     : Value to return as-is.
 
     # Type
 
     ```
-    bool -> string -> a -> a
+    Boolean -> String -> a -> a
     ```
   */
   warnIfNot = cond: msg: if cond then x: x else warn msg;

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -710,8 +710,8 @@ in {
           # `builtins.warn` requires a string message, so we enforce that in our implementation, so that callers aren't accidentally incompatible with newer Nix versions.
           assert isString msg;
           if mustAbort
-          then builtins.trace "[1;31mevaluation warning: ${msg}[0m" (abort "NIX_ABORT_ON_WARN=true; warnings are treated as unrecoverable errors.")
-          else builtins.trace "[1;35mevaluation warning: ${msg}[0m" v
+          then builtins.trace "[1;31mevaluation warning:[0m ${msg}" (abort "NIX_ABORT_ON_WARN=true; warnings are treated as unrecoverable errors.")
+          else builtins.trace "[1;35mevaluation warning:[0m ${msg}" v
     );
 
   /**


### PR DESCRIPTION
## Description of changes

Base `lib.warn` on [`builtins.warn`](https://github.com/NixOS/nix/pull/10592) when available.
Behave like it when it's not available.

> A variation of `trace`, but
> 
>   * with the correct log level
> 
>   * no ANSI codes in expressions
> 
>   * can be debugged without stopping for actual `trace` calls (ie intentional "info level" or trace logging).
> 
>   * logs warnings without `trace:` in front of it
> 
>   * follows the Nix color scheme.

Alternative to, and
- Closes https://github.com/NixOS/nixpkgs/pull/306026

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
