### PR TITLE
Revert "nixos-option: fix self inclusive src"

### DIFF
--- a/pkgs/tools/nix/nixos-option/default.nix
+++ b/pkgs/tools/nix/nixos-option/default.nix
@@ -10,10 +10,7 @@
 stdenv.mkDerivation {
   name = "nixos-option";
 
-  src = lib.fileset.toSource {
-    root = ./.;
-    fileset = lib.fileset.fileFilter (file: file.name != "default.nix") ./.;
-  };
+  src = ./.;
   postInstall = ''
     installManPage ${./nixos-option.8}
   '';


### PR DESCRIPTION
Reverts NixOS/nixpkgs#307564

This broke the installer tests, reverting pending further investigation.