### PR TITLE
invidious: 0.20.1-unstable-2024-04-10 -> 2.20240427

### DIFF
--- a/pkgs/servers/invidious/default.nix
+++ b/pkgs/servers/invidious/default.nix
@@ -124,6 +124,11 @@ crystal.buildCrystalPackage rec {
     mainProgram = "invidious";
     homepage = "https://invidious.io/";
     license = licenses.agpl3Plus;
-    maintainers = with maintainers; [ sbruder ];
+    maintainers = with maintainers; [
+      _999eagle
+      GaetanLepage
+      sbruder
+      pbsds
+    ];
   };
 }

--- a/pkgs/servers/invidious/default.nix
+++ b/pkgs/servers/invidious/default.nix
@@ -1,5 +1,15 @@
-{ lib, stdenv, crystal, fetchFromGitea, librsvg, pkg-config, libxml2, openssl, shards, sqlite, videojs, nixosTests }:
-let
+{ lib
+, callPackage
+, crystal
+, fetchFromGitea
+, librsvg
+, pkg-config
+, libxml2
+, openssl
+, shards
+, sqlite
+, nixosTests
+
   # All versions, revisions, and checksums are stored in ./versions.json.
   # The update process is the following:
   #   * pick the latest tag
@@ -9,10 +19,11 @@ let
   #     but nix's sandboxing does not allow that)
   #   * if shard.lock changed
   #     * recreate shards.nix by running crystal2nix
-  #     * update lsquic and boringssl if necessarry, lsquic.cr depends on
-  #       the same version of lsquic and lsquic requires the boringssl
-  #       commit mentioned in its README
-  versions = lib.importJSON ./versions.json;
+, versions ? lib.importJSON ./versions.json
+}:
+let
+  # normally video.js is downloaded at build time
+  videojs = callPackage ./videojs.nix { inherit versions; };
 in
 crystal.buildCrystalPackage rec {
   pname = "invidious";
@@ -23,7 +34,7 @@ crystal.buildCrystalPackage rec {
     owner = "iv-org";
     repo = "invidious";
     fetchSubmodules = true;
-    rev = "v${version}";
+    rev = versions.invidious.rev or "v${version}";
     inherit (versions.invidious) hash;
   };
 

--- a/pkgs/servers/invidious/default.nix
+++ b/pkgs/servers/invidious/default.nix
@@ -16,14 +16,17 @@ let
 in
 crystal.buildCrystalPackage rec {
   pname = "invidious";
-  inherit (versions.invidious) version;
+  version = "2.20240427";
+  # inherit (versions.invidious) version;
 
   src = fetchFromGitea {
     domain = "gitea.invidious.io";
     owner = "iv-org";
     repo = pname;
     fetchSubmodules = true;
-    inherit (versions.invidious) rev hash;
+    rev = "v${version}";
+    hash = "sha256-YZ+uhn1ESuRTZxAMoxKCpxEaUfeCUqOrSr3LkdbrTkU=";
+    # inherit (versions.invidious) rev hash;
   };
 
   postPatch =
@@ -43,23 +46,23 @@ crystal.buildCrystalPackage rec {
       # Use the version metadata from the derivation instead of using git at
       # build-time
       substituteInPlace src/invidious.cr \
-          --replace ${lib.escapeShellArg branchTemplate} '"master"' \
-          --replace ${lib.escapeShellArg commitTemplate} '"${lib.substring 0 7 versions.invidious.rev}"' \
-          --replace ${lib.escapeShellArg versionTemplate} '"${lib.concatStringsSep "." (lib.drop 2 (lib.splitString "-" version))}"' \
-          --replace ${lib.escapeShellArg assetCommitTemplate} '"${lib.substring 0 7 versions.invidious.rev}"'
+          --replace-fail ${lib.escapeShellArg branchTemplate} '"master"' \
+          --replace-fail ${lib.escapeShellArg commitTemplate} '"${lib.substring 0 7 versions.invidious.rev}"' \
+          --replace-fail ${lib.escapeShellArg versionTemplate} '"${lib.concatStringsSep "." (lib.drop 2 (lib.splitString "-" version))}"' \
+          --replace-fail ${lib.escapeShellArg assetCommitTemplate} '"${lib.substring 0 7 versions.invidious.rev}"'
 
       # Patch the assets and locales paths to be absolute
       substituteInPlace src/invidious.cr \
-          --replace 'public_folder "assets"' 'public_folder "${placeholder "out"}/share/invidious/assets"'
+          --replace-fail 'public_folder "assets"' 'public_folder "${placeholder "out"}/share/invidious/assets"'
       substituteInPlace src/invidious/helpers/i18n.cr \
-          --replace 'File.read("locales/' 'File.read("${placeholder "out"}/share/invidious/locales/'
+          --replace-fail 'File.read("locales/' 'File.read("${placeholder "out"}/share/invidious/locales/'
 
       # Reference sql initialisation/migration scripts by absolute path
       substituteInPlace src/invidious/database/base.cr \
-            --replace 'config/sql' '${placeholder "out"}/share/invidious/config/sql'
+            --replace-fail 'config/sql' '${placeholder "out"}/share/invidious/config/sql'
 
       substituteInPlace src/invidious/user/captcha.cr \
-          --replace 'Process.run(%(rsvg-convert' 'Process.run(%(${lib.getBin librsvg}/bin/rsvg-convert'
+          --replace-fail 'Process.run(%(rsvg-convert' 'Process.run(%(${lib.getBin librsvg}/bin/rsvg-convert'
     '';
 
   nativeBuildInputs = [ pkg-config shards ];

--- a/pkgs/servers/invidious/default.nix
+++ b/pkgs/servers/invidious/default.nix
@@ -16,8 +16,7 @@ let
 in
 crystal.buildCrystalPackage rec {
   pname = "invidious";
-  version = "2.20240427";
-  # inherit (versions.invidious) version;
+  inherit (versions.invidious) version;
 
   src = fetchFromGitea {
     domain = "gitea.invidious.io";
@@ -25,8 +24,7 @@ crystal.buildCrystalPackage rec {
     repo = pname;
     fetchSubmodules = true;
     rev = "v${version}";
-    hash = "sha256-YZ+uhn1ESuRTZxAMoxKCpxEaUfeCUqOrSr3LkdbrTkU=";
-    # inherit (versions.invidious) rev hash;
+    inherit (versions.invidious) hash;
   };
 
   postPatch =

--- a/pkgs/servers/invidious/update.sh
+++ b/pkgs/servers/invidious/update.sh
@@ -44,7 +44,12 @@ if [ "$new_version" = "$old_version" ]; then
     exit
 fi
 
+commit="$(git -C "$git_dir" rev-list "$new_tag" --max-count=1 --abbrev-commit)"
+date="$(git -C "$git_dir" log -1 --format=%cd --date=format:%Y.%m.%d)"
+json_set '.invidious.date' "$date"
+json_set '.invidious.commit' "$commit"
 json_set '.invidious.version' "$new_version"
+
 new_hash=$(nix-prefetch -I 'nixpkgs=../../..' "$pkg")
 json_set '.invidious.hash' "$new_hash"
 

--- a/pkgs/servers/invidious/update.sh
+++ b/pkgs/servers/invidious/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl crystal crystal2nix jq git moreutils nix nix-prefetch pkg-config pcre
+#!nix-shell -i bash -p curl crystal crystal2nix jq git moreutils nix nix-prefetch pkg-config pcre gnugrep
 git_url='https://github.com/iv-org/invidious.git'
 git_branch='master'
 git_dir='/var/tmp/invidious.git'
@@ -26,7 +26,6 @@ json_set() {
     jq --arg x "$2" "$1 = \$x" < 'versions.json' | sponge 'versions.json'
 }
 
-old_rev=$(json_get '.invidious.rev')
 old_version=$(json_get '.invidious.version')
 today=$(LANG=C date -u +'%Y-%m-%d')
 
@@ -37,38 +36,30 @@ if [ ! -d "$git_dir" ]; then
 fi
 git -C "$git_dir" fetch origin --tags "$git_branch"
 
-# use latest commit before today, we should not call the version *today*
-# because there might still be commits coming
-# use the day of the latest commit we picked as version
-new_rev=$(git -C "$git_dir" log -n 1 --format='format:%H' --before="${today}T00:00:00Z" "origin/$git_branch")
-new_tag=$(git -C "$git_dir" describe --tags --abbrev=0 "$new_rev")
-new_version="$new_tag-unstable-$(TZ=UTC git -C "$git_dir" log -n 1 --date='format-local:%Y-%m-%d' --format='%cd' "$new_rev")"
-info "latest commit before $today: $new_rev"
+new_tag="$(git -C "$git_dir" ls-remote --tags --sort=committerdate origin | head -n1 | grep -Po '(?<=refs/tags/).*')"
+new_version="${new_tag#v}"
 
-if [ "$new_rev" = "$old_rev" ]; then
+if [ "$new_version" = "$old_version" ]; then
     info "$pkg is up-to-date."
     exit
 fi
 
 json_set '.invidious.version' "$new_version"
-json_set '.invidious.rev' "$new_rev"
 new_hash=$(nix-prefetch -I 'nixpkgs=../../..' "$pkg")
 json_set '.invidious.hash' "$new_hash"
-commit_msg="$pkg: $old_version -> $new_version"
 
 # fetch video.js dependencies
 info "Running scripts/fetch-player-dependencies.cr..."
-git -C "$git_dir" reset --hard "$new_rev"
+git -C "$git_dir" reset --hard "$new_tag"
 (cd "$git_dir" && crystal run scripts/fetch-player-dependencies.cr -- --minified)
 rm -f "$git_dir/assets/videojs/.gitignore"
 videojs_new_hash=$(nix-hash --type sha256 --sri "$git_dir/assets/videojs")
 json_set '.videojs.hash' "$videojs_new_hash"
 
-if git -C "$git_dir" diff-tree --quiet "${old_rev}..${new_rev}" -- 'shard.lock'; then
-    info "shard.lock did not change since $old_rev."
+if git -C "$git_dir" diff-tree --quiet "v${old_version}..${new_tag}" -- 'shard.lock'; then
+    info "shard.lock did not change since v$old_version."
 else
     info "Updating shards.nix..."
-    crystal2nix -- "$git_dir/shard.lock"  # argv's index seems broken
+    (cd "$git_dir" && crystal2nix)
+    mv "$git_dir/shards.nix" .
 fi
-
-git commit --verbose --message "$commit_msg" -- versions.json shards.nix

--- a/pkgs/servers/invidious/versions.json
+++ b/pkgs/servers/invidious/versions.json
@@ -1,7 +1,9 @@
 {
   "invidious": {
     "hash": "sha256-YZ+uhn1ESuRTZxAMoxKCpxEaUfeCUqOrSr3LkdbrTkU=",
-    "version": "2.20240427"
+    "version": "2.20240427",
+    "date": "2024.04.27",
+    "commit": "eda7444c"
   },
   "videojs": {
     "hash": "sha256-jED3zsDkPN8i6GhBBJwnsHujbuwlHdsVpVqa1/pzSH4="

--- a/pkgs/servers/invidious/versions.json
+++ b/pkgs/servers/invidious/versions.json
@@ -1,8 +1,7 @@
 {
   "invidious": {
-    "rev": "b673695aa2704b880562399ac78659ad23b7940d",
-    "hash": "sha256-2vYCQNAf+o1Z2HFMk4sIlKNBFAsiLZe0Iw34oThC2Vs=",
-    "version": "0.20.1-unstable-2024-04-10"
+    "hash": "sha256-YZ+uhn1ESuRTZxAMoxKCpxEaUfeCUqOrSr3LkdbrTkU=",
+    "version": "2.20240427"
   },
   "videojs": {
     "hash": "sha256-jED3zsDkPN8i6GhBBJwnsHujbuwlHdsVpVqa1/pzSH4="

--- a/pkgs/servers/invidious/videojs.nix
+++ b/pkgs/servers/invidious/videojs.nix
@@ -1,8 +1,12 @@
-{ lib, stdenvNoCC, cacert, crystal, openssl, pkg-config, invidious }:
+{ stdenvNoCC
+, cacert
+, crystal
+, openssl
+, pkg-config
+, invidious
+, versions
+}:
 
-let
-  versions = lib.importJSON ./versions.json;
-in
 stdenvNoCC.mkDerivation {
   name = "videojs";
 

--- a/pkgs/servers/invidious/videojs.nix
+++ b/pkgs/servers/invidious/videojs.nix
@@ -14,5 +14,5 @@ stdenvNoCC.mkDerivation {
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "sha256-jED3zsDkPN8i6GhBBJwnsHujbuwlHdsVpVqa1/pzSH4=";
+  outputHash = versions.videojs.hash;
 }

--- a/pkgs/servers/invidious/videojs.nix
+++ b/pkgs/servers/invidious/videojs.nix
@@ -14,5 +14,5 @@ stdenvNoCC.mkDerivation {
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = versions.videojs.hash;
+  outputHash = "sha256-jED3zsDkPN8i6GhBBJwnsHujbuwlHdsVpVqa1/pzSH4=";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9258,10 +9258,7 @@ with pkgs;
 
   internetarchive = with python3Packages; toPythonApplication internetarchive;
 
-  invidious = callPackage ../servers/invidious {
-    # normally video.js is downloaded at build time
-    videojs = callPackage ../servers/invidious/videojs.nix { };
-  };
+  invidious = callPackage ../servers/invidious { };
 
   invoice2data  = callPackage ../tools/text/invoice2data  { };
 


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/iv-org/invidious/releases/tag/v2.20240427

Invidious has now switched to a conventional release model.
Thus, [our update script](https://github.com/NixOS/nixpkgs/blob/2b1f64b358f2cab62617f26b3870fd0ee375d848/pkgs/servers/invidious/update.sh) has to be adapted in consequence. I would be glad to get some help on this.

cc @infinisil @jbedo @999eagle 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
