### PR TITLE
workflows: add concurrency group to check-by-name workflow (again)

### DIFF
--- a/.github/workflows/check-by-name.yml
+++ b/.github/workflows/check-by-name.yml
@@ -20,6 +20,13 @@ permissions:
   # We need this permission to cancel the workflow run if there's a merge conflict
   actions: write
 
+# Create a check-by-name concurrency group based on the pull request number. if
+# an event triggers a run on the same PR while a previous run is still in
+# progress, the previous run will be canceled and the new one will start.
+concurrency:
+  group: check-by-name-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check:
     # This needs to be x86_64-linux, because we depend on the tooling being pre-built in the GitHub releases


### PR DESCRIPTION
## Description of changes

This is the second attempt to add a concurrency group to the check-by-name in hopes that it will reduce unnecessary load on the CI system (wasted electricity) despite free cost.

first attempt: https://github.com/NixOS/nixpkgs/pull/306072
revert: https://github.com/NixOS/nixpkgs/pull/306430

## Things done

Testing here https://github.com/willbush/nixpkgs/actions/workflows/check-by-name.yml

- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
