### PR TITLE
gitprompt-rs: add cafkafk as maintainer

### DIFF
--- a/pkgs/applications/version-management/gitprompt-rs/default.nix
+++ b/pkgs/applications/version-management/gitprompt-rs/default.nix
@@ -12,10 +12,10 @@ rustPlatform.buildRustPackage rec {
     owner = "9ary";
     repo = pname;
     rev = version;
-    sha256 = "00xxz7awk01981daabp8m3kwq127y733ynijiwqgs8xvn4nkg8h6";
+    hash = "sha256-BqI3LbG7I/0wjzJaP8bxRwTM56joLqVaQCmAydX5vQM=";
   };
 
-  cargoSha256 = "0avs833vb6q1avjbfygm55s83iy942xgqsx6qdzksry44n35s418";
+  cargoHash = "sha256-KBBdhiXEZz1/w6Zr/LogyceBdCn1ebfkVgGbtcdAeis=";
 
   postPatch = ''
     substituteInPlace src/main.rs \

--- a/pkgs/applications/version-management/gitprompt-rs/default.nix
+++ b/pkgs/applications/version-management/gitprompt-rs/default.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
     description = "Simple Git prompt";
     homepage = "https://github.com/9ary/gitprompt-rs";
     license = with licenses; [ mpl20 ];
-    maintainers = with maintainers; [ isabelroses ];
+    maintainers = with maintainers; [ isabelroses cafkafk ];
     mainProgram = "gitprompt-rs";
   };
 }


### PR DESCRIPTION
## Description of changes
Adds myself as maintainer. Also updates hashes to sri.

Supersedes: #307494.

- **gitprompt-rs: add cafkafk as maintainer**
- **gitprompt-rs: convert sha256 hashes to sri**

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
