### PR TITLE
hotspot: 1.4.1 -> 1.5.0

### DIFF
--- a/pkgs/development/libraries/kddockwidgets/default.nix
+++ b/pkgs/development/libraries/kddockwidgets/default.nix
@@ -1,24 +1,32 @@
 { lib
-, mkDerivation
+, stdenv
 , fetchFromGitHub
 , cmake
 , qtbase
+, qtdeclarative
+, qtquickcontrols2
 , qtx11extras
+, spdlog
+, fmt
+, nlohmann_json
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "KDDockWidgets";
-  version = "1.7.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "KDAB";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-k5Hn9kxq1+tH5kV/ZeD4xzQLDgcY4ACC+guP7YJD4C8=";
+    sha256 = "sha256-V4BMD1kYyaMlqNBo8otpV5yBt/PICzhBTkEMX9N3lbk=";
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ qtbase qtx11extras ];
+  buildInputs = [ spdlog fmt nlohmann_json ];
+  propagatedBuildInputs = [ qtbase qtdeclarative qtquickcontrols2 qtx11extras ];
+
+  dontWrapQtApps = true;
 
   meta = with lib; {
     description = "KDAB's Dock Widget Framework for Qt";

--- a/pkgs/development/tools/analysis/hotspot/default.nix
+++ b/pkgs/development/tools/analysis/hotspot/default.nix
@@ -1,10 +1,15 @@
 { lib
-, mkDerivation
+, stdenv
+, binutils
 , cmake
-, elfutils
 , extra-cmake-modules
+, patchelfUnstable
+, wrapQtAppsHook
+, elfutils
 , fetchFromGitHub
+, fetchpatch
 , kconfigwidgets
+, kddockwidgets
 , ki18n
 , kio
 , kitemmodels
@@ -12,33 +17,48 @@
 , kparts
 , kwindowsystem
 , libelf
+, linuxPackages
 , qtbase
-, threadweaver
-, qtx11extras
-, zstd
-, kddockwidgets
+, qtsvg
 , rustc-demangle
+, syntax-highlighting
+, threadweaver
+, zstd
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "hotspot";
-  version = "1.4.1";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "KDAB";
     repo = "hotspot";
     rev = "refs/tags/v${version}";
-    hash = "sha256-DW4R7+rnonmEMbCkNS7TGodw+3mEyHl6OlFK3kbG5HM=";
+    hash = "sha256-FJkDPWqNwoWg/15tvMnwke7PVtWVuqT0gtJBFQE0qZ4=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    # Backport stuck UI bug fix
+    # FIXME: remove in next update
+    (fetchpatch {
+      url = "https://github.com/KDAB/hotspot/commit/7639dee8617dba9b88182c7ff4887e8d3714ac98.patch";
+      hash = "sha256-aAo9uEy+MBztMhnC5jB08moZBeRCENU22R39pqSBXOY=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
+    # stable patchelf corrupts the binary
+    patchelfUnstable
+    wrapQtAppsHook
   ];
+
   buildInputs = [
     (elfutils.override { enableDebuginfod = true; }) # perfparser needs to find debuginfod.h
     kconfigwidgets
+    kddockwidgets
     ki18n
     kio
     kitemmodels
@@ -47,24 +67,23 @@ mkDerivation rec {
     kwindowsystem
     libelf
     qtbase
-    threadweaver
-    qtx11extras
-    zstd
-    kddockwidgets
+    qtsvg
     rustc-demangle
+    syntax-highlighting
+    threadweaver
+    zstd
   ];
-
-  # hotspot checks for the presence of third party libraries'
-  # git directory to give a nice warning when you forgot to clone
-  # submodules; but Nix clones them and removes .git (for reproducibility).
-  # So we need to fake their existence here.
-  postPatch = ''
-    mkdir -p 3rdparty/{perfparser,PrefixTickLabels}/.git
-  '';
 
   qtWrapperArgs = [
-    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ rustc-demangle ]}"
+    "--suffix PATH : ${lib.makeBinPath [ linuxPackages.perf binutils ]}"
   ];
+
+  preFixup = ''
+    patchelf \
+      --add-rpath ${lib.makeLibraryPath [ rustc-demangle ]} \
+      --add-needed librustc_demangle.so \
+      $out/libexec/hotspot-perfparser
+  '';
 
   meta = with lib; {
     description = "A GUI for Linux perf";


### PR DESCRIPTION
## Description of changes

Finally!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
