### PR TITLE
corretto21: init at 21.0.3.9.1

### DIFF
--- a/pkgs/development/compilers/corretto/11.nix
+++ b/pkgs/development/compilers/corretto/11.nix
@@ -14,6 +14,12 @@ let
     inherit lib stdenv rsync runCommand testers;
     jdk = jdk11;
     gradle = gradle_7;
+    extraConfig = [
+      # jdk11 is built with --disable-warnings-as-errors (see openjdk/11.nix)
+      # because of several compile errors. We need to include this parameter for
+      # Corretto, too.
+      "--disable-warnings-as-errors"
+    ];
     version = "11.0.20.9.1";
     src = fetchFromGitHub {
       owner = "corretto";
@@ -23,15 +29,4 @@ let
     };
   };
 in
-corretto.overrideAttrs (oldAttrs: {
-  # jdk11 is built with --disable-warnings-as-errors (see openjdk/11.nix)
-  # because of several compile errors. We need to include this parameter for
-  # Corretto, too. Since the build is invoked via `gradle` build.gradle has to
-  # be adapted.
-  postPatch = oldAttrs.postPatch + ''
-    for file in $(find installers -name "build.gradle"); do
-      substituteInPlace $file --replace "command += archSpecificFlags" "command += archSpecificFlags + ['--disable-warnings-as-errors']"
-    done
-  '';
-
-})
+corretto

--- a/pkgs/development/compilers/corretto/21.nix
+++ b/pkgs/development/compilers/corretto/21.nix
@@ -1,0 +1,26 @@
+{ corretto21
+, fetchFromGitHub
+, gradle_7
+, jdk21
+, lib
+, stdenv
+, rsync
+, runCommand
+, testers
+}:
+
+let
+  corretto = import ./mk-corretto.nix {
+    inherit lib stdenv rsync runCommand testers;
+    jdk = jdk21;
+    gradle = gradle_7;
+    version = "21.0.3.9.1";
+    src = fetchFromGitHub {
+      owner = "corretto";
+      repo = "corretto-21";
+      rev = "97b366227b4dc8f5a89bbedea88b0b18c9e21886";
+      sha256 = "sha256-V8UDyukDCQVTWUg4IpSKoY0qnnQ5fePbm3rxcw06Vr0=";
+    };
+  };
+in
+corretto

--- a/pkgs/development/compilers/corretto/mk-corretto.nix
+++ b/pkgs/development/compilers/corretto/mk-corretto.nix
@@ -4,6 +4,7 @@
 , lib
 , stdenv
 , gradle
+, extraConfig ? [ ]
 , rsync
 , runCommand
 , testers
@@ -38,7 +39,7 @@ jdk.overrideAttrs (finalAttrs: oldAttrs: {
 
     # `/usr/bin/rsync` is invoked to copy the source tree. We don't have that.
     for file in $(find installers -name "build.gradle"); do
-      substituteInPlace $file --replace "workingDir '/usr/bin'" "workingDir '.'"
+      substituteInPlace $file --replace-warn "workingDir '/usr/bin'" "workingDir '.'"
     done
   '';
 
@@ -51,12 +52,13 @@ jdk.overrideAttrs (finalAttrs: oldAttrs: {
         if stdenv.isDarwin then
           ":installers:mac:tar:packageBuildResults"
         else ":installers:linux:universal:tar:packageBuildResults";
+      extra_config = builtins.concatStringsSep " " extraConfig;
     in
     ''
       runHook preBuild
 
       # Corretto's actual built is triggered via `gradle`.
-      gradle --console=plain --no-daemon ${task}
+      gradle -Pcorretto.extra_config="${extra_config}" --console=plain --no-daemon ${task}
 
       # Prepare for the installPhase so that it looks like if a normal
       # OpenJDK had been built.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15663,6 +15663,7 @@ with pkgs;
   corretto11 = javaPackages.compiler.corretto11;
   corretto17 = javaPackages.compiler.corretto17;
   corretto19 = javaPackages.compiler.corretto19;
+  corretto21 = javaPackages.compiler.corretto21;
 
   cotton = callPackage ../development/tools/cotton {
     inherit (darwin.apple_sdk.frameworks) CoreServices;

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -98,6 +98,7 @@ in {
     corretto11 = callPackage ../development/compilers/corretto/11.nix { };
     corretto17 = callPackage ../development/compilers/corretto/17.nix { };
     corretto19 = callPackage ../development/compilers/corretto/19.nix { };
+    corretto21 = callPackage ../development/compilers/corretto/21.nix { };
 
     openjdk8-bootstrap = mkBootstrap adoptopenjdk-8
       ../development/compilers/openjdk/bootstrap.nix


### PR DESCRIPTION
## Description of changes

This adds [corretto21](https://github.com/corretto/corretto-21) to nixpkgs. This PR uses the same approach as for corretto{11,17,19}. 

Building on darwin doesn't work. See this [PR](https://github.com/NixOS/nixpkgs/pull/290808) for details. This PR here does not make it worse nor better.

The additional `extraConfig` idea is stolen from @pcasaretto as done in the PR linked above.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
