### PR TITLE
apptainer, singularity: precede system-level bin paths in `defaultPath` and fix `singularity` image running

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -223,6 +223,19 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - `appimageTools.wrapAppImage` now creates the binary at `$out/bin/${pname}` rather than `$out/bin/${pname}-${version}`, which will break downstream workarounds.
 
+- `apptainer` and `singularity` now prioritize system-wide `PATH` over those constructed from dependent packages when searching for third-party utilities. The `PATH` to search for third-party utilities, known as `defaultPath` inside Apptainer/Singularity source code, is now constructed from the following sources, ordered by their precedence:
+  - `systemBinPaths`, a new argument introduced to specify system-wide `"/**/bin"` directories.
+  - The FHS `defaultPath` value set by Apptainer/Singularity developers, making Apptainer/Singularity work out of the box in FHS systems.
+  - `defaultPathInputs`, a list of packages to form the fall-back `PATH`.
+
+  This change is required to enable Sylabs SingularityCE (`singularity`) to run images, as it requires a `fusermount3` commant with the SUID bit set.
+
+  `newuidmapPath` and `newgidmapPath` arguments are deprecated in favour of `systemBinPaths`. Their support will be removed in future releases.
+
+  `programs.singularity.systemBinPaths` option is introduced to specify the `systemBinPaths` argument of the overridden package. It includes `"/run/wrappers/bin"` even if specified empty.
+
+  `programs.singularity.enableFakeroot` option is deprecated and has no effect. `--fakeroot` support is now always enabled as long as `programs.singularity.systemBinPaths` is not forcefully overridden.
+
 - `azure-cli` now has extension support. For example, to install the `aks-preview` extension, use
 
   ```nix

--- a/nixos/modules/programs/singularity.nix
+++ b/nixos/modules/programs/singularity.nix
@@ -56,9 +56,12 @@ in
     enableFakeroot = lib.mkOption {
       type = lib.types.bool;
       default = true;
-      example = false;
       description = ''
         Whether to enable the `--fakeroot` support of Singularity/Apptainer.
+
+        This option is deprecated and has no effect.
+        `--fakeroot` support is enabled automatically,
+        as `systemBinPaths = [ "/run/wrappers/bin" ]` is always specified.
       '';
     };
     enableSuid = lib.mkOption {
@@ -74,22 +77,34 @@ in
         Whether to enable the SUID support of Singularity/Apptainer.
       '';
     };
+    systemBinPaths = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
+      default = [ ];
+      description = ''
+        (Extra) system-wide /**/bin paths
+        for Apptainer/Singularity to find command-line utilities in.
+
+        `"/run/wrappers/bin"` is included by default to make
+        utilities with SUID bit set available to Apptainer/Singularity.
+        Use `lib.mkForce` to shadow the default values.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
     programs.singularity.packageOverriden = (
       cfg.package.override (
-        lib.optionalAttrs cfg.enableExternalLocalStateDir { externalLocalStateDir = "/var/lib"; }
-        // lib.optionalAttrs cfg.enableFakeroot {
-          newuidmapPath = "/run/wrappers/bin/newuidmap";
-          newgidmapPath = "/run/wrappers/bin/newgidmap";
+        {
+          systemBinPaths = cfg.systemBinPaths;
         }
+        // lib.optionalAttrs cfg.enableExternalLocalStateDir { externalLocalStateDir = "/var/lib"; }
         // lib.optionalAttrs cfg.enableSuid {
           enableSuid = true;
           starterSuidPath = "/run/wrappers/bin/${cfg.package.projectName}-suid";
         }
       )
     );
+    programs.singularity.systemBinPaths = [ "/run/wrappers/bin" ];
     environment.systemPackages = [ cfg.packageOverriden ];
     security.wrappers."${cfg.packageOverriden.projectName}-suid" = lib.mkIf cfg.enableSuid {
       setuid = true;

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -116,11 +116,15 @@ let
     if ((newuidmapPath == null) && (newgidmapPath == null)) then
       null
     else
-      runCommandLocal "privileged-un-utils" { } ''
-        mkdir -p "$out/bin"
-        ln -s ${lib.escapeShellArg newuidmapPath} "$out/bin/newuidmap"
-        ln -s ${lib.escapeShellArg newgidmapPath} "$out/bin/newgidmap"
-      '';
+      lib.warn
+        "${pname}: arguments newuidmapPath and newgidmapPath is deprecated in favour of systemBinPaths."
+        (
+          runCommandLocal "privileged-un-utils" { } ''
+            mkdir -p "$out/bin"
+            ln -s ${lib.escapeShellArg newuidmapPath} "$out/bin/newuidmap"
+            ln -s ${lib.escapeShellArg newgidmapPath} "$out/bin/newgidmap"
+          ''
+        );
 
   # Backward compatibility for privileged-un-utils.
   # TODO(@ShamrockLee): Remove after Nixpkgs 24.05 branch-off.


### PR DESCRIPTION
## Description of changes

`apptainer` and `singularity` now prioritize `PATH` from the system over those constructed from dependent packages, when it comes to the substitution of `defaultPath` values (the `PATH` hard-coded inside Apptainer/Singularity library for them to find third-party utilities). It is now constructed by the following sources, ordered by their precedence:
  - `systemBinPaths`, a new argument introduced to specify the `/**/bin` paths from the system, especially those with their SUID bit set.
  - The original `defaultPath` value, making it work out of the box in FHS systems.
  - `defaultPathInputs`, a list of packages to form the fall-back `PATH`.

This change is required to enable Sylabs SingularityCE (`singularity`) to run images, as it requires a `fusermount3` commant with SUID bit set.

The arguments `newuidmapPath` and `newgidmapPath` is deprecated in favour of `systemBinPaths`. Their support will be removed in future releases.

New option `programs.singularity.systemBinPaths` is introduced to specify the `systemBinPaths` argument of the overridden package. It includes `"/run/wrappers/bin"` even if specified empty.

The option `programs.singularity.enableFakeroot` is deprecated and has no effect. `--fakeroot` support is now always enabled as long as `programs.singularity.systemBinPaths` is not forcefully overridden.

This PR depends on #306656 and #306716, and currently contains their commits. The size of this PR will reduce once the dependent PRs are merged.

Together with #306716, this PR fixes #295809 and prevents the broken `singularity` from going into the stable release. If this fails to merge before the branch-off, I would like to have the changes backported without the deprecation warnings.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [X] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
