### PR TITLE
maintainers: remove titanous

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20326,12 +20326,6 @@
     github = "tirimia";
     githubId = 11174371;
   };
-  titanous = {
-    email = "jonathan@titanous.com";
-    github = "titanous";
-    githubId = 13026;
-    name = "Jonathan Rudenberg";
-  };
   tjni = {
     email = "43ngvg@masqt.com";
     matrix = "@tni:matrix.org";

--- a/pkgs/applications/networking/cluster/temporal/default.nix
+++ b/pkgs/applications/networking/cluster/temporal/default.nix
@@ -45,7 +45,7 @@ buildGoModule rec {
     homepage = "https://temporal.io";
     changelog = "https://github.com/temporalio/temporal/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ titanous ];
+    maintainers = with maintainers; [ ];
     mainProgram = "temporal-server";
   };
 }

--- a/pkgs/applications/video/ccextractor/default.nix
+++ b/pkgs/applications/video/ccextractor/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     # during Linking C executable ccextractor
     broken = stdenv.isAarch64;
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ titanous ];
+    maintainers = with maintainers; [ ];
     mainProgram = "ccextractor";
   };
 }

--- a/pkgs/applications/video/makemkv/default.nix
+++ b/pkgs/applications/video/makemkv/default.nix
@@ -87,6 +87,6 @@ in mkDerivation {
     license = [ licenses.unfree licenses.lgpl21 ];
     homepage = "http://makemkv.com";
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ titanous ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/applications/video/mythtv/default.nix
+++ b/pkgs/applications/video/mythtv/default.nix
@@ -42,6 +42,6 @@ mkDerivation rec {
     description = "Open Source DVR";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.titanous ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/libcec/default.nix
+++ b/pkgs/development/libraries/libcec/default.nix
@@ -40,6 +40,6 @@ stdenv.mkDerivation rec {
     homepage = "http://libcec.pulse-eight.com";
     license = lib.licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.titanous ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/libcec/platform.nix
+++ b/pkgs/development/libraries/libcec/platform.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Pulse-Eight/platform";
     license = lib.licenses.gpl2Plus;
     platforms = platforms.all;
-    maintainers = [ maintainers.titanous ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/libhdhomerun/default.nix
+++ b/pkgs/development/libraries/libhdhomerun/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     mainProgram = "hdhomerun_config";
     homepage = "https://www.silicondust.com/support/linux";
     license = licenses.lgpl21Only;
-    maintainers = with maintainers; [ sielicki titanous ];
+    maintainers = with maintainers; [ sielicki ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
## Description of changes

I seem to have made the same mistake that @danderson mentioned in #307033. This PR rectifies the issue by leaving the Determinate Systems community.

This orphans a bunch of long tail packages, but hopefully someone who loves the idea of hunting migrants with Nix-powered surveillance can take over.