### PR TITLE
miniz: 2.2.0 → 3.0.2

### DIFF
--- a/pkgs/development/libraries/miniz/default.nix
+++ b/pkgs/development/libraries/miniz/default.nix
@@ -2,21 +2,21 @@
 
 stdenv.mkDerivation rec {
   pname = "miniz";
-  version = "2.2.0";
+  version = "3.0.2";
 
   src = fetchFromGitHub {
     owner = "richgel999";
     repo = pname;
     rev = version;
-    sha256 = "sha256-7hc/yNJh4sD5zGQLeHjowbUtV/1mUDQre1tp9yKMSSY=";
+    hash = "sha256-3J0bkr2Yk+MJXilUqOCHsWzuykySv5B1nepmucvA4hg=";
   };
 
   nativeBuildInputs = [ cmake ];
 
   postFixup = ''
-    substituteInPlace "$out"/share/pkgconfig/miniz.pc \
-      --replace '=''${prefix}//' '=/' \
-      --replace '=''${exec_prefix}//' '=/'
+    substituteInPlace "$out"/lib/pkgconfig/miniz.pc \
+      --replace-fail '=''${prefix}//' '=/' \
+      --replace-fail '=''${exec_prefix}//' '=/'
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/miniz/default.nix
+++ b/pkgs/development/libraries/miniz/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
   passthru.updateScript = nix-update-script {};
 
+  strictDeps = true;
   nativeBuildInputs = [ cmake validatePkgConfig ];
 
   postFixup = ''

--- a/pkgs/development/libraries/miniz/default.nix
+++ b/pkgs/development/libraries/miniz/default.nix
@@ -2,22 +2,24 @@
 , fetchFromGitHub
 , nix-update-script
 , stdenv
+, testers
+, validatePkgConfig
 , cmake
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "miniz";
   version = "3.0.2";
 
   src = fetchFromGitHub {
     owner = "richgel999";
-    repo = pname;
-    rev = version;
+    repo = "miniz";
+    rev = finalAttrs.version;
     hash = "sha256-3J0bkr2Yk+MJXilUqOCHsWzuykySv5B1nepmucvA4hg=";
   };
   passthru.updateScript = nix-update-script {};
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake validatePkgConfig ];
 
   postFixup = ''
     substituteInPlace "$out"/lib/pkgconfig/miniz.pc \
@@ -25,11 +27,14 @@ stdenv.mkDerivation rec {
       --replace-fail '=''${exec_prefix}//' '=/'
   '';
 
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
   meta = with lib; {
     description = "Single C source file zlib-replacement library";
     homepage = "https://github.com/richgel999/miniz";
     license = licenses.mit;
     maintainers = with maintainers; [ astro ];
     platforms = platforms.unix;
+    pkgConfigModules = [ "miniz" ];
   };
-}
+})

--- a/pkgs/development/libraries/miniz/default.nix
+++ b/pkgs/development/libraries/miniz/default.nix
@@ -1,4 +1,9 @@
-{ lib, stdenv, fetchFromGitHub, cmake }:
+{ lib
+, fetchFromGitHub
+, nix-update-script
+, stdenv
+, cmake
+}:
 
 stdenv.mkDerivation rec {
   pname = "miniz";
@@ -10,6 +15,7 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-3J0bkr2Yk+MJXilUqOCHsWzuykySv5B1nepmucvA4hg=";
   };
+  passthru.updateScript = nix-update-script {};
 
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
## Description of changes

In `miniz`:
- update from 2.2.0 to 3.0.2,
- add `updateScript`,
- add `meta.pkgConfigModules` and `tests.pkg-config`,
- add the `validatePkgConfig` hook.

cc @astro

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - new [package test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
- [ ] Tested compilation of all packages that depend on this change using `nixpkgs-review`.
  Currently running
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
