### PR TITLE
maintainers: remove andrew-d as a maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1247,12 +1247,6 @@
     githubId = 962885;
     name = "Andrew Chambers";
   };
-  andrew-d = {
-    email = "andrew@du.nham.ca";
-    github = "andrew-d";
-    githubId = 1079173;
-    name = "Andrew Dunham";
-  };
   andrewrk = {
     email = "superjoe30@gmail.com";
     github = "andrewrk";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -32,7 +32,6 @@ with lib.maintainers; {
   acme = {
     members = [
       aanderse
-      andrew-d
       arianvp
       emily
       flokli

--- a/nixos/tests/gvisor.nix
+++ b/nixos/tests/gvisor.nix
@@ -3,7 +3,7 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "gvisor";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ andrew-d ];
+    maintainers = [ ];
   };
 
   nodes = {

--- a/pkgs/applications/graphics/xournalpp/default.nix
+++ b/pkgs/applications/graphics/xournalpp/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://xournalpp.github.io/";
     changelog   = "https://github.com/xournalpp/xournalpp/blob/v${version}/CHANGELOG.md";
     license     = licenses.gpl2Plus;
-    maintainers = with maintainers; [ andrew-d sikmir ];
+    maintainers = with maintainers; [ sikmir ];
     platforms   = platforms.unix;
     mainProgram = "xournalpp";
   };

--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -66,7 +66,7 @@ let
         description = "Open Source Continuous File Synchronization";
         changelog = "https://github.com/syncthing/syncthing/releases/tag/v${version}";
         license = licenses.mpl20;
-        maintainers = with maintainers; [ joko peterhoeg andrew-d ];
+        maintainers = with maintainers; [ joko peterhoeg ];
         mainProgram = target;
         platforms = platforms.unix;
       };

--- a/pkgs/applications/radio/dsd/default.nix
+++ b/pkgs/applications/radio/dsd/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/szechyjs/dsd";
     license = licenses.gpl2;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ andrew-d ];
+    maintainers = with maintainers; [ ];
     mainProgram = "dsd";
   };
 }

--- a/pkgs/by-name/gv/gvisor/package.nix
+++ b/pkgs/by-name/gv/gvisor/package.nix
@@ -46,7 +46,7 @@ buildGoModule {
     description = "Application Kernel for Containers";
     homepage = "https://github.com/google/gvisor";
     license = licenses.asl20;
-    maintainers = with maintainers; [ andrew-d gpl ];
+    maintainers = with maintainers; [ gpl ];
     platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 }

--- a/pkgs/development/libraries/audio/mbelib/default.nix
+++ b/pkgs/development/libraries/audio/mbelib/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/szechyjs/mbelib";
     license = licenses.isc;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ andrew-d ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/libraries/science/math/itpp/default.nix
+++ b/pkgs/development/libraries/science/math/itpp/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     homepage = "https://itpp.sourceforge.net/";
     license = licenses.gpl3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ andrew-d ];
+    maintainers = with maintainers; [ ];
     broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/itpp.x86_64-darwin
   };
 }

--- a/pkgs/development/python-modules/m2crypto/default.nix
+++ b/pkgs/development/python-modules/m2crypto/default.nix
@@ -50,6 +50,6 @@ buildPythonPackage rec {
     homepage = "https://gitlab.com/m2crypto/m2crypto";
     changelog = "https://gitlab.com/m2crypto/m2crypto/-/blob/${version}/CHANGES";
     license = licenses.mit;
-    maintainers = with maintainers; [ andrew-d ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/X11/xloadimage/default.nix
+++ b/pkgs/tools/X11/xloadimage/default.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation rec {
 
     license = lib.licenses.gpl2Plus;
 
-    maintainers = with lib.maintainers; [ andrew-d ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;  # arbitrary choice
   };
 }

--- a/pkgs/tools/misc/massren/default.nix
+++ b/pkgs/tools/misc/massren/default.nix
@@ -39,7 +39,7 @@ buildGoModule rec {
     description = "Easily rename multiple files using your text editor";
     license = licenses.mit;
     homepage = "https://github.com/laurent22/massren";
-    maintainers = with maintainers; [ andrew-d ];
+    maintainers = with maintainers; [ ];
     mainProgram = "massren";
   };
 }

--- a/pkgs/tools/networking/gping/default.nix
+++ b/pkgs/tools/networking/gping/default.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/orf/gping";
     changelog = "https://github.com/orf/gping/releases/tag/gping-v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ andrew-d ];
+    maintainers = with maintainers; [ ];
     mainProgram = "gping";
   };
 }

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -11383,7 +11383,7 @@ with self; {
     propagatedBuildInputs = [ DateCalc ];
     meta = {
       description = "Finnish APRS Parser (Fabulous APRS Parser)";
-      maintainers = with maintainers; [ andrew-d ];
+      maintainers = with maintainers; [ ];
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };


### PR DESCRIPTION
I am deeply saddened at the fact that I need to do this. I have no interest in re-litigating everything that has happened over the past weeks and months, but I want to make my position(s) extremely clear:

The thought of any of my work contributing to someone's death by drone makes me feel physically ill.

Recent communications from senior members of the NixOS community have made it clear that leadership is unaware or uninterested in the basics of how to run and moderate a community in a way that is resilient to bad actors. The recent post by @edolstra is oblivious, and gives me no confidence that the Nix/NixOS community is a place that I want to remain involved in going forward. I am thus choosing to remove myself from such a community.

I also hereby resign from the ACME team.

See also: #307033