### PR TITLE
fontbakery: fix passthru.tests for 0.12

### DIFF
--- a/pkgs/development/python-modules/fontbakery/tests.nix
+++ b/pkgs/development/python-modules/fontbakery/tests.nix
@@ -10,13 +10,10 @@ runCommand "${pname}-tests" { meta.timeout = 5; } ''
   # Check the version matches what we packaged.
   ${fontbakery}/bin/fontbakery --version | grep -q "${version}"
 
-  # Can it list its own subcommands?
-  ${fontbakery}/bin/fontbakery --list-subcommands >>$out
-
   # Unpack src to get some test fonts.
   tar -xzf ${src} --strip-components=1 ${pname}-${version}/data/test
 
   # Run some font checks.
-  ${fontbakery}/bin/fontbakery check-ufo-sources --no-progress --no-colors data/test/test.ufo >>$out
+  ${fontbakery}/bin/fontbakery check-ufo --no-progress --no-colors data/test/test.ufo >>$out
   # TODO add more
 ''

--- a/pkgs/development/python-modules/fonttools/default.nix
+++ b/pkgs/development/python-modules/fonttools/default.nix
@@ -26,7 +26,7 @@
 
 buildPythonPackage rec {
   pname = "fonttools";
-  version = "4.49.0";
+  version = "4.51.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     owner  = pname;
     repo   = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-8xQVuAnIS/mwYKwI+ow0YArIP8wFTKWGLZ+NCgIFYok=";
+    hash = "sha256-JUAFGLjyq/2OXlhTB6dIcO3Mq7Rx1HII+sg2TaQfPYU=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/glyphsets/default.nix
+++ b/pkgs/development/python-modules/glyphsets/default.nix
@@ -6,6 +6,7 @@
 , gflanguages
 , glyphslib
 , pytestCheckHook
+, pyyaml
 , requests
 , setuptools
 , setuptools-scm
@@ -27,6 +28,7 @@ buildPythonPackage rec {
     fonttools
     gflanguages
     glyphslib
+    pyyaml
     requests
     setuptools
     unicodedata2

--- a/pkgs/development/python-modules/ufo2ft/default.nix
+++ b/pkgs/development/python-modules/ufo2ft/default.nix
@@ -6,6 +6,7 @@
 , cu2qu
 , defcon
 , fetchPypi
+, fontmath
 , fonttools
 , pytestCheckHook
 , pythonOlder
@@ -38,6 +39,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     cu2qu
+    fontmath
     fonttools
     defcon
     compreffor


### PR DESCRIPTION
## Description of changes

Python mass-update PR #305152 introduced some build failures in `fontbakery` and its dependencies. This PR fixes them up.

This includes an update for `fonttools` since `ufo2ft` depends on a new API added in fonttools 4.50.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- ~For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - ~[ ] (Package updates) Added a release notes entry if the change is major or breaking~
  - ~[ ] (Module updates) Added a release notes entry if the change is significant~
  - ~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
