### PR TITLE
maintainers: remove fogti

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6730,12 +6730,6 @@
     githubId = 5918766;
     name = "Franz Thoma";
   };
-  fogti = {
-    name = "Alain Fogtia Zscheile";
-    email = "fogti+devel@ytrizja.de";
-    github = "fogti";
-    githubId = 1618343;
-  };
   foo-dogsquared = {
     email = "foodogsquared@foodogsquared.one";
     github = "foo-dogsquared";

--- a/pkgs/development/libraries/audio/zix/default.nix
+++ b/pkgs/development/libraries/audio/zix/default.nix
@@ -47,9 +47,6 @@ stdenv.mkDerivation rec {
     changelog = "https://gitlab.com/drobilla/zix/-/blob/${src.rev}/NEWS";
     license = licenses.isc;
     platforms = platforms.unix;
-    maintainers = with maintainers; [
-      fogti
-      yuu
-    ];
+    maintainers = with maintainers; [ yuu ];
   };
 }

--- a/pkgs/development/libraries/libowlevelzs/default.nix
+++ b/pkgs/development/libraries/libowlevelzs/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     description = "Zscheile Lowlevel (utility) library";
     homepage = "https://github.com/fogti/libowlevelzs";
     license = licenses.mit;
-    maintainers = [ maintainers.fogti ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/os-specific/linux/libnvme/default.nix
+++ b/pkgs/os-specific/linux/libnvme/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "C Library for NVM Express on Linux";
     homepage = "https://github.com/linux-nvme/libnvme";
-    maintainers = with maintainers; [ fogti vifino ];
+    maintainers = with maintainers; [ vifino ];
     license = with licenses; [ lgpl21Plus ];
     platforms = platforms.linux;
   };

--- a/pkgs/os-specific/linux/libzbc/default.nix
+++ b/pkgs/os-specific/linux/libzbc/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "ZBC device manipulation library";
     homepage = "https://github.com/westerndigitalcorporation/libzbc";
-    maintainers = [ maintainers.fogti ];
+    maintainers = [ ];
     license = with licenses; [ bsd2 lgpl3Plus ];
     platforms = platforms.linux;
   };

--- a/pkgs/os-specific/linux/libzbd/default.nix
+++ b/pkgs/os-specific/linux/libzbd/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     description = "Zoned block device manipulation library and tools";
     mainProgram = "zbd";
     homepage = "https://github.com/westerndigitalcorporation/libzbd";
-    maintainers = [ maintainers.fogti ];
+    maintainers = [ ];
     license = with licenses; [ lgpl3Plus gpl3Plus ];
     platforms = platforms.linux;
   };

--- a/pkgs/tools/archivers/rpm2targz/default.nix
+++ b/pkgs/tools/archivers/rpm2targz/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     description = "Convert a .rpm file to a .tar.gz archive";
     homepage = "http://slackware.com/config/packages.php";
     license = licenses.bsd1;
-    maintainers = [ maintainers.fogti ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/misc/digitemp/default.nix
+++ b/pkgs/tools/misc/digitemp/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://www.digitemp.com";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.fogti ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/networking/apc-temp-fetch/default.nix
+++ b/pkgs/tools/networking/apc-temp-fetch/default.nix
@@ -30,6 +30,6 @@ buildPythonApplication rec {
     description = "unified temperature fetcher interface to several UPS network adapters";
     homepage = "https://github.com/YZITE/APC_Temp_fetch";
     license = licenses.asl20;
-    maintainers = [ maintainers.fogti ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/tools/networking/zs-apc-spdu-ctl/default.nix
+++ b/pkgs/tools/networking/zs-apc-spdu-ctl/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "APC SPDU control utility";
     license = licenses.mit;
-    maintainers = [ maintainers.fogti ];
+    maintainers = [ ];
     platforms = platforms.linux;
     mainProgram = "zs-apc-spdu-ctl";
   };

--- a/pkgs/tools/networking/zs-wait4host/default.nix
+++ b/pkgs/tools/networking/zs-wait4host/default.nix
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Wait for a host to come up/go down";
     homepage = "https://ytrizja.de/";
     license = licenses.gpl3Plus;
-    maintainers = [ maintainers.fogti ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/text/zstxtns-utils/default.nix
+++ b/pkgs/tools/text/zstxtns-utils/default.nix
@@ -33,7 +33,7 @@ stdenvNoCC.mkDerivation rec {
     description = "utilities to deal with text based name service databases";
     homepage = "https://ytrizja.de/";
     license = licenses.gpl3Plus;
-    maintainers = [ maintainers.fogti ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
This essentially echos the sentiment of #306702, #307173, #307186.
Recent controversies, the debate around moderation and around the Andur'l sponsorship has made it apparent that I don't want to be part of this community anymore.  The problems around the maintenance of the Nix package manager were apparent to me for a long time, and sufficed for me to try to build my own similar systems (see also [RIIR Nix](https://riir-nix.github.io/)). This collection of problems and their history first somewhat drove me away from this, it now becomes apparent that I don't want to return given these circumstances.

Feel free to remove the following packages, which were essentially personal tools:
- `apc-temp-fetch`: this is outdated anyways, it needs `flit` to build now, see also: https://github.com/fogti/portage-zscheile/blob/53bcaab3e9c92a0fe63194f548b146b1df12814f/net-analyzer/APC-Temp-fetch/APC-Temp-fetch-0.0.9.ebuild
- `libowlevelzs`
- `zs-apc-spdu-ctl`
- `zs-wait4host`
- `zstxtns-utils`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
