### PR TITLE
Update `tests.config`

### DIFF
--- a/pkgs/test/config.nix
+++ b/pkgs/test/config.nix
@@ -2,22 +2,19 @@
 lib.recurseIntoAttrs {
 
   # https://github.com/NixOS/nixpkgs/issues/175196
+  # This test has since been simplified to test the recursion without
+  # the fluff to make it look like a real-world example.
+  # The requirement we test here is:
+  # - `permittedInsecurePackages` must be allowed to
+  #   use `pkgs` to retrieve at least *some* information.
+  #
+  # Instead of `builtins.seq`, the list may be constructed based on actual package info.
   allowPkgsInPermittedInsecurePackages =
     let pkgs = import ../.. {
           config = {
-            permittedInsecurePackages =
-              tempAllow pkgs.authy "2.1.0" [ "electron-9.4.4" ];
+            permittedInsecurePackages = builtins.seq pkgs.glibc.version [];
           };
         };
-        # A simplification of `tempAllow` that doesn't check the version, but
-        # has the same strictness characteristics. Actually checking a version
-        # here would add undue maintenance.
-        #
-        # Original:
-        #     tempAllow = p: v: pa:
-        #       lib.optionals (lib.assertMsg (p.version == v) "${p.name} is no longer at version ${v}, consider removing the tempAllow") pa;
-        #
-        tempAllow = p: v: pa: builtins.seq v builtins.seq p.version pa;
 
     in pkgs.hello;
 

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -1,5 +1,11 @@
 # This file defines the structure of the `config` nixpkgs option.
 
+# This file is tested in `pkgs/test/config.nix`.
+# Run tests with:
+#
+#     nix-build -A tests.config
+#
+
 { config, lib, ... }:
 
 let


### PR DESCRIPTION
## Description of changes

authy is about to be removed, so this test has to be updated.

- https://github.com/NixOS/nixpkgs/pull/305268

Please review someone else's PR.
I have a good understanding of the original problem, and there's no value to be added here. I'd be happy to explain or improve it, but that'd happen at the cost of something more important.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - **Manually red-greened**
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
