### PR TITLE
vcv-rack: 2.4.1 -> 2.5.1

### DIFF
--- a/pkgs/applications/audio/vcv-rack/default.nix
+++ b/pkgs/applications/audio/vcv-rack/default.nix
@@ -36,8 +36,8 @@ let
   pffft-source = fetchFromBitbucket {
     owner = "jpommier";
     repo = "pffft";
-    rev = "38946c766c1afecfa4c5945af77913e38b3cec31";
-    sha256 = "1w6g9v9fy7bavqacb6qw1nxhcik2w36cvl2d7b0bh68w0pd70j5q";
+    rev = "fbc4058602803f40dc554b8a5d2bcc694c005f2f";
+    sha256 = "16biji3115232cr1j975hpxw68lfybajlspnhfjcwg8jz2d8ybrf";
   };
   fuzzysearchdatabase-source = fetchFromBitbucket {
     owner = "j_norberg";
@@ -64,28 +64,28 @@ let
     sha256 = "1d3058x6wgzw7b0wai792flk7s6ffw0z4n9sl016v91yjwv7ds3a";
   };
   oui-blendish-source = fetchFromGitHub {
-    owner = "AndrewBelt";
+    owner = "VCVRack";
     repo = "oui-blendish";
     rev = "2fc6405883f8451944ed080547d073c8f9f31898";
-    sha256 = "/QZFZuI5kSsEvSfMJlcqB1HiZ9Vcf3vqLqWIMEgxQK8=";
+    sha256 = "1bs0654312555vm7nzswsmky4l8759bjdk17pl22p49rw9k4a1px";
   };
   simde-source = fetchFromGitHub {
     owner = "simd-everywhere";
     repo = "simde";
-    rev = "b309d8951997201e493380a2fd09198c09ae1b4e";
-    sha256 = "1hz8mfbhbiafvim4qrkyvh1yndlhydqkxwhls7cfqa48wkpxfip8";
+    rev = "416091ebdb9e901b29d026633e73167d6353a0b0";
+    sha256 = "064ygc6c737yjx04rydwwhkr4n4s4rbvj27swxwyzvp1h8nka6xf";
   };
   tinyexpr-source = fetchFromGitHub {
     owner = "codeplea";
     repo = "tinyexpr";
-    rev = "74804b8c5d296aad0866bbde6c27e2bc1d85e5f2";
-    sha256 = "0z3r7wfw7p2wwl6wls2nxacirppr2147yz29whxmjaxy89ic1744";
+    rev = "9907207e5def0fabdb60c443517b0d9e9d521393";
+    sha256 = "0xbpd09zvrk2ppm1qm1skk6p50mqr9mzjixv3s0biqq6jpabs88l";
   };
   fundamental-source = fetchFromGitHub {
     owner = "VCVRack";
     repo = "Fundamental";
-    rev = "962547d7651260fb6a04f4d8aafd7c27f0221bee"; # tip of branch v2
-    sha256 = "066gcjkni8ba98vv0di59x3f9piir0vyy5sb53cqrbrl51x853cg";
+    rev = "5ed79544161e0fa9a55faa7c0a5f299e828e12ab"; # tip of branch v2
+    sha256 = "0c6qpigyr0ppvra20hcy1fdcmqa212jckb9wkx4f6fgdby7565wv";
   };
   vcv-rtaudio = stdenv.mkDerivation rec {
     pname = "vcv-rtaudio";
@@ -112,7 +112,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "vcv-rack";
-  version = "2.4.1";
+  version = "2.5.1";
 
   desktopItems = [
     (makeDesktopItem {
@@ -132,7 +132,7 @@ stdenv.mkDerivation rec {
     owner = "VCVRack";
     repo = "Rack";
     rev = "v${version}";
-    hash = "sha256-Gn/sFltLXX2mLv4dDqmr/UPd+JBXVkIZGwMI6Rm0Ih4=";
+    sha256 = "1q2bwjfn6crk9lyd6m3py0v754arw1xgpv5kkj6ka1bc2yz839qh";
   };
 
   patches = [


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/VCVRack/Rack/blob/v2.5.1/CHANGELOG.md#251-2024-04-16

I compared dependency sources against the .gitmodules file in Rack repo v.2.5.1, and made any necessary updates to ensure each one is pulling in the commit that was most recent on the date of the Rack v.2.5.1 release. This skips v2.5.0, which introduced some new features but also a few bugs which are fixed in the newer version.

## Things done

Tested ./result/bin/Rack and it seemed to work just fine on XFCE. I got a fatal GLFW initialization error on sway, but I believe this to be caused by a mismatch between the glfw-wayland version on my base system and in nixpkgs unstable.

Edited to add: I got this to run on sway in NixOS 23.11 by modifying the derivation slightly to build against glfw in the stable NixOS channel instead of glfw from unstable nixpkgs, so this confirms for me that the issue I experienced is about a glfw API mismatch in my build environment and not an issue with the derivation itself.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
