### PR TITLE
treewide: migrate some packages to finalAttrs, also reference lib explicitly in meta

### DIFF
--- a/pkgs/applications/networking/instant-messengers/whatsapp-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/whatsapp-for-linux/default.nix
@@ -25,15 +25,15 @@
 , xorg
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "whatsapp-for-linux";
   version = "1.6.4";
 
   src = fetchFromGitHub {
     owner = "eneshecan";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-DU9tvIvDfOtBydR68yeRMFYdMjiBrOobCDXIZMmm7pQ=";
+    repo = "whatsapp-for-linux";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-DU9tvIvDfOtBydR68yeRMFYdMjiBrOobCDXIZMmm7pQ=";
   };
 
   nativeBuildInputs = [
@@ -68,12 +68,12 @@ stdenv.mkDerivation rec {
     xorg.libXtst
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/eneshecan/whatsapp-for-linux";
     description = "Whatsapp desktop messaging app";
     mainProgram = "whatsapp-for-linux";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ bartuka ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ bartuka ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/applications/networking/remote/anydesk/default.nix
+++ b/pkgs/applications/networking/remote/anydesk/default.nix
@@ -5,14 +5,14 @@
 
 let
   description = "Desktop sharing application, providing remote support and online meetings";
-in stdenv.mkDerivation rec {
+in stdenv.mkDerivation (finalAttrs: {
   pname = "anydesk";
   version = "6.3.2";
 
   src = fetchurl {
     urls = [
-      "https://download.anydesk.com/linux/anydesk-${version}-amd64.tar.gz"
-      "https://download.anydesk.com/linux/generic-linux/anydesk-${version}-amd64.tar.gz"
+      "https://download.anydesk.com/linux/anydesk-${finalAttrs.version}-amd64.tar.gz"
+      "https://download.anydesk.com/linux/generic-linux/anydesk-${finalAttrs.version}-amd64.tar.gz"
     ];
     hash = "sha256-nSY4qHRsEvQk4M3JDHalAk3C6Y21WlfDQ2Gpp6/jjMs=";
   };
@@ -54,7 +54,7 @@ in stdenv.mkDerivation rec {
   postFixup = ''
     patchelf \
       --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-      --set-rpath "${lib.makeLibraryPath buildInputs}" \
+      --set-rpath "${lib.makeLibraryPath finalAttrs.buildInputs}" \
       $out/bin/anydesk
 
     # pangox is not actually necessary (it was only added as a part of gtkglext)
@@ -77,12 +77,12 @@ in stdenv.mkDerivation rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     inherit description;
     homepage = "https://www.anydesk.com";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ shyim cheriimoya ];
+    maintainers = with lib.maintainers; [ shyim cheriimoya ];
   };
-}
+})

--- a/pkgs/by-name/ke/keydb/package.nix
+++ b/pkgs/by-name/ke/keydb/package.nix
@@ -18,14 +18,14 @@
   nixosTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "keydb";
   version = "6.3.4";
 
   src = fetchFromGitHub {
     owner = "snapchat";
     repo = "keydb";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-j6qgK6P3Fv+b6k9jwKQ5zW7XLkKbXXcmHKBCQYvwEIU=";
   };
 
@@ -94,13 +94,13 @@ stdenv.mkDerivation rec {
   passthru.tests.redis = nixosTests.redis;
   passthru.serverBin = "keydb-server";
 
-  meta = with lib; {
+  meta = {
     homepage = "https://keydb.dev";
     description = "A Multithreaded Fork of Redis";
-    license = licenses.bsd3;
-    platforms = platforms.all;
-    changelog = "https://github.com/Snapchat/KeyDB/raw/v${version}/00-RELEASENOTES";
-    maintainers = teams.helsinki-systems.members;
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+    changelog = "https://github.com/Snapchat/KeyDB/raw/v${finalAttrs.version}/00-RELEASENOTES";
+    maintainers = lib.teams.helsinki-systems.members;
     mainProgram = "keydb-cli";
   };
-}
+})

--- a/pkgs/by-name/la/lager/package.nix
+++ b/pkgs/by-name/la/lager/package.nix
@@ -8,15 +8,17 @@
 , zug
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lager";
   version = "0.1.0";
+
   src = fetchFromGitHub {
     owner = "arximboldi";
     repo = "lager";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-KTHrVV/186l4klwlcfDwFsKVoOVqWCUPzHnIbWuatbg=";
   };
+
   buildInputs = [
     boost
     immer
@@ -28,10 +30,11 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-Dlager_BUILD_EXAMPLES=OFF"
   ];
