### PR TITLE
petsc: fix build by detecting updated UCX warning message in patch

### DIFF
--- a/pkgs/development/libraries/science/math/petsc/filter_mpi_warnings.patch
+++ b/pkgs/development/libraries/science/math/petsc/filter_mpi_warnings.patch
@@ -1,12 +1,12 @@
 diff --git a/src/snes/tutorials/makefile b/src/snes/tutorials/makefile
-index 168febb34b6..71068469066 100644
+index 672a62a..a5fd1c4 100644
 --- a/src/snes/tutorials/makefile
 +++ b/src/snes/tutorials/makefile
 @@ -13,6 +13,7 @@ include ${PETSC_DIR}/lib/petsc/conf/rules
  #  these tests are used by the makefile in PETSC_DIR for basic tests of the install and should not be removed
  testex5f: ex5f.PETSc
  	-@${MPIEXEC} -n 1 ${MPIEXEC_TAIL} ./ex5f -snes_rtol 1e-4 > ex5f_1.tmp 2>&1; \
-+        sed -i '/hwloc\/linux/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex5f_1.tmp; \
++        sed -i '/hwloc\/linux/d ; /ERROR scandir(\/sys\/class\/net) failed/d' ex5f_1.tmp; \
          if (${DIFF} output/ex5f_1.testout ex5f_1.tmp > /dev/null 2>&1) then \
            echo "Fortran example src/snes/tutorials/ex5f run successfully with 1 MPI process"; \
          else \
@@ -14,7 +14,7 @@ index 168febb34b6..71068469066 100644
          ${MAKE} PETSC_ARCH=${PETSC_ARCH} PETSC_DIR=${PETSC_DIR} ex5f.rm;
  testex19: ex19.PETSc
  	-@${MPIEXEC} -n 1 ${MPIEXEC_TAIL} ./ex19 -da_refine 3 -pc_type mg -ksp_type fgmres  > ex19_1.tmp 2>&1; \
-+        sed -i '/hwloc\/linux/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
++        sed -i '/hwloc\/linux/d ; /ERROR scandir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
          if (${DIFF} output/ex19_1.testout ex19_1.tmp > /dev/null 2>&1) then \
            echo "C/C++ example src/snes/tutorials/ex19 run successfully with 1 MPI process"; \
          else \
@@ -22,7 +22,7 @@ index 168febb34b6..71068469066 100644
          ${RM} -f ex19_1.tmp;
  testex19_mpi:
  	-@${MPIEXEC} -n 2 ${MPIEXEC_TAIL} ./ex19 -da_refine 3 -pc_type mg -ksp_type fgmres  > ex19_1.tmp 2>&1; \
-+        sed -i '/hwloc\/linux/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
++        sed -i '/hwloc\/linux/d ; /ERROR scandir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
          if (${DIFF} output/ex19_1.testout ex19_1.tmp > /dev/null 2>&1) then \
            echo "C/C++ example src/snes/tutorials/ex19 run successfully with 2 MPI processes"; \
          else \
@@ -30,7 +30,7 @@ index 168febb34b6..71068469066 100644
  #use unpreconditioned norm because HYPRE device installations use different AMG parameters
  runex19_hypre:
  	-@${MPIEXEC} -n 2 ${MPIEXEC_TAIL} ./ex19 -da_refine 3 -snes_monitor_short -ksp_norm_type unpreconditioned -pc_type hypre > ex19_1.tmp 2>&1; \
-+        sed -i '/hwloc\/linux/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
++        sed -i '/hwloc\/linux/d ; /ERROR scandir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
            if (${DIFF} output/ex19_hypre.out ex19_1.tmp) then \
              echo "C/C++ example src/snes/tutorials/ex19 run successfully with hypre"; \
            else  \
@@ -38,7 +38,7 @@ index 168febb34b6..71068469066 100644
            ${RM} -f ex19_1.tmp
  runex19_hypre_cuda:
  	-@${MPIEXEC} -n 2 ${MPIEXEC_TAIL} ./ex19 -dm_vec_type cuda -dm_mat_type aijcusparse -da_refine 3 -snes_monitor_short -ksp_norm_type unpreconditioned -pc_type hypre > ex19_1.tmp 2>&1; \
-+        sed -i '/hwloc\/linux/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
++        sed -i '/hwloc\/linux/d ; /ERROR scandir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
  	   if (${DIFF} output/ex19_hypre.out ex19_1.tmp) then \
             echo "C/C++ example src/snes/tutorials/ex19 run successfully with hypre/cuda"; \
             else  \
@@ -46,7 +46,7 @@ index 168febb34b6..71068469066 100644
  	   ${RM} -f ex19_1.tmp
  runex19_hypre_hip:
  	-@${MPIEXEC} -n 2 ${MPIEXEC_TAIL} ./ex19 -dm_vec_type hip -da_refine 3 -snes_monitor_short -ksp_norm_type unpreconditioned -pc_type hypre > ex19_1.tmp 2>&1; \
-+        sed -i '/hwloc\/linux/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
++        sed -i '/hwloc\/linux/d ; /ERROR scandir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
  	   if (${DIFF} output/ex19_hypre.out ex19_1.tmp) then \
             echo "C/C++ example src/snes/tutorials/ex19 run successfully with hypre/hip"; \
             else \
