### PR TITLE
jetbrains.plugins: add nx-console

### DIFF
--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -434,17 +434,17 @@
         "webstorm"
       ],
       "builds": {
-        "233.13135.1068": "https://plugins.jetbrains.com/files/17718/551329/github-copilot-intellij-1.5.6.5692.zip",
-        "241.15989.206": "https://plugins.jetbrains.com/files/17718/551329/github-copilot-intellij-1.5.6.5692.zip",
-        "241.17011.166": "https://plugins.jetbrains.com/files/17718/551329/github-copilot-intellij-1.5.6.5692.zip",
-        "241.17890.1": "https://plugins.jetbrains.com/files/17718/551329/github-copilot-intellij-1.5.6.5692.zip",
-        "241.17890.13": "https://plugins.jetbrains.com/files/17718/551329/github-copilot-intellij-1.5.6.5692.zip",
-        "241.17890.14": "https://plugins.jetbrains.com/files/17718/551329/github-copilot-intellij-1.5.6.5692.zip",
-        "241.17890.15": "https://plugins.jetbrains.com/files/17718/551329/github-copilot-intellij-1.5.6.5692.zip",
-        "241.17890.19": "https://plugins.jetbrains.com/files/17718/551329/github-copilot-intellij-1.5.6.5692.zip",
-        "241.17890.21": "https://plugins.jetbrains.com/files/17718/551329/github-copilot-intellij-1.5.6.5692.zip",
-        "241.17890.24": "https://plugins.jetbrains.com/files/17718/551329/github-copilot-intellij-1.5.6.5692.zip",
-        "241.17890.8": "https://plugins.jetbrains.com/files/17718/551329/github-copilot-intellij-1.5.6.5692.zip"
+        "233.13135.1068": "https://plugins.jetbrains.com/files/17718/556037/github-copilot-intellij-1.5.8.5775.zip",
+        "241.15989.206": "https://plugins.jetbrains.com/files/17718/556037/github-copilot-intellij-1.5.8.5775.zip",
+        "241.17011.166": "https://plugins.jetbrains.com/files/17718/556037/github-copilot-intellij-1.5.8.5775.zip",
+        "241.17890.1": "https://plugins.jetbrains.com/files/17718/556037/github-copilot-intellij-1.5.8.5775.zip",
+        "241.17890.13": "https://plugins.jetbrains.com/files/17718/556037/github-copilot-intellij-1.5.8.5775.zip",
+        "241.17890.14": "https://plugins.jetbrains.com/files/17718/556037/github-copilot-intellij-1.5.8.5775.zip",
+        "241.17890.15": "https://plugins.jetbrains.com/files/17718/556037/github-copilot-intellij-1.5.8.5775.zip",
+        "241.17890.19": "https://plugins.jetbrains.com/files/17718/556037/github-copilot-intellij-1.5.8.5775.zip",
+        "241.17890.21": "https://plugins.jetbrains.com/files/17718/556037/github-copilot-intellij-1.5.8.5775.zip",
+        "241.17890.24": "https://plugins.jetbrains.com/files/17718/556037/github-copilot-intellij-1.5.8.5775.zip",
+        "241.17890.8": "https://plugins.jetbrains.com/files/17718/556037/github-copilot-intellij-1.5.8.5775.zip"
       },
       "name": "github-copilot"
     },
@@ -479,6 +479,29 @@
       },
       "name": "netbeans-6-5-keymap"
     },
+    "21060": {
+      "compatible": [
+        "clion",
+        "goland",
+        "idea-ultimate",
+        "phpstorm",
+        "pycharm-professional",
+        "rider",
+        "ruby-mine",
+        "webstorm"
+      ],
+      "builds": {
+        "241.17011.166": "https://plugins.jetbrains.com/files/21060/546274/nx-console-1.25.0.zip",
+        "241.17890.1": "https://plugins.jetbrains.com/files/21060/546274/nx-console-1.25.0.zip",
+        "241.17890.13": "https://plugins.jetbrains.com/files/21060/546274/nx-console-1.25.0.zip",
+        "241.17890.14": "https://plugins.jetbrains.com/files/21060/546274/nx-console-1.25.0.zip",
+        "241.17890.15": "https://plugins.jetbrains.com/files/21060/546274/nx-console-1.25.0.zip",
+        "241.17890.19": "https://plugins.jetbrains.com/files/21060/546274/nx-console-1.25.0.zip",
+        "241.17890.21": "https://plugins.jetbrains.com/files/21060/546274/nx-console-1.25.0.zip",
+        "241.17890.8": "https://plugins.jetbrains.com/files/21060/546274/nx-console-1.25.0.zip"
+      },
+      "name": "nx-console"
+    },
     "22407": {
       "compatible": [
         "clion",
@@ -486,9 +509,9 @@
         "rust-rover"
       ],
       "builds": {
-        "241.15989.206": "https://plugins.jetbrains.com/files/22407/542571/intellij-rust-241.25989.199.zip",
-        "241.17890.1": "https://plugins.jetbrains.com/files/22407/542571/intellij-rust-241.25989.199.zip",
-        "241.17890.19": "https://plugins.jetbrains.com/files/22407/542571/intellij-rust-241.25989.199.zip"
+        "241.15989.206": "https://plugins.jetbrains.com/files/22407/555351/intellij-rust-241.27011.169.zip",
+        "241.17890.1": "https://plugins.jetbrains.com/files/22407/555351/intellij-rust-241.27011.169.zip",
+        "241.17890.19": "https://plugins.jetbrains.com/files/22407/555351/intellij-rust-241.27011.169.zip"
       },
       "name": "rust"
     }