-  meta = with lib; {
-    homepage    = "https://github.com/arximboldi/lager";
+
+  meta = {
+    homepage = "https://github.com/arximboldi/lager";
     description = "C++ library for value-oriented design using the unidirectional data-flow architecture — Redux for C++";
-    license     = licenses.mit;
-    maintainers = with maintainers; [ nek0 ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nek0 ];
   };
-}
+})

--- a/pkgs/by-name/sy/syslogng/package.nix
+++ b/pkgs/by-name/sy/syslogng/package.nix
@@ -59,14 +59,14 @@ let
   ];
   py = python3.withPackages python-deps;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "syslog-ng";
   version = "4.7.1";
 
   src = fetchFromGitHub {
     owner = "syslog-ng";
     repo = "syslog-ng";
-    rev = "syslog-ng-${version}";
+    rev = "syslog-ng-${finalAttrs.version}";
     hash = "sha256-runFMUxQv7B023I38QfGqn89ZbzA5vMXHOOkYwMxArI=";
     fetchSubmodules = true;
   };
@@ -117,11 +117,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://www.syslog-ng.com";
     description = "Next-generation syslogd with advanced networking and filtering capabilities";
-    license = with licenses; [ gpl2Plus lgpl21Plus ];
-    maintainers = with maintainers; [ vifino ];
-    platforms = platforms.linux;
+    license = with lib.licenses; [ gpl2Plus lgpl21Plus ];
+    maintainers = with lib.maintainers; [ vifino ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/games/abuse/default.nix
+++ b/pkgs/games/abuse/default.nix
@@ -4,14 +4,14 @@
 , SDL2, SDL2_mixer, freepats
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname   = "abuse";
   version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "Xenoveritas";
-    repo = pname;
-    rev = "v${version}";
+    repo = "abuse";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-eneu0HxEoM//Ju2XMHnDMZ/igeVMPSLg7IaxR2cnJrk=";
   };
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = ''
-    cp --reflink=auto -r ${data}/data/sfx ${data}/data/music data/
+    cp --reflink=auto -r ${finalAttrs.data}/data/sfx ${finalAttrs.data}/data/music data/
   '';
 
   desktopItems = [ (makeDesktopItem {
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     substituteAll "${./abuse.sh}" $out/bin/abuse
     chmod +x $out/bin/abuse
 
-    install -Dm644 ${data}/doc/abuse.png $out/share/pixmaps/abuse.png
+    install -Dm644 ${finalAttrs.data}/doc/abuse.png $out/share/pixmaps/abuse.png
   '';
 
   env.NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL2}/include/SDL2";
@@ -49,16 +49,16 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ copyDesktopItems cmake ];
   buildInputs       = [ SDL2 SDL2_mixer freepats ];
 
-  meta = with lib; {
+  meta = {
     description = "Side-scroller action game that pits you against ruthless alien killers";
     homepage    = "http://abuse.zoy.org/";
-    license     = with licenses; [ unfree ];
+    license     = lib.licenses.unfree;
     # Most of abuse is free (public domain, GPL2+, WTFPL), however the creator
     # of its sfx and music only gave Debian permission to redistribute the
     # files. Our friends from Debian thought about it some more:
     # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=648272
-    maintainers = with maintainers; [ iblech ];
-    platforms   = platforms.unix;
+    maintainers = with lib.maintainers; [ iblech ];
+    platforms   = lib.platforms.unix;
     broken      = stdenv.isDarwin;
   };
-}
+})

--- a/pkgs/games/steam/runtime.nix
+++ b/pkgs/games/steam/runtime.nix
@@ -4,16 +4,16 @@
 , writeShellScript, curl, nix-update
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
 
   pname = "steam-runtime";
   # from https://repo.steampowered.com/steamrt-images-scout/snapshots/latest-steam-client-general-availability/VERSION.txt
   version = "0.20231127.68515";
 
   src = fetchurl {
-    url = "https://repo.steampowered.com/steamrt-images-scout/snapshots/${version}/steam-runtime.tar.xz";
-    sha256 = "sha256-invUOdJGNhrswsj9Vj/bSAkEigWtBQ554sBAyvPf0mk=";
-    name = "scout-runtime-${version}.tar.gz";
+    url = "https://repo.steampowered.com/steamrt-images-scout/snapshots/${finalAttrs.version}/steam-runtime.tar.xz";
+    hash = "sha256-invUOdJGNhrswsj9Vj/bSAkEigWtBQ554sBAyvPf0mk=";
+    name = "scout-runtime-${finalAttrs.version}.tar.gz";
   };
 
   buildCommand = ''
