### PR TITLE
python312Packages.typed-settings: 24.1.0 -> 24.2.0

### DIFF
--- a/pkgs/development/python-modules/typed-settings/default.nix
+++ b/pkgs/development/python-modules/typed-settings/default.nix
@@ -6,6 +6,8 @@
 , click-option-group
 , fetchPypi
 , hatchling
+, jinja2
+, pydantic
 , pytestCheckHook
 , pythonOlder
 , tomli
@@ -14,39 +16,59 @@
 
 buildPythonPackage rec {
   pname = "typed-settings";
-  version = "24.1.0";
-  format = "pyproject";
+  version = "24.2.0";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     pname = "typed_settings";
     inherit version;
-    hash = "sha256-luUfVsN6uNYZkXfcAUc5P6Y+WYpfAdU6D01kgQMNniw=";
+    hash = "sha256-BuosfIlCgCD+h7eA/6/oE98zdURaT3eik+dysBpJR+Y=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
-    attrs
-    cattrs
-    click-option-group
-  ] ++ lib.optionals (pythonOlder "3.11") [
+  dependencies = lib.optionals (pythonOlder "3.11") [
     tomli
   ];
 
   passthru.optional-dependencies = {
+    all = [
+      attrs
+      cattrs
+      click
+      click-option-group
+      jinja2
+      pydantic
+    ];
+    attrs = [
+      attrs
+    ];
+    cattrs = [
+      cattrs
+    ];
     click = [
       click
     ];
+    option-groups = [
+      click
+      click-option-group
+    ];
+    jinja = [
+      jinja2
+    ];
+    pydantic = [
+      pydantic
+    ];
   };
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
     typing-extensions
-  ] ++ passthru.optional-dependencies.click;
+  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
 
   pytestFlagsArray = [
     "tests"
@@ -55,16 +77,25 @@ buildPythonPackage rec {
   disabledTests = [
     # AssertionError: assert [OptionInfo(p...
     "test_deep_options"
+    # 1Password CLI is not available
+    "TestOnePasswordLoader"
+    "test_handle_op"
+  ];
+
+  disabledTestPaths = [
+    # 1Password CLI is not available
+    "tests/test_onepassword.py"
   ];
 
   pythonImportsCheck = [
     "typed_settings"
   ];
 
-  meta = {
+  meta = with lib; {
     description = "Typed settings based on attrs classes";
     homepage = "https://gitlab.com/sscherfke/typed-settings";
     changelog = "https://gitlab.com/sscherfke/typed-settings/-/blob/${version}/CHANGELOG.rst";
     license = lib.licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/typed-settings/default.nix
+++ b/pkgs/development/python-modules/typed-settings/default.nix
@@ -1,17 +1,18 @@
-{ lib
-, attrs
-, buildPythonPackage
-, cattrs
-, click
-, click-option-group
-, fetchPypi
-, hatchling
-, jinja2
-, pydantic
-, pytestCheckHook
-, pythonOlder
-, tomli
-, typing-extensions
+{
+  lib,
+  attrs,
+  buildPythonPackage,
+  cattrs,
+  click,
+  click-option-group,
+  fetchPypi,
+  hatchling,
+  jinja2,
+  pydantic,
+  pytestCheckHook,
+  pythonOlder,
+  tomli,
+  typing-extensions,
 }:
 
 buildPythonPackage rec {
@@ -27,13 +28,9 @@ buildPythonPackage rec {
     hash = "sha256-BuosfIlCgCD+h7eA/6/oE98zdURaT3eik+dysBpJR+Y=";
   };
 
-  build-system = [
-    hatchling
-  ];
+  build-system = [ hatchling ];
 
-  dependencies = lib.optionals (pythonOlder "3.11") [
-    tomli
-  ];
+  dependencies = lib.optionals (pythonOlder "3.11") [ tomli ];
 
   passthru.optional-dependencies = {
     all = [
@@ -44,25 +41,15 @@ buildPythonPackage rec {
       jinja2
       pydantic
     ];
-    attrs = [
-      attrs
-    ];
-    cattrs = [
-      cattrs
-    ];
-    click = [
-      click
-    ];
+    attrs = [ attrs ];
+    cattrs = [ cattrs ];
+    click = [ click ];
     option-groups = [
       click
       click-option-group
     ];
-    jinja = [
-      jinja2
-    ];
-    pydantic = [
-      pydantic
-    ];
+    jinja = [ jinja2 ];
+    pydantic = [ pydantic ];
   };
 
   nativeCheckInputs = [
@@ -70,9 +57,7 @@ buildPythonPackage rec {
     typing-extensions
   ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
 
-  pytestFlagsArray = [
-    "tests"
-  ];
+  pytestFlagsArray = [ "tests" ];
 
   disabledTests = [
     # AssertionError: assert [OptionInfo(p...
@@ -87,15 +72,13 @@ buildPythonPackage rec {
     "tests/test_onepassword.py"
   ];
 
-  pythonImportsCheck = [
-    "typed_settings"
-  ];
+  pythonImportsCheck = [ "typed_settings" ];
 
   meta = with lib; {
     description = "Typed settings based on attrs classes";
     homepage = "https://gitlab.com/sscherfke/typed-settings";
     changelog = "https://gitlab.com/sscherfke/typed-settings/-/blob/${version}/CHANGELOG.rst";
-    license = lib.licenses.mit;
+    license = licenses.mit;
     maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
Changelog: https://gitlab.com/sscherfke/typed-settings/-/blob/24.2.0/CHANGELOG.rst

## Description of changes
Fix build (https://hydra.nixos.org/build/256977130)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
