### PR TITLE
Blender darwin

### DIFF
--- a/pkgs/applications/misc/blender/darwin.patch
+++ b/pkgs/applications/misc/blender/darwin.patch
@@ -1,27 +1,25 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -1894,7 +1894,7 @@ if(WITH_COMPILER_SHORT_FILE_MACRO)
-   ADD_CHECK_CXX_COMPILER_FLAG(CXX_PREFIX_MAP_FLAGS CXX_MACRO_PREFIX_MAP -fmacro-prefix-map=foo=bar)
+--- a/CMakeLists.txt	2024-03-01 08:08:05
++++ b/CMakeLists.txt	2024-04-24 15:45:30
+@@ -2134,7 +2134,7 @@
+   )
    if(C_MACRO_PREFIX_MAP AND CXX_MACRO_PREFIX_MAP)
      if(APPLE)
 -      if(XCODE AND ${XCODE_VERSION} VERSION_LESS 12.0)
 +      if(FALSE)
        # Developers may have say LLVM Clang-10.0.1 toolchain (which supports the flag)
        # with Xcode-11 (the Clang of which doesn't support the flag).
-         message(WARNING
-diff --git a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake/platform/platform_apple.cmake
---- a/build_files/cmake/platform/platform_apple.cmake
-+++ b/build_files/cmake/platform/platform_apple.cmake
-@@ -60,7 +60,6 @@ else()
-   message(STATUS "Using pre-compiled LIBDIR: ${LIBDIR}")
+         message(
+--- a/build_files/cmake/platform/platform_apple.cmake	2024-02-22 15:31:36
++++ b/build_files/cmake/platform/platform_apple.cmake	2024-04-24 16:06:13
+@@ -55,7 +55,6 @@
+   endif()
  endif()
- if(NOT EXISTS "${LIBDIR}/")
+ if(NOT EXISTS "${LIBDIR}/.git")
 -  message(FATAL_ERROR "Mac OSX requires pre-compiled libs at: '${LIBDIR}'")
  endif()
- 
- # Prefer lib directory paths
-@@ -98,10 +97,6 @@ if(WITH_CODEC_SNDFILE)
+ if(FIRST_RUN)
+   message(STATUS "Using pre-compiled LIBDIR: ${LIBDIR}")
+@@ -115,10 +114,6 @@
    find_library(_sndfile_VORBIS_LIBRARY NAMES vorbis HINTS ${LIBDIR}/ffmpeg/lib)
    find_library(_sndfile_VORBISENC_LIBRARY NAMES vorbisenc HINTS ${LIBDIR}/ffmpeg/lib)
    list(APPEND LIBSNDFILE_LIBRARIES
@@ -32,44 +30,26 @@ diff --git a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake
    )
  
    print_found_status("SndFile libraries" "${LIBSNDFILE_LIBRARIES}")
-@@ -118,7 +113,7 @@ if(WITH_PYTHON)
-     # Normally cached but not since we include them with blender.
-     set(PYTHON_INCLUDE_DIR "${LIBDIR}/python/include/python${PYTHON_VERSION}")
-     set(PYTHON_EXECUTABLE "${LIBDIR}/python/bin/python${PYTHON_VERSION}")
--    set(PYTHON_LIBRARY ${LIBDIR}/python/lib/libpython${PYTHON_VERSION}.a)
-+    set(PYTHON_LIBRARY ${LIBDIR}/python/lib/libpython${PYTHON_VERSION}.dylib)
-     set(PYTHON_LIBPATH "${LIBDIR}/python/lib/python${PYTHON_VERSION}")
-   else()
-     # Module must be compiled against Python framework.
-@@ -147,7 +142,7 @@ endif()
- 
- # FreeType compiled with Brotli compression for woff2.
- find_package(Freetype REQUIRED)
--list(APPEND FREETYPE_LIBRARIES
-+message(TRACE APPEND FREETYPE_LIBRARIES
-   ${LIBDIR}/brotli/lib/libbrotlicommon-static.a
-   ${LIBDIR}/brotli/lib/libbrotlidec-static.a)
- 
-@@ -159,9 +154,7 @@ if(WITH_CODEC_FFMPEG)
+@@ -162,9 +157,7 @@
    set(FFMPEG_ROOT_DIR ${LIBDIR}/ffmpeg)
    set(FFMPEG_FIND_COMPONENTS
      avcodec avdevice avformat avutil
 -    mp3lame ogg opus swresample swscale
 -    theora theoradec theoraenc vorbis vorbisenc
--    vorbisfile vpx x264 xvidcore)
-+    swresample swscale)
+-    vorbisfile vpx x264)
++   swresample swscale)
    if(EXISTS ${LIBDIR}/ffmpeg/lib/libaom.a)
      list(APPEND FFMPEG_FIND_COMPONENTS aom)
    endif()
