### PR TITLE
Add Intel VTune

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -83,6 +83,8 @@
 
 - [Conduwuit](https://conduwuit.puppyirl.gay/), a federated chat server implementing the Matrix protocol, forked from Conduit. Available as [services.conduwuit](#opt-services.conduwuit.enable).
 
+- [Intel VTune Profiler](https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler.html), a performance analysis tool for x86-based machines. Available as [programs.vtune](#opt-programs.vtune.enable).
+
 - [Readeck](https://readeck.org/), a read-it later web-application. Available as [services.readeck](#opt-services.readeck.enable).
 
 - [Traccar](https://www.traccar.org/), a modern GPS Tracking Platform. Available as [services.traccar](#opt-services.traccar.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -319,6 +319,7 @@
   ./programs/vim.nix
   ./programs/virt-manager.nix
   ./programs/vivid.nix
+  ./programs/vtune.nix
   ./programs/wavemon.nix
   ./programs/wayland/cardboard.nix
   ./programs/wayland/hyprlock.nix

--- a/nixos/modules/programs/vtune.nix
+++ b/nixos/modules/programs/vtune.nix
@@ -1,0 +1,74 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkOption
+    mkPackageOption
+    types
+    ;
+
+  cfg = config.programs.vtune;
+in
+{
+  options.programs.vtune = {
+    enable = mkEnableOption "VTune Profiler";
+
+    package = mkPackageOption pkgs "intel-oneapi-vtune" {
+      nullable = true;
+      extraDescription = ''
+        Set to `null` to install only the kernel module.
+      '';
+    };
+
+    modulePackage = mkOption {
+      type = types.nullOr types.package;
+      default = config.boot.kernelPackages.intel-vtune-sepdk.override {
+        intel-oneapi-vtune = config.programs.package or pkgs.intel-oneapi-vtune;
+      };
+      defaultText = ''
+        config.boot.kernelPackages.intel-vtune-sepdk.override {
+          intel-oneapi-vtune = config.programs.vtune.package or pkgs.intel-oneapi-vtune;
+        }
+      '';
+      example = "config.boot.kernelPackages.intel-vtune-sepdk";
+      description = ''
+        The package to use for the VTune Profiler kernel module.
+        Set to `null` to disable the kernel module.
+        An user should be in the `vtune` group to use the module.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf (cfg.package != null) { environment.systemPackages = [ cfg.package ]; })
+
+    (mkIf (cfg.modulePackage != null) {
+      boot.extraModulePackages = [ cfg.modulePackage ];
+
+      environment.systemPackages = [ cfg.modulePackage ];
+
+      users.groups.vtune = { };
+
+      systemd.services.vtune-sep5 = {
+        description = "Load VTune SEP5 driver";
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${cfg.modulePackage}/bin/insmod-sep --load-in-tree-driver";
+          ExecStop = "${cfg.modulePackage}/bin/rmmod-sep";
+          RemainAfterExit = true;
+        };
+      };
+    })
+  ]);
+
+  meta.maintainers = [ lib.maintainers.xzfc ];
+}

--- a/pkgs/by-name/in/intel-oneapi-vtune/package.nix
+++ b/pkgs/by-name/in/intel-oneapi-vtune/package.nix
@@ -1,0 +1,142 @@
+{
+  alsa-lib,
+  atk,
+  autoPatchelfHook,
+  cairo,
+  cups,
+  dbus,
+  elfutils,
+  expat,
+  fetchurl,
+  file-rename,
+  glib,
+  gtk3,
+  kmod,
+  lib,
+  libdrm,
+  libndctl,
+  libsafec,
+  libxcrypt-legacy,
+  libxkbcommon,
+  mesa,
+  ncurses5,
+  nspr,
+  nss,
+  opencl-clang,
+  p7zip,
+  pango,
+  stdenv,
+  systemd,
+  wrapGAppsHook3,
+  xorg,
+}:
+
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    versionMajorMinor = lib.versions.majorMinor finalAttrs.version;
+  in
+  {
+    pname = "intel-oneapi-vtune";
+    version = "2025.0.1";
+
+    src = fetchurl {
+      url = "https://installer.repos.intel.com/oneapi/vtune/lin/intel.oneapi.lin.vtune,v=2025.0.1%2B14/cupPayload.cup";
+      sha256 = "1pzh0kx7wxwr48rbv7wfkpkixqxsaass3xkpwhvvkdm09v5fhm7h";
+    };
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      file-rename
+      p7zip
+      wrapGAppsHook3
+    ];
+
+    buildInputs = [
+      alsa-lib
+      atk
+      cairo
+      cups
+      dbus
+      elfutils
+      expat
+      glib
+      gtk3
+      kmod
+      libdrm
+      libndctl
+      libsafec
+      libxcrypt-legacy
+      libxkbcommon
+      mesa
+      ncurses5
+      nspr
+      nss
+      opencl-clang
+      pango
+      stdenv.cc.cc.lib
+      xorg.libX11
+      xorg.libXcomposite
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXrandr
+      xorg.libxcb
+    ];
+
+    unpackPhase = ''
+      runHook preUnpack
+
+      7za x $src _installdir/vtune/${versionMajorMinor}
+
+      # Fix percent-encoded filenames, e.g. "libstdc%2B%2B.so.6" -> "libstdc++.so.6"
+      find -depth -name '*%*' -execdir rename 's/%2B/+/g; s/%5B/[/g; s/%5D/]/g' {} \;
+
+      runHook postUnpack
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/opt/intel/oneapi
+      mv _installdir/vtune $out/opt/intel/oneapi
+      ln -s $out/opt/intel/oneapi/vtune/{${versionMajorMinor},latest}
+
+      mkdir -p $out/bin
+      for bin in vtune vtune-backend vtune-gui; do
+        ln -s $out/opt/intel/oneapi/vtune/${versionMajorMinor}/bin64/$bin $out/bin/
+      done
+
+      mkdir -p $out/share/applications
+      cp $out/opt/intel/oneapi/vtune/${versionMajorMinor}/bin64/vtune-gui.desktop $out/share/applications/
+      sed -i $out/share/applications/vtune-gui.desktop -e "
+        s|^Exec=.*|Exec=vtune-gui|g;
+        s|^Icon=./|Icon=$out/opt/intel/oneapi/vtune/${versionMajorMinor}/bin64/|g;
+      "
+
+      runHook postInstall
+    '';
+
+    autoPatchelfIgnoreMissingDeps = [
+      "libffi.so.6" # Used in vendored python
+      "libgdbm.so.4" # Used in vendored python
+      "libgdbm_compat.so.4" # Used in vendored python
+      "libsycl.so.8" # Used in bin64/self_check_apps/matrix.dpcpp/matrix.dpcpp
+    ];
+
+    runtimeDependencies = [
+      systemd # for zygote (vtune-gui)
+    ];
+
+    passthru.updateScript = ./update.sh;
+
+    meta = {
+      changelog = "https://www.intel.com/content/www/us/en/developer/articles/release-notes/vtune-profiler-release-notes.html";
+      description = "Performance analysis tool for x86-based machines";
+      homepage = "https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler.html";
+      license = lib.licenses.unfree;
+      maintainers = [ lib.maintainers.xzfc ];
+      platforms = [ "x86_64-linux" ];
+    };
+  }
+)

