### PR TITLE
treewide: fixes to packages i maintain

### DIFF
--- a/pkgs/by-name/no/normcap/package.nix
+++ b/pkgs/by-name/no/normcap/package.nix
@@ -57,7 +57,7 @@ ps.buildPythonApplication rec {
     ps.babel
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     ps.pyside6
     ps.jeepney
   ];

--- a/pkgs/by-name/no/normcap/package.nix
+++ b/pkgs/by-name/no/normcap/package.nix
@@ -40,7 +40,7 @@ ps.buildPythonApplication rec {
   postPatch = ''
     # disable coverage testing
     substituteInPlace pyproject.toml \
-      --replace "addopts = [" "addopts_ = ["
+      --replace-fail "addopts = [" "addopts_ = ["
   '';
 
   pythonRemoveDeps = [

--- a/pkgs/development/compilers/gnu-cim/default.nix
+++ b/pkgs/development/compilers/gnu-cim/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     for fname in lib/{simulation,simset}.c; do
       substituteInPlace "$fname" \
-        --replace \
+        --replace-fail \
           '#include "../../lib/cim.h"' \
           '#include "../lib/cim.h"'
     done

--- a/pkgs/development/libraries/librealsense/default.nix
+++ b/pkgs/development/libraries/librealsense/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
   # ( https://github.com/IntelRealSense/meta-intel-realsense/issues/20 )
   postInstall = ''
     substituteInPlace $out/lib/cmake/realsense2/realsense2Targets.cmake \
-    --replace "\''${_IMPORT_PREFIX}/include" "$dev/include"
+    --replace-fail "\''${_IMPORT_PREFIX}/include" "$dev/include"
   '' + lib.optionalString enablePython  ''
     cp ../wrappers/python/pyrealsense2/__init__.py $out/${pythonPackages.python.sitePackages}/pyrealsense2
   '';

--- a/pkgs/development/python-modules/amaranth-boards/default.nix
+++ b/pkgs/development/python-modules/amaranth-boards/default.nix
@@ -9,7 +9,7 @@
 buildPythonPackage rec {
   pname = "amaranth-boards";
   version = "0-unstable-2023-12-13";
-  format = "setuptools";
+  pyproject = true;
   # python setup.py --version
   realVersion = "0.1.dev202+g${lib.substring 0 7 src.rev}";
 
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     hash = "sha256-dwZCKMJnEY9RjzkcJ9r3TEC7W+Wfi/P7Hjl4/d60/qo=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
+  nativeBuildInputs = [ setuptools setuptools-scm ];
   dependencies = [ setuptools amaranth ];
 
   preBuild = ''

--- a/pkgs/development/python-modules/amaranth-boards/default.nix
+++ b/pkgs/development/python-modules/amaranth-boards/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ setuptools-scm ];
-  propagatedBuildInputs = [ setuptools amaranth ];
+  dependencies = [ setuptools amaranth ];
 
   preBuild = ''
     export SETUPTOOLS_SCM_PRETEND_VERSION="${realVersion}"

--- a/pkgs/development/python-modules/amaranth-soc/default.nix
+++ b/pkgs/development/python-modules/amaranth-soc/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ pdm-backend ];
-  propagatedBuildInputs = [ amaranth ];
+  dependencies = [ amaranth ];
 
   preBuild = ''
     export PDM_BUILD_SCM_VERSION="${realVersion}"

--- a/pkgs/development/python-modules/amaranth/default.nix
+++ b/pkgs/development/python-modules/amaranth/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     pdm-backend
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     jinja2
     pyvcd
   ] ++

--- a/pkgs/development/python-modules/birch/default.nix
+++ b/pkgs/development/python-modules/birch/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     strct
   ];
 

--- a/pkgs/development/python-modules/birch/default.nix
+++ b/pkgs/development/python-modules/birch/default.nix
@@ -31,13 +31,13 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pytest.ini \
-      --replace  \
+      --replace-fail  \
         "--cov" \
         "#--cov"
 
     # configure correct version, which fails due to missing .git
     substituteInPlace versioneer.py birch/_version.py \
-      --replace '"0+unknown"' '"${version}"'
+      --replace-fail '"0+unknown"' '"${version}"'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/cachier/default.nix
+++ b/pkgs/development/python-modules/cachier/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
 
   preCheck = ''
     substituteInPlace pyproject.toml \
-      --replace  \
+      --replace-fail  \
         '"--cov' \
         '#"--cov'
   '';

--- a/pkgs/development/python-modules/cachier/default.nix
+++ b/pkgs/development/python-modules/cachier/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     watchdog
     portalocker
   ];