-@@ -273,7 +266,6 @@ if(WITH_BOOST)
- endif()
+@@ -275,7 +268,6 @@
+ add_bundled_libraries(boost/lib)
  
  if(WITH_INTERNATIONAL OR WITH_CODEC_FFMPEG)
 -  string(APPEND PLATFORM_LINKFLAGS " -liconv") # boost_locale and ffmpeg needs it !
  endif()
  
  if(WITH_PUGIXML)
-@@ -402,7 +394,7 @@ endif()
+@@ -350,7 +342,7 @@
  
  # CMake FindOpenMP doesn't know about AppleClang before 3.12, so provide custom flags.
  if(WITH_OPENMP)
@@ -78,3 +58,12 @@ diff --git a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake
      # Use OpenMP from our precompiled libraries.
      message(STATUS "Using ${LIBDIR}/openmp for OpenMP")
      set(OPENMP_CUSTOM ON)
+@@ -427,7 +419,7 @@
+   " -Wl,-unexported_symbols_list,'${PLATFORM_SYMBOLS_MAP}'"
+ )
+ 
+-if(${XCODE_VERSION} VERSION_GREATER_EQUAL 15.0)
++if(FALSE)
+   if("${CMAKE_OSX_ARCHITECTURES}" STREQUAL "x86_64")
+     # Silence "no platform load command found in <static library>, assuming: macOS".
+     string(APPEND PLATFORM_LINKFLAGS " -Wl,-ld_classic")

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -8,12 +8,14 @@
   addOpenGLRunpath,
   alembic,
   boost,
+  brotli,
   callPackage,
   cmake,
   colladaSupport ? true,
   config,
   cudaPackages,
   cudaSupport ? config.cudaSupport,
+  darwin,
   dbus,
   embree,
   fetchurl,
@@ -71,6 +73,7 @@
   rocmPackages, # comes with a significantly larger closure size
   runCommand,
   spaceNavSupport ? stdenv.isLinux,
+  sse2neon,
   stdenv,
   tbb,
   wayland,
