### PR TITLE
python3Packages.plaso: init at 20240308

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9043,6 +9043,12 @@
     githubId = 5579359;
     name = "Jason Yundt";
   };
+  jayrovacsek = {
+    email = "nixpkgs@jay.rovacsek.com";
+    github = "JayRovacsek";
+    githubId = 29395089;
+    name = "Jay Rovacsek";
+  };
   jb55 = {
     email = "jb55@jb55.com";
     github = "jb55";

--- a/pkgs/development/python-modules/acstore/default.nix
+++ b/pkgs/development/python-modules/acstore/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  pyyaml,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "acstore";
+  version = "20240407";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-yubHDEZ5nwltQW8sLEAhgyaXI0svHCS3a7Mewi6cvpg=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ pyyaml ];
+
+  disabled = pythonOlder "3.8";
+
+  pythonImportsCheck = [ pname ];
+
+  meta = with lib; {
+    changelog = "https://github.com/log2timeline/acstore/releases/tag/${version}";
+    description = "ACStore, or Attribute Container Storage, provides a stand-alone implementation to read and write attribute container storage files.";
+    downloadPage = "https://github.com/log2timeline/acstore/releases";
+    homepage = "https://github.com/log2timeline/acstore";
+    license = licenses.asl20;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/artifacts/default.nix
+++ b/pkgs/development/python-modules/artifacts/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pip,
+  pythonOlder,
+  pyyaml,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "artifacts";
+  version = "20230928";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-uRjyl35Xl+BuTfERNRumsm2LdEag62TuxrLz+n3xy48=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pip
+    pyyaml
+  ];
+
+  disabled = pythonOlder "3.8";
+
+  pythonImportsCheck = [ pname ];
+
+  meta = with lib; {
+    changelog = "https://github.com/ForensicArtifacts/artifacts/releases/tag/${version}";
+    description = "A free, community-sourced, machine-readable knowledge base of forensic artifacts that the world can use both as an information source and within other tools.";
+    homepage = "https://github.com/ForensicArtifacts/artifacts";
+    downloadPage = "https://github.com/ForensicArtifacts/artifacts/releases";
+    license = licenses.asl20;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/dfdatetime/default.nix
+++ b/pkgs/development/python-modules/dfdatetime/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "dfdatetime";
+  version = "20240330";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-vRKhR+/pPLWhzo5s1sXK/oOIu+HZmjEgZflICnXsiJ0=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.8";
+
+  pythonImportsCheck = [ pname ];
+
+  meta = with lib; {
+    changelog = "https://github.com/log2timeline/dfdatetime/releases/tag/${version}";
+    description = "dfDateTime, or Digital Forensics date and time, provides date and time objects to preserve accuracy and precision.";
+    homepage = "https://github.com/log2timeline/dfdatetime";
+    downloadPage = "https://github.com/log2timeline/dfdatetime/releases";
+    license = licenses.asl20;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/dfvfs/default.nix
+++ b/pkgs/development/python-modules/dfvfs/default.nix
@@ -1,0 +1,112 @@
+{
+  lib,
+  attr,
+  buildPythonPackage,
+  cffi,
+  dfdatetime,
+  dtfabric,
+  fetchPypi,
+  libbde-python,
+  libcaes-python,
+  libewf-python,
+  libfcrypto-python,
+  libfsapfs-python,
+  libfsext-python,
+  libfsfat-python,
+  libfshfs-python,
+  libfsntfs-python,
+  libfsxfs-python,
+  libfvde-python,
+  libfwnt-python,
+  libluksde-python,
+  libmodi-python,
+  libphdi-python,
+  libqcow-python,
+  libsigscan-python,
+  libsmdev-python,
+  libsmraw-python,
+  libvhdi-python,
+  libvmdk-python,
+  libvsapm-python,
+  libvsgpt-python,
+  libvshadow-python,
+  libvslvm-python,
+  pythonOlder,
+  pytsk3,
+  pyxattr,
+  pyyaml,
+  setuptools,
+  stdenv,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "dfvfs";
+  version = "20240115";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-FkOB26OdxD9j82oaQFqtGYxKdjGQRLZNCFDq7dOKt7s=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    cffi
+    dfdatetime
+    dtfabric
+    libbde-python
+    libcaes-python
+    libewf-python
+    libfcrypto-python
+    libfsapfs-python
+    libfsext-python
+    libfsfat-python
+    libfshfs-python
+    libfsntfs-python
+    libfsxfs-python
+    libfvde-python
+    libfwnt-python
+    libluksde-python
+    libmodi-python
+    libphdi-python
+    libqcow-python
+    libsigscan-python
+    libsmdev-python
+    libsmraw-python
+    libvhdi-python
+    libvmdk-python
+    libvsapm-python
+    libvsgpt-python
+    libvshadow-python
+    libvslvm-python
+    pytsk3
+    # This is required to support the darwin architecture for pyxattr
+    (pyxattr.overrideAttrs (old: rec {
+      buildInputs = lib.optional stdenv.isLinux attr;
+      meta.platforms = old.meta.platforms ++ [
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      hardeningDisable = lib.optional stdenv.isDarwin "strictoverflow";
+    }))
+    pyyaml
+  ];
+
+  disabled = pythonOlder "3.8";
+
+  # This is required only as the build process incorrectly assumes xattr
+  # is not installed, despite it being included in dependencies.
+  patches = [ ./no-xattr-dependency.patch ];
+
+  pythonImportsCheck = [ pname ];
+
+  meta = with lib; {
+    changelog = "https://github.com/log2timeline/dfvfs/releases/tag/${version}";
+    description = "dfVFS, or Digital Forensics Virtual File System, provides read-only access to file-system objects from various storage media types and file formats. The goal of dfVFS is to provide a generic interface for accessing file-system objects, for which it uses several back-ends that provide the actual implementation of the various storage media types, volume systems and file systems.";
+    downloadPage = "https://github.com/log2timeline/dfvfs/releases";
+    homepage = "https://github.com/log2timeline/dfvfs";
+    license = licenses.asl20;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/dfvfs/no-xattr-dependency.patch
+++ b/pkgs/development/python-modules/dfvfs/no-xattr-dependency.patch
@@ -1,0 +1,21 @@
+From 3c296e00498e56382fcfa8963df2b8fb9fc97f81 Mon Sep 17 00:00:00 2001
+From: jayrovacsek <jay@rovacsek.com>
+Date: Sat, 6 Apr 2024 07:35:59 +1100
+Subject: [PATCH] no xattr dependency
+
+---
+ requirements.txt | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/requirements.txt b/requirements.txt
+index af72d9a..0d32e6e 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -28,4 +28,3 @@ libvsgpt-python >= 20211115
+ libvshadow-python >= 20160109
+ libvslvm-python >= 20160109
+ pytsk3 >= 20210419
+-xattr >= 0.7.2 ; platform_system != "Windows"
+-- 
+2.43.2
+

--- a/pkgs/development/python-modules/dfwinreg/default.nix
+++ b/pkgs/development/python-modules/dfwinreg/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  dfdatetime,
+  dtfabric,
+  fetchPypi,
+  libcreg-python,
+  libregf-python,
+  pyyaml,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "dfwinreg";
+  version = "20240229";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-guiWjSx3LsPkPOgqN6axfE36FOuZet5LrnYIHZqQ6WM=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    dfdatetime
+    libregf-python
+    libcreg-python
+    pyyaml
+    dtfabric
+  ];
+
+  pythonImportsCheck = [ pname ];
+
+  meta = with lib; {
+    changelog = "https://github.com/log2timeline/dfwinreg/releases/tag/${version}";
+    description = "dfWinReg, or Digital Forensics Windows Registry, provides read-only access to Windows Registry objects. The goal of dfWinReg is to provide a generic interface for accessing Windows Registry objects that resembles the Registry key hierarchy as seen on a live Windows system.";
+    downloadPage = "https://github.com/log2timeline/dfwinreg/releases";
+    homepage = "https://github.com/log2timeline/dfwinreg";
+    license = licenses.asl20;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/dtfabric/default.nix
+++ b/pkgs/development/python-modules/dtfabric/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pip,
+  pythonOlder,
+  pyyaml,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "dtfabric";
+  version = "20230520";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-rJPBEe/eAQ7OPPZHeFbomkb8ca3WTheDhs/ic6GohVM=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pip
+    pyyaml
+  ];
+
+  disabled = pythonOlder "3.8";
+
+  pythonImportsCheck = [ pname ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/dtfabric/releases/tag/${version}";
+    description = "dtFabric, or data type fabric, is a project to manage data types and structures, as used in the libyal projects.";
+    downloadPage = "https://github.com/libyal/dtfabric/releases";
+    homepage = "https://github.com/libyal/dtfabric";
+    license = licenses.asl20;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/flor/default.nix
+++ b/pkgs/development/python-modules/flor/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "Flor";
+  version = "1.1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-H6wQHhYURtuy7lN51blQuwFf5tkFaDhaVJtTjKEv6UI=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "flor" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/DCSO/flor/releases/tag/${version}";
+    description = "Flor - An efficient Bloom filter implementation in Python";
+    downloadPage = "https://github.com/DCSO/flor/releases";
+    homepage = "https://github.com/DCSO/flor";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libbde-python/default.nix
+++ b/pkgs/development/python-modules/libbde-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libbde-python";
+  version = "20240223";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-6Au2V4rZ1YAa4gumZXbiWs0DeJQbEM9oJJVjsjJCiYA=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pybde" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libbde/releases/tag/${version}";
+    description = "ACStore, or Attribute Container Storage, provides a stand-alone implementation to read and write attribute container storage files.";
+    downloadPage = "https://github.com/libyal/libbde/releases";
+    homepage = "https://github.com/libyal/libbde";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libcaes-python/default.nix
+++ b/pkgs/development/python-modules/libcaes-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libcaes-python";
+  version = "20240413";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-L39X0Y65cRAkATLVxS+v32A7VNeVL6uJVOBHENNlDqo=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pycaes" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libcaes/releases/tag/${version}";
+    description = "Python bindings module for libcaes";
+    downloadPage = "https://github.com/libyal/libcaes/releases";
+    homepage = "https://github.com/libyal/libcaes";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libcreg-python/default.nix
+++ b/pkgs/development/python-modules/libcreg-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libcreg-python";
+  version = "20240419";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-yXis81GljgJSP6N/Vl7xWkNq049w/lqVjYBEZWL4/04=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pycreg" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libcreg/releases/tag/${version}";
+    description = "Python bindings module for libcreg";
+    homepage = "https://github.com/libyal/libcreg";
+    downloadPage = "https://github.com/libyal/libcreg/releases";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libesedb-python/default.nix
+++ b/pkgs/development/python-modules/libesedb-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libesedb-python";
+  version = "20240420";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-RyfQpuPRUfShQQfouOP4zO0QuUZmV8xqhWycf4bX0IE=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyesedb" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libesedb/releases/tag/${version}";
+    description = "Python bindings module for libesedb";
+    homepage = "https://github.com/libyal/libesedb";
+    downloadPage = "https://github.com/libyal/libesedb/releases";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libevt-python/default.nix
+++ b/pkgs/development/python-modules/libevt-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libevt-python";
+  version = "20240421";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-z2kZ+rl7IEZpANJ4Vc9JiSMz5PLuQ5ySDoX6JgtZ1xU=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyevt" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libevt/releases/releases/tag/${version}";
+    description = "Python bindings module for libevt";
+    homepage = "https://github.com/libyal/libevt";
+    downloadPage = "https://github.com/libyal/libevt/releases";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libevtx-python/default.nix
+++ b/pkgs/development/python-modules/libevtx-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libevtx-python";
+  version = "20240204";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ndEyCnp8H8D9y8bw5i3noEeSMo+R9FmavaM/FeQbCyI=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyevtx" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libevtx/releases/tag/${version}";
+    description = "Python bindings module for libevtx";
+    homepage = "https://github.com/libyal/libevtx";
+    downloadPage = "https://github.com/libyal/libevtx/releases";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libewf-python/default.nix
+++ b/pkgs/development/python-modules/libewf-python/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  zlib,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libewf-python";
+  version = "20231119";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-35hPmLSVZnAQTputkeputePD2pVwYOt7qerbAe8CE4I=";
+  };
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ zlib ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyewf" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libewf/releases/tag/${version}";
+    description = "Python bindings module for libewf";
+    downloadPage = "https://github.com/libyal/libewf/releases";
+    homepage = "https://github.com/libyal/libewf";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libfcrypto-python/default.nix
+++ b/pkgs/development/python-modules/libfcrypto-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libfcrypto-python";
+  version = "20240414";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-I7UKtc4+ELoijGzGpFHxrBml1MesRxRQ2/BC35bZ4AQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyfcrypto" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libfcrypto/releases/tag/${version}";
+    description = "Python bindings module for libfcrypto";
+    downloadPage = "https://github.com/libyal/libfcrypto/releases";
+    homepage = "https://github.com/libyal/libfcrypto";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libfsapfs-python/default.nix
+++ b/pkgs/development/python-modules/libfsapfs-python/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  zlib,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libfsapfs-python";
+  version = "20240218";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-88F2RrVw9+JitNyg3mnkkMaWHKBDZoYxdvfeDRe+slw=";
+  };
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ zlib ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyfsapfs" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libfsapfs/releases/tag/${version}";
+    description = "Python bindings module for libfsapfs";
+    downloadPage = "https://github.com/libyal/libfsapfs/releases";
+    homepage = "https://github.com/libyal/libfsapfs";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libfsext-python/default.nix
+++ b/pkgs/development/python-modules/libfsext-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libfsext-python";
+  version = "20240301";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-BZ8Jta4YoGMraoSbVheYi5BV8AdWjbPi142BdvRTW7g=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyfsext" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libfsext/releases/tag/${version}";
+    description = "Python bindings module for libfsext";
+    homepage = "https://github.com/libyal/libfsext";
+    downloadPage = "https://github.com/libyal/libfsext/releases";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libfsfat-python/default.nix
+++ b/pkgs/development/python-modules/libfsfat-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libfsfat-python";
+  version = "20240220";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-eABliX9tg+AMjbtr0g1BbjZUbgJE+uIljCB7GIMWs2w=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyfsfat" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libfsfat/releases/tag/${version}";
+    description = "Python bindings module for libfsfat";
+    downloadPage = "https://github.com/libyal/libfsfat/releases";
+    homepage = "https://github.com/libyal/libfsfat";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libfshfs-python/default.nix
+++ b/pkgs/development/python-modules/libfshfs-python/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  zlib,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libfshfs-python";
+  version = "20240221";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-7iSD02FCbgClPIbyK2jxbdpX91ccpUt+J0QTnPcSmbM=";
+  };
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ zlib ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyfshfs" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libfshfs/releases/tag/${version}";
+    description = "Python bindings module for libfshfs";
+    downloadPage = "https://github.com/libyal/libfshfs/releases";
+    homepage = "https://github.com/libyal/libfshfs";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libfsntfs-python/default.nix
+++ b/pkgs/development/python-modules/libfsntfs-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libfsntfs-python";
+  version = "20240119";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-Ts400b8VQpDLHlGJvHokUsHiS/OhGTtB27Sn2foqAUY=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyfsntfs" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libfsntfs/releases/tag/${version}";
+    description = "Python bindings module for libfsntfs";
+    homepage = "https://github.com/libyal/libfsntfs";
+    downloadPage = "https://github.com/libyal/libfsntfs/releases";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libfsxfs-python/default.nix
+++ b/pkgs/development/python-modules/libfsxfs-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libfsxfs-python";
+  version = "20240222";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-s5W6rGh+WbFGf7uIU4Cy38EumdMu7GdWHxxBpAN3x5c=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyfsxfs" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libfsxfs/releases/tag/${version}";
+    description = "Python bindings module for libfsxfs";
+    downloadPage = "https://github.com/libyal/libfsxfs/releases";
+    homepage = "https://github.com/libyal/libfsxfs";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libfvde-python/default.nix
+++ b/pkgs/development/python-modules/libfvde-python/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  zlib,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libfvde-python";
+  version = "20240113";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-GN9Je1s2w2o/ps9zZaZgajJiuHWd8vbAmHpqRfBdssg=";
+  };
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ zlib ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyfvde" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libfvde/releases/tag/${version}";
+    description = "Python bindings module for libfvde";
+    downloadPage = "https://github.com/libyal/libfvde/releases";
+    homepage = "https://github.com/libyal/libfvde";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libfwnt-python/default.nix
+++ b/pkgs/development/python-modules/libfwnt-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libfwnt-python";
+  version = "20240415";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-tDdndZKwW2ymR8Gh2AMUki+mXrb4JaxTByY/+Q0+JJM=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyfwnt" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libfwnt/releases/tag/${version}";
+    description = "Python bindings module for libfwnt";
+    downloadPage = "https://github.com/libyal/libfwnt/releases";
+    homepage = "https://github.com/libyal/libfwnt";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libfwsi-python/default.nix
+++ b/pkgs/development/python-modules/libfwsi-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libfwsi-python";
+  version = "20240423";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-2lgCmNhsSr8uD4Ed5scw+BWSxhxCt+d/jyrwZSVaKEM=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyfwsi" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libfwsi/releases/tag/${version}";
+    description = "Python bindings module for libfwsi";
+    downloadPage = "https://github.com/libyal/libfwsi/releases";
+    homepage = "https://github.com/libyal/libfwsi";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/liblnk-python/default.nix
+++ b/pkgs/development/python-modules/liblnk-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "liblnk-python";
+  version = "20240423";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-oCRa/Z9Pbj5dnGbWR8c8PiChrfBPMpL4mGuMqw6Gfx8=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pylnk" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/liblnk/releases/tag/${version}";
+    description = "Python bindings module for liblnk";
+    downloadPage = "https://github.com/libyal/liblnk/releases";
+    homepage = "https://github.com/libyal/liblnk";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libluksde-python/default.nix
+++ b/pkgs/development/python-modules/libluksde-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libluksde-python";
+  version = "20240114";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-3memvir7wBXruXgmVG83aw6NI/T/jIw2mWnJFuoPuBc=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyluksde" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libluksde/releases/tag/${version}";
+    description = "Python bindings module for libluksde";
+    downloadPage = "https://github.com/libyal/libluksde/releases";
+    homepage = "https://github.com/libyal/libluksde";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libmodi-python/default.nix
+++ b/pkgs/development/python-modules/libmodi-python/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  zlib,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libmodi-python";
+  version = "20240305";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-cZy1/RdFbT6OwIT/+MCVpdzRO8sz0P3I6EtcI9HdfNI=";
+  };
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ zlib ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pymodi" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libmodi/releases/tag/${version}";
+    description = "Python bindings module for libmodi";
+    downloadPage = "https://github.com/libyal/libmodi/releases";
+    homepage = "https://github.com/libyal/libmodi";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libmsiecf-python/default.nix
+++ b/pkgs/development/python-modules/libmsiecf-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libmsiecf-python";
+  version = "20240425";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-mdylekKq2hfUO8xQkbvr9F0X5hMp2zE3qkFvfyw9rhY=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pymsiecf" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libmsiecf/releases/tag/${version}";
+    description = "Python bindings module for libmsiecf";
+    downloadPage = "https://github.com/libyal/libmsiecf/releases";
+    homepage = "https://github.com/libyal/libmsiecf";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libolecf-python/default.nix
+++ b/pkgs/development/python-modules/libolecf-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libolecf-python";
+  version = "20240427";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-Awz/Gbc7MPDwEPPR5C06/kzAE69uYLswQMdo8AQW+/0=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyolecf" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libolecf/releases/tag/${version}";
+    description = "Python bindings module for libolecf";
+    downloadPage = "https://github.com/libyal/libolecf/releases";
+    homepage = "https://github.com/libyal/libolecf";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libphdi-python/default.nix
+++ b/pkgs/development/python-modules/libphdi-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libphdi-python";
+  version = "20240307";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-qn4iZkVpWcm2leVWpJx0l3BFYBY3U8nsR6EzgBz1Uak=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyphdi" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libphdi/releases/tag/${version}";
+    description = "Python bindings module for libphdi";
+    downloadPage = "https://github.com/libyal/libphdi/releases";
+    homepage = "https://github.com/libyal/libphdi";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libqcow-python/default.nix
+++ b/pkgs/development/python-modules/libqcow-python/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  zlib,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libqcow-python";
+  version = "20240308";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-6bPjrY0uiJu4nVWklso9lzyoAEMBASeGvLr2H5h5YWU=";
+  };
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ zlib ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyqcow" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libqcow/releases/tag/${version}";
+    description = "Python bindings module for libqcow";
+    downloadPage = "https://github.com/libyal/libqcow/releases";
+    homepage = "https://github.com/libyal/libqcow";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libregf-python/default.nix
+++ b/pkgs/development/python-modules/libregf-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libregf-python";
+  version = "20240421";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-oYbCR1zX59Cj4yQbM1fk5SC/YFB14BmiL0F4mix0Gvw=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyregf" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libregf/releases/tag/${version}";
+    description = "Python bindings module for libregf";
+    downloadPage = "https://github.com/libyal/libregf/releases";
+    homepage = "https://github.com/libyal/libregf";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libscca-python/default.nix
+++ b/pkgs/development/python-modules/libscca-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libscca-python";
+  version = "20240215";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-hes6R8xO0ZlEtalRz0NHaFuW7v0J5P6AKAFSNqoYjWw=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyscca" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libscca/releases/tag/${version}";
+    description = "Python bindings module for libscca";
+    downloadPage = "https://github.com/libyal/libscca/releases";
+    homepage = "https://github.com/libyal/libscca";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libsigscan-python/default.nix
+++ b/pkgs/development/python-modules/libsigscan-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libsigscan-python";
+  version = "20240219";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-iSsEQyHrBMcr+p+Vyei9J05+PXCWAvsR6G2EMVTXNGU=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pysigscan" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libsigscan/releases/tag/${version}";
+    description = "Python bindings module for libsigscan";
+    downloadPage = "https://github.com/libyal/libsigscan/releases";
+    homepage = "https://github.com/libyal/libsigscan";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libsmdev-python/default.nix
+++ b/pkgs/development/python-modules/libsmdev-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libsmdev-python";
+  version = "20240309";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ERRXEggcxoRob3nnC9hQ9JMOfuvc9CXIOKFlrblcg9g=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pysmdev" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libsmdev/releases/tag/${version}";
+    description = "Python bindings module for libsmdev";
+    downloadPage = "https://github.com/libyal/libsmdev/releases";
+    homepage = "https://github.com/libyal/libsmdev";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libsmraw-python/default.nix
+++ b/pkgs/development/python-modules/libsmraw-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libsmraw-python";
+  version = "20240310";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-m51g5B1c5dn2rSatMjWaztVqFSqQTiolAjvMbauVHkM=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pysmraw" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libsmraw/releases/tag/${version}";
+    description = "Python bindings module for libsmraw";
+    downloadPage = "https://github.com/libyal/libsmraw/releases";
+    homepage = "https://github.com/libyal/libsmraw";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libvhdi-python/default.nix
+++ b/pkgs/development/python-modules/libvhdi-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libvhdi-python";
+  version = "20240303";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-p5Se/gk6g2DdBEYk1IkwAs5VvkTnbq4Xe+7WNlnvKCc=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyvhdi" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libvhdi/releases/tag/${version}";
+    description = "Python bindings module for libvhdi";
+    downloadPage = "https://github.com/libyal/libvhdi/releases";
+    homepage = "https://github.com/libyal/libvhdi";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libvmdk-python/default.nix
+++ b/pkgs/development/python-modules/libvmdk-python/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  zlib,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libvmdk-python";
+  version = "20240303";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-v4/9iiMfOtF12DQIThLkL29NmVP1lNK0fwbLsZIX0v4=";
+  };
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ zlib ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyvmdk" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libvmdk/releases/tag/${version}";
+    description = "Python bindings module for libvmdk";
+    downloadPage = "https://github.com/libyal/libvmdk/releases";
+    homepage = "https://github.com/libyal/libvmdk";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libvsapm-python/default.nix
+++ b/pkgs/development/python-modules/libvsapm-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libvsapm-python";
+  version = "20240226";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-hiorYQ3xw6+rBKD0fn2lY2yzPcVxljYcmd13sUfYrkE=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyvsapm" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libvsapm/releases/tag/${version}";
+    description = "Python bindings module for libvsapm";
+    downloadPage = "https://github.com/libyal/libvsapm/releases";
+    homepage = "https://github.com/libyal/libvsapm";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libvsgpt-python/default.nix
+++ b/pkgs/development/python-modules/libvsgpt-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libvsgpt-python";
+  version = "20240228";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-6knIN5K0m0s5Wp7++tEuCBhhhu+Ego2OvRv87RAA3lQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyvsgpt" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libvsgpt/releases/tag/${version}";
+    description = "Python bindings module for libvsgpt";
+    downloadPage = "https://github.com/libyal/libvsgpt/releases";
+    homepage = "https://github.com/libyal/libvsgpt";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libvshadow-python/default.nix
+++ b/pkgs/development/python-modules/libvshadow-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libvshadow-python";
+  version = "20240229";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-3tp3ceYfa557jzAsUlCgr+GOjRmnq9Va5x7so3UX/aY=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyvshadow" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libvshadow/releases/tag/${version}";
+    description = "Python bindings module for libvshadow";
+    downloadPage = "https://github.com/libyal/libvshadow/releases";
+    homepage = "https://github.com/libyal/libvshadow";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/libvslvm-python/default.nix
+++ b/pkgs/development/python-modules/libvslvm-python/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "libvslvm-python";
+  version = "20240301";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-1+7okPMphNzQl5kCf7wQaNgu4xonFyjLvV6AT7WTfUw=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.7";
+
+  pythonImportsCheck = [ "pyvslvm" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/libyal/libvslvm/releases/tag/${version}";
+    description = "Python bindings module for libvslvm";
+    downloadPage = "https://github.com/libyal/libvslvm/releases";
+    homepage = "https://github.com/libyal/libvslvm";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/plaso/default.nix
+++ b/pkgs/development/python-modules/plaso/default.nix
@@ -1,0 +1,176 @@
+{
+  lib,
+  acstore,
+  artifacts,
+  attr,
+  bencode-py,
+  buildPythonPackage,
+  certifi,
+  cffi,
+  defusedxml,
+  dfdatetime,
+  dfvfs,
+  dfwinreg,
+  fetchPypi,
+  flor,
+  future,
+  libbde-python,
+  libcaes-python,
+  libcreg-python,
+  libesedb-python,
+  libevt-python,
+  libevtx-python,
+  libewf-python,
+  libfcrypto-python,
+  libfsapfs-python,
+  libfsext-python,
+  libfsfat-python,
+  libfshfs-python,
+  libfsntfs-python,
+  libfsxfs-python,
+  libfvde-python,
+  libfwnt-python,
+  libfwsi-python,
+  liblnk-python,
+  libluksde-python,
+  libmodi-python,
+  libmsiecf-python,
+  libolecf-python,
+  libphdi-python,
+  libqcow-python,
+  libregf-python,
+  libscca-python,
+  libsigscan-python,
+  libsmdev-python,
+  libsmraw-python,
+  libvhdi-python,
+  libvmdk-python,
+  libvsgpt-python,
+  libvshadow-python,
+  libvslvm-python,
+  lz4,
+  opensearch-py,
+  pefile,
+  pip,
+  psutil,
+  pyparsing,
+  python-dateutil,
+  pythonOlder,
+  pytsk3,
+  pytz,
+  pyxattr,
+  pyyaml,
+  pyzmq,
+  redis,
+  requests,
+  setuptools,
+  six,
+  stdenv,
+  xlsxwriter,
+  yara-python,
+  zstd,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "plaso";
+  version = "20240308";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-pRYppmsIRBJHlPipM7cLpvWqLNJ5QiX9+/thI83/Gvc=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    acstore
+    artifacts
+    bencode-py
+    certifi
+    cffi
+    defusedxml
+    dfdatetime
+    dfvfs
+    dfwinreg
+    flor
+    future
+    libbde-python
+    libcaes-python
+    libcreg-python
+    libesedb-python
+    libevt-python
+    libevtx-python
+    libewf-python
+    libfcrypto-python
+    libfsapfs-python
+    libfsext-python
+    libfsfat-python
+    libfshfs-python
+    libfsntfs-python
+    libfsxfs-python
+    libfvde-python
+    libfwnt-python
+    libfwsi-python
+    liblnk-python
+    libluksde-python
+    libmodi-python
+    libmsiecf-python
+    libolecf-python
+    libphdi-python
+    libqcow-python
+    libregf-python
+    libscca-python
+    libsigscan-python
+    libsmdev-python
+    libsmraw-python
+    libvhdi-python
+    libvmdk-python
+    libvsgpt-python
+    libvshadow-python
+    libvslvm-python
+    lz4
+    opensearch-py
+    pefile
+    pip
+    psutil
+    pyparsing
+    python-dateutil
+    pytsk3
+    pytz
+    # This is required to support the darwin architecture for pyxattr
+    (pyxattr.overrideAttrs (old: rec {
+      buildInputs = lib.optional stdenv.isLinux attr;
+      meta.platforms = old.meta.platforms ++ [
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      hardeningDisable = lib.optional stdenv.isDarwin "strictoverflow";
+    }))
+    pyyaml
+    pyzmq
+    redis
+    requests
+    six
+    xlsxwriter
+    yara-python
+    zstd
+  ];
+
+  disabled = pythonOlder "3.8";
+
+  # This is required only as the build process incorrectly assumes xattr
+  # is not installed, despite it being included in dependencies.
+  patches = [ ./no-xattr-dependency.patch ];
+
+  pythonImportsCheck = [ "plaso" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/log2timeline/plaso/releases/tag/${version}";
+    description = "Plaso (Plaso Langar Að Safna Öllu), or super timeline all the things, is a Python-based engine used by several tools for automatic creation of timelines. Plaso default behavior is to create super timelines but it also supports creating more targeted timelines.";
+    downloadPage = "https://github.com/log2timeline/plaso/releases";
+    homepage = "https://github.com/log2timeline/plaso";
+    license = licenses.asl20;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/development/python-modules/plaso/no-xattr-dependency.patch
+++ b/pkgs/development/python-modules/plaso/no-xattr-dependency.patch
@@ -1,0 +1,23 @@
+From ffb105bd4838e2480fa24beb65d81a75d49393a8 Mon Sep 17 00:00:00 2001
+From: jayrovacsek <jay@rovacsek.com>
+Date: Sat, 6 Apr 2024 07:40:54 +1100
+Subject: [PATCH] no xattr dependency
+
+---
+ requirements.txt | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/requirements.txt b/requirements.txt
+index 7b55e74..534843d 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -59,6 +59,5 @@ pyzmq >= 2.1.11
+ redis >= 3.4
+ requests >= 2.18.0
+ six >= 1.1.0
+-xattr >= 0.7.2 ; platform_system != "Windows"
+ yara-python >= 3.4.0
+ zstd >= 1.3.0.2
+-- 
+2.43.2
+

--- a/pkgs/development/python-modules/pytsk3/default.nix
+++ b/pkgs/development/python-modules/pytsk3/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  setuptools,
+  ...
+}:
+buildPythonPackage rec {
+  pname = "pytsk3";
+  version = "20231007";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-uPE5ytLj+sv/fp1AYjwIdrHLRQU/EVnDZQEGwcK6T/g=";
+  };
+
+  build-system = [ setuptools ];
+
+  disabled = pythonOlder "3.8";
+
+  pythonImportsCheck = [ "pytsk3" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/py4n6/pytsk/releases/tag/${version}";
+    description = "Python bindings for the sleuthkit (http://www.sleuthkit.org/)";
+    downloadPage = "https://github.com/py4n6/pytsk/releases";
+    homepage = "https://github.com/py4n6/pytsk";
+    license = licenses.asl20;
+    maintainers = [ maintainers.jayrovacsek ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9920,6 +9920,8 @@ self: super: with self; {
 
   pkuseg = callPackage ../development/python-modules/pkuseg { };
 
+  plaso = callPackage ../development/python-modules/plaso { };
+
   playwright = callPackage ../development/python-modules/playwright { };
 
   playwright-stealth = callPackage ../development/python-modules/playwright-stealth { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6712,6 +6712,8 @@ self: super: with self; {
     pkgsLibpcap = pkgs.libpcap; # Needs the C library
   };
 
+  libphdi-python = callPackage ../development/python-modules/libphdi-python { };
+
   libpurecool = callPackage ../development/python-modules/libpurecool { };
 
   libpyfoscam = callPackage ../development/python-modules/libpyfoscam { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6818,6 +6818,8 @@ self: super: with self; {
 
   libvsgpt-python = callPackage ../development/python-modules/libvsgpt-python { };
 
+  libvshadow-python = callPackage ../development/python-modules/libvshadow-python { };
+
   libxml2 = (toPythonModule (pkgs.libxml2.override {
     pythonSupport = true;
     inherit python;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6637,6 +6637,8 @@ self: super: with self; {
 
   libfsapfs-python = callPackage ../development/python-modules/libfsapfs-python { };
 
+  libfsext-python = callPackage ../development/python-modules/libfsext-python { };
+
   libgpiod = callPackage ../development/python-modules/libgpiod {
     inherit (pkgs) libgpiod;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4395,6 +4395,8 @@ self: super: with self; {
 
   flit-scm = callPackage ../development/python-modules/flit-scm { };
 
+  flor = callPackage ../development/python-modules/flor { };
+
   floret = callPackage ../development/python-modules/floret { };
 
   flow-record = callPackage ../development/python-modules/flow-record { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3572,6 +3572,8 @@ self: super: with self; {
 
   dsnap = callPackage ../development/python-modules/dsnap { };
 
+  dtfabric = callPackage ../development/python-modules/dtfabric { };
+
   dtlssocket = callPackage ../development/python-modules/dtlssocket { };
 
   dtschema = callPackage ../development/python-modules/dtschema { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6590,6 +6590,8 @@ self: super: with self; {
 
   libbde-python = callPackage ../development/python-modules/libbde-python { };
 
+  libcaes-python = callPackage ../development/python-modules/libcaes-python { };
+
   libclang = callPackage ../development/python-modules/libclang { };
 
   libcloud = callPackage ../development/python-modules/libcloud { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6816,6 +6816,8 @@ self: super: with self; {
 
   libvsapm-python = callPackage ../development/python-modules/libvsapm-python { };
 
+  libvsgpt-python = callPackage ../development/python-modules/libvsgpt-python { };
+
   libxml2 = (toPythonModule (pkgs.libxml2.override {
     pythonSupport = true;
     inherit python;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6734,6 +6734,8 @@ self: super: with self; {
     inherit (self) python libxml2;
   });
 
+  libregf-python = callPackage ../development/python-modules/libregf-python { };
+
   librepo = lib.pipe pkgs.librepo [
     toPythonModule
     (p: p.overrideAttrs (super: { meta = super.meta // { outputsToInstall = [ "py" ]; }; }))

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6620,6 +6620,8 @@ self: super: with self; {
 
   libevt-python = callPackage ../development/python-modules/libevt-python { };
 
+  libevtx-python = callPackage ../development/python-modules/libevtx-python { };
+
   libfdt = toPythonModule (pkgs.dtc.override {
     inherit python;
     pythonSupport = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6614,6 +6614,8 @@ self: super: with self; {
     (p: p.py)
   ];
 
+  libesedb-python = callPackage ../development/python-modules/libesedb-python { };
+
   libevdev = callPackage ../development/python-modules/libevdev { };
 
   libfdt = toPythonModule (pkgs.dtc.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6588,6 +6588,8 @@ self: super: with self; {
     inherit (pkgs) libasyncns;
   };
 
+  libbde-python = callPackage ../development/python-modules/libbde-python { };
+
   libclang = callPackage ../development/python-modules/libclang { };
 
   libcloud = callPackage ../development/python-modules/libcloud { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9018,6 +9018,8 @@ self: super: with self; {
 
   python-youtube = callPackage ../development/python-modules/python-youtube { };
 
+  pytsk3 = callPackage ../development/python-modules/pytsk3 { };
+
   py-aosmith = callPackage ../development/python-modules/py-aosmith { };
 
   py-deprecate = callPackage ../development/python-modules/py-deprecate { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6618,6 +6618,8 @@ self: super: with self; {
 
   libevdev = callPackage ../development/python-modules/libevdev { };
 
+  libevt-python = callPackage ../development/python-modules/libevt-python { };
+
   libfdt = toPythonModule (pkgs.dtc.override {
     inherit python;
     pythonSupport = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6759,6 +6759,8 @@ self: super: with self; {
 
   libscca-python = callPackage ../development/python-modules/libscca-python { };
 
+  libsigscan-python = callPackage ../development/python-modules/libsigscan-python { };
+
   libsixel = callPackage ../development/python-modules/libsixel {
     inherit (pkgs) libsixel;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2968,6 +2968,8 @@ self: super: with self; {
 
   dfdiskcache = callPackage ../development/python-modules/dfdiskcache { };
 
+  dfwinreg = callPackage ../development/python-modules/dfwinreg { };
+
   diagrams = callPackage ../development/python-modules/diagrams { };
 
   diceware = callPackage ../development/python-modules/diceware { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6814,6 +6814,8 @@ self: super: with self; {
 
   libvmdk-python = callPackage ../development/python-modules/libvmdk-python { };
 
+  libvsapm-python = callPackage ../development/python-modules/libvsapm-python { };
+
   libxml2 = (toPythonModule (pkgs.libxml2.override {
     pythonSupport = true;
     inherit python;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6649,6 +6649,8 @@ self: super: with self; {
 
   libfvde-python = callPackage ../development/python-modules/libfvde-python { };
 
+  libfwnt-python = callPackage ../development/python-modules/libfwnt-python { };
+
   libgpiod = callPackage ../development/python-modules/libgpiod {
     inherit (pkgs) libgpiod;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -769,6 +769,8 @@ self: super: with self; {
 
   art = callPackage ../development/python-modules/art { };
 
+  artifacts = callPackage ../development/python-modules/artifacts { };
+
   arviz = callPackage ../development/python-modules/arviz { };
 
   arxiv2bib = callPackage ../development/python-modules/arxiv2bib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6706,6 +6706,8 @@ self: super: with self; {
     inherit (pkgs) libsodium;
   };
 
+  libolecf-python = callPackage ../development/python-modules/libolecf-python { };
+
   libpcap = callPackage ../development/python-modules/libpcap {
     pkgsLibpcap = pkgs.libpcap; # Needs the C library
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6645,6 +6645,8 @@ self: super: with self; {
 
   libfsntfs-python = callPackage ../development/python-modules/libfsntfs-python { };
 
+  libfsxfs-python = callPackage ../development/python-modules/libfsxfs-python { };
+
   libgpiod = callPackage ../development/python-modules/libgpiod {
     inherit (pkgs) libgpiod;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6622,6 +6622,8 @@ self: super: with self; {
 
   libevtx-python = callPackage ../development/python-modules/libevtx-python { };
 
+  libewf-python = callPackage ../development/python-modules/libewf-python { };
+
   libfdt = toPythonModule (pkgs.dtc.override {
     inherit python;
     pythonSupport = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6812,6 +6812,8 @@ self: super: with self; {
     inherit (pkgs) libvirt;
   };
 
+  libvmdk-python = callPackage ../development/python-modules/libvmdk-python { };
+
   libxml2 = (toPythonModule (pkgs.libxml2.override {
     pythonSupport = true;
     inherit python;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6647,6 +6647,8 @@ self: super: with self; {
 
   libfsxfs-python = callPackage ../development/python-modules/libfsxfs-python { };
 
+  libfvde-python = callPackage ../development/python-modules/libfvde-python { };
+
   libgpiod = callPackage ../development/python-modules/libgpiod {
     inherit (pkgs) libgpiod;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6700,6 +6700,8 @@ self: super: with self; {
 
   libmr = callPackage ../development/python-modules/libmr { };
 
+  libmsiecf-python = callPackage ../development/python-modules/libmsiecf-python { };
+
   libnacl = callPackage ../development/python-modules/libnacl {
     inherit (pkgs) libsodium;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6820,6 +6820,8 @@ self: super: with self; {
 
   libvshadow-python = callPackage ../development/python-modules/libvshadow-python { };
 
+  libvslvm-python = callPackage ../development/python-modules/libvslvm-python { };
+
   libxml2 = (toPythonModule (pkgs.libxml2.override {
     pythonSupport = true;
     inherit python;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6673,6 +6673,8 @@ self: super: with self; {
 
   liblarch = callPackage ../development/python-modules/liblarch { };
 
+  liblnk-python = callPackage ../development/python-modules/liblnk-python { };
+
   liblzfse = callPackage ../development/python-modules/liblzfse {
     inherit (pkgs) lzfse;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6635,6 +6635,8 @@ self: super: with self; {
     inherit python;
   });
 
+  libfsapfs-python = callPackage ../development/python-modules/libfsapfs-python { };
+
   libgpiod = callPackage ../development/python-modules/libgpiod {
     inherit (pkgs) libgpiod;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2968,6 +2968,8 @@ self: super: with self; {
 
   dfdiskcache = callPackage ../development/python-modules/dfdiskcache { };
 
+  dfvfs = callPackage ../development/python-modules/dfvfs { };
+
   dfwinreg = callPackage ../development/python-modules/dfwinreg { };
 
   diagrams = callPackage ../development/python-modules/diagrams { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6643,6 +6643,8 @@ self: super: with self; {
 
   libfshfs-python = callPackage ../development/python-modules/libfshfs-python { };
 
+  libfsntfs-python = callPackage ../development/python-modules/libfsntfs-python { };
+
   libgpiod = callPackage ../development/python-modules/libgpiod {
     inherit (pkgs) libgpiod;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6784,6 +6784,8 @@ self: super: with self; {
 
   libsmdev-python = callPackage ../development/python-modules/libsmdev-python { };
 
+  libsmraw-python = callPackage ../development/python-modules/libsmraw-python { };
+
   libsoundtouch = callPackage ../development/python-modules/libsoundtouch { };
 
   libthumbor = callPackage ../development/python-modules/libthumbor { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6603,6 +6603,8 @@ self: super: with self; {
     (p: p.py)
   ];
 
+  libcreg-python = callPackage ../development/python-modules/libcreg-python { };
+
   libcst = callPackage ../development/python-modules/libcst { };
 
   libdnf = lib.pipe pkgs.libdnf [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6683,6 +6683,8 @@ self: super: with self; {
 
   libmambapy = callPackage ../development/python-modules/libmambapy { };
 
+  libmodi-python = callPackage ../development/python-modules/libmodi-python { };
+
   libmodulemd = lib.pipe pkgs.libmodulemd [
     toPythonModule
     (p:

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6651,6 +6651,8 @@ self: super: with self; {
 
   libfwnt-python = callPackage ../development/python-modules/libfwnt-python { };
 
+  libfwsi-python = callPackage ../development/python-modules/libfwsi-python { };
+
   libgpiod = callPackage ../development/python-modules/libgpiod {
     inherit (pkgs) libgpiod;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6641,6 +6641,8 @@ self: super: with self; {
 
   libfsfat-python = callPackage ../development/python-modules/libfsfat-python { };
 
+  libfshfs-python = callPackage ../development/python-modules/libfshfs-python { };
+
   libgpiod = callPackage ../development/python-modules/libgpiod {
     inherit (pkgs) libgpiod;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6757,6 +6757,7 @@ self: super: with self; {
 
   libsavitar = callPackage ../development/python-modules/libsavitar { };
 
+  libscca-python = callPackage ../development/python-modules/libscca-python { };
 
   libsixel = callPackage ../development/python-modules/libsixel {
     inherit (pkgs) libsixel;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6624,6 +6624,8 @@ self: super: with self; {
 
   libewf-python = callPackage ../development/python-modules/libewf-python { };
 
+  libfcrypto-python = callPackage ../development/python-modules/libfcrypto-python { };
+
   libfdt = toPythonModule (pkgs.dtc.override {
     inherit python;
     pythonSupport = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -53,6 +53,8 @@ self: super: with self; {
 
   acquire = callPackage ../development/python-modules/acquire { };
 
+  acstore = callPackage ../development/python-modules/acstore { };
+
   actdiag = callPackage ../development/python-modules/actdiag { };
 
   acunetix = callPackage ../development/python-modules/acunetix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2964,6 +2964,8 @@ self: super: with self; {
 
   devtools = callPackage ../development/python-modules/devtools { };
 
+  dfdatetime = callPackage ../development/python-modules/dfdatetime { };
+
   dfdiskcache = callPackage ../development/python-modules/dfdiskcache { };
 
   diagrams = callPackage ../development/python-modules/diagrams { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6782,6 +6782,8 @@ self: super: with self; {
     (p: p.py)
   ];
 
+  libsmdev-python = callPackage ../development/python-modules/libsmdev-python { };
+
   libsoundtouch = callPackage ../development/python-modules/libsoundtouch { };
 
   libthumbor = callPackage ../development/python-modules/libthumbor { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6806,6 +6806,8 @@ self: super: with self; {
     inherit (pkgs) libversion;
   };
 
+  libvhdi-python = callPackage ../development/python-modules/libvhdi-python { };
+
   libvirt = callPackage ../development/python-modules/libvirt {
     inherit (pkgs) libvirt;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6727,6 +6727,8 @@ self: super: with self; {
     (p: p.py)
   ];
 
+  libqcow-python = callPackage ../development/python-modules/libqcow-python { };
+
   libredwg = toPythonModule (pkgs.libredwg.override {
     enablePython = true;
     inherit (self) python libxml2;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6675,6 +6675,8 @@ self: super: with self; {
 
   liblnk-python = callPackage ../development/python-modules/liblnk-python { };
 
+  libluksde-python = callPackage ../development/python-modules/libluksde-python { };
+
   liblzfse = callPackage ../development/python-modules/liblzfse {
     inherit (pkgs) lzfse;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6639,6 +6639,8 @@ self: super: with self; {
 
   libfsext-python = callPackage ../development/python-modules/libfsext-python { };
 
+  libfsfat-python = callPackage ../development/python-modules/libfsfat-python { };
+
   libgpiod = callPackage ../development/python-modules/libgpiod {
     inherit (pkgs) libgpiod;
   };


### PR DESCRIPTION
## Description of changes

The following PR includes all required changes to build the Plaso python package and all missing dependencies as prerequisite commits. 
Please note this PR supersedes https://github.com/NixOS/nixpkgs/pull/232046 and https://github.com/NixOS/nixpkgs/pull/224579, rationale for a new PR again is a mixture of required changes needing to rewrite existing commits in those PRs, a level of misunderstanding on my part initially and great feedback from participants being incorporated into this PR.

Plaso, or super timeline all the things, is a Python-based engine used by several tools for automatic creation of timelines. Plaso default behavior is to create super timelines but it also supports creating more [targeted timelines](http://blog.kiddaland.net/2013/02/targeted-timelines-part-i.html).
Homepage: https://github.com/log2timeline/plaso

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
