### PR TITLE
openjdk22: add updateScript

### DIFF
--- a/pkgs/development/compilers/openjdk/JavaUpdater.java
+++ b/pkgs/development/compilers/openjdk/JavaUpdater.java
@@ -1,0 +1,181 @@
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URI;
+import java.net.http.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class JavaUpdater {
+
+  record GitHubResult(Optional<String> latestVersion, Optional<String> next) {
+  }
+
+  record JsonInfo(String repo, String version, String hash) {
+    public JsonInfo(JSONObject json) {
+      this(json.getString("repo"), json.getString("version"), json.getString("hash"));
+    }
+
+    public String toJsonString(String featureVersion) {
+      return """
+        \s "%s": {
+        \s   "version": "%s",
+        \s   "repo":    "%s",
+        \s   "hash":    "%s"
+        \s }\
+        """.formatted(featureVersion, version, repo, hash);
+    }
+  }
+
+  // Parses the GitHub Link header
+  public static Optional<String> getNextLink(HttpHeaders headers) {
+    var linkHeader = headers.map().get("Link");
+    if (linkHeader == null || linkHeader.isEmpty()) return null;
+
+    var links = linkHeader.getFirst();
+    var linksRegex = Pattern.compile("<(.+)>;\\s*rel=\"next\"");
+    return Pattern.compile(",")
+      .splitAsStream(links)
+      .map(x -> linksRegex.matcher(x).results()
+        .map(g -> g.group(1))
+        .findFirst()
+      )
+      .filter(Optional::isPresent)
+      .map(Optional::orElseThrow)
+      .findFirst();
+  }
+
+  // HTTP request helper, sets GITHUB_TOKEN if present
+  private static HttpRequest NewGithubRequest(String url) {
+    var token = System.getenv().get("GITHUB_TOKEN");
+    var builder = HttpRequest.newBuilder()
+      .uri(URI.create(url));
+    if (token != null)
+      builder.setHeader("Authorization", "Bearer " + token);
+    return builder.build();
+  }
+
+  private static GitHubResult getLatestTag(String url) {
+    var request = NewGithubRequest(url);
+
+    var response =
+      HttpClient.newHttpClient().sendAsync(request, HttpResponse.BodyHandlers.ofString())
+        .join();
+
+    var json = new JSONArray(response.body());
+
+    Optional<String> version = StreamSupport.stream(json.spliterator(), false)
+      .map(JSONObject.class::cast)
+      .map(x -> x.getString("name").replaceFirst("jdk-", ""))
+      .filter(x -> x.contains("-ga"))
+      .max(Comparator.comparing(Runtime.Version::parse));
+
+    return new GitHubResult(version, getNextLink(response.headers()));
+  }
+
+  public String findNewerVersion() {
+    var url = Optional.of("https://api.github.com/repos/openjdk/" + getRepo() + "/tags?per_page=100");
+    String version = getCurrentVersion();
+    do {
+      GitHubResult response = getLatestTag(url.orElseThrow());
+      if (response.latestVersion.isPresent() && response.latestVersion.orElseThrow().equals(version)) {
+        return null;
+      }
+
+      String latestVersion = Stream.of(version, response.latestVersion.orElse(version))
+        .max(Comparator.comparing(Runtime.Version::parse)).orElseThrow();
+
+      if (latestVersion != version)
+        return latestVersion;
+
+      url = response.next;
+    } while (url.isPresent());
+    return null;
+  }
+
+
+  private static String prettyPrint(JSONObject json) {
+
+    Iterable<String> iterable = () -> json.keys();
+
+    return StreamSupport
+      .stream(iterable.spliterator(), false)
+      .sorted(Comparator.reverseOrder())
+      .map(majorVersion -> (new JsonInfo(json.getJSONObject(majorVersion))).toJsonString(majorVersion))
+      .collect(
+        Collectors.joining(",\n", "{\n", "\n}")
+      );
+  }
+
+  public void updateJsonInfo(String newVersion) {
+    try {
+      JSONObject json = getJsonInfo();
+      var info = json.getJSONObject(featureNumber);
+      info.put("version", newVersion);
+      info.put("hash", nixHash(newVersion));
+
+      try (PrintWriter out = new PrintWriter(infoJsonPath)) {
+        out.println(prettyPrint(json));
+      }
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private String nixHash(String version) {
+    try {
+      var process = new ProcessBuilder("nix", "flake", "prefetch",
+        "--extra-experimental-features", "'nix-command flakes'",
+        "--json", "github:openjdk/" + getRepo() + "/jdk-" + version).start();
+
+      var json = new JSONObject(new String(process.getInputStream().readAllBytes()));
+      process.waitFor();
+      return json.getString("hash");
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private final String featureNumber;
+  private final String infoJsonPath;
+  private final JSONObject jsonInfo;
+
+  public String getCurrentVersion() {
+    return this.jsonInfo.getJSONObject(this.featureNumber).getString("version");
+  }
+
+  public String getRepo() {
+    return this.jsonInfo.getJSONObject(this.featureNumber).getString("repo");
+  }
+
+  public JSONObject getJsonInfo() {
+    try {
+      String infoStr = Files.readString(Path.of(this.infoJsonPath));
+      return new JSONObject(infoStr);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public JavaUpdater(String featureNumber, String infoJsonPath) {
+    this.featureNumber = featureNumber;
+    this.infoJsonPath = infoJsonPath;
+    this.jsonInfo = getJsonInfo();
+  }
+
+  public static void main(String[] args) {
+    var updater = new JavaUpdater(args[0], args[1]);
+    String newerVersion = updater.findNewerVersion();
+    if (newerVersion != null) {
+      updater.updateJsonInfo(newerVersion);
+    }
+  }
+}

--- a/pkgs/development/compilers/openjdk/info.json
+++ b/pkgs/development/compilers/openjdk/info.json
@@ -1,0 +1,12 @@
+{
+  "22": {
+    "version": "22-ga",
+    "repo":    "jdk22u",
+    "hash":    "sha256-itjvIedPwJl/l3a2gIVpNMs1zkbrjioVqbCj1Z1nCJE="
+  },
+  "21": {
+    "version": "21.0.3-ga",
+    "repo":    "jdk21u",
+    "hash":    "sha256-zRN16lrc5gtDlTVIQJRRx103w/VbRkatCLeEc9AXWPE="
+  }
+}


### PR DESCRIPTION
## Description of changes

Adds an update script for openjdk22. I tried to do make the script generic enough so it can be re-used for any openjdk version, but I'll handle that on a following PR if this one gets merged. 
I had to replace the `version` attribute set with a string. The version is updated and validated in the updateScript with Java using  [Runtime.Version](https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/lang/Runtime.Version.html) 


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
