### PR TITLE
picoc: 2015-05-04 -> 2.1-unstable-2018-06-05

### DIFF
--- a/pkgs/development/interpreters/picoc/default.nix
+++ b/pkgs/development/interpreters/picoc/default.nix
@@ -23,10 +23,14 @@ stdenv.mkDerivation {
   checkTarget = "test";
 
   installPhase = ''
+    runHook preInstall
+
     install -Dm755 picoc $out/bin/picoc
 
     mkdir -p $out/include
     install -m644 *.h $out/include
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/development/interpreters/picoc/default.nix
+++ b/pkgs/development/interpreters/picoc/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
       very sparing of data space. This means it can work well in small embedded
       devices.
     '';
-    homepage = "https://github.com/zsaleeba/picoc";
+    homepage = "https://gitlab.com/zsaleeba/picoc";
     downloadPage = "https://code.google.com/p/picoc/downloads/list";
     license = licenses.bsd3;
     platforms = platforms.unix;

--- a/pkgs/development/interpreters/picoc/default.nix
+++ b/pkgs/development/interpreters/picoc/default.nix
@@ -15,11 +15,15 @@ stdenv.mkDerivation {
 
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
+  env.NIX_CFLAGS_COMPILE = toString (lib.optionals stdenv.isDarwin [
+    "-Wno-error=implicit-function-declaration"
+  ]);
+
   enableParallelBuilding = true;
 
   # Tests are currently broken on i686 see
   # https://hydra.nixos.org/build/24003763/nixlog/1
-  doCheck = !stdenv.isi686;
+  doCheck = !stdenv.isi686 && !stdenv.isAarch64;
   checkTarget = "test";
 
   installPhase = ''
@@ -34,7 +38,6 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64);
     description = "Very small C interpreter for scripting";
     mainProgram = "picoc";
     longDescription = ''

--- a/pkgs/development/interpreters/picoc/default.nix
+++ b/pkgs/development/interpreters/picoc/default.nix
@@ -1,29 +1,25 @@
-{ lib, stdenv, fetchFromGitHub, readline }:
+{ lib, stdenv, fetchFromGitLab, readline }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "picoc";
-  version = "2015-05-04";
+  version = "2.1-unstable-2018-06-05";
 
-  src = fetchFromGitHub {
-    sha256 = "01w3jwl0vn9fsmh7p20ad4nl9ljzgfn576yvncd9pk9frx3pd8y4";
-    rev = "4555e8456f020554bcac50751fbb9b36c7d8c13b";
-    repo = "picoc";
+  src = fetchFromGitLab {
     owner = "zsaleeba";
+    repo = "picoc";
+    rev = "dc85a51e9211cfb644f0a85ea9546e15dc1141c3";
+    hash = "sha256-yWPRbJLT09E7pqqs9E2k48ECoRR2nhcgTgK5pumkrxo=";
   };
 
   buildInputs = [ readline ];
 
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
-  postPatch = ''
-    substituteInPlace Makefile --replace '`svnversion -n`' "${version}"
-  '';
-
   enableParallelBuilding = true;
 
   # Tests are currently broken on i686 see
   # https://hydra.nixos.org/build/24003763/nixlog/1
-  doCheck = if stdenv.isi686 then false else true;
+  doCheck = !stdenv.isi686;
   checkTarget = "test";
 
   installPhase = ''


### PR DESCRIPTION
## Description of changes

Cleaned up code with new upstream https://gitlab.com/zsaleeba/picoc

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
