### PR TITLE
nixos/oauth2_proxy_nginx: allow passing parameters to auth endpoint

### DIFF
--- a/nixos/modules/services/security/oauth2_proxy_nginx.nix
+++ b/nixos/modules/services/security/oauth2_proxy_nginx.nix
@@ -25,10 +25,41 @@ in
     };
 
     virtualHosts = mkOption {
-      type = types.listOf types.str;
-      default = [];
+      type = let
+        vhostSubmodule = types.submodule {
+          options = {
+            allowed_groups = mkOption {
+              type = types.nullOr (types.listOf types.str);
+              description = "List of groups to allow access to this vhost, or null to allow all.";
+              default = null;
+            };
+            allowed_emails = mkOption {
+              type = types.nullOr (types.listOf types.str);
+              description = "List of emails to allow access to this vhost, or null to allow all.";
+              default = null;
+            };
+            allowed_email_domains = mkOption {
+              type = types.nullOr (types.listOf types.str);
+              description = "List of email domains to allow access to this vhost, or null to allow all.";
+              default = null;
+            };
+          };
+        };
+        oldType = types.listOf types.str;
+        convertFunc = x:
+          lib.warn "services.oauth2_proxy.nginx.virtualHosts should be an attrset, found ${lib.generators.toPretty {} x}"
+          lib.genAttrs x (_: {});
+        newType = types.attrsOf vhostSubmodule;
+      in types.coercedTo oldType convertFunc newType;
+      default = {};
+      example = {
+        "protected.foo.com" = {
+          allowed_groups = ["admins"];
+          allowed_emails = ["boss@foo.com"];
+        };
+      };
       description = ''
-        A list of nginx virtual hosts to put behind the oauth2 proxy.
+        Nginx virtual hosts to put behind the oauth2 proxy.
         You can exclude specific locations by setting `auth_request off;` in the locations extraConfig setting.
       '';
     };
@@ -50,11 +81,20 @@ in
     }
   ] ++ optional (cfg.virtualHosts != []) {
     recommendedProxySettings = true; # needed because duplicate headers
-  } ++ (map (vhost: {
+  } ++ (lib.mapAttrsToList (vhost: conf: {
     virtualHosts.${vhost} = {
       locations = {
-        "/oauth2/auth" = {
-          proxyPass = cfg.proxy;
+        "/oauth2/auth" = let
+          maybeQueryArg = name: value:
+            if value == null then null
+            else "${name}=${lib.concatStringsSep "," value}";
+          allArgs = lib.mapAttrsToList maybeQueryArg conf;
+          cleanArgs = builtins.map lib.escapeURL (builtins.filter (x: x != null) allArgs);
+          cleanArgsStr = lib.concatStringsSep "&" cleanArgs;
+        in {
+          # nginx doesn't support passing query string arguments to auth_request,
+          # so pass them here instead
+          proxyPass = "${cfg.proxy}/oauth2/auth?${cleanArgsStr}";
           extraConfig = ''
             auth_request off;
             proxy_set_header X-Scheme         $scheme;


### PR DESCRIPTION
## Description of changes

This allows, e.g., setting `allowed_groups` to use the same proxy instance for different endpoints with different access levels.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
