### PR TITLE
fcitx5-fluent: init at 0.4.0-unstable-2024-03-30

### DIFF
--- a/pkgs/by-name/fc/fcitx5-fluent/package.nix
+++ b/pkgs/by-name/fc/fcitx5-fluent/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  jdupes,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "fcitx5-fluent";
+  version = "0.4.0-unstable-2024-03-30";
+
+  src = fetchFromGitHub {
+    owner = "Reverier-Xu";
+    repo = "Fluent-fcitx5";
+    rev = "dc98bc13e8eadabed7530a68706f0a2a0a07340e";
+    hash = "sha256-d1Y0MUOofBxwyeoXxUzQHrngL1qnL3TMa5DhDki7Pk8=";
+  };
+
+  nativeBuildInputs = [ jdupes ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fcitx5/themes
+    cp -r FluentDark FluentDark-solid FluentLight FluentLight-solid $out/share/fcitx5/themes
+    jdupes --quiet --link-soft --recurse $out/share
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A fluent-design theme with blur effect and shadow";
+    homepage = "https://github.com/Reverier-Xu/Fluent-fcitx5";
+    license = licenses.mpl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ oo-infty ];
+  };
+}


### PR DESCRIPTION
## Description of changes

`fcitx5-fluent` is a fluent-design fcitx5 theme with blur effect and shadow. Homepage: https://github.com/Reverier-Xu/Fluent-fcitx5.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
