### PR TITLE
Revert "python312Packages.msgraph-sdk: 1.2.0 -> 1.3.0"

### DIFF
--- a/pkgs/development/python-modules/msgraph-sdk/default.nix
+++ b/pkgs/development/python-modules/msgraph-sdk/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "msgraph-sdk";
-  version = "1.3.0";
+  version = "1.2.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "microsoftgraph";
     repo = "msgraph-sdk-python";
     rev = "refs/tags/v${version}";
-    hash = "sha256-RdjACxEB4w1Sbdf8lPHd12XcEMXBqaa84mF9XvavyHo=";
+    hash = "sha256-UaGdusPGWlF7gTzpCq9WrF/evdDSK5srrkH8/Vz9O8M=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#304702

1.3.0 was yanked (https://pypi.org/project/msgraph-sdk/1.3.0/)