### PR TITLE
Filebrowser  init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19038,6 +19038,12 @@
     githubId = 8904314;
     name = "Konstantin Nick";
   };
+  sqlazer = {
+    email = "me@sqlazer.com";
+    github = "sdellysse";
+    githubId = 293035;
+    name = "sqlazer";
+  };
   squalus = {
     email = "squalus@squalus.net";
     github = "squalus";

--- a/pkgs/by-name/fi/filebrowser/filebrowser.nix
+++ b/pkgs/by-name/fi/filebrowser/filebrowser.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, fetchurl }:
+let
+  pname = "filebrowser";
+  version = "2.28.0";
+  sources = {
+    x86_64-linux = {
+      url =
+        "https://github.com/filebrowser/filebrowser/releases/download/v${version}/linux-amd64-filebrowser.tar.gz";
+      hash = "sha256-GNRSiEmOfUo+I+MvEFy+Zcrcktbk3DNGR9/ElrLU3fw=";
+    };
+  };
+in stdenv.mkDerivation rec {
+  inherit pname version;
+
+  src = let
+    platform = stdenv.hostPlatform.system;
+    platforms = builtins.attrNames sources;
+  in if (builtins.elem platform platforms) then
+    fetchurl sources."${platform}"
+  else
+    throw
+    "Source for ${pname} unavailable for system '${platform}'";
+
+  nativeBuildInputs = [ ];
+
+  buildInputs = [ ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    install -m755 -D filebrowser $out/bin/filebrowser
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://filebrowser.org";
+    description = "Web File Browser";
+    license = lib.licenses.asl20;
+    mainProgram = "filebrowser";
+    maintainers = [ lib.maintainers.sqlazer ];
+    platforms = builtins.attrNames sources;
+  };
+}
+


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Filebrowser: web file browser

filebrowser provides a file managing interface within a specified directory and it can be used to upload, delete, preview, rename and edit your files. It allows the creation of multiple users and each user can have its own directory. It can be used as a standalone app.

https://filebrowser.org

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
