### PR TITLE
 nixos/tailscale-derper: init 

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1230,6 +1230,7 @@
   ./services/networking/syncthing.nix
   ./services/networking/tailscale.nix
   ./services/networking/tailscale-auth.nix
+  ./services/networking/tailscale-derper.nix
   ./services/networking/tayga.nix
   ./services/networking/tcpcrypt.nix
   ./services/networking/teamspeak3.nix

--- a/nixos/modules/services/networking/tailscale-derper.nix
+++ b/nixos/modules/services/networking/tailscale-derper.nix
@@ -1,0 +1,132 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.tailscale.derper;
+in
+{
+  meta.maintainers = with lib.maintainers; [ SuperSandro2000 ];
+
+  options = {
+    services.tailscale.derper = {
+      enable = lib.mkEnableOption "Tailscale Derper. See upstream doc <https://tailscale.com/kb/1118/custom-derp-servers> how to configure it on clients";
+
+      domain = lib.mkOption {
+        type = lib.types.str;
+        description = "Domain name under which the derper server is reachable.";
+      };
+
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to open the firewall for the specified port.
+          Derper requires the used ports to be opened, otherwise it doesn't work as expected.
+        '';
+      };
+
+      package = lib.mkPackageOption pkgs [
+        "tailscale"
+        "derper"
+      ] { };
+
+      stunPort = lib.mkOption {
+        type = lib.types.port;
+        default = 3478;
+        description = ''
+          STUN port to listen on.
+          See online docs <https://tailscale.com/kb/1118/custom-derp-servers#prerequisites> on how to configure a different external port.
+        '';
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 8010;
+        description = "The port the derper process will listen on. This is not the port tailscale will connect to.";
+      };
+
+      verifyClients = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to verify clients against a locally running tailscale daemon if they are allowed to connect to this node or not.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      # port 80 and 443 are opened by nginx already
+      allowedUDPPorts = [ cfg.stunPort ];
+    };
+
+    services = {
+      nginx = {
+        enable = true;
+        upstreams.tailscale-derper = {
+          servers."127.0.0.1:${toString cfg.port}" = { };
+          extraConfig = ''
+            keepalive 64;
+          '';
+        };
+        virtualHosts."${cfg.domain}" = {
+          addSSL = true; # this cannot be forceSSL as derper sends some information over port 80, too.
+          locations."/" = {
+            proxyPass = "http://tailscale-derper";
+            proxyWebsockets = true;
+            extraConfig = ''
+              keepalive_timeout 0;
+              proxy_buffering off;
+            '';
+          };
+        };
+      };
+
+      tailscale.enable = lib.mkIf cfg.verifyClients true;
+    };
+
+    systemd.services.tailscale-derper = {
+      serviceConfig = {
+        ExecStart =
+          "${lib.getExe' cfg.package "derper"} -a :${toString cfg.port} -c /var/lib/derper/derper.key -hostname=${cfg.domain} -stun-port ${toString cfg.stunPort}"
+          + lib.optionalString cfg.verifyClients " -verify-clients";
+        DynamicUser = true;
+        Restart = "always";
+        RestartSec = "5sec"; # don't crash loop immediately
+        StateDirectory = "derper";
+        Type = "simple";
+
+        CapabilityBoundingSet = [ "" ];
+        DeviceAllow = null;
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        MemoryDenyWriteExecute = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" ];
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+}

--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -21,6 +21,8 @@ buildGoModule {
   pname = "tailscale";
   inherit version;
 
+  outputs = [ "out" "derper" ];
+
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "tailscale";
@@ -43,7 +45,7 @@ buildGoModule {
 
   CGO_ENABLED = 0;
 
-  subPackages = [ "cmd/tailscaled" ];
+  subPackages = [ "cmd/derper" "cmd/tailscaled" ];
 
   ldflags = [
     "-w"
@@ -60,6 +62,7 @@ buildGoModule {
 
   postInstall = ''
     ln -s $out/bin/tailscaled $out/bin/tailscale
+    moveToOutput "bin/derper" "$derper"
   '' + lib.optionalString stdenv.hostPlatform.isLinux ''
     wrapProgram $out/bin/tailscaled \
       --prefix PATH : ${lib.makeBinPath [ iproute2 iptables getent shadow ]} \


### PR DESCRIPTION
## Description of changes

inlcudes #306532

when I am done figuring out how to setup derp completely, I will probably do a PR for a module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
