### PR TITLE
tpm2-tss: 4.0.1 -> 4.1.0

### DIFF
--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fetchurl
+{ stdenv, lib, fetchFromGitHub
 , autoreconfHook, autoconf-archive, pkg-config, doxygen, perl
 , openssl, json_c, curl, libgcrypt
 , cmocka, uthash, ibm-sw-tpm2, iproute2, procps, which
@@ -15,13 +15,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "tpm2-tss";
-  version = "4.0.1";
+  version = "4.1.0";
 
   src = fetchFromGitHub {
     owner = "tpm2-software";
     repo = pname;
     rev = version;
-    sha256 = "sha256-75yiKVZrR1vcCwKp4tDO4A9JB0KDM0MXPJ1N85kAaRk=";
+    hash = "sha256-cQdIPQNZzy5CisWw5yifPXC7FqaZxj4VKWpvtPOffE8=";
   };
 
   outputs = [ "out" "man" "dev" ];
@@ -53,11 +53,6 @@ stdenv.mkDerivation rec {
     # Do not rely on dynamic loader path
     # TCTI loader relies on dlopen(), this patch prefixes all calls with the output directory
     ./no-dynamic-loader-path.patch
-    (fetchurl {
-      name = "skip-test-fapi-fix-provisioning-with-template-if-no-certificate-available.patch";
-      url = "https://github.com/tpm2-software/tpm2-tss/commit/218c0da8d9f675766b1de502a52e23a3aa52648e.patch";
-      sha256 = "sha256-dnl9ZAknCdmvix2TdQvF0fHoYeWp+jfCTg8Uc7h0voA=";
-    })
   ];
 
   postPatch = ''
@@ -65,7 +60,7 @@ stdenv.mkDerivation rec {
     substituteInPlace src/tss2-tcti/tctildr-dl.c \
       --replace '@PREFIX@' $out/lib/
     substituteInPlace ./test/unit/tctildr-dl.c \
-      --replace '@PREFIX@' $out/lib
+      --replace '@PREFIX@' $out/lib/
     substituteInPlace ./bootstrap \
       --replace 'git describe --tags --always --dirty' 'echo "${version}"'
   '';

--- a/pkgs/development/libraries/tpm2-tss/no-dynamic-loader-path.patch
+++ b/pkgs/development/libraries/tpm2-tss/no-dynamic-loader-path.patch
@@ -1,232 +1,503 @@
 diff --git a/src/tss2-tcti/tctildr-dl.c b/src/tss2-tcti/tctildr-dl.c
-index 622637dc..88fc3d8f 100644
+index d26219d2..92d2b6a3 100644
 --- a/src/tss2-tcti/tctildr-dl.c
 +++ b/src/tss2-tcti/tctildr-dl.c
-@@ -92,7 +92,7 @@ handle_from_name(const char *file,
-         LOG_DEBUG("Could not load TCTI file: \"%s\": %s", file, dlerror());
-     }
+@@ -88,14 +88,24 @@ handle_from_name(const char *file,
+     const char *formats[] = {
+         /* <name> */
+         "%s",
++        /* <name> */
++        "@PREFIX@" "%s",
+         /* libtss2-tcti-<name>.so.0 */
+         FMT_TCTI_PREFIX "%s" FMT_LIB_SUFFIX_0,
++        /* libtss2-tcti-<name>.so.0 */
++        "@PREFIX@" FMT_TCTI_PREFIX "%s" FMT_LIB_SUFFIX_0,
+         /* libtss2-tcti-<name>.so */
+         FMT_TCTI_PREFIX "%s" FMT_LIB_SUFFIX,
++        /* libtss2-tcti-<name>.so */
++        "@PREFIX@" FMT_TCTI_PREFIX "%s" FMT_LIB_SUFFIX,
+         /* libtss2-<name>.so.0 */
+         FMT_TSS_PREFIX "%s" FMT_LIB_SUFFIX_0,
++        /* libtss2-<name>.so.0 */
++        "@PREFIX@" FMT_TSS_PREFIX "%s" FMT_LIB_SUFFIX_0,
+         /* libtss2-<name>.so */
+         FMT_TSS_PREFIX "%s" FMT_LIB_SUFFIX,
++        /* libtss2-<name>.so */
++        "@PREFIX@" FMT_TSS_PREFIX "%s" FMT_LIB_SUFFIX,
+     };
  
--    len = snprintf(NULL, 0, TCTI_NAME_TEMPLATE_0, file);
-+    len = snprintf(NULL, 0, "@PREFIX@" TCTI_NAME_TEMPLATE_0, file);
-     if (len >= PATH_MAX) {
-         LOG_ERROR("TCTI name truncated in transform.");
-         return TSS2_TCTI_RC_BAD_VALUE;
-@@ -129,6 +129,50 @@ handle_from_name(const char *file,
-         return TSS2_TCTI_RC_BAD_VALUE;
-     }
-     *handle = dlopen(file_xfrm, RTLD_NOW);
-+    if (*handle != NULL) {
-+        return TSS2_RC_SUCCESS;
-+    } else {
-+        LOG_DEBUG("Failed to load TCTI for name \"%s\": %s", file, dlerror());
-+    }
-+    size = snprintf(file_xfrm,
-+                    len + 1,
-+                    "@PREFIX@%s",
-+                    file);
-+    if (size >= len + 1) {
-+        LOG_ERROR("TCTI name truncated in transform.");
-+        return TSS2_TCTI_RC_BAD_VALUE;
-+    }
-+    *handle = dlopen(file_xfrm, RTLD_NOW);
-+    if (*handle != NULL) {
-+        return TSS2_RC_SUCCESS;
-+    } else {
-+        LOG_DEBUG("Could not load TCTI file: \"%s\": %s", file, dlerror());
-+    }
-+    /* 'name' alone didn't work, try libtss2-tcti-<name>.so.0 */
-+    size = snprintf(file_xfrm,
-+                    len + 1,
-+                    "@PREFIX@" TCTI_NAME_TEMPLATE_0,
-+                    file);
-+    if (size >= len + 1) {
-+        LOG_ERROR("TCTI name truncated in transform.");
-+        return TSS2_TCTI_RC_BAD_VALUE;
-+    }
-+    *handle = dlopen(file_xfrm, RTLD_NOW);
-+    if (*handle != NULL) {
-+        return TSS2_RC_SUCCESS;
-+    } else {
-+        LOG_DEBUG("Could not load TCTI file \"%s\": %s", file, dlerror());
-+    }
-+    /* libtss2-tcti-<name>.so.0 didn't work, try libtss2-tcti-<name>.so */
-+    size = snprintf(file_xfrm,
-+                    len + 1,
-+                    "@PREFIX@" TCTI_NAME_TEMPLATE,
-+                    file);
-+    if (size >= len + 1) {
-+        LOG_ERROR("TCTI name truncated in transform.");
-+        return TSS2_TCTI_RC_BAD_VALUE;
-+    }
-+    *handle = dlopen(file_xfrm, RTLD_NOW);
-     if (*handle == NULL) {
-         LOG_DEBUG("Failed to load TCTI for name \"%s\": %s", file, dlerror());
-         SAFE_FREE(file_xfrm);
+     if (handle == NULL) {
 diff --git a/test/unit/tctildr-dl.c b/test/unit/tctildr-dl.c
-index 4279baee..6685c811 100644
+index 135e1b14..7d654d1f 100644
 --- a/test/unit/tctildr-dl.c
 +++ b/test/unit/tctildr-dl.c
-@@ -229,6 +229,18 @@ test_get_info_default_success (void **state)
+@@ -168,6 +168,10 @@ test_handle_from_name_second_dlopen_success (void **state)
      expect_value(__wrap_dlopen, flags, RTLD_NOW);
      will_return(__wrap_dlopen, NULL);
  
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-default.so");
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" TEST_TCTI_TRY_A);
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
 +
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-default.so.so.0");
-+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
-+    will_return(__wrap_dlopen, NULL);
-+
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-default.so.so");
-+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
-+    will_return(__wrap_dlopen, NULL);
-+
-     expect_string(__wrap_dlopen, filename, "libtss2-tcti-tabrmd.so.0");
+     expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_B);
      expect_value(__wrap_dlopen, flags, RTLD_NOW);
-     will_return(__wrap_dlopen, HANDLE);
-@@ -261,6 +273,18 @@ test_get_info_default_info_fail (void **state)
+     will_return(__wrap_dlopen, TEST_HANDLE);
+@@ -186,10 +190,18 @@ test_handle_from_name_third_dlopen_success (void **state)
      expect_value(__wrap_dlopen, flags, RTLD_NOW);
      will_return(__wrap_dlopen, NULL);
  
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-default.so");
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" TEST_TCTI_TRY_A);
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
 +
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-default.so.so.0");
-+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
-+    will_return(__wrap_dlopen, NULL);
-+
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-default.so.so");
-+    expect_value(__wrap_dlopen, flags, RTLD_NOW);
-+    will_return(__wrap_dlopen, NULL);
-+
-     expect_string(__wrap_dlopen, filename, "libtss2-tcti-tabrmd.so.0");
+     expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_B);
      expect_value(__wrap_dlopen, flags, RTLD_NOW);
-     will_return(__wrap_dlopen, HANDLE);
-@@ -413,6 +437,15 @@ test_tcti_fail_all (void **state)
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" TEST_TCTI_TRY_B);
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_C);
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, TEST_HANDLE);
+@@ -208,14 +220,26 @@ test_handle_from_name_fourth_dlopen_success (void **state)
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" TEST_TCTI_TRY_A);
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_B);
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" TEST_TCTI_TRY_B);
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_C);
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" TEST_TCTI_TRY_C);
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_D);
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, TEST_HANDLE);
+@@ -234,18 +258,34 @@ test_handle_from_name_fifth_dlopen_success (void **state)
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" TEST_TCTI_TRY_A);
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_B);
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" TEST_TCTI_TRY_B);
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_C);
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" TEST_TCTI_TRY_C);
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_D);
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" TEST_TCTI_TRY_D);
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, TEST_TCTI_TRY_E);
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, TEST_HANDLE);
+@@ -281,22 +321,42 @@ test_get_info_default_success (void **state)
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-default.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-default.so.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-default.so.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
      expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-default.so.so");
      expect_value(__wrap_dlopen, flags, RTLD_NOW);
      will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-default.so");
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-default.so.so");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-default.so.so.0");
++
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-default.so.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-default.so.so.0");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-default.so.so");
++
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-default.so.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-default.so.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-tabrmd.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, HANDLE);
+@@ -321,22 +381,42 @@ test_get_info_default_info_fail (void **state)
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-default.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-default.so.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-default.so.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-default.so.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-default.so.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-default.so.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-default.so.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-default.so.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-default.so.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-tabrmd.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, HANDLE);
+@@ -483,120 +563,225 @@ test_tcti_fail_all (void **state)
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-default.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-default.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-default.so.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-default.so.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-default.so.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-default.so.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-default.so.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-default.so.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-default.so.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-default.so.so");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
  
      /* Skip over libtss2-tcti-tabrmd.so */
      expect_string(__wrap_dlopen, filename, "libtss2-tcti-tabrmd.so.0");
