### PR TITLE
jetbrains: respect boot java runtime settings

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/linux.nix
+++ b/pkgs/applications/editors/jetbrains/bin/linux.nix
@@ -102,14 +102,15 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
     jdk=${jdk.home}
     item=${desktopItem}
 
-    BOOT_JDK_BASE_NAME=$(grep '\.jdk' "$out/$pname/bin/${loName}.sh" \
+    BOOT_JDK_FULL_NAME=$(grep '\.jdk' "$out/$pname/bin/${loName}.sh" \
                          | grep '^if' \
                          | head -n 1 \
                          | sed -e 's|\(.*\)".*|\1|' \
                                -e 's|.*"||' \
                                -e 's|.*/\(.*/.*\)|\1|')
-    BOOT_JDK_NAME="\$HOME/.config/JetBrains/$BOOT_JDK_BASE_NAME"
-    wrapProgram  "$out/$pname/bin/${loName}.sh" \
+    BOOT_JDK_DIR_NAME=$(dirname $BOOT_JDK_FULL_NAME)
+    BOOT_JDK_BASE_NAME=$(basename $BOOT_JDK_FULL_NAME)
+    wrapProgram "$out/$pname/bin/${loName}.sh" \
       --prefix PATH : "${lib.makeBinPath [ jdk coreutils gnugrep which git ]}" \
       --suffix PATH : "${lib.makeBinPath [ python3 ]}" \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath extraLdPath}" \
@@ -120,12 +121,15 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
       --set-default JETBRAINSCLIENT_JDK "$jdk" \
       --set-default ${hiName}_JDK "$jdk" \
       --set-default ${hiName}_VM_OPTIONS ${vmoptsFile}
+
     sed -i -e '/^export ${hiName}_JDK=/afi' \
