### PR TITLE
nixos/evcc: restart on failure

### DIFF
--- a/nixos/modules/services/home-automation/evcc.nix
+++ b/nixos/modules/services/home-automation/evcc.nix
@@ -63,6 +63,7 @@ in
         DynamicUser = true;
         LockPersonality = true;
         MemoryDenyWriteExecute = true;
+        Restart = "on-failure";
         RestrictAddressFamilies = [
           "AF_INET"
           "AF_INET6"


### PR DESCRIPTION
## Description of changes

Make sure we restart on failures.

```
systemd[1]: Started evcc.service.
evcc[1192]: [main  ] INFO 2024/04/23 22:37:25 evcc 0.124.10 (0.124.10)
evcc[1192]: [main  ] INFO 2024/04/23 22:37:25 using config file: /nix/store/v85gk7knxz6xqlkngj6gwgg9qj97kv8c-evcc.yml
evcc[1192]: [main  ] INFO 2024/04/23 22:37:25 starting ui and api at :7070
evcc[1192]: [db    ] INFO 2024/04/23 22:37:25 using sqlite database: /var/lib/evcc/.evcc/evcc.db
evcc[1192]: [mqtt  ] INFO 2024/04/23 22:37:25 connecting evcc-1837238894 at tcp://127.0.0.1:1883
evcc[1192]: [main  ] FATAL 2024/04/23 22:37:26 cannot create charger 'keba-p30-c': cannot create charger type 'template': cannot create charger type 'keba-udp': recv timeout
evcc[1192]: [main  ] FATAL 2024/04/23 22:37:26 will attempt restart in: 5m0s
systemd[1]: evcc.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: evcc.service: Failed with result 'exit-code'.
systemd[1]: evcc.service: Consumed 757ms CPU time, received 1.6K IP traffic, sent 2.1K IP traffic.
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
