### PR TITLE
dolphin-emu-primehack: 1.0.6a -> 1.0.7a

### DIFF
--- a/pkgs/applications/emulators/dolphin-emu/primehack.nix
+++ b/pkgs/applications/emulators/dolphin-emu/primehack.nix
@@ -1,138 +1,163 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, pkg-config
+, fetchpatch
 , cmake
+, pkg-config
 , wrapQtAppsHook
-, qtbase
-, bluez
-, ffmpeg
-, libao
-, libGLU
-, libGL
-, pcre
-, gettext
-, libXrandr
-, libusb1
-, libpthreadstubs
-, libXext
-, libXxf86vm
-, libXinerama
-, libSM
-, libXdmcp
-, readline
-, openal
-, udev
-, libevdev
-, portaudio
-, curl
 , alsa-lib
-, miniupnpc
+, bluez
+, bzip2
+, cubeb
+, curl
 , enet
-, mbedtls_2
-, soundtouch
-, sfml
-, fmt
-, xz
-, vulkan-loader
+, ffmpeg
+, fmt_10
+, gtest
+, hidapi
+, libevdev
+, libGL
+, libiconv
 , libpulseaudio
+, libspng
+, libusb1
+, libXdmcp
+, libXext
+, libXrandr
+, lz4
+, lzo
+, mbedtls_2
+, miniupnpc
+, openal
+, pugixml
+, qtbase
+, qtsvg
+, sfml
+, udev
+, vulkan-loader
+, xxHash
+, xz
 
-# - Inputs used for Darwin
+  # Darwin-only dependencies
 , CoreBluetooth
 , ForceFeedback
+, IOBluetooth
 , IOKit
+, moltenvk
 , OpenGL
-, libpng
-, hidapi
+, VideoToolbox
 }:
 
 stdenv.mkDerivation rec {
   pname = "dolphin-emu-primehack";
-  version = "1.0.6a";
+  version = "1.0.7a";
 
   src = fetchFromGitHub {
     owner = "shiiion";
     repo = "dolphin";
     rev = version;
-    sha256 = "sha256-gc4+ofoLKR+cvm+SaWEnGaKrSjWMKq7pF6pEIi75Rtk=";
+    sha256 = "sha256-vuTSXQHnR4HxAGGiPg5tUzfiXROU3+E9kyjH+T6zVmc=";
     fetchSubmodules = true;
   };
 
+  patches = [
+    # fix build w/ glibc-2.39
+    (fetchpatch {
+      url = "https://github.com/dolphin-emu/dolphin/commit/3da2e15e6b95f02f66df461e87c8b896e450fdab.patch";
+      hash = "sha256-+8yGF412wQUYbyEuYWd41pgOgEbhCaezexxcI5CNehc=";
+    })
+  ];
+
   nativeBuildInputs = [
-    pkg-config
     cmake
-  ] ++ lib.optional stdenv.isLinux wrapQtAppsHook;
+    pkg-config
+    wrapQtAppsHook
+  ];
 
   buildInputs = [
+    bzip2
+    cubeb
     curl
-    ffmpeg
-    libao
-    libGLU
-    libGL
-    pcre
-    gettext
-    libpthreadstubs
-    libpulseaudio
-    libXrandr
-    libXext
-    libXxf86vm
-    libXinerama
-    libSM
-    readline
-    openal
-    libXdmcp
-    portaudio
-    libusb1
-    libpng
-    hidapi
-    miniupnpc
     enet
+    ffmpeg
+    fmt_10
+    gtest
+    hidapi
+    libiconv
+    libpulseaudio
+    libspng
+    libusb1
+    libXdmcp
+    lz4
+    lzo
     mbedtls_2
-    soundtouch
-    sfml
-    fmt
-    xz
+    miniupnpc
+    #minizip-ng # Not wanting to make a mess with patches, leaving the vendored one for now
+    openal
+    pugixml
     qtbase
+    qtsvg
+    #SDL2 # Not used yet
+    sfml
+    xxHash
+    xz
+    # Causes linker errors with minizip-ng, prefer vendored. Possible reason why: https://github.com/dolphin-emu/dolphin/pull/12070#issuecomment-1677311838
+    #zlib-ng
   ] ++ lib.optionals stdenv.isLinux [
-    bluez
-    udev
-    libevdev
     alsa-lib
+    bluez
+    libevdev
+    libGL
+    libXext
+    libXrandr
+    # FIXME: Vendored version is newer than mgba's stable release, remove the comment on next mgba's version
+    #mgba # Derivation doesn't support Darwin
+    udev
     vulkan-loader
   ] ++ lib.optionals stdenv.isDarwin [
     CoreBluetooth
-    OpenGL
     ForceFeedback
+    IOBluetooth
     IOKit
+    moltenvk
+    OpenGL
+    VideoToolbox
   ];
 
   cmakeFlags = [
-    "-DUSE_SHARED_ENET=ON"
-    "-DENABLE_LTO=ON"
+    "-DDISTRIBUTOR=NixOS"
   ] ++ lib.optionals stdenv.isDarwin [
     "-DOSX_USE_DEFAULT_SEARCH_PATH=True"
+    "-DUSE_BUNDLED_MOLTENVK=OFF"
+    "-DMACOS_CODE_SIGNING=OFF"
+    # Bundles the application folder into a standalone executable, so we cannot devendor libraries
+    "-DSKIP_POSTPROCESS_BUNDLE=ON"
+    # Needs xcode so compilation fails with it enabled. We would want the version to be fixed anyways.
+    # Note: The updater isn't available on linux, so we don't need to disable it there.
+    "-DENABLE_AUTOUPDATE=OFF"
   ];
 
   qtWrapperArgs = lib.optionals stdenv.isLinux [
-    "--prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib"
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}"
     # https://bugs.dolphin-emu.org/issues/11807
     # The .desktop file should already set this, but Dolphin may be launched in other ways
     "--set QT_QPA_PLATFORM xcb"
   ];
 
