### PR TITLE
nodeinfo: init at 0.3.2

### DIFF
--- a/pkgs/by-name/no/nodeinfo/package.nix
+++ b/pkgs/by-name/no/nodeinfo/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  fetchFromGitea,
+  buildGoModule,
+}:
+buildGoModule rec {
+  pname = "nodeinfo";
+  version = "0.3.2";
+  vendorHash = "sha256-4nHdz/Js8xBUMiH+hH+hSYP25cB4yHbe+QVk0RMqLgc=";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "thefederationinfo";
+    repo = "nodeinfo-go";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-NNrMv4AS7ybuJfTgs+p61btSIxo+iMvzH7Y5ct46Dag=";
+  };
+
+  tags = "extension";
+
+  sourceRoot = "${src.name}/cli";
+
+  CGO_ENABLED = 0;
+
+  meta = with lib; {
+    mainProgram = "nodeinfo";
+    description = "A command line tool to query nodeinfo based on a given domain";
+    homepage = "https://codeberg.org/thefederationinfo/nodeinfo-go";
+    changelog = "https://codeberg.org/thefederationinfo/nodeinfo-go/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ _6543 ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Package **nodeinfo** an cli tool that query's [nodeinfo](http://nodeinfo.diaspora.software/) based on a given domain

https://codeberg.org/thefederationinfo/nodeinfo-go

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
