### PR TITLE
treewide: Move away from wiki.gnome.org (part 1)

### DIFF
--- a/doc/languages-frameworks/gnome.section.md
+++ b/doc/languages-frameworks/gnome.section.md
@@ -8,7 +8,7 @@ Programs in the GNOME universe are written in various languages but they all use
 
 [GSettings](https://developer.gnome.org/gio/stable/GSettings.html) API is often used for storing settings. GSettings schemas are required, to know the type and other metadata of the stored values. GLib looks for `glib-2.0/schemas/gschemas.compiled` files inside the directories of `XDG_DATA_DIRS`.
 
-On Linux, GSettings API is implemented using [dconf](https://wiki.gnome.org/Projects/dconf) backend. You will need to add `dconf` [GIO module](#ssec-gnome-gio-modules) to `GIO_EXTRA_MODULES` variable, otherwise the `memory` backend will be used and the saved settings will not be persistent.
+On Linux, GSettings API is implemented using [dconf](https://gitlab.gnome.org/GNOME/dconf) backend. You will need to add `dconf` [GIO module](#ssec-gnome-gio-modules) to `GIO_EXTRA_MODULES` variable, otherwise the `memory` backend will be used and the saved settings will not be persistent.
 
 Last you will need the dconf database D-Bus service itself. You can enable it using `programs.dconf.enable`.
 
@@ -76,11 +76,11 @@ Previously, a GTK theme needed to be in `XDG_DATA_DIRS`. This is no longer neces
 
 ### GObject introspection typelibs {#ssec-gnome-typelibs}
 
-[GObject introspection](https://wiki.gnome.org/Projects/GObjectIntrospection) allows applications to use C libraries in other languages easily. It does this through `typelib` files searched in `GI_TYPELIB_PATH`.
+[GObject introspection](https://gitlab.gnome.org/GNOME/gobject-introspection) allows applications to use C libraries in other languages easily. It does this through `typelib` files searched in `GI_TYPELIB_PATH`.
 
 ### Various plug-ins {#ssec-gnome-plugins}
 
-If your application uses [GStreamer](https://gstreamer.freedesktop.org/) or [Grilo](https://wiki.gnome.org/Projects/Grilo), you should set `GST_PLUGIN_SYSTEM_PATH_1_0` and `GRL_PLUGIN_PATH`, respectively.
+If your application uses [GStreamer](https://gstreamer.freedesktop.org/) or [Grilo](https://gitlab.gnome.org/GNOME/grilo), you should set `GST_PLUGIN_SYSTEM_PATH_1_0` and `GRL_PLUGIN_PATH`, respectively.
 
 ## Onto `wrapGAppsHook` {#ssec-gnome-hooks}
 

--- a/pkgs/applications/accessibility/mousetweaks/default.nix
+++ b/pkgs/applications/accessibility/mousetweaks/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
       The features can be activated and configured through the Universal Access
       panel of the GNOME Control Center.
     '';
-    homepage = "https://wiki.gnome.org/Projects/Mousetweaks";
+    homepage = "https://gitlab.gnome.org/Archive/mousetweaks";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = [ maintainers.johnazoidberg ];

--- a/pkgs/data/misc/mobile-broadband-provider-info/default.nix
+++ b/pkgs/data/misc/mobile-broadband-provider-info/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Mobile broadband service provider database";
-    homepage = "https://wiki.gnome.org/Projects/NetworkManager/MobileBroadband/ServiceProviders";
+    homepage = "https://gitlab.gnome.org/GNOME/mobile-broadband-provider-info";
     license = licenses.publicDomain;
     maintainers = [ ];
     platforms = platforms.all;

--- a/pkgs/desktops/gnome/core/caribou/default.nix
+++ b/pkgs/desktops/gnome/core/caribou/default.nix
@@ -62,7 +62,7 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "An input assistive technology intended for switch and pointer users";
     mainProgram = "caribou-preferences";
-    homepage = "https://wiki.gnome.org/Projects/Caribou";
+    homepage = "https://gitlab.gnome.org/Archive/caribou";
     license = licenses.lgpl21;
     maintainers = teams.gnome.members;
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome/core/gdm/default.nix
+++ b/pkgs/desktops/gnome/core/gdm/default.nix
@@ -187,7 +187,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "A program that manages graphical display servers and handles graphical user logins";
-    homepage = "https://wiki.gnome.org/Projects/GDM";
+    homepage = "https://gitlab.gnome.org/GNOME/gdm";
     license = licenses.gpl2Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome/core/gnome-keyring/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-keyring/default.nix
@@ -97,7 +97,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Collection of components in GNOME that store secrets, passwords, keys, certificates and make them available to applications";
-    homepage = "https://wiki.gnome.org/Projects/GnomeKeyring";
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-keyring";
     license = licenses.gpl2;
     maintainers = teams.gnome.members;
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome/core/gnome-online-miners/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-online-miners/default.nix
@@ -107,7 +107,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/GnomeOnlineMiners";
+    homepage = "https://gitlab.gnome.org/Archive/gnome-online-miners";
     description = "A set of crawlers that go through your online content and index them locally in Tracker";
     maintainers = teams.gnome.members;
     license = licenses.gpl2Plus;

--- a/pkgs/desktops/gnome/core/gnome-remote-desktop/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-remote-desktop/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/Mutter/RemoteDesktop";
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-remote-desktop";
     description = "GNOME Remote Desktop server";
     mainProgram = "grdctl";
     maintainers = teams.gnome.members;

--- a/pkgs/desktops/gnome/core/gnome-session/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-session/default.nix
@@ -132,7 +132,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "GNOME session manager";
-    homepage = "https://wiki.gnome.org/Projects/SessionManagement";
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-session";
     license = licenses.gpl2Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome/core/gnome-shell-extensions/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-shell-extensions/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/GnomeShell/Extensions";
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-shell-extensions";
     description = "Modify and extend GNOME Shell functionality and behavior";
     maintainers = teams.gnome.members;
     license = licenses.gpl2Plus;

--- a/pkgs/desktops/gnome/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-shell/default.nix
@@ -227,7 +227,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Core user interface for the GNOME 3 desktop";
-    homepage = "https://wiki.gnome.org/Projects/GnomeShell";
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-shell";
     license = licenses.gpl2Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome/core/libgnome-keyring/default.nix
+++ b/pkgs/desktops/gnome/core/libgnome-keyring/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Framework for managing passwords and other secrets";
-    homepage = "https://wiki.gnome.org/Projects/GnomeKeyring";
+    homepage = "https://gitlab.gnome.org/Archive/libgnome-keyring";
     license = with lib.licenses; [ gpl2Plus lgpl2Plus ];
     pkgConfigModules = [ "gnome-keyring-1" ];
     platforms = lib.platforms.unix;

--- a/pkgs/desktops/gnome/core/rygel/default.nix
+++ b/pkgs/desktops/gnome/core/rygel/default.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A home media solution (UPnP AV MediaServer) that allows you to easily share audio, video and pictures to other devices";
-    homepage = "https://wiki.gnome.org/Projects/Rygel";
+    homepage = "https://gitlab.gnome.org/GNOME/rygel";
     license = licenses.lgpl21Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome/core/zenity/default.nix
+++ b/pkgs/desktops/gnome/core/zenity/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     mainProgram = "zenity";
     description = "Tool to display dialogs from the commandline and shell scripts";
-    homepage = "https://wiki.gnome.org/Projects/Zenity";
+    homepage = "https://gitlab.gnome.org/GNOME/zenity";
     license = licenses.lgpl21Plus;
     platforms = platforms.unix;
     maintainers = teams.gnome.members;

--- a/pkgs/desktops/gnome/extensions/buildGnomeExtension.nix
+++ b/pkgs/desktops/gnome/extensions/buildGnomeExtension.nix
@@ -54,7 +54,7 @@ let
       description = builtins.head (lib.splitString "\n" description);
       longDescription = description;
       homepage = link;
-      license = lib.licenses.gpl2Plus; # https://wiki.gnome.org/Projects/GnomeShell/Extensions/Review#Licensing
+      license = lib.licenses.gpl2Plus; # https://gjs.guide/extensions/review-guidelines/review-guidelines.html#licensing
       platforms = lib.platforms.linux;
       maintainers = with lib.maintainers; [ ];
     };

--- a/pkgs/desktops/gnome/extensions/gnome-browser-connector/default.nix
+++ b/pkgs/desktops/gnome/extensions/gnome-browser-connector/default.nix
@@ -57,9 +57,9 @@ buildPythonApplication rec {
 
   meta = with lib; {
     description = "Native host connector for the GNOME Shell browser extension";
-    homepage = "https://wiki.gnome.org/Projects/GnomeShellIntegration";
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-browser-connector";
     longDescription = ''
-      To use the integration, install the <link xlink:href="https://wiki.gnome.org/Projects/GnomeShellIntegration/Installation">browser extension</link>, and then set <option>services.gnome.gnome-browser-connector.enable</option> to <literal>true</literal>.
+      To use the integration, install the [browser extension](https://gitlab.gnome.org/GNOME/gnome-browser-extension), and then set `services.gnome.gnome-browser-connector.enable` to `true`.
     '';
     license = licenses.gpl3Plus;
     maintainers = teams.gnome.members;

--- a/pkgs/desktops/gnome/misc/gnome-applets/default.nix
+++ b/pkgs/desktops/gnome/misc/gnome-applets/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Applets for use with the GNOME panel";
     mainProgram = "cpufreq-selector";
-    homepage = "https://wiki.gnome.org/Projects/GnomeApplets";
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-applets";
     license = licenses.gpl2Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome/misc/gnome-flashback/default.nix
+++ b/pkgs/desktops/gnome/misc/gnome-flashback/default.nix
@@ -185,7 +185,7 @@ let
     meta = with lib; {
       description = "GNOME 2.x-like session for GNOME 3";
       mainProgram = "gnome-flashback";
-      homepage = "https://wiki.gnome.org/Projects/GnomeFlashback";
+      homepage = "https://gitlab.gnome.org/GNOME/gnome-flashback";
       license = licenses.gpl2;
       maintainers = teams.gnome.members;
       platforms = platforms.linux;

--- a/pkgs/desktops/gnome/misc/gnome-panel/default.nix
+++ b/pkgs/desktops/gnome/misc/gnome-panel/default.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Component of Gnome Flashback that provides panels and default applets for the desktop";
     mainProgram = "gnome-panel";
-    homepage = "https://wiki.gnome.org/Projects/GnomePanel";
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-panel";
     license = licenses.gpl2Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome/misc/metacity/default.nix
+++ b/pkgs/desktops/gnome/misc/metacity/default.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Window manager used in Gnome Flashback";
-    homepage = "https://wiki.gnome.org/Projects/Metacity";
+    homepage = "https://gitlab.gnome.org/GNOME/metacity";
     license = licenses.gpl2;
     maintainers = teams.gnome.members;
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome/misc/nautilus-python/default.nix
+++ b/pkgs/desktops/gnome/misc/nautilus-python/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Python bindings for the Nautilus Extension API";
-    homepage = "https://wiki.gnome.org/Projects/NautilusPython";
+    homepage = "https://gitlab.gnome.org/GNOME/nautilus-python";
     license = licenses.gpl2Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.unix;

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -77,7 +77,7 @@ let
 
     meta = with lib; {
       description = "Compiler for GObject type system";
-      homepage = "https://wiki.gnome.org/Projects/Vala";
+      homepage = "https://vala.dev";
       license = licenses.lgpl21Plus;
       platforms = platforms.unix;
       maintainers = with maintainers; [ antono jtojnar ] ++ teams.pantheon.members;

--- a/pkgs/development/libraries/dconf/default.nix
+++ b/pkgs/development/libraries/dconf/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/dconf";
+    homepage = "https://gitlab.gnome.org/GNOME/dconf";
     license = licenses.lgpl21Plus;
     platforms = platforms.unix;
     maintainers = teams.gnome.members;

--- a/pkgs/development/libraries/folks/default.nix
+++ b/pkgs/development/libraries/folks/default.nix
@@ -110,7 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "A library that aggregates people from multiple sources to create metacontacts";
-    homepage = "https://wiki.gnome.org/Projects/Folks";
+    homepage = "https://gitlab.gnome.org/GNOME/folks";
     license = licenses.lgpl21Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/gexiv2/default.nix
+++ b/pkgs/development/libraries/gexiv2/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/gexiv2";
+    homepage = "https://gitlab.gnome.org/GNOME/gexiv2";
     description = "GObject wrapper around the Exiv2 photo metadata library";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/gfbgraph/default.nix
+++ b/pkgs/development/libraries/gfbgraph/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/GFBGraph";
+    homepage = "https://gitlab.gnome.org/GNOME/libgfbgraph";
     description = "GLib/GObject wrapper for the Facebook Graph API";
     maintainers = teams.gnome.members;
     license = licenses.lgpl21Plus;

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -282,7 +282,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "C library of programming buildings blocks";
-    homepage    = "https://wiki.gnome.org/Projects/GLib";
+    homepage    = "https://gitlab.gnome.org/GNOME/glib";
     license     = licenses.lgpl21Plus;
     maintainers = teams.gnome.members ++ (with maintainers; [ lovek323 raskin ]);
     pkgConfigModules = [

--- a/pkgs/development/libraries/gnome-online-accounts/default.nix
+++ b/pkgs/development/libraries/gnome-online-accounts/default.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/GnomeOnlineAccounts";
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-online-accounts";
     description = "Single sign-on framework for GNOME";
     platforms = platforms.unix;
     license = licenses.lgpl2Plus;

--- a/pkgs/development/libraries/gnome-video-effects/default.nix
+++ b/pkgs/development/libraries/gnome-video-effects/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A collection of GStreamer effects to be used in different GNOME Modules";
-    homepage = "https://wiki.gnome.org/Projects/GnomeVideoEffects";
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-video-effects";
     platforms = platforms.unix;
     maintainers = teams.gnome.members;
     license = licenses.gpl2;

--- a/pkgs/development/libraries/gom/default.nix
+++ b/pkgs/development/libraries/gom/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A GObject to SQLite object mapper";
-    homepage = "https://wiki.gnome.org/Projects/Gom";
+    homepage = "https://gitlab.gnome.org/GNOME/gom";
     license = licenses.lgpl21Plus;
     platforms = platforms.unix;
     maintainers = teams.gnome.members;

--- a/pkgs/development/libraries/goocanvas/2.x.nix
+++ b/pkgs/development/libraries/goocanvas/2.x.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Canvas widget for GTK based on the the Cairo 2D library";
-    homepage = "https://wiki.gnome.org/Projects/GooCanvas";
+    homepage = "https://gitlab.gnome.org/Archive/goocanvas";
     license = licenses.lgpl2;
     maintainers = with maintainers; [ ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/goocanvas/3.x.nix
+++ b/pkgs/development/libraries/goocanvas/3.x.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Canvas widget for GTK based on the the Cairo 2D library";
-    homepage = "https://wiki.gnome.org/Projects/GooCanvas";
+    homepage = "https://gitlab.gnome.org/Archive/goocanvas";
     license = licenses.lgpl2; # https://gitlab.gnome.org/GNOME/goocanvas/-/issues/12
     maintainers = with maintainers; [ bobby285271 ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/goocanvas/default.nix
+++ b/pkgs/development/libraries/goocanvas/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Canvas widget for GTK based on the the Cairo 2D library";
-    homepage = "https://wiki.gnome.org/Projects/GooCanvas";
+    homepage = "https://gitlab.gnome.org/Archive/goocanvas";
     license = licenses.lgpl2;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/libraries/goocanvasmm/default.nix
+++ b/pkgs/development/libraries/goocanvasmm/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "C++ bindings for GooCanvas";
-    homepage = "https://wiki.gnome.org/Projects/GooCanvas";
+    homepage = "https://gitlab.gnome.org/Archive/goocanvasmm";
     license = licenses.lgpl2;
     maintainers = with maintainers; [ ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/grilo-plugins/default.nix
+++ b/pkgs/development/libraries/grilo-plugins/default.nix
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/Grilo";
+    homepage = "https://gitlab.gnome.org/GNOME/grilo-plugins";
     description = "A collection of plugins for the Grilo framework";
     maintainers = teams.gnome.members;
     license = licenses.lgpl21Plus;

--- a/pkgs/development/libraries/grilo/default.nix
+++ b/pkgs/development/libraries/grilo/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/Grilo";
+    homepage = "https://gitlab.gnome.org/GNOME/grilo";
     description = "Framework that provides access to various sources of multimedia content, using a pluggable system";
     maintainers = teams.gnome.members;
     license = licenses.lgpl2Plus;

--- a/pkgs/development/libraries/gsound/default.nix
+++ b/pkgs/development/libraries/gsound/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/GSound";
+    homepage = "https://gitlab.gnome.org/GNOME/gsound";
     description = "Small library for playing system sounds";
     mainProgram = "gsound-play";
     maintainers = teams.gnome.members;

--- a/pkgs/development/libraries/gspell/default.nix
+++ b/pkgs/development/libraries/gspell/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A spell-checking library for GTK applications";
     mainProgram = "gspell-app1";
-    homepage = "https://wiki.gnome.org/Projects/gspell";
+    homepage = "https://gitlab.gnome.org/GNOME/gspell";
     license = licenses.lgpl21Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/gtk-mac-integration/default.nix
+++ b/pkgs/development/libraries/gtk-mac-integration/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Provides integration for GTK applications into the Mac desktop";
     license = licenses.lgpl21;
-    homepage = "https://wiki.gnome.org/Projects/GTK/OSX/Integration";
+    homepage = "https://gitlab.gnome.org/GNOME/gtk-mac-integration";
     maintainers = with maintainers; [ matthewbauer ];
     platforms = platforms.darwin;
   };

--- a/pkgs/development/libraries/gtkimageview/default.nix
+++ b/pkgs/development/libraries/gtkimageview/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    homepage = "https://wiki.gnome.org/Projects/GTK/GtkImageView";
+    homepage = "https://gitlab.gnome.org/Archive/gtkimageview";
 
     description = "Image viewer widget for GTK";
 

--- a/pkgs/development/libraries/gtksourceview/3.x.nix
+++ b/pkgs/development/libraries/gtksourceview/3.x.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/GtkSourceView";
+    homepage = "https://gitlab.gnome.org/GNOME/gtksourceview";
     pkgConfigModules = [ "gtksourceview-3.0" ];
     platforms = with platforms; linux ++ darwin;
     license = licenses.lgpl21;

--- a/pkgs/development/libraries/gtksourceview/4.x.nix
+++ b/pkgs/development/libraries/gtksourceview/4.x.nix
@@ -122,7 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Source code editing widget for GTK";
-    homepage = "https://wiki.gnome.org/Projects/GtkSourceView";
+    homepage = "https://gitlab.gnome.org/GNOME/gtksourceview";
     pkgConfigModules = [ "gtksourceview-4" ];
     platforms = platforms.unix;
     license = licenses.lgpl21Plus;

--- a/pkgs/development/libraries/gtksourceview/5.x.nix
+++ b/pkgs/development/libraries/gtksourceview/5.x.nix
@@ -110,7 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Source code editing widget for GTK";
-    homepage = "https://wiki.gnome.org/Projects/GtkSourceView";
+    homepage = "https://gitlab.gnome.org/GNOME/gtksourceview";
     pkgConfigModules = [ "gtksourceview-5" ];
     platforms = platforms.unix;
     license = licenses.lgpl21Plus;

--- a/pkgs/development/libraries/gupnp-dlna/default.nix
+++ b/pkgs/development/libraries/gupnp-dlna/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/GUPnP/";
+    homepage = "https://gitlab.gnome.org/GNOME/gupnp-dlna";
     description = "Library to ease DLNA-related bits for applications using GUPnP";
     license = licenses.lgpl2Plus;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/json-glib/default.nix
+++ b/pkgs/development/libraries/json-glib/default.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A library providing (de)serialization support for the JavaScript Object Notation (JSON) format";
-    homepage = "https://wiki.gnome.org/Projects/JsonGlib";
+    homepage = "https://gitlab.gnome.org/GNOME/json-glib";
     license = licenses.lgpl21Plus;
     maintainers = teams.gnome.members;
     platforms = with platforms; unix;

--- a/pkgs/development/libraries/lasem/default.nix
+++ b/pkgs/development/libraries/lasem/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     description = "SVG and MathML rendering library";
     mainProgram = "lasem-render-0.4";
 
-    homepage = "https://wiki.gnome.org/Projects/Lasem";
+    homepage = "https://github.com/LasemProject/lasem";
     license = lib.licenses.gpl2Plus;
 
     platforms = lib.platforms.unix;

--- a/pkgs/development/libraries/libchamplain/default.nix
+++ b/pkgs/development/libraries/libchamplain/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/libchamplain";
+    homepage = "https://gitlab.gnome.org/GNOME/libchamplain";
     license = licenses.lgpl2Plus;
 
     description = "C library providing a ClutterActor to display maps";

--- a/pkgs/development/libraries/libepc/default.nix
+++ b/pkgs/development/libraries/libepc/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Easy Publish and Consume Library";
-    homepage = "https://wiki.gnome.org/Projects/libepc";
+    homepage = "https://gitlab.gnome.org/Archive/libepc";
     license = licenses.lgpl21Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libgdata/default.nix
+++ b/pkgs/development/libraries/libgdata/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "GData API library";
-    homepage = "https://wiki.gnome.org/Projects/libgdata";
+    homepage = "https://gitlab.gnome.org/GNOME/libgdata";
     maintainers = with maintainers; [ raskin ] ++ teams.gnome.members;
     platforms = platforms.linux;
     license = licenses.lgpl21Plus;

--- a/pkgs/development/libraries/libgee/default.nix
+++ b/pkgs/development/libraries/libgee/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Utility library providing GObject-based interfaces and classes for commonly used data structures";
-    homepage = "https://wiki.gnome.org/Projects/Libgee";
+    homepage = "https://gitlab.gnome.org/GNOME/libgee";
     license = licenses.lgpl21Plus;
     platforms = platforms.unix;
     maintainers = teams.gnome.members;

--- a/pkgs/development/libraries/libgit2-glib/default.nix
+++ b/pkgs/development/libraries/libgit2-glib/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A glib wrapper library around the libgit2 git access library";
-    homepage = "https://wiki.gnome.org/Projects/Libgit2-glib";
+    homepage = "https://gitlab.gnome.org/GNOME/libgit2-glib";
     license = licenses.lgpl21Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libgnome-keyring/default.nix
+++ b/pkgs/development/libraries/libgnome-keyring/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     pkgConfigModules = [ "gnome-keyring-1" ];
     inherit (glib.meta) platforms maintainers;
-    homepage = "https://wiki.gnome.org/Projects/GnomeKeyring";
+    homepage = "https://gitlab.gnome.org/Archive/libgnome-keyring";
     license = with lib.licenses; [ gpl2 lgpl2 ];
   };
 })

--- a/pkgs/development/libraries/libgrss/default.nix
+++ b/pkgs/development/libraries/libgrss/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Glib abstaction to handle feeds in RSS, Atom and other formats";
-    homepage = "https://wiki.gnome.org/Projects/Libgrss";
+    homepage = "https://gitlab.gnome.org/GNOME/libgrss";
     license = licenses.lgpl3Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libgudev/default.nix
+++ b/pkgs/development/libraries/libgudev/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "A library that provides GObject bindings for libudev";
-    homepage = "https://wiki.gnome.org/Projects/libgudev";
+    homepage = "https://gitlab.gnome.org/GNOME/libgudev";
     maintainers = [ maintainers.eelco ] ++ teams.gnome.members;
     platforms = platforms.linux;
     license = licenses.lgpl2Plus;

--- a/pkgs/development/libraries/libgweather/default.nix
+++ b/pkgs/development/libraries/libgweather/default.nix
@@ -101,7 +101,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A library to access weather information from online services for numerous locations";
-    homepage = "https://wiki.gnome.org/Projects/LibGWeather";
+    homepage = "https://gitlab.gnome.org/GNOME/libgweather";
     license = licenses.gpl2Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libgxps/default.nix
+++ b/pkgs/development/libraries/libgxps/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A GObject based library for handling and rendering XPS documents";
-    homepage = "https://wiki.gnome.org/Projects/libgxps";
+    homepage = "https://gitlab.gnome.org/GNOME/libgxps";
     license = licenses.lgpl21Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libpeas/2.x.nix
+++ b/pkgs/development/libraries/libpeas/2.x.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A GObject-based plugins engine";
-    homepage = "https://wiki.gnome.org/Projects/Libpeas";
+    homepage = "https://gitlab.gnome.org/GNOME/libpeas";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = teams.gnome.members;

--- a/pkgs/development/libraries/libpeas/default.nix
+++ b/pkgs/development/libraries/libpeas/default.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A GObject-based plugins engine";
     mainProgram = "peas-demo";
-    homepage = "https://wiki.gnome.org/Projects/Libpeas";
+    homepage = "https://gitlab.gnome.org/GNOME/libpeas";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = teams.gnome.members;

--- a/pkgs/development/libraries/librest/1.0.nix
+++ b/pkgs/development/libraries/librest/1.0.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Helper library for RESTful services";
-    homepage = "https://wiki.gnome.org/Projects/Librest";
+    homepage = "https://gitlab.gnome.org/GNOME/librest";
     license = licenses.lgpl21Only;
     platforms = platforms.unix;
     maintainers = teams.gnome.members;

--- a/pkgs/development/libraries/librest/default.nix
+++ b/pkgs/development/libraries/librest/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Helper library for RESTful services";
-    homepage = "https://wiki.gnome.org/Projects/Librest";
+    homepage = "https://gitlab.gnome.org/GNOME/librest";
     license = licenses.lgpl21Only;
     platforms = platforms.unix;
     maintainers = teams.gnome.members;

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -217,7 +217,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "A small library to render SVG images to Cairo surfaces";
-    homepage = "https://wiki.gnome.org/Projects/LibRsvg";
+    homepage = "hhttps://gitlab.gnome.org/GNOME/librsvg";
     license = licenses.lgpl2Plus;
     maintainers = teams.gnome.members;
     mainProgram = "rsvg-convert";

--- a/pkgs/development/libraries/libsecret/default.nix
+++ b/pkgs/development/libraries/libsecret/default.nix
@@ -121,7 +121,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A library for storing and retrieving passwords and other secrets";
-    homepage = "https://wiki.gnome.org/Projects/Libsecret";
+    homepage = "https://gitlab.gnome.org/GNOME/libsecret";
     license = lib.licenses.lgpl21Plus;
     mainProgram = "secret-tool";
     inherit (glib.meta) platforms maintainers;

--- a/pkgs/development/libraries/libsoup/3.x.nix
+++ b/pkgs/development/libraries/libsoup/3.x.nix
@@ -101,7 +101,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "HTTP client/server library for GNOME";
-    homepage = "https://wiki.gnome.org/Projects/libsoup";
+    homepage = "https://gitlab.gnome.org/GNOME/libsoup";
     license = lib.licenses.lgpl2Plus;
     inherit (glib.meta) maintainers platforms;
   };

--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "HTTP client/server library for GNOME";
-    homepage = "https://wiki.gnome.org/Projects/libsoup";
+    homepage = "https://gitlab.gnome.org/GNOME/libsoup";
     license = lib.licenses.lgpl2Plus;
     inherit (glib.meta) maintainers platforms;
     pkgConfigModules = [

--- a/pkgs/development/libraries/libzapojit/default.nix
+++ b/pkgs/development/libraries/libzapojit/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "GObject wrapper for the SkyDrive and Hotmail REST APIs";
-    homepage = "https://wiki.gnome.org/Projects/Zapojit";
+    homepage = "https://gitlab.gnome.org/Archive/libzapojit";
     license = licenses.lgpl21Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/tracker-miners/default.nix
+++ b/pkgs/development/libraries/tracker-miners/default.nix
@@ -135,7 +135,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/Tracker";
+    homepage = "https://gitlab.gnome.org/GNOME/tracker-miners";
     description = "Desktop-neutral user information store, search tool and indexer";
     maintainers = teams.gnome.members;
     license = licenses.gpl2Plus;

--- a/pkgs/development/libraries/tracker/default.nix
+++ b/pkgs/development/libraries/tracker/default.nix
@@ -171,7 +171,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/Tracker";
+    homepage = "https://tracker.gnome.org/";
     description = "Desktop-neutral user information store, search tool and indexer";
     mainProgram = "tracker3";
     maintainers = teams.gnome.members;

--- a/pkgs/development/tools/gtk-mac-bundler/default.nix
+++ b/pkgs/development/tools/gtk-mac-bundler/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     description = "a helper script that creates application bundles form GTK executables for macOS";
     maintainers = [ maintainers.matthewbauer ];
     platforms = platforms.darwin;
-    homepage = "https://wiki.gnome.org/Projects/GTK/OSX/Bundling";
+    homepage = "https://gitlab.gnome.org/GNOME/gtk-mac-bundler";
     license = licenses.gpl2;
   };
 }

--- a/pkgs/servers/hqplayerd/rygel.nix
+++ b/pkgs/servers/hqplayerd/rygel.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A home media solution (UPnP AV MediaServer) that allows you to easily share audio, video and pictures to other devices";
-    homepage = "https://wiki.gnome.org/Projects/Rygel";
+    homepage = "https://gitlab.gnome.org/GNOME/rygel";
     license = licenses.lgpl21Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.linux;

--- a/pkgs/tools/admin/gtk-vnc/default.nix
+++ b/pkgs/tools/admin/gtk-vnc/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "GTK VNC widget";
-    homepage = "https://wiki.gnome.org/Projects/gtk-vnc";
+    homepage = "https://gitlab.gnome.org/GNOME/gtk-vnc";
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ raskin offline ];
     platforms = platforms.unix;

--- a/pkgs/tools/networking/gupnp-tools/default.nix
+++ b/pkgs/tools/networking/gupnp-tools/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Set of utilities and demos to work with UPnP";
-    homepage = "https://wiki.gnome.org/Projects/GUPnP";
+    homepage = "https://gitlab.gnome.org/GNOME/gupnp-tools";
     license = licenses.gpl2Plus;
     maintainers = teams.gnome.members;
     platforms = platforms.unix;

--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -210,7 +210,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://wiki.gnome.org/Projects/NetworkManager";
+    homepage = "https://networkmanager.dev";
     description = "Network configuration and management tool";
     license = licenses.gpl2Plus;
     changelog = "https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/raw/${version}/NEWS";


### PR DESCRIPTION
## Description of changes

The [wiki.gnome.org](https://wiki.gnome.org/) site is planned for retirement, as shown in the banner there.

Also various links here are [already](https://wiki.gnome.org/Projects/Libgrss) [not](https://wiki.gnome.org/Projects/Lasem) [working](https://wiki.gnome.org/Projects/libepc) or [unmaintained](https://wiki.gnome.org/Projects/gexiv2).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
