### PR TITLE
python3Packages.django-allauth: compile `.mo` files

### DIFF
--- a/pkgs/development/python-modules/django-allauth/default.nix
+++ b/pkgs/development/python-modules/django-allauth/default.nix
@@ -6,6 +6,9 @@
 # build-system
 , setuptools
 
+# build-time dependencies
+, gettext
+
 # dependencies
 , django
 , python3-openid
@@ -41,6 +44,7 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
+    gettext
     setuptools
   ];
 
@@ -51,6 +55,8 @@ buildPythonPackage rec {
     requests
     requests-oauthlib
   ] ++ pyjwt.optional-dependencies.crypto;
+
+  preBuild = "python -m django compilemessages";
 
   passthru.optional-dependencies = {
     saml = [


### PR DESCRIPTION
## Description of changes

Runs `compilemessages` in order to produce `.mo` binary translation files.

These files are included in the [PyPI releases of django-allauth](https://pypi.org/project/django-allauth/), but *not* in the [source repository](https://github.com/pennersr/django-allauth). This means that translations are provided if you `pip install` the package, but not when you install the package with Nix.

Other Django packages (notably, Django itself) usually do include the `.mo` files in source control, so it's not an issue there.

With this change, django-allauth translations will work out of the box for Python projects packaged using Nix.

<hr/>

*Note*: I'm not sure if `configurePhase` is the correct place to put this...

## Things done

- Built on platform(s)
  - [x] x86_64-linux
