### PR TITLE
tmuxp: add pyyaml as build dep, to fix build error

### DIFF
--- a/pkgs/tools/misc/tmuxp/default.nix
+++ b/pkgs/tools/misc/tmuxp/default.nix
@@ -1,13 +1,16 @@
 { lib, python3Packages, fetchPypi, installShellFiles }:
 
-python3Packages.buildPythonApplication rec {
+let
   pname = "tmuxp";
   version = "1.46.0";
+  hash = "sha256-+aXpsB4mjw9sZLalv3knW8okP+mh2P/nbZCiCwa3UBU=";
+in
+python3Packages.buildPythonApplication {
+  inherit pname version;
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-+aXpsB4mjw9sZLalv3knW8okP+mh2P/nbZCiCwa3UBU=";
+    inherit pname version hash;
   };
 
   nativeBuildInputs = [
@@ -31,12 +34,12 @@ python3Packages.buildPythonApplication rec {
       --zsh <(shtab --shell=zsh -u tmuxp.cli.create_parser)
   '';
 
-  meta = with lib; {
+  meta = {
     description = "tmux session manager";
     homepage = "https://tmuxp.git-pull.com/";
     changelog = "https://github.com/tmux-python/tmuxp/raw/v${version}/CHANGES";
-    license = licenses.mit;
-    maintainers = with maintainers; [ peterhoeg otavio ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ peterhoeg otavio ];
     mainProgram = "tmuxp";
   };
 }

--- a/pkgs/tools/misc/tmuxp/default.nix
+++ b/pkgs/tools/misc/tmuxp/default.nix
@@ -39,7 +39,7 @@ python3Packages.buildPythonApplication {
     homepage = "https://tmuxp.git-pull.com/";
     changelog = "https://github.com/tmux-python/tmuxp/raw/v${version}/CHANGES";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ peterhoeg otavio ];
+    maintainers = with lib.maintainers; [ otavio ];
     mainProgram = "tmuxp";
   };
 }

--- a/pkgs/tools/misc/tmuxp/default.nix
+++ b/pkgs/tools/misc/tmuxp/default.nix
@@ -19,6 +19,7 @@ python3Packages.buildPythonApplication rec {
   propagatedBuildInputs = with python3Packages; [
     colorama
     libtmux
+    pyyaml
   ];
 
   # No tests in archive


### PR DESCRIPTION
## Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/307046
- adds pyyaml as build dependency, so nix does not complain :)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
