### PR TITLE
nixos/prometheus/exporters: Remove all `with lib;` usage

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/apcupsd.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/apcupsd.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.apcupsd;
+  inherit (lib) mkOption types concatStringsSep;
 in
 {
   port = 9162;

--- a/nixos/modules/services/monitoring/prometheus/exporters/artifactory.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/artifactory.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.artifactory;
+  inherit (lib) mkOption types concatStringsSep;
 in
 {
   port = 9531;

--- a/nixos/modules/services/monitoring/prometheus/exporters/bind.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/bind.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.bind;
+  inherit (lib) mkOption types concatStringsSep;
 in
 {
   port = 9119;

--- a/nixos/modules/services/monitoring/prometheus/exporters/bird.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/bird.nix
@@ -1,9 +1,13 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.bird;
+  inherit (lib)
+    mkOption
+    types
+    concatStringsSep
+    singleton
+    ;
 in
 {
   port = 9324;

--- a/nixos/modules/services/monitoring/prometheus/exporters/bitcoin.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/bitcoin.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.bitcoin;
+  inherit (lib) mkOption types concatStringsSep;
 in
 {
   port = 9332;

--- a/nixos/modules/services/monitoring/prometheus/exporters/blackbox.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/blackbox.nix
@@ -1,10 +1,14 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   logPrefix = "services.prometheus.exporter.blackbox";
   cfg = config.services.prometheus.exporters.blackbox;
+  inherit (lib)
+    mkOption
+    types
+    concatStringsSep
+    escapeShellArg
+    ;
 
   # This ensures that we can deal with string paths, path types and
   # store-path strings with context.

--- a/nixos/modules/services/monitoring/prometheus/exporters/buildkite-agent.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/buildkite-agent.nix
@@ -1,9 +1,14 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.buildkite-agent;
+  inherit (lib)
+    mkOption
+    types
+    concatStringsSep
+    optionalString
+    literalExpression
+    ;
 in
 {
   port = 9876;

--- a/nixos/modules/services/monitoring/prometheus/exporters/collectd.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/collectd.nix
@@ -1,9 +1,15 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.collectd;
+  inherit (lib)
+    mkOption
+    mkEnableOption
+    types
+    optionalString
+    concatStringsSep
+    escapeShellArg
+    ;
 in
 {
   port = 9103;

--- a/nixos/modules/services/monitoring/prometheus/exporters/dmarc.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/dmarc.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.dmarc;
+  inherit (lib) mkOption types optionalString;
 
   json = builtins.toJSON {
     inherit (cfg) folders port;

--- a/nixos/modules/services/monitoring/prometheus/exporters/dnsmasq.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/dnsmasq.nix
@@ -1,9 +1,13 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.dnsmasq;
+  inherit (lib)
+    mkOption
+    types
+    concatStringsSep
+    escapeShellArg
+    ;
 in
 {
   port = 9153;

--- a/nixos/modules/services/monitoring/prometheus/exporters/domain.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/domain.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.domain;
+  inherit (lib) concatStringsSep;
 in
 {
   port = 9222;

--- a/nixos/modules/services/monitoring/prometheus/exporters/dovecot.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/dovecot.nix
@@ -1,9 +1,13 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.dovecot;
+  inherit (lib)
+    mkOption
+    types
+    escapeShellArg
+    concatStringsSep
+    ;
 in
 {
   port = 9166;

--- a/nixos/modules/services/monitoring/prometheus/exporters/flow.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/flow.nix
@@ -1,9 +1,14 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.flow;
+  inherit (lib)
+    mkOption
+    types
+    literalExpression
+    concatStringsSep
+    optionalString
+    ;
 in {
   port = 9590;
   extraOpts = {

--- a/nixos/modules/services/monitoring/prometheus/exporters/fritzbox.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/fritzbox.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.fritzbox;
+  inherit (lib) mkOption types concatStringsSep;
 in
 {
   port = 9133;

--- a/nixos/modules/services/monitoring/prometheus/exporters/idrac.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/idrac.nix
@@ -1,8 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
 let
   cfg = config.services.prometheus.exporters.idrac;
+  inherit (lib) mkOption types;
 
   configFile = if cfg.configurationPath != null
                then cfg.configurationPath

--- a/nixos/modules/services/monitoring/prometheus/exporters/imap-mailstat.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/imap-mailstat.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.imap-mailstat;
   valueToString = value:
@@ -13,6 +11,15 @@ let
         else "XXX ${toString value}"
       )
     );
+  inherit (lib)
+    mkOption
+    types
+    concatStrings
+    concatStringsSep
+    attrValues
+    mapAttrs
+    optionalString
+    ;
   createConfigFile = accounts:
     # unfortunately on toTOML yet
     # https://github.com/NixOS/nix/issues/3929

--- a/nixos/modules/services/monitoring/prometheus/exporters/influxdb.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/influxdb.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.influxdb;
+  inherit (lib) mkOption types concatStringsSep;
 in
 {
   port = 9122;

--- a/nixos/modules/services/monitoring/prometheus/exporters/ipmi.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/ipmi.nix
@@ -1,10 +1,15 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   logPrefix = "services.prometheus.exporter.ipmi";
   cfg = config.services.prometheus.exporters.ipmi;
+  inherit (lib)
+    mkOption
+    types
+    concatStringsSep
+    optionals
+    escapeShellArg
+    ;
 in {
   port = 9290;
 

--- a/nixos/modules/services/monitoring/prometheus/exporters/jitsi.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/jitsi.nix
@@ -1,9 +1,13 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.jitsi;
+  inherit (lib)
+    mkOption
+    types
+    escapeShellArg
+    concatStringsSep
+    ;
 in
 {
   port = 9700;

--- a/nixos/modules/services/monitoring/prometheus/exporters/json.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/json.nix
@@ -1,9 +1,14 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.json;
+  inherit (lib)
+    mkOption
+    types
+    escapeShellArg
+    concatStringsSep
+    mkRemovedOptionModule
+    ;
 in
 {
   port = 7979;

--- a/nixos/modules/services/monitoring/prometheus/exporters/junos-czerwonk.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/junos-czerwonk.nix
@@ -1,9 +1,14 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.junos-czerwonk;
+  inherit (lib)
+    mkOption
+    types
+    escapeShellArg
+    mkIf
+    concatStringsSep
+    ;
 
   configFile = if cfg.configuration != null then configurationFile else (escapeShellArg cfg.configurationFile);
 

--- a/nixos/modules/services/monitoring/prometheus/exporters/kea.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/kea.nix
@@ -5,10 +5,14 @@
 , ...
 }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.kea;
+  inherit (lib)
+    mkOption
+    types
+    mkRenamedOptionModule
+    literalExpression
+    ;
 in {
   imports = [
     (mkRenamedOptionModule [ "controlSocketPaths" ] [ "targets" ])

--- a/nixos/modules/services/monitoring/prometheus/exporters/keylight.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/keylight.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.keylight;
+  inherit (lib) concatStringsSep;
 in
 {
   port = 9288;

--- a/nixos/modules/services/monitoring/prometheus/exporters/knot.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/knot.nix
@@ -1,9 +1,13 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.knot;
+  inherit (lib)
+    mkOption
+    types
+    literalExpression
+    concatStringsSep
+    ;
 in {
   port = 9433;
   extraOpts = {

--- a/nixos/modules/services/monitoring/prometheus/exporters/lnd.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/lnd.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.lnd;
+  inherit (lib) mkOption types concatStringsSep;
 in
 {
   port = 9092;

--- a/nixos/modules/services/monitoring/prometheus/exporters/mail.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/mail.nix
@@ -1,9 +1,19 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.mail;
+  inherit (lib)
+    mkOption
+    types
+    mapAttrs'
+    nameValuePair
+    toLower
+    filterAttrs
+    escapeShellArg
+    literalExpression
+    mkIf
+    concatStringsSep
+    ;
 
   configFile = if cfg.configuration != null then configurationFile else (escapeShellArg cfg.configFile);
 

--- a/nixos/modules/services/monitoring/prometheus/exporters/mikrotik.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/mikrotik.nix
@@ -1,9 +1,14 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.mikrotik;
+  inherit (lib)
+    mkOption
+    types
+    literalExpression
+    concatStringsSep
+    escapeShellArg
+    ;
 in
 {
   port = 9436;

--- a/nixos/modules/services/monitoring/prometheus/exporters/minio.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/minio.nix
@@ -1,9 +1,14 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.minio;
+  inherit (lib)
+    mkOption
+    types
+    optionalString
+    concatStringsSep
+    escapeShellArg
+    ;
 in
 {
   port = 9290;

--- a/nixos/modules/services/monitoring/prometheus/exporters/modemmanager.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/modemmanager.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.modemmanager;
+  inherit (lib) mkOption types concatStringsSep;
 in
 {
   port = 9539;

--- a/nixos/modules/services/monitoring/prometheus/exporters/mongodb.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/mongodb.nix
@@ -1,9 +1,17 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.mongodb;
+  inherit (lib)
+    mkOption
+    types
+    optionalString
+    getExe
+    length
+    concatStringsSep
+    concatMapStringsSep
+    escapeShellArgs
+    ;
 in
 {
   port = 9216;

--- a/nixos/modules/services/monitoring/prometheus/exporters/nats.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/nats.nix
@@ -1,11 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
-
   cfg = config.services.prometheus.exporters.nats;
-
+  inherit (lib) mkOption types concatStringsSep;
 in
 {
   port = 7777;

--- a/nixos/modules/services/monitoring/prometheus/exporters/nextcloud.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/nextcloud.nix
@@ -1,9 +1,13 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.nextcloud;
+  inherit (lib)
+    mkOption
+    types
+    escapeShellArg
+    concatStringsSep
+    ;
 in
 {
   port = 9205;

--- a/nixos/modules/services/monitoring/prometheus/exporters/nginx.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/nginx.nix
@@ -1,9 +1,16 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.nginx;
+  inherit (lib)
+    mkOption
+    types
+    mkMerge
+    mkRemovedOptionModule
+    mkRenamedOptionModule
+    mkIf
+    concatStringsSep
+    ;
 in
 {
   port = 9113;

--- a/nixos/modules/services/monitoring/prometheus/exporters/nginxlog.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/nginxlog.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.nginxlog;
+  inherit (lib) mkOption types;
 in {
   port = 9117;
   extraOpts = {

--- a/nixos/modules/services/monitoring/prometheus/exporters/node.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/node.nix
@@ -1,9 +1,15 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.node;
+  inherit (lib)
+    mkOption
+    types
+    concatStringsSep
+    concatMapStringsSep
+    any
+    optionals
+    ;
   collectorIsEnabled = final: any (collector: (final == collector)) cfg.enabledCollectors;
   collectorIsDisabled = final: any (collector: (final == collector)) cfg.disabledCollectors;
 in

--- a/nixos/modules/services/monitoring/prometheus/exporters/nut.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/nut.nix
@@ -1,9 +1,13 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.nut;
+  inherit (lib)
+    mkOption
+    types
+    optionalString
+    concatStringsSep
+    ;
 in
 {
   port = 9199;

--- a/nixos/modules/services/monitoring/prometheus/exporters/openldap.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/openldap.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.openldap;
+  inherit (lib) mkOption types concatStringsSep;
 in {
   port = 9330;
   extraOpts = {

--- a/nixos/modules/services/monitoring/prometheus/exporters/pgbouncer.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/pgbouncer.nix
@@ -1,9 +1,14 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.pgbouncer;
+  inherit (lib)
+    mkOption
+    types
+    optionals
+    escapeShellArg
+    concatStringsSep
+    ;
 in
 {
   port = 9127;

--- a/nixos/modules/services/monitoring/prometheus/exporters/pihole.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/pihole.nix
@@ -1,9 +1,13 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.pihole;
+  inherit (lib)
+    mkOption
+    types
+    mkRemovedOptionModule
+    optionalString
+    ;
 in
 {
   imports = [

--- a/nixos/modules/services/monitoring/prometheus/exporters/ping.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/ping.nix
@@ -1,9 +1,9 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
 
 let
   cfg = config.services.prometheus.exporters.ping;
+  inherit (lib) mkOption types concatStringsSep;
 
   settingsFormat = pkgs.formats.yaml {};
   configFile = settingsFormat.generate "config.yml" cfg.settings;

--- a/nixos/modules/services/monitoring/prometheus/exporters/postfix.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/postfix.nix
@@ -1,9 +1,15 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.postfix;
+  inherit (lib)
+    mkOption
+    types
+    mkIf
+    escapeShellArg
+    concatStringsSep
+    optional
+    ;
 in
 {
   port = 9154;

--- a/nixos/modules/services/monitoring/prometheus/exporters/postgres.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/postgres.nix
@@ -1,9 +1,14 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.postgres;
+  inherit (lib)
+    mkOption
+    types
+    mkIf
+    mkForce
+    concatStringsSep
+    ;
 in
 {
   port = 9187;

--- a/nixos/modules/services/monitoring/prometheus/exporters/process.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/process.nix
@@ -1,9 +1,13 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.process;
+  inherit (lib)
+    mkOption
+    types
+    literalExpression
+    concatStringsSep
+    ;
   configFile = pkgs.writeText "process-exporter.yaml" (builtins.toJSON cfg.settings);
 in
 {

--- a/nixos/modules/services/monitoring/prometheus/exporters/pve.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/pve.nix
@@ -1,8 +1,14 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
 let
   cfg = config.services.prometheus.exporters.pve;
+  inherit (lib)
+    mkOption
+    types
+    mkPackageOption
+    optionalString
+    optionalAttrs
+    ;
 
   # pve exporter requires a config file so create an empty one if configFile is not provided
   emptyConfigFile = pkgs.writeTextFile {

--- a/nixos/modules/services/monitoring/prometheus/exporters/py-air-control.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/py-air-control.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.py-air-control;
+  inherit (lib) mkOption types;
 
   workingDir = "/var/lib/${cfg.stateDir}";
 

--- a/nixos/modules/services/monitoring/prometheus/exporters/redis.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/redis.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.redis;
+  inherit (lib) concatStringsSep;
 in
 {
   port = 9121;

--- a/nixos/modules/services/monitoring/prometheus/exporters/restic.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/restic.nix
@@ -1,9 +1,18 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.restic;
+  inherit (lib)
+    mkOption
+    types
+    concatStringsSep
+    mkIf
+    mapAttrs'
+    splitString
+    toUpper
+    optionalAttrs
+    nameValuePair
+    ;
 in
 {
   port = 9753;

--- a/nixos/modules/services/monitoring/prometheus/exporters/rspamd.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/rspamd.nix
@@ -1,9 +1,16 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.rspamd;
+  inherit (lib)
+    mkOption
+    types
+    replaceStrings
+    mkRemovedOptionModule
+    recursiveUpdate
+    concatStringsSep
+    literalExpression
+    ;
 
   mkFile = conf:
     pkgs.writeText "rspamd-exporter-config.yml" (builtins.toJSON conf);

--- a/nixos/modules/services/monitoring/prometheus/exporters/script.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/script.nix
@@ -1,9 +1,13 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.script;
+  inherit (lib)
+    mkOption
+    types
+    literalExpression
+    concatStringsSep
+    ;
   configFile = pkgs.writeText "script-exporter.yaml" (builtins.toJSON cfg.settings);
 in
 {

--- a/nixos/modules/services/monitoring/prometheus/exporters/shelly.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/shelly.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.shelly;
+  inherit (lib) mkOption types;
 in
 {
   port = 9784;

--- a/nixos/modules/services/monitoring/prometheus/exporters/smartctl.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/smartctl.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.smartctl;
+  inherit (lib) mkOption types literalExpression;
   args = lib.escapeShellArgs ([
     "--web.listen-address=${cfg.listenAddress}:${toString cfg.port}"
     "--smartctl.path=${pkgs.smartmontools}/bin/smartctl"

--- a/nixos/modules/services/monitoring/prometheus/exporters/smokeping.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/smokeping.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.smokeping;
+  inherit (lib) mkOption types concatStringsSep;
   goDuration = types.mkOptionType {
     name = "goDuration";
     description = "Go duration (https://golang.org/pkg/time/#ParseDuration)";

--- a/nixos/modules/services/monitoring/prometheus/exporters/snmp.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/snmp.nix
@@ -1,10 +1,15 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   logPrefix = "services.prometheus.exporters.snmp";
   cfg = config.services.prometheus.exporters.snmp;
+  inherit (lib)
+    mkOption
+    types
+    literalExpression
+    escapeShellArg
+    concatStringsSep
+    ;
 
   # This ensures that we can deal with string paths, path types and
   # store-path strings with context.

--- a/nixos/modules/services/monitoring/prometheus/exporters/sql.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/sql.nix
@@ -1,7 +1,13 @@
 { config, lib, pkgs, options, ... }:
-with lib;
 let
   cfg = config.services.prometheus.exporters.sql;
+  inherit (lib)
+    mkOption
+    types
+    mapAttrs
+    mapAttrsToList
+    concatStringsSep
+    ;
   cfgOptions = {
     options = with types; {
       jobs = mkOption {

--- a/nixos/modules/services/monitoring/prometheus/exporters/statsd.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/statsd.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.statsd;
+  inherit (lib) concatStringsSep;
 in
 {
   port = 9102;

--- a/nixos/modules/services/monitoring/prometheus/exporters/surfboard.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/surfboard.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.surfboard;
+  inherit (lib) mkOption types concatStringsSep;
 in
 {
   port = 9239;

--- a/nixos/modules/services/monitoring/prometheus/exporters/systemd.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/systemd.nix
@@ -1,9 +1,8 @@
 { config, pkgs, lib, ... }:
 
-with lib;
-
-let cfg = config.services.prometheus.exporters.systemd;
-
+let
+  cfg = config.services.prometheus.exporters.systemd;
+  inherit (lib) concatStringsSep;
 in {
   port = 9558;
 

--- a/nixos/modules/services/monitoring/prometheus/exporters/tor.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/tor.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.tor;
+  inherit (lib) mkOption types concatStringsSep;
 in
 {
   port = 9130;

--- a/nixos/modules/services/monitoring/prometheus/exporters/unbound.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/unbound.nix
@@ -5,10 +5,17 @@
 , ...
 }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.unbound;
+  inherit (lib)
+    mkOption
+    types
+    mkRemovedOptionModule
+    optionalAttrs
+    optionalString
+    mkMerge
+    mkIf
+    ;
 in
 {
   imports = [

--- a/nixos/modules/services/monitoring/prometheus/exporters/unifi.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/unifi.nix
@@ -1,9 +1,14 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.unifi;
+  inherit (lib)
+    mkOption
+    types
+    escapeShellArg
+    optionalString
+    concatStringsSep
+    ;
 in
 {
   port = 9130;

--- a/nixos/modules/services/monitoring/prometheus/exporters/unpoller.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/unpoller.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.unpoller;
+  inherit (lib) mkEnableOption generators;
 
   configFile = pkgs.writeText "prometheus-unpoller-exporter.json" (generators.toJSON {} {
     poller = { inherit (cfg.log) debug quiet; };

--- a/nixos/modules/services/monitoring/prometheus/exporters/v2ray.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/v2ray.nix
@@ -1,9 +1,8 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.v2ray;
+  inherit (lib) mkOption types concatStringsSep;
 in
 {
   port = 9299;

--- a/nixos/modules/services/monitoring/prometheus/exporters/varnish.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/varnish.nix
@@ -1,9 +1,15 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.varnish;
+  inherit (lib)
+    mkOption
+    types
+    mkDefault
+    optional
+    escapeShellArg
+    concatStringsSep
+    ;
 in
 {
   port = 9131;

--- a/nixos/modules/services/monitoring/prometheus/exporters/wireguard.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/wireguard.nix
@@ -1,9 +1,15 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
-
 let
   cfg = config.services.prometheus.exporters.wireguard;
+  inherit (lib)
+    mkOption
+    types
+    mkRenamedOptionModule
+    mkEnableOption
+    optionalString
+    escapeShellArg
+    ;
 in {
   port = 9586;
   imports = [

--- a/nixos/modules/services/monitoring/prometheus/exporters/zfs.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/zfs.nix
@@ -1,9 +1,14 @@
 { config, lib, pkgs, options, ... }:
 
-with lib;
 
 let
   cfg = config.services.prometheus.exporters.zfs;
+  inherit (lib)
+    mkOption
+    types
+    concatStringsSep
+    concatMapStringsSep
+    ;
 in
 {
   port = 9134;

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -907,7 +907,7 @@ let
               attrs = {
                 objectClass = [ "olcDatabaseConfig" "olcMdbConfig" ];
                 olcDatabase = "{1}mdb";
-                olcDbDirectory = "/var/db/openldap";
+                olcDbDirectory = "/var/lib/openldap/db";
                 olcSuffix = "dc=example";
                 olcRootDN = {
                   # cn=root,dc=example


### PR DESCRIPTION
Fixes issues described in #208242 for this part of the nixpkgs tree.

There are no behavioral changes in this, it only adjusts the code so that it is cleaner and resolves the above issue.

Also fixes a test failure in `nixosTests.prometheus-exporters.openldap` where the `olcDbDirectory` must be configured as a subdirectory of `/var/lib/openldap`, but was instead improperly configured as `/var/db/openldap`. The test now passes, as do all the other tests under prometheus-exporters.
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
