### PR TITLE
python312Packages.{islpy,loopy}: fix build, add missing deps, refactor and adopt

### DIFF
--- a/pkgs/development/python-modules/loopy/default.nix
+++ b/pkgs/development/python-modules/loopy/default.nix
@@ -1,39 +1,47 @@
-{ lib
-, buildPythonPackage
-, codepy
-, cgen
-, colorama
-, fetchFromGitHub
-, genpy
-, islpy
-, mako
-, numpy
-, pymbolic
-, pyopencl
-, pyrsistent
-, pythonOlder
-, pytools
+{
+  lib,
+  buildPythonPackage,
+  codepy,
+  cgen,
+  colorama,
+  fetchFromGitHub,
+  genpy,
+  immutables,
+  islpy,
+  mako,
+  numpy,
+  pymbolic,
+  pyopencl,
+  pyrsistent,
+  pythonOlder,
+  pytools,
+  setuptools,
+  typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "loopy";
   version = "2024.1";
-  format = "setuptools";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "inducer";
-    repo = pname;
+    repo = "loopy";
     rev = "refs/tags/v${version}";
-    hash = "sha256-R0Wry4r8Y7VKqsyrZ3odEOUy4T9di9rFQzq7BD0LG58=";
+    hash = "sha256-mU8vXEPR88QpJpzXZlZdDhMtlwIx5YpeYhXU8Vw2T9g=";
+    fetchSubmodules = true; # submodule at `loopy/target/c/compyte`
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     codepy
     cgen
     colorama
     genpy
+    immutables
     islpy
     mako
     numpy
@@ -41,15 +49,22 @@ buildPythonPackage rec {
     pyopencl
     pyrsistent
     pytools
+    typing-extensions
   ];
+
+  postConfigure = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  pythonImportsCheck = [ "loopy" ];
 
   # pyopencl._cl.LogicError: clGetPlatformIDs failed: PLATFORM_NOT_FOUND_KHR
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "A code generator for array-based code on CPUs and GPUs";
     homepage = "https://github.com/inducer/loopy";
-    license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tomasajt ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5907,7 +5907,9 @@ self: super: with self; {
 
   isbnlib = callPackage ../development/python-modules/isbnlib { };
 
-  islpy = callPackage ../development/python-modules/islpy { };
+  islpy = callPackage ../development/python-modules/islpy {
+    isl = pkgs.isl_0_24;
+  };
 
   iso3166 = callPackage ../development/python-modules/iso3166 { };
 


### PR DESCRIPTION
## Description of changes

ZHF: #309482

I was trying to use the `loopy` package when I discovered that it one of its dependencies (`islpy`) broke in an earlier python-version bump.
This PR addresses the breakage and does some cleanup and refactoring to both.

Changes to `islpy`
- use GitHub source
- use `pyproject = true`
- bump python req
- use highest `isl` version on nixpkgs (the default version of `isl` is too low for building this package)
- use `configure.py` to tell it to use `isl` provided by nixpkgs
- add myself as the maintainer

Changes to `loopy`
- fetch missed git submodules
- bump python req
- use `pyproject = true`
  - this revealed missing dependencies
- add missing depenencies
- add pythonImportsCheck
  - importing the package needs the `HOME` directory to be set
- add myself as the maintainer

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
