### PR TITLE
apptainer, singularity: refactor defaultPath substitution

### DIFF
--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -44,6 +44,7 @@ in
   gpgme,
   libseccomp,
   libuuid,
+  mount,
   # This is for nvidia-container-cli
   nvidia-docker,
   openssl,
@@ -185,6 +186,7 @@ in
     fakeroot
     fuse2fs # Mount ext3 filesystems
     go
+    mount # mount
     privileged-un-utils
     squashfsTools # mksquashfs unsquashfs # Make / unpack squashfs image
     squashfuse # squashfuse_ll squashfuse # Mount (without unpacking) a squashfs image without privileges

--- a/pkgs/applications/virtualization/singularity/packages.nix
+++ b/pkgs/applications/virtualization/singularity/packages.nix
@@ -35,6 +35,12 @@ let
         # when building on a system with disabled unprivileged namespace.
         # See https://github.com/NixOS/nixpkgs/pull/215690#issuecomment-1426954601
         defaultToSuid = null;
+
+        sourceFilesWithDefaultPaths = {
+          "cmd/internal/cli/actions.go" = [ "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin" ];
+          "e2e/env/env.go" = [ "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" ];
+          "internal/pkg/util/env/env.go" = [ "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" ];
+        };
       };
 
   singularity =
@@ -71,6 +77,14 @@ let
         # on UNIX-like platforms,
         # and only have --without-suid but not --with-suid.
         defaultToSuid = true;
+
+        sourceFilesWithDefaultPaths = {
+          "cmd/internal/cli/actions.go" = [ "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin" ];
+          "e2e/env/env.go" = [ "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" ];
+          "internal/pkg/util/env/clean.go" = [
+            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          ];
+        };
       };
 
   genOverridenNixos =

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -45,7 +45,7 @@ rec {
     , diskSize ? 1024
     , runScript ? "#!${stdenv.shell}\nexec /bin/sh"
     , runAsRoot ? null
-    , memSize ? 512
+    , memSize ? 1024
     , singularity ? defaultSingularity
     }:
     let


### PR DESCRIPTION
## Description of changes

- Add argument `sourceFilesWithDefaultPaths` to specify the `defaultPath`s to substitute.

- Passthru `sourceFilesWithDefaultPaths` for easier overriding.

- Use `--replace-fail` during `defalutPath` substitution.

- Add `mount` to the `defaultPathInputs` of `apptainer` and `singularity`.

#### How to verify that the fix takes effect:

When executing images using `singularity` from the master branch, it will complain that the `mount` command is not found in PATH. The error persists even after applying the firsts commit of this PR that adds `mount` into `defaultPathInputs`. After applying the second commit of this PR that fix the `defaultPath` substitution, the error will disappear.

Note, `singularity` still fails to execute images, complaining that "`fusermount3` not found" and "permission denied" when unmounting `/tmp/rootfs-.../root`. That won't be fixed simply by adding `fuse3` into `defaultPathInputs`, as unprivileged users need the SUID-bit set `fusermount3` to unmount with `fusermount3 -r`. That one will be solved in #306730.

This PR also increase the default `memSize` of `singularity-tools.buildImage` from 512 to 1024, in the hope that `singularity.tests.image-hello-cowsay` could build successfully on CI without memory allocation error.

This is an initial effort toward fixing #295809, and it needs to be backported to Nixpkgs 24.05 if merged after branch-off.

Cc: @GaetanLepage @jbedo @SomeoneSerge @FynnFreyer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) (My own laptop is under repair, and the one I borrow doesn't have enough physical RAM to run `nixpkgs-review` within sensible amount of time. Hope someone could help me run this test.)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
