### PR TITLE
obj-magic: init at unstable-2020-09-20

### DIFF
--- a/pkgs/by-name/ob/obj-magic/package.nix
+++ b/pkgs/by-name/ob/obj-magic/package.nix
@@ -1,0 +1,38 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation {
+  pname = "obj-magic";
+  version = "0.5-unstable-2020-09-20";
+
+  src = fetchFromGitHub {
+    owner = "tapio";
+    repo = "obj-magic";
+    rev = "f25c9b78cee6529a3295ed314d1c200677dc56c0";
+    hash = "sha256-4A8TasyLOh6oz21/AwBbE5s3055EPftFh8mymrveTvY=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+    ./make.sh
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D obj-magic $out/bin/obj-magic
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A command line tool for manipulating Wavefront OBJ 3D meshes";
+    homepage = "https://github.com/tapio/obj-magic";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ lorenz ];
+    platforms = lib.platforms.unix;
+    mainProgram = "obj-magic";
+  };
+}
+

--- a/pkgs/by-name/ob/obj-magic/package.nix
+++ b/pkgs/by-name/ob/obj-magic/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "A command line tool for manipulating Wavefront OBJ 3D meshes";
+    description = "Command line tool for manipulating Wavefront OBJ 3D meshes";
     homepage = "https://github.com/tapio/obj-magic";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ lorenz ];


### PR DESCRIPTION
## Description of changes

Adds obj-magic, a command line tool for manipulating Wavefront OBJ 3d meshes.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
