### PR TITLE
git-vanity-hash: fix build and execution

### DIFF
--- a/pkgs/applications/version-management/git-vanity-hash/default.nix
+++ b/pkgs/applications/version-management/git-vanity-hash/default.nix
@@ -1,17 +1,22 @@
-{ lib, fetchFromGitHub, rustPlatform }:
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "git-vanity-hash";
   version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "prasmussen";
     repo = "git-vanity-hash";
-    rev = "v${version}";
-    hash = "sha256-jD8cSFXf9UNBZ9d8JTnuwhs6nPHY/xGd5RyqF+mQOlo=";
+    # v1.0.0 + build fix
+    rev = "a80e7725ac6d0b7e6807cd7315cfdc7eaf0584f6";
+    hash = "sha256-1z4jbtzUB3SH79dDXAITf7Vup1YZdTLHBieSrhrvSXc=";
   };
 
-  cargoHash = "sha256-8oW6gRtdQdmSmdwKlcU2EhHsyhk9hFhKl7RtsYwC7Ps=";
+  cargoHash = "sha256-+SQ0HpURBjnnwH1Ue7IUReOtI4LxVPK9AGSAihs0qsc=";
 
   postInstall = ''
     mkdir -p $out/share/doc/git-vanity-hash


### PR DESCRIPTION
Build has been broken in Hydra: https://hydra.nixos.org/build/256865980/nixlog/2.

Potential cause seems to be an old dependency, with a possible workaround sent upstream.

## Description of changes

I left a PR to switch dependencies and work around the issue in https://github.com/prasmussen/git-vanity-hash/pull/2. 

## Things done

~Marking as broken with comments documenting the issue.~

Change the fetched rev of the package to pick up the upstreamed solution.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