-@@ -424,6 +457,15 @@ test_tcti_fail_all (void **state)
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-tabrmd.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-tabrmd.so.0.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-tabrmd.so.0.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
      expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-tabrmd.so.0.so");
      expect_value(__wrap_dlopen, flags, RTLD_NOW);
      will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-tabrmd.so.0");
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-tabrmd.so.0.so");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-tabrmd.so.0.so.0");
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-tabrmd.so.0.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-tabrmd.so.0.so.0");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-tabrmd.so.0.so");
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-tabrmd.so.0.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-tabrmd.so.0.so");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
  
      /* Skip over libtss2-tcti-device.so, /dev/tpmrm0 */
      expect_string(__wrap_dlopen, filename, "libtss2-tcti-device.so.0");
-@@ -435,6 +477,15 @@ test_tcti_fail_all (void **state)
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-device.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-device.so.0.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-device.so.0.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
      expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-device.so.0.so");
      expect_value(__wrap_dlopen, flags, RTLD_NOW);
      will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-device.so.0");
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-device.so.0.so");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-device.so.0.so.0");
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-device.so.0.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-device.so.0.so.0");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-device.so.0.so");
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-device.so.0.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-device.so.0.so");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
  
      /* Skip over libtss2-tcti-device.so, /dev/tpm0 */
      expect_string(__wrap_dlopen, filename, "libtss2-tcti-device.so.0");
