### PR TITLE
dolphin-emu: 5.0-21088 -> 5.0-21460

### DIFF
--- a/pkgs/applications/emulators/dolphin-emu/default.nix
+++ b/pkgs/applications/emulators/dolphin-emu/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , pkg-config
 , wrapQtAppsHook
@@ -59,45 +58,30 @@
 
 stdenv.mkDerivation rec {
   pname = "dolphin-emu";
-  version = "5.0-21088";
+  version = "5.0-21460";
 
   src = fetchFromGitHub {
     owner = "dolphin-emu";
     repo = "dolphin";
-    rev = "9240f579eab18a2f67eef23846a6b508393d0e6c";
-    hash = "sha256-lOiDbEQZoi9Bsiyta/w+B1VXNNW4qST2cBZekqo5dDA=";
+    rev = "a9544510468740b77cf06ef28daaa65fe247fd32";
+    hash = "sha256-mhD7Uaqi8GzHdR7Y81TspvCnrZH2evWuWFgXMQ2c8g0=";
     fetchSubmodules = true;
   };
 
   patches = [
-    # Remove when merged https://github.com/dolphin-emu/dolphin/pull/12070
+    # TODO: Remove when merged https://github.com/dolphin-emu/dolphin/pull/12736
     ./find-minizip-ng.patch
-
-    # fix buidl w/ glibc-2.39
-    (fetchpatch {
-      url = "https://github.com/dolphin-emu/dolphin/commit/3da2e15e6b95f02f66df461e87c8b896e450fdab.patch";
-      hash = "sha256-+8yGF412wQUYbyEuYWd41pgOgEbhCaezexxcI5CNehc=";
-    })
   ];
 
   strictDeps = true;
 
   nativeBuildInputs = [
-    stdenv.cc
     cmake
     pkg-config
     wrapQtAppsHook
   ];
 
-  buildInputs = lib.optionals stdenv.isDarwin [
-    CoreBluetooth
-    ForceFeedback
-    IOBluetooth
-    IOKit
-    moltenvk
-    OpenGL
-    VideoToolbox
-  ] ++ [
+  buildInputs = [
     bzip2
     cubeb
     curl
@@ -123,7 +107,9 @@ stdenv.mkDerivation rec {
     SDL2
     sfml
     xxHash
-    xz # LibLZMA
+    xz
+    # Causes linker errors with minizip-ng, prefer vendored. Possible reason why: https://github.com/dolphin-emu/dolphin/pull/12070#issuecomment-1677311838
+    #zlib-ng
   ] ++ lib.optionals stdenv.isLinux [
     alsa-lib
     bluez
@@ -135,6 +121,14 @@ stdenv.mkDerivation rec {
     #mgba # Derivation doesn't support Darwin
     udev
     vulkan-loader
+  ] ++ lib.optionals stdenv.isDarwin [
+    CoreBluetooth
+    ForceFeedback
+    IOBluetooth
+    IOKit
+    moltenvk
+    OpenGL
+    VideoToolbox
   ];
 
   cmakeFlags = [
@@ -163,8 +157,8 @@ stdenv.mkDerivation rec {
   # Use nix-provided libraries instead of submodules
   postPatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace CMakeLists.txt \
-      --replace "if(NOT APPLE)" "if(true)" \
-      --replace "if(LIBUSB_FOUND AND NOT APPLE)" "if(LIBUSB_FOUND)"
+      --replace-fail "if(NOT APPLE)" "if(true)" \
+      --replace-fail "if(LIBUSB_FOUND AND NOT APPLE)" "if(LIBUSB_FOUND)"
   '';
 
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''

--- a/pkgs/applications/emulators/dolphin-emu/default.nix
+++ b/pkgs/applications/emulators/dolphin-emu/default.nix
@@ -154,13 +154,6 @@ stdenv.mkDerivation rec {
     "--set QT_QPA_PLATFORM xcb"
   ];
 
-  # Use nix-provided libraries instead of submodules
-  postPatch = lib.optionalString stdenv.isDarwin ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail "if(NOT APPLE)" "if(true)" \
-      --replace-fail "if(LIBUSB_FOUND AND NOT APPLE)" "if(LIBUSB_FOUND)"
-  '';
-
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     install -D $src/Data/51-usb-device.rules $out/etc/udev/rules.d/51-usb-device.rules
   '' + lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/applications/emulators/dolphin-emu/find-minizip-ng.patch
+++ b/pkgs/applications/emulators/dolphin-emu/find-minizip-ng.patch
@@ -1,11 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ee44d04458..2fa6bd8a10 100644
+index fb37788513..289a25fa57 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -678,7 +678,7 @@ dolphin_find_optional_system_library_pkgconfig(ZSTD libzstd>=1.4.0 zstd::zstd Ex
+@@ -676,7 +676,7 @@ dolphin_find_optional_system_library_pkgconfig(ZLIB zlib-ng ZLIB::ZLIB Externals
  
- dolphin_find_optional_system_library_pkgconfig(ZLIB zlib-ng ZLIB::ZLIB Externals/zlib-ng)
- 
+ # https://github.com/zlib-ng/minizip-ng/commit/6c5f265a55f1a12a7a016cd2962feff91cff5d2e
+ add_definitions(-DMZ_COMPAT_VERSION=110)  # This macro is for forwards compatibility with 4.0.4+
 -dolphin_find_optional_system_library_pkgconfig(MINIZIP minizip>=3.0.0 minizip::minizip Externals/minizip)
 +dolphin_find_optional_system_library_pkgconfig(MINIZIP minizip-ng>=3.0.0 minizip::minizip Externals/minizip)
  

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2826,6 +2826,7 @@ with pkgs;
   ### APPLICATIONS/EMULATORS/DOLPHIN-EMU
 
   dolphin-emu = qt6Packages.callPackage ../applications/emulators/dolphin-emu {
+    stdenv = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
     inherit (darwin.apple_sdk_11_0.frameworks) CoreBluetooth ForceFeedback IOBluetooth IOKit OpenGL VideoToolbox;
     inherit (darwin) moltenvk;
   };


### PR DESCRIPTION
## Description of changes

https://dolphin-emu.org/blog/2024/04/30/dolphin-progress-report-february-march-and-april-2024/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