--- a/pkgs/by-name/in/intel-oneapi-vtune/update.sh
+++ b/pkgs/by-name/in/intel-oneapi-vtune/update.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+
+set -e
+
+# Check on https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler-download.html
+DOWNLOAD_ID=bef05a56-52f3-40ad-a91a-040a98316680
+
+INSTALLER_URL=$(
+    curl --silent "https://www.intel.com/libs/apps/intel/idz/productsinfo?downloadId=$DOWNLOAD_ID" |
+        jq -r '
+            .downloads.downloads.productVersionsBuilds[0].files[]
+            | select (.operatingSystem == "Linux" and .fileType == "Custom Package")
+            .url
+        ' |
+        uniq
+)
+echo "INSTALLER_URL=$INSTALLER_URL"
+[ "$INSTALLER_URL" ] || exit 1
+
+{
+    read -r CUP_URL
+    read -r VERSION
+} < <(
+    curl --silent "$INSTALLER_URL" |
+        sed '0,/^__CONTENT__$/d' |
+        tar -zx -O --wildcards './packages/intel.oneapi.lin.vtune,v=*/manifest.json' |
+        jq -r '
+            [(.payloads[] | select (.fileName == "cupPayload.cup") | .url),
+             (.version | split("+")[0])
+            ][]
+        '
+)
+echo "CUP_URL=$CUP_URL"
+echo "VERSION=$VERSION"
+[ "$CUP_URL" ] || exit 1
+[ "$VERSION" ] || exit 1
+
+CUP_HASH=$(nix-prefetch-url "$CUP_URL")
+echo "CUP_HASH=$CUP_HASH"
+
+update-source-version intel-oneapi-vtune "$VERSION" "$CUP_HASH" "$CUP_URL"

