### PR TITLE
kb: 0.1.7 -> unstable-20231017

### DIFF
--- a/pkgs/tools/misc/kb/default.nix
+++ b/pkgs/tools/misc/kb/default.nix
@@ -5,14 +5,15 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "kb";
-  version = "0.1.7";
+  version = "0.1.7-unstable-2023-10-17";
+  rev = "862a1abc68da7af5128dfb346a2c0f22e2cc9c1d";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "gnebbia";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-K8EAqZbl2e0h03fFwaKIclZTZARDQp1tRo44znxwW0I=";
+    repo = "kb";
+    inherit rev;
+    hash = "sha256-d2NO3E4hX921E/oD93c1w9mROSU2eoGzcO+fO2R5rKo=";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Update needed due to "python-colored is updated and changed the parameter name from 'underlined' to 'underline'".

## Things done

Build, execute and use.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
