### PR TITLE
llvmPackages*.llvm: Disable checkPhase on powerpc64-linux

### DIFF
--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -30,6 +30,7 @@
 , debugVersion ? false
 , doCheck ? (if lib.versionOlder release_version "15" then stdenv.isLinux else true)
   && (!stdenv.isx86_32 /* TODO: why */) && (!stdenv.hostPlatform.isMusl)
+  && !(stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isBigEndian)
   && (stdenv.hostPlatform == stdenv.buildPlatform)
 , enableManpages ? false
 , enableSharedLibraries ? !stdenv.hostPlatform.isStatic


### PR DESCRIPTION
Attempt number two, #296666. :sweat: 

CC @NixOS/llvm 

---

Many failures, mostly in MCJIT & Orc(more JIT).

##### LLVM 9

<details>
  <summary>Failing Tests (125):</summary>

```
    LLVM :: ExecutionEngine/MCJIT/2002-12-16-ArgTest.ll
    LLVM :: ExecutionEngine/MCJIT/2003-01-04-ArgumentBug.ll
    LLVM :: ExecutionEngine/MCJIT/2003-01-04-LoopTest.ll
    LLVM :: ExecutionEngine/MCJIT/2003-01-04-PhiTest.ll
    LLVM :: ExecutionEngine/MCJIT/2003-01-09-SARTest.ll
    LLVM :: ExecutionEngine/MCJIT/2003-01-10-FUCOM.ll
    LLVM :: ExecutionEngine/MCJIT/2003-01-15-AlignmentTest.ll
    LLVM :: ExecutionEngine/MCJIT/2003-05-06-LivenessClobber.ll
    LLVM :: ExecutionEngine/MCJIT/2003-05-07-ArgumentTest.ll
    LLVM :: ExecutionEngine/MCJIT/2003-05-11-PHIRegAllocBug.ll
    LLVM :: ExecutionEngine/MCJIT/2003-06-04-bzip2-bug.ll
    LLVM :: ExecutionEngine/MCJIT/2003-06-05-PHIBug.ll
    LLVM :: ExecutionEngine/MCJIT/2003-08-15-AllocaAssertion.ll
    LLVM :: ExecutionEngine/MCJIT/2003-08-21-EnvironmentTest.ll
    LLVM :: ExecutionEngine/MCJIT/2003-08-23-RegisterAllocatePhysReg.ll
    LLVM :: ExecutionEngine/MCJIT/2003-10-18-PHINode-ConstantExpr-CondCode-Failure.ll
    LLVM :: ExecutionEngine/MCJIT/2005-12-02-TailCallBug.ll
    LLVM :: ExecutionEngine/MCJIT/2013-04-04-RelocAddend.ll
    LLVM :: ExecutionEngine/MCJIT/cross-module-a.ll
    LLVM :: ExecutionEngine/MCJIT/cross-module-sm-pic-a.ll
    LLVM :: ExecutionEngine/MCJIT/eh-lg-pic.ll
    LLVM :: ExecutionEngine/MCJIT/eh.ll
    LLVM :: ExecutionEngine/MCJIT/hello.ll
    LLVM :: ExecutionEngine/MCJIT/hello2.ll
    LLVM :: ExecutionEngine/MCJIT/load-object-a.ll
    LLVM :: ExecutionEngine/MCJIT/multi-module-a.ll
    LLVM :: ExecutionEngine/MCJIT/multi-module-eh-a.ll
    LLVM :: ExecutionEngine/MCJIT/multi-module-sm-pic-a.ll
    LLVM :: ExecutionEngine/MCJIT/non-extern-addend.ll
    LLVM :: ExecutionEngine/MCJIT/pr13727.ll
    LLVM :: ExecutionEngine/MCJIT/simplesttest.ll
    LLVM :: ExecutionEngine/MCJIT/simpletest.ll
    LLVM :: ExecutionEngine/MCJIT/stubs-sm-pic.ll
    LLVM :: ExecutionEngine/MCJIT/stubs.ll
    LLVM :: ExecutionEngine/MCJIT/test-arith.ll
    LLVM :: ExecutionEngine/MCJIT/test-branch.ll
    LLVM :: ExecutionEngine/MCJIT/test-call-no-external-funcs.ll
    LLVM :: ExecutionEngine/MCJIT/test-call.ll
    LLVM :: ExecutionEngine/MCJIT/test-cast.ll
    LLVM :: ExecutionEngine/MCJIT/test-common-symbols-alignment.ll
    LLVM :: ExecutionEngine/MCJIT/test-common-symbols.ll
    LLVM :: ExecutionEngine/MCJIT/test-constantexpr.ll
    LLVM :: ExecutionEngine/MCJIT/test-data-align.ll
    LLVM :: ExecutionEngine/MCJIT/test-fp-no-external-funcs.ll
    LLVM :: ExecutionEngine/MCJIT/test-fp.ll
    LLVM :: ExecutionEngine/MCJIT/test-global-ctors.ll
    LLVM :: ExecutionEngine/MCJIT/test-global-init-nonzero-sm-pic.ll
    LLVM :: ExecutionEngine/MCJIT/test-global-init-nonzero.ll
    LLVM :: ExecutionEngine/MCJIT/test-global.ll
    LLVM :: ExecutionEngine/MCJIT/test-loadstore.ll
    LLVM :: ExecutionEngine/MCJIT/test-local.ll
    LLVM :: ExecutionEngine/MCJIT/test-logical.ll
    LLVM :: ExecutionEngine/MCJIT/test-loop.ll
    LLVM :: ExecutionEngine/MCJIT/test-phi.ll
    LLVM :: ExecutionEngine/MCJIT/test-ptr-reloc-sm-pic.ll
    LLVM :: ExecutionEngine/MCJIT/test-ptr-reloc.ll
    LLVM :: ExecutionEngine/MCJIT/test-ret.ll
    LLVM :: ExecutionEngine/MCJIT/test-return.ll
    LLVM :: ExecutionEngine/MCJIT/test-setcond-fp.ll
    LLVM :: ExecutionEngine/MCJIT/test-setcond-int.ll
    LLVM :: ExecutionEngine/MCJIT/test-shift.ll
    LLVM :: ExecutionEngine/MCJIT/weak-function.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2002-12-16-ArgTest.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2003-01-04-ArgumentBug.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2003-01-04-LoopTest.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2003-01-04-PhiTest.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2003-01-09-SARTest.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2003-01-10-FUCOM.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2003-01-15-AlignmentTest.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2003-05-06-LivenessClobber.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2003-05-07-ArgumentTest.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2003-05-11-PHIRegAllocBug.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2003-06-04-bzip2-bug.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2003-06-05-PHIBug.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2003-08-15-AllocaAssertion.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2003-08-21-EnvironmentTest.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2003-08-23-RegisterAllocatePhysReg.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2003-10-18-PHINode-ConstantExpr-CondCode-Failure.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2005-12-02-TailCallBug.ll
    LLVM :: ExecutionEngine/OrcMCJIT/2013-04-04-RelocAddend.ll
    LLVM :: ExecutionEngine/OrcMCJIT/cross-module-a.ll
    LLVM :: ExecutionEngine/OrcMCJIT/cross-module-sm-pic-a.ll
    LLVM :: ExecutionEngine/OrcMCJIT/eh-lg-pic.ll
    LLVM :: ExecutionEngine/OrcMCJIT/eh.ll
    LLVM :: ExecutionEngine/OrcMCJIT/hello.ll
    LLVM :: ExecutionEngine/OrcMCJIT/hello2.ll
    LLVM :: ExecutionEngine/OrcMCJIT/load-object-a.ll
    LLVM :: ExecutionEngine/OrcMCJIT/multi-module-a.ll
    LLVM :: ExecutionEngine/OrcMCJIT/multi-module-eh-a.ll
    LLVM :: ExecutionEngine/OrcMCJIT/multi-module-sm-pic-a.ll
    LLVM :: ExecutionEngine/OrcMCJIT/non-extern-addend.ll
    LLVM :: ExecutionEngine/OrcMCJIT/pr13727.ll
    LLVM :: ExecutionEngine/OrcMCJIT/pr32650.ll
    LLVM :: ExecutionEngine/OrcMCJIT/simplesttest.ll
    LLVM :: ExecutionEngine/OrcMCJIT/simpletest.ll
    LLVM :: ExecutionEngine/OrcMCJIT/stubs-sm-pic.ll
    LLVM :: ExecutionEngine/OrcMCJIT/stubs.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-arith.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-branch.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-call-no-external-funcs.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-call.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-cast.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-common-symbols-alignment.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-common-symbols.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-constantexpr.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-data-align.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-fp-no-external-funcs.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-fp.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-global-ctors.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-global-init-nonzero-sm-pic.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-global-init-nonzero.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-global.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-loadstore.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-local.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-logical.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-loop.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-phi.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-ptr-reloc-sm-pic.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-ptr-reloc.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-ret.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-return.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-setcond-fp.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-setcond-int.ll
    LLVM :: ExecutionEngine/OrcMCJIT/test-shift.ll
    LLVM :: ExecutionEngine/OrcMCJIT/weak-function.ll
```

