### PR TITLE
pragtical: init at 3.3.1

### DIFF
--- a/pkgs/by-name/pr/pragtical/package.nix
+++ b/pkgs/by-name/pr/pragtical/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cacert,
+  meson,
+  ninja,
+  pkg-config,
+  freetype,
+  libgit2,
+  libuchardet,
+  libzip,
+  lua5_4,
+  luajit,
+  mbedtls_2,
+  pcre2,
+  SDL2,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pragtical";
+  version = "3.3.1";
+  pluginManagerVersion = "1.2.9";
+
+  src = fetchFromGitHub {
+    owner = "pragtical";
+    repo = "pragtical";
+    rev = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+
+    # also fetch required git submodules
+    postFetch = ''
+      cd "$out"
+
+      export NIX_SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
+
+      substituteInPlace subprojects/ppm.wrap \
+          --replace-fail 'revision = head' 'revision = v${finalAttrs.pluginManagerVersion}'
+
+      ${lib.getExe meson} subprojects download \
+          colors plugins ppm
+
+      find subprojects -type d -name .git -prune -execdir rm -r {} +
+    '';
+
+    hash = "sha256-T0IHpfMfx4P84RyBLtaYNead6a7cID2cUYwkyNnYMgc=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    freetype
+    libgit2
+    libuchardet
+    libzip
+    lua5_4
+    luajit
+    mbedtls_2
+    pcre2
+    SDL2
+    zlib
+  ];
+
+  # workaround for `libmbedx509.so.1, libmbedcrypto.so.7: error adding symbols: DSO missing from command line`
+  env.NIX_LDFLAGS = "-lmbedx509 -lmbedcrypto";
+
+  mesonFlags = [ "-Duse_system_lua=true" ];
+
+  meta = {
+    changelog = "https://github.com/pragtical/pragtical/blob/${finalAttrs.src.rev}/changelog.md";
+    description = "A practical and pragmatic code editor";
+    homepage = "https://pragtical.dev";
+    license = lib.licenses.mit;
+    mainProgram = "pragtical";
+    maintainers = with lib.maintainers; [
+      suhr
+      tomasajt
+    ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/305113
@suhr I also added you as a maintainer, if that's fine for you.

---

This PR adds 1 package: `pragtical`

I used `meson subproject download` in the fetcher FOD, so that there's only 1 FOD hash to keep track of. I think this is the ideal solution.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
