### PR TITLE
tetrio-desktop: unstable-2024-04-20 -> 0.27.2

### DIFF
--- a/pkgs/by-name/te/tetrio-desktop/package.nix
+++ b/pkgs/by-name/te/tetrio-desktop/package.nix
@@ -28,7 +28,12 @@ stdenv.mkDerivation (finalAttrs: {
     let
       tetrio-plus' =
         if tetrio-plus == null
-        then callPackage ./tetrio-plus.nix { tetrio-src = finalAttrs.src; }
+        then
+          callPackage ./tetrio-plus.nix
+            {
+              tetrio-src = finalAttrs.src;
+              tetrio-version = finalAttrs.version;
+            }
         else tetrio-plus;
 
       asarPath =

--- a/pkgs/by-name/te/tetrio-desktop/tetrio-plus.nix
+++ b/pkgs/by-name/te/tetrio-desktop/tetrio-plus.nix
@@ -14,16 +14,17 @@
 , asar
 
 , tetrio-src
+, tetrio-version
 }:
 
 let
-  version = "unstable-2024-04-20";
+  version = "0.27.2";
 
   src = fetchFromGitLab {
     owner = "UniQMG";
     repo = "tetrio-plus";
-    rev = "8091b969cddbff32254eaebf8088efb63f4c519a";
-    hash = "sha256-ow9DrS3jWNtTbz8Obj4l8Zdr3u9m7f9V3dYUE2H3thk=";
+    rev = "electron-v${version}-tetrio-v${lib.versions.major tetrio-version}";
+    hash = "sha256-PvTivTt1Zuvk5gaCcQDcIBFsUf/ZG7TJYXqm0NP++Bw=";
     fetchSubmodules = true;
 
     # tetrio-plus uses this info for displaying its version,
@@ -52,7 +53,7 @@ let
 
     sourceRoot = "${src.name}/tpsecore";
 
-    cargoHash = "sha256-r5Qcu2u/ju0b/1PWz9tE5jNlNS3PfzS79Gm1XSKA3W4=";
+    cargoHash = "sha256-K9l8wQOtjf3l8gZMMdVnaNrgzVWGl62iBBcpA+ulJbw=";
 
     nativeBuildInputs = [
       wasm-pack
@@ -126,6 +127,11 @@ stdenv.mkDerivation (finalAttrs: {
     # Finally, we install the tetrio-plus code where the above patch script expects
     cp -r $src out/tetrioplus
     chmod -R u+w out/tetrioplus
+
+    # Disable the uninstall button in the tetrio-plus popup,
+    # as it doesn't make sense to mutably uninstall it in a nix package
+    substituteInPlace out/tetrioplus/desktop-manifest.js \
+      --replace-fail '"show_uninstaller_button": true' '"show_uninstaller_button": false'
 
     # We don't need the tpsecore source code bundled
     rm -rf out/tetrioplus/tpsecore/


### PR DESCRIPTION
## Description of changes
Finally moving to a stable tag, also includes a small change to disable the uninstall button, since it doesn't make sense to uninstall from the nix-store.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
