### PR TITLE
[23.11] sngrep: add patch for CVE-2024-3119 & CVE-2024-3120

### DIFF
--- a/pkgs/applications/networking/sniffers/sngrep/1.7.0-CVE-2024-3119-CVE-2024-3120.patch
+++ b/pkgs/applications/networking/sniffers/sngrep/1.7.0-CVE-2024-3119-CVE-2024-3120.patch
@@ -1,0 +1,74 @@
+Based on upstream dd5fec92730562af6f96891291cd4e102b80bfcc, adjusted to
+apply cleanly to 1.7.0
+
+diff --git a/src/sip.c b/src/sip.c
+index 20a2d81..f2dde5c 100644
+--- a/src/sip.c
++++ b/src/sip.c
+@@ -264,7 +264,7 @@ sip_validate_packet(packet_t *packet)
+     uint32_t plen = packet_payloadlen(packet);
+     u_char payload[MAX_SIP_PAYLOAD];
+     regmatch_t pmatch[4];
+-    char cl_header[10];
++    char cl_header[MAX_CONTENT_LENGTH_SIZE];
+     int content_len;
+     int bodylen;
+ 
+@@ -291,7 +291,15 @@ sip_validate_packet(packet_t *packet)
+         return VALIDATE_PARTIAL_SIP;
+     }
+ 
+-    strncpy(cl_header, (const char *)payload +  pmatch[2].rm_so, (int)pmatch[2].rm_eo - pmatch[2].rm_so);
++    // Ensure the copy length does not exceed MAX_CONTENT_LENGTH_SIZE - 1
++    int cl_match_len = pmatch[2].rm_eo - pmatch[2].rm_so;
++    if (cl_match_len > MAX_CONTENT_LENGTH_SIZE - 1) {
++        cl_match_len = MAX_CONTENT_LENGTH_SIZE - 1;
++    }
++
++    strncpy(cl_header, (const char *)payload +  pmatch[2].rm_so, cl_match_len);
++    cl_header[cl_match_len] = '\0'; // Ensuring null termination
++
+     content_len = atoi(cl_header);
+ 
+     // Check if we have Body separator field
+@@ -756,7 +764,7 @@ void
+ sip_parse_extra_headers(sip_msg_t *msg, const u_char *payload)
+ {
+     regmatch_t pmatch[4];
+-    char warning[10];
++    char warning[MAX_WARNING_SIZE];
+ 
+      // Reason text
+      if (regexec(&calls.reg_reason, (const char *)payload, 2, pmatch, 0) == 0) {
+@@ -766,8 +774,16 @@ sip_parse_extra_headers(sip_msg_t *msg, const u_char *payload)
+ 
+      // Warning code
+      if (regexec(&calls.reg_warning, (const char *)payload, 2, pmatch, 0) == 0) {
+-         strncpy(warning, (const char *)payload +  pmatch[1].rm_so, (int)pmatch[1].rm_eo - pmatch[1].rm_so);
+-         msg->call->warning = atoi(warning);
++
++        // Ensure the copy length does not exceed MAX_WARNING_SIZE - 1
++        int warning_match_len = pmatch[1].rm_eo - pmatch[1].rm_so;
++        if (warning_match_len > MAX_WARNING_SIZE - 1) {
++            warning_match_len = MAX_WARNING_SIZE - 1;
++        }
++        strncpy(warning, (const char *)payload +  pmatch[1].rm_so, warning_match_len);
++        warning[warning_match_len] = '\0'; // Ensuring null termination
++
++        msg->call->warning = atoi(warning);
+      }
+ }
+ 
+diff --git a/src/sip.h b/src/sip.h
+index 78afdc2..a9fd06e 100644
+--- a/src/sip.h
++++ b/src/sip.h
+@@ -45,6 +45,8 @@
+ #include "hash.h"
+ 
+ #define MAX_SIP_PAYLOAD 10240
++#define MAX_CONTENT_LENGTH_SIZE 10
++#define MAX_WARNING_SIZE 10
+ 
+ //! Shorter declaration of sip_call_list structure
+ typedef struct sip_call_list sip_call_list_t;

--- a/pkgs/applications/networking/sniffers/sngrep/default.nix
+++ b/pkgs/applications/networking/sniffers/sngrep/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
       url = "https://github.com/irontec/sngrep/commit/ad1daf15c8387bfbb48097c25197bf330d2d98fc.patch";
       hash = "sha256-g8fxvxi3d7jmZEKTbxqw29hJbm/ShsKKxstsOUGxTug=";
     })
+    ./1.7.0-CVE-2024-3119-CVE-2024-3120.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2024-3119
https://nvd.nist.gov/vuln/detail/CVE-2024-3120

Unstable already addressed by 1.8.1.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
