### PR TITLE
responsively-app: init at 1.15.0

### DIFF
--- a/pkgs/by-name/re/responsively-app/package.nix
+++ b/pkgs/by-name/re/responsively-app/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchurl,
+  appimageTools,
+}:
+
+appimageTools.wrapType2 rec {
+  pname = "responsively-app";
+  version = "1.15.0";
+
+  src = fetchurl {
+    url = "https://github.com/responsively-org/responsively-app-releases/releases/download/v${version}/ResponsivelyApp-${version}.AppImage";
+    hash = "sha256-BkljY8Il45A2JbsLgQbjsxCy0lnFZvtpc5HzvI1nwWk=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+  };
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/responsivelyapp.desktop $out/share/applications/responsivelyapp.desktop
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/responsivelyapp.png \
+      $out/share/icons/hicolor/512x512/apps/responsivelyapp.png
+    substituteInPlace $out/share/applications/responsivelyapp.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=${pname}'
+  '';
+
+  meta = {
+    description = "Modified web browser that helps in responsive web development";
+    mainProgram = "responsively-desktop";
+    homepage = "https://responsively.app/";
+    changelog = "https://github.com/responsively-org/responsively-app/releases/tag/v${version}";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ kashw2 ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Description of changes

closes https://github.com/NixOS/nixpkgs/issues/304348

https://responsively.app/
https://github.com/responsively-org/responsively-app

Future plans are to introduce src based builds which will bring with it cross platform support, however upstream uses yarn lock v2 with support for such being tracked in https://github.com/NixOS/nixpkgs/issues/254369. As of current I am unable to assist in making this application available across other platforms bar x86_64-linux and aarch64-linux as i don't have a machine that supports other platforms.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
