### PR TITLE
nixos/xserver: Remove {desktop,window}Manager.default options

### DIFF
--- a/nixos/modules/services/display-managers/default.nix
+++ b/nixos/modules/services/display-managers/default.nix
@@ -29,12 +29,6 @@ let
         fi
       '') cfg.sessionPackages}
     '';
-
-  dmDefault = config.services.xserver.desktopManager.default;
-  # fallback default for cases when only default wm is set
-  dmFallbackDefault = if dmDefault != null then dmDefault else "none";
-  wmDefault = config.services.xserver.windowManager.default;
-  defaultSessionFromLegacyOptions = dmFallbackDefault + lib.optionalString (wmDefault != null && wmDefault != "none") "+${wmDefault}";
 in
 {
   options = {
@@ -125,14 +119,7 @@ in
                   ${lib.concatStringsSep "\n  " cfg.displayManager.sessionData.sessionNames}
               '';
         };
-        default =
-          if dmDefault != null || wmDefault != null then
-            defaultSessionFromLegacyOptions
-          else
-            null;
-        defaultText = lib.literalMD ''
-          Taken from display manager settings or window manager settings, if either is set.
-        '';
+        default = null;
         example = "gnome";
         description = ''
           Graphical session to pre-select in the session chooser (only effective for GDM, LightDM and SDDM).
@@ -191,20 +178,6 @@ in
         '';
       }
     ];
-
-    warnings =
-      lib.mkIf (dmDefault != null || wmDefault != null) [
-        ''
-          The following options are deprecated:
-            ${lib.concatStringsSep "\n  " (map ({c, t}: t) (lib.filter ({c, t}: c != null) [
-            { c = dmDefault; t = "- services.xserver.desktopManager.default"; }
-            { c = wmDefault; t = "- services.xserver.windowManager.default"; }
-            ]))}
-          Please use
-            services.displayManager.defaultSession = "${defaultSessionFromLegacyOptions}";
-          instead.
-        ''
-      ];
 
     # Make xsessions and wayland sessions available in XDG_DATA_DIRS
     # as some programs have behavior that depends on them being present

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -1,8 +1,7 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) mkOption types;
 
   xcfg = config.services.xserver;
   cfg = xcfg.desktopManager;
@@ -59,7 +58,7 @@ in
       session = mkOption {
         internal = true;
         default = [];
-        example = singleton
+        example = lib.singleton
           { name = "kde";
             bgSupport = true;
             start = "...";
@@ -73,10 +72,10 @@ in
           manage = "desktop";
           start = d.start
           # literal newline to ensure d.start's last line is not appended to
-          + optionalString (needBGCond d) ''
+          + lib.optionalString (needBGCond d) ''
 
             if [ -e $HOME/.background-image ]; then
-              ${pkgs.feh}/bin/feh --bg-${cfg.wallpaper.mode} ${optionalString cfg.wallpaper.combineScreens "--no-xinerama"} $HOME/.background-image
+              ${pkgs.feh}/bin/feh --bg-${cfg.wallpaper.mode} ${lib.optionalString cfg.wallpaper.combineScreens "--no-xinerama"} $HOME/.background-image
             fi
           '';
         });

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -82,17 +82,6 @@ in
         });
       };
 
