### PR TITLE
Removing FRidh as active maintainer of packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,6 @@
 
 # GitHub actions
 /.github/workflows @NixOS/Security @Mic92 @zowoq
-/.github/workflows/merge-staging @FRidh
 
 # EditorConfig
 /.editorconfig @Mic92 @zowoq
@@ -125,10 +124,8 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @raitobezarius @ma27
 /pkgs/common-updater/scripts/update-source-version    @jtojnar
 
 # Python-related code and docs
-/maintainers/scripts/update-python-libraries	              @FRidh
-/pkgs/development/interpreters/python                       @FRidh
-/doc/languages-frameworks/python.section.md                 @FRidh @mweinelt
-/pkgs/development/interpreters/python/hooks                 @FRidh @jonringer
+/doc/languages-frameworks/python.section.md                 @mweinelt
+/pkgs/development/interpreters/python/hooks                 @jonringer
 
 # Haskell
 /doc/languages-frameworks/haskell.section.md  @sternenseemann @maralorn @ncfavier

--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -878,7 +878,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/pytoolz/toolz";
     description = "List processing tools and functional utilities";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }
 ```
@@ -1013,7 +1012,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/ContinuumIO/datashape";
     description = "A data description language";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }
 ```
@@ -1134,7 +1132,6 @@ buildPythonPackage rec {
     description = "A pythonic wrapper around FFTW, the FFT library, presenting a unified interface for all the supported transforms";
     homepage = "http://hgomersall.github.com/pyFFTW";
     license = with lib.licenses; [ bsd2 bsd3 ];
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }
 ```
@@ -1494,7 +1491,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/pytoolz/toolz/";
     description = "List processing tools and functional utilities";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }
 ```

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -826,7 +826,6 @@ with lib.maintainers; {
 
   python = {
     members = [
-      fridh
       hexa
       jonringer
       tjni

--- a/pkgs/applications/editors/kile/default.nix
+++ b/pkgs/applications/editors/kile/default.nix
@@ -42,7 +42,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "User-friendly TeX/LaTeX authoring tool for the KDE desktop environment";
     homepage = "https://www.kde.org/applications/office/kile/";
-    maintainers = with lib.maintainers; [ fridh ];
     license = lib.licenses.gpl2Plus;
     mainProgram = "kile";
   };

--- a/pkgs/applications/kde/filelight.nix
+++ b/pkgs/applications/kde/filelight.nix
@@ -20,7 +20,7 @@ mkDerivation {
     mainProgram = "filelight";
     homepage = "https://apps.kde.org/filelight/";
     license = with lib.licenses; [ gpl2 ];
-    maintainers = with lib.maintainers; [ fridh vcunat ];
+    maintainers = with lib.maintainers; [ vcunat ];
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   propagatedBuildInputs = [

--- a/pkgs/applications/kde/kcalc.nix
+++ b/pkgs/applications/kde/kcalc.nix
@@ -12,7 +12,6 @@ mkDerivation {
     description = "Scientific calculator";
     mainProgram = "kcalc";
     license = with lib.licenses; [ gpl2 ];
-    maintainers = [ lib.maintainers.fridh ];
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [

--- a/pkgs/applications/kde/kdeconnect-kde.nix
+++ b/pkgs/applications/kde/kdeconnect-kde.nix
@@ -77,7 +77,6 @@ mkDerivation {
     description = "KDE Connect provides several features to integrate your phone and your computer";
     homepage = "https://community.kde.org/KDEConnect";
     license = with licenses; [ gpl2 ];
-    maintainers = with maintainers; [ fridh ];
     mainProgram = "kdeconnect-app";
   };
 }

--- a/pkgs/applications/kde/kolourpaint.nix
+++ b/pkgs/applications/kde/kolourpaint.nix
@@ -20,7 +20,6 @@ mkDerivation {
     homepage = "https://apps.kde.org/kolourpaint/";
     description = "Paint program";
     mainProgram = "kolourpaint";
-    maintainers = [ lib.maintainers.fridh ];
     license = with lib.licenses; [ gpl2 ];
   };
 }

--- a/pkgs/applications/kde/kwalletmanager.nix
+++ b/pkgs/applications/kde/kwalletmanager.nix
@@ -19,7 +19,6 @@ mkDerivation {
     description = "KDE wallet management tool";
     mainProgram = "kwalletmanager5";
     license = with lib.licenses; [ gpl2 ];
-    maintainers = with lib.maintainers; [ fridh ];
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [

--- a/pkgs/applications/kde/yakuake.nix
+++ b/pkgs/applications/kde/yakuake.nix
@@ -29,7 +29,6 @@ mkDerivation {
     homepage = "https://yakuake.kde.org";
     description = "Quad-style terminal emulator for KDE";
     mainProgram = "yakuake";
-    maintainers = with lib.maintainers; [ fridh ];
     license = lib.licenses.gpl2;
   };
 }

--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -350,7 +350,6 @@ in with passthru; stdenv.mkDerivation ({
       '';
       license = lib.licenses.psfl;
       platforms = lib.platforms.all;
-      maintainers = with lib.maintainers; [ fridh ];
       knownVulnerabilities = [
         "Python 2.7 has reached its end of life after 2020-01-01. See https://www.python.org/doc/sunset-python-2/."
         # Quote: That means that we will not improve it anymore after that day,

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -662,7 +662,6 @@ in with passthru; stdenv.mkDerivation (finalAttrs: {
     license = licenses.psfl;
     pkgConfigModules = [ "python3" ];
     platforms = platforms.linux ++ platforms.darwin ++ platforms.windows;
-    maintainers = with maintainers; [ fridh ];
     mainProgram = executable;
   };
 })

--- a/pkgs/development/python-modules/acoustics/default.nix
+++ b/pkgs/development/python-modules/acoustics/default.nix
@@ -53,7 +53,6 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python package for acousticians";
-    maintainers = with maintainers; [ fridh ];
     license = with licenses; [ bsd3 ];
     homepage = "https://github.com/python-acoustics/python-acoustics";
   };

--- a/pkgs/development/python-modules/aiofiles/default.nix
+++ b/pkgs/development/python-modules/aiofiles/default.nix
@@ -49,6 +49,5 @@ buildPythonPackage rec {
     description = "File support for asyncio";
     homepage = "https://github.com/Tinche/aiofiles";
     license = with licenses; [ asl20 ];
-    maintainers = with maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/bibtexparser/default.nix
+++ b/pkgs/development/python-modules/bibtexparser/default.nix
@@ -36,6 +36,5 @@ buildPythonPackage rec {
     description = "Bibtex parser for Python";
     homepage = "https://github.com/sciunto-org/python-bibtexparser";
     license = with licenses; [ lgpl3Only /* or */ bsd3 ];
-    maintainers = with maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/cycler/default.nix
+++ b/pkgs/development/python-modules/cycler/default.nix
@@ -36,6 +36,5 @@ buildPythonPackage rec {
     description = "Composable style cycles";
     homepage = "https://github.com/matplotlib/cycler";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/cython/0.nix
+++ b/pkgs/development/python-modules/cython/0.nix
@@ -86,6 +86,5 @@ in buildPythonPackage rec {
     description = "An optimising static compiler for both the Python programming language and the extended Cython programming language";
     homepage = "https://cython.org";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/cython/default.nix
+++ b/pkgs/development/python-modules/cython/default.nix
@@ -66,6 +66,5 @@ in buildPythonPackage rec {
     description = "An optimising static compiler for both the Python programming language and the extended Cython programming language";
     homepage = "https://cython.org";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/cytoolz/default.nix
+++ b/pkgs/development/python-modules/cytoolz/default.nix
@@ -47,6 +47,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/pytoolz/cytoolz/";
     description = "Cython implementation of Toolz: High performance functional utilities";
     license = licenses.bsd3;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -191,6 +191,5 @@ let self = buildPythonPackage rec {
     homepage = "https://dask.org/";
     changelog = "https://docs.dask.org/en/latest/changelog.html";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ fridh ];
   };
 }; in self

--- a/pkgs/development/python-modules/datashape/default.nix
+++ b/pkgs/development/python-modules/datashape/default.nix
@@ -46,6 +46,5 @@ in buildPythonPackage rec {
     homepage = "https://github.com/ContinuumIO/datashape";
     description = "A data description language";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/flit/default.nix
+++ b/pkgs/development/python-modules/flit/default.nix
@@ -56,6 +56,5 @@ buildPythonPackage rec {
     mainProgram = "flit";
     homepage = "https://github.com/pypa/flit";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/folium/default.nix
+++ b/pkgs/development/python-modules/folium/default.nix
@@ -75,6 +75,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/python-visualization/folium";
     changelog = "https://github.com/python-visualization/folium/blob/v${version}/CHANGES.txt";
     license = with lib.licenses; [ mit ];
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/ipykernel/default.nix
+++ b/pkgs/development/python-modules/ipykernel/default.nix
@@ -70,6 +70,6 @@ buildPythonPackage rec {
     homepage = "https://ipython.org/";
     changelog = "https://github.com/ipython/ipykernel/releases/tag/v${version}";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ fridh ] ++ lib.teams.jupyter.members;
+    maintainers = lib.teams.jupyter.members;
   };
 }

--- a/pkgs/development/python-modules/ipyparallel/default.nix
+++ b/pkgs/development/python-modules/ipyparallel/default.nix
@@ -66,6 +66,5 @@ buildPythonPackage rec {
     homepage = "https://ipyparallel.readthedocs.io/";
     changelog = "https://github.com/ipython/ipyparallel/blob/${version}/docs/source/changelog.md";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/ipython-genutils/default.nix
+++ b/pkgs/development/python-modules/ipython-genutils/default.nix
@@ -44,6 +44,5 @@ buildPythonPackage rec {
     description = "Vestigial utilities from IPython";
     homepage = "https://ipython.org/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/ipython/default.nix
+++ b/pkgs/development/python-modules/ipython/default.nix
@@ -112,6 +112,6 @@ buildPythonPackage rec {
     homepage = "https://ipython.org/";
     changelog = "https://github.com/ipython/ipython/blob/${version}/docs/source/whatsnew/version${lib.versions.major version}.rst";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ bjornfor fridh ];
+    maintainers = with maintainers; [ bjornfor ];
   };
 }

--- a/pkgs/development/python-modules/ipywidgets/default.nix
+++ b/pkgs/development/python-modules/ipywidgets/default.nix
@@ -48,6 +48,5 @@ buildPythonPackage rec {
     description = "IPython HTML widgets for Jupyter";
     homepage = "https://github.com/jupyter-widgets/ipywidgets";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/jupyter-client/default.nix
+++ b/pkgs/development/python-modules/jupyter-client/default.nix
@@ -48,6 +48,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/jupyter/jupyter_client";
     changelog = "https://github.com/jupyter/jupyter_client/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/lark/default.nix
+++ b/pkgs/development/python-modules/lark/default.nix
@@ -47,6 +47,6 @@ buildPythonPackage rec {
     homepage = "https://lark-parser.readthedocs.io/";
     changelog = "https://github.com/lark-parser/lark/releases/tag/${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ fridh drewrisinger ];
+    maintainers = with maintainers; [ drewrisinger ];
   };
 }

--- a/pkgs/development/python-modules/line-profiler/default.nix
+++ b/pkgs/development/python-modules/line-profiler/default.nix
@@ -60,6 +60,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/pyutils/line_profiler";
     changelog = "https://github.com/pyutils/line_profiler/blob/v${version}/CHANGELOG.rst";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/llvmlite/default.nix
+++ b/pkgs/development/python-modules/llvmlite/default.nix
@@ -61,6 +61,5 @@ buildPythonPackage rec {
     downloadPage = "https://github.com/numba/llvmlite";
     homepage = "http://llvmlite.pydata.org/";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/meson-python/default.nix
+++ b/pkgs/development/python-modules/meson-python/default.nix
@@ -48,6 +48,6 @@ buildPythonPackage rec {
     description = "Meson Python build backend (PEP 517)";
     homepage = "https://github.com/mesonbuild/meson-python";
     license = [ lib.licenses.mit ];
-    maintainers = with lib.maintainers; [ fridh doronbehar ];
+    maintainers = with lib.maintainers; [ doronbehar ];
   };
 }

--- a/pkgs/development/python-modules/mesonpep517/default.nix
+++ b/pkgs/development/python-modules/mesonpep517/default.nix
@@ -41,6 +41,5 @@ buildPythonPackage rec {
     description = "Create pep517 compliant packages from the meson build system";
     homepage = "https://gitlab.com/thiblahute/mesonpep517";
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.fridh ];
   };
 }

--- a/pkgs/development/python-modules/multipledispatch/default.nix
+++ b/pkgs/development/python-modules/multipledispatch/default.nix
@@ -23,6 +23,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/mrocklin/multipledispatch/";
     description = "A relatively sane approach to multiple dispatch in Python";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/nbformat/default.nix
+++ b/pkgs/development/python-modules/nbformat/default.nix
@@ -54,6 +54,6 @@ buildPythonPackage rec {
     mainProgram = "jupyter-trust";
     homepage = "https://jupyter.org/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ fridh globin ];
+    maintainers = with lib.maintainers; [ globin ];
   };
 }

--- a/pkgs/development/python-modules/nidaqmx/default.nix
+++ b/pkgs/development/python-modules/nidaqmx/default.nix
@@ -55,6 +55,5 @@ buildPythonPackage rec {
   meta = {
     description = "API for interacting with the NI-DAQmx driver";
     license = [ lib.licenses.mit ];
-    maintainers = [ lib.maintainers.fridh ];
   };
 }

--- a/pkgs/development/python-modules/nose-exclude/default.nix
+++ b/pkgs/development/python-modules/nose-exclude/default.nix
@@ -24,6 +24,5 @@ buildPythonPackage rec {
     license = lib.licenses.lgpl21;
     description = "Exclude specific directories from nosetests runs";
     homepage = "https://github.com/kgrandis/nose-exclude";
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -139,6 +139,5 @@ in buildPythonPackage rec {
     homepage = "https://numba.pydata.org/";
     license = licenses.bsd2;
     mainProgram = "numba";
-    maintainers = with maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -186,6 +186,5 @@ in buildPythonPackage rec {
     mainProgram = "f2py";
     homepage = "https://numpy.org/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/onnxconverter-common/default.nix
+++ b/pkgs/development/python-modules/onnxconverter-common/default.nix
@@ -48,7 +48,6 @@ buildPythonPackage rec {
     description = "ONNX Converter and Optimization Tools";
     homepage = "https://github.com/microsoft/onnxconverter-common";
     changelog = "https://github.com/microsoft/onnxconverter-common/releases/tag/v${version}";
-    maintainers = with lib.maintainers; [ fridh ];
     license = with lib.licenses; [ mit ];
   };
 }

--- a/pkgs/development/python-modules/onnxruntime/default.nix
+++ b/pkgs/development/python-modules/onnxruntime/default.nix
@@ -70,5 +70,5 @@ buildPythonPackage {
     # sympy
   ];
 
-  meta = onnxruntime.meta // { maintainers = with lib.maintainers; [ fridh ]; };
+  meta = onnxruntime.meta;
 }

--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -266,7 +266,7 @@ let pandas = buildPythonPackage rec {
       Python, providing labeled data structures similar to R data.frame
       objects, statistical functions, and much more.
     '';
-    maintainers = with maintainers; [ raskin fridh knedlsepp ];
+    maintainers = with maintainers; [ raskin knedlsepp ];
   };
 };
 in pandas

--- a/pkgs/development/python-modules/pyfftw/default.nix
+++ b/pkgs/development/python-modules/pyfftw/default.nix
@@ -27,6 +27,5 @@ buildPythonPackage rec {
     description = "A pythonic wrapper around FFTW, the FFT library, presenting a unified interface for all the supported transforms";
     homepage = "http://hgomersall.github.com/pyFFTW/";
     license = with licenses; [ bsd2 bsd3 ];
-    maintainers = with maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/pyopencl/default.nix
+++ b/pkgs/development/python-modules/pyopencl/default.nix
@@ -69,6 +69,5 @@ in buildPythonPackage rec {
     description = "Python wrapper for OpenCL";
     homepage = "https://github.com/pyopencl/pyopencl";
     license = licenses.mit;
-    maintainers = [ maintainers.fridh ];
   };
 }

--- a/pkgs/development/python-modules/pyproject-metadata/default.nix
+++ b/pkgs/development/python-modules/pyproject-metadata/default.nix
@@ -48,6 +48,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/FFY00/python-pyproject-metadata";
     changelog = "https://github.com/FFY00/python-pyproject-metadata/blob/${version}/CHANGELOG.rst";
     license = licenses.mit;
-    maintainers = with maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/qtconsole/default.nix
+++ b/pkgs/development/python-modules/qtconsole/default.nix
@@ -54,7 +54,6 @@ buildPythonPackage rec {
     mainProgram = "jupyter-qtconsole";
     homepage = "https://qtconsole.readthedocs.io/";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ fridh ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/recommonmark/default.nix
+++ b/pkgs/development/python-modules/recommonmark/default.nix
@@ -38,6 +38,5 @@ buildPythonPackage rec {
     description = "A docutils-compatibility bridge to CommonMark";
     homepage = "https://github.com/rtfd/recommonmark";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/reikna/default.nix
+++ b/pkgs/development/python-modules/reikna/default.nix
@@ -38,7 +38,6 @@ buildPythonPackage rec {
     description = "GPGPU algorithms for PyCUDA and PyOpenCL";
     homepage = "https://github.com/fjarri/reikna";
     license = licenses.mit;
-    maintainers = [ maintainers.fridh ];
 
   };
 

--- a/pkgs/development/python-modules/requests-download/default.nix
+++ b/pkgs/development/python-modules/requests-download/default.nix
@@ -27,6 +27,5 @@ buildPythonPackage rec {
     description = "Download files using requests and save them to a target path";
     homepage = "https://www.github.com/takluyver/requests_download";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.fridh ];
   };
 }

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -203,6 +203,6 @@ in buildPythonPackage {
     downloadPage = "https://github.com/scipy/scipy";
     homepage = "https://www.scipy.org/";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ fridh doronbehar ];
+    maintainers = with maintainers; [ doronbehar ];
   };
 }

--- a/pkgs/development/python-modules/seaborn/default.nix
+++ b/pkgs/development/python-modules/seaborn/default.nix
@@ -70,6 +70,5 @@ buildPythonPackage rec {
     homepage = "https://seaborn.pydata.org/";
     changelog = "https://github.com/mwaskom/seaborn/blob/master/doc/whatsnew/${src.rev}.rst";
     license = with licenses; [ bsd3 ];
-    maintainers = with maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/skl2onnx/default.nix
+++ b/pkgs/development/python-modules/skl2onnx/default.nix
@@ -51,7 +51,6 @@ buildPythonPackage rec {
 
   meta = {
     description = "Convert scikit-learn models to ONNX";
-    maintainers = with lib.maintainers; [ fridh ];
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/pkgs/development/python-modules/sounddevice/default.nix
+++ b/pkgs/development/python-modules/sounddevice/default.nix
@@ -38,6 +38,5 @@ buildPythonPackage rec {
     description = "Play and Record Sound with Python";
     homepage = "http://python-sounddevice.rtfd.org/";
     license = with lib.licenses; [ mit ];
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/soundfile/default.nix
+++ b/pkgs/development/python-modules/soundfile/default.nix
@@ -37,6 +37,5 @@ buildPythonPackage rec {
     description = "An audio library based on libsndfile, CFFI and NumPy";
     license = lib.licenses.bsd3;
     homepage = "https://github.com/bastibe/python-soundfile";
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/statsmodels/default.nix
+++ b/pkgs/development/python-modules/statsmodels/default.nix
@@ -56,6 +56,5 @@ buildPythonPackage rec {
     homepage = "https://www.github.com/statsmodels/statsmodels";
     changelog = "https://github.com/statsmodels/statsmodels/releases/tag/v${version}";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/tabulate/default.nix
+++ b/pkgs/development/python-modules/tabulate/default.nix
@@ -38,6 +38,5 @@ buildPythonPackage rec {
     mainProgram = "tabulate";
     homepage = "https://github.com/astanin/python-tabulate";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/tiledb/default.nix
+++ b/pkgs/development/python-modules/tiledb/default.nix
@@ -78,7 +78,6 @@ buildPythonPackage rec {
     description = "Python interface to the TileDB storage manager";
     homepage = "https://github.com/TileDB-Inc/TileDB-Py";
     license = licenses.mit;
-    maintainers = with maintainers; [ fridh ];
     # tiledb/core.cc:556:30: error: ‘struct std::array<long unsigned int, 2>’ has no member named ‘second’
     broken = true;
   };

--- a/pkgs/development/python-modules/toolz/default.nix
+++ b/pkgs/development/python-modules/toolz/default.nix
@@ -25,6 +25,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/pytoolz/toolz";
     description = "List processing tools and functional utilities";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/tqdm/default.nix
+++ b/pkgs/development/python-modules/tqdm/default.nix
@@ -67,6 +67,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/tqdm/tqdm";
     changelog = "https://tqdm.github.io/releases/";
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/traitlets/default.nix
+++ b/pkgs/development/python-modules/traitlets/default.nix
@@ -49,6 +49,5 @@ buildPythonPackage rec {
     description = "Traitlets Python config system";
     homepage = "https://github.com/ipython/traitlets";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/twine/default.nix
+++ b/pkgs/development/python-modules/twine/default.nix
@@ -49,6 +49,5 @@ buildPythonPackage rec {
     mainProgram = "twine";
     homepage = "https://github.com/pypa/twine";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/typed-settings/default.nix
+++ b/pkgs/development/python-modules/typed-settings/default.nix
@@ -66,6 +66,5 @@ buildPythonPackage rec {
     homepage = "https://gitlab.com/sscherfke/typed-settings";
     changelog = "https://gitlab.com/sscherfke/typed-settings/-/blob/${version}/CHANGELOG.rst";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/widgetsnbextension/default.nix
+++ b/pkgs/development/python-modules/widgetsnbextension/default.nix
@@ -30,6 +30,5 @@ buildPythonPackage rec {
     description = "IPython HTML widgets for Jupyter";
     homepage = "https://github.com/jupyter-widgets/ipywidgets/tree/master/python/widgetsnbextension";
     license = ipywidgets.meta.license; # Build from same repo
-    maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/xarray/default.nix
+++ b/pkgs/development/python-modules/xarray/default.nix
@@ -52,6 +52,5 @@ buildPythonPackage rec {
     description = "N-D labeled arrays and datasets in Python";
     homepage = "https://github.com/pydata/xarray";
     license = licenses.asl20;
-    maintainers = with maintainers; [ fridh ];
   };
 }

--- a/pkgs/servers/sabnzbd/default.nix
+++ b/pkgs/servers/sabnzbd/default.nix
@@ -82,7 +82,7 @@ in stdenv.mkDerivation rec {
     homepage = "https://sabnzbd.org";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with lib.maintainers; [ fridh jojosch adamcstephens ];
+    maintainers = with lib.maintainers; [ jojosch adamcstephens ];
     mainProgram = "sabnzbd";
   };
 }

--- a/pkgs/tools/package-management/niff/default.nix
+++ b/pkgs/tools/package-management/niff/default.nix
@@ -29,7 +29,6 @@ in stdenv.mkDerivation {
     description = "A program that compares two Nix expressions and determines which attributes changed";
     homepage = "https://github.com/FRidh/niff";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.fridh ];
     mainProgram = "niff";
   };
 }


### PR DESCRIPTION
In the past I was very active with Python packaging. For several years now I was hardly around as maintainer, so it does not make sense I am listed as a maintainer for these makes. Looking back, I should have removed myself as maintainer already much longer ago. Anyway, better late than never.

It's been a fun ride, and  I do intend to occasionally contribute to Nixpkgs, but not in the same way it once was.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
