### PR TITLE
nixos/mautrix-meta: add defaults for messenger

### DIFF
--- a/nixos/modules/services/matrix/mautrix-meta.nix
+++ b/nixos/modules/services/matrix/mautrix-meta.nix
@@ -541,6 +541,7 @@ in {
 
             bridge = {
               username_template = mkDefault "facebook_{{.}}";
+              management_room_text.welcome = "Hello, I'm an Facebook bridge bot.";
             };
 
             appservice = {

--- a/nixos/modules/services/matrix/mautrix-meta.nix
+++ b/nixos/modules/services/matrix/mautrix-meta.nix
@@ -555,6 +555,26 @@ in {
             };
           };
         };
+        messenger = {
+          settings = {
+            meta.mode = mkDefault "messenger";
+
+            bridge = {
+              username_template = mkDefault "messenger_{{.}}";
+              management_room_text.welcome = "Hello, I'm an Messenger bridge bot.";
+            };
+
+            appservice = {
+              id = mkDefault "messenger";
+              port = mkDefault 29322;
+              bot = {
+                username = mkDefault "messengerbot";
+                displayname = mkDefault "Messenger bridge bot";
+                avatar = mkDefault "mxc://maunium.net/ygtkteZsXnGJLJHRchUwYWak";
+              };
+            };
+          };
+        };
       };
     }
   ];

--- a/nixos/tests/matrix/mautrix-meta-postgres.nix
+++ b/nixos/tests/matrix/mautrix-meta-postgres.nix
@@ -92,6 +92,7 @@ import ../make-test-python.nix ({ pkgs, ... }:
             };
 
             bridge.permissions."@${userName}:server" = "user";
+            bridgemanagement_room_text.welcome = "Hello, I'm an mautrix bridge bot.";
           };
         };
 
@@ -138,7 +139,7 @@ import ../make-test-python.nix ({ pkgs, ... }:
                   assert isinstance(response, RoomInviteResponse)
 
                   callback = functools.partial(
-                      message_callback, matrix, "Hello, I'm an Instagram bridge bot."
+                      message_callback, matrix, "Hello, I'm an mautrix bridge bot."
                   )
                   matrix.add_event_callback(callback, RoomMessageNotice)
 

--- a/nixos/tests/matrix/mautrix-meta-sqlite.nix
+++ b/nixos/tests/matrix/mautrix-meta-sqlite.nix
@@ -57,6 +57,7 @@ import ../make-test-python.nix ({ pkgs, ... }:
             };
 
             bridge.permissions."@${username}:server" = "user";
+            bridgemanagement_room_text.welcome = "Hello, I'm an mautrix bridge bot.";
           };
         };
 
@@ -76,6 +77,7 @@ import ../make-test-python.nix ({ pkgs, ... }:
             };
 
             bridge.permissions."@${username}:server" = "user";
+            bridgemanagement_room_text.welcome = "Hello, I'm an mautrix bridge bot.";
           };
         };
 
@@ -150,7 +152,7 @@ import ../make-test-python.nix ({ pkgs, ... }:
                   assert isinstance(response, RoomInviteResponse)
 
                   callback = functools.partial(
-                      message_callback, matrix, "Hello, I'm an Instagram bridge bot."
+                      message_callback, matrix, "Hello, I'm an mautrix bridge bot."
                   )
                   matrix.add_event_callback(callback, RoomMessageNotice)
 


### PR DESCRIPTION
## Description of changes
Adds default settings for mautrix-meta Messenger, as well as change the default `management_room_text.welcome`, to say Facebook instead of Instagram (same goes for messenger).

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