@@ -114,15 +117,13 @@ stdenv.mkDerivation (finalAttrs: {
         ''
           : > build_files/cmake/platform/platform_apple_xcode.cmake
           substituteInPlace source/creator/CMakeLists.txt \
-            --replace '${"$"}{LIBDIR}/python' \
+            --replace-fail '${"$"}{LIBDIR}/python' \
                       '${python3}'
           substituteInPlace build_files/cmake/platform/platform_apple.cmake \
-            --replace '${"$"}{LIBDIR}/python' \
-                      '${python3}' \
-            --replace '${"$"}{LIBDIR}/opencollada' \
-                      '${opencollada}' \
-            --replace '${"$"}{PYTHON_LIBPATH}/site-packages/numpy' \
-                      '${python3Packages.numpy}/${python3.sitePackages}/numpy'
+            --replace-fail '${"$"}{LIBDIR}/brotli/lib/libbrotlicommon-static.a' \
+                      '${lib.getLib brotli}/lib/libbrotlicommon.dylib' \
+            --replace-fail '${"$"}{LIBDIR}/brotli/lib/libbrotlidec-static.a' \
+                      '${lib.getLib brotli}/lib/libbrotlidec.dylib'
         ''
       else
         ''
@@ -164,7 +165,7 @@ stdenv.mkDerivation (finalAttrs: {
 
       # Blender supplies its own FindAlembic.cmake (incompatible with the Alembic-supplied config file)
       "-DALEMBIC_INCLUDE_DIR=${lib.getDev alembic}/include"
-      "-DALEMBIC_LIBRARY=${lib.getLib alembic}/lib/libAlembic.so"
+      "-DALEMBIC_LIBRARY=${lib.getLib alembic}/lib/libAlembic${stdenv.hostPlatform.extensions.sharedLibrary}"
     ]
     ++ lib.optionals waylandSupport [
       "-DWITH_GHOST_WAYLAND=ON"
@@ -172,11 +173,12 @@ stdenv.mkDerivation (finalAttrs: {
       "-DWITH_GHOST_WAYLAND_DYNLOAD=OFF"
       "-DWITH_GHOST_WAYLAND_LIBDECOR=ON"
     ]
-    ++ lib.optionals stdenv.hostPlatform.isAarch64 [ "-DWITH_CYCLES_EMBREE=OFF" ]
+    ++ lib.optionals (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) [ "-DWITH_CYCLES_EMBREE=OFF" ]
     ++ lib.optionals stdenv.isDarwin [
       "-DLIBDIR=/does-not-exist"
-      "-DWITH_CYCLES_OSL=OFF" # requires LLVM
-      "-DWITH_OPENVDB=OFF" # OpenVDB currently doesn't build on darwin
+      "-DWITH_CYCLES_OSL=OFF" # causes segfault on aarch64-darwin
+      "-DSSE2NEON_INCLUDE_DIR=${sse2neon}/lib"
+      "-DWITH_USD=OFF" # currently fails on darwin
     ]
     ++ lib.optional stdenv.cc.isClang "-DPYTHON_LINKFLAGS=" # Clang doesn't support "-export-dynamic"
     ++ lib.optional jackaudioSupport "-DWITH_JACK=ON"
@@ -225,15 +227,15 @@ stdenv.mkDerivation (finalAttrs: {
       openjpeg
       openpgl
       (opensubdiv.override { inherit cudaSupport; })
+      openvdb
       potrace
       pugixml
-      pyPkgsOpenusd
       python3
       tbb
       zlib
       zstd
     ]
-    ++ lib.optionals (!stdenv.isAarch64) [
+    ++ lib.optionals (!stdenv.isAarch64 && stdenv.isLinux) [
       embree
       (openimagedenoise.override { inherit cudaSupport; })
     ]
@@ -248,8 +250,8 @@ stdenv.mkDerivation (finalAttrs: {
           libXrender
           libXxf86vm
           openal
-          openvdb # OpenVDB currently doesn't build on darwin
           openxr-loader
+          pyPkgsOpenusd
         ]
       else
         [
@@ -259,7 +261,11 @@ stdenv.mkDerivation (finalAttrs: {
           OpenAL
           OpenGL
           SDL
+          brotli
+          embree
           llvmPackages.openmp
+          (openimagedenoise.override { inherit cudaSupport; })
+          sse2neon
         ]
     )
     ++ lib.optionals cudaSupport [ cudaPackages.cuda_cudart ]
@@ -283,8 +289,8 @@ stdenv.mkDerivation (finalAttrs: {
       ps.numpy
       ps.requests
       ps.zstandard
-      pyPkgsOpenusd
-    ];
+    ]
+    ++ lib.optionals (!stdenv.isDarwin) [ pyPkgsOpenusd ];
 
   blenderExecutable =
     placeholder "out"
@@ -295,8 +301,10 @@ stdenv.mkDerivation (finalAttrs: {
       mkdir $out/Applications
       mv $out/Blender.app $out/Applications
     ''
-    + ''
+    + lib.optionalString stdenv.isLinux ''
       mv $out/share/blender/${lib.versions.majorMinor finalAttrs.version}/python{,-ext}
+    ''
+    + ''
       buildPythonPath "$pythonPath"
       wrapProgram $blenderExecutable \
         --prefix PATH : $program_PATH \
@@ -311,6 +319,9 @@ stdenv.mkDerivation (finalAttrs: {
       isELF "$program" || continue
       addOpenGLRunpath "$program"
     done
+  ''
+  + lib.optionalString stdenv.isDarwin ''
+    makeWrapper $out/Applications/Blender.app/Contents/MacOS/Blender $out/bin/blender
   '';
 
   passthru = {
@@ -327,15 +338,13 @@ stdenv.mkDerivation (finalAttrs: {
     tests = {
       render = runCommand "${finalAttrs.pname}-test" { } ''
         set -euo pipefail
-
         export LIBGL_DRIVERS_PATH=${mesa.drivers}/lib/dri
         export __EGL_VENDOR_LIBRARY_FILENAMES=${mesa.drivers}/share/glvnd/egl_vendor.d/50_mesa.json
-
         cat <<'PYTHON' > scene-config.py
         import bpy
         bpy.context.scene.eevee.taa_render_samples = 32
         bpy.context.scene.cycles.samples = 32
-        if ${if stdenv.isAarch64 then "True" else "False"}:
+        if ${if (stdenv.isAarch64 && stdenv.isLinux) then "True" else "False"}:
             bpy.context.scene.cycles.use_denoising = False
         bpy.context.scene.render.resolution_x = 100
         bpy.context.scene.render.resolution_y = 100
@@ -347,7 +356,7 @@ stdenv.mkDerivation (finalAttrs: {
         for engine in BLENDER_EEVEE CYCLES; do
           echo "Rendering with $engine..."
           # Beware that argument order matters
-          ${finalAttrs.finalPackage}/bin/blender \
+          ${lib.getExe finalAttrs.finalPackage} \
             --background \
             -noaudio \
             --factory-startup \
@@ -372,8 +381,10 @@ stdenv.mkDerivation (finalAttrs: {
       "aarch64-linux"
       "x86_64-darwin"
       "x86_64-linux"
+      "aarch64-darwin"
     ];
-    broken = stdenv.isDarwin;
+    # the current apple sdk is too old (currently 11_0) and fails to build "metal" on x86_64-darwin
+    broken = stdenv.hostPlatform.system == "x86_64-darwin";
     maintainers = with lib.maintainers; [
       goibhniu
       veprbl

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -53,6 +53,7 @@
   libxkbcommon,
   llvmPackages,
   makeWrapper,
+  materialx,
   mesa,
   ocl-icd,
   openal,
@@ -118,7 +119,8 @@ stdenv.mkDerivation (finalAttrs: {
           : > build_files/cmake/platform/platform_apple_xcode.cmake
           substituteInPlace source/creator/CMakeLists.txt \
             --replace-fail '${"$"}{LIBDIR}/python' \
-                      '${python3}'
+                      '${python3}' \
+            --replace-fail '${"$"}{LIBDIR}/materialx/' '${materialx}/'
           substituteInPlace build_files/cmake/platform/platform_apple.cmake \
             --replace-fail '${"$"}{LIBDIR}/brotli/lib/libbrotlicommon-static.a' \
                       '${lib.getLib brotli}/lib/libbrotlicommon.dylib' \
@@ -151,6 +153,7 @@ stdenv.mkDerivation (finalAttrs: {
       "-DWITH_FFTW3=ON"
       "-DWITH_IMAGE_OPENJPEG=ON"
       "-DWITH_INSTALL_PORTABLE=OFF"
+      "-DMaterialX_DIR=${materialx}/lib/cmake/MaterialX"
       "-DWITH_MOD_OCEANSIM=ON"
       "-DWITH_OPENCOLLADA=${if colladaSupport then "ON" else "OFF"}"
       "-DWITH_OPENCOLORIO=ON"
@@ -221,6 +224,7 @@ stdenv.mkDerivation (finalAttrs: {
       libsndfile
       libtiff
       libwebp
+      materialx
       opencolorio
       openexr
       openimageio
@@ -286,6 +290,7 @@ stdenv.mkDerivation (finalAttrs: {
       ps = python3Packages;
     in
     [
+      materialx
       ps.numpy
       ps.requests
       ps.zstandard

--- a/pkgs/by-name/ma/materialx/package.nix
+++ b/pkgs/by-name/ma/materialx/package.nix
@@ -52,6 +52,8 @@ python3Packages.buildPythonPackage rec {
   cmakeFlags = [
     (lib.cmakeBool "MATERIALX_BUILD_OIIO" true)
     (lib.cmakeBool "MATERIALX_BUILD_PYTHON" true)
+    # don't build MSL shader back-end on x86_x64-darwin, as it requires a newer SDK with metal support
+    (lib.cmakeBool "MATERIALX_BUILD_GEN_MSL" (stdenv.isLinux || (stdenv.isAarch64 && stdenv.isDarwin)))
   ];
 
   pythonImportsCheck = [ "MaterialX" ];

--- a/pkgs/by-name/ma/materialx/package.nix
+++ b/pkgs/by-name/ma/materialx/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  darwin,
+  libX11,
+  libXt,
+  libGL,
+  openimageio,
+  imath,
+  python3Packages,
+  python3
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "materialx";
+  version = "1.38.10";
+
+  src = fetchFromGitHub {
+    owner = "AcademySoftwareFoundation";
+    repo = "MaterialX";
+    rev = "v${version}";
+    sha256 = "sha256-/kMHmW2dptZNtjuhE5s+jvPRIdtY+FRiVtMU+tiBgQo=";
+  };
+
+  format = "other";
+
+  nativeBuildInputs = [
+    cmake
+    python3Packages.setuptools
+  ];
+
+  buildInputs =
+    [
+      openimageio
+      imath
+    ]
+    ++ lib.optionals stdenv.isDarwin (
+      with darwin.apple_sdk.frameworks;
+      [
+        OpenGL
+        Cocoa
+      ]
+    )
+    ++ lib.optionals (!stdenv.isDarwin) [
+      libX11
+      libXt
+      libGL
+    ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "MATERIALX_BUILD_OIIO" true)
+    (lib.cmakeBool "MATERIALX_BUILD_PYTHON" true)
+  ];
+
+  pythonImportsCheck = [ "MaterialX" ];
+
+  postInstall = ''
+    # Make python lib properly accessible
+    target_dir=$out/${python3.sitePackages}
+    mkdir -p $(dirname $target_dir)
+    # required for cmake to find the bindings, when included in other projects
+    ln -s $out/python $target_dir
+  '';
+
+  meta = {
+    description = "Open standard for representing rich material and look-development content in computer graphics";
+    homepage = "https://materialx.org";
+    maintainers = [ lib.maintainers.gador ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.mpl20;
+  };
+}

--- a/pkgs/by-name/op/openpgl/package.nix
+++ b/pkgs/by-name/op/openpgl/package.nix
@@ -31,12 +31,12 @@ stdenv.mkDerivation (finalAttrs: {
     "-DTBB_ROOT=${tbb.out}"
   ];
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isAarch64 "-flax-vector-conversions";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.isAarch64 && !stdenv.isDarwin) "-flax-vector-conversions";
 
   meta = {
     description = "Intel Open Path Guiding Library";
     homepage = "https://github.com/OpenPathGuidingLibrary/openpgl";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.amarshall ];
     license = lib.licenses.asl20;
   };

--- a/pkgs/by-name/op/openpgl/package.nix
+++ b/pkgs/by-name/op/openpgl/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "OpenPathGuidingLibrary";
-    repo = finalAttrs.pname;
+    repo = "openpgl";
     rev = "v${finalAttrs.version}";
     hash = "sha256-dbHmGGiHQkU0KPpQYpY/o0uCWdb3L5namETdOcOREgs=";
   };

--- a/pkgs/by-name/ss/sse2neon/package.nix
+++ b/pkgs/by-name/ss/sse2neon/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sse2neon";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "DLTcollab";
+    repo = "sse2neon";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-riFFGIA0H7e5StYSjO0/JDrduzfwS+lOASzk5BRUyo4=";
+  };
+
+  postPatch = ''
+    # remove warning about gcc < 10
+    substituteInPlace sse2neon.h --replace-fail "#warning \"GCC versions" "// "
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+
+  dontInstall = true;
+  # use postBuild instead of installPhase, because the build
+  # in itself doesn't produce any ($out) output
+  postBuild = ''
+    mkdir -p $out/lib
+    install -m444 sse2neon.h $out/lib/
+  '';
+
+  meta = {
+    description = "Mono library that provides a GDI+-compatible API on non-Windows operating systems";
+    homepage = "https://www.mono-project.com/docs/gui/libgdiplus/";
+    platforms = lib.platforms.unix;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.gador ];
+  };
+})

--- a/pkgs/development/libraries/openimagedenoise/default.nix
+++ b/pkgs/development/libraries/openimagedenoise/default.nix
@@ -3,34 +3,54 @@
   config,
   cudaPackages,
   cudaSupport ? config.cudaSupport,
+  darwin,
   fetchzip,
   ispc,
   lib,
   python3,
   stdenv,
   tbb,
+  xcodebuild,
 }:
 
-stdenv.mkDerivation rec {
+let
+  stdenv' = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
+in
+stdenv'.mkDerivation (finalAttrs: {
   pname = "openimagedenoise";
   version = "2.2.2";
 
   # The release tarballs include pretrained weights, which would otherwise need to be fetched with git-lfs
   src = fetchzip {
-    url = "https://github.com/OpenImageDenoise/oidn/releases/download/v${version}/oidn-${version}.src.tar.gz";
+    url = "https://github.com/OpenImageDenoise/oidn/releases/download/v${finalAttrs.version}/oidn-${finalAttrs.version}.src.tar.gz";
     sha256 = "sha256-ZIrs4oEb+PzdMh2x2BUFXKyu/HBlFb3CJX24ciEHy3Q=";
   };
 
   patches = lib.optional cudaSupport ./cuda.patch;
 
+  postPatch =
+    ''
+      substituteInPlace devices/metal/CMakeLists.txt \
+        --replace-fail "AppleClang" "Clang"
+    '';
+
   nativeBuildInputs = [
     cmake
     python3
     ispc
-  ] ++ lib.optional cudaSupport cudaPackages.cuda_nvcc;
+  ] ++ lib.optional cudaSupport cudaPackages.cuda_nvcc
+    ++ lib.optionals stdenv.isDarwin [ xcodebuild ];
 
   buildInputs =
     [ tbb ]
+    ++ lib.optionals stdenv.isDarwin (
+      with darwin.apple_sdk_11_0.frameworks;
+      [
+        Accelerate
+        MetalKit
+        MetalPerformanceShadersGraph
+      ]
+    )
     ++ lib.optionals cudaSupport [
       cudaPackages.cuda_cudart
       cudaPackages.cuda_cccl
@@ -50,4 +70,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     changelog = "https://github.com/OpenImageDenoise/oidn/blob/v${version}/CHANGELOG.md";
   };
-}
+})

--- a/pkgs/development/libraries/openvdb/default.nix
+++ b/pkgs/development/libraries/openvdb/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec
 
   buildInputs = [ boost tbb jemalloc c-blosc zlib ];
 
-  cmakeFlags = [ "-DOPENVDB_CORE_STATIC=OFF" ];
+  cmakeFlags = [ "-DOPENVDB_CORE_STATIC=OFF" "-DOPENVDB_BUILD_NANOVDB=ON"];
 
   # error: aligned deallocation function of type 'void (void *, std::align_val_t) noexcept' is only available on macOS 10.13 or newer
   env = lib.optionalAttrs (stdenv.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinMinVersion "10.13" && lib.versionAtLeast tbb.version "2021.8.0") {

--- a/pkgs/development/python-modules/openusd/default.nix
+++ b/pkgs/development/python-modules/openusd/default.nix
@@ -18,6 +18,8 @@
   lib,
   libGL,
   libX11,
+  libXt,
+  materialx,
   ninja,
   numpy,
   opencolorio,
@@ -86,6 +88,7 @@ buildPythonPackage rec {
     (lib.cmakeBool "PXR_BUILD_PYTHON_DOCUMENTATION" withDocs)
     (lib.cmakeBool "PXR_BUILD_USDVIEW" withUsdView)
     (lib.cmakeBool "PXR_BUILD_USD_TOOLS" withTools)
+    (lib.cmakeBool "PXR_ENABLE_MATERIALX_SUPPORT" true)
     (lib.cmakeBool "PXR_ENABLE_OSL_SUPPORT" (!stdenv.isDarwin && withOsl))
   ];
 
@@ -111,6 +114,7 @@ buildPythonPackage rec {
       embree
       flex
       imath
+      materialx
       opencolorio
       openimageio
       opensubdiv
@@ -120,6 +124,7 @@ buildPythonPackage rec {
     ++ lib.optionals stdenv.isLinux [
       libGL
       libX11
+      libXt
     ]
     ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk_11_0.frameworks; [ Cocoa ])
     ++ lib.optionals withOsl [ osl ]


### PR DESCRIPTION
## Description of changes

This PR fixes the build of `blender` on darwin.

To do so, the following changes have been made:

- add `sse2neon` package (fixed compiler warning)
- fixed `openpgl` darwin build (needed as build input)
- fixed `openimagedenoise` darwin build. This could theoretically build with `metal` M1 support, but due to the older apple sdk in nixpkgs, this doesn't work, yet. When the sdk is updated, changes should be easy to include `metal`support. 
- add `materialx`. This fixes another compiler warning, enables the `materialx` build flag and can be used in other packages, too
- add `NanoVDB` libraries included by `openvdb` to also be built (needed by blender)
- `python311Packages.openusd` enable `materialx` build flag

Due to these changes, blender can now be build with sse2neon, materialx and open/nanoVDB support. 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
