### PR TITLE
projectlibre: 1.7.0 -> 1.9.3

### DIFF
--- a/pkgs/applications/misc/projectlibre/default.nix
+++ b/pkgs/applications/misc/projectlibre/default.nix
@@ -1,23 +1,24 @@
-{ lib
-, stdenv
-, fetchgit
-, ant
-, jdk
-, stripJavaArchivesHook
-, makeWrapper
-, jre
-, coreutils
-, which
+{
+  lib,
+  stdenv,
+  fetchgit,
+  ant,
+  jdk,
+  stripJavaArchivesHook,
+  makeWrapper,
+  jre,
+  coreutils,
+  which,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "projectlibre";
-  version = "1.7.0";
+  version = "1.9.3";
 
   src = fetchgit {
     url = "https://git.code.sf.net/p/projectlibre/code";
-    rev = "0c939507cc63e9eaeb855437189cdec79e9386c2"; # version 1.7.0 was not tagged
-    hash = "sha256-eLUbsQkYuVQxt4px62hzfdUNg2zCL/VOSVEVctfbxW8=";
+    rev = "20814e88dc83694f9fc6780c2550ca5c8a87aa16"; # version 1.9.3 was not tagged
+    hash = "sha256-yXgYyy3jWxYMXKsNCRWdO78gYRmjKpO9U5WWU6PtwMU=";
   };
 
   nativeBuildInputs = [
@@ -27,9 +28,17 @@ stdenv.mkDerivation {
     makeWrapper
   ];
 
+  runtimeDeps = [
+    jre
+    coreutils
+    which
+  ];
+
+  env.JAVA_TOOL_OPTIONS = "-Dfile.encoding=UTF8";
+
   buildPhase = ''
     runHook preBuild
-    ant -f openproj_build/build.xml
+    ant -f projectlibre_build/build.xml
     runHook postBuild
   '';
 
@@ -38,7 +47,7 @@ stdenv.mkDerivation {
 
     mkdir -p $out/share/{projectlibre/samples,doc/projectlibre}
 
-    pushd openproj_build
+    pushd projectlibre_build
     cp -R dist/* $out/share/projectlibre
     cp -R license $out/share/doc/projectlibre
     cp -R resources/samples/* $out/share/projectlibre/samples
@@ -51,7 +60,7 @@ stdenv.mkDerivation {
         --replace-fail "/usr/share/projectlibre" "$out/share/projectlibre"
 
     wrapProgram $out/bin/projectlibre \
-        --prefix PATH : ${lib.makeBinPath [ jre coreutils which ]}
+        --prefix PATH : ${lib.makeBinPath finalAttrs.runtimeDeps}
 
     runHook postInstall
   '';
@@ -61,8 +70,10 @@ stdenv.mkDerivation {
     homepage = "https://www.projectlibre.com/";
     license = lib.licenses.cpal10;
     mainProgram = "projectlibre";
-    maintainers = with lib.maintainers; [ Mogria tomasajt ];
+    maintainers = with lib.maintainers; [
+      Mogria
+      tomasajt
+    ];
     platforms = jre.meta.platforms;
   };
-}
-
+})


### PR DESCRIPTION
## Description of changes

This PR bumps the version of `projectlibre`, which was seriously outdated.
The latest version, `1.9.3`,  was released in 2021.

I extracted the `makeBinPath` args into a separate list to make it overridable and more pleasant to look at.
I had to set `-Dfile.encoding=UTF8` for some reason (it wouldn't build otherwise)
I also formatted the file with `nixfmt-rfc-style`.

Note: running the program will print an exception in the console, however this is to be expected, because it tries to load a bundle even if `useExternalLocales` is not enabled.
Not sure why it is this way.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
