### PR TITLE
virtualbox: fix symlink to guest additions iso

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -251,7 +251,7 @@ in stdenv.mkDerivation {
 
     mkdir -p "$out/share/virtualbox"
     cp -rv src/VBox/Main/UnattendedTemplates "$out/share/virtualbox"
-    ln -s "${virtualboxGuestAdditionsIso}/VBoxGuestAdditions_${version}.iso" "$out/share/virtualbox/VBoxGuestAdditions.iso"
+    ln -s "${virtualboxGuestAdditionsIso}" "$out/share/virtualbox/VBoxGuestAdditions.iso"
   '';
 
   preFixup = optionalString (!headless) ''

--- a/pkgs/applications/virtualization/virtualbox/guest-additions-iso/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions-iso/default.nix
@@ -1,22 +1,11 @@
-{ stdenv, fetchurl, lib, virtualbox}:
+{ fetchurl, lib, virtualbox}:
 
 let
   inherit (virtualbox) version;
 in
-stdenv.mkDerivation rec {
-  pname = "VirtualBox-GuestAdditions-iso";
-  inherit version;
-
-  src = fetchurl {
-    url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = "0efbcb9bf4722cb19292ae00eba29587432e918d3b1f70905deb70f7cf78e8ce";
-  };
-
-  buildCommand = ''
-    mkdir -p $out
-    cp $src $out/
-  '';
-
+fetchurl {
+  url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
+  sha256 = "0efbcb9bf4722cb19292ae00eba29587432e918d3b1f70905deb70f7cf78e8ce";
   meta = {
     description = "Guest additions ISO for VirtualBox";
     longDescription = ''


### PR DESCRIPTION
## Description of changes

The menu entry "Insert Guest Additions CD image..." of a running VirtualBox VM window currently fails to locate the file on disk and wants to the download the file.  This is caused by a broken symlink in the virtualbox package.

The pull request fixes the symlink and adds a tiny test so the build fails if the iso image is missing.

Notifying VirtualBox maintainers: @svanderburg @friedrichaltheide @blitz


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>28 packages built:</summary>
  <ul>
    <li>linuxKernel.packages.linux_4_19.virtualbox</li>
    <li>linuxKernel.packages.linux_4_19_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_5_10.virtualbox</li>
    <li>linuxKernel.packages.linux_5_10_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_5_15.virtualbox</li>
    <li>linuxKernel.packages.linux_5_15_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_5_4.virtualbox</li>
    <li>linuxKernel.packages.linux_5_4_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_6_1.virtualbox</li>
    <li>linuxKernel.packages.linux_6_1_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_6_6.virtualbox</li>
    <li>linuxKernel.packages.linux_hardened.virtualbox (linuxKernel.packages.linux_6_6_hardened.virtualbox)</li>
    <li>linuxKernel.packages.linux_6_8.virtualbox</li>
    <li>linuxKernel.packages.linux_latest_libre.virtualbox</li>
    <li>linuxKernel.packages.linux_libre.virtualbox</li>
    <li>linuxKernel.packages.linux_lqx.virtualbox</li>
    <li>linuxKernel.packages.linux_xanmod.virtualbox</li>
    <li>linuxKernel.packages.linux_xanmod_latest.virtualbox (linuxKernel.packages.linux_xanmod_stable.virtualbox)</li>
    <li>linuxKernel.packages.linux_zen.virtualbox</li>
    <li>virtualbox</li>
    <li>virtualbox.modsrc</li>
    <li>virtualboxHardened</li>
    <li>virtualboxHardened.modsrc</li>
    <li>virtualboxHeadless</li>
    <li>virtualboxHeadless.modsrc</li>
    <li>virtualboxKvm</li>
    <li>virtualboxWithExtpack</li>
    <li>virtualboxWithExtpack.modsrc</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
