### PR TITLE
tdnf: init at 3.5.6

### DIFF
--- a/pkgs/by-name/td/tdnf/package.nix
+++ b/pkgs/by-name/td/tdnf/package.nix
@@ -1,0 +1,77 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, curl
+, gpgme
+, libsolv
+, libxml2
+, pkg-config
+, python3
+, rpm
+, sqlite
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tdnf";
+  version = "3.5.6";
+
+  src = fetchFromGitHub {
+    owner = "vmware";
+    repo = "tdnf";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-gj0IW0EwWBXi2s7xFdghop8f1lMhkUJVAkns5nnl7sg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    curl.dev
+    gpgme.dev
+    libsolv
+    libxml2.dev
+    sqlite.dev
+  ];
+
+  propagatedBuildInputs = [
+    rpm
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=$out"
+    "-DCMAKE_INSTALL_FULL_SYSCONDIR=$out/etc"
+    "-DCMAKE_INSTALL_SYSCONFDIR=$out/etc"
+    "-DSYSTEMD_DIR=$out/lib/systemd/system"
+  ];
+
+  # error: format not a string literal and no format arguments [-Werror=format-security]
+  hardeningDisable = [ "format" ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'SYSCONFDIR /etc' 'SYSCONFDIR $out/etc' \
+      --replace-fail '/etc/motdgen.d' '$out/etc/motdgen.d'
+    substituteInPlace client/tdnf.pc.in \
+      --replace-fail 'libdir=''${prefix}/@CMAKE_INSTALL_LIBDIR@' 'libdir=@CMAKE_INSTALL_FULL_LIBDIR@'
+    substituteInPlace tools/cli/lib/tdnf-cli-libs.pc.in \
+      --replace-fail 'libdir=''${prefix}/@CMAKE_INSTALL_LIBDIR@' 'libdir=@CMAKE_INSTALL_FULL_LIBDIR@'
+  '';
+
+  # remove binaries used for testing from the final output
+  postInstall = "rm $out/bin/*test";
+
+  meta = {
+    description = "Tiny Dandified Yum";
+    homepage = "https://github.com/vmware/tdnf";
+    changelog = "https://github.com/vmware/tdnf/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [ gpl2 lgpl21 ];
+    maintainers = [ lib.maintainers.malt3 ];
+    mainProgram = "tdnf";
+    # rpm only supports linux
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add tdnf, a dnf variant similar to microdnf.
This package manager is used to assemble the linux distributions VMWare Photon OS and Microsoft's cbl-mariner / Azure Linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