-        -e "/^export ${hiName}_JDK=/iif [[ ! -s \"$BOOT_JDK_NAME\" ]]; then" \
+        -e "/^export ${hiName}_JDK=/iCONFIG_HOME=\"\''${XDG_CONFIG_HOME-\''${HOME}/.config}/JetBrains/$BOOT_JDK_DIR_NAME\"\\
+    if [[ ! -s \"\$CONFIG_HOME/$BOOT_JDK_BASE_NAME\" ]]; then" \
         -e 's|^export ${hiName}_JDK\(.*\)|    export ${hiName}_JDK\1|' \
         "$out/$pname/bin/${loName}.sh"
+
     sed -i -e '/^export ${hiName}_VM_OPTIONS=/afi' \
-        -e "/^export ${hiName}_VM_OPTIONS=/iVMOPTS_STR=\"\$(dirname $BOOT_JDK_NAME)/*.vmoptions\"\\
+        -e "/^export ${hiName}_VM_OPTIONS=/iVMOPTS_STR=\"\$CONFIG_HOME/*.vmoptions\"\\
     VMOPTS=\"\$(echo \$VMOPTS_STR)\"\\
     if [[ -s \"\$VMOPTS\" ]]; then\\
         export ${hiName}_VM_OPTIONS=\$(cat \"\$VMOPTS\")\\

--- a/pkgs/applications/editors/jetbrains/bin/linux.nix
+++ b/pkgs/applications/editors/jetbrains/bin/linux.nix
@@ -128,13 +128,11 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
         -e 's|^export ${hiName}_JDK\(.*\)|    export ${hiName}_JDK\1|' \
         "$out/$pname/bin/${loName}.sh"
 
-    sed -i -e '/^export ${hiName}_VM_OPTIONS=/afi' \
-        -e "/^export ${hiName}_VM_OPTIONS=/iVMOPTS_STR=\"\$CONFIG_HOME/*.vmoptions\"\\
-    VMOPTS=\"\$(echo \$VMOPTS_STR)\"\\
-    if [[ -s \"\$VMOPTS\" ]]; then\\
-        export ${hiName}_VM_OPTIONS=\$(cat \"\$VMOPTS\")\\
-    else" \
-        -e 's|^export ${hiName}_VM_OPTIONS\(.*\)|    export ${hiName}_VM_OPTIONS\1|' \
+    sed -i -e '/^export ${hiName}_VM_OPTIONS=/aVMOPTS_PATTERN=\"\$CONFIG_HOME/*.vmoptions\"' \
+           -e '/^export ${hiName}_VM_OPTIONS=/aVMOPTS=\"\$(echo \$VMOPTS_PATTERN)\"' \
+           -e '/^export ${hiName}_VM_OPTIONS=/aif [[ -s \"\$VMOPTS\" ]]; then' \
+           -e '/^export ${hiName}_VM_OPTIONS=/a\ \ \ \ export ${hiName}_VM_OPTIONS=\"''$${hiName}_VM_OPTIONS \$(cat \"\$VMOPTS\")\"' \
+           -e '/^export ${hiName}_VM_OPTIONS=/afi' \
         "$out/$pname/bin/${loName}.sh"
 
     ln -s "$out/$pname/bin/${loName}.sh" $out/bin/$pname

--- a/pkgs/applications/editors/jetbrains/bin/linux.nix
+++ b/pkgs/applications/editors/jetbrains/bin/linux.nix
@@ -102,6 +102,13 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
     jdk=${jdk.home}
     item=${desktopItem}
 
+    BOOT_JDK_BASE_NAME=$(grep '\.jdk' "$out/$pname/bin/${loName}.sh" \
+                         | grep '^if' \
+                         | head -n 1 \
+                         | sed -e 's|\(.*\)".*|\1|' \
+                               -e 's|.*"||' \
+                               -e 's|.*/\(.*/.*\)|\1|')
+    BOOT_JDK_NAME="\$HOME/.config/JetBrains/$BOOT_JDK_BASE_NAME"
     wrapProgram  "$out/$pname/bin/${loName}.sh" \
       --prefix PATH : "${lib.makeBinPath [ jdk coreutils gnugrep which git ]}" \
       --suffix PATH : "${lib.makeBinPath [ python3 ]}" \
@@ -113,6 +120,18 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
       --set-default JETBRAINSCLIENT_JDK "$jdk" \
       --set-default ${hiName}_JDK "$jdk" \
       --set-default ${hiName}_VM_OPTIONS ${vmoptsFile}
+    sed -i -e '/^export ${hiName}_JDK=/afi' \
+        -e "/^export ${hiName}_JDK=/iif [[ ! -s \"$BOOT_JDK_NAME\" ]]; then" \
+        -e 's|^export ${hiName}_JDK\(.*\)|    export ${hiName}_JDK\1|' \
+        "$out/$pname/bin/${loName}.sh"
+    sed -i -e '/^export ${hiName}_VM_OPTIONS=/afi' \
+        -e "/^export ${hiName}_VM_OPTIONS=/iVMOPTS_STR=\"\$(dirname $BOOT_JDK_NAME)/*.vmoptions\"\\
+    VMOPTS=\"\$(echo \$VMOPTS_STR)\"\\
+    if [[ -s \"\$VMOPTS\" ]]; then\\
+        export ${hiName}_VM_OPTIONS=\$(cat \"\$VMOPTS\")\\
+    else" \
+        -e 's|^export ${hiName}_VM_OPTIONS\(.*\)|    export ${hiName}_VM_OPTIONS\1|' \
+        "$out/$pname/bin/${loName}.sh"
 
     ln -s "$out/$pname/bin/${loName}.sh" $out/bin/$pname
     rm -rf $out/$pname/plugins/remote-dev-server/selfcontained/


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

All JetBrain IDEs support setting the boot-time Java runtime, which is helpful in some cases. For example, I had the issue of `error reading /nix/store/liz01j673lwb0wzkrykg39a7z388fy41-mps-2023.2/mps/lib/app.jar; Invalid CEN header (invalid zip64 extra data field size)` with an old version of JetBrains MPS. Similar issues have been [reported](https://youtrack.jetbrains.com/issue/MPS-36113) and the recommended solution at the time was to change the boot-time JDK.

This setting can be changed, for example, as described [here for MPS](https://www.jetbrains.com/help/mps/switching-boot-jdk.html), but also [similarly for other JetBrains IDEs](https://intellij-support.jetbrains.com/hc/en-us/articles/206544879-Selecting-the-JDK-version-the-IDE-will-run-under), by creating `*.jdk` files in `~/.config/JetBrains/*`. JetBrain's scripts will then load them for the boot time JDKs. For example, `~/.config/JetBrains/MPS2023.3/mps.jdk` is generated for MPS 2023.3 and `~/.config/JetBrains/IntelliJIdea2024.1/idea.jdk` is generated for IntelliJ Ultimate 2024.1.

Unfortunately, the current wrapper scripts ignore such settings and always enforce the Java runtime chosen at installation time.

This PR fixes the wrapper scripts so that they respect boot-time JDK settings. It achieves the goal by tweaking the procedure that sets environment variables. For example, while the two variables were set directly for MPS as below:

```
export MPS_JDK=${MPS_JDK-'/nix/store/a9hjq76qi7acm4pfi928ih7z70d5bndj-jetbrains-jdk-jcef-17.0.8-b1000.8/lib/openjdk'}
export MPS_VM_OPTIONS=${MPS_VM_OPTIONS-''}
```

They are now only set when boot-time JDKs are not set, as below:

```
CONFIG_HOME="${XDG_CONFIG_HOME-${HOME}/.config}/JetBrains/MPS2023.3"
if [[ ! -s "$CONFIG_HOME/mps.jdk" ]]; then
    export MPS_JDK=${MPS_JDK-'/nix/store/grdjncqiwimlbgpgxvbadbnrfvybvaz6-jetbrains-jdk-jcef-21.0.3-b465.3/lib/openjdk'}
fi
export MPS_VM_OPTIONS=${MPS_VM_OPTIONS-''}
VMOPTS_PATTERN="$CONFIG_HOME/*.vmoptions"
VMOPTS="$(echo $VMOPTS_PATTERN)"
if [[ -s "$VMOPTS" ]]; then
    export MPS_VM_OPTIONS="$MPS_VM_OPTIONS $(cat "$VMOPTS")"
fi
```

Loading of `*.jdk` files is then delegated to the corresponding upstream scripts. Note also that the `*.vmoptions` files are also treated specially.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