@@ -28,10 +28,10 @@ stdenv.mkDerivation rec {
     '';
   };
 
-  meta = with lib; {
+  meta = {
     description = "The official runtime used by Steam";
     homepage = "https://github.com/ValveSoftware/steam-runtime";
-    license = licenses.unfreeRedistributable; # Includes NVIDIA CG toolkit
-    maintainers = with maintainers; [ hrdinka abbradar ];
+    license = lib.licenses.unfreeRedistributable; # Includes NVIDIA CG toolkit
+    maintainers = with lib.maintainers; [ hrdinka abbradar ];
   };
-}
+})

--- a/pkgs/misc/sndio/default.nix
+++ b/pkgs/misc/sndio/default.nix
@@ -1,12 +1,12 @@
 { lib, stdenv, fetchurl, alsa-lib, fixDarwinDylibNames }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sndio";
   version = "1.9.0";
 
   src = fetchurl {
-    url = "https://www.sndio.org/sndio-${version}.tar.gz";
-    sha256 = "sha256-8wgm/JwH42nTkk1fzt9qClPA30rh9atQ/pzygFQPaZo=";
+    url = "https://www.sndio.org/sndio-${finalAttrs.version}.tar.gz";
+    hash = "sha256-8wgm/JwH42nTkk1fzt9qClPA30rh9atQ/pzygFQPaZo=";
   };
 
   nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
@@ -19,11 +19,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://www.sndio.org";
     description = "Small audio and MIDI framework part of the OpenBSD project";
-    license = licenses.isc;
-    maintainers = with maintainers; [ Madouura ];
-    platforms = platforms.all;
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ Madouura ];
+    platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/tools/misc/wv/default.nix
+++ b/pkgs/tools/misc/wv/default.nix
@@ -1,16 +1,18 @@
-{ lib, stdenv, fetchurl, zlib, imagemagick, libpng, glib, pkg-config, libgsf
+{ lib, stdenv, fetchFromGitHub, zlib, imagemagick, libpng, glib, pkg-config, libgsf
 , libxml2, bzip2
 , autoreconfHook
 , buildPackages
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "wv";
   version = "1.2.9";
 
-  src = fetchurl {
-    url = "http://www.abisource.com/downloads/${pname}/${version}/${pname}-${version}.tar.gz";
-    sha256 = "17f16lkdv1c3amaz2hagiicih59ynpp4786k1m2qa1sw68xhswsc";
+  src = fetchFromGitHub {
+    owner = "AbiWord";
+    repo = "wv";
+    rev = "wv-${builtins.replaceStrings ["."] ["-"] finalAttrs.version}";
+    hash = "sha256-xcC+/M1EzFqQFeF5Dw9qd8VIy7r8JdKMp2X/GHkFiPA=";
   };
 
   nativeBuildInputs = [ pkg-config autoreconfHook ];
@@ -30,8 +32,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
+    homepage = "https://github.com/AbiWord/wv";
     description = "Converter from Microsoft Word formats to human-editable ones";
     platforms = lib.platforms.unix;
     license = lib.licenses.gpl2;
   };
-}
+})

--- a/pkgs/tools/text/recode/default.nix
+++ b/pkgs/tools/text/recode/default.nix
@@ -8,13 +8,13 @@
 , libintl
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "recode";
   version = "3.7.14";
 
   # Use official tarball, avoid need to bootstrap/generate build system
   src = fetchurl {
-    url = "https://github.com/rrthomas/${pname}/releases/download/v${version}/${pname}-${version}.tar.gz";
+    url = "https://github.com/rrthomas/recode/releases/download/v${finalAttrs.version}/recode-${finalAttrs.version}.tar.gz";
     hash = "sha256-eGqv1USFGisTsKN36sFQD4IM5iYVzMLmMLUB53Q7nzM=";
   };
 
@@ -35,9 +35,9 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/rrthomas/recode";
     description = "Converts files between various character sets and usages";
     mainProgram = "recode";
-    changelog = "https://github.com/rrthomas/recode/raw/v${version}/NEWS";
+    changelog = "https://github.com/rrthomas/recode/raw/v${finalAttrs.version}/NEWS";
     platforms = lib.platforms.unix;
     license = with lib.licenses; [ lgpl3Plus gpl3Plus ];
     maintainers = with lib.maintainers; [ jcumming ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

- Transition from `rec`ursion to `finalAttrs`.
- Also explicitly mention `lib` in meta fields, when used.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
