### PR TITLE
oxipng: 9.0.0 -> 9.1.1

### DIFF
--- a/pkgs/tools/graphics/oxipng/default.nix
+++ b/pkgs/tools/graphics/oxipng/default.nix
@@ -1,17 +1,18 @@
-{ lib, stdenv, fetchCrate, rustPlatform }:
+{ lib, fetchCrate, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  version = "9.0.0";
+  version = "9.1.1";
   pname = "oxipng";
 
   src = fetchCrate {
     inherit version pname;
-    hash = "sha256-1OpSweosYiqtLqCcAw1EsAtBAYVc/VH8kRtVSpmTytM=";
+    hash = "sha256-I+1yQQEzhGApvHxPM8W1wySQtDglGp3V4vkwoTd92EU=";
   };
 
-  cargoHash = "sha256-kPdAfqMNOoQPSdv+VLRDUr6AXGPy47UnldXwvpwKp6s=";
+  cargoHash = "sha256-miXrQVFahz9WYRCduSF5+RSY4j/XNEt8lnSuOohBUFU=";
 
-  doCheck = !stdenv.isAarch64 && !stdenv.isDarwin;
+  # crates.io tree doesn't include any tests.
+  doCheck = false;
 
   meta = {
     homepage = "https://github.com/shssoichiro/oxipng";


### PR DESCRIPTION
## Description of changes

Straightforward version bump. Tested on some images -- seems to work.

Changelog: <https://github.com/shssoichiro/oxipng/releases>

Changes since 9.0.0:

+ [Build] Change man page generation path to resolve issue with cargo publish.
+ [Improvement] Add --keep display equivalent to --strip safe.
+ [Improvement] Add modified zeng palette sorting method, improving optimization of indexed images.
+ [Improvement] If only one filter is specified, guarantee to only use this one.
+ [Improvement] Evaluate low-depth indexed even if low-depth grayscale was already achieved.
+ [Bugfix] Fix battiato palette sorting method not being used if the input was not already indexed.
+ [Bugfix] Fix rare crash caused by a truncated palette.
+ [Build] Reduce size of binaries.
+ [Build] Add man page generation.
+ [Build] Publish deb archives for Linux.
+ [Misc] Bump minimum Rust version to 1.74.0.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
