### PR TITLE
nixos/containers: Reload container service when possible

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -260,7 +260,10 @@ let
 
     SyslogIdentifier = "container %i";
 
-    EnvironmentFile = "-${configurationDirectory}/%i.conf";
+    EnvironmentFile = [
+      "-${configurationDirectory}/%i.conf"
+      "-${configurationDirectory}/%i.system"
+    ];
 
     Type = "notify";
 
@@ -661,6 +664,9 @@ in
               description = ''
                 Whether the container should be restarted during a NixOS
                 configuration switch if its definition has changed.
+
+                If only the container {option}`path` is changed, the container
+                is reloaded instead, to activate the new configuration.
               '';
             };
 
@@ -844,9 +850,13 @@ in
                 wantedBy = [ "machines.target" ];
                 wants = [ "network.target" ];
                 after = [ "network.target" ];
+                # restart container if any of the host side settings change
                 restartTriggers = [
-                  containerConfig.path
                   config.environment.etc."${configurationDirectoryName}/${name}.conf".source
+                ];
+                # perform a reload when only the container content changes
+                reloadTriggers = [
+                  config.environment.etc."${configurationDirectoryName}/${name}.system".source
                 ];
                 restartIfChanged = containerConfig.restartIfChanged;
               }
@@ -857,12 +867,12 @@ in
       # Generate a configuration file in /etc/nixos-containers for each
       # container so that container@.target can get the container
       # configuration.
-      environment.etc =
-        let mkPortStr = p: p.protocol + ":" + (toString p.hostPort) + ":" + (if p.containerPort == null then toString p.hostPort else toString p.containerPort);
+      environment.etc = mkMerge [
+        # file containing settings which influence the container setup or host configuration.
+        (let mkPortStr = p: p.protocol + ":" + (toString p.hostPort) + ":" + (if p.containerPort == null then toString p.hostPort else toString p.containerPort);
         in mapAttrs' (name: cfg: nameValuePair "${configurationDirectoryName}/${name}.conf"
         { text =
             ''
-              SYSTEM_PATH=${cfg.path}
               ${optionalString cfg.privateNetwork ''
                 PRIVATE_NETWORK=1
                 ${optionalString (cfg.hostBridge != null) ''
@@ -893,7 +903,14 @@ in
                 optionalString (cfg.extraFlags != [])
                   (" " + concatStringsSep " " cfg.extraFlags)}"
             '';
-        }) config.containers;
+        }) config.containers)
+        # file containing settings which influence container interal state (they dont affect the host).
+        (mapAttrs' (name: cfg: nameValuePair "${configurationDirectoryName}/${name}.system"
+        { text = ''
+            SYSTEM_PATH=${cfg.path}
+          '';
+        }) config.containers)
+      ];
 
       # Generate /etc/hosts entries for the containers.
       networking.extraHosts = concatStrings (mapAttrsToList (name: cfg: optionalString (cfg.localAddress != null)

--- a/nixos/tests/containers-reloadable.nix
+++ b/nixos/tests/containers-reloadable.nix
@@ -41,11 +41,22 @@ in {
         services.nginx.enable = true;
       };
     };
+    client_c3 = { lib, ... }: {
+      imports = [ client_base ];
+
+      # influence container creation to force a restart
+      containers.test1.extraVeths.veth = {};
+      containers.test1.config = {
+        environment.etc.check.text = lib.mkForce "client_c3";
+        services.nginx.enable = true;
+      };
+    };
   };
 
   testScript = {nodes, ...}: let
-    c1System = nodes.client_c1.config.system.build.toplevel;
-    c2System = nodes.client_c2.config.system.build.toplevel;
+    c1System = nodes.client_c1.system.build.toplevel;
+    c2System = nodes.client_c2.system.build.toplevel;
+    c3System = nodes.client_c3.system.build.toplevel;
   in ''
     client.start()
     client.wait_for_unit("default.target")
@@ -53,19 +64,31 @@ in {
     assert "client_base" in client.succeed("nixos-container run test1 cat /etc/check")
 
     with subtest("httpd is available after activating config1"):
+        out = client.succeed("${c1System}/bin/switch-to-configuration test 2>&1 | tee -a /dev/stderr")
+        assert 'reloading the following units: container@test1.service' in out
         client.succeed(
-            "${c1System}/bin/switch-to-configuration test >&2",
             "[[ $(nixos-container run test1 cat /etc/check) == client_c1 ]] >&2",
             "systemctl status httpd -M test1 >&2",
         )
 
     with subtest("httpd is not available any longer after switching to config2"):
+        out = client.succeed("${c2System}/bin/switch-to-configuration test 2>&1 | tee -a /dev/stderr")
+        assert 'reloading the following units: container@test1.service' in out
         client.succeed(
-            "${c2System}/bin/switch-to-configuration test >&2",
             "[[ $(nixos-container run test1 cat /etc/check) == client_c2 ]] >&2",
             "systemctl status nginx -M test1 >&2",
         )
         client.fail("systemctl status httpd -M test1 >&2")
+
+    with subtest("container is restarted when switching to config3"):
+        out = client.succeed("${c3System}/bin/switch-to-configuration test 2>&1 | tee -a /dev/stderr")
+        assert 'stopping the following units: container@test1.service' in out
+        assert 'starting the following units: container@test1.service' in out
+        client.succeed(
+            "[[ $(nixos-container run test1 cat /etc/check) == client_c3 ]] >&2",
+            "systemctl status nginx -M test1 >&2",
+            "ip link show veth >&2",
+        )
   '';
 
 })


### PR DESCRIPTION
## Description of changes

At the moment, whenever any path in a `containers.*` system closure changes, the whole container will be shutdown and recreated when the corresponding `container@*.service` restarted.

By removing the container `path` from all service attributes, which cause a restart during a `switch-to-configuration`, the container service can be reloaded (using `switch-to-configuration test`) when only the system `path` changes.

The separation is achieved by introducing a new configuration file, which contains all the settings that don't affect the host or the container setup process.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - `nixosTests.containers-bridge`
    - `nixosTests.containers-custom-pkgs.nix`
    - `nixosTests.containers-ephemeral`
    - `nixosTests.containers-extra_veth`
    - `nixosTests.containers-hosts`
    - `nixosTests.containers-imperative`
    - `nixosTests.containers-ip`
    - `nixosTests.containers-macvlans`
    - `nixosTests.containers-names`
    - `nixosTests.containers-nested`
    - `nixosTests.containers-physical_interfaces`
    - `nixosTests.containers-portforward`
    - `nixosTests.containers-reloadable`
    - `nixosTests.containers-require-bind-mounts`
    - `nixosTests.containers-restart_networking`
    - `nixosTests.containers-tmpfs`
    - `nixosTests.containers-unified-hierarchy`
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
