### PR TITLE
maintainers: remove keksbg

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10381,15 +10381,6 @@
     github = "keenanweaver";
     githubId = 37268985;
   };
-  keksbg = {
-    email = "keksbg@riseup.net";
-    name = "Stella";
-    github = "keksbg";
-    githubId = 10682187;
-    keys = [{
-      fingerprint = "AB42 1F18 5A19 A160 AD77  9885 3D6D CA5B 6F2C 2A7A";
-    }];
-  };
   keldu = {
     email = "mail@keldu.de";
     github = "keldu";

--- a/pkgs/tools/filesystems/dwarfs/default.nix
+++ b/pkgs/tools/filesystems/dwarfs/default.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
     description = "A fast high compression read-only file system";
     homepage = "https://github.com/mhx/dwarfs";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ keksbg ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
## Description of changes

tl;dr: Removed self from maintainers due to inactivity.

I've been inactive for some time on nixpkgs and haven't been able to maintain the dwarfs package. Recently there was also a PR requesting an update which I can't really do.

I haven't been using nix for some time, I've switched away from NixOS and won't be doing much with nix for the foreseeable future. As such, I'm removing myself from all maintainer roles for the time being.