### PR TITLE
inputmodule: init inputmodule-control (pkg), init inputmodule (module)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11860,6 +11860,12 @@
     githubId = 148352;
     name = "Jim Fowler";
   };
+  Kitt3120 = {
+    email = "nixpkgs@schweren.dev";
+    github = "Kitt3120";
+    githubId = 10689811;
+    name = "Torben Schweren";
+  };
   kittywitch = {
     email = "kat@inskip.me";
     github = "kittywitch";

--- a/nixos/modules/hardware/inputmodule.nix
+++ b/nixos/modules/hardware/inputmodule.nix
@@ -1,0 +1,15 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  options.hardware.inputmodule.enable = lib.mkEnableOption ''Support for Framework input modules'';
+
+  config = lib.mkIf config.hardware.inputmodule.enable {
+    environment.systemPackages = [ pkgs.inputmodule-control ];
+    services.udev.packages = [ pkgs.inputmodule-control ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -71,6 +71,7 @@
   ./hardware/hackrf.nix
   ./hardware/i2c.nix
   ./hardware/infiniband.nix
+  ./hardware/inputmodule.nix
   ./hardware/keyboard/qmk.nix
   ./hardware/keyboard/teck.nix
   ./hardware/keyboard/uhk.nix

--- a/pkgs/by-name/in/inputmodule-control/package.nix
+++ b/pkgs/by-name/in/inputmodule-control/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  testers,
+  rustPlatform,
+  fetchFromGitHub,
+  inputmodule-control,
+  pkg-config,
+  libudev-zero,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "inputmodule-control";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "FrameworkComputer";
+    repo = "inputmodule-rs";
+    rev = "v${version}";
+    hash = "sha256-5sqTkaGqmKDDH7byDZ84rzB3FTu9AKsWxA6EIvUrLCU=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-s5k23p0Fo+DQvGpDvy/VmGNFK7ZysqLIyDPuUn6n724=";
+
+  buildAndTestSubdir = "inputmodule-control";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libudev-zero ];
+
+  postInstall = ''
+    install -Dm644 release/50-framework-inputmodule.rules $out/etc/udev/rules.d/50-framework-inputmodule.rules
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = inputmodule-control;
+  };
+
+  meta = {
+    description = "CLI tool to control Framework input modules like the LED matrix";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "inputmodule-control";
+    homepage = "https://github.com/FrameworkComputer/inputmodule-rs";
+    downloadPage = "https://github.com/FrameworkComputer/inputmodule-rs/releases/tag/${src.rev}";
+    changelog = "https://github.com/FrameworkComputer/inputmodule-rs/releases/tag/${src.rev}";
+    maintainers = with lib.maintainers; [ Kitt3120 ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This adds support for Framework input modules, like the LED matrix module.

I added an `inputmodule-control` pkg which builds the binary of the official CLI tool by Framework. It also provides udev rules when added to the list of udev packages, which allow for rootless access to input modules. The udev rules are also provided by Framework. It's fetched from GitHub using fetchFromGitHub and builds using buildRustPackage.

I additionally added a NixOS module that adds the option `hardware.inputmodule.enable`. Setting it to `true` adds `inputmodule-control` pkg to `config.environment.systemPackages` and `config.services.udev.packages`.

Repo: https://github.com/FrameworkComputer/inputmodule-rs

Release: https://github.com/FrameworkComputer/inputmodule-rs/releases/tag/v0.2.0

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
