### PR TITLE
tree-wide: Replace unsupported dontCheck with doCheck attribute

### DIFF
--- a/pkgs/by-name/py/pyxel/package.nix
+++ b/pkgs/by-name/py/pyxel/package.nix
@@ -56,7 +56,7 @@ python3.pkgs.buildPythonApplication rec {
   env.NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL2}/include/SDL2";
 
   # Tests can't use the display
-  dontCheck = true;
+  doCheck = false;
 
   pythonImportsCheck = [
     "pyxel"

--- a/pkgs/development/python-modules/gpt-2-simple/default.nix
+++ b/pkgs/development/python-modules/gpt-2-simple/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   regex,
   requests,
+  setuptools,
   tqdm,
   numpy,
   toposort,
@@ -13,7 +14,7 @@
 buildPythonPackage rec {
   pname = "gpt-2-simple";
   version = "0.8.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "minimaxir";
@@ -21,6 +22,8 @@ buildPythonPackage rec {
     rev = "v${version}";
     hash = "sha256-WwD4sDcc28zXEOISJsq8e+rgaNrrgIy79Wa4J3E7Ovc=";
   };
+
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [
     regex
@@ -31,7 +34,7 @@ buildPythonPackage rec {
     tensorflow
   ];
 
-  dontCheck = true; # no tests in upstream
+  doCheck = false; # no tests in upstream
 
   meta = with lib; {
     description = "Easily retrain OpenAI's GPT-2 text-generating model on new texts";

--- a/pkgs/development/python-modules/kaitaistruct/default.nix
+++ b/pkgs/development/python-modules/kaitaistruct/default.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   brotli,
   lz4,
+  setuptools,
 }:
 
 let
@@ -18,7 +19,7 @@ in
 buildPythonPackage rec {
   pname = "kaitaistruct";
   version = "0.10";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -30,13 +31,14 @@ buildPythonPackage rec {
     sed '32ipackages = kaitai/compress' -i setup.cfg
   '';
 
+  build-system = [ setuptools ];
+
   propagatedBuildInputs = [
     brotli
     lz4
   ];
 
-  # no tests
-  dontCheck = true;
+  doCheck = false; # no tests in upstream
 
   pythonImportsCheck = [
     "kaitaistruct"


### PR DESCRIPTION
## Description of changes

Remove unsupported `dontCheck` attribute (for context see [this comment on #293498](https://github.com/NixOS/nixpkgs/pull/293498#discussion_r1531436723)).

ℹ️ Since `python3Module.gpt-2-simple` is broken on `aarch64-darwin` I was not able to test it locally; yet the GitHub tests indicate that the changes proposed in this PR do not affect it negatively.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
