### PR TITLE
nixops_unstable*: Fix some unstableGitUpdater users

### DIFF
--- a/pkgs/applications/networking/cluster/nixops/plugins/nixops-aws.nix
+++ b/pkgs/applications/networking/cluster/nixops/plugins/nixops-aws.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage {
   pname = "nixops-aws";
-  version = "unstable-2024-02-29";
+  version = "1.0.0-unstable-2024-02-29";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -45,7 +45,9 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "nixops_aws" ];
 
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
 
   meta = with lib; {
     description = "AWS plugin for NixOps";

--- a/pkgs/applications/networking/cluster/nixops/plugins/nixops-digitalocean.nix
+++ b/pkgs/applications/networking/cluster/nixops/plugins/nixops-digitalocean.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage {
   pname = "nixops-digitalocean";
-  version = "unstable-2022-08-14";
+  version = "0.1.0-unstable-2022-08-14";
   pyproject = true;
 
   disabled = pythonOlder "3.7";

--- a/pkgs/applications/networking/cluster/nixops/plugins/nixops-encrypted-links.nix
+++ b/pkgs/applications/networking/cluster/nixops/plugins/nixops-encrypted-links.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage {
   pname = "nixops-encrypted-links";
-  version = "unstable-2021-02-16";
+  version = "0-unstable-2021-02-16";
   pyproject = true;
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/cluster/nixops/plugins/nixops-gce.nix
+++ b/pkgs/applications/networking/cluster/nixops/plugins/nixops-gce.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage {
   pname = "nixops-gce";
-  version = "unstable-2023-05-26";
+  version = "0-unstable-2023-05-26";
   pyproject = true;
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/cluster/nixops/plugins/nixops-hercules-ci.nix
+++ b/pkgs/applications/networking/cluster/nixops/plugins/nixops-hercules-ci.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage {
   pname = "nixops-hercules-ci";
-  version = "unstable-2021-10-06";
+  version = "0-unstable-2021-10-06";
   pyproject = true;
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/cluster/nixops/plugins/nixops-hetzner.nix
+++ b/pkgs/applications/networking/cluster/nixops/plugins/nixops-hetzner.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage {
   pname = "nixops-hetzner";
-  version = "unstable-2022-04-23";
+  version = "1.0.1-unstable-2022-04-24";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -43,7 +43,9 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "nixops_hetzner" ];
 
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
 
   meta = with lib; {
     description = "Hetzner bare metal NixOps plugin";

--- a/pkgs/applications/networking/cluster/nixops/plugins/nixops-hetznercloud.nix
+++ b/pkgs/applications/networking/cluster/nixops/plugins/nixops-hetznercloud.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage {
   pname = "nixops-hetznercloud";
-  version = "unstable-2023-02-19";
+  version = "0-unstable-2023-02-19";
   pyproject = true;
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/cluster/nixops/plugins/nixops-libvirtd.nix
+++ b/pkgs/applications/networking/cluster/nixops/plugins/nixops-libvirtd.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage {
   pname = "nixops-libvirtd";
-  version = "unstable-2023-09-01";
+  version = "1.0.0-unstable-2023-09-01";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -39,7 +39,9 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "nixops_virtd" ];
 
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
 
   meta = with lib; {
     description = "NixOps libvirtd backend plugin";

--- a/pkgs/applications/networking/cluster/nixops/plugins/nixops-vbox.nix
+++ b/pkgs/applications/networking/cluster/nixops/plugins/nixops-vbox.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage {
   pname = "nixops-vbox";
-  version = "unstable-2023-08-10";
+  version = "1.0.0-unstable-2023-08-10";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -34,7 +34,9 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "nixopsvbox" ];
 
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
 
   meta = with lib; {
     description = "NixOps plugin for VirtualBox VMs";

--- a/pkgs/applications/networking/cluster/nixops/plugins/nixos-modules-contrib.nix
+++ b/pkgs/applications/networking/cluster/nixops/plugins/nixos-modules-contrib.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage {
   pname = "nixos-modules-contrib";
-  version = "unstable-2021-01-20";
+  version = "0-unstable-2021-01-20";
   pyproject = true;
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/cluster/nixops/unwrapped.nix
+++ b/pkgs/applications/networking/cluster/nixops/unwrapped.nix
@@ -13,7 +13,7 @@
 
 buildPythonApplication rec {
   pname = "nixops";
-  version = "unstable-2024-02-28";
+  version = "1.7-unstable-2024-02-28";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -51,7 +51,9 @@ buildPythonApplication rec {
 
   passthru = {
     tests.nixos = nixosTests.nixops.unstable;
-    updateScript = unstableGitUpdater {};
+    updateScript = unstableGitUpdater {
+      tagPrefix = "v";
+    };
   };
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

#280501 now makes `unstableGitUpdater` produce versions that match our desired unstable version schema. Start fixing the versions of packages that use it, and their `unstableGitUpdater` arguments as needed.

Tackling nixops & its plugins here. Checked running the update script of all the plugins, which results in the same version & revs as corrected here, and nixops itself (`nixops_unstable_minimal.internals.rawPackage` AFAICT), which would result in a bump (1.7-unstable-2024-02-28 -> 1.7-unstable-2024-04-10).

Review results look not great, but seems [consistent with what Hydra's already reporting](https://hydra.nixos.org/eval/1805996?filter=nixops&compare=1805988&full=#tabs-still-fail):

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>10 packages failed to build:</summary>
  <ul>
    <li>nixops_unstablePlugins.nixops-gce</li>
    <li>nixops_unstablePlugins.nixops-gce.dist</li>
    <li>nixops_unstablePlugins.nixops-hetzner</li>
    <li>nixops_unstablePlugins.nixops-hetzner.dist</li>
    <li>nixops_unstablePlugins.nixops-hetznercloud</li>
    <li>nixops_unstablePlugins.nixops-hetznercloud.dist</li>
    <li>nixops_unstablePlugins.nixops-libvirtd</li>
    <li>nixops_unstablePlugins.nixops-libvirtd.dist</li>
    <li>nixops_unstable_full</li>
    <li>nixops_unstable_full.dist</li>
  </ul>
</details>
<details>
  <summary>14 packages built:</summary>
  <ul>
    <li>nixops_unstablePlugins.nixops-aws</li>
    <li>nixops_unstablePlugins.nixops-aws.dist</li>
    <li>nixops_unstablePlugins.nixops-digitalocean</li>
    <li>nixops_unstablePlugins.nixops-digitalocean.dist</li>
    <li>nixops_unstablePlugins.nixops-encrypted-links</li>
    <li>nixops_unstablePlugins.nixops-encrypted-links.dist</li>
    <li>nixops_unstablePlugins.nixops-hercules-ci</li>
    <li>nixops_unstablePlugins.nixops-hercules-ci.dist</li>
    <li>nixops_unstablePlugins.nixops-vbox</li>
    <li>nixops_unstablePlugins.nixops-vbox.dist</li>
    <li>nixops_unstablePlugins.nixos-modules-contrib</li>
    <li>nixops_unstablePlugins.nixos-modules-contrib.dist</li>
    <li>nixops_unstable_minimal</li>
    <li>nixops_unstable_minimal.dist</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
