### PR TITLE
ironbar: 0.14.1 -> 0.15.0; added feature checks

### DIFF
--- a/pkgs/by-name/ir/ironbar/package.nix
+++ b/pkgs/by-name/ir/ironbar/package.nix
@@ -1,63 +1,76 @@
-{ gtk3
-, gdk-pixbuf
-, librsvg
-, webp-pixbuf-loader
-, gobject-introspection
-, glib-networking
-, glib
-, shared-mime-info
-, gsettings-desktop-schemas
-, wrapGAppsHook3
-, gtk-layer-shell
-, gnome
-, libxkbcommon
-, openssl
-, pkg-config
-, hicolor-icon-theme
-, rustPlatform
-, lib
-, fetchFromGitHub
+{
+  gtk3,
+  gdk-pixbuf,
+  librsvg,
+  webp-pixbuf-loader,
+  gobject-introspection,
+  glib-networking,
+  glib,
+  shared-mime-info,
+  gsettings-desktop-schemas,
+  wrapGAppsHook3,
+  gtk-layer-shell,
+  gnome,
+  libxkbcommon,
+  openssl,
+  pkg-config,
+  hicolor-icon-theme,
+  rustPlatform,
+  lib,
+  fetchFromGitHub,
+  luajit,
+  luajitPackages,
+  libpulseaudio,
+  features ? [ ],
 }:
 
+let
+  hasFeature = f: features == [ ] || builtins.elem f features;
+in
 rustPlatform.buildRustPackage rec {
   pname = "ironbar";
-  version = "0.14.1";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "JakeStanger";
     repo = "ironbar";
     rev = "v${version}";
-    hash = "sha256-y4w4i/IVe1+wjB2tsCPQH6c7XTl93u45Q0pXFi3TY1E=";
+    hash = "sha256-SowZ3qo06x32+A02Wmq4N/rU/yxyKqkn407qHzJLU0M=";
   };
 
-  cargoHash = "sha256-h5yNJM+NvX/Hi86iSegHWevPcPZeDmJ4y/qNr3G20Qg=";
+  cargoHash = "sha256-DaF669mOnICTnUzH4mc640xIecin/UEZSk7PWDjQbr0=";
 
-  buildInputs = [
-    gtk3
-    gdk-pixbuf
-    glib
-    gtk-layer-shell
-    glib-networking
-    shared-mime-info
-    gnome.adwaita-icon-theme
-    hicolor-icon-theme
-    gsettings-desktop-schemas
-    libxkbcommon
-    openssl
-  ];
+  buildInputs =
+    [
+      gtk3
+      gdk-pixbuf
+      glib
+      gtk-layer-shell
+      glib-networking
+      shared-mime-info
+      gnome.adwaita-icon-theme
+      hicolor-icon-theme
+      gsettings-desktop-schemas
+      libxkbcommon
+    ]
+    ++ lib.optionals (hasFeature "http") [ openssl ]
+    ++ lib.optionals (hasFeature "volume") [ libpulseaudio ]
+    ++ lib.optionals (hasFeature "cairo") [ luajit ];
 
   nativeBuildInputs = [
     pkg-config
     wrapGAppsHook3
     gobject-introspection
   ];
+  propagatedBuildInputs = [ gtk3 ];
 
-  propagatedBuildInputs = [
-    gtk3
-  ];
+  runtimeDeps = [ luajitPackages.lgi ];
 
-  preFixup = ''
-    gappsWrapperArgs+=(
+  buildNoDefaultFeatures = features != [ ];
+  buildFeatures = features;
+
+  gappsWrapperArgs =
+    ''
       # Thumbnailers
       --prefix XDG_DATA_DIRS : "${gdk-pixbuf}/share"
       --prefix XDG_DATA_DIRS : "${librsvg}/share"
@@ -66,6 +79,15 @@ rustPlatform.buildRustPackage rec {
 
       # gtk-launch
       --suffix PATH : "${lib.makeBinPath [ gtk3 ]}"
+    ''
+    + lib.optionalString (hasFeature "cairo") ''
+      --prefix LUA_PATH : "./?.lua;${luajitPackages.lgi}/share/lua/5.1/?.lua;${luajitPackages.lgi}/share/lua/5.1/?/init.lua;${luajit}/share/lua/5.1/\?.lua;${luajit}/share/lua/5.1/?/init.lua"
+      --prefix LUA_CPATH : "./?.so;${luajitPackages.lgi}/lib/lua/5.1/?.so;${luajit}/lib/lua/5.1/?.so;${luajit}/lib/lua/5.1/loadall.so"
+    '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      ${gappsWrapperArgs}
     )
   '';
 
@@ -74,7 +96,11 @@ rustPlatform.buildRustPackage rec {
     description = "Customizable gtk-layer-shell wlroots/sway bar written in Rust";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ yavko donovanglover jakestanger ];
+    maintainers = with maintainers; [
+      yavko
+      donovanglover
+      jakestanger
+    ];
     mainProgram = "ironbar";
   };
 }


### PR DESCRIPTION
## Description of changes

closes https://github.com/NixOS/nixpkgs/issues/307687

https://github.com/JakeStanger/ironbar/releases/tag/v0.15.0

overcame a few build issues using `nix develop .#ironbar` in a cloned version of ironbar, this resulted in me adding the following new inputs to fix the build issues:
- `libpulseaudio`
- `luajit`
- `lua51Packages.lgi`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
