### PR TITLE
kanshi: 1.5.1 -> 1.6.0

### DIFF
--- a/pkgs/by-name/li/libscfg/package.nix
+++ b/pkgs/by-name/li/libscfg/package.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, fetchFromSourcehut, meson, ninja, pkg-config, wayland }:
+
+stdenv.mkDerivation rec {
+  pname = "libscfg";
+  version = "0.1.1";
+
+  src = fetchFromSourcehut {
+    owner = "~emersion";
+    repo = "libscfg";
+    rev = "v${version}";
+    sha256 = "sha256-aTcvs7QuDOx17U/yP37LhvIGxmm2WR/6qFYRtfjRN6w=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [ wayland ];
+
+  meta = with lib; {
+    homepage = "https://sr.ht/~emersion/libscfg";
+    description = "A simple configuration file format";
+    license = licenses.mit;
+    maintainers = with maintainers; [ michaeladler ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/wayland/kanshi/default.nix
+++ b/pkgs/tools/wayland/kanshi/default.nix
@@ -8,17 +8,18 @@
 , wayland
 , wayland-scanner
 , libvarlink
+, libscfg
 }:
 
 stdenv.mkDerivation rec {
   pname = "kanshi";
-  version = "1.5.1";
+  version = "1.6.0";
 
   src = fetchFromSourcehut {
     owner = "~emersion";
     repo = "kanshi";
     rev = "v${version}";
-    sha256 = "sha256-Ck0yRt9TYLFRojn+VKnjP5RzkX0hciuQOT6drTH7gtU=";
+    sha256 = "sha256-KjP7EdssaZwa1OupLQgzwJSAADKLsjHltEavPjsS1YM=";
   };
 
   strictDeps = true;
@@ -26,7 +27,11 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
   nativeBuildInputs = [ meson ninja pkg-config scdoc wayland-scanner ];
-  buildInputs = [ wayland libvarlink ];
+  buildInputs = [ wayland libvarlink libscfg ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-error=maybe-uninitialized"
+  ];
 
   meta = with lib; {
     homepage = "https://sr.ht/~emersion/kanshi";


### PR DESCRIPTION
## Description of changes

This release introduces a new dependency (https://git.sr.ht/~emersion/libscfg) which is not yet packaged in nixpkgs. I decided to go for a separate package although we could also bundle it into kanshi's nix file.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
