### PR TITLE
nixVersions.nix_2_{10..17}: remove

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -109,27 +109,6 @@ let
     hash = "sha256-f+F0fUO+bqyPXjt+IXJtISVr589hdc3y+Cdrxznb+Nk=";
   };
 
-  # https://github.com/NixOS/nix/pull/7473
-  patch-sqlite-exception = fetchpatch2 {
-    name = "nix-7473-sqlite-exception-add-message.patch";
-    url = "https://github.com/hercules-ci/nix/commit/c965f35de71cc9d88f912f6b90fd7213601e6eb8.patch";
-    hash = "sha256-tI5nKU7SZgsJrxiskJ5nHZyfrWf5aZyKYExM0792N80=";
-  };
-
-  patch-non-existing-output = fetchpatch {
-    # https://github.com/NixOS/nix/pull/7283
-    name = "fix-requires-non-existing-output.patch";
-    url = "https://github.com/NixOS/nix/commit/3ade5f5d6026b825a80bdcc221058c4f14e10a27.patch";
-    hash = "sha256-s1ybRFCjQaSGj7LKu0Z5g7UiHqdJGeD+iPoQL0vaiS0=";
-  };
-
-  patch-rapidcheck-shared = fetchpatch2 {
-    # https://github.com/NixOS/nix/pull/9431
-    name = "fix-missing-librapidcheck.patch";
-    url = "https://github.com/NixOS/nix/commit/46131567da96ffac298b9ec54016b37114b0dfd5.patch";
-    hash = "sha256-lShYxYKRDWwBqCysAFmFBudhhAL1eendWcL8sEFLCGg=";
-  };
-
   # Intentionally does not support overrideAttrs etc
   # Use only for tests that are about the package relation to `pkgs` and/or NixOS.
   addTestsShallowly = tests: pkg: pkg // {
@@ -174,72 +153,6 @@ in lib.makeExtensible (self: ({
     # https://github.com/NixOS/nix/issues/10222
     # spurious test/add.sh failures
     enableParallelChecking = false;
-  };
-
-  nix_2_10 = common {
-    version = "2.10.3";
-    hash = "sha256-B9EyDUz/9tlcWwf24lwxCFmkxuPTVW7HFYvp0C4xGbc=";
-    patches = [
-      ./patches/flaky-tests.patch
-      patch-non-existing-output
-      patch-monitorfdhup
-      patch-sqlite-exception
-    ];
-  };
-
-  nix_2_11 = common {
-    version = "2.11.1";
-    hash = "sha256-qCV65kw09AG+EkdchDPq7RoeBznX0Q6Qa4yzPqobdOk=";
-    patches = [
-      ./patches/flaky-tests.patch
-      patch-non-existing-output
-      patch-monitorfdhup
-      patch-sqlite-exception
-    ];
-  };
-
-  nix_2_12 = common {
-    version = "2.12.1";
-    hash = "sha256-GmHKhq0uFtdOiJnuBwj2YwlZjvh6YTkfQZgeu4e0dLU=";
-    patches = [
-      ./patches/flaky-tests.patch
-      patch-monitorfdhup
-      patch-sqlite-exception
-    ];
-  };
-
-  nix_2_13 = common {
-    version = "2.13.6";
-    hash = "sha256-pd2yGmHWn4njfbrSP6cMJx8qL+yeGieqcbLNICzcRFs=";
-  };
-
-  nix_2_14 = common {
-    version = "2.14.1";
-    hash = "sha256-5aCmGZbsFcLIckCDfvnPD4clGPQI7qYAqHYlttN/Wkg=";
-    patches = [
-      patch-rapidcheck-shared
-    ];
-  };
-
-  nix_2_15 = common {
-    version = "2.15.3";
-    hash = "sha256-sfFXbjC5iIdSAbctZIuFozxX0uux/KFBNr9oh33xINs=";
-    patches = [
-      patch-rapidcheck-shared
-    ];
-  };
-
-  nix_2_16 = common {
-    version = "2.16.3";
-    hash = "sha256-/tnjRCk+VaWPThzdn3C0zU1AMON+7AFsHgTTzErFxV4=";
-  };
-
-  nix_2_17 = common {
-    version = "2.17.1";
-    hash = "sha256-Q5L+rHzjp0bYuR2ogg+YPCn6isjmlQ4CJVT0zpn/hFc=";
-    patches = [
-      patch-rapidcheck-shared
-    ];
   };
 
   nix_2_18 = common {
@@ -287,16 +200,12 @@ in lib.makeExtensible (self: ({
   stable = addFallbackPathsCheck self.nix_2_18;
 
   unstable = self.nix_2_22;
-} // lib.optionalAttrs config.allowAliases {
-  nix_2_4 = throw "nixVersions.nix_2_4 has been removed";
-
-  nix_2_5 = throw "nixVersions.nix_2_5 has been removed";
-
-  nix_2_6 = throw "nixVersions.nix_2_6 has been removed";
-
-  nix_2_7 = throw "nixVersions.nix_2_7 has been removed";
-
-  nix_2_8 = throw "nixVersions.nix_2_8 has been removed";
-
-  nix_2_9 = throw "nixVersions.nix_2_9 has been removed";
-}))
+} // lib.optionalAttrs config.allowAliases (
+  lib.listToAttrs (map (
+    minor:
+    let
+      attr = "nix_2_${toString minor}";
+    in
+    lib.nameValuePair attr (throw "${attr} has been removed")
+  ) (lib.range 4 17))
+)))


### PR DESCRIPTION

## Description of changes

Those are not maintained anymore by upstream Nix[1]. In fact, Nix intends to only maintain

> * The latest release
> * The version used in the stable NixOS release, which is announced in the NixOS release notes.

Given that security issues and regressions happen, for instance latest 2.17 unconditionally rejects leading dots in store-paths, a regression fixed in other Nix versions[2].

The only package having a problem is `nix-web` which cannot be upgraded to 2.18 since the JSON representation of `nix derivation show` has changed[3]. Upstream seems to be aware of the problem, hence marking the package as broken until there's a new release.

I didn't touch

* 2.3 since there's still a rather large user-base and it has a special role as the last pre-flakes release.

* 2.19 - 2.22: I'm not really sure what the next stable nix for nixpkgs will be and at least 2.19 seems to work relatively well for me. Anyways, touching those seems way more controversial than touching 2.10-2.17, so I'll skip that for now.

[1] https://nixos.org/manual/nix/stable/release-notes/
[2] https://github.com/NixOS/nix/issues/10497
[3] https://codeberg.org/gorgon/gorgon/commit/7b700904e1230b9ac89ce5a1285ed2418733f96c


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @RaitoBezarius @Artturin 
cc @liclac for nix-web

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