--- a/pkgs/by-name/li/libsafec/package.nix
+++ b/pkgs/by-name/li/libsafec/package.nix
@@ -1,0 +1,46 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  autoreconfHook,
+  perl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "safeclib";
+  version = "3.3.0";
+
+  src = fetchFromGitHub {
+    owner = "rurban";
+    repo = "safeclib";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-vwMyxGgJvvv2Nlo14HKZtq8YnmAVqAHDvBL6CUmbaYQ=";
+  };
+
+  patches = [
+    # Fix linking error.
+    # Upstreamed in v3.4.0, but intel-opeapi-vtune wants libsafec-3.3.so.3.
+    (fetchpatch {
+      name = "0001-add-pic_flag-to-RETPOLINE-cflags-and-ldflags.patch";
+      url = "https://github.com/rurban/safeclib/commit/23ae79fe84a3fa5d995b8c6b9be70587e37a6cd8.patch";
+      hash = "sha256-iv9OZJT9WILug1vVmUgIh8RxGAx8accwR1R0LOxYqYQ=";
+    })
+  ];
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [ perl ];
+
+  env = {
+    CFLAGS = "-Wno-error=dangling-pointer";
+  };
+
+  meta = {
+    description = "Libc extension with all C11 Annex K functions";
+    homepage = "https://github.com/rurban/safeclib";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.xzfc ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/os-specific/linux/intel-vtune-sepdk/default.nix
+++ b/pkgs/os-specific/linux/intel-vtune-sepdk/default.nix
@@ -1,0 +1,106 @@
+{
+  bash,
+  coreutils,
+  gnugrep,
+  gnused,
+  intel-oneapi-vtune,
+  kernel,
+  kmod,
+  lib,
+  makeWrapper,
+  p7zip,
+  procps,
+  python3,
+  shadow,
+  stdenv,
+  which,
+}:
+
+let
+  binPath = lib.makeBinPath [
+    bash
+    coreutils
+    gnugrep
+    gnused
+    kmod
+    procps
+    python3
+    shadow
+    which
+  ];
+  libexecDir = "\${out}/libexec/intel-vtune-sepdk";
+  modDestDir = "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/platform/x86";
+  versionMajorMinor = lib.versions.majorMinor intel-oneapi-vtune.version;
+in
+stdenv.mkDerivation {
+  pname = "intel-vtune-sepdk";
+  version = "${intel-oneapi-vtune.version}-${kernel.version}";
+
+  inherit (intel-oneapi-vtune) src;
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    p7zip
+  ] ++ kernel.moduleBuildDependencies;
+
+  makeFlags = [
+    "KERNEL_SRC_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "KERNEL_VERSION=${kernel.modDirVersion}" # Output of `uname -r`
+    "MACH=x86_64" # Output of `uname -m`
+    "SMP=1"
+    "VERBOSE=1"
+    "INSTALL=${libexecDir}"
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    7za x $src _installdir/vtune/${versionMajorMinor}/sepdk
+    cd _installdir/vtune/${versionMajorMinor}/sepdk/src
+    runHook postUnpack
+  '';
+
+  prePatch = ''
+    # Allow using --load-in-tree-driver option
+    substituteInPlace insmod-sep pax/insmod-pax socperf/src/insmod-socperf \
+      --replace-fail IS_INTREE_DRIVER_OS=0 IS_INTREE_DRIVER_OS=1
+  '';
+
+  preBuild = ''
+    makeFlags="$makeFlags KBUILD_EXTRA_SYMBOLS=$PWD/socperf/src/Module.symvers"
+  '';
+
+  preInstall = "mkdir -p ${libexecDir}";
+
+  postInstall = ''
+    # Install wrappers to bin
+    for i in insmod-sep pax/insmod-pax socperf/src/insmod-socperf \
+             rmmod-sep  pax/rmmod-pax  socperf/src/rmmod-socperf; do
+      sed -i '
+        s/^PATH=/# &/;
+        # Do not check for su to make it usable with clean PATH (e.g. as systemd service)
+        s/\(\bCOMMANDS_TO_CHECK="[^"]*\)''${SU}\([^"]*"\)/\1\2/;
+      ' ${libexecDir}/$i
+      makeWrapper ${libexecDir}/$i $out/bin/''${i##*/} --prefix PATH : "${binPath}"
+    done
+
+    # Install kernel modules
+    mkdir -p ${modDestDir}/{socperf,sepdk/sep,sepdk/pax}
+    ln -s ${libexecDir}/sep5-*.ko ${modDestDir}/sepdk/sep/sep5.ko
+    ln -s ${libexecDir}/pax/pax-*.ko ${modDestDir}/sepdk/pax/pax.ko
+    ln -s ${libexecDir}/socperf/src/socperf3-*.ko ${modDestDir}/socperf/socperf3.ko
+  '';
+
+  meta = {
+    description = "Kernel module for Intel VTune Profiler";
+    homepage = "https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-0/sep-driver.html";
+    license = [
+      lib.licenses.bsd3
+      lib.licenses.gpl2Only
+      lib.licenses.unfree
+    ];
+    maintainers = [ lib.maintainers.xzfc ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -392,6 +392,8 @@ in {
 
     intel-speed-select = if lib.versionAtLeast kernel.version "5.3" then callPackage ../os-specific/linux/intel-speed-select { } else null;
 
+    intel-vtune-sepdk = callPackage ../os-specific/linux/intel-vtune-sepdk { };
+
     ipu6-drivers = callPackage ../os-specific/linux/ipu6-drivers {};
 
     ivsc-driver = callPackage ../os-specific/linux/ivsc-driver {};


### PR DESCRIPTION
## Description of changes

[website]: https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler.html
[wiki]: https://en.wikipedia.org/wiki/VTune

This PR brings Intel VTune Profiler v2025.0.1 ([website], [wiki]), a proprietary performance analysis tool for x86-based machines.
This PR consists of the following additions:

### 1. Application Package
1. Name: `vtune-oneapi-vtune`.
2. Ernomous installed size of 1.6 GiB.
3. Provides a desktop entry for `vtune-gui`, a CLI utility `vtune`, and a lot more.
4. Uses the same package name as the official deb/rpm packages made by Intel.
5. Most of the files are installed to `$out/opt/intel/oneapi/vtune`, following the same structure as the official packages.
6. The `opt/…/bin64` directory contains a lot of garbage, so I've added only the bare minimum to `$out/bin`.

### 2. Sampling Drivers Package
1.  Name: `linuxPackages.vtune-sepdk`.
2.  Kernel drivers to enable hardware event-based sampling for VTune Profiler. ([website](https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/sep-driver.html))
3.  It's possible to use these drivers without installing the application package, e.g., if [running VTune Profiler in a Docker container](https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2023-0/run-from-container.html).
4.  The package provides `*.ko` files as well as `insmod-*` and `rmmod-*` scripts (upstream) to load/unload the modules.
5.  In order to use these modules, a user should be in the `vtune` group.
6.  These modules are optional, and basic profiling could be performed by configuring `/proc/sys/kernel` parameters instead.
7.  Caveat: loading the modules directly using `modprobe` could lead to kernel panics, so using the provided scripts is recommended.
8.  Caveat: these scripts might want to create `vtune` group if it doesn't exist. The NixOS module handles this.

9.  The source of these modules is available from either:
    - The same installer package as the application, i.e., a 547.8MiB archive.
    - An 612KiB `*.tar.gz` file [at the Intel website](https://www.intel.com/content/www/us/en/developer/articles/code-sample/vtune-profiler-sampling-driver-downloads.html). It's a bit outdated and belongs to VTune v2023.1.

    I've used the former to keep versions of both packages in sync.
    We might add the later if there's a demand for it.

10. Modules self-report their licenses as "Dual BSD/GPL" (run `modinfo sep5 pax socperf3`), but:
    - The source package is a part of large proprietary archive. (see above)
    - A few header files contain an unclear license notice. Might be an oversight.

    So, I've marked the package as `unfree bsd3 gpl2Only`.

### 3. NixOS module
1.  Option name: `programs.vtune`.
2.  Enable it to install both the application and the kernel module, or just one of them.
3.  It provides a systemd service to load/unload the modules, similar to the official packages.
4.  Allocates a new group id `vtune` in `nixos/modules/misc/ids.nix`.

### 4. Dependencies
1.  `safeclib` v3.3.0. Some `*.so` in the application package is linked to this particular version of `safeclib`.
2.  Some `*.so` dependencies for the vendored python are missing.
    I'm not sure if they are worth adding as I haven't stumbled upon any issues yet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc