### PR TITLE
python312Packages.rich-click: 1.7.4 -> 1.8.0,  robotframework-tidy: 4.11.0 -> 4.13.0 

### DIFF
--- a/pkgs/by-name/ro/robotframework-tidy/package.nix
+++ b/pkgs/by-name/ro/robotframework-tidy/package.nix
@@ -6,14 +6,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "robotframework-tidy";
-  version = "4.11.0";
+  version = "4.13.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "MarketSquare";
     repo = "robotframework-tidy";
     rev = version;
-    hash = "sha256-pWW7Ex184WgnPfqHg5qQjfE+9UPvCmE5pwkY8jrp9bI=";
+    hash = "sha256-MCx0J+uZ2LI0K1TrIwJbLVTUTJnLxTvYXUJNtIMsnQU=";
   };
 
   build-system = with python3.pkgs; [ setuptools ];

--- a/pkgs/development/python-modules/rich-click/default.nix
+++ b/pkgs/development/python-modules/rich-click/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "rich-click";
-  version = "1.8.0";
+  version = "1.8.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "ewels";
     repo = "rich-click";
     rev = "refs/tags/v${version}";
-    hash = "sha256-jrtGq+iOGpSm/aQM7aaY9mmH2j7IfncEN2EtgT3rG3k=";
+    hash = "sha256-O7ZV6+p0nvWmKHUy/aK+qcED/KT4hZojoQRKr9Eg848=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/rich-click/default.nix
+++ b/pkgs/development/python-modules/rich-click/default.nix
@@ -1,12 +1,13 @@
-{ lib
-, buildPythonPackage
-, click
-, fetchFromGitHub
-, pythonOlder
-, rich
-, setuptools
-, typer
-, typing-extensions
+{
+  lib,
+  buildPythonPackage,
+  click,
+  fetchFromGitHub,
+  pythonOlder,
+  rich,
+  setuptools,
+  typer,
+  typing-extensions,
 }:
 
 buildPythonPackage rec {
@@ -23,9 +24,7 @@ buildPythonPackage rec {
     hash = "sha256-jrtGq+iOGpSm/aQM7aaY9mmH2j7IfncEN2EtgT3rG3k=";
   };
 
-  build-system = [
-    setuptools
-  ];
+  build-system = [ setuptools ];
 
   dependencies = [
     click
@@ -36,9 +35,7 @@ buildPythonPackage rec {
   # Module has no test
   doCheck = false;
 
-  pythonImportsCheck = [
-    "rich_click"
-  ];
+  pythonImportsCheck = [ "rich_click" ];
 
   meta = with lib; {
     description = "Module to format click help output nicely with rich";

--- a/pkgs/development/python-modules/rich-click/default.nix
+++ b/pkgs/development/python-modules/rich-click/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "rich-click";
-  version = "1.7.4";
+  version = "1.8.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "ewels";
     repo = "rich-click";
     rev = "refs/tags/v${version}";
-    hash = "sha256-eqpxNurMHn4ClD0KjTQ7Yfny61tcYBRKlW74axjLI8A=";
+    hash = "sha256-jrtGq+iOGpSm/aQM7aaY9mmH2j7IfncEN2EtgT3rG3k=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/rich-click/default.nix
+++ b/pkgs/development/python-modules/rich-click/default.nix
@@ -23,11 +23,11 @@ buildPythonPackage rec {
     hash = "sha256-jrtGq+iOGpSm/aQM7aaY9mmH2j7IfncEN2EtgT3rG3k=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     click
     rich
     typing-extensions
@@ -42,10 +42,10 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Module to format click help output nicely with rich";
-    mainProgram = "rich-click";
     homepage = "https://github.com/ewels/rich-click";
     changelog = "https://github.com/ewels/rich-click/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "rich-click";
   };
 }


### PR DESCRIPTION
Diff: https://github.com/ewels/rich-click/compare/refs/tags/v1.7.4...v1.8.0

Changelog: https://github.com/ewels/rich-click/blob/v1.8.0/CHANGELOG.md

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