@@ -504,9 +527,10 @@
     "https://plugins.jetbrains.com/files/13017/508253/keymap-visualStudio-241.14494.150.zip": "sha256-tNgt0vIkdCB/LcaSj58mT6cNlw4lytRo0cZSt7sIERU=",
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",
     "https://plugins.jetbrains.com/files/164/546759/IdeaVim-2.12.0-signed.zip": "sha256-6ibo1vdwO4olQTCWpWAefT3QCwgtzTo1ojilDes8Rvg=",
-    "https://plugins.jetbrains.com/files/17718/551329/github-copilot-intellij-1.5.6.5692.zip": "sha256-p2xY8eN3tOvlXhuZm4R7zl67lnKbaJwKwPZSolDTaX0=",
+    "https://plugins.jetbrains.com/files/17718/556037/github-copilot-intellij-1.5.8.5775.zip": "sha256-FGSOBtSpOqF9dDl/z1QPKwjByEMwYswyHtK7LFlraHg=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
-    "https://plugins.jetbrains.com/files/22407/542571/intellij-rust-241.25989.199.zip": "sha256-ACeMU2llicj8VHBJJSAk2SIQaZrD2ykmY0b3VDiedV4=",
+    "https://plugins.jetbrains.com/files/21060/546274/nx-console-1.25.0.zip": "sha256-jzIzdxTJ7BpA7otBWU28yer+rv8rroZJgNr715ERDNY=",
+    "https://plugins.jetbrains.com/files/22407/555351/intellij-rust-241.27011.169.zip": "sha256-7rbYfO5CUvsW3HXWmEadreKbhJhX6joX15miODb2N+4=",
     "https://plugins.jetbrains.com/files/631/552809/python-241.17890.1.zip": "sha256-ASnW9SteKd88h2tAuZSHjnK+NMV7lm/3MN1tMqRvtmg=",
     "https://plugins.jetbrains.com/files/6981/547306/ini-241.17011.124.zip": "sha256-6EU2ExUMvXG2pJ77ZgZIsPC6gWX8MTZB0rRttYNRfX4=",
     "https://plugins.jetbrains.com/files/6981/552764/ini-241.17890.13.zip": "sha256-7JQpKNttNfTvzfZ2Qj42FZAtSqx6GjWHhT0WRecK3tc=",

--- a/pkgs/applications/editors/jetbrains/plugins/specialPlugins.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/specialPlugins.nix
@@ -1,4 +1,4 @@
-{ delve, autoPatchelfHook, stdenv, lib, glibc, gcc-unwrapped }:
+{ delve, autoPatchelfHook, stdenv, lib, glibc, gcc-unwrapped, musl }:
 # This is a list of plugins that need special treatment. For example, the go plugin (id is 9568) comes with delve, a
 # debugger, but that needs various linking fixes. The changes here replace it with the system one.
 {
@@ -59,6 +59,11 @@
       fix_offset PAYLOAD_POSITION
       fix_offset PRELUDE_POSITION
     '';
+  };
+  "21060" = {
+    # Nx Console
+    nativeBuildInputs = [ autoPatchelfHook ];
+    buildInputs = [ stdenv.cc.cc.lib musl ];
   };
   "22407" = {
     # Rust


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Ran `plugins/update_plugins.py add 21060` as per the `readme.md` instructions.

Tried testing the build with:

```
NIXPKGS_ALLOW_UNFREE=1 nix shell --expr 'let pkgs = import ./. {}; in pkgs.jetbrains.plugins.addPlugins pkgs.jetbrains.webstorm [ "nx-console" ]' --impure
```

As well as, with my more typical plugin set of:

```
NIXPKGS_ALLOW_UNFREE=1 nix shell --expr 'let pkgs = import ./. {}; in pkgs.jetbrains.plugins.addPlugins pkgs.jetbrains.webstorm [ "github-copilot" "ideavim" "nx-console" ]' --impure
```

Both seem to work well!

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
