### PR TITLE
python3Packages.wasmer: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/development/python-modules/wasmer/default.nix
+++ b/pkgs/development/python-modules/wasmer/default.nix
@@ -1,10 +1,10 @@
 { stdenv
 , lib
 , rustPlatform
-, rustc
 , callPackage
 , fetchFromGitHub
 , buildPythonPackage
+, pythonAtLeast
 , libiconv
 , libffi
 , libxml2
@@ -22,7 +22,7 @@ let
     , extraBuildInputs ? [ ]
     }: buildPythonPackage rec {
       inherit pname;
-      version = "1.1.0";
+      version = "1.1.1";
       format = "pyproject";
 
       outputs = [ "out" ] ++ lib.optional (pname == "wasmer") "testsout";
@@ -31,7 +31,7 @@ let
         owner = "wasmerio";
         repo = "wasmer-python";
         rev = version;
-        hash = "sha256-nOeOhQ1XY+9qmLGURrI5xbgBUgWe5XRpV38f73kKX2s=";
+        hash = "sha256-Iu28LMDNmtL2r7gJV5Vbb8HZj18dlkHe+mw/Y1L8YKE=";
       };
 
       cargoDeps = rustPlatform.fetchCargoTarball {
@@ -69,6 +69,8 @@ let
       pythonImportsCheck = [ "${lib.replaceStrings ["-"] ["_"] pname}" ];
 
       meta = with lib; {
+        # https://github.com/wasmerio/wasmer-python/issues/778
+        broken = pythonAtLeast "3.12";
         description = "Python extension to run WebAssembly binaries";
         homepage = "https://github.com/wasmerio/wasmer-python";
         license = licenses.mit;
@@ -81,19 +83,19 @@ in
   wasmer = common {
     pname = "wasmer";
     buildAndTestSubdir = "packages/api";
-    cargoHash = "sha256-twoog8LjQtoli+TlDipSuB7yLFkXQJha9BqobqgZW3Y=";
+    cargoHash = "sha256-vpbwU1HrIQmQkce9SK8UOHrX5tOLv/XKsfJHteqOteA=";
   };
 
   wasmer-compiler-cranelift = common {
     pname = "wasmer-compiler-cranelift";
     buildAndTestSubdir = "packages/compiler-cranelift";
-    cargoHash = "sha256-IqeMOY6emhIC7ekH8kIOZCr3JVkjxUg/lQli+ZZpdq4=";
+    cargoHash = "sha256-nv4cr52mUIuR3LWRT3eXU5b2LORwuN4iMbLX1efzovI=";
   };
 
   wasmer-compiler-llvm = common {
     pname = "wasmer-compiler-llvm";
     buildAndTestSubdir = "packages/compiler-llvm";
-    cargoHash = "sha256-xawbf5gXXV+7I2F2fDSaMvjtFvGDBtqX7wL3c28TSbA=";
+    cargoHash = "sha256-FA/xXlPaK8NxZIw7MCm9Fyesgu72Dsxhmb5xzOIINhE=";
     extraNativeBuildInputs = [ llvm_14 ];
     extraBuildInputs = [ libffi libxml2.out ncurses zlib ];
   };
@@ -101,6 +103,6 @@ in
   wasmer-compiler-singlepass = common {
     pname = "wasmer-compiler-singlepass";
     buildAndTestSubdir = "packages/compiler-singlepass";
-    cargoHash = "sha256-4nZHMCNumNhdGPOmHXlJ5POYP7K+VPjwhEUMgzGb/Rk=";
+    cargoHash = "sha256-yew7cB/7RLjW55jZmHFfIvaErgZ6XVxL1ucGGX2Cx18=";
   };
 }


### PR DESCRIPTION
## Description of changes

https://github.com/wasmerio/wasmer-python/releases/tag/1.1.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
