### PR TITLE
howard-hinnant-date: fix installed cmake version

### DIFF
--- a/pkgs/development/libraries/howard-hinnant-date/default.nix
+++ b/pkgs/development/libraries/howard-hinnant-date/default.nix
@@ -33,6 +33,13 @@ stdenv.mkDerivation rec {
       src = ./make-zoneinfo-available.diff;
       inherit tzdata;
     })
+    # The reported version to cmake's find_package() is 3.0.0, but the actual
+    # version is 3.0.1. This patch fixes that.
+    (fetchpatch {
+      name = "fix-cmake-version.patch";
+      url = "https://github.com/HowardHinnant/date/commit/2e19c006e2218447ee31f864191859517603f59f.patch";
+      hash = "sha256-SRAWrwv64ap3Qh3RlhwqgS0L2YsrjqVSgw6iH3KlWvk=";
+    })
   ];
 
   # Tweaks to fix undefined variable substitutions


### PR DESCRIPTION
The report installed version report to cmake was `3.0.0`, however the
real version is `3.0.1`. This was causing cmake's `find_package(date
3.0.1)` to fail.

```console
cat /nix/store/cx2jc7aay0if0f3s0nc1i5raahd3p4hk-howard-hinnant-date-3.0.1-dev/lib/cmake/date/dateConfigVersion.cmake

set(PACKAGE_VERSION "3.0.1")
```

Before this patch, the file contained `set(PACKAGE_VERSION "3.0.0")`.

This patch is already merged upstream in the `master` branch.
