### PR TITLE
flips: unstable-2023-03-15 -> unstable-2024-04-17, add jchw as maintainer

### DIFF
--- a/pkgs/tools/compression/flips/default.nix
+++ b/pkgs/tools/compression/flips/default.nix
@@ -1,18 +1,32 @@
-{ lib, stdenv, fetchFromGitHub, gtk3, libdivsufsort, pkg-config, wrapGAppsHook }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gtk3,
+  libdivsufsort,
+  pkg-config,
+  wrapGAppsHook,
+}:
 
 stdenv.mkDerivation {
   pname = "flips";
-  version = "unstable-2023-03-15";
+  version = "unstable-2024-04-17";
 
   src = fetchFromGitHub {
     owner = "Alcaro";
     repo = "Flips";
-    rev = "fdd5c6e34285beef5b9be759c9b91390df486c66";
-    hash = "sha256-uuHgpt7aWqiMTUILm5tAEGGeZrls3g/DdylYQgsfpTw=";
+    rev = "20b0da9ab95d23da89f821bbddedb11b8e0e6531";
+    hash = "sha256-/i/0FvZqMvG4FFIKaOtUe0A5BfG4NXjpBfLYIQOFky8=";
   };
 
-  nativeBuildInputs = [ pkg-config wrapGAppsHook ];
-  buildInputs = [ gtk3 libdivsufsort ];
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook
+  ];
+  buildInputs = [
+    gtk3
+    libdivsufsort
+  ];
   patches = [ ./use-system-libdivsufsort.patch ];
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
   buildPhase = ''
@@ -25,7 +39,7 @@ stdenv.mkDerivation {
     description = "A patcher for IPS and BPS files";
     homepage = "https://github.com/Alcaro/Flips";
     license = licenses.gpl3Plus;
-    maintainers = [ ];
+    maintainers = [ maintainers.jchw ];
     platforms = platforms.linux;
     mainProgram = "flips";
   };


### PR DESCRIPTION
## Description of changes

Re: the version update; there aren't many important changes. The main differences are related to the file dialog, which has had several bugfixes and was migrated to use GtkFileChooserNative. (This was now deprecated in favor of Gtk.FileDialog apparently, but oh well.)

More importantly, this package no longer has a maintainer, unfortunately. I would like to step up as a maintainer.

As an aside, I also allowed my editor to auto-format using the new RFC formatting. There were very few changes, so I did not separate it into another commit.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
