### PR TITLE
pkgs/applications: Fix some unstableGitUpdater users

### DIFF
--- a/pkgs/applications/audio/littlegptracker/default.nix
+++ b/pkgs/applications/audio/littlegptracker/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation {
   pname = "littlegptracker";
-  version = "unstable-2020-11-26";
+  version = "0-unstable-2020-11-26";
 
   src = fetchFromGitHub {
     owner = "Mdashdotdashn";

--- a/pkgs/applications/audio/mmlgui/default.nix
+++ b/pkgs/applications/audio/mmlgui/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation rec {
   pname = "mmlgui";
-  version = "unstable-2024-04-15";
+  version = "210420-preview-unstable-2024-04-15";
 
   src = fetchFromGitHub {
     owner = "superctr";

--- a/pkgs/applications/audio/mopidy/spotify.nix
+++ b/pkgs/applications/audio/mopidy/spotify.nix
@@ -2,7 +2,7 @@
 
 pythonPackages.buildPythonApplication rec {
   pname = "mopidy-spotify";
-  version = "unstable-2024-02-27";
+  version = "4.1.1-unstable-2024-02-27";
 
   src = fetchFromGitHub {
     owner = "mopidy";
@@ -22,7 +22,9 @@ pythonPackages.buildPythonApplication rec {
 
   pythonImportsCheck = [ "mopidy_spotify" ];
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
 
   meta = with lib; {
     homepage = "https://github.com/mopidy/mopidy-spotify";

--- a/pkgs/applications/audio/vgmplay-libvgm/default.nix
+++ b/pkgs/applications/audio/vgmplay-libvgm/default.nix
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation {
   pname = "vgmplay-libvgm";
-  version = "unstable-2024-01-03";
+  version = "0.51.1-unstable-2024-01-03";
 
   src = fetchFromGitHub {
     owner = "ValleyBell";

--- a/pkgs/applications/emulators/retroarch/retroarch-assets.nix
+++ b/pkgs/applications/emulators/retroarch/retroarch-assets.nix
@@ -6,7 +6,7 @@
 
 stdenvNoCC.mkDerivation {
   pname = "retroarch-assets";
-  version = "unstable-2024-04-24";
+  version = "1.17.0-unstable-2024-04-24";
 
   src = fetchFromGitHub {
     owner = "libretro";
@@ -24,7 +24,9 @@ stdenvNoCC.mkDerivation {
 
   dontBuild = true;
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
 
   meta = with lib; {
     description = "Assets needed for RetroArch";

--- a/pkgs/applications/misc/kile-wl/default.nix
+++ b/pkgs/applications/misc/kile-wl/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "kile-wl";
-  version = "unstable-2023-07-23";
+  version = "2.1-unstable-2023-07-23";
 
   src = fetchFromGitLab {
     owner = "snakedye";
@@ -13,6 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   passthru.updateScript = unstableGitUpdater {
     url = "https://gitlab.com/snakedye/kile.git";
+    tagPrefix = "v";
   };
 
   cargoLock = {

--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/tg_owt.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/tg_owt.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation {
   pname = "tg_owt";
-  version = "unstable-2023-12-21";
+  version = "0-unstable-2023-12-21";
 
   src = fetchFromGitHub {
     owner = "desktop-app";

--- a/pkgs/applications/networking/p2p/libutp/3.4.nix
+++ b/pkgs/applications/networking/p2p/libutp/3.4.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libutp";
-  version = "unstable-2023-11-14";
+  version = "0-unstable-2023-11-14";
 
   src = fetchFromGitHub {
     # Use transmission fork from post-3.4-transmission branch

--- a/pkgs/applications/networking/p2p/transgui/default.nix
+++ b/pkgs/applications/networking/p2p/transgui/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   pname = "transgui";
-  version = "unstable-2024-02-26";
+  version = "5.18.0-unstable-2024-02-26";
 
   src = fetchFromGitHub {
     owner = "transmission-remote-gui";
@@ -60,7 +60,9 @@ stdenv.mkDerivation rec {
     cp -r "./lang" "$out/share/transgui"
   '';
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
 
   meta = {
     description = "A cross platform front-end for the Transmission BitTorrent client";

--- a/pkgs/applications/networking/sync/wdt/default.nix
+++ b/pkgs/applications/networking/sync/wdt/default.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation {
   pname = "wdt";
-  version = "unstable-2024-02-05";
+  version = "1.27.1612021-unstable-2024-02-05";
 
   src = fetchFromGitHub {
     owner = "facebook";
@@ -37,7 +37,9 @@ stdenv.mkDerivation {
   ];
 
   passthru = {
-    updateScript = unstableGitUpdater { };
+    updateScript = unstableGitUpdater {
+      tagPrefix = "v";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/radio/chirp/default.nix
+++ b/pkgs/applications/radio/chirp/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, writeShellScript
 , glib
 , gsettings-desktop-schemas
 , python3
@@ -9,7 +10,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "chirp";
-  version = "unstable-2024-02-08";
+  version = "0.4.0-unstable-2024-02-08";
 
   src = fetchFromGitHub {
     owner = "kk7ds";
@@ -37,7 +38,9 @@ python3.pkgs.buildPythonApplication rec {
   doCheck = false;
 
   passthru.updateScript = unstableGitUpdater {
-    branch = "py3";
+    tagConverter = writeShellScript "chirp-tag-converter.sh" ''
+      sed -e 's/^release_//g' -e 's/_/./g'
+    '';
   };
 
   meta = with lib; {

--- a/pkgs/applications/science/math/eigenmath/default.nix
+++ b/pkgs/applications/science/math/eigenmath/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   pname = "eigenmath";
-  version = "unstable-2024-04-26";
+  version = "0-unstable-2024-04-26";
 
   src = fetchFromGitHub {
     owner = "georgeweigt";

--- a/pkgs/applications/window-managers/miriway/default.nix
+++ b/pkgs/applications/window-managers/miriway/default.nix
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "miriway";
-  version = "unstable-2024-04-25";
+  version = "0-unstable-2024-04-25";
 
   src = fetchFromGitHub {
     owner = "Miriway";


### PR DESCRIPTION
## Description of changes

#280501 now makes `unstableGitUpdater` produce versions that match our desired unstable version schema. Start fixing the versions of packages that use it, and their `unstableGitUpdater` arguments as needed.

Excluded from here are `nixops_unstable.passthru.plugins` and `mpvScripts` attrs, just to keep the scope abit more managable.

Pinging @eclairevoyant since they seem to have some interest in implementing this more (sorry if I'm wrong about that!).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>28 packages built:</summary>
  <ul>
    <li>_64gram</li>
    <li>chirp</li>
    <li>chirp.dist</li>
    <li>eigenmath</li>
    <li>kile-wl</li>
    <li>libtransmission_4</li>
    <li>libtransmission_4.apparmor</li>
    <li>libutp_3_4</li>
    <li>littlegptracker</li>
    <li>miriway</li>
    <li>mmlgui</li>
    <li>mopidy-spotify</li>
    <li>mopidy-spotify.dist</li>
    <li>retroarch</li>
    <li>retroarch-assets</li>
    <li>retroarchFull</li>
    <li>telegram-desktop</li>
    <li>transgui</li>
    <li>transmission_4</li>
    <li>transmission_4-gtk</li>
    <li>transmission_4-gtk.apparmor</li>
    <li>transmission_4-qt</li>
    <li>transmission_4-qt.apparmor</li>
    <li>transmission_4-qt6</li>
    <li>transmission_4-qt6.apparmor</li>
    <li>transmission_4.apparmor</li>
    <li>vgmplay-libvgm</li>
    <li>wdt</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