-@@ -446,6 +497,15 @@ test_tcti_fail_all (void **state)
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-device.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-device.so.0.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-device.so.0.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
      expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-device.so.0.so");
      expect_value(__wrap_dlopen, flags, RTLD_NOW);
      will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-device.so.0");
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-device.so.0.so");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-device.so.0.so.0");
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-device.so.0.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-device.so.0.so.0");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-device.so.0.so");
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-device.so.0.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-device.so.0.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+ 
+     /* Skip over libtss2-tcti-device.so, /dev/tcm0 */
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-device.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-device.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-device.so.0.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-device.so.0.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-device.so.0.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-device.so.0.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-device.so.0.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-device.so.0.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-device.so.0.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-device.so.0.so");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
  
      /* Skip over libtss2-tcti-swtpm.so */
      expect_string(__wrap_dlopen, filename, "libtss2-tcti-swtpm.so.0");
-@@ -457,6 +517,15 @@ test_tcti_fail_all (void **state)
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-swtpm.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-swtpm.so.0.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-swtpm.so.0.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
      expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-swtpm.so.0.so");
      expect_value(__wrap_dlopen, flags, RTLD_NOW);
      will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-swtpm.so.0");
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-swtpm.so.0.so");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-swtpm.so.0.so.0");
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-swtpm.so.0.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-swtpm.so.0.so.0");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-swtpm.so.0.so");
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-swtpm.so.0.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-swtpm.so.0.so");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
  
      /* Skip over libtss2-tcti-mssim.so */
      expect_string(__wrap_dlopen, filename, "libtss2-tcti-mssim.so.0");
