### PR TITLE
darwin.system_cmds: fix build without CoreFoundation hook

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/system_cmds/meson.build
+++ b/pkgs/os-specific/darwin/apple-source-releases/system_cmds/meson.build
@@ -88,6 +88,7 @@ install_man('accton/accton.8')
 executable(
     'arch',
     build_by_default : sdk_version.version_compare('>=11'),
+    dependencies : [ core_foundation ],
     install : sdk_version.version_compare('>=11'),
     sources : 'arch/arch.c'
 )
@@ -145,7 +146,7 @@ install_man('chkpasswd/chkpasswd.8')
 
 executable(
     'chpass',
-    dependencies : [ cfopen_directory, directory_service, open_directory ],
+    dependencies : [ core_foundation, cfopen_directory, directory_service, open_directory ],
     install : true,
     sources : [
         'chpass/chpass.c',
@@ -358,7 +359,7 @@ install_man(
 executable(
     'nvram',
     c_args : '-DTARGET_OS_BRIDGE=0',
-    dependencies : [ iokit, libc_private, xnu_private ],
+    dependencies : [ core_foundation, iokit, libc_private, xnu_private ],
     install : true,
     sources : 'nvram/nvram.c'
 )
@@ -377,7 +378,7 @@ install_man('pagesize/pagesize.1')
 
 executable(
     'passwd',
-    dependencies : [ cfopen_directory, directory_service, open_directory, pam ],
+    dependencies : [ core_foundation, cfopen_directory, directory_service, open_directory, pam ],
     install : true,
     sources : [
         'passwd/file_passwd.c',
@@ -521,7 +522,7 @@ executable(
     'zlog',
     build_by_default : sdk_version.version_compare('>=11'),
     c_args : '-DKERN_NOT_FOUND=56',
-    dependencies : core_symbolication,
+    dependencies : [ core_foundation, core_symbolication ],
     install : sdk_version.version_compare('>=11'),
     sources : [
         'zlog/SymbolicationHelper.c',


### PR DESCRIPTION
## Description of changes

I ran into this issue while working on the cctools and ld64 updates. hfsevents (a Haskell package) was failing to build because apple_sdk framework hooks were adding `-rpath` to every linker invocation, but the updated ld64 does not allow that when merging objects. The fix is to drop the hooks, but that broke building system_cmds. The fix for system_cmds is to link CoreFoundation explicitly, which is what is should have been doing anyway.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
