### PR TITLE
python3Packages.ward: fix broken build

### DIFF
--- a/pkgs/development/python-modules/ward/default.nix
+++ b/pkgs/development/python-modules/ward/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "darrenburns";
     repo = "ward";
     rev = "refs/tags/release%2F${version}";
-    hash = "sha256-4dEMEEPySezgw3dIcYMl56HrhyaYlql9JvtamOn7Y8g=";
+    hash = "sha256-Qc209wGrBk5rPWR6vS17w9aQyydU6U/8QBD85LbJWV0=";
   };
 
   build-system = [
@@ -36,7 +36,15 @@ buildPythonPackage rec {
     rich
     tomli
     pprintpp
-    cucumber-tag-expressions
+    (cucumber-tag-expressions.overridePythonAttrs (_: rec {
+      version = "4.1.0";
+      src = fetchFromGitHub{
+        owner = "cucumber";
+        repo = "tag-expressions";
+        rev = "refs/tags/v${version}";
+        hash = "sha256-tKvLOAHi6CMWOW4qNeLkxInqoG4KJjmj7YtFZf4Bmi4=";
+      };
+    }))
     click-default-group
     click-completion
     pluggy


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

This PR fixes a build error for the Python package `ward` which I was encountering on nixos-unstable. Part of the build error message is included below for refrence:
```nix
error: builder for '/nix/store/sp03is988s3jj6kmalp20c6ssmamcdmy-python3.11-ward-0.68.0b0.drv' failed with exit code 1;
       last 10 log lines:
       > * Getting build dependencies for wheel...
       > * Building wheel...
       > Successfully built ward-0.67.0b0-py3-none-any.whl
       > Finished creating a wheel...
       > Finished executing pypaBuildPhase
       > Running phase: pythonRuntimeDepsCheckHook
       > Executing pythonRuntimeDepsCheck
       > Checking runtime dependencies for ward-0.67.0b0-py3-none-any.whl
       >   - cucumber-tag-expressions<5.0.0,>=2.0.0 not satisfied by version 6.1.0
       >   - rich<13.0.0,>=12.2.0 not satisfied by version 13.7.1
```
I think there are two issues which this PR seeks to address:
- The hash for version `0.68.0b0` of `ward` did not seem to be correctly specified and was loading in an older version of `ward`. I have updated the hash - this fixes the `rich` version constraint .
- The version of `cucumber-tag-expressions` in nixpkgs unstable seems to be too up-to-date for the requirements of ward. I downgrade this to the version required by `ward`. Not sure if this is the best solution.


Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
