### PR TITLE
pinocchio: 2.7.0 -> 2.7.1

### DIFF
--- a/pkgs/development/libraries/pinocchio/default.nix
+++ b/pkgs/development/libraries/pinocchio/default.nix
@@ -4,6 +4,7 @@
 , cmake
 , boost
 , eigen
+, example-robot-data
 , collisionSupport ? !stdenv.isDarwin
 , jrl-cmakemodules
 , hpp-fcl
@@ -22,6 +23,13 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-Ks5dvKi5iutjM+iovDOYGx3vsr45JWRqGOXV8+Ko4gg=";
   };
+
+  # example-robot-data models are used in checks.
+  # Upstream provide them as git submodule, but we can use our own version instead.
+  postPatch = ''
+    rmdir models/example-robot-data
+    ln -s ${example-robot-data.src} models/example-robot-data
+  '';
 
   strictDeps = true;
 

--- a/pkgs/development/libraries/pinocchio/default.nix
+++ b/pkgs/development/libraries/pinocchio/default.nix
@@ -5,6 +5,7 @@
 , boost
 , eigen
 , collisionSupport ? !stdenv.isDarwin
+, jrl-cmakemodules
 , hpp-fcl
 , urdfdom
 , pythonSupport ? false
@@ -13,14 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pinocchio";
-  version = "2.7.0";
+  version = "2.7.1";
 
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
     repo = finalAttrs.pname;
     rev = "v${finalAttrs.version}";
-    fetchSubmodules = true;
-    hash = "sha256-yhrG+MilGJkvwLUNTAgNhDqUWGjPswjrbg38yOLsmHc=";
+    hash = "sha256-Ks5dvKi5iutjM+iovDOYGx3vsr45JWRqGOXV8+Ko4gg=";
   };
 
   strictDeps = true;
@@ -30,6 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   propagatedBuildInputs = [
+    jrl-cmakemodules
     urdfdom
   ] ++ lib.optionals (!pythonSupport) [
     boost
@@ -43,15 +44,13 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.hpp-fcl
   ];
 
-  cmakeFlags = lib.optionals collisionSupport [
-    "-DBUILD_WITH_COLLISION_SUPPORT=ON"
-  ] ++ lib.optionals pythonSupport [
-    "-DBUILD_WITH_LIBPYTHON=ON"
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_PYTHON_INTERFACE" pythonSupport)
+    (lib.cmakeBool "BUILD_WITH_LIBPYTHON" pythonSupport)
+    (lib.cmakeBool "BUILD_WITH_COLLISION_SUPPORT" collisionSupport)
   ] ++ lib.optionals (pythonSupport && stdenv.isDarwin) [
     # AssertionError: '.' != '/tmp/nix-build-pinocchio-2.7.0.drv/sou[84 chars].dae'
     "-DCMAKE_CTEST_ARGUMENTS='--exclude-regex;test-py-bindings_geometry_model_urdf'"
-  ] ++ lib.optionals (!pythonSupport) [
-    "-DBUILD_PYTHON_INTERFACE=OFF"
   ];
 
   doCheck = true;

--- a/pkgs/development/libraries/pinocchio/default.nix
+++ b/pkgs/development/libraries/pinocchio/default.nix
@@ -67,11 +67,11 @@ stdenv.mkDerivation (finalAttrs: {
     "pinocchio"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "A fast and flexible implementation of Rigid Body Dynamics algorithms and their analytical derivatives";
     homepage = "https://github.com/stack-of-tasks/pinocchio";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ nim65s wegank ];
-    platforms = platforms.unix;
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ nim65s wegank ];
+    platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
## Description of changes

changelog: https://github.com/stack-of-tasks/pinocchio/releases/tag/v2.7.1
packaging changes:
- use jrl-cmakemodules from nixpkgs instead of git submodule
- use lib.cmakeBool

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
