### PR TITLE
perfect_dark: init at 0-unstable-2025-08-25

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19603,6 +19603,13 @@
     githubId = 81905706;
     name = "Pau Kaifler";
   };
+  PaulGrandperrin = {
+    name = "Paul Grandperrin";
+    email = "paul.grandperrin@gmail.com";
+    github = "PaulGrandperrin";
+    githubId = 1748936;
+    keys = [ { fingerprint = "FEDA B009 17FA A574 F536 ED52 4AB1 3530 3377 4DA3"; } ];
+  };
   paulsmith = {
     email = "paulsmith@pobox.com";
     github = "paulsmith";

--- a/pkgs/by-name/pe/perfect_dark/package.nix
+++ b/pkgs/by-name/pe/perfect_dark/package.nix
@@ -1,0 +1,130 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  SDL2,
+  cmake,
+  libGL,
+  pkg-config,
+  python3,
+  zlib,
+  romID ? "ntsc-final",
+}:
+let
+  roms = [
+    "ntsc-final"
+    "pal-final"
+    "jpn-final"
+  ];
+in
+assert lib.assertOneOf "romID" romID roms;
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "perfect_dark";
+  version = "0-unstable-2025-08-25";
+
+  src = fetchFromGitHub {
+    owner = "fgsfdsfgs";
+    repo = "perfect_dark";
+    rev = "bb4fcffeb5dc382fce4c609897a2e82590d7d709";
+    hash = "sha256-XLmAjwEzz4fPpHuk3IBmhhDfiuudwMTnYgVe6Wcfdsg=";
+  };
+
+  enableParallelBuilding = true;
+
+  # Fails to build if not set:
+  hardeningDisable = [ "format" ];
+  hardeningEnable = [ "pie" ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "ROMID" romID)
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    SDL2
+    libGL
+    zlib
+  ];
+
+  postPatch =
+    # The project uses Git to retrieve version informations but our
+    # fetcher deletes the .git directory, so we replace the commands
+    # with the correct data directly.
+    ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail "git rev-parse --short HEAD" \
+                       "echo ${builtins.substring 0 9 finalAttrs.src.rev}" \
+        --replace-fail "git rev-parse --abbrev-ref HEAD" \
+                       "echo port"
+    ''
+    # Point toward the compiled binary and not the shell wrapper since
+    # the rom auto-detection logic is not needed in this build.
+    + ''
+      substituteInPlace dist/linux/io.github.fgsfdsfgs.perfect_dark.desktop \
+        --replace-fail "Exec=io.github.fgsfdsfgs.perfect_dark.sh" \
+                       "Exec=io.github.fgsfdsfgs.perfect_dark"
+    '';
+
+  preConfigure = ''
+    patchShebangs --build .
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    pushd ..
+    install -Dm755 build/pd.* $out/bin/io.github.fgsfdsfgs.perfect_dark
+    install -Dm644 dist/linux/io.github.fgsfdsfgs.perfect_dark.desktop \
+            -t $out/share/applications
+    install -Dm644 dist/linux/io.github.fgsfdsfgs.perfect_dark.png \
+            -t $out/share/icons/hicolor/256x256/apps
+    install -Dm644 dist/linux/io.github.fgsfdsfgs.perfect_dark.metainfo.xml \
+            -t $out/share/metainfo
+    popd
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Modern cross-platform port of Perfect Dark";
+    longDescription = ''
+      This is a port of Ryan Dywer's decompilation of classic N64
+      shooter Perfect Dark to modern systems.
+
+      You will need to provide a copy of the ROM at
+      `$HOME/.local/share/perfectdark/data/pd.${romID}.z64` to launch
+      the game.
+
+      Though `ntsc-final` is the recommended default, you can change
+      the ROM variant of this game with an expression like this:
+
+      ```nix
+        perfect_dark.override { romID = "jpn-final"; }
+      ```
+
+      Supported romIDs are `${lib.generators.toPretty { } roms}`.
+    '';
+    homepage = "https://github.com/fgsfdsfgs/perfect_dark/";
+    license = with lib.licenses; [
+      # perfect_dark, khrplatform.h, port/fast3d
+      mit
+      # Vendored source code and binaries of 'gzip'.
+      gpl3Plus
+      # Derivative work of "Perfect Dark" © 2000 Rare Ltd.
+      unfree
+    ];
+    maintainers = with lib.maintainers; [
+      PaulGrandperrin
+      normalcea
+      sigmasquadron
+    ];
+    mainProgram = "io.github.fgsfdsfgs.perfect_dark";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

A PC port of Perfect Dark based on the decompilation of the Nintendo 64 game

https://github.com/fgsfdsfgs/perfect_dark

To play the game, you need to put the corresponding ROM at `$XDG_DATA_HOME/perfectdark/data/pd.ntsc-final.z64` and then `nix run github:NixOS/nixpkgs/pull/306767/head#pd`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
