### PR TITLE
texlive: avoid top-level `with` in helper script

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/generate-fixed-hashes.nix
+++ b/pkgs/tools/typesetting/tex/texlive/generate-fixed-hashes.nix
@@ -1,10 +1,23 @@
-with import ../../../../.. { };
+{ pkgs ? (import ../../../../.. { }) }:
 
-with lib; let
-  getFods = drv: lib.optional (isDerivation drv.tex) (drv.tex // { tlType = "run"; })
-    ++ lib.optional (drv ? texdoc) (drv.texdoc // { tlType = "doc"; })
-    ++ lib.optional (drv ? texsource) (drv.texsource // { tlType = "source"; })
-    ++ lib.optional (drv ? tlpkg) (drv.tlpkg // { tlType = "tlpkg"; });
+let
+  inherit (pkgs) runCommand writeText texlive nix;
+  inherit (pkgs.lib)
+    attrValues
+    concatMap
+    concatMapStrings
+    isDerivation
+    filter
+    optional
+    optionalString
+    sort
+    strings
+    ;
+
+  getFods = drv: optional (isDerivation drv.tex) (drv.tex // { tlType = "run"; })
+    ++ optional (drv ? texdoc) (drv.texdoc // { tlType = "doc"; })
+    ++ optional (drv ? texsource) (drv.texsource // { tlType = "source"; })
+    ++ optional (drv ? tlpkg) (drv.tlpkg // { tlType = "tlpkg"; });
 
   sorted = sort (a: b: a.pname < b.pname) (attrValues texlive.pkgs);
   fods = concatMap getFods sorted;


### PR DESCRIPTION
## Description of changes

There's a helper script at `pkgs/tools/typesetting/tex/texlive/generate-fixed-hashes.nix` that's invoked through `nix-build pkgs/tools/typesetting/tex/texlive/generate-fixed-hashes.nix` to generate a set of fixed-output derivations for the texlive project.

This PR edits that script to avoid the use of top-level `with`.

- #208242 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).