### PR TITLE
testers.hasPkgConfigModules: add optional version check

### DIFF
--- a/doc/languages-frameworks/pkg-config.section.md
+++ b/doc/languages-frameworks/pkg-config.section.md
@@ -7,10 +7,11 @@ Nixpkgs provides a couple of facilities for working with this tool.
 ## Writing packages providing pkg-config modules {#pkg-config-writing-packages}
 
 Packages should set `meta.pkgConfigModules` with the list of package config modules they provide.
-They should also use `testers.testMetaPkgConfig` to check that the final built package matches that list.
+They should also use `testers.hasPkgConfigModules` to check that the final built package matches that list,
+and optionally check that the pkgconf modules' version metadata matches the derivation's.
 Additionally, the [`validatePkgConfig` setup hook](https://nixos.org/manual/nixpkgs/stable/#validatepkgconfig), will do extra checks on to-be-installed pkg-config modules.
 
-A good example of all these things is zlib:
+A good example of all these things is miniz:
 
 ```nix
 { pkg-config, testers, ... }:
@@ -20,11 +21,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ pkg-config validatePkgConfig ];
 
-  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  passthru.tests.pkg-config = testers.hasPkgConfigModules {
+    package = finalAttrs.finalPackage;
+    versionCheck = true;
+  };
 
   meta = {
     /* ... */
-    pkgConfigModules = [ "zlib" ];
+    pkgConfigModules = [ "miniz" ];
   };
 })
 ```

--- a/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
+++ b/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
@@ -31,6 +31,7 @@ runCommand testName {
         package.meta;
   } ''
     touch "$out"
+    notFound=0
     for moduleName in $moduleNames; do
       echo "checking pkg-config module $moduleName in $buildInputs"
       set +e
@@ -41,10 +42,15 @@ runCommand testName {
         echo "✅ pkg-config module $moduleName exists and has version $version"
         printf '%s\t%s\n' "$moduleName" "$version" >> "$out"
       else
-        echo "These modules were available in the input propagation closure:"
-        $PKG_CONFIG --list-all
         echo "❌ pkg-config module $moduleName was not found"
-        false
+        ((notFound+=1))
       fi
     done
+
+    if [[ $notFound -ne 0 ]]; then
+      echo "$notFound modules not found"
+      echo "These modules were available in the input propagation closure:"
+      $PKG_CONFIG --list-all
+      exit 1
+    fi
   ''

--- a/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
+++ b/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
@@ -5,12 +5,14 @@
 { package,
   moduleNames ? package.meta.pkgConfigModules,
   testName ? "check-pkg-config-${lib.concatStringsSep "-" moduleNames}",
+  version ? package.version or null,
+  versionCheck ? false,
 }:
 
 runCommand testName {
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ package ];
-    inherit moduleNames;
+    inherit moduleNames version versionCheck;
     meta = {
       description = "Test whether ${package.name} exposes pkg-config modules ${lib.concatStringsSep ", " moduleNames}.";
     }
@@ -32,14 +34,20 @@ runCommand testName {
   } ''
     touch "$out"
     notFound=0
+    versionMismatch=0
     for moduleName in $moduleNames; do
       echo "checking pkg-config module $moduleName in $buildInputs"
       set +e
-      version="$($PKG_CONFIG --modversion $moduleName)"
+      moduleVersion="$($PKG_CONFIG --modversion $moduleName)"
       r=$?
       set -e
       if [[ $r = 0 ]]; then
-        echo "✅ pkg-config module $moduleName exists and has version $version"
+        if [[ "$moduleVersion" == "$version" ]]; then
+          echo "✅ pkg-config module $moduleName exists and has version $moduleVersion"
+        else
+          echo "❌ pkg-config module $moduleName exists and has version $moduleVersion when $version was expected"
+          ((versionMismatch+=1))
+        fi
         printf '%s\t%s\n' "$moduleName" "$version" >> "$out"
       else
         echo "❌ pkg-config module $moduleName was not found"
@@ -47,10 +55,16 @@ runCommand testName {
       fi
     done
 
+    if [[ $notFound -eq 0 ]] && ([[ $versionMismatch -eq 0 ]] || [[ "$versionCheck" == false ]]); then
+      exit 0
+    fi
     if [[ $notFound -ne 0 ]]; then
       echo "$notFound modules not found"
       echo "These modules were available in the input propagation closure:"
       $PKG_CONFIG --list-all
-      exit 1
     fi
+    if [[ $versionMismatch -ne 0 ]]; then
+      echo "$versionMismatch version mismatches"
+    fi
+    exit 1
   ''

--- a/pkgs/build-support/testers/hasPkgConfigModules/tests.nix
+++ b/pkgs/build-support/testers/hasPkgConfigModules/tests.nix
@@ -1,5 +1,5 @@
 # cd nixpkgs
-# nix-build -A tests.testers.hasPkgConfigModule
+# nix-build -A tests.testers.hasPkgConfigModules
 { lib, testers, miniz, zlib, openssl, runCommand }:
 
 lib.recurseIntoAttrs {

--- a/pkgs/build-support/testers/hasPkgConfigModules/tests.nix
+++ b/pkgs/build-support/testers/hasPkgConfigModules/tests.nix
@@ -1,8 +1,19 @@
 # cd nixpkgs
 # nix-build -A tests.testers.hasPkgConfigModule
-{ lib, testers, zlib, openssl, runCommand }:
+{ lib, testers, miniz, zlib, openssl, runCommand }:
 
 lib.recurseIntoAttrs {
+
+  miniz-versions-match = testers.hasPkgConfigModules {
+    package = miniz;
+    versionCheck = true;
+  };
+
+  miniz-versions-mismatch = testers.testBuildFailure (testers.hasPkgConfigModules {
+    package = miniz;
+    version = "1.2.3";
+    versionCheck = true;
+  });
 
   zlib-has-zlib = testers.hasPkgConfigModules {
     package = zlib;

--- a/pkgs/development/libraries/miniz/default.nix
+++ b/pkgs/development/libraries/miniz/default.nix
@@ -28,7 +28,10 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail '=''${exec_prefix}//' '=/'
   '';
 
-  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  passthru.tests.pkg-config = testers.hasPkgConfigModules {
+    package = finalAttrs.finalPackage;
+    versionCheck = true;
+  };
 
   meta = with lib; {
     description = "Single C source file zlib-replacement library";


### PR DESCRIPTION
## Description of changes

- `testers`: add `pkgConfigModulesVersions`, which tests that pkgconf modules' version metadata match the package's
- `miniz`: use the new tester
- `doc`: mention the new tester in `pkg-config` section

**Not** done: making the new tester run as part of `testMetaPkgConfig`, as the new test fails on some drvs.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review`.
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
