### PR TITLE
jumppad: 0.5.59 -> 0.11.1

### DIFF
--- a/pkgs/tools/virtualization/jumppad/default.nix
+++ b/pkgs/tools/virtualization/jumppad/default.nix
@@ -2,15 +2,15 @@
 
 buildGoModule rec {
   pname = "jumppad";
-  version = "0.5.59";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "jumppad-labs";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-ObDbZ3g+BtH8JCqLIa+gR69GowZA8T9HMPuKNDgW3uA=";
+    repo = "jumppad";
+    rev = version;
+    hash = "sha256-ZlwRHHacgUzsap89tm5soCTcWWWN3i/Mr8gk+6DhBjQ=";
   };
-  vendorHash = "sha256-9DLDc6zI0BYd2AK9xwqFNJTFdKXagkdPwczLhCvud94=";
+  vendorHash = "sha256-4iYyb0P7WXCSoZhfHQHFXBu8q7h57YfKyABgv1/YiX0=";
 
   ldflags = [
     "-s" "-w" "-X main.version=${version}"

--- a/pkgs/tools/virtualization/jumppad/default.nix
+++ b/pkgs/tools/virtualization/jumppad/default.nix
@@ -2,18 +2,21 @@
 
 buildGoModule rec {
   pname = "jumppad";
-  version = "0.11.0";
+  version = "0.11.1";
 
   src = fetchFromGitHub {
     owner = "jumppad-labs";
     repo = "jumppad";
     rev = version;
-    hash = "sha256-ZlwRHHacgUzsap89tm5soCTcWWWN3i/Mr8gk+6DhBjQ=";
+    hash = "sha256-8oynWGvWRqXcIBpgLEpFFDwPCbyePXJmFC8xgKPaN9Q=";
   };
-  vendorHash = "sha256-4iYyb0P7WXCSoZhfHQHFXBu8q7h57YfKyABgv1/YiX0=";
+  vendorHash = "sha256-39CORZ5qqbMJuTzYt1sKbHPPYkQEwQWSIQ4hWqdUFmk=";
+
+  subPackages = [ "." ];
 
   ldflags = [
-    "-s" "-w" "-X main.version=${version}"
+    "-s"
+    "-X main.version=${version}"
   ];
 
   # Tests require a large variety of tools and resources to run including


### PR DESCRIPTION
## Description of changes

Update includes a bunch of vulnerability fixes:

https://pkg.go.dev/vuln/GO-2024-2611
https://pkg.go.dev/vuln/GO-2023-2153
https://pkg.go.dev/vuln/GO-2024-2687
https://pkg.go.dev/vuln/GO-2024-2554
https://pkg.go.dev/vuln/GO-2023-2074
https://pkg.go.dev/vuln/GO-2023-1990
https://pkg.go.dev/vuln/GO-2023-1989
https://pkg.go.dev/vuln/GO-2023-1572
https://pkg.go.dev/vuln/GO-2023-1547
https://pkg.go.dev/vuln/GO-2022-1167
https://pkg.go.dev/vuln/GO-2022-1166
https://pkg.go.dev/vuln/GO-2022-1165
https://pkg.go.dev/vuln/GO-2022-0962

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
