### PR TITLE
polychromatic: 0.8.0 -> 0.9.1

### DIFF
--- a/pkgs/applications/misc/polychromatic/default.nix
+++ b/pkgs/applications/misc/polychromatic/default.nix
@@ -12,23 +12,24 @@
   python3Packages,
   gobject-introspection,
   wrapGAppsHook3,
-  libappindicator-gtk3,
+  libayatana-appindicator,
   libxcb,
-  qt5,
+  qt6,
   ibus,
   usbutils,
+  psmisc,
 }:
 
 python3Packages.buildPythonApplication rec {
   name = "polychromatic";
-  version = "0.8.0";
+  version = "0.9.1";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "polychromatic";
     repo = "polychromatic";
     rev = "v${version}";
-    sha256 = "sha256-ym2pcGUWM5zCUx/lYs+WECj+wbyBtWnx04W/NRXNKlw=";
+    sha256 = "sha256-3Pt1Z8G0xDWlFD7LxJILPUifMBTN4OvPNHZv80umO1s=";
   };
 
   postPatch = ''
@@ -50,23 +51,31 @@ python3Packages.buildPythonApplication rec {
     ninja
     sassc
     wrapGAppsHook3
-    qt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
+    qt6.qtbase
   ];
 
-  propagatedBuildInputs = with python3Packages; [
-    colorama
-    colour
-    openrazer
-    pyqt5
-    pyqtwebengine
-    requests
-    setproctitle
-    libxcb
-    openrazer-daemon
-    libappindicator-gtk3
-    ibus
-    usbutils
-  ];
+  buildInputs = [ qt6.qtwayland ];
+
+  propagatedBuildInputs =
+    with python3Packages;
+    [
+      colorama
+      colour
+      openrazer
+      pyqt6
+      pyqt6-webengine
+      requests
+      setproctitle
+      libxcb
+      openrazer-daemon
+      ibus
+      usbutils
+    ]
+    ++ [
+      libayatana-appindicator
+      psmisc
+    ];
 
   dontWrapGapps = true;
   dontWrapQtApps = true;

--- a/pkgs/applications/misc/polychromatic/default.nix
+++ b/pkgs/applications/misc/polychromatic/default.nix
@@ -1,21 +1,22 @@
-{ lib
-, fetchFromGitHub
-, bash
-, glib
-, gdk-pixbuf
-, gettext
-, imagemagick
-, ninja
-, meson
-, sassc
-, python3Packages
-, gobject-introspection
-, wrapGAppsHook3
-, libappindicator-gtk3
-, libxcb
-, qt5
-, ibus
-, usbutils
+{
+  lib,
+  fetchFromGitHub,
+  bash,
+  glib,
+  gdk-pixbuf,
+  gettext,
+  imagemagick,
+  ninja,
+  meson,
+  sassc,
+  python3Packages,
+  gobject-introspection,
+  wrapGAppsHook3,
+  libappindicator-gtk3,
+  libxcb,
+  qt5,
+  ibus,
+  usbutils,
 }:
 
 python3Packages.buildPythonApplication rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29030,7 +29030,7 @@ with pkgs;
 
   poly = callPackage ../data/fonts/poly { };
 
-  polychromatic = libsForQt5.callPackage ../applications/misc/polychromatic { };
+  polychromatic = qt6Packages.callPackage ../applications/misc/polychromatic { };
 
   polytopes_db = callPackage ../data/misc/polytopes_db { };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelogs:

  - https://github.com/polychromatic/polychromatic/releases/tag/v0.9.0
  - https://github.com/polychromatic/polychromatic/releases/tag/v0.8.4
  - https://github.com/polychromatic/polychromatic/releases/tag/v0.8.3
  - https://github.com/polychromatic/polychromatic/releases/tag/v0.8.2
  - https://github.com/polychromatic/polychromatic/releases/tag/v0.8.1


The qt6 port of polychromatic just got released and I noticed that the package hasn't been updated in a while

I don't really know what I'm doing, but I did my best to get it running and it *does*. The tray icon appears as expected and the controller/main app runs fine.

I added qt6.qtbase as I got the following build error without it:
```
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
wrapQtAppsHook qtHostPathHook: qtPluginPrefix is unset. hint: add qt6.qtbase to buildInputs
/nix/store/7cn0p1zbg7cgklcldk08ld6hvrwrq4av-wrap-qt6-apps-hook/nix-support/setup-hook: line 27: qtPluginPrefix: parameter null or not set
```
So I did what the hint said and things build fine.

I also replaced `libappindicator-gtk3` with `libayatana-appindicator` as the former seems to be deprecated and this seems to be the recommended replacement.

Would be grateful if somebody would look over the changes and improve things I missed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
