### PR TITLE
nixos/initrd-network: run DHCP in the background to increase its resiliency

### DIFF
--- a/nixos/modules/system/boot/initrd-network.nix
+++ b/nixos/modules/system/boot/initrd-network.nix
@@ -152,7 +152,8 @@ in
           # Acquire DHCP leases.
           for iface in ${dhcpIfShellExpr}; do
             echo "acquiring IP address via DHCP on $iface..."
-            udhcpc --quit --now -i $iface -O staticroutes --script ${udhcpcScript} ${udhcpcArgs}
+            # run DHCP in the background until it acquires an address
+            udhcpc --quit -i $iface -O staticroutes --script ${udhcpcScript} ${udhcpcArgs} &
           done
         ''
 


### PR DESCRIPTION
## Description of changes

This changeset changes the behavior of the DHCP client during the initrd boot sequence.

Previously, the DHCP client (udhcpc) would try a single time to acquire a DHCP address on each interface for which DHCP was configured. It would also block until the DHCP request either succeeded or failed.

If the DHCP server on the network is not available when udhcpc tries to get an address, then there will be no further attempts to obtain an address, even if the DHCP server becomes available again. A common situation in which this can happen is during boot up after a power loss: the DHCP server may be slower to come up than the system.

If ssh has been enabled in initrd, the result is that the system is not accessible if DHCP did not succeed. (Local console use is unaffected).

This changeset removes the --now option and puts udhcpc in the background for all interfaces. This means that udhcpc will continue to attempt to get a DHCP address in the background until one is obtained.

Tested by booting up a system with the network cable unplugged; waiting for the first DHCP request to time out; plugging the network cable back in; and observing that a DHCP address was obtained successfully. Then the boot procedure finished normally.

Resolves #306858

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