</details>

[llvm-9.0.1.log](https://github.com/NixOS/nixpkgs/files/14627585/llvm-9.0.1.log)

##### LLVM 17

<details>
  <summary>Failed Tests (91):</summary>

```
  LLVM :: ExecutionEngine/MCJIT/2002-12-16-ArgTest.ll
  LLVM :: ExecutionEngine/MCJIT/2003-01-04-ArgumentBug.ll
  LLVM :: ExecutionEngine/MCJIT/2003-01-04-LoopTest.ll
  LLVM :: ExecutionEngine/MCJIT/2003-01-04-PhiTest.ll
  LLVM :: ExecutionEngine/MCJIT/2003-01-09-SARTest.ll
  LLVM :: ExecutionEngine/MCJIT/2003-01-10-FUCOM.ll
  LLVM :: ExecutionEngine/MCJIT/2003-01-15-AlignmentTest.ll
  LLVM :: ExecutionEngine/MCJIT/2003-05-06-LivenessClobber.ll
  LLVM :: ExecutionEngine/MCJIT/2003-05-07-ArgumentTest.ll
  LLVM :: ExecutionEngine/MCJIT/2003-05-11-PHIRegAllocBug.ll
  LLVM :: ExecutionEngine/MCJIT/2003-06-04-bzip2-bug.ll
  LLVM :: ExecutionEngine/MCJIT/2003-06-05-PHIBug.ll
  LLVM :: ExecutionEngine/MCJIT/2003-08-15-AllocaAssertion.ll
  LLVM :: ExecutionEngine/MCJIT/2003-08-21-EnvironmentTest.ll
  LLVM :: ExecutionEngine/MCJIT/2003-08-23-RegisterAllocatePhysReg.ll
  LLVM :: ExecutionEngine/MCJIT/2003-10-18-PHINode-ConstantExpr-CondCode-Failure.ll
  LLVM :: ExecutionEngine/MCJIT/2005-12-02-TailCallBug.ll
  LLVM :: ExecutionEngine/MCJIT/2013-04-04-RelocAddend.ll
  LLVM :: ExecutionEngine/MCJIT/cross-module-a.ll
  LLVM :: ExecutionEngine/MCJIT/cross-module-sm-pic-a.ll
  LLVM :: ExecutionEngine/MCJIT/eh-lg-pic.ll
  LLVM :: ExecutionEngine/MCJIT/eh.ll
  LLVM :: ExecutionEngine/MCJIT/hello.ll
  LLVM :: ExecutionEngine/MCJIT/hello2.ll
  LLVM :: ExecutionEngine/MCJIT/load-object-a.ll
  LLVM :: ExecutionEngine/MCJIT/multi-module-a.ll
  LLVM :: ExecutionEngine/MCJIT/multi-module-eh-a.ll
  LLVM :: ExecutionEngine/MCJIT/multi-module-sm-pic-a.ll
  LLVM :: ExecutionEngine/MCJIT/non-extern-addend.ll
  LLVM :: ExecutionEngine/MCJIT/pr13727.ll
  LLVM :: ExecutionEngine/MCJIT/remote/cross-module-a.ll
  LLVM :: ExecutionEngine/MCJIT/remote/eh.ll
  LLVM :: ExecutionEngine/MCJIT/remote/multi-module-a.ll
  LLVM :: ExecutionEngine/MCJIT/remote/simpletest-remote.ll
  LLVM :: ExecutionEngine/MCJIT/remote/stubs-remote.ll
  LLVM :: ExecutionEngine/MCJIT/remote/test-common-symbols-remote.ll
  LLVM :: ExecutionEngine/MCJIT/remote/test-data-align-remote.ll
  LLVM :: ExecutionEngine/MCJIT/remote/test-fp-no-external-funcs-remote.ll
  LLVM :: ExecutionEngine/MCJIT/remote/test-global-init-nonzero-remote.ll
  LLVM :: ExecutionEngine/MCJIT/remote/test-global-init-nonzero-sm-pic.ll
  LLVM :: ExecutionEngine/MCJIT/remote/test-ptr-reloc-remote.ll
  LLVM :: ExecutionEngine/MCJIT/remote/test-ptr-reloc-sm-pic.ll
  LLVM :: ExecutionEngine/MCJIT/simplesttest.ll
  LLVM :: ExecutionEngine/MCJIT/simpletest.ll
  LLVM :: ExecutionEngine/MCJIT/stubs-sm-pic.ll
  LLVM :: ExecutionEngine/MCJIT/stubs.ll
  LLVM :: ExecutionEngine/MCJIT/test-arith.ll
  LLVM :: ExecutionEngine/MCJIT/test-branch.ll
  LLVM :: ExecutionEngine/MCJIT/test-call-no-external-funcs.ll
  LLVM :: ExecutionEngine/MCJIT/test-call.ll
  LLVM :: ExecutionEngine/MCJIT/test-cast.ll
  LLVM :: ExecutionEngine/MCJIT/test-common-symbols-alignment.ll
  LLVM :: ExecutionEngine/MCJIT/test-common-symbols.ll
  LLVM :: ExecutionEngine/MCJIT/test-constantexpr.ll
  LLVM :: ExecutionEngine/MCJIT/test-data-align.ll
  LLVM :: ExecutionEngine/MCJIT/test-fp-no-external-funcs.ll
  LLVM :: ExecutionEngine/MCJIT/test-fp.ll
  LLVM :: ExecutionEngine/MCJIT/test-global-ctors.ll
  LLVM :: ExecutionEngine/MCJIT/test-global-init-nonzero-sm-pic.ll
  LLVM :: ExecutionEngine/MCJIT/test-global-init-nonzero.ll
  LLVM :: ExecutionEngine/MCJIT/test-global.ll
  LLVM :: ExecutionEngine/MCJIT/test-loadstore.ll
  LLVM :: ExecutionEngine/MCJIT/test-local.ll
  LLVM :: ExecutionEngine/MCJIT/test-logical.ll
  LLVM :: ExecutionEngine/MCJIT/test-loop.ll
  LLVM :: ExecutionEngine/MCJIT/test-phi.ll
  LLVM :: ExecutionEngine/MCJIT/test-ptr-reloc-sm-pic.ll
  LLVM :: ExecutionEngine/MCJIT/test-ptr-reloc.ll
  LLVM :: ExecutionEngine/MCJIT/test-ret.ll
  LLVM :: ExecutionEngine/MCJIT/test-return.ll
  LLVM :: ExecutionEngine/MCJIT/test-setcond-fp.ll
  LLVM :: ExecutionEngine/MCJIT/test-setcond-int.ll
  LLVM :: ExecutionEngine/MCJIT/test-shift.ll
  LLVM :: ExecutionEngine/MCJIT/weak-function.ll
  LLVM :: ExecutionEngine/Orc/global-ctor-with-cast.ll
  LLVM :: ExecutionEngine/Orc/global-variable-alignment.ll
  LLVM :: ExecutionEngine/Orc/trivial-call-to-function.ll
  LLVM :: ExecutionEngine/Orc/trivial-call-to-internal-function.ll
  LLVM :: ExecutionEngine/Orc/trivial-reference-to-global-variable.ll
  LLVM :: ExecutionEngine/Orc/trivial-reference-to-internal-variable-nonzeroinit.ll
  LLVM :: ExecutionEngine/Orc/trivial-reference-to-internal-variable-zeroinit.ll
  LLVM :: ExecutionEngine/Orc/trivial-return-zero.ll
  LLVM :: ExecutionEngine/Orc/weak-comdat.ll
  LLVM :: ExecutionEngine/frem.ll
  LLVM :: ExecutionEngine/mov64zext32.ll
  LLVM :: ExecutionEngine/test-interp-vec-arithm_float.ll
  LLVM :: ExecutionEngine/test-interp-vec-arithm_int.ll
  LLVM :: ExecutionEngine/test-interp-vec-logical.ll
  LLVM :: ExecutionEngine/test-interp-vec-setcond-fp.ll
  LLVM :: ExecutionEngine/test-interp-vec-setcond-int.ll
  LLVM-Unit :: ExecutionEngine/Orc/./OrcJITTests/0/2
```

</details>

[llvm-17.0.6.log](https://github.com/NixOS/nixpkgs/files/14627588/llvm-17.0.6.log)

---

Notes:

- Only verified that building 9, 17 & git fails, and that disabling the tests makes all 3 of them build. I can check other versions if desired, but…
- Building any LLVM version takes ~10h on my machine, so I haven't done alot of looking into what causes these failures, if any version is unaffected, or if it's potentially caused by using gnuabielfv2.

<details>
  <summary>Clang-based stdenv *mostly works*, though it'll need some help from our cc-wrapper</summary>

LLVM/Clang ignores the `gnuabielfv{1,2}` ABI part of the config triplet and culls it down to just `gnu`:
- Triplet class doesn't have `GNUABIELFV1` / `GNUABIELFV2` values
  [/llvm/include/llvm/TargetParser/Triple.h:230-242](https://github.com/llvm/llvm-project/blob/llvmorg-17.0.6/llvm/include/llvm/TargetParser/Triple.h#L230-L242)
- Parsing is prefix-based, the final `StartsWith("gnu", Triple::GNU)` catches the otherwise-unhandled `gnuabielfv{1,2}` and reduces it to just `"gnu"`
  [/llvm/lib/TargetParser/Triple.cpp:622-636](https://github.com/llvm/llvm-project/blob/llvmorg-17.0.6/llvm/lib/TargetParser/Triple.cpp#L622-L636)
- ELF ABI default for ppc64 is determined by examining arch, OS & libc
  [/llvm/include/llvm/TargetParser/Triple.h:906-912](https://github.com/llvm/llvm-project/blob/llvmorg-17.0.6/llvm/include/llvm/TargetParser/Triple.h#L906-L912)

Which results in the compiler producing ELFv1 objects, even though we're asking for ELFv2 ones. So most linking will fail.
```
configure:4527: checking whether the C compiler works
configure:4549: clang    conftest.c  >&5
/nix/store/amf0m5dg8iacfy5ni3dk9rpgv8kwrrvg-binutils-2.41/bin/ld: /build/conftest-67e02b.o: ABI version 1 is not compatible with ABI version 2 output
/nix/store/amf0m5dg8iacfy5ni3dk9rpgv8kwrrvg-binutils-2.41/bin/ld: failed to merge target specific data of file /build/conftest-67e02b.o
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

When running with `-v`:
```
clang version 17.0.6
Target: powerpc64-unknown-linux-gnuabielfv2
Thread model: posix
InstalledDir: /nix/store/09cfx6kdrgl622qvv812d1igxhz76xyl-clang-17.0.6/bin
Found candidate GCC installation: /nix/store/c7g75hwfhrn2z1b03y5qq62mblx7dycf-gcc-13.2.0/lib/gcc/powerpc64-unknown-linux-gnuabielfv2/13.2.0
Found candidate GCC installation: /nix/store/c7g75hwfhrn2z1b03y5qq62mblx7dycf-gcc-13.2.0/lib64/gcc/powerpc64-unknown-linux-gnuabielfv2/13.2.0
Selected GCC installation: /nix/store/c7g75hwfhrn2z1b03y5qq62mblx7dycf-gcc-13.2.0/lib64/gcc/powerpc64-unknown-linux-gnuabielfv2/13.2.0
Candidate multilib: .;@m64
Selected multilib: .;@m64
 "/nix/store/09cfx6kdrgl622qvv812d1igxhz76xyl-clang-17.0.6/bin/clang-17" -cc1 -triple powerpc64-unknown-linux-gnuabielfv2 -emit-obj -mrelax-all -dumpdir /dev/shm/conftest- -disable-free -clear-ast-before-backend -disable-llvm-verifier -discard-value-names -main-file-name conftest.c -mrelocation-model pic -pic-level 2 -pic-is-pie -mframe-pointer=all -fmath-errno -ffp-contract=on -fno-rounding-math -mconstructor-aliases -funwind-tables=2 -target-cpu ppc64 -mfloat-abi hard -target-abi elfv1 -debugger-tuning=gdb -v -fcoverage-compilation-dir=/home/puna/devel/nixpkgs -nostdsysteminc -resource-dir /nix/store/h4li1h7pr918ms4b4bl048kfihcvybaa-clang-wrapper-17.0.6/resource-root -idirafter /nix/store/hcazi292x6d6l782dm6ss20q512a5wrl-glibc-2.38-44-dev/include -internal-isystem /nix/store/h4li1h7pr918ms4b4bl048kfihcvybaa-clang-wrapper-17.0.6/resource-root/include/ppc_wrappers -internal-isystem /nix/store/h4li1h7pr918ms4b4bl048kfihcvybaa-clang-wrapper-17.0.6/resource-root/include -fdebug-compilation-dir=/home/puna/devel/nixpkgs -ferror-limit 19 -fno-signed-char -fgnuc-version=4.2.1 -fcolor-diagnostics -faddrsig -D__GCC_HAVE_DWARF2_CFI_ASM=1 -o /tmp/conftest-a4408e.o -x c /dev/shm/conftest.c
clang -cc1 version 17.0.6 based upon LLVM 17.0.6 default target powerpc64-unknown-linux-gnuabielfv2
#include "..." search starts here:
#include <...> search starts here:
 /nix/store/h4li1h7pr918ms4b4bl048kfihcvybaa-clang-wrapper-17.0.6/resource-root/include/ppc_wrappers
 /nix/store/h4li1h7pr918ms4b4bl048kfihcvybaa-clang-wrapper-17.0.6/resource-root/include
 /nix/store/hcazi292x6d6l782dm6ss20q512a5wrl-glibc-2.38-44-dev/include
End of search list.
 "/nix/store/h4li1h7pr918ms4b4bl048kfihcvybaa-clang-wrapper-17.0.6/bin/ld" -pie --hash-style=gnu --eh-frame-hdr -m elf64ppc -o /dev/shm/conftest /nix/store/13mhdf5x574x9wnrjpdk79k8ir52fw5n-glibc-2.38-44/lib/Scrt1.o /nix/store/13mhdf5x574x9wnrjpdk79k8ir52fw5n-glibc-2.38-44/lib/crti.o /nix/store/c7g75hwfhrn2z1b03y5qq62mblx7dycf-gcc-13.2.0/lib/gcc/powerpc64-unknown-linux-gnuabielfv2/13.2.0/crtbeginS.o -L/nix/store/13mhdf5x574x9wnrjpdk79k8ir52fw5n-glibc-2.38-44/lib -L/nix/store/c7g75hwfhrn2z1b03y5qq62mblx7dycf-gcc-13.2.0/lib/gcc/powerpc64-unknown-linux-gnuabielfv2/13.2.0 -L/nix/store/06p31qlrln7nf6bvlgs3kswgfsvnrz6d-gcc-13.2.0-lib/lib -L/nix/store/c7g75hwfhrn2z1b03y5qq62mblx7dycf-gcc-13.2.0//lib -L/nix/store/85l7pnrc4pjdza8j8pa9rcn378hcp26f-gcc-13.2.0-libgcc/lib -L/nix/store/8pgjm8r18w14z042jxcqg2ww08ldw1zq-clang-17.0.6-lib/lib -L/nix/store/c7g75hwfhrn2z1b03y5qq62mblx7dycf-gcc-13.2.0/lib64/gcc/powerpc64-unknown-linux-gnuabielfv2/13.2.0 -L/nix/store/c7g75hwfhrn2z1b03y5qq62mblx7dycf-gcc-13.2.0/lib64/gcc/powerpc64-unknown-linux-gnuabielfv2/13.2.0/../../../../lib64 -L/lib/powerpc64-linux-gnu -L/lib/../lib64 -L/usr/lib/powerpc64-linux-gnu -L/usr/lib/../lib64 -L/lib -L/usr/lib -dynamic-linker=/nix/store/13mhdf5x574x9wnrjpdk79k8ir52fw5n-glibc-2.38-44/lib/ld64.so.2 /tmp/conftest-a4408e.o -lgcc --as-needed -lgcc_s --no-as-needed -lc -lgcc --as-needed -lgcc_s --no-as-needed /nix/store/c7g75hwfhrn2z1b03y5qq62mblx7dycf-gcc-13.2.0/lib/gcc/powerpc64-unknown-linux-gnuabielfv2/13.2.0/crtendS.o /nix/store/13mhdf5x574x9wnrjpdk79k8ir52fw5n-glibc-2.38-44/lib/crtn.o
/nix/store/amf0m5dg8iacfy5ni3dk9rpgv8kwrrvg-binutils-2.41/bin/ld: /tmp/conftest-a4408e.o: ABI version 1 is not compatible with ABI version 2 output
/nix/store/amf0m5dg8iacfy5ni3dk9rpgv8kwrrvg-binutils-2.41/bin/ld: failed to merge target specific data of file /tmp/conftest-a4408e.o
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Relevant part:
```
Target: powerpc64-unknown-linux-gnuabielfv2
[...]
"/nix/store/09cfx6kdrgl622qvv812d1igxhz76xyl-clang-17.0.6/bin/clang-17" -cc1 -triple powerpc64-unknown-linux-gnuabielfv2 [...] -target-cpu ppc64 -mfloat-abi hard -target-abi elfv1 [...]
```

Planning to add something like this to our cc-wrapper to work around this, which gets `hello` building with `llvmPackages_17.stdenv`:
```diff
diff --git a/pkgs/build-support/cc-wrapper/default.nix b/pkgs/build-support/cc-wrapper/default.nix
index d788076dda51..a78fb5c4d62c 100644
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -643,6 +643,12 @@ stdenv.mkDerivation {
       echo "-mtune=${tune}" >> $out/nix-support/cc-cflags-before
     '')
 
+    # Clang doesn't parse gnuabielfv{1,2} triplet parts for powerpc64{,le}, need to manually override abi
+    + optionalString (isClang && targetPlatform.isPower64 && targetPlatform.parsed.abi.name != "gnu") ''
+      echo "-mabi=${targetPlatform.parsed.abi.abi}" >> $out/nix-support/cc-cflags-before
+    ''
+
+
     # TODO: categorize these and figure out a better place for them
     + optionalString targetPlatform.isWindows ''
       hardening_unsupported_flags+=" pic"
```

But we can figure out the details of that in a separate PR.

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux [for time reasons, only tested LLVM 9 & 17]
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
