### PR TITLE
linuxPackages.drbd: fix file collision

### DIFF
--- a/pkgs/os-specific/linux/drbd/driver.nix
+++ b/pkgs/os-specific/linux/drbd/driver.nix
@@ -41,6 +41,9 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace 'SHELL=/bin/bash' 'SHELL=${builtins.getEnv "SHELL"}'
   '';
 
+  # builder.pl had complained about the same file (drbd.ko.xz) provided by two different packages
+  # builder.pl also had complained about different permissions between the files from the two packages
+  # The compression is required because the kernel has the CONFIG_MODULE_COMPRESS_XZ option enabled
   postFixup = ''
     for ko in $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd9/*.ko; do
       xz --compress -6 --threads=0 $ko

--- a/pkgs/os-specific/linux/drbd/driver.nix
+++ b/pkgs/os-specific/linux/drbd/driver.nix
@@ -26,12 +26,12 @@ stdenv.mkDerivation rec {
   # 6.4 and newer provide a in-tree version of the handshake module https://www.kernel.org/doc/html/v6.4/networking/tls-handshake.html
   installPhase = ''
     runHook preInstall
-    install -D drbd/drbd.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd
-    install -D drbd/drbd_transport_tcp.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd
-    install -D drbd/drbd_transport_lb-tcp.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd
-    install -D drbd/drbd_transport_rdma.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd
+    install -D drbd/drbd.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd9
+    install -D drbd/drbd_transport_tcp.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd9
+    install -D drbd/drbd_transport_lb-tcp.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd9
+    install -D drbd/drbd_transport_rdma.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd9
     ${lib.optionalString (lib.versionOlder kernel.version "6.4") ''
-      install -D drbd/drbd-kernel-compat/handshake/handshake.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd
+      install -D drbd/drbd-kernel-compat/handshake/handshake.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd9
     ''}
     runHook postInstall
   '';
@@ -42,8 +42,9 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    for ko in $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd/*.ko; do
+    for ko in $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/block/drbd9/*.ko; do
       xz --compress -6 --threads=0 $ko
+      chmod 0444 $ko.xz
     done
   '';
 


### PR DESCRIPTION
## Description of changes

- chmod step added to enforce 0444 permissions for the ko.xz files
- drbd9 directory used
- [builder.pl](https://github.com/NixOS/nixpkgs/blob/cc1c4a2832714f26c7e226bb3a8b73f4903383a8/pkgs/build-support/buildenv/builder.pl#L187) had complained about the same file (drbd.ko.xz) provided by two different packages
- builder.pl also had complained about [different permissions](https://github.com/NixOS/nixpkgs/blob/cc1c4a2832714f26c7e226bb3a8b73f4903383a8/pkgs/build-support/buildenv/builder.pl#L103) between the files from the two packages

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - `nix-build ${NIXPKGS} --attr pkgs.drbd.passthru.tests`
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
    - `nix-build --attr nixosTests.drbd`
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] `nix-build pkgs/top-level/release.nix -A tarball.nixpkgs-basic-release-checks --arg supportedSystems '[ "aarch64-linux" "x86_64-linux" ]'` 
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