--- a/pkgs/development/python-modules/domeneshop/default.nix
+++ b/pkgs/development/python-modules/domeneshop/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     hash = "sha256-kL0X1mEsmVWqnq5NgsMBxeAu48zjmi3muhZYryTCOMo=";
   };
 
-  propagatedBuildInputs = [
+  dependencies = [
     certifi
     urllib3
   ];

--- a/pkgs/development/python-modules/domeneshop/default.nix
+++ b/pkgs/development/python-modules/domeneshop/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
+, setuptools
 , urllib3
 , pyopenssl
 , cryptography
@@ -12,7 +13,7 @@
 buildPythonPackage rec {
   pname = "domeneshop";
   version = "0.4.3";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.4";
 
@@ -20,6 +21,10 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-kL0X1mEsmVWqnq5NgsMBxeAu48zjmi3muhZYryTCOMo=";
   };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   dependencies = [
     certifi

--- a/pkgs/development/python-modules/ffmpy/default.nix
+++ b/pkgs/development/python-modules/ffmpy/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   postPatch = ''
     # default to store ffmpeg
     substituteInPlace ffmpy.py \
-      --replace 'executable="ffmpeg",' 'executable="${ffmpeg-headless}/bin/ffmpeg",'
+      --replace-fail 'executable="ffmpeg",' 'executable="${ffmpeg-headless}/bin/ffmpeg",'
 
     #  The tests test a mock that does not behave like ffmpeg. If we default to the nix-store ffmpeg they fail.
     for fname in tests/*.py; do

--- a/pkgs/development/python-modules/frozendict/default.nix
+++ b/pkgs/development/python-modules/frozendict/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 , pytestCheckHook
 , pythonAtLeast
 , pythonOlder
@@ -9,7 +10,7 @@
 buildPythonPackage rec {
   pname = "frozendict";
   version = "2.4.2";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.6";
 
@@ -31,6 +32,10 @@ buildPythonPackage rec {
       export FROZENDICT_PURE_PY=1
     fi
   '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/gradio-pdf/default.nix
+++ b/pkgs/development/python-modules/gradio-pdf/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     hatchling
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     gradio-client
   ];
 

--- a/pkgs/development/python-modules/gradio/client.nix
+++ b/pkgs/development/python-modules/gradio/client.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     pythonRelaxDepsHook
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     setuptools # needed for 'pkg_resources'
     fsspec
     httpx

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -99,7 +99,7 @@ buildPythonPackage rec {
     hatch-fancy-pypi-readme
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     setuptools # needed for 'pkg_resources'
     aiofiles
     altair

--- a/pkgs/development/python-modules/hdf5plugin/default.nix
+++ b/pkgs/development/python-modules/hdf5plugin/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     hash = "sha256-MnqY1PyGzo31H696J9CekiA2rJrUYzUMDC3UJMZaFLA=";
   };
 
-  propagatedBuildInputs = [
+  dependencies = [
     h5py
   ];
 

--- a/pkgs/development/python-modules/pdoc/default.nix
+++ b/pkgs/development/python-modules/pdoc/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     jinja2
     pygments
     markupsafe

--- a/pkgs/development/python-modules/pymongo-inmemory/default.nix
+++ b/pkgs/development/python-modules/pymongo-inmemory/default.nix
@@ -25,13 +25,13 @@ buildPythonPackage rec {
   postPatch = ''
     # move cache location from nix store to home
     substituteInPlace pymongo_inmemory/context.py \
-      --replace \
+      --replace-fail \
         'CACHE_FOLDER = path.join(path.dirname(__file__), "..", ".cache")' \
         'CACHE_FOLDER = os.environ.get("XDG_CACHE_HOME", os.environ["HOME"] + "/.cache") + "/pymongo-inmemory"'
 
     # fix a broken assumption arising from the above fix
     substituteInPlace pymongo_inmemory/_utils.py \
-      --replace \
+      --replace-fail \
         'os.mkdir(current_path)' \
         'os.makedirs(current_path)'
   '';

--- a/pkgs/development/python-modules/pymongo-inmemory/default.nix
+++ b/pkgs/development/python-modules/pymongo-inmemory/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     poetry-core
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     pymongo
   ];
 

--- a/pkgs/development/python-modules/pyrender/default.nix
+++ b/pkgs/development/python-modules/pyrender/default.nix
@@ -3,6 +3,7 @@
 , pythonOlder
 , fetchFromGitHub
 , fetchpatch
+, setuptools
 , freetype-py
 , imageio
 , networkx
@@ -19,7 +20,7 @@
 buildPythonPackage rec {
   pname = "pyrender";
   version = "0.1.45";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.5";
 
@@ -49,6 +50,10 @@ buildPythonPackage rec {
         "bm = trimesh.load('tests/data/WaterBottle.glb').dump()[0]" \
         'bm = trimesh.load("tests/data/WaterBottle.glb").geometry["WaterBottle"]'
   '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   dependencies = [
     freetype-py

--- a/pkgs/development/python-modules/pyrender/default.nix
+++ b/pkgs/development/python-modules/pyrender/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
         'bm = trimesh.load("tests/data/WaterBottle.glb").geometry["WaterBottle"]'
   '';
 
-  propagatedBuildInputs = [
+  dependencies = [
     freetype-py
     imageio
     networkx

--- a/pkgs/development/python-modules/pyrender/default.nix
+++ b/pkgs/development/python-modules/pyrender/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   # the commit does not apply as a patch when cherry picked, hence the substituteInPlace
   postPatch = ''
     substituteInPlace tests/unit/test_meshes.py \
-      --replace \
+      --replace-fail \
         "bm = trimesh.load('tests/data/WaterBottle.glb').dump()[0]" \
         'bm = trimesh.load("tests/data/WaterBottle.glb").geometry["WaterBottle"]'
   '';

--- a/pkgs/development/python-modules/pytikz-allefeld/default.nix
+++ b/pkgs/development/python-modules/pytikz-allefeld/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     hash = "sha256-G59UUkpjttJKNBN0MB/A9CftO8tO3nv8qlTxt3/fKHk=";
   };
 
-  propagatedBuildInputs = [
+  dependencies = [
     pymupdf
     numpy
     ipython

--- a/pkgs/development/python-modules/pytikz-allefeld/default.nix
+++ b/pkgs/development/python-modules/pytikz-allefeld/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , buildPythonPackage
 , pythonOlder
+, setuptools
 , pymupdf
 , numpy
 , ipython
@@ -12,7 +13,7 @@
 buildPythonPackage rec {
   pname = "pytikz-allefeld"; # "pytikz" on pypi is a different module
   version = "unstable-2022-11-01";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.5";
 
@@ -22,6 +23,10 @@ buildPythonPackage rec {
     rev = "f878ebd6ce5a647b1076228b48181b147a61abc1";
     hash = "sha256-G59UUkpjttJKNBN0MB/A9CftO8tO3nv8qlTxt3/fKHk=";
   };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   dependencies = [
     pymupdf

--- a/pkgs/development/python-modules/pyunpack/default.nix
+++ b/pkgs/development/python-modules/pyunpack/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     easyprocess
     entrypoint2
   ];

--- a/pkgs/development/python-modules/pyunpack/default.nix
+++ b/pkgs/development/python-modules/pyunpack/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyunpack/__init__.py \
-      --replace \
+      --replace-fail \
        '_exepath("patool")' \
        '"${lib.getBin patool}/bin/.patool-wrapped"'
   '';

--- a/pkgs/development/python-modules/pyvis/default.nix
+++ b/pkgs/development/python-modules/pyvis/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , fetchpatch
 , buildPythonPackage
+, setuptools
 , networkx
 , jinja2
 , ipython
@@ -13,7 +14,7 @@
 buildPythonPackage rec {
   pname = "pyvis";
   version = "0.3.2";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "WestHealth";
@@ -21,6 +22,10 @@ buildPythonPackage rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-eo9Mk2c0hrBarCrzwmkXha3Qt4Bl1qR7Lhl9EkUx96E=";
   };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   dependencies = [
     jinja2

--- a/pkgs/development/python-modules/pyvis/default.nix
+++ b/pkgs/development/python-modules/pyvis/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     hash = "sha256-eo9Mk2c0hrBarCrzwmkXha3Qt4Bl1qR7Lhl9EkUx96E=";
   };
 
-  propagatedBuildInputs = [
+  dependencies = [
     jinja2
     networkx
     ipython

--- a/pkgs/development/python-modules/remi/default.nix
+++ b/pkgs/development/python-modules/remi/default.nix
@@ -23,19 +23,19 @@ buildPythonPackage rec {
   preCheck = ''
     # for some reason, REMI already deal with these using try blocks, but they fail
     substituteInPlace test/test_widget.py \
-      --replace \
+      --replace-fail \
         "from html_validator import " \
         "from .html_validator import "
     substituteInPlace test/test_examples_app.py \
-      --replace \
+      --replace-fail \
         "from mock_server_and_request import " \
         "from .mock_server_and_request import " \
-      --replace \
+      --replace-fail \
         "from html_validator import " \
         "from .html_validator import "
     # Halves number of warnings
     substituteInPlace test/test_*.py \
-      --replace \
+      --replace-quiet \
         "self.assertEquals(" \
         "self.assertEqual("
   '';

--- a/pkgs/development/python-modules/remi/default.nix
+++ b/pkgs/development/python-modules/remi/default.nix
@@ -2,6 +2,7 @@
 , lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 , pytestCheckHook
 , matplotlib
 , python-snap7
@@ -11,7 +12,7 @@
 buildPythonPackage rec {
   pname = "remi";
   version = "2022.7.27";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rawpython";
@@ -39,6 +40,10 @@ buildPythonPackage rec {
         "self.assertEquals(" \
         "self.assertEqual("
   '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/snaptime/default.nix
+++ b/pkgs/development/python-modules/snaptime/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , python-dateutil
 , pytz
 }:
@@ -8,12 +9,16 @@
 buildPythonPackage rec {
   pname = "snaptime";
   version = "0.2.4";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-4/HriQQ9WNMHIauYy2UCPxpMJ0DjsZdwQpixY8ktUIs=";
   };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   dependencies = [
     python-dateutil

--- a/pkgs/development/python-modules/snaptime/default.nix
+++ b/pkgs/development/python-modules/snaptime/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     hash = "sha256-4/HriQQ9WNMHIauYy2UCPxpMJ0DjsZdwQpixY8ktUIs=";
   };
 
-  propagatedBuildInputs = [
+  dependencies = [
     python-dateutil
     pytz
   ];

--- a/pkgs/development/python-modules/strct/default.nix
+++ b/pkgs/development/python-modules/strct/default.nix
@@ -30,13 +30,13 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pytest.ini \
-      --replace  \
+      --replace-fail  \
         "--cov" \
         "#--cov"
 
     # configure correct version, which fails due to missing .git
     substituteInPlace versioneer.py strct/_version.py \
-      --replace '"0+unknown"' '"${version}"'
+      --replace-fail '"0+unknown"' '"${version}"'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/trimesh/default.nix
+++ b/pkgs/development/python-modules/trimesh/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
-  propagatedBuildInputs = [ numpy ];
+  dependencies = [ numpy ];
 
   nativeCheckInputs = [ lxml pytestCheckHook ];
 

--- a/pkgs/tools/misc/pokemonsay/default.nix
+++ b/pkgs/tools/misc/pokemonsay/default.nix
@@ -28,27 +28,27 @@ stdenvNoCC.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace pokemonsay.sh \
-      --replace \
+      --replace-fail \
         'INSTALL_PATH=''${HOME}/.bin/pokemonsay' \
         "" \
-      --replace \
+      --replace-fail \
         'POKEMON_PATH=''${INSTALL_PATH}/pokemons' \
         'POKEMON_PATH=${placeholder "out"}/share/pokemonsay' \
-      --replace \
+      --replace-fail \
         '$(find ' \
         '$(${findutils}/bin/find ' \
-      --replace \
+      --replace-fail \
         '$(basename ' \
         '$(${coreutils}/bin/basename ' \
-      --replace \
+      --replace-fail \
         'cowsay -f ' \
         '${cowsay}/bin/cowsay -f ' \
-      --replace \
+      --replace-fail \
         'cowthink -f ' \
         '${cowsay}/bin/cowthink -f '
 
     substituteInPlace pokemonthink.sh \
-      --replace \
+      --replace-fail \
         './pokemonsay.sh' \
         "${placeholder "out"}/bin/pokemonsay"
   '';

--- a/pkgs/tools/misc/remote-exec/default.nix
+++ b/pkgs/tools/misc/remote-exec/default.nix
@@ -34,7 +34,7 @@ buildPythonApplication rec {
   # remove legacy endpoints, we use --multi now
   postPatch = ''
     substituteInPlace setup.py \
-      --replace '"mremote' '#"mremote'
+      --replace-fail '"mremote' '#"mremote'
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/tools/misc/remote-exec/default.nix
+++ b/pkgs/tools/misc/remote-exec/default.nix
@@ -37,7 +37,7 @@ buildPythonApplication rec {
       --replace-fail '"mremote' '#"mremote'
   '';
 
-  propagatedBuildInputs = [
+  dependencies = [
     click
     pydantic
     toml

--- a/pkgs/tools/misc/rmate-sh/default.nix
+++ b/pkgs/tools/misc/rmate-sh/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     runHook preBuild
 
     substituteInPlace rmate \
-      --replace \
+      --replace-fail \
         'echo "hostname"' \
         'echo "${hostname}/bin/hostname"'
     patsh -f rmate -s ${builtins.storeDir}


### PR DESCRIPTION
## Description of changes

* `format = "setuptools"` -> `pyproject = true;`, except for `hdf5plugin` whose `pyproject.toml` has issues
* `propagatedBuildInputs` -> `dependencies`
* `--replace` -> `--replace-fail`, except for `python3Packages.remi`, which does a glob `--replace-quiet` to reduce warnings

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