-  # - Allow Dolphin to use nix-provided libraries instead of building them
-  postPatch = ''
-    substituteInPlace CMakeLists.txt --replace 'DISTRIBUTOR "None"' 'DISTRIBUTOR "NixOS"'
-  '' + lib.optionalString stdenv.isDarwin ''
-    substituteInPlace CMakeLists.txt --replace 'if(NOT APPLE)' 'if(true)'
-    substituteInPlace CMakeLists.txt --replace 'if(LIBUSB_FOUND AND NOT APPLE)' 'if(LIBUSB_FOUND)'
+  # Use nix-provided libraries instead of submodules
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "if(NOT APPLE)" "if(true)" \
+      --replace-fail "if(LIBUSB_FOUND AND NOT APPLE)" "if(LIBUSB_FOUND)"
   '';
 
+  # Check out https://github.com/shiiion/dolphin/pull/118
   postInstall = ''
     mv $out/bin/dolphin-emu $out/bin/dolphin-emu-primehack
     mv $out/bin/dolphin-emu-nogui $out/bin/dolphin-emu-primehack-nogui
     mv $out/share/applications/dolphin-emu.desktop $out/share/applications/dolphin-emu-primehack.desktop
     mv $out/share/icons/hicolor/256x256/apps/dolphin-emu.png $out/share/icons/hicolor/256x256/apps/dolphin-emu-primehack.png
+    rm $out/share/icons/hicolor/scalable/apps/dolphin-emu.svg # https://github.com/shiiion/dolphin/issues/164
     substituteInPlace $out/share/applications/dolphin-emu-primehack.desktop --replace 'dolphin-emu' 'dolphin-emu-primehack'
     substituteInPlace $out/share/applications/dolphin-emu-primehack.desktop --replace 'Dolphin Emulator' 'PrimeHack'
   '' + lib.optionalString stdenv.hostPlatform.isLinux ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2826,9 +2826,9 @@ with pkgs;
     inherit (darwin) moltenvk;
   };
 
-  dolphin-emu-primehack = qt5.callPackage ../applications/emulators/dolphin-emu/primehack.nix {
-    inherit (darwin.apple_sdk.frameworks) CoreBluetooth ForceFeedback IOKit OpenGL;
-    fmt = fmt_8;
+  dolphin-emu-primehack = qt6Packages.callPackage ../applications/emulators/dolphin-emu/primehack.nix {
+    inherit (darwin.apple_sdk_11_0.frameworks) CoreBluetooth ForceFeedback IOBluetooth IOKit OpenGL VideoToolbox;
+    inherit (darwin) moltenvk;
   };
 
   ### APPLICATIONS/EMULATORS/RETROARCH


### PR DESCRIPTION
## Description of changes

https://github.com/shiiion/dolphin/releases/tag/1.0.7a

Unlike #300928, I'm keeping it divergent from regular Dolphin, as it often lags behind for a long time.
I admit it's a bit of a mess, since I'm leaving Darwin stuff here, even though it's broken. (Though it was also messy before, since it's basically a copy-paste of an older version of Dolphin.)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
