### PR TITLE
rsdkv4: init at 1.3.2

### DIFF
--- a/pkgs/by-name/rs/rsdkv4/package.nix
+++ b/pkgs/by-name/rs/rsdkv4/package.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ glew SDL2 libvorbis libXcursor libXext libXScrnSaver libXrandr libXi libXfixes ];
 
+  makeFlags = [ "RETRO_DISABLE_PLUS=1" ];
   installFlags = [ "prefix=$(out)" ];
 
   meta = {

--- a/pkgs/by-name/rs/rsdkv4/package.nix
+++ b/pkgs/by-name/rs/rsdkv4/package.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, glew
+, SDL2
+, libvorbis
+, libXcursor
+, libXrandr
+, libXext
+, libXScrnSaver
+, libXi
+, libXfixes
+}:
+
+stdenv.mkDerivation rec {
+  pname = "RSDKv4";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "Rubberduckycooly";
+    repo = "Sonic-1-2-2013-Decompilation";
+    rev = version;
+    fetchSubmodules = true;
+    sha256 = "sha256-hTBhSfauu0ccEtu/chyIr7EAXjlgYiZpeU66AkgreUo=";
+  };
+
+  postPatch = ''
+    substituteInPlace RSDKv4/RetroEngine.hpp \
+      --replace-fail '#include <SDL.h>' '#include <SDL2/SDL.h>'
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ glew SDL2 libvorbis libXcursor libXext libXScrnSaver libXrandr libXi libXfixes ];
+
+  installFlags = [ "prefix=$(out)" ];
+
+  meta = {
+    description = "Decompilation of Sonic 1 & Sonic 2";
+    homepage = "https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation";
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = [ lib.maintainers.puffnfresh ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation

Running the binary creates a bunch of files in the current working directory and tries to read `Data.rsdk`, which needs to come from the published game. A wrapper would be useful to automate creating and changing to a known path (e.g. maybe separate `sonic1` and `sonic2` scripts).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
