### PR TITLE
pkgsMusl.patchutils_0_4_2: fix build

### DIFF
--- a/pkgs/tools/text/patchutils/0.4.2.nix
+++ b/pkgs/tools/text/patchutils/0.4.2.nix
@@ -5,4 +5,5 @@ callPackage ./generic.nix (args // {
   sha256 = "sha256-iHWwll/jPeYriQ9s15O+f6/kGk5VLtv2QfH+1eu/Re0=";
   # for gitdiff
   extraBuildInputs = [ python3 ];
+  patches = [ ./Revert-Fix-grepdiff-test.patch ];
 })

--- a/pkgs/tools/text/patchutils/Revert-Fix-grepdiff-test.patch
+++ b/pkgs/tools/text/patchutils/Revert-Fix-grepdiff-test.patch
@@ -1,0 +1,38 @@
+From 13672e53371ea9593130bdca178f3b8b2e174032 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Thu, 25 Apr 2024 09:10:54 +0200
+Subject: [PATCH] Revert "Fix grepdiff test"
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This reverts commit a6538753a51db973a05c9034ed78f2dd946453db.
+
+There's no need for an escape here, because POSIX regexes don't treat
+'+' specially if it's at the start of the experssion.  musl rejects
+the version with the backslash.
+
+I'm still not clear why this change was made in the first place, but
+reverting it seems to make the test pass on both glibc and musl…
+
+Link: https://github.com/twaugh/patchutils/issues/61
+---
+ tests/grepdiff1/run-test | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/grepdiff1/run-test b/tests/grepdiff1/run-test
+index c4311f8..c3cebdd 100755
+--- a/tests/grepdiff1/run-test
++++ b/tests/grepdiff1/run-test
+@@ -20,7 +20,7 @@ cat << EOF > diff
+ +b
+ EOF
+ 
+-${GREPDIFF} '\+a' diff 2>errors >index || exit 1
++${GREPDIFF} '+a' diff 2>errors >index || exit 1
+ [ -s errors ] && exit 1
+ 
+ cat << EOF | cmp - index || exit 1
+-- 
+2.44.0
+


### PR DESCRIPTION
## Description of changes

See comments in patch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
