### PR TITLE
rtaudio_6: init at 6.0.1

### DIFF
--- a/pkgs/applications/audio/bambootracker/default.nix
+++ b/pkgs/applications/audio/bambootracker/default.nix
@@ -8,7 +8,7 @@
 , qtbase
 , qttools
 , qtwayland
-, rtaudio
+, rtaudio_6
 , rtmidi
 , wrapQtAppsHook
 }:
@@ -43,16 +43,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     qtbase
+    rtaudio_6
     rtmidi
   ] ++ lib.optionals stdenv.hostPlatform.isLinux [
     qtwayland
   ] ++ lib.optionals (lib.versionAtLeast qtbase.version "6.0") [
     qt5compat
-  ] ++ rtaudio.buildInputs;
+  ];
 
   qmakeFlags = [
-    # we don't have RtAudio 6 yet: https://github.com/NixOS/nixpkgs/pull/245075
-    # "CONFIG+=system_rtaudio"
+    "CONFIG+=system_rtaudio"
     "CONFIG+=system_rtmidi"
   ];
 

--- a/pkgs/by-name/rt/rtaudio_6/package.nix
+++ b/pkgs/by-name/rt/rtaudio_6/package.nix
@@ -2,6 +2,7 @@
 , lib
 , config
 , fetchFromGitHub
+, testers
 , cmake
 , pkg-config
 , alsaSupport ? stdenv.hostPlatform.isLinux
@@ -9,41 +10,59 @@
 , pulseaudioSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux
 , libpulseaudio
 , jackSupport ? true
-, jack
+, libjack2
 , coreaudioSupport ? stdenv.hostPlatform.isDarwin
-, CoreAudio
+, darwin
+, validatePkgConfig
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rtaudio";
   version = "6.0.1";
 
   src = fetchFromGitHub {
     owner = "thestk";
     repo = "rtaudio";
-    rev = version;
-    sha256 = "11llxdg62gs6l2zc473s9zfb8jczflyq1dd0k0wfcmvyg5p33jq1";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-Acsxbnl+V+Y4mKC1gD11n0m03E96HMK+oEY/YV7rlIY=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  strictDeps = true;
 
-  buildInputs = lib.optional alsaSupport alsa-lib
-    ++ lib.optional pulseaudioSupport libpulseaudio
-    ++ lib.optional jackSupport jack
-    ++ lib.optional coreaudioSupport CoreAudio;
-
-  cmakeFlags = [
-    "-DRTAUDIO_API_ALSA=${if alsaSupport then "ON" else "OFF"}"
-    "-DRTAUDIO_API_PULSE=${if pulseaudioSupport then "ON" else "OFF"}"
-    "-DRTAUDIO_API_JACK=${if jackSupport then "ON" else "OFF"}"
-    "-DRTAUDIO_API_CORE=${if coreaudioSupport then "ON" else "OFF"}"
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    validatePkgConfig
   ];
 
-  meta = with lib; {
+  buildInputs = lib.optionals alsaSupport [
+    alsa-lib
+  ] ++ lib.optionals pulseaudioSupport [
+    libpulseaudio
+  ] ++ lib.optionals jackSupport [
+    libjack2
+  ] ++ lib.optionals coreaudioSupport [
+    darwin.apple_sdk.frameworks.CoreAudio
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "RTAUDIO_API_ALSA" alsaSupport)
+    (lib.cmakeBool "RTAUDIO_API_PULSE" pulseaudioSupport)
+    (lib.cmakeBool "RTAUDIO_API_JACK" jackSupport)
+    (lib.cmakeBool "RTAUDIO_API_CORE" coreaudioSupport)
+  ];
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  meta = {
     description = "A set of C++ classes that provide a cross platform API for realtime audio input/output";
     homepage = "https://www.music.mcgill.ca/~gary/rtaudio/";
-    license = licenses.mit;
-    maintainers = with maintainers; [ magnetophon ];
-    platforms = platforms.unix;
+    changelog = "https://github.com/thestk/rtaudio/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ magnetophon ];
+    platforms = lib.platforms.unix;
+    pkgConfigModules = [
+      "rtaudio"
+    ];
   };
-}
+})

--- a/pkgs/by-name/rt/rtaudio_6/package.nix
+++ b/pkgs/by-name/rt/rtaudio_6/package.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, lib
+, config
+, fetchFromGitHub
+, cmake
+, pkg-config
+, alsaSupport ? stdenv.hostPlatform.isLinux
+, alsa-lib
+, pulseaudioSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux
+, libpulseaudio
+, jackSupport ? true
+, jack
+, coreaudioSupport ? stdenv.hostPlatform.isDarwin
+, CoreAudio
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rtaudio";
+  version = "6.0.1";
+
+  src = fetchFromGitHub {
+    owner = "thestk";
+    repo = "rtaudio";
+    rev = version;
+    sha256 = "11llxdg62gs6l2zc473s9zfb8jczflyq1dd0k0wfcmvyg5p33jq1";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = lib.optional alsaSupport alsa-lib
+    ++ lib.optional pulseaudioSupport libpulseaudio
+    ++ lib.optional jackSupport jack
+    ++ lib.optional coreaudioSupport CoreAudio;
+
+  cmakeFlags = [
+    "-DRTAUDIO_API_ALSA=${if alsaSupport then "ON" else "OFF"}"
+    "-DRTAUDIO_API_PULSE=${if pulseaudioSupport then "ON" else "OFF"}"
+    "-DRTAUDIO_API_JACK=${if jackSupport then "ON" else "OFF"}"
+    "-DRTAUDIO_API_CORE=${if coreaudioSupport then "ON" else "OFF"}"
+  ];
+
+  meta = with lib; {
+    description = "A set of C++ classes that provide a cross platform API for realtime audio input/output";
+    homepage = "https://www.music.mcgill.ca/~gary/rtaudio/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ magnetophon ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12289,6 +12289,11 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreAudio;
   };
 
+  rtaudio_6 = callPackage ../by-name/rt/rtaudio_6/package.nix {
+    jack = libjack2;
+    inherit (darwin.apple_sdk.frameworks) CoreAudio;
+  };
+
   rtmidi = callPackage ../development/libraries/audio/rtmidi {
     jack = libjack2;
     inherit (darwin.apple_sdk.frameworks) CoreMIDI CoreAudio CoreServices;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12289,11 +12289,6 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreAudio;
   };
 
-  rtaudio_6 = callPackage ../by-name/rt/rtaudio_6/package.nix {
-    jack = libjack2;
-    inherit (darwin.apple_sdk.frameworks) CoreAudio;
-  };
-
   rtmidi = callPackage ../development/libraries/audio/rtmidi {
     jack = libjack2;
     inherit (darwin.apple_sdk.frameworks) CoreMIDI CoreAudio CoreServices;


### PR DESCRIPTION
## Description of changes

Closes #274031

Due to RtAudio 6 being an API-breaking update, some reverse dependencies' upstreams being quite slow to adapt to it, and others' updates being blocked by the `rtaudio` version getting held back, introduce a separate `rtaudio_6` for reverse dependencies to opt into. As an example, also switch `bambootracker{,-qt6}` from its vendored RtAudio 6 to the new `rtaudio_6` to check that it works.

I'm not sure if making v6 the default should be included in 24.05, so I haven't made any treewide adjustments here.

Pinging some involved ppl from #245075: @PowerUser64 @lilyinstarlight @luzpaz @eclairevoyant 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
