### PR TITLE
resticprofile: init at 0.27.0

### DIFF
--- a/pkgs/by-name/re/resticprofile/package.nix
+++ b/pkgs/by-name/re/resticprofile/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  restic,
+  bash,
+  testers,
+  resticprofile,
+}:
+
+buildGoModule rec {
+  pname = "resticprofile";
+  version = "0.27.0";
+
+  src = fetchFromGitHub {
+    owner = "creativeprojects";
+    repo = "resticprofile";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-CUTDlSpP0ztr3sEKT0ppFnWx/bcVuY1oIKWJNZylDoM=";
+  };
+
+  postPatch = ''
+    substituteInPlace schedule_jobs.go \
+        --replace-fail "os.Executable()" "\"$out/bin/resticprofile\", nil"
+
+    substituteInPlace shell/command.go \
+        --replace-fail '"bash"' '"${lib.getExe bash}"'
+
+    substituteInPlace filesearch/filesearch.go \
+        --replace-fail 'paths := getSearchBinaryLocations()' 'return "${lib.getExe restic}", nil; paths := getSearchBinaryLocations()'
+
+  '';
+
+  vendorHash = "sha256-t2R5uNsliSn+rIvRM0vT6lQJY62DhhozXnONiCJ9CMc=";
+
+  ldflags = [
+    "-X main.commit=${src.rev}"
+    "-X main.date=unknown"
+    "-X main.builtBy=nixpkgs"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  preCheck = ''
+    rm battery_test.go # tries to get battery data
+    rm update_test.go # tries to use network
+    rm lock/lock_test.go # needs ping
+    rm preventsleep/caffeinate_test.go # tries to communicate with dbus
+    rm priority/ioprio_test.go # tries to set nice(2) IO priority
+    rm restic/downloader_test.go # tries to use network
+    rm schedule/schedule_test.go # tries to use systemctl
+
+    # `config/path_test.go` expects `$HOME` to be the same as `~nixbld` which is `$NIX_BUILD_TOP`
+    export HOME="$NIX_BUILD_TOP"
+    # `util/tempdir_test.go` expects `$HOME/.cache` to exist
+    mkdir "$HOME/.cache"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $GOPATH/bin/resticprofile -t $out/bin
+
+    installShellCompletion --cmd resticprofile \
+        --bash <($out/bin/resticprofile generate --bash-completion) \
+        --zsh <($out/bin/resticprofile generate --zsh-completion)
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = resticprofile;
+      command = "resticprofile version";
+    };
+  };
+
+  meta = {
+    changelog = "https://github.com/creativeprojects/resticprofile/releases/tag/v${version}";
+    description = "Configuration profiles manager for restic backup";
+    homepage = "https://creativeprojects.github.io/resticprofile/";
+    license = with lib.licenses; [
+      gpl3Only
+      lgpl3 # bash shell completion
+    ];
+    mainProgram = "resticprofile";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/306256

---
This PR adds 1 package: `resticprofile`

Note, that I haven't yet tested this, so if you want to or can, please do.

A thing that may still need to be done is using `makeWrapper` to include shell commands used by the app (e.g. systemctl).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
