### PR TITLE
apptainer, singularity: format Nix expression according to Nix RFC 166

### DIFF
--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -26,6 +26,7 @@ in
 { lib
 , buildGoModule
 , runCommandLocal
+, substituteAll
   # Native build inputs
 , addDriverRunpath
 , makeWrapper
@@ -70,7 +71,6 @@ in
   # Whether to compile with SUID support
 , enableSuid ? false
 , starterSuidPath ? null
-, substituteAll
   # newuidmapPath and newgidmapPath are to support --fakeroot
   # where those SUID-ed executables are unavailable from the FHS system PATH.
   # Path to SUID-ed newuidmap executable

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -1,107 +1,111 @@
 # Configurations that should only be overrided by
 # overrideAttrs
-{ pname
-, version
-, src
-, projectName # "apptainer" or "singularity"
-, vendorHash ? null
-, deleteVendor ? false
-, proxyVendor ? false
-, extraConfigureFlags ? [ ]
-, extraDescription ? ""
-, extraMeta ? { }
+{
+  pname,
+  version,
+  src,
+  projectName, # "apptainer" or "singularity"
+  vendorHash ? null,
+  deleteVendor ? false,
+  proxyVendor ? false,
+  extraConfigureFlags ? [ ],
+  extraDescription ? "",
+  extraMeta ? { },
 }:
 
 let
   # Workaround for vendor-related attributes not overridable (#86349)
   # should be removed when the issue is resolved
   _defaultGoVendorArgs = {
-    inherit
-      vendorHash
-      deleteVendor
-      proxyVendor
-      ;
+    inherit vendorHash deleteVendor proxyVendor;
   };
 in
-{ lib
-, buildGoModule
-, runCommandLocal
-, substituteAll
+{
+  lib,
+  buildGoModule,
+  runCommandLocal,
+  substituteAll,
   # Native build inputs
-, addDriverRunpath
-, makeWrapper
-, pkg-config
-, util-linux
-, which
+  addDriverRunpath,
+  makeWrapper,
+  pkg-config,
+  util-linux,
+  which,
   # Build inputs
-, bash
-, callPackage
-, conmon
-, coreutils
-, cryptsetup
-, e2fsprogs
-, fakeroot
-, fuse2fs ? e2fsprogs.fuse2fs
-, go
-, gpgme
-, libseccomp
-, libuuid
+  bash,
+  callPackage,
+  conmon,
+  coreutils,
+  cryptsetup,
+  e2fsprogs,
+  fakeroot,
+  fuse2fs ? e2fsprogs.fuse2fs,
+  go,
+  gpgme,
+  libseccomp,
+  libuuid,
   # This is for nvidia-container-cli
-, nvidia-docker
-, openssl
-, squashfsTools
-, squashfuse
+  nvidia-docker,
+  openssl,
+  squashfsTools,
+  squashfuse,
   # Test dependencies
-, singularity-tools
-, cowsay
-, hello
+  singularity-tools,
+  cowsay,
+  hello,
   # Overridable configurations
-, enableNvidiaContainerCli ? true
+  enableNvidiaContainerCli ? true,
   # --nvccli currently requires extra privileges:
   # https://github.com/apptainer/apptainer/issues/1893#issuecomment-1881240800
-, forceNvcCli ? false
+  forceNvcCli ? false,
   # Compile with seccomp support
   # SingularityCE 3.10.0 and above requires explicit --without-seccomp when libseccomp is not available.
-, enableSeccomp ? true
+  enableSeccomp ? true,
   # Whether the configure script treat SUID support as default
   # When equal to enableSuid, it supress the --with-suid / --without-suid build flag
   # It can be set to `null` to always pass either --with-suid or --without-suided
   # Type: null or boolean
-, defaultToSuid ? true
+  defaultToSuid ? true,
   # Whether to compile with SUID support
-, enableSuid ? false
-, starterSuidPath ? null
+  enableSuid ? false,
+  starterSuidPath ? null,
   # newuidmapPath and newgidmapPath are to support --fakeroot
   # where those SUID-ed executables are unavailable from the FHS system PATH.
   # Path to SUID-ed newuidmap executable
-, newuidmapPath ? null
+  newuidmapPath ? null,
   # Path to SUID-ed newgidmap executable
-, newgidmapPath ? null
+  newgidmapPath ? null,
   # External LOCALSTATEDIR
-, externalLocalStateDir ? null
+  externalLocalStateDir ? null,
   # Remove the symlinks to `singularity*` when projectName != "singularity"
-, removeCompat ? false
+  removeCompat ? false,
   # Workaround #86349
   # should be removed when the issue is resolved
-, vendorHash ? _defaultGoVendorArgs.vendorHash
-, deleteVendor ? _defaultGoVendorArgs.deleteVendor
-, proxyVendor ? _defaultGoVendorArgs.proxyVendor
+  vendorHash ? _defaultGoVendorArgs.vendorHash,
+  deleteVendor ? _defaultGoVendorArgs.deleteVendor,
+  proxyVendor ? _defaultGoVendorArgs.proxyVendor,
 }:
 
 let
   defaultPathOriginal = "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin";
-  privileged-un-utils = if ((newuidmapPath == null) && (newgidmapPath == null)) then null else
-  (runCommandLocal "privileged-un-utils" { } ''
-    mkdir -p "$out/bin"
-    ln -s ${lib.escapeShellArg newuidmapPath} "$out/bin/newuidmap"
-    ln -s ${lib.escapeShellArg newgidmapPath} "$out/bin/newgidmap"
-  '');
+  privileged-un-utils =
+    if ((newuidmapPath == null) && (newgidmapPath == null)) then
+      null
+    else
+      (runCommandLocal "privileged-un-utils" { } ''
+        mkdir -p "$out/bin"
+        ln -s ${lib.escapeShellArg newuidmapPath} "$out/bin/newuidmap"
+        ln -s ${lib.escapeShellArg newgidmapPath} "$out/bin/newgidmap"
+      '');
 in
 (buildGoModule {
   inherit pname version src;
 
   patches = lib.optionals (projectName == "apptainer") [
-    (substituteAll { src = ./apptainer/0001-ldCache-patch-for-driverLink.patch; inherit (addDriverRunpath) driverLink; })
+    (substituteAll {
+      src = ./apptainer/0001-ldCache-patch-for-driverLink.patch;
+      inherit (addDriverRunpath) driverLink;
+    })
   ];
 
   # Override vendorHash with the output got from
@@ -146,21 +150,22 @@ in
     libuuid
     openssl
     squashfsTools # Required at build time by SingularityCE
-  ]
-  ++ lib.optional enableNvidiaContainerCli nvidia-docker
-  ++ lib.optional enableSeccomp libseccomp
-  ;
+  ] ++ lib.optional enableNvidiaContainerCli nvidia-docker ++ lib.optional enableSeccomp libseccomp;
 
   configureScript = "./mconfig";
 
-  configureFlags = [
-    "--localstatedir=${if externalLocalStateDir != null then externalLocalStateDir else "${placeholder "out"}/var/lib"}"
-    "--runstatedir=/var/run"
-  ]
-  ++ lib.optional (!enableSeccomp) "--without-seccomp"
-  ++ lib.optional (enableSuid != defaultToSuid) (if enableSuid then "--with-suid" else "--without-suid")
-  ++ extraConfigureFlags
-  ;
+  configureFlags =
+    [
+      "--localstatedir=${
+        if externalLocalStateDir != null then externalLocalStateDir else "${placeholder "out"}/var/lib"
+      }"
+      "--runstatedir=/var/run"
+    ]
+    ++ lib.optional (!enableSeccomp) "--without-seccomp"
+    ++ lib.optional (enableSuid != defaultToSuid) (
+      if enableSuid then "--with-suid" else "--without-suid"
+    )
+    ++ extraConfigureFlags;
 
   # causes redefinition of _FORTIFY_SOURCE
   hardeningDisable = [ "fortify3" ];
@@ -177,9 +182,7 @@ in
     privileged-un-utils
     squashfsTools # mksquashfs unsquashfs # Make / unpack squashfs image
     squashfuse # squashfuse_ll squashfuse # Mount (without unpacking) a squashfs image without privileges
-  ]
-  ++ lib.optional enableNvidiaContainerCli nvidia-docker
-  ;
+  ] ++ lib.optional enableNvidiaContainerCli nvidia-docker;
 
   postPatch = ''
     if [[ ! -e .git || ! -e VERSION ]]; then
