### PR TITLE
uhd: fix python api feature

### DIFF
--- a/pkgs/applications/radio/gnuradio/wrapper.nix
+++ b/pkgs/applications/radio/gnuradio/wrapper.nix
@@ -58,6 +58,10 @@ let
   # may wish to wrap GR without python support.
   pythonPkgs = extraPythonPackages
     ++ [ (unwrapped.python.pkgs.toPythonModule unwrapped) ]
+    ++ unwrapped.passthru.uhd.pythonPath
+    ++ lib.optionals (unwrapped.passthru.uhd.pythonPath != []) [
+      (unwrapped.python.pkgs.toPythonModule unwrapped.passthru.uhd)
+    ]
     # Add the extraPackages as python modules as well
     ++ (builtins.map unwrapped.python.pkgs.toPythonModule extraPackages)
     ++ lib.flatten (lib.mapAttrsToList (

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -38,8 +38,7 @@
 }:
 
 let
-  onOffBool = b: if b then "ON" else "OFF";
-  inherit (lib) optionals;
+  inherit (lib) optionals cmakeBool;
   # Later used in pythonEnv generation. Python + mako are always required for the build itself but not necessary for runtime.
   pythonEnvArg = (ps: with ps; [ mako ]
     ++ optionals (enablePythonApi) [ numpy setuptools ]
@@ -84,23 +83,23 @@ stdenv.mkDerivation (finalAttrs: {
     "-DENABLE_LIBUHD=ON"
     "-DENABLE_USB=ON"
     "-DENABLE_TESTS=ON" # This installs tests as well so we delete them via postPhases
-    "-DENABLE_EXAMPLES=${onOffBool enableExamples}"
-    "-DENABLE_UTILS=${onOffBool enableUtils}"
-    "-DENABLE_C_API=${onOffBool enableCApi}"
-    "-DENABLE_PYTHON_API=${onOffBool enablePythonApi}"
-    "-DENABLE_DPDK=${onOffBool enableDpdk}"
+    (cmakeBool "ENABLE_EXAMPLES" enableExamples)
+    (cmakeBool "ENABLE_UTILS" enableUtils)
+    (cmakeBool "ENABLE_C_API" enableCApi)
+    (cmakeBool "ENABLE_PYTHON_API" enablePythonApi)
+    (cmakeBool "ENABLE_DPDK" enableDpdk)
     # Devices
-    "-DENABLE_OCTOCLOCK=${onOffBool enableOctoClock}"
-    "-DENABLE_MPMD=${onOffBool enableMpmd}"
-    "-DENABLE_B100=${onOffBool enableB100}"
-    "-DENABLE_B200=${onOffBool enableB200}"
-    "-DENABLE_USRP1=${onOffBool enableUsrp1}"
-    "-DENABLE_USRP2=${onOffBool enableUsrp2}"
-    "-DENABLE_X300=${onOffBool enableX300}"
-    "-DENABLE_N300=${onOffBool enableN300}"
-    "-DENABLE_N320=${onOffBool enableN320}"
-    "-DENABLE_E300=${onOffBool enableE300}"
-    "-DENABLE_E320=${onOffBool enableE320}"
+    (cmakeBool "ENABLE_OCTOCLOCK" enableOctoClock)
+    (cmakeBool "ENABLE_MPMD" enableMpmd)
+    (cmakeBool "ENABLE_B100" enableB100)
+    (cmakeBool "ENABLE_B200" enableB200)
+    (cmakeBool "ENABLE_USRP1" enableUsrp1)
+    (cmakeBool "ENABLE_USRP2" enableUsrp2)
+    (cmakeBool "ENABLE_X300" enableX300)
+    (cmakeBool "ENABLE_N300" enableN300)
+    (cmakeBool "ENABLE_N320" enableN320)
+    (cmakeBool "ENABLE_E300" enableE300)
+    (cmakeBool "ENABLE_E320" enableE320)
   ]
     # TODO: Check if this still needed
     # ABI differences GCC 7.1

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -82,7 +82,9 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DENABLE_LIBUHD=ON"
     "-DENABLE_USB=ON"
-    "-DENABLE_TESTS=ON" # This installs tests as well so we delete them via postPhases
+    # Regardless of doCheck, we want to build the tests to help us gain
+    # confident that the package is OK.
+    "-DENABLE_TESTS=ON"
     (cmakeBool "ENABLE_EXAMPLES" enableExamples)
     (cmakeBool "ENABLE_UTILS" enableUtils)
     (cmakeBool "ENABLE_C_API" enableCApi)

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -68,6 +68,18 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ optionals (enableUtils) [
     python3.pkgs.requests
     python3.pkgs.six
+
+    /* These deps are needed for the usrp_hwd.py utility, however even if they
+    would have been added here, the utility wouldn't have worked because it
+    depends on an old python library mprpc that is not supported for Python >
+    3.8. See also report upstream:
+    https://github.com/EttusResearch/uhd/issues/744
+
+    python3.pkgs.gevent
+    python3.pkgs.pyudev
+    python3.pkgs.pyroute2
+
+    */
   ];
   passthru = {
     runtimePython = python3.withPackages (ps: finalAttrs.pythonPath);

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -155,10 +155,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Build only the host software
   preConfigure = "cd host";
-  # TODO: Check if this still needed, perhaps relevant:
-  # https://files.ettus.com/manual_archive/v3.15.0.0/html/page_build_guide.html#build_instructions_unix_arm
   patches = [
-    # Disable tests that fail in the sandbox
+    # Disable tests that fail in the sandbox, last checked at version 4.6.0.0
     ./no-adapter-tests.patch
   ];
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
