### PR TITLE
[23.11] qdrant: add patch for CVE-2024-2221

### DIFF
--- a/pkgs/servers/search/qdrant/1.6.1-CVE-2024-2221.patch
+++ b/pkgs/servers/search/qdrant/1.6.1-CVE-2024-2221.patch
@@ -1,0 +1,23 @@
+Based on upstream 3ab8ec7d14178bb2ac39a4bcc972f2258254196e with unnecessary
+conflicting hunk dropped
+
+diff --git a/src/actix/api/snapshot_api.rs b/src/actix/api/snapshot_api.rs
+index b8b40c6b..0fbed314 100644
+--- a/src/actix/api/snapshot_api.rs
++++ b/src/actix/api/snapshot_api.rs
+@@ -75,6 +75,15 @@ pub async fn do_save_uploaded_snapshot(
+ ) -> std::result::Result<Url, StorageError> {
+     let filename = snapshot
+         .file_name
++        // Sanitize the file name:
++        // - only take the top level path (no directories such as ../)
++        // - require the file name to be valid UTF-8
++        .and_then(|x| {
++            Path::new(&x)
++                .file_name()
++                .map(|filename| filename.to_owned())
++        })
++        .and_then(|x| x.to_str().map(|x| x.to_owned()))
+         .unwrap_or_else(|| Uuid::new_v4().to_string());
+     let collection_snapshot_path = toc.snapshots_path_for_collection(collection_name);
+     if !collection_snapshot_path.exists() {

--- a/pkgs/servers/search/qdrant/default.nix
+++ b/pkgs/servers/search/qdrant/default.nix
@@ -23,6 +23,7 @@ rustPlatform.buildRustPackage rec {
 
   patches = [
     ./1.6.1-CVE-2024-3078.patch
+    ./1.6.1-CVE-2024-2221.patch
   ];
 
   cargoLock = {


### PR DESCRIPTION
## Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2024-2221

It's hard to tell whether this is necessary given the CVE-2024-3078 patch we already have - they appear to address the same bug, but at different levels - this patch performs some sanitization at the REST handler level while the CVE-2024-3078 patch operates at a lower level. Better safe than sorry, and I guess the CVE-2024-3078 patch is written expecting this sanitization to have been applied here.

See also #307322

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
