### PR TITLE
mpvScripts.*: Fix some unstableGitUpdater users

### DIFF
--- a/pkgs/applications/video/mpv/scripts/chapterskip.nix
+++ b/pkgs/applications/video/mpv/scripts/chapterskip.nix
@@ -6,7 +6,7 @@
 buildLua {
   pname = "chapterskip";
 
-  version = "unstable-2022-09-08";
+  version = "0-unstable-2022-09-08";
   src = fetchFromGitHub {
     owner = "po5";
     repo  = "chapterskip";

--- a/pkgs/applications/video/mpv/scripts/convert.nix
+++ b/pkgs/applications/video/mpv/scripts/convert.nix
@@ -10,7 +10,7 @@
 
 buildLua {
   pname = "mpv-convert-script";
-  version = "unstable-2015-07-02";
+  version = "0-unstable-2015-07-02";
   src = fetchgit {
     url = "https://gist.github.com/Zehkul/25ea7ae77b30af959be0";
     rev = "f95cee43e390e843a47e8ec9d1711a12a8cd343d";

--- a/pkgs/applications/video/mpv/scripts/cutter.nix
+++ b/pkgs/applications/video/mpv/scripts/cutter.nix
@@ -2,7 +2,7 @@
 
 buildLua {
   pname = "video-cutter";
-  version = "unstable-2023-11-09";
+  version = "0-unstable-2023-11-10";
 
   src = fetchFromGitHub {
     owner = "rushmj";

--- a/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
@@ -2,7 +2,7 @@
 
 buildLua rec {
   pname = "mpv-playlistmanager";
-  version = "unstable-2024-02-26";
+  version = "0-unstable-2024-02-26";
 
   src = fetchFromGitHub {
     owner = "jonniek";

--- a/pkgs/applications/video/mpv/scripts/mpv-webm.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-webm.nix
@@ -7,7 +7,7 @@
 
 buildLua {
   pname = "mpv-webm";
-  version = "unstable-2024-04-22";
+  version = "0-unstable-2024-04-22";
 
   src = fetchFromGitHub {
     owner = "ekisu";
@@ -15,7 +15,10 @@ buildLua {
     rev = "225e8e53842f7da6f77034309c1e54293dc629a4";
     hash = "sha256-82xWiuOChxfzX6e0+cGFxTqyuiPefyVwpvLM5ka7nPk=";
   };
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater {
+    # only "latest" tag pointing at HEAD
+    hardcodeZeroVersion = true;
+  };
 
   dontBuild = false;
   nativeBuildInputs = [ luaPackages.moonscript ];

--- a/pkgs/applications/video/mpv/scripts/occivink.nix
+++ b/pkgs/applications/video/mpv/scripts/occivink.nix
@@ -13,7 +13,7 @@ let
   mkScript = name: args:
     let self = rec {
       pname = camelToKebab name;
-      version = "unstable-2024-01-11";
+      version = "0-unstable-2024-01-11";
       src = fetchFromGitHub {
         owner = "occivink";
         repo = "mpv-scripts";

--- a/pkgs/applications/video/mpv/scripts/quack.nix
+++ b/pkgs/applications/video/mpv/scripts/quack.nix
@@ -6,7 +6,7 @@
 buildLua rec {
   pname = "mpv-quack";
 
-  version = "unstable-2020-05-26";
+  version = "0-unstable-2020-05-27";
   src = fetchFromGitHub {
     owner = "CounterPillow";
     repo  = pname;

--- a/pkgs/applications/video/mpv/scripts/reload.nix
+++ b/pkgs/applications/video/mpv/scripts/reload.nix
@@ -6,7 +6,7 @@
 buildLua rec {
   pname = "mpv-reload";
 
-  version = "unstable-2024-03-22";
+  version = "0-unstable-2024-03-22";
   src = fetchFromGitHub {
     owner = "4e6";
     repo  = pname;

--- a/pkgs/applications/video/mpv/scripts/sponsorblock-minimal.nix
+++ b/pkgs/applications/video/mpv/scripts/sponsorblock-minimal.nix
@@ -2,7 +2,7 @@
 
 buildLua {
   pname = "mpv_sponsorblock_minimal";
-  version = "unstable-2023-08-20";
+  version = "0-unstable-2023-08-20";
   scriptPath = "sponsorblock_minimal.lua";
 
   src = fetchFromGitea {

--- a/pkgs/applications/video/mpv/scripts/thumbfast.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbfast.nix
@@ -2,7 +2,7 @@
 
 buildLua {
   pname = "mpv-thumbfast";
-  version = "unstable-2023-12-08";
+  version = "0-unstable-2023-12-08";
 
   src = fetchFromGitHub {
     owner = "po5";

--- a/pkgs/applications/video/mpv/scripts/visualizer.nix
+++ b/pkgs/applications/video/mpv/scripts/visualizer.nix
@@ -6,7 +6,7 @@
 }:
 buildLua {
   pname = "visualizer";
-  version = "unstable-2024-03-10";
+  version = "0-unstable-2024-03-10";
 
   src = fetchFromGitHub {
     owner = "mfcc64";


### PR DESCRIPTION
## Description of changes

#280501 now makes `unstableGitUpdater` produce versions that match our desired unstable version schema. Start fixing the versions of packages that use it, and their `unstableGitUpdater` arguments as needed.

Tackling `mpvScripts` here. Checked running the update script of all the script, which results in the same version & revs as corrected here.

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>12 packages built:</summary>
  <ul>
    <li>mpvScripts.blacklistExtensions</li>
    <li>mpvScripts.chapterskip</li>
    <li>mpvScripts.convert</li>
    <li>mpvScripts.cutter</li>
    <li>mpvScripts.mpv-playlistmanager</li>
    <li>mpvScripts.mpv-webm</li>
    <li>mpvScripts.quack</li>
    <li>mpvScripts.reload</li>
    <li>mpvScripts.seekTo</li>
    <li>mpvScripts.sponsorblock-minimal</li>
    <li>mpvScripts.thumbfast</li>
    <li>mpvScripts.visualizer</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