-      default = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        example = "none";
-        description = ''
-          **Deprecated**, please use [](#opt-services.displayManager.defaultSession) instead.
-
-          Default desktop manager loaded if none have been chosen.
-        '';
-      };
-
     };
 
   };

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -222,13 +222,6 @@ in
   };
 
   config = {
-    assertions = [
-      {
-        assertion = cfg.desktopManager.default != null || cfg.windowManager.default != null -> cfg.displayManager.defaultSession == defaultSessionFromLegacyOptions;
-        message = "You cannot use both services.displayManager.defaultSession option and legacy options (services.xserver.desktopManager.default and services.xserver.windowManager.default).";
-      }
-    ];
-
     services.displayManager.sessionData.wrapper = xsessionWrapper;
 
     services.xserver.displayManager.xserverBin = "${xorg.xorgserver.out}/bin/X";

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -9,9 +9,8 @@
 
 { config, lib, options, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) mkOption types literalExpression optionalString;
 
   cfg = config.services.xserver;
   xorg = pkgs.xorg;
@@ -91,7 +90,7 @@ let
       # Import environment variables into the systemd user environment.
       ${optionalString (cfg.displayManager.importedVariables != []) (
         "/run/current-system/systemd/bin/systemctl --user import-environment "
-          + toString (unique cfg.displayManager.importedVariables)
+          + toString (lib.unique cfg.displayManager.importedVariables)
       )}
 
       # Speed up application start by 50-150ms according to
@@ -247,8 +246,8 @@ in
     # that do not have upstream session files (those defined using services.{display,desktop,window}Manager.session options).
     services.displayManager.sessionPackages =
       let
-        dms = filter (s: s.manage == "desktop") cfg.displayManager.session;
-        wms = filter (s: s.manage == "window") cfg.displayManager.session;
+        dms = lib.filter (s: s.manage == "desktop") cfg.displayManager.session;
+        wms = lib.filter (s: s.manage == "window") cfg.displayManager.session;
 
         # Script responsible for starting the window manager and the desktop manager.
         xsession = dm: wm: pkgs.writeScript "xsession" ''
@@ -276,16 +275,16 @@ in
         '';
       in
         # We will generate every possible pair of WM and DM.
-        concatLists (
+        lib.concatLists (
             lib.mapCartesianProduct
             ({dm, wm}: let
               sessionName = "${dm.name}${optionalString (wm.name != "none") ("+" + wm.name)}";
               script = xsession dm wm;
               desktopNames = if dm ? desktopNames
-                             then concatStringsSep ";" dm.desktopNames
+                             then lib.concatStringsSep ";" dm.desktopNames
                              else sessionName;
             in
-              optional (dm.name != "none" || wm.name != "none")
+              lib.optional (dm.name != "none" || wm.name != "none")
                 (pkgs.writeTextFile {
                   name = "${sessionName}-xsession";
                   destination = "/share/xsessions/${sessionName}.desktop";
@@ -310,11 +309,11 @@ in
   };
 
   imports = [
-    (mkRemovedOptionModule [ "services" "xserver" "displayManager" "desktopManagerHandlesLidAndPower" ]
+    (lib.mkRemovedOptionModule [ "services" "xserver" "displayManager" "desktopManagerHandlesLidAndPower" ]
      "The option is no longer necessary because all display managers have already delegated lid management to systemd.")
-    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "job" "logsXsession" ] [ "services" "displayManager" "logToFile" ])
-    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "logToJournal" ] [ "services" "displayManager" "logToJournal" ])
-    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "extraSessionFilesPackages" ] [ "services" "displayManager" "sessionPackages" ])
+    (lib.mkRenamedOptionModule [ "services" "xserver" "displayManager" "job" "logsXsession" ] [ "services" "displayManager" "logToFile" ])
+    (lib.mkRenamedOptionModule [ "services" "xserver" "displayManager" "logToJournal" ] [ "services" "displayManager" "logToJournal" ])
+    (lib.mkRenamedOptionModule [ "services" "xserver" "displayManager" "extraSessionFilesPackages" ] [ "services" "displayManager" "sessionPackages" ])
   ];
 
 }

--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -1,8 +1,7 @@
 { config, lib, ... }:
 
-with lib;
-
 let
+  inherit (lib) mkOption types;
   cfg = config.services.xserver.windowManager;
 in
 

--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -72,17 +72,6 @@ in
         });
       };
 
-      default = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        example = "wmii";
-        description = ''
-          **Deprecated**, please use [](#opt-services.displayManager.defaultSession) instead.
-
-          Default window manager loaded if none have been chosen.
-        '';
-      };
-
     };
 
   };


### PR DESCRIPTION
## Description of changes

These have been deprecated since NixOS 20.03.

Fixes evaluation error from 6be2bfcc32d5ee203acf3b85354f5028c8bb50eb.

cc @NixOS/gnome, @SuperSandro2000

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux NixOS manual
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
