### PR TITLE
stackit-cli: 0.2.2 -> 0.2.3

### DIFF
--- a/pkgs/by-name/st/stackit-cli/package.nix
+++ b/pkgs/by-name/st/stackit-cli/package.nix
@@ -12,16 +12,16 @@
 
 buildGoModule rec {
   pname = "stackit-cli";
-  version = "0.2.2";
+  version = "0.2.3";
 
   src = fetchFromGitHub {
     owner = "stackitcloud";
     repo = "stackit-cli";
     rev = "v${version}";
-    hash = "sha256-0SI7hRJxdtdpGgEsUCWNsIcT50W7uyxLs5Mp+alHE0I=";
+    hash = "sha256-ci7P0VbIuYoIzaiNhUCNRFa3YxYxBsat5U46DwGq6WY=";
   };
 
-  vendorHash = "sha256-FXy3qVSf57cPmxkY2XPEjFz3qRYkH5pPmCoIiWb28FY=";
+  vendorHash = "sha256-ecf/7BoCvybga8RVRiXvrAf2a5uLvIOFk4qNJiguSpo=";
 
   subPackages = [ "." ];
 
@@ -35,22 +35,13 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles makeWrapper ];
 
-  preCheck = ''
-    export HOME=$TMPDIR # needed because the binary always creates a dir & config file
-  '';
-
   postInstall = ''
-    export HOME=$TMPDIR # needed because the binary always creates a dir & config file
     mv $out/bin/{${pname},stackit} # rename the binary
 
-    installShellCompletion --cmd stackit --bash <($out/bin/stackit completion bash)
-    installShellCompletion --cmd stackit --zsh <($out/bin/stackit completion zsh)
-    installShellCompletion --cmd stackit --fish <($out/bin/stackit completion fish)
-    # Use this instead, once https://github.com/stackitcloud/stackit-cli/issues/153 is fixed:
-    # installShellCompletion --cmd stackit \
-    #   --bash <($out/bin/stackit completion bash) \
-    #   --zsh  <($out/bin/stackit completion zsh)  \
-    #   --fish <($out/bin/stackit completion fish)
+    installShellCompletion --cmd stackit \
+      --bash <($out/bin/stackit completion bash) \
+      --zsh  <($out/bin/stackit completion zsh)  \
+      --fish <($out/bin/stackit completion fish)
     # Ensure that all 3 completion scripts exist AND have content (should be kept for regression testing)
     [ $(find $out/share -not -empty -type f | wc -l) -eq 3 ]
   '';
@@ -65,7 +56,7 @@ buildGoModule rec {
   passthru.tests = {
     version = testers.testVersion {
       package = stackit-cli;
-      command = "HOME=$TMPDIR stackit --version";
+      command = "stackit --version";
     };
   };
 


### PR DESCRIPTION
## Description of changes

release notes: [`0.2.3`](https://github.com/stackitcloud/stackit-cli/releases/tag/v0.2.3)

Additionally, I've removed the now unnecessary `HOME=$TMPDIR` assignments as well as switched from the three separate `installShellCompletion` calls to just one.  
This is possible because https://github.com/stackitcloud/stackit-cli/issues/153 got fixed and is included in this release.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
