### PR TITLE
psitransfer: 2.1.2 -> 2.2.0

### DIFF
--- a/pkgs/servers/psitransfer/default.nix
+++ b/pkgs/servers/psitransfer/default.nix
@@ -1,22 +1,24 @@
 { lib
 , buildNpmPackage
 , fetchFromGitHub
+, pkg-config
+, vips
 }:
 
 let
   pname = "psitransfer";
-  version = "2.1.2";
+  version = "2.2.0";
   src = fetchFromGitHub {
     owner = "psi-4ward";
     repo = "psitransfer";
     rev = "v${version}";
-    hash = "sha256-dBAieXIwCEstR9m+6+2/OLPKo2qHynZ1t372Il0mkXk=";
+    hash = "sha256-5o4QliAXgSZekIy0CNWfEuOxNl0uetL8C8RKUJ8HsNA=";
   };
   app = buildNpmPackage {
     pname = "${pname}-app";
     inherit version src;
 
-    npmDepsHash = "sha256-iCd+I/aTMwQqAMRHan3T191XNz4S3Cy6CDxSLIYY7IA=";
+    npmDepsHash = "sha256-q7E+osWIf6VZ3JvxCXoZYeF28aMgmKP6EzQkksUUjeY=";
 
     postPatch = ''
       # https://github.com/psi-4ward/psitransfer/pull/284
@@ -31,7 +33,12 @@ let
 in buildNpmPackage {
   inherit pname version src;
 
-  npmDepsHash = "sha256-H22T5IU8bjbsWhwhchDqppvYfcatbXSWqp6gdoek1Z8=";
+  npmDepsHash = "sha256-EW/Fej58LE/nbJomPtWvEjDveAUdo0jIWwC+ziN0gy0=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    vips  # for 'sharp' dependency
+  ];
 
   postPatch = ''
     rm -r public/app


### PR DESCRIPTION
## Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2024-31453
https://nvd.nist.gov/vuln/detail/CVE-2024-31454

Will need some assistance from maintainer (@hyshka ?) - attempting to run this gives me:

```
/nix/store/p86xmn07y59skyrm9pz53mjbz2ca07hh-psitransfer-2.2.0/lib/node_modules/psitransfer/lib/db.js:50
      throw e;
      ^

Error: db initialization failed with error EACCES: permission denied, mkdir '/nix/store/p86xmn07y59skyrm9pz53mjbz2ca07hh-psitransfer-2.2.0/lib/node_modules/psitransfer/data'
    at Object.mkdirSync (node:fs:1373:26)
    at Object.mkdirsSync (/nix/store/p86xmn07y59skyrm9pz53mjbz2ca07hh-psitransfer-2.2.0/lib/node_modules/psitransfer/node_modules/fs-extra/lib/mkdirs/mkdirs-sync.js:31:9)
    at DB._sync (/nix/store/p86xmn07y59skyrm9pz53mjbz2ca07hh-psitransfer-2.2.0/lib/node_modules/psitransfer/lib/db.js:59:9)
    at DB.init (/nix/store/p86xmn07y59skyrm9pz53mjbz2ca07hh-psitransfer-2.2.0/lib/node_modules/psitransfer/lib/db.js:46:12)
    at Object.<anonymous> (/nix/store/p86xmn07y59skyrm9pz53mjbz2ca07hh-psitransfer-2.2.0/lib/node_modules/psitransfer/lib/endpoints.js:34:4)
    at Module._compile (node:internal/modules/cjs/loader:1369:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1427:10)
    at Module.load (node:internal/modules/cjs/loader:1206:32)
    at Module._load (node:internal/modules/cjs/loader:1022:12)
    at Module.require (node:internal/modules/cjs/loader:1231:19) {
  errno: -13,
  code: 'EACCES',
  syscall: 'mkdir',
  path: '/nix/store/p86xmn07y59skyrm9pz53mjbz2ca07hh-psitransfer-2.2.0/lib/node_modules/psitransfer/data'
}

Node.js v20.12.2
```

..but the same thing happens for me with the current version, so perhaps I'm doing something wrong?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