@@ -54,7 +54,7 @@ index 168febb34b6..71068469066 100644
  	   ${RM} -f ex19_1.tmp
  runex19_cuda:
  	-@${MPIEXEC} -n 1 ${MPIEXEC_TAIL} ./ex19 -snes_monitor -dm_mat_type seqaijcusparse -dm_vec_type seqcuda -pc_type gamg -pc_gamg_esteig_ksp_max_it 10 -ksp_monitor -mg_levels_ksp_max_it 3  > ex19_1.tmp 2>&1; \
-+        sed -i '/hwloc\/linux/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
++        sed -i '/hwloc\/linux/d ; /ERROR scandir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
  	   if (${DIFF} output/ex19_cuda_1.out ex19_1.tmp) then \
             echo "C/C++ example src/snes/tutorials/ex19 run successfully with cuda"; \
             else  \
@@ -62,7 +62,7 @@ index 168febb34b6..71068469066 100644
  	   ${RM} -f ex19_1.tmp
  runex19_ml:
  	-@${MPIEXEC} -n 2 ${MPIEXEC_TAIL} ./ex19 -da_refine 3 -snes_monitor_short -pc_type ml > ex19_1.tmp 2>&1; \
-+        sed -i '/hwloc\/linux/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
++        sed -i '/hwloc\/linux/d ; /ERROR scandir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
  	   if (${DIFF} output/ex19_ml.out ex19_1.tmp) then  \
             echo "C/C++ example src/snes/tutorials/ex19 run successfully with ml"; \
             else \
@@ -70,7 +70,7 @@ index 168febb34b6..71068469066 100644
             ${RM} -f ex19_1.tmp
  runex19_fieldsplit_mumps:
  	-@${MPIEXEC} -n 2 ${MPIEXEC_TAIL} ./ex19 -pc_type fieldsplit -pc_fieldsplit_block_size 4 -pc_fieldsplit_type SCHUR -pc_fieldsplit_0_fields 0,1,2 -pc_fieldsplit_1_fields 3 -fieldsplit_0_pc_type lu -fieldsplit_1_pc_type lu -snes_monitor_short -ksp_monitor_short  -fieldsplit_0_pc_factor_mat_solver_type mumps -fieldsplit_1_pc_factor_mat_solver_type mumps > ex19_6.tmp 2>&1; \
-+        sed -i '/hwloc\/linux/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_6.tmp; \
++        sed -i '/hwloc\/linux/d ; /ERROR scandir(\/sys\/class\/net) failed/d' ex19_6.tmp; \
  	   if (${DIFF} output/ex19_fieldsplit_5.out ex19_6.tmp) then  \
             echo "C/C++ example src/snes/tutorials/ex19 run successfully with mumps"; \
             else  \
@@ -78,7 +78,7 @@ index 168febb34b6..71068469066 100644
             ${RM} -f ex19_6.tmp
  runex19_superlu_dist:
  	-@${MPIEXEC} -n 1 ${MPIEXEC_TAIL} ./ex19 -da_grid_x 20 -da_grid_y 20 -pc_type lu -pc_factor_mat_solver_type superlu_dist > ex19.tmp 2>&1; \
-+        sed -i '/hwloc\/linux/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19.tmp; \
++        sed -i '/hwloc\/linux/d ; /ERROR scandir(\/sys\/class\/net) failed/d' ex19.tmp; \
  	   if (${DIFF} output/ex19_superlu.out ex19.tmp) then \
             echo "C/C++ example src/snes/tutorials/ex19 run successfully with superlu_dist"; \
             else  \
@@ -86,7 +86,7 @@ index 168febb34b6..71068469066 100644
  	   ${RM} -f ex19.tmp
  runex19_suitesparse:
  	-@${MPIEXEC} -n 1 ${MPIEXEC_TAIL} ./ex19 -da_refine 3 -snes_monitor_short -pc_type lu -pc_factor_mat_solver_type umfpack > ex19_1.tmp 2>&1; \
-+        sed -i '/hwloc\/linux/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
++        sed -i '/hwloc\/linux/d ; /ERROR scandir(\/sys\/class\/net) failed/d' ex19_1.tmp; \
  	   if (${DIFF} output/ex19_suitesparse.out ex19_1.tmp) then \
             echo "C/C++ example src/snes/tutorials/ex19 run successfully with suitesparse"; \
             else \
@@ -94,7 +94,7 @@ index 168febb34b6..71068469066 100644
  	   ${RM} -f ex19_1.tmp
  runex3k_kokkos: ex3k.PETSc
  	-@OMP_PROC_BIND=false ${MPIEXEC} -n 2 ${MPIEXEC_TAIL} ./ex3k -view_initial -dm_vec_type kokkos -dm_mat_type aijkokkos -use_gpu_aware_mpi 0 -snes_monitor > ex3k_1.tmp 2>&1 ;\
-+        sed -i '/hwloc\/linux/d ; /ERROR opendir(\/sys\/class\/net) failed/d' ex3k_1.tmp; \
++        sed -i '/hwloc\/linux/d ; /ERROR scandir(\/sys\/class\/net) failed/d' ex3k_1.tmp; \
  	if (${DIFF} output/ex3k_1.out ex3k_1.tmp) then \
            echo "C/C++ example src/snes/tutorials/ex3k run successfully with kokkos-kernels"; \
          else \


### PR DESCRIPTION
## Description of changes

Closes: https://github.com/NixOS/nixpkgs/issues/307298
See the issue for details.

After an UCX update, the warning messages changed, and the existing patch no longer blacklisted them properly. This PR addresses this by updating the patch.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
