### PR TITLE
python3Packages.docutils: 0.21.1 -> 0.21.2

### DIFF
--- a/pkgs/development/python-modules/docutils/default.nix
+++ b/pkgs/development/python-modules/docutils/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , lib
-, fetchgit
+, fetchFromRepoOrCz
 , buildPythonPackage
 , flit-core
 , pillow
@@ -8,17 +8,20 @@
 , pythonOlder
 }:
 
+# Note: this package is used to build LLVM’s documentation, which is part of the Darwin stdenv.
+# It cannot use `fetchgit` because that would pull curl into the bootstrap, which is disallowed.
+
 let self = buildPythonPackage rec {
   pname = "docutils";
-  version = "0.21.1";
+  version = "0.21.2";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
 
-  src = fetchgit {
-    url = "git://repo.or.cz/docutils.git";
+  src = fetchFromRepoOrCz {
+    repo = "docutils";
     rev = "docutils-${version}";
-    hash = "sha256-ahnj6iKjyUCDxhgxJdwEb8huFIGpbuuLQBHDzKj6O9E=";
+    hash = "sha256-Q+9yW+BYUEvPYV504368JsAoKKoaTZTeKh4tVeiNv5Y=";
   };
 
   build-system = [ flit-core ];


### PR DESCRIPTION
## Description of changes

https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-21-2-2024-04-23

Due to the fix to the tests, docutils can switch to `fetchFromRepoOrCz`, which avoids including curl in the Darwin stdenv bootstrap. Testing was confirming the LLVM manpages built and Darwin bootstrapped with curl set to throw.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
