### PR TITLE
add a gdb wrapper capable of lazy loading pwndbg's gdbinit.py

### DIFF
--- a/pkgs/by-name/pw/pwndbg/package.nix
+++ b/pkgs/by-name/pw/pwndbg/package.nix
@@ -4,8 +4,8 @@
 , fetchFromGitHub
 , makeWrapper
 , gdb
+,
 }:
-
 let
   pwndbg-py = python3.pkgs.pwndbg;
 
@@ -13,7 +13,8 @@ let
 
   binPath = lib.makeBinPath ([
     python3.pkgs.pwntools # ref: https://github.com/pwndbg/pwndbg/blob/2022.12.19/pwndbg/wrappers/checksec.py#L8
-  ] ++ lib.optionals stdenv.isLinux [
+  ]
+  ++ lib.optionals stdenv.isLinux [
     python3.pkgs.ropper # ref: https://github.com/pwndbg/pwndbg/blob/2022.12.19/pwndbg/commands/ropper.py#L30
     python3.pkgs.ropgadget # ref: https://github.com/pwndbg/pwndbg/blob/2022.12.19/pwndbg/commands/rop.py#L32
   ]);
@@ -40,7 +41,13 @@ stdenv.mkDerivation rec {
     makeWrapper ${gdb}/bin/gdb $out/bin/pwndbg \
       --add-flags "-q -x $out/share/pwndbg/gdbinit.py" \
       --prefix PATH : ${binPath} \
+      --set PYTHONPATH ${pythonPath}
+
+    makeWrapper ${gdb}/bin/gdb $out/bin/gdb-with-pwndbg-env \
+      --add-flags "-q" \
+      --prefix PATH : ${binPath} \
       --set PYTHONPATH ${pythonPath} \
+      --set PWNDBG_VENV_PATH PWNDBG_PLEASE_SKIP_VENV
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Description of changes

Adds a gdb wrapper whose environment is capable of lazy loading pwndbg via gdbinit.py. The use case is that I very often have to run gdb without pwndbg in order to setup initial debugging and attach to remote targets, to avoid crashes/errors, but once I hit the state that I actually want to proper analysis I load pwndbg. Some of the things that caused this to be required can be (and have been) fixed upstream in pwndbg, but the reality is day-to-day I still need use this approach and have been for years.

So the idea is from your dev shell (or wherever) you would use gdb-with-pwndbg-env (via aliasing gdb cmd or manually running), then when you actually need pwndbg you source ~/.nix-profile/share/pwndbg/gdbinit.py. The way I've been dealing with this in my devshells is using something like this: 
```bash
sed -e 's/^exec \(.*\)-x.*/export PWNDBG_VENV_PATH=PWNDBG_PLEASE_SKIP_VENV\nexec \1 "\$@"/g' ${pkgs.lib.getBin pkgs.pwndbg}/bin/pwndbg > debug/gdb-with-pwndbg-env
``` 

But, I'd rather have a solution in nixpkgs itself if possible, as it will benefit other pwndbg users.

I'm open to a different name for `gdb-with-pwndbg-env`; I'm not sure if there's precedent for this type of thing elsewhere in nixpkgs, so maybe there is a standard.

@mic92 @patryk4815 @msanft 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
