### PR TITLE
k3s: skip pre-releases in update script

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/update-script.sh
+++ b/pkgs/applications/networking/cluster/k3s/update-script.sh
@@ -19,7 +19,9 @@ LATEST_TAG_RAWFILE=${WORKDIR}/latest_tag.json
 curl --silent -f ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
     https://api.github.com/repos/k3s-io/k3s/releases > ${LATEST_TAG_RAWFILE}
 
-LATEST_TAG_NAME=$(jq 'map(.tag_name)' ${LATEST_TAG_RAWFILE} | \
+LATEST_TAG_NAME=$(cat ${LATEST_TAG_RAWFILE} | \
+    jq -r 'map(select(.prerelease == false))' | \
+    jq 'map(.tag_name)' | \
     grep -v -e rc -e engine | tail -n +2 | head -n -1 | sed 's|[", ]||g' | sort -rV | grep -E "^v1\.${MINOR_VERSION}\." | head -n1)
 
 K3S_VERSION=$(echo ${LATEST_TAG_NAME} | sed 's/^v//')


### PR DESCRIPTION
k3s: skip pre-releases in update script

Avoids bot offering updates when in pre-release.
Currently there are packages in pre-release in: https://github.com/k3s-io/k3s/releases
Soon the bot will open a pre-release PR...

CC @euank @mic92 @yajo