### PR TITLE
container-structure-test: init at 1.17.0

### DIFF
--- a/pkgs/by-name/co/container-structure-test/package.nix
+++ b/pkgs/by-name/co/container-structure-test/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGo122Module,
+  fetchFromGitHub,
+  testers,
+  container-structure-test
+}:
+
+buildGo122Module rec {
+  pname = "container-structure-test";
+  version = "1.17.0";
+
+  src = fetchFromGitHub {
+    owner = "GoogleContainerTools";
+    repo = "container-structure-test";
+    rev = "v${version}";
+    hash = "sha256-YUI5HP8u91xmYkFMdSIuwAVMVPTagEhNmoPOLpi2/Fk=";
+  };
+
+  subPackages = [ "cmd/container-structure-test" ];
+
+  vendorHash = "sha256-2D4iqNbcaYyPiYugc+1W2aBvje2aODxe21E/mlYTmr0=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/GoogleContainerTools/container-structure-test/pkg/version.version=${version}"
+  ];
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = container-structure-test;
+    };
+  };
+
+  meta = with lib; {
+    description = "The Container Structure Tests provide a powerful framework to validate the structure of a container image.";
+    homepage = "https://github.com/GoogleContainerTools/container-structure-test";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ brpaz ];
+    mainProgram = "container-structure-test";
+  };
+}


### PR DESCRIPTION
## Description of changes

[Container Structure Tests](https://github.com/GoogleContainerTools/container-structure-test) provide a powerful framework to validate the structure of a container image. These tests can be used to check the output of commands in an image, as well as verify metadata and contents of the filesystem.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