-@@ -468,6 +537,15 @@ test_tcti_fail_all (void **state)
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-mssim.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-mssim.so.0.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-mssim.so.0.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
      expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-mssim.so.0.so");
      expect_value(__wrap_dlopen, flags, RTLD_NOW);
      will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-mssim.so.0");
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-libtss2-tcti-mssim.so.0.so");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-mssim.so.0.so.0");
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-mssim.so.0.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-mssim.so.0.so.0");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-mssim.so.0.so");
+     expect_string(__wrap_dlopen, filename, "libtss2-libtss2-tcti-mssim.so.0.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-libtss2-tcti-mssim.so.0.so");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
  
      TSS2_RC r;
      TSS2_TCTI_CONTEXT *tcti;
-@@ -496,6 +574,15 @@ test_info_from_name_handle_fail (void **state)
+@@ -619,18 +804,33 @@ test_info_from_name_handle_fail (void **state)
+     expect_string(__wrap_dlopen, filename, "foo");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "foo");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-foo.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-foo.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
      expect_string(__wrap_dlopen, filename, "libtss2-tcti-foo.so");
      expect_value(__wrap_dlopen, flags, RTLD_NOW);
      will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/foo");
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-foo.so");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-foo.so.0");
+     expect_string(__wrap_dlopen, filename, "libtss2-foo.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-foo.so.0");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-foo.so");
+     expect_string(__wrap_dlopen, filename, "libtss2-foo.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-foo.so");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
  
      TSS2_RC rc = info_from_name ("foo", &info, &data);
      assert_int_equal (rc, TSS2_TCTI_RC_NOT_SUPPORTED);
-@@ -612,6 +699,15 @@ test_tctildr_get_info_from_name (void **state)
+@@ -741,18 +941,33 @@ test_tctildr_get_info_from_name (void **state)
+     expect_string(__wrap_dlopen, filename, "foo");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "foo");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-foo.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-foo.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
      expect_string(__wrap_dlopen, filename, "libtss2-tcti-foo.so");
      expect_value(__wrap_dlopen, flags, RTLD_NOW);
      will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/foo");
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-tcti-foo.so");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-foo.so.0");
+     expect_string(__wrap_dlopen, filename, "libtss2-foo.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-foo.so.0");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
-+    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-foo.so");
+     expect_string(__wrap_dlopen, filename, "libtss2-foo.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@" "libtss2-foo.so");
 +    expect_value(__wrap_dlopen, flags, RTLD_NOW);
 +    will_return(__wrap_dlopen, NULL);
  

--- a/pkgs/development/python-modules/tpm2-pytss/default.nix
+++ b/pkgs/development/python-modules/tpm2-pytss/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, fetchurl
 , substituteAll
 , buildPythonPackage
 , fetchPypi
@@ -37,6 +38,10 @@ buildPythonPackage rec {
   patches = [
     # Fix hardcoded `fapi-config.json` configuration path
     ./fapi-config.patch
+    (fetchurl {
+      url = "https://github.com/tpm2-software/tpm2-pytss/pull/571/commits/b02fdc8e259fe977c1065389c042be69e2985bdf.patch";
+      hash = "sha256-+jZFv+s9p52JxtUcNeJx7ayzKDVtPoQSSGgyZqPDuEc=";
+    })
   ] ++ lib.optionals isCross [
     # pytss will regenerate files from headers of tpm2-tss.
     # Those headers are fed through a compiler via pycparser. pycparser expects `cpp`


### PR DESCRIPTION

## Description of changes

Because upstream rewrote the loader for TCTI, the order for loading backend got shuffled. This explains the noise in the patch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
