### PR TITLE
clapper:  0.5.2 -> 0.6.0; clean up and move to finalAttrs

### DIFF
--- a/pkgs/applications/video/clapper/default.nix
+++ b/pkgs/applications/video/clapper/default.nix
@@ -2,9 +2,7 @@
 , lib
 , stdenv
 , fetchFromGitHub
-, glib
 , gobject-introspection
-, python3
 , pkg-config
 , ninja
 , wayland
@@ -14,42 +12,41 @@
 , shared-mime-info
 , wrapGAppsHook4
 , meson
-, gjs
 , gtk4
 , gst_all_1
 , libGL
 , libadwaita
-, appstream-glib
-, libsoup
+, libsoup_3
+, vala
+, cmake
+, libmicrodns
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "clapper";
-  version = "0.5.2";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner  = "Rafostar";
-    repo   = pname;
-    rev    = version;
-    sha256 = "sha256-s+qdTq3/pHHstwr1W3Hs2Zje++iJFHM6hQTFoZD43bY=";
+    repo   = "clapper";
+    rev    = finalAttrs.version;
+    hash = "sha256-5fD1OnVcY3ZC+QfoFqe2jV43/J36r85SpLUYF2ti7dY=";
   };
 
   nativeBuildInputs = [
-    appstream-glib
-    desktop-file-utils # for update-desktop-database
-    glib
     gobject-introspection
     meson
+    cmake
     ninja
     makeWrapper
     pkg-config
-    python3
-    shared-mime-info # for update-mime-database
     wrapGAppsHook4 # for gsettings
+    desktop-file-utils # for update-desktop-database
+    shared-mime-info # for update-mime-database
+    vala
   ];
 
   buildInputs = [
-    gjs
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good
@@ -58,29 +55,25 @@ stdenv.mkDerivation rec {
     gtk4
     libGL
     libadwaita
-    libsoup
+    libsoup_3
     wayland
     wayland-protocols
+    libmicrodns
   ];
 
   postPatch = ''
-    patchShebangs build-aux/meson/postinstall.py
-  '';
-
-  postInstall = ''
-    cp ${src}/data/icons/*.svg $out/share/icons/hicolor/scalable/apps/
-    cp ${src}/data/icons/*.svg $out/share/icons/hicolor/symbolic/apps/
+    patchShebangs --build build-aux/meson/postinstall.py
   '';
 
   meta = with lib; {
-    description = "A GNOME media player built using GJS with GTK4 toolkit and powered by GStreamer with OpenGL rendering. ";
+    description = "A GNOME media player built using GTK4 toolkit and powered by GStreamer with OpenGL rendering";
     longDescription = ''
-      Clapper is a GNOME media player build using GJS with GTK4 toolkit.
-      The media player is using GStreamer as a media backend and renders everything via OpenGL.
+      Clapper is a GNOME media player built using the GTK4 toolkit.
+      The media player is using GStreamer as a media backend.
     '';
     homepage = "https://github.com/Rafostar/clapper";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

closes https://github.com/NixOS/nixpkgs/issues/306475

https://github.com/Rafostar/clapper/releases/tag/0.6.0

removed the explicit `postInstall` as the icons and other images are now output to $out/share without it
removed variable and overwritable repo name by explicitly declaring `clapper` as the repo in `src`
moved some `nativeBuildInputs` into `buildInputs`
added vala, cmake and libmicrodns as `nativeBuildInputs` and `buildInputs` respectively
updated `libsoup` to `libsoup_3`
moved the derivation to finalAttrs

in the future it may be worth it to split this derivation into two for the two different outputs (the clappergtk lib and clapper the application)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
