### PR TITLE
taler: 0.10.1 -> 0.10.2

### DIFF
--- a/pkgs/by-name/ta/taler-exchange/package.nix
+++ b/pkgs/by-name/ta/taler-exchange/package.nix
@@ -21,7 +21,7 @@
 }:
 
 let
-  version = "0.10.1";
+  version = "0.10.2";
 in
 stdenv.mkDerivation {
   pname = "taler-exchange";
@@ -31,14 +31,7 @@ stdenv.mkDerivation {
     url = "https://git.taler.net/exchange.git";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-SKnMep8bMQaJt4r3u0SrzwYSuFbzv4RnflbutSqwtPg=";
-
-    # When fetching submodules without the .git folder we get the following error:
-    # "Server does not allow request for unadvertised object"
-    leaveDotGit = true;
-    postFetch = ''
-      rm -rf $out/.git
-    '';
+    hash = "sha256-dl8lZ7uKUr+KSUaT4xlkaX3W5UoW2Zfu/0iVXvLejnA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ta/taler-merchant/package.nix
+++ b/pkgs/by-name/ta/taler-merchant/package.nix
@@ -12,12 +12,12 @@
 }:
 
 let
-  version = "0.10.1";
+  version = "0.10.2";
 
   taler-wallet-core = fetchgit {
     url = "https://git.taler.net/wallet-core.git";
     rev = "v${version}";
-    hash = "sha256-sgiJd1snN9JDqS7IUeORKL60Gcm7XwL/JCX3sNRDTdY=";
+    hash = "sha256-jC8XhcHZxv7ww+wspJUqTq6x6FIeEehQmE03ttJZWT4=";
   };
 in
 stdenv.mkDerivation {
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
     url = "https://git.taler.net/merchant.git";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-8VpoyloLpd/HckSIRU6IclWUXQyEHqlcNdoJI9U3t0Y=";
+    hash = "sha256-WY5Fk5HcVjxsnqt69m8E9ikW+nQDkCuKtT1CTsupz5c=";
   };
 
   postUnpack = ''


### PR DESCRIPTION
## Description of changes

https://taler.net/fr/news/2024-06.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
