### PR TITLE
switch-to-configuration.pl: Fix timers resulting in old unit running

### DIFF
--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -806,6 +806,7 @@ if (scalar(keys(%units_to_stop)) > 0) {
         print STDERR "stopping the following units: ", join(", ", @units_to_stop_filtered), "\n";
     }
     # Use current version of systemctl binary before daemon is reexeced.
+    # The stop may be cancelled by a timer, see note [systemd-timers-cancelling-stop-commands].
     system("$cur_systemd/systemctl", "stop", "--", sort(keys(%units_to_stop)));
 }
 
@@ -933,16 +934,51 @@ if (scalar(keys(%units_to_restart)) > 0) {
     unlink($restart_list_file);
 }
 
-# Start all active targets, as well as changed units we stopped above.
-# The latter is necessary because some may not be dependencies of the
-# targets (i.e., they were manually started).  FIXME: detect units
+# Start all active _targets_, as well as changed _units_ we stopped above.
+# Both are included in `units_to_start`.
+# Starting the changed units explicitly is necessary because
+# some may not be dependencies of the
+# targets (i.e., they were manually started).
+#
+# Note [systemd-timers-cancelling-stop-commands]:
+# We need to start the changed units with `restart` instead of `start`.
+# This is because of systemd timers, which can make our life miserable:
+#     https://github.com/NixOS/nixpkgs/issues/49415
+# If during `systemctl stop` above, a timer restarts a unit (directly or
+# as a dependency), systemctl will cancel the stop and execute the restart.
+# The stop command in that case prints:
+#     Job for myjob.service canceled
+# If a timer-caused restart cancels a stop, the unit will have been
+# restarted with the unit definition from before the configuration switch,
+# so it will be outdated (e.g. run the wrong binary or config).
+# If we only `start`ed such a unit here, it would continue running outdated.
+# Thus, we must `restart` the units we stopped above.
+# But we need to do that only with the units we stopped above,
+# not all `units_to_start`: If we `restart`ed all `.target`s,
+# this would do too much, e.g. kill the network.
+# A minor drawback of this approach is that units that fail the `restart`
+# get a second chance with the subsequent `start`.
+# This may be confusing to users when reading logs or designing timeouts.
+# Unfortunately, we must do it this way, because otherwise a fundamental promise
+# of NixOS is broken (congruent configuration management:
+# "the system runs the declared services, not some old leftover ones").
+# A better solution would be if systemd provided a command where one
+# could, within a single systemd transaction, say which units should
+# be started and which ones restarted.
+# For what "transaction" means, see:
+#     https://github.com/systemd/systemd/issues/10626
+#
+# FIXME: detect units
 # that are symlinks to other units.  We shouldn't start both at the
 # same time because we'll get a "Failed to add path to set" error from
 # systemd.
 my @units_to_start_filtered = filter_units(\%units_to_start);
 if (scalar(@units_to_start_filtered)) {
-    print STDERR "starting the following units: ", join(", ", @units_to_start_filtered), "\n"
+    # See note [systemd-timers-cancelling-stop-commands].
+    print STDERR "starting (via restart, see #49415) the following units: ", join(", ", sort(@units_to_start_filtered)), "\n";
+    system("$new_systemd/bin/systemctl", "restart", "--", sort(@units_to_start_filtered)) == 0 or $res = 4;
 }
+print STDERR "ensuring the following units and targets are started: ", join(", ", sort(keys(%units_to_start))), "\n";
 system("$new_systemd/bin/systemctl", "start", "--", sort(keys(%units_to_start))) == 0 or $res = 4;
 unlink($start_list_file);
 


### PR DESCRIPTION
Fixes #49415.

See the added comment for a detail description.

See also the related #49528.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

CC:

* @flokli @arianvp @Gabriella439 from #49415.
* @symphorien from https://github.com/NixOS/nixpkgs/issues/49528#issuecomment-747723198
* @dasJ from #49528