### PR TITLE
maintainers: remove endocrimes

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5945,12 +5945,6 @@
     name = "Zhenbo Li";
     matrix = "@zhenbo:matrix.org";
   };
-  endocrimes = {
-    email = "dani@builds.terrible.systems";
-    github = "endocrimes";
-    githubId = 1330683;
-    name = "Danielle Lancashire";
-  };
   enorris = {
     name = "Eric Norris";
     email = "erictnorris@gmail.com";

--- a/pkgs/applications/networking/cluster/nomad/default.nix
+++ b/pkgs/applications/networking/cluster/nomad/default.nix
@@ -41,7 +41,7 @@ let
         description = "A Distributed, Highly Available, Datacenter-Aware Scheduler";
         mainProgram = "nomad";
         inherit license;
-        maintainers = with maintainers; [ rushmorem pradeepchhetri endocrimes techknowlogick cottand ];
+        maintainers = with maintainers; [ rushmorem pradeepchhetri techknowlogick cottand ];
       };
     } // attrs');
 in

--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -50,7 +50,7 @@ buildGoModule rec {
     homepage = "https://containerd.io/";
     description = "A daemon to control runC";
     license = licenses.asl20;
-    maintainers = with maintainers; [ offline vdemeester endocrimes ];
+    maintainers = with maintainers; [ offline vdemeester ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/virtualization/firecracker/default.nix
+++ b/pkgs/applications/virtualization/firecracker/default.nix
@@ -54,6 +54,6 @@ stdenv.mkDerivation {
     mainProgram = "firecracker";
     license = licenses.asl20;
     platforms = [ "x86_64-linux" "aarch64-linux" ];
-    maintainers = with maintainers; [ thoughtpolice endocrimes qjoly ];
+    maintainers = with maintainers; [ thoughtpolice qjoly ];
   };
 }

--- a/pkgs/development/python-modules/rfc6555/default.nix
+++ b/pkgs/development/python-modules/rfc6555/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     description = "Python implementation of the Happy Eyeballs Algorithm";
     homepage = "https://github.com/sethmlarson/rfc6555";
     license = licenses.asl20;
-    maintainers = with maintainers; [ endocrimes ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/tools/continuous-integration/drone-runner-docker/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone-runner-docker/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
   vendorHash = "sha256-KcNp3VdJ201oxzF0bLXY4xWHqHNz54ZrVSI96cfhU+k=";
 
   meta = with lib; {
-    maintainers = with maintainers; [ endocrimes ];
+    maintainers = with maintainers; [ ];
     license = licenses.unfreeRedistributable;
     homepage = "https://github.com/drone-runners/drone-runner-docker";
     description = "Drone pipeline runner that executes builds inside Docker containers";

--- a/pkgs/development/tools/gotestsum/default.nix
+++ b/pkgs/development/tools/gotestsum/default.nix
@@ -33,6 +33,6 @@ buildGoModule rec {
     mainProgram = "gotestsum";
     platforms = platforms.linux ++ platforms.darwin;
     license = licenses.asl20;
-    maintainers = with maintainers; [ endocrimes ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/servers/bindle/default.nix
+++ b/pkgs/servers/bindle/default.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     description = "Bindle: Aggregate Object Storage";
     homepage = "https://github.com/deislabs/bindle";
     license = licenses.asl20;
-    maintainers = with maintainers; [ endocrimes ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/etcd/3.5/default.nix
+++ b/pkgs/servers/etcd/3.5/default.nix
@@ -20,7 +20,7 @@ let
     description = "Distributed reliable key-value store for the most critical data of a distributed system";
     license = licenses.asl20;
     homepage = "https://etcd.io/";
-    maintainers = with maintainers; [ endocrimes offline superherointj ];
+    maintainers = with maintainers; [ offline superherointj ];
     platforms = platforms.darwin ++ platforms.linux;
   };
 

--- a/pkgs/tools/misc/goreleaser/default.nix
+++ b/pkgs/tools/misc/goreleaser/default.nix
@@ -50,7 +50,6 @@ buildGoModule rec {
     homepage = "https://goreleaser.com";
     maintainers = with maintainers; [
       c0deaddict
-      endocrimes
       sarcasticadmin
       techknowlogick
       developer-guy

--- a/pkgs/tools/networking/offlineimap/default.nix
+++ b/pkgs/tools/networking/offlineimap/default.nix
@@ -75,7 +75,7 @@ python3.pkgs.buildPythonApplication rec {
     description = "Synchronize emails between two repositories, so that you can read the same mailbox from multiple computers";
     homepage = "http://offlineimap.org";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ endocrimes ];
+    maintainers = with maintainers; [ ];
     mainProgram = "offlineimap";
   };
 }


### PR DESCRIPTION
My original commit was somewhat more tongue in cheek, but I think this time I'm going to be honest, rather than hiding behind humor.

I'm angry that we as a community have reached a point where we're falling apart because people would rather accept sealioning and bad faith arguments that belong in a 2002 mailing list, not a 2024 software community.

Every time I dare come back to the Nix community as a more active contributor it feels like we have a fresh wave of controversy that we don't ever heal from, everyone just moves on, more tired, and more broken than before. And now it's crossed a line.

I'm out.

I hope the community decides to actually try and heal. Tolerating the intolerant for too long has consequences - and the [paradox
of tolerance](https://en.wikipedia.org/wiki/Paradox_of_tolerance) has come to its natural conclusion here.

If it does heal, I'll be back with a vengeance, because it turns out replacing Nix is hard - emotionally and technically, and I'll miss it.

~Danielle

follow up to #307119.

![giphy](https://github.com/NixOS/nixpkgs/assets/1330683/bd389c9c-4e72-4802-851b-84e5e802486e)
