### PR TITLE
qt6: drop debug and developerBuild in favor of cmakeBuildType

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -15,10 +15,6 @@
 , buildPackages
 , python3
 , config
-
-  # options
-, developerBuild ? false
-, debug ? false
 }:
 
 let
@@ -47,7 +43,6 @@ let
       qtbase = callPackage ./modules/qtbase.nix {
         withGtk3 = !stdenv.hostPlatform.isMinGW;
         inherit (srcs.qtbase) src version;
-        inherit developerBuild;
         inherit (darwin.apple_sdk_11_0.frameworks)
           AGL AVFoundation AppKit Contacts CoreBluetooth EventKit GSS MetalKit;
         patches = [
@@ -197,7 +192,6 @@ let
             name = "qmake6-hook";
             propagatedBuildInputs = [ qtbase.dev ];
             substitutions = {
-              inherit debug;
               fix_qmake_libtool = ./hooks/fix-qmake-libtool.sh;
             };
           } ./hooks/qmake-hook.sh)

--- a/pkgs/development/libraries/qt-6/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qmake-hook.sh
@@ -18,12 +18,6 @@ qmakePrePhase() {
         "NIX_OUTPUT_PLUGIN=${!outputBin}/${qtPluginPrefix:?}"
     )
 
-    if [ -n "@debug@" ]; then
-        qmakeFlags+=("CONFIG+=debug")
-    else
-        qmakeFlags+=("CONFIG+=release")
-    fi
-
     qmakeFlags+=("${qmakeFlags_orig[@]}")
 }
 prePhases+=" qmakePrePhase"

--- a/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
@@ -15,20 +15,6 @@ else # Only set up Qt once.
     . @fix_qt_builtin_paths@
     . @fix_qt_module_paths@
 
-    # Disable debug symbols if qtbase was built without debugging.
-    # This stops -dev paths from leaking into other outputs.
-    if [ -z "@debug@" ]; then
-        NIX_CFLAGS_COMPILE="${NIX_CFLAGS_COMPILE-}${NIX_CFLAGS_COMPILE:+ }-DQT_NO_DEBUG"
-    fi
-
-    # Integration with CMake:
-    # Set the CMake build type corresponding to how qtbase was built.
-    if [ -n "@debug@" ]; then
-        cmakeBuildType="Debug"
-    else
-        cmakeBuildType="Release"
-    fi
-
     # Build tools are often confused if QMAKE is unset.
     export QMAKE=@out@/bin/qmake
 

--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -92,21 +92,16 @@
   # options
 , libGLSupported ? stdenv.hostPlatform.isLinux
 , libGL
-, debug ? false
-, developerBuild ? false
 , qttranslations ? null
 }:
 
 let
-  debugSymbols = debug || developerBuild;
   isCrossBuild = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 in
 stdenv.mkDerivation rec {
   pname = "qtbase";
 
   inherit src version;
-
-  debug = debugSymbols;
 
   propagatedBuildInputs = [
     libxml2
@@ -195,7 +190,6 @@ stdenv.mkDerivation rec {
     CoreBluetooth
   ]
   ++ lib.optional withGtk3 gtk3
-  ++ lib.optional developerBuild gdb
   ++ lib.optional (cups != null && lib.meta.availableOn stdenv.hostPlatform cups) cups
   ++ lib.optional (libmysqlclient != null && !stdenv.hostPlatform.isMinGW) libmysqlclient
   ++ lib.optional (postgresql != null && lib.meta.availableOn stdenv.hostPlatform postgresql) postgresql;
@@ -265,8 +259,6 @@ stdenv.mkDerivation rec {
     # FIXME: not sure why this isn't added automatically?
     patchelf --add-rpath "${libmysqlclient}/lib/mariadb" $out/${qtPluginPrefix}/sqldrivers/libqsqlmysql.so
   '';
-
-  dontStrip = debugSymbols;
 
   dontWrapQtApps = true;
 


### PR DESCRIPTION
## Description of changes
Alternative version of https://github.com/NixOS/nixpkgs/pull/299364, dropping the ad-hoc debug flags altogether.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