@@ -249,70 +252,86 @@ in
         rm "$file"
       done
     ''}
-    ${lib.optionalString enableSuid (lib.warnIf (starterSuidPath == null) "${projectName}: Null starterSuidPath when enableSuid produces non-SUID-ed starter-suid and run-time permission denial." ''
-      chmod +x $out/libexec/${projectName}/bin/starter-suid
-    '')}
+    ${lib.optionalString enableSuid (
+      lib.warnIf (starterSuidPath == null)
+        "${projectName}: Null starterSuidPath when enableSuid produces non-SUID-ed starter-suid and run-time permission denial."
+        ''
+          chmod +x $out/libexec/${projectName}/bin/starter-suid
+        ''
+    )}
     ${lib.optionalString (enableSuid && (starterSuidPath != null)) ''
       mv "$out"/libexec/${projectName}/bin/starter-suid{,.orig}
       ln -s ${lib.escapeShellArg starterSuidPath} "$out/libexec/${projectName}/bin/starter-suid"
     ''}
   '';
 
-  meta = with lib; {
-    description = "Application containers for linux" + extraDescription;
-    longDescription = ''
-      Singularity (the upstream) renamed themselves to Apptainer
-      to distinguish themselves from a fork made by Sylabs Inc.. See
+  meta =
+    with lib;
+    {
+      description = "Application containers for linux" + extraDescription;
+      longDescription = ''
+        Singularity (the upstream) renamed themselves to Apptainer
+        to distinguish themselves from a fork made by Sylabs Inc.. See
 
-      https://sylabs.io/2021/05/singularity-community-edition
-      https://apptainer.org/news/community-announcement-20211130
-    '';
-    license = licenses.bsd3;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ jbedo ShamrockLee ];
-    mainProgram = projectName;
-  } // extraMeta;
-}).overrideAttrs (finalAttrs: prevAttrs: {
-  passthru = prevAttrs.passthru or { } // {
-    tests = {
-      image-hello-cowsay = singularity-tools.buildImage {
-        name = "hello-cowsay";
-        contents = [ hello cowsay ];
-        singularity = finalAttrs.finalPackage;
-      };
-    };
-    gpuChecks = lib.optionalAttrs (projectName == "apptainer") {
-      # Should be in tests, but Ofborg would skip image-hello-cowsay because
-      # saxpy is unfree.
-      image-saxpy = callPackage
-        ({ singularity-tools, cudaPackages }:
-          singularity-tools.buildImage {
-            name = "saxpy";
-            contents = [ cudaPackages.saxpy ];
-            memSize = 2048;
-            diskSize = 2048;
+        https://sylabs.io/2021/05/singularity-community-edition
+        https://apptainer.org/news/community-announcement-20211130
+      '';
+      license = licenses.bsd3;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [
+        jbedo
+        ShamrockLee
+      ];
+      mainProgram = projectName;
+    }
+    // extraMeta;
+}).overrideAttrs
+  (
+    finalAttrs: prevAttrs: {
+      passthru = prevAttrs.passthru or { } // {
+        tests = {
+          image-hello-cowsay = singularity-tools.buildImage {
+            name = "hello-cowsay";
+            contents = [
+              hello
+              cowsay
+            ];
             singularity = finalAttrs.finalPackage;
-          })
-        { };
-      saxpy =
-        callPackage
-          ({ runCommand, writeShellScriptBin }:
+          };
+        };
+        gpuChecks = lib.optionalAttrs (projectName == "apptainer") {
+          # Should be in tests, but Ofborg would skip image-hello-cowsay because
+          # saxpy is unfree.
+          image-saxpy = callPackage (
+            { singularity-tools, cudaPackages }:
+            singularity-tools.buildImage {
+              name = "saxpy";
+              contents = [ cudaPackages.saxpy ];
+              memSize = 2048;
+              diskSize = 2048;
+              singularity = finalAttrs.finalPackage;
+            }
+          ) { };
+          saxpy = callPackage (
+            { runCommand, writeShellScriptBin }:
             let
-              unwrapped = writeShellScriptBin "apptainer-cuda-saxpy"
-                ''
-                  ${lib.getExe finalAttrs.finalPackage} exec --nv $@ ${finalAttrs.passthru.gpuChecks.image-saxpy} saxpy
-                '';
+              unwrapped = writeShellScriptBin "apptainer-cuda-saxpy" ''
+                ${lib.getExe finalAttrs.finalPackage} exec --nv $@ ${finalAttrs.passthru.gpuChecks.image-saxpy} saxpy
+              '';
             in
             runCommand "run-apptainer-cuda-saxpy"
               {
                 requiredSystemFeatures = [ "cuda" ];
                 nativeBuildInputs = [ unwrapped ];
-                passthru = { inherit unwrapped; };
+                passthru = {
+                  inherit unwrapped;
+                };
               }
               ''
                 apptainer-cuda-saxpy
-              '')
-          { };
-    };
-  };
-})
+              ''
+          ) { };
+        };
+      };
+    }
+  )

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -142,15 +142,21 @@ in
   # apptainer/apptainer: https://github.com/apptainer/apptainer/blob/main/dist/debian/control
   # sylabs/singularity: https://github.com/sylabs/singularity/blob/main/debian/control
 
-  buildInputs = [
-    bash # To patch /bin/sh shebangs.
-    conmon
-    cryptsetup
-    gpgme
-    libuuid
-    openssl
-    squashfsTools # Required at build time by SingularityCE
-  ] ++ lib.optional enableNvidiaContainerCli nvidia-docker ++ lib.optional enableSeccomp libseccomp;
+  buildInputs =
+    [
+      bash # To patch /bin/sh shebangs.
+      conmon
+      cryptsetup
+      gpgme
+      libuuid
+      openssl
+      squashfsTools # Required at build time by SingularityCE
+    ]
+    # Optional dependencies.
+    # Formatting: Optional dependencies are likely to increase.
+    # Don't squash them into the same line.
+    ++ lib.optional enableNvidiaContainerCli nvidia-docker
+    ++ lib.optional enableSeccomp libseccomp;
 
   configureScript = "./mconfig";
 

--- a/pkgs/applications/virtualization/singularity/packages.nix
+++ b/pkgs/applications/virtualization/singularity/packages.nix
@@ -1,92 +1,98 @@
-{ callPackage
-, fetchFromGitHub
-, nixos
-, conmon
+{
+  callPackage,
+  fetchFromGitHub,
+  nixos,
+  conmon,
 }:
 let
-  apptainer = callPackage
-    (import ./generic.nix rec {
-      pname = "apptainer";
-      version = "1.3.1";
-      projectName = "apptainer";
+  apptainer =
+    callPackage
+      (import ./generic.nix rec {
+        pname = "apptainer";
+        version = "1.3.1";
+        projectName = "apptainer";
 
-      src = fetchFromGitHub {
-        owner = "apptainer";
-        repo = "apptainer";
-        rev = "refs/tags/v${version}";
-        hash = "sha256-XhJecINx8jC6pRzIoM4nC6Aunj40xL8EmYIA4UizfAY=";
+        src = fetchFromGitHub {
+          owner = "apptainer";
+          repo = "apptainer";
+          rev = "refs/tags/v${version}";
+          hash = "sha256-XhJecINx8jC6pRzIoM4nC6Aunj40xL8EmYIA4UizfAY=";
+        };
+
+        # Update by running
+        # nix-prefetch -E "{ sha256 }: ((import ./. { }).apptainer.override { vendorHash = sha256; }).goModules"
+        # at the root directory of the Nixpkgs repository
+        vendorHash = "sha256-MXW1U13uDRAx4tqZvqsuJvoD22nEL2gcxiGaa/6zwU0=";
+
+        extraDescription = " (previously known as Singularity)";
+        extraMeta.homepage = "https://apptainer.org";
+      })
+      {
+        # Apptainer doesn't depend on conmon
+        conmon = null;
+
+        # Apptainer builders require explicit --with-suid / --without-suid flag
+        # when building on a system with disabled unprivileged namespace.
+        # See https://github.com/NixOS/nixpkgs/pull/215690#issuecomment-1426954601
+        defaultToSuid = null;
       };
 
-      # Update by running
-      # nix-prefetch -E "{ sha256 }: ((import ./. { }).apptainer.override { vendorHash = sha256; }).goModules"
-      # at the root directory of the Nixpkgs repository
-      vendorHash = "sha256-MXW1U13uDRAx4tqZvqsuJvoD22nEL2gcxiGaa/6zwU0=";
+  singularity =
+    callPackage
+      (import ./generic.nix rec {
+        pname = "singularity-ce";
+        version = "4.1.2";
+        projectName = "singularity";
 
-      extraDescription = " (previously known as Singularity)";
-      extraMeta.homepage = "https://apptainer.org";
-    })
-    {
-      # Apptainer doesn't depend on conmon
-      conmon = null;
+        src = fetchFromGitHub {
+          owner = "sylabs";
+          repo = "singularity";
+          rev = "refs/tags/v${version}";
+          hash = "sha256-/KTDdkCMkZ5hO+VYHzw9vB8FDWxg7PS1yb2waRJQngY=";
+        };
 
-      # Apptainer builders require explicit --with-suid / --without-suid flag
-      # when building on a system with disabled unprivileged namespace.
-      # See https://github.com/NixOS/nixpkgs/pull/215690#issuecomment-1426954601
-      defaultToSuid = null;
-    };
+        # Update by running
+        # nix-prefetch -E "{ sha256 }: ((import ./. { }).singularity.override { vendorHash = sha256; }).goModules"
+        # at the root directory of the Nixpkgs repository
+        vendorHash = "sha256-4Nxj2PzZmFdvouWKyXLFDk8iuRhFuvyPW/+VRTw75Zw=";
 
-  singularity = callPackage
-    (import ./generic.nix rec {
-      pname = "singularity-ce";
-      version = "4.1.2";
-      projectName = "singularity";
+        # Do not build conmon and squashfuse from the Git submodule sources,
+        # Use Nixpkgs provided version
+        extraConfigureFlags = [
+          "--without-conmon"
+          "--without-squashfuse"
+        ];
 
-      src = fetchFromGitHub {
-        owner = "sylabs";
-        repo = "singularity";
-        rev = "refs/tags/v${version}";
-        hash = "sha256-/KTDdkCMkZ5hO+VYHzw9vB8FDWxg7PS1yb2waRJQngY=";
+        extraDescription = " (Sylabs Inc's fork of Singularity, a.k.a. SingularityCE)";
+        extraMeta.homepage = "https://sylabs.io/";
+      })
+      {
+        # Sylabs SingularityCE builders defaults to set the SUID flag
+        # on UNIX-like platforms,
+        # and only have --without-suid but not --with-suid.
+        defaultToSuid = true;
       };
 
-      # Update by running
-      # nix-prefetch -E "{ sha256 }: ((import ./. { }).singularity.override { vendorHash = sha256; }).goModules"
-      # at the root directory of the Nixpkgs repository
-      vendorHash = "sha256-4Nxj2PzZmFdvouWKyXLFDk8iuRhFuvyPW/+VRTw75Zw=";
+  genOverridenNixos =
+    package: packageName:
+    (nixos {
+      programs.singularity = {
+        enable = true;
+        inherit package;
+      };
+    }).config.programs.singularity.packageOverriden.overrideAttrs
+      (oldAttrs: {
+        meta = oldAttrs.meta // {
+          description = "";
+          longDescription = ''
+            This package produces identical store derivations to `pkgs.${packageName}`
+            overriden and installed by the NixOS module `programs.singularity`
+            with default configuration.
 
-      # Do not build conmon and squashfuse from the Git submodule sources,
-      # Use Nixpkgs provided version
-      extraConfigureFlags = [
-        "--without-conmon"
-        "--without-squashfuse"
-      ];
-
-      extraDescription = " (Sylabs Inc's fork of Singularity, a.k.a. SingularityCE)";
-      extraMeta.homepage = "https://sylabs.io/";
-    })
-    {
-      # Sylabs SingularityCE builders defaults to set the SUID flag
-      # on UNIX-like platforms,
-      # and only have --without-suid but not --with-suid.
-      defaultToSuid = true;
-    };
-
-  genOverridenNixos = package: packageName: (nixos {
-    programs.singularity = {
-      enable = true;
-      inherit package;
-    };
-  }).config.programs.singularity.packageOverriden.overrideAttrs (oldAttrs: {
-    meta = oldAttrs.meta // {
-      description = "";
-      longDescription = ''
-        This package produces identical store derivations to `pkgs.${packageName}`
-        overriden and installed by the NixOS module `programs.singularity`
-        with default configuration.
-
-        This is for binary substitutes only. Use pkgs.${packageName} instead.
-      '';
-    };
-  });
+            This is for binary substitutes only. Use pkgs.${packageName} instead.
+          '';
+        };
+      });
 in
 {
   inherit apptainer singularity;

--- a/pkgs/applications/virtualization/singularity/packages.nix
+++ b/pkgs/applications/virtualization/singularity/packages.nix
@@ -64,6 +64,9 @@ let
       extraMeta.homepage = "https://sylabs.io/";
     })
     {
+      # Sylabs SingularityCE builders defaults to set the SUID flag
+      # on UNIX-like platforms,
+      # and only have --without-suid but not --with-suid.
       defaultToSuid = true;
     };
 


### PR DESCRIPTION
## Description of changes

Format `pkgs/applications/virtualization/singularity/{generic.nix,packages.nix}` and `nixos/modules/programs/singularity.nix` with [nixfmt](https://github.com/NixOS/nixfmt) to make them conform Nix RFC 166, providing a clean ground for subsequent changes.

Prevent unwanted absorption by comments. See also NixOS/nixfmt#198.

Cc: @GaetanLepage @jbedo @SomeoneSerge

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (evaluation result should stay the same)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
