### PR TITLE
mpvScripts: comply with RFC166 formatting

### DIFF
--- a/.github/workflows/check-nix-format.yml
+++ b/.github/workflows/check-nix-format.yml
@@ -32,6 +32,7 @@ jobs:
         # Each environment variable beginning with NIX_FMT_PATHS_ is a list of
         # paths to check with nixfmt.
         env:
+          NIX_FMT_PATHS_MPVSCRIPTS: pkgs/applications/video/mpv/scripts
           # Format paths related to the Nixpkgs CUDA ecosystem.
           NIX_FMT_PATHS_CUDA: |
             pkgs/development/cuda-modules

--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -1,5 +1,4 @@
-{ lib
-, stdenvNoCC }:
+{ lib, stdenvNoCC }:
 
 let
   # Escape strings for embedding in shell scripts
@@ -10,74 +9,90 @@ let
   scriptsDir = "$out/share/mpv/scripts";
 
   # similar to `lib.extends`, but with inverted precedence and recursive update
-  extendedBy = args: orig: self:
-    let super = args self;
-    in lib.recursiveUpdate (orig super) super
-  ;
+  extendedBy =
+    args: orig: self:
+    let
+      super = args self;
+    in
+    lib.recursiveUpdate (orig super) super;
 in
 
-lib.makeOverridable (args: stdenvNoCC.mkDerivation (extendedBy
-  (if lib.isFunction args then args else (_: args)) (
-  { pname
-  , extraScripts ? []
-  , ... }@args:
-  let
-    strippedName = with builtins;
-      let groups = match "mpv[-_](.*)" pname; in
-      if groups != null
-      then head groups
-      else pname
-    ;
-    # either passthru.scriptName, inferred from scriptPath, or from pname
-    scriptName = (args.passthru or {}).scriptName or (
-      if args ? scriptPath
-      then fileName args.scriptPath
-      else "${strippedName}.lua"
-    );
-    scriptPath = args.scriptPath or "./${scriptName}";
-  in {
-    dontBuild = true;
-    preferLocalBuild = true;
+lib.makeOverridable (
+  args:
+  stdenvNoCC.mkDerivation (
+    extendedBy (if lib.isFunction args then args else (_: args)) (
+      {
+        pname,
+        extraScripts ? [ ],
+        ...
+      }@args:
+      let
+        strippedName =
+          with builtins;
+          let
+            groups = match "mpv[-_](.*)" pname;
+          in
+          if groups != null then head groups else pname;
+        # either passthru.scriptName, inferred from scriptPath, or from pname
+        scriptName =
+          (args.passthru or { }).scriptName
+            or (if args ? scriptPath then fileName args.scriptPath else "${strippedName}.lua");
+        scriptPath = args.scriptPath or "./${scriptName}";
+      in
+      {
+        dontBuild = true;
+        preferLocalBuild = true;
 
-    # Prevent `patch` from emitting `.orig` files (that end up in the output)
-    patchFlags = [ "--no-backup-if-mismatch" "-p1" ];
+        # Prevent `patch` from emitting `.orig` files (that end up in the output)
+        patchFlags = [
+          "--no-backup-if-mismatch"
+          "-p1"
+        ];
 
-    outputHashMode = "recursive";
-    installPhase = ''
-      runHook preInstall
+        outputHashMode = "recursive";
+        installPhase = ''
+          runHook preInstall
 
-      if [ -d "${scriptPath}" ]; then
-        [ -f "${scriptPath}/main.lua" ] || {
-          echo "Script directory '${scriptPath}' does not contain 'main.lua'" >&2
-          exit 1
-        }
-        [ ${with builtins; toString (length extraScripts)} -eq 0 ] || {
-          echo "mpvScripts.buildLua does not support 'extraScripts'" \
-               "when 'scriptPath' is a directory" >&2
-          exit 1
-        }
-        mkdir -p "${scriptsDir}"
-        cp -a "${scriptPath}" "${scriptsDir}/${scriptName}"
-      else
-        install -m644 -Dt "${scriptsDir}" ${escaped scriptPath}
-        ${lib.optionalString (extraScripts != []) ''cp -at "${scriptsDir}/" ${escapedList extraScripts}''}
-      fi
+          if [ -d "${scriptPath}" ]; then
+            [ -f "${scriptPath}/main.lua" ] || {
+              echo "Script directory '${scriptPath}' does not contain 'main.lua'" >&2
+              exit 1
+            }
+            [ ${with builtins; toString (length extraScripts)} -eq 0 ] || {
+              echo "mpvScripts.buildLua does not support 'extraScripts'" \
+                   "when 'scriptPath' is a directory" >&2
+              exit 1
+            }
+            mkdir -p "${scriptsDir}"
+            cp -a "${scriptPath}" "${scriptsDir}/${scriptName}"
+          else
+            install -m644 -Dt "${scriptsDir}" ${escaped scriptPath}
+            ${
+              lib.optionalString (extraScripts != [ ]) ''cp -at "${scriptsDir}/" ${escapedList extraScripts}''
+            }
+          fi
 
-      runHook postInstall
-    '';
+          runHook postInstall
+        '';
 
-    passthru = { inherit scriptName; };
-    meta = {
-      platforms = lib.platforms.all;
-    } // (
-      let pos =
-        if (args.meta or {}) ? description then
-          builtins.unsafeGetAttrPos "description" args.meta
-        else
-          builtins.unsafeGetAttrPos "pname" args;
-      in lib.optionalAttrs
-        (pos != null)
-        { position = "${pos.file}:${toString pos.line}"; }
-    );
-  })
-))
+        passthru = {
+          inherit scriptName;
+        };
+        meta =
+          {
+            platforms = lib.platforms.all;
+          }
+          // (
+            let
+              pos =
+                if (args.meta or { }) ? description then
+                  builtins.unsafeGetAttrPos "description" args.meta
+                else
+                  builtins.unsafeGetAttrPos "pname" args;
+            in
+            lib.optionalAttrs (pos != null) { position = "${pos.file}:${toString pos.line}"; }
+          );
+      }
+    )
+  )
+)

--- a/pkgs/applications/video/mpv/scripts/chapterskip.nix
+++ b/pkgs/applications/video/mpv/scripts/chapterskip.nix
@@ -1,7 +1,9 @@
-{ lib
-, fetchFromGitHub
-, unstableGitUpdater
-, buildLua }:
+{
+  lib,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  buildLua,
+}:
 
 buildLua {
   pname = "chapterskip";
@@ -9,20 +11,20 @@ buildLua {
   version = "0-unstable-2022-09-08";
   src = fetchFromGitHub {
     owner = "po5";
-    repo  = "chapterskip";
-    rev   = "b26825316e3329882206ae78dc903ebc4613f039";
-    hash  = "sha256-OTrLQE3rYvPQamEX23D6HttNjx3vafWdTMxTiWpDy90=";
+    repo = "chapterskip";
+    rev = "b26825316e3329882206ae78dc903ebc4613f039";
+    hash = "sha256-OTrLQE3rYvPQamEX23D6HttNjx3vafWdTMxTiWpDy90=";
   };
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "Automatically skips chapters based on title";
     longDescription = ''
-    MPV script that skips chapters based on their title, categorized using regexes.
-    The set of skipped categories can be configured globally, or by an auto-profile.
+      MPV script that skips chapters based on their title, categorized using regexes.
+      The set of skipped categories can be configured globally, or by an auto-profile.
     '';
     homepage = "https://github.com/po5/chapterskip";
-    license = lib.licenses.unfree;  # https://github.com/po5/chapterskip/issues/10
+    license = lib.licenses.unfree; # https://github.com/po5/chapterskip/issues/10
     maintainers = with lib.maintainers; [ nicoo ];
   };
 }

--- a/pkgs/applications/video/mpv/scripts/convert.nix
+++ b/pkgs/applications/video/mpv/scripts/convert.nix
@@ -1,11 +1,12 @@
-{ lib
-, fetchgit
-, unstableGitUpdater
+{
+  lib,
+  fetchgit,
+  unstableGitUpdater,
 
-, buildLua
-, libnotify
-, mkvtoolnix-cli
-, yad
+  buildLua,
+  libnotify,
+  mkvtoolnix-cli,
+  yad,
 }:
 
 buildLua {
@@ -16,7 +17,7 @@ buildLua {
     rev = "f95cee43e390e843a47e8ec9d1711a12a8cd343d";
     sha256 = "13m7l4sy2r8jv2sfrb3vvqvnim4a9ilnv28q5drlg09v298z3mck";
   };
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater { };
 
   patches = [ ./convert.patch ];
 

--- a/pkgs/applications/video/mpv/scripts/cutter.nix
+++ b/pkgs/applications/video/mpv/scripts/cutter.nix
@@ -1,4 +1,10 @@
-{ lib, buildLua, fetchFromGitHub, makeWrapper, unstableGitUpdater }:
+{
+  lib,
+  buildLua,
+  fetchFromGitHub,
+  makeWrapper,
+  unstableGitUpdater,
+}:
 
 buildLua {
   pname = "video-cutter";
@@ -10,7 +16,7 @@ buildLua {
     rev = "01a0396c075d5f8bbd1de5b571e6231f8899ab65";
     sha256 = "sha256-veoRFzUCRH8TrvR7x+WWoycpDyxqrJZ/bnp61dVc0pE=";
   };
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater { };
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -1,111 +1,145 @@
-{ lib
-, config
-, newScope
-, runCommand
+{
+  lib,
+  config,
+  newScope,
+  runCommand,
 }:
 
 let
-  unionOfDisjoints = lib.fold lib.attrsets.unionOfDisjoint {};
+  unionOfDisjoints = lib.fold lib.attrsets.unionOfDisjoint { };
 
-  addTests = name: drv:
-    if ! lib.isDerivation drv then
+  addTests =
+    name: drv:
+    if !lib.isDerivation drv then
       drv
-    else let
-      inherit (drv) scriptName;
-      scriptPath = "share/mpv/scripts/${scriptName}";
-      fullScriptPath = "${drv}/${scriptPath}";
-    in drv.overrideAttrs (old: { passthru = (old.passthru or {}) // { tests = unionOfDisjoints [
-      (old.passthru.tests or {})
+    else
+      let
+        inherit (drv) scriptName;
+        scriptPath = "share/mpv/scripts/${scriptName}";
+        fullScriptPath = "${drv}/${scriptPath}";
+      in
+      drv.overrideAttrs (old: {
+        passthru = (old.passthru or { }) // {
+          tests = unionOfDisjoints [
+            (old.passthru.tests or { })
 
-      {
-        scriptName-is-valid = runCommand "mpvScripts.${name}.passthru.tests.scriptName-is-valid" {
-          meta.maintainers = with lib.maintainers; [ nicoo ];
-          preferLocalBuild = true;
-        } ''
-          if [ -e "${fullScriptPath}" ]; then
-            touch $out
-          else
-            echo "mpvScripts.\"${name}\" does not contain a script named \"${scriptName}\"" >&2
-            exit 1
-          fi
-        '';
-      }
+            {
+              scriptName-is-valid =
+                runCommand "mpvScripts.${name}.passthru.tests.scriptName-is-valid"
+                  {
+                    meta.maintainers = with lib.maintainers; [ nicoo ];
+                    preferLocalBuild = true;
+                  }
+                  ''
+                    if [ -e "${fullScriptPath}" ]; then
+                      touch $out
+                    else
+                      echo "mpvScripts.\"${name}\" does not contain a script named \"${scriptName}\"" >&2
+                      exit 1
+                    fi
+                  '';
+            }
 
-      # can't check whether `fullScriptPath` is a directory, in pure-evaluation mode
-      (with lib; optionalAttrs (! any (s: hasSuffix s drv.passthru.scriptName) [ ".js" ".lua" ".so" ]) {
-        single-main-in-script-dir = runCommand "mpvScripts.${name}.passthru.tests.single-main-in-script-dir" {
-          meta.maintainers = with lib.maintainers; [ nicoo ];
-          preferLocalBuild = true;
-        } ''
-          die() {
-            echo "$@" >&2
-            exit 1
-          }
+            # can't check whether `fullScriptPath` is a directory, in pure-evaluation mode
+            (
+              with lib;
+              optionalAttrs
+                (
+                  !any (s: hasSuffix s drv.passthru.scriptName) [
+                    ".js"
+                    ".lua"
+                    ".so"
+                  ]
+                )
+                {
+                  single-main-in-script-dir =
+                    runCommand "mpvScripts.${name}.passthru.tests.single-main-in-script-dir"
+                      {
+                        meta.maintainers = with lib.maintainers; [ nicoo ];
+                        preferLocalBuild = true;
+                      }
+                      ''
+                        die() {
+                          echo "$@" >&2
+                          exit 1
+                        }
 
-          cd "${drv}/${scriptPath}"  # so the glob expands to filenames only
-          mains=( main.* )
-          if [ "''${#mains[*]}" -eq 1 ]; then
-            touch $out
-          elif [ "''${#mains[*]}" -eq 0 ]; then
-            die "'${scriptPath}' contains no 'main.*' file"
-          else
-            die "'${scriptPath}' contains multiple 'main.*' files:" "''${mains[*]}"
-          fi
-        '';
-      })
-    ]; }; });
+                        cd "${drv}/${scriptPath}"  # so the glob expands to filenames only
+                        mains=( main.* )
+                        if [ "''${#mains[*]}" -eq 1 ]; then
+                          touch $out
+                        elif [ "''${#mains[*]}" -eq 0 ]; then
+                          die "'${scriptPath}' contains no 'main.*' file"
+                        else
+                          die "'${scriptPath}' contains multiple 'main.*' files:" "''${mains[*]}"
+                        fi
+                      '';
+                }
+            )
+          ];
+        };
+      });
 
-  scope = self: let
-    inherit (self) callPackage;
-  in lib.mapAttrs addTests {
-    inherit (callPackage ./mpv.nix { })
-      acompressor autocrop autodeint autoload;
-    inherit (callPackage ./occivink.nix { })
-      blacklistExtensions seekTo;
+  scope =
+    self:
+    let
+      inherit (self) callPackage;
+    in
+    lib.mapAttrs addTests {
+      inherit (callPackage ./mpv.nix { })
+        acompressor
+        autocrop
+        autodeint
+        autoload
+        ;
+      inherit (callPackage ./occivink.nix { }) blacklistExtensions seekTo;
 
-    buildLua = callPackage ./buildLua.nix { };
-    chapterskip = callPackage ./chapterskip.nix { };
-    convert = callPackage ./convert.nix { };
-    cutter = callPackage ./cutter.nix { };
-    dynamic-crop = callPackage ./dynamic-crop.nix { };
-    inhibit-gnome = callPackage ./inhibit-gnome.nix { };
-    memo = callPackage ./memo.nix { };
-    manga-reader = callPackage ./manga-reader.nix { };
-    modernx = callPackage ./modernx.nix { };
-    modernx-zydezu = callPackage ./modernx-zydezu.nix { };
-    mpris = callPackage ./mpris.nix { };
-    mpv-cheatsheet = callPackage ./mpv-cheatsheet.nix { };
-    mpv-notify-send = callPackage ./mpv-notify-send.nix { };
-    mpv-osc-modern = callPackage ./mpv-osc-modern.nix { };
-    mpv-playlistmanager = callPackage ./mpv-playlistmanager.nix { };
-    mpv-slicing = callPackage ./mpv-slicing.nix { };
-    mpv-webm = callPackage ./mpv-webm.nix { };
-    mpvacious = callPackage ./mpvacious.nix { };
-    quack = callPackage ./quack.nix { };
-    quality-menu = callPackage ./quality-menu.nix { };
-    reload = callPackage ./reload.nix { };
-    simple-mpv-webui = callPackage ./simple-mpv-webui.nix { };
-    sponsorblock = callPackage ./sponsorblock.nix { };
-    sponsorblock-minimal = callPackage ./sponsorblock-minimal.nix { };
-    thumbfast = callPackage ./thumbfast.nix { };
-    thumbnail = callPackage ./thumbnail.nix { };
-    uosc = callPackage ./uosc.nix { };
-    videoclip = callPackage ./videoclip.nix { };
-    visualizer = callPackage ./visualizer.nix { };
-    vr-reversal = callPackage ./vr-reversal.nix { };
-    webtorrent-mpv-hook = callPackage ./webtorrent-mpv-hook.nix { };
-    youtube-upnext = callPackage ./youtube-upnext.nix { };
-  };
+      buildLua = callPackage ./buildLua.nix { };
+      chapterskip = callPackage ./chapterskip.nix { };
+      convert = callPackage ./convert.nix { };
+      cutter = callPackage ./cutter.nix { };
+      dynamic-crop = callPackage ./dynamic-crop.nix { };
+      inhibit-gnome = callPackage ./inhibit-gnome.nix { };
+      memo = callPackage ./memo.nix { };
+      manga-reader = callPackage ./manga-reader.nix { };
+      modernx = callPackage ./modernx.nix { };
+      modernx-zydezu = callPackage ./modernx-zydezu.nix { };
+      mpris = callPackage ./mpris.nix { };
+      mpv-cheatsheet = callPackage ./mpv-cheatsheet.nix { };
+      mpv-notify-send = callPackage ./mpv-notify-send.nix { };
+      mpv-osc-modern = callPackage ./mpv-osc-modern.nix { };
+      mpv-playlistmanager = callPackage ./mpv-playlistmanager.nix { };
+      mpv-slicing = callPackage ./mpv-slicing.nix { };
+      mpv-webm = callPackage ./mpv-webm.nix { };
+      mpvacious = callPackage ./mpvacious.nix { };
+      quack = callPackage ./quack.nix { };
+      quality-menu = callPackage ./quality-menu.nix { };
+      reload = callPackage ./reload.nix { };
+      simple-mpv-webui = callPackage ./simple-mpv-webui.nix { };
+      sponsorblock = callPackage ./sponsorblock.nix { };
+      sponsorblock-minimal = callPackage ./sponsorblock-minimal.nix { };
+      thumbfast = callPackage ./thumbfast.nix { };
+      thumbnail = callPackage ./thumbnail.nix { };
+      uosc = callPackage ./uosc.nix { };
+      videoclip = callPackage ./videoclip.nix { };
+      visualizer = callPackage ./visualizer.nix { };
+      vr-reversal = callPackage ./vr-reversal.nix { };
+      webtorrent-mpv-hook = callPackage ./webtorrent-mpv-hook.nix { };
+      youtube-upnext = callPackage ./youtube-upnext.nix { };
+    };
 
   aliases = {
     youtube-quality = throw "'youtube-quality' is no longer maintained, use 'quality-menu' instead"; # added 2023-07-14
   };
 in
 
-with lib; pipe scope [
+with lib;
+pipe scope [
   (makeScope newScope)
-  (self:
-    assert builtins.intersectAttrs self aliases == {};
-    self // optionalAttrs config.allowAliases aliases)
+  (
+    self:
+    assert builtins.intersectAttrs self aliases == { };
+    self // optionalAttrs config.allowAliases aliases
+  )
   recurseIntoAttrs
 ]

--- a/pkgs/applications/video/mpv/scripts/dynamic-crop.nix
+++ b/pkgs/applications/video/mpv/scripts/dynamic-crop.nix
@@ -1,7 +1,8 @@
-{ lib
-, fetchFromGitHub
-, unstableGitUpdater
-, buildLua
+{
+  lib,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  buildLua,
 }:
 buildLua {
   pname = "dynamic-crop";

--- a/pkgs/applications/video/mpv/scripts/inhibit-gnome.nix
+++ b/pkgs/applications/video/mpv/scripts/inhibit-gnome.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, fetchFromGitHub, gitUpdater, pkg-config, dbus, mpv-unwrapped }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  pkg-config,
+  dbus,
+  mpv-unwrapped,
+}:
 
 stdenv.mkDerivation rec {
   pname = "mpv-inhibit-gnome";
@@ -10,13 +18,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-LSGg5gAQE2JpepBqhz6D6d3NlqYaU4bjvYf1F+oLphQ=";
   };
-  passthru.updateScript = gitUpdater {
-    rev-prefix = "v";
-  };
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ dbus mpv-unwrapped ];
+  buildInputs = [
+    dbus
+    mpv-unwrapped
+  ];
 
   passthru.scriptName = "mpv_inhibit_gnome.so";
 

--- a/pkgs/applications/video/mpv/scripts/memo.nix
+++ b/pkgs/applications/video/mpv/scripts/memo.nix
@@ -1,7 +1,8 @@
-{ fetchFromGitHub
-, buildLua
-, lib
-, unstableGitUpdater
+{
+  fetchFromGitHub,
+  buildLua,
+  lib,
+  unstableGitUpdater,
 }:
 
 buildLua {
@@ -15,7 +16,7 @@ buildLua {
     hash = "sha256-m8ikXuw7PM4Btg8w7ufLneKA4fnYjMyfVJYueZILMw8=";
   };
 
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = with lib; {
     description = "A recent files menu for mpv";

--- a/pkgs/applications/video/mpv/scripts/modernx-zydezu.nix
+++ b/pkgs/applications/video/mpv/scripts/modernx-zydezu.nix
@@ -1,8 +1,9 @@
-{ lib
-, buildLua
-, fetchFromGitHub
-, makeFontsConf
-, nix-update-script
+{
+  lib,
+  buildLua,
+  fetchFromGitHub,
+  makeFontsConf,
+  nix-update-script,
 }:
 buildLua (finalAttrs: {
   pname = "modernx-zydezu";

--- a/pkgs/applications/video/mpv/scripts/modernx.nix
+++ b/pkgs/applications/video/mpv/scripts/modernx.nix
@@ -1,8 +1,9 @@
-{ lib
-, buildLua
-, fetchFromGitHub
-, makeFontsConf
-, nix-update-script
+{
+  lib,
+  buildLua,
+  fetchFromGitHub,
+  makeFontsConf,
+  nix-update-script,
 }:
 buildLua (finalAttrs: {
   pname = "modernx";

--- a/pkgs/applications/video/mpv/scripts/mpris.nix
+++ b/pkgs/applications/video/mpv/scripts/mpris.nix
@@ -1,4 +1,13 @@
-{ lib, stdenv, fetchFromGitHub, gitUpdater, pkg-config, glib, mpv-unwrapped, ffmpeg }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  pkg-config,
+  glib,
+  mpv-unwrapped,
+  ffmpeg,
+}:
 
 stdenv.mkDerivation rec {
   pname = "mpv-mpris";
@@ -10,11 +19,15 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-vZIO6ILatIWa9nJYOp4AMKwvaZLahqYWRLMDOizyBI0=";
   };
-  passthru.updateScript = gitUpdater {};
+  passthru.updateScript = gitUpdater { };
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ glib mpv-unwrapped ffmpeg ];
+  buildInputs = [
+    glib
+    mpv-unwrapped
+    ffmpeg
+  ];
 
   postPatch = ''
     substituteInPlace Makefile --replace-fail 'PKG_CONFIG =' 'PKG_CONFIG ?='

--- a/pkgs/applications/video/mpv/scripts/mpv-cheatsheet.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-cheatsheet.nix
@@ -1,8 +1,9 @@
-{ lib
-, fetchFromGitHub
-, gitUpdater
-, nodePackages
-, stdenvNoCC
+{
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  nodePackages,
+  stdenvNoCC,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mpv-cheatsheet";
@@ -16,9 +17,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   };
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
-  nativeBuildInputs = [
-    nodePackages.browserify
-  ];
+  nativeBuildInputs = [ nodePackages.browserify ];
 
   buildPhase = ''
     runHook preBuild
@@ -35,7 +34,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
-
 
   passthru.scriptName = "cheatsheet.js";
 

--- a/pkgs/applications/video/mpv/scripts/mpv-notify-send.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-notify-send.nix
@@ -1,9 +1,11 @@
-{ lib
-, buildLua
-, fetchFromGitHub
-, fetchpatch
-, unstableGitUpdater
-, libnotify }:
+{
+  lib,
+  buildLua,
+  fetchFromGitHub,
+  fetchpatch,
+  unstableGitUpdater,
+  libnotify,
+}:
 
 buildLua rec {
   pname = "mpv-notify-send";
@@ -25,7 +27,10 @@ buildLua rec {
   ];
 
   passthru.extraWrapperArgs = [
-    "--prefix" "PATH" ":" (lib.makeBinPath libnotify)
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath libnotify)
   ];
 
   passthru.updateScript = unstableGitUpdater { };

--- a/pkgs/applications/video/mpv/scripts/mpv-osc-modern.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-osc-modern.nix
@@ -1,8 +1,9 @@
-{ lib
-, buildLua
-, fetchFromGitHub
-, makeFontsConf
-, nix-update-script
+{
+  lib,
+  buildLua,
+  fetchFromGitHub,
+  makeFontsConf,
+  nix-update-script,
 }:
 buildLua (finalAttrs: {
   pname = "mpv-osc-modern";

--- a/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
@@ -1,4 +1,10 @@
-{ lib, buildLua, fetchFromGitHub, unstableGitUpdater, yt-dlp }:
+{
+  lib,
+  buildLua,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  yt-dlp,
+}:
 
 buildLua rec {
   pname = "mpv-playlistmanager";
@@ -10,7 +16,7 @@ buildLua rec {
     rev = "1911dc053951169c98cfcfd9f44ef87d9122ca80";
     hash = "sha256-pcdOMhkivLF5B86aNuHrqj77DuYLAFGlwFwY7jxkDkE=";
   };
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater { };
 
   postPatch = ''
     substituteInPlace playlistmanager.lua \

--- a/pkgs/applications/video/mpv/scripts/mpv-webm.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-webm.nix
@@ -1,8 +1,9 @@
-{ lib
-, buildLua
-, fetchFromGitHub
-, luaPackages
-, unstableGitUpdater
+{
+  lib,
+  buildLua,
+  fetchFromGitHub,
+  luaPackages,
+  unstableGitUpdater,
 }:
 
 buildLua {

--- a/pkgs/applications/video/mpv/scripts/mpv.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv.nix
@@ -1,24 +1,31 @@
-{ lib
-, buildLua
-, mpv-unwrapped
+{
+  lib,
+  buildLua,
+  mpv-unwrapped,
 }:
 
-let mkBuiltin = name: args:
-  let srcPath = "TOOLS/lua/${name}.lua";
-  in buildLua (lib.attrsets.recursiveUpdate rec {
-    inherit (mpv-unwrapped) src version;
-    pname = "mpv-${name}";
+let
+  mkBuiltin =
+    name: args:
+    let
+      srcPath = "TOOLS/lua/${name}.lua";
+    in
+    buildLua (
+      lib.attrsets.recursiveUpdate rec {
+        inherit (mpv-unwrapped) src version;
+        pname = "mpv-${name}";
 
-    dontUnpack = true;
-    scriptPath = "${src}/${srcPath}";
+        dontUnpack = true;
+        scriptPath = "${src}/${srcPath}";
 
-    meta = with lib; {
-      inherit (mpv-unwrapped.meta) license;
-      homepage = "https://github.com/mpv-player/mpv/blob/v${version}/${srcPath}";
-    };
-  } args);
-
-in lib.mapAttrs (name: lib.makeOverridable (mkBuiltin name)) {
+        meta = with lib; {
+          inherit (mpv-unwrapped.meta) license;
+          homepage = "https://github.com/mpv-player/mpv/blob/v${version}/${srcPath}";
+        };
+      } args
+    );
+in
+lib.mapAttrs (name: lib.makeOverridable (mkBuiltin name)) {
   acompressor.meta = {
     description = "Script to toggle and control ffmpeg's dynamic range compression filter.";
     maintainers = with lib.maintainers; [ nicoo ];

--- a/pkgs/applications/video/mpv/scripts/mpvacious.nix
+++ b/pkgs/applications/video/mpv/scripts/mpvacious.nix
@@ -1,10 +1,11 @@
-{ lib
-, buildLua
-, fetchFromGitHub
-, gitUpdater
-, curl
-, wl-clipboard
-, xclip
+{
+  lib,
+  buildLua,
+  fetchFromGitHub,
+  gitUpdater,
+  curl,
+  wl-clipboard,
+  xclip,
 }:
 
 buildLua rec {
@@ -17,9 +18,7 @@ buildLua rec {
     rev = "v${version}";
     sha256 = "sha256-VHMXW2AzgX88EDnNshxo9Gh8mpXzRoTAq+58HKasUdo=";
   };
-  passthru.updateScript = gitUpdater {
-    rev-prefix = "v";
-  };
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   postPatch = ''
     substituteInPlace utils/forvo.lua \

--- a/pkgs/applications/video/mpv/scripts/occivink.nix
+++ b/pkgs/applications/video/mpv/scripts/occivink.nix
@@ -1,45 +1,49 @@
-{ lib
-, fetchFromGitHub
-, unstableGitUpdater
-, buildLua
+{
+  lib,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  buildLua,
 }:
 
 let
-  camelToKebab = let
-    inherit (lib.strings) match stringAsChars toLower;
-    isUpper = match "[A-Z]";
-  in stringAsChars (c: if isUpper c != null then "-${toLower c}" else c);
+  camelToKebab =
+    let
+      inherit (lib.strings) match stringAsChars toLower;
+      isUpper = match "[A-Z]";
+    in
+    stringAsChars (c: if isUpper c != null then "-${toLower c}" else c);
 
-  mkScript = name: args:
-    let self = rec {
-      pname = camelToKebab name;
-      version = "0-unstable-2024-01-11";
-      src = fetchFromGitHub {
-        owner = "occivink";
-        repo = "mpv-scripts";
-        rev = "d0390c8e802c2e888ff4a2e1d5e4fb040f855b89";
-        hash = "sha256-pc2aaO7lZaoYMEXv5M0WI7PtmqgkNbdtNiLZZwVzppM=";
+  mkScript =
+    name: args:
+    let
+      self = rec {
+        pname = camelToKebab name;
+        version = "0-unstable-2024-01-11";
+        src = fetchFromGitHub {
+          owner = "occivink";
+          repo = "mpv-scripts";
+          rev = "d0390c8e802c2e888ff4a2e1d5e4fb040f855b89";
+          hash = "sha256-pc2aaO7lZaoYMEXv5M0WI7PtmqgkNbdtNiLZZwVzppM=";
+        };
+        passthru.updateScript = unstableGitUpdater { };
+
+        scriptPath = "scripts/${pname}.lua";
+
+        meta = with lib; {
+          homepage = "https://github.com/occivink/mpv-scripts";
+          license = licenses.unlicense;
+          maintainers = with maintainers; [ nicoo ];
+        };
+
+        # Sadly needed to make `common-updaters` work here
+        pos = builtins.unsafeGetAttrPos "version" self;
       };
-      passthru.updateScript = unstableGitUpdater {};
-
-      scriptPath = "scripts/${pname}.lua";
-
-      meta = with lib; {
-        homepage = "https://github.com/occivink/mpv-scripts";
-        license = licenses.unlicense;
-        maintainers = with maintainers; [ nicoo ];
-      };
-
-      # Sadly needed to make `common-updaters` work here
-      pos = builtins.unsafeGetAttrPos "version" self;
-    };
-    in buildLua (lib.attrsets.recursiveUpdate self args);
-
+    in
+    buildLua (lib.attrsets.recursiveUpdate self args);
 in
 lib.mapAttrs (name: lib.makeOverridable (mkScript name)) {
 
   # Usage: `pkgs.mpv.override { scripts = [ pkgs.mpvScripts.seekTo ]; }`
   seekTo.meta.description = "Mpv script for seeking to a specific position";
-  blacklistExtensions.meta.description =
-    "Automatically remove playlist entries based on their extension.";
+  blacklistExtensions.meta.description = "Automatically remove playlist entries based on their extension.";
 }

--- a/pkgs/applications/video/mpv/scripts/quack.nix
+++ b/pkgs/applications/video/mpv/scripts/quack.nix
@@ -1,7 +1,9 @@
-{ lib
-, fetchFromGitHub
-, unstableGitUpdater
-, buildLua }:
+{
+  lib,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  buildLua,
+}:
 
 buildLua rec {
   pname = "mpv-quack";
@@ -9,11 +11,11 @@ buildLua rec {
   version = "0-unstable-2020-05-27";
   src = fetchFromGitHub {
     owner = "CounterPillow";
-    repo  = "mpv-quack";
-    rev   = "1c87f36f9726d462dd112188c04be54d85692cf3";
-    hash  = "sha256-dEnJbS8RJoAxpKINdoMHN4l7vpEdf7+C5JVWpK0VXMw=";
+    repo = "mpv-quack";
+    rev = "1c87f36f9726d462dd112188c04be54d85692cf3";
+    hash = "sha256-dEnJbS8RJoAxpKINdoMHN4l7vpEdf7+C5JVWpK0VXMw=";
   };
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "Reduce audio volume after seeking";

--- a/pkgs/applications/video/mpv/scripts/quality-menu.nix
+++ b/pkgs/applications/video/mpv/scripts/quality-menu.nix
@@ -1,8 +1,9 @@
-{ lib
-, buildLua
-, fetchFromGitHub
-, gitUpdater
-, oscSupport ? false
+{
+  lib,
+  buildLua,
+  fetchFromGitHub,
+  gitUpdater,
+  oscSupport ? false,
 }:
 
 buildLua rec {
@@ -15,9 +16,7 @@ buildLua rec {
     rev = "v${version}";
     hash = "sha256-yrcTxqpLnOI1Tq3khhflO3wzhyeTPuvKifyH5/P57Ns=";
   };
-  passthru.updateScript = gitUpdater {
-    rev-prefix = "v";
-  };
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   extraScripts = lib.optional oscSupport "quality-menu-osc.lua";
 

--- a/pkgs/applications/video/mpv/scripts/reload.nix
+++ b/pkgs/applications/video/mpv/scripts/reload.nix
@@ -1,7 +1,9 @@
-{ lib
-, fetchFromGitHub
-, unstableGitUpdater
-, buildLua }:
+{
+  lib,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  buildLua,
+}:
 
 buildLua rec {
   pname = "mpv-reload";
@@ -9,11 +11,11 @@ buildLua rec {
   version = "0-unstable-2024-03-22";
   src = fetchFromGitHub {
     owner = "4e6";
-    repo  = pname;
-    rev   = "1a6a9383ba1774708fddbd976e7a9b72c3eec938";
-    hash  = "sha256-BshxCjec/UNGyiC0/g1Rai2NvG2qOIHXDDEUYwwdij0=";
+    repo = pname;
+    rev = "1a6a9383ba1774708fddbd976e7a9b72c3eec938";
+    hash = "sha256-BshxCjec/UNGyiC0/g1Rai2NvG2qOIHXDDEUYwwdij0=";
   };
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "Manual & automatic reloading of videos";

--- a/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
+++ b/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
@@ -1,6 +1,8 @@
-{ lib, buildLua
-, fetchFromGitHub
-, gitUpdater
+{
+  lib,
+  buildLua,
+  fetchFromGitHub,
+  gitUpdater,
 }:
 buildLua rec {
   pname = "simple-mpv-ui";
@@ -11,11 +13,12 @@ buildLua rec {
     repo = "simple-mpv-webui";
     rev = "v${version}";
     hash = "sha256-I8lwpo3Hfpy3UnPMmHEJCdArVQnNL245NkxsYVmnMF0=";
-    sparseCheckout = [ "main.lua" "webui-page" ];
+    sparseCheckout = [
+      "main.lua"
+      "webui-page"
+    ];
   };
-  passthru.updateScript = gitUpdater {
-    rev-prefix = "v";
-  };
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   scriptPath = ".";
   passthru.scriptName = "webui";
@@ -23,7 +26,10 @@ buildLua rec {
   meta = with lib; {
     description = "A web based user interface with controls for the mpv mediaplayer";
     homepage = "https://github.com/open-dynaMIX/simple-mpv-webui";
-    maintainers = with maintainers; [ cript0nauta zopieux ];
+    maintainers = with maintainers; [
+      cript0nauta
+      zopieux
+    ];
     longDescription = ''
       You can access the webui when accessing http://127.0.0.1:8080 or
       http://[::1]:8080 in your webbrowser. By default it listens on

--- a/pkgs/applications/video/mpv/scripts/sponsorblock-minimal.nix
+++ b/pkgs/applications/video/mpv/scripts/sponsorblock-minimal.nix
@@ -1,4 +1,11 @@
-{ lib, buildLua, fetchFromGitea, unstableGitUpdater, curl, coreutils }:
+{
+  lib,
+  buildLua,
+  fetchFromGitea,
+  unstableGitUpdater,
+  curl,
+  coreutils,
+}:
 
 buildLua {
   pname = "mpv_sponsorblock_minimal";
@@ -21,8 +28,7 @@ buildLua {
   '';
 
   meta = with lib; {
-    description =
-      "A minimal script to skip sponsored segments of YouTube videos";
+    description = "A minimal script to skip sponsored segments of YouTube videos";
     homepage = "https://codeberg.org/jouni/mpv_sponsorblock_minimal";
     license = licenses.gpl3Only;
     platforms = platforms.all;

--- a/pkgs/applications/video/mpv/scripts/sponsorblock.nix
+++ b/pkgs/applications/video/mpv/scripts/sponsorblock.nix
@@ -1,4 +1,11 @@
-{ lib, buildLua, fetchFromGitHub, fetchpatch, python3, nix-update-script }:
+{
+  lib,
+  buildLua,
+  fetchFromGitHub,
+  fetchpatch,
+  python3,
+  nix-update-script,
+}:
 
 # Usage: `pkgs.mpv.override { scripts = [ pkgs.mpvScripts.sponsorblock ]; }`
 buildLua {
@@ -34,9 +41,7 @@ buildLua {
 
   extraScripts = [ "sponsorblock_shared" ];
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [ "--version=branch" ];
-  };
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = with lib; {
     description = "Script for mpv to skip sponsored segments of YouTube videos";

--- a/pkgs/applications/video/mpv/scripts/thumbfast.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbfast.nix
@@ -1,4 +1,10 @@
-{ lib, fetchFromGitHub, unstableGitUpdater, buildLua, mpv-unwrapped }:
+{
+  lib,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  buildLua,
+  mpv-unwrapped,
+}:
 
 buildLua {
   pname = "mpv-thumbfast";
@@ -10,10 +16,13 @@ buildLua {
     rev = "03e93feee5a85bf7c65db953ada41b4826e9f905";
     hash = "sha256-5u5WBvWOEydJrnr/vilEgW4+fxkxM6wNjb9Fyyxx/1c=";
   };
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater { };
 
   passthru.extraWrapperArgs = [
-    "--prefix" "PATH" ":" (lib.makeBinPath [ mpv-unwrapped ])
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [ mpv-unwrapped ])
   ];
 
   meta = {

--- a/pkgs/applications/video/mpv/scripts/thumbnail.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbnail.nix
@@ -1,4 +1,10 @@
-{ lib, buildLua, fetchFromGitHub, gitUpdater, python3 }:
+{
+  lib,
+  buildLua,
+  fetchFromGitHub,
+  gitUpdater,
+  python3,
+}:
 
 buildLua rec {
   pname = "mpv-thumbnail-script";
@@ -10,7 +16,7 @@ buildLua rec {
     rev = version;
     sha256 = "sha256-J24Rou7BTE7zoiPlBkWuO9dtYJiuzkuwB4FROuzXzag=";
   };
-  passthru.updateScript = gitUpdater {};
+  passthru.updateScript = gitUpdater { };
 
   nativeBuildInputs = [ python3 ];
   postPatch = "patchShebangs concat_files.py";

--- a/pkgs/applications/video/mpv/scripts/uosc.nix
+++ b/pkgs/applications/video/mpv/scripts/uosc.nix
@@ -1,10 +1,11 @@
-{ lib
-, fetchFromGitHub
-, fetchpatch
-, gitUpdater
-, makeFontsConf
-, buildLua
-, buildGoModule
+{
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  gitUpdater,
+  makeFontsConf,
+  buildLua,
+  buildGoModule,
 }:
 
 buildLua (finalAttrs: {
@@ -18,7 +19,7 @@ buildLua (finalAttrs: {
     rev = finalAttrs.version;
     hash = "sha256-0GPDna9uOuhFDhA9A1fbkoKkgSB76qiDzJVQ9gjGcWo=";
   };
-  passthru.updateScript = gitUpdater {};
+  passthru.updateScript = gitUpdater { };
 
   tools = buildGoModule {
     pname = "uosc-bin";

--- a/pkgs/applications/video/mpv/scripts/videoclip.nix
+++ b/pkgs/applications/video/mpv/scripts/videoclip.nix
@@ -1,11 +1,12 @@
-{ lib
-, fetchFromGitHub
-, curl
-, xclip
-, wl-clipboard
-, stdenv
-, buildLua
-, unstableGitUpdater
+{
+  lib,
+  fetchFromGitHub,
+  curl,
+  xclip,
+  wl-clipboard,
+  stdenv,
+  buildLua,
+  unstableGitUpdater,
 }:
 buildLua {
   pname = "videoclip";
@@ -18,13 +19,15 @@ buildLua {
     hash = "sha256-Sg6LHU9OVmVx3cTs8Y0WL8wACb5BlVyeBRccoX+7BXY=";
   };
 
-  patchPhase = ''
-    substituteInPlace platform.lua \
-    --replace \'curl\' \'${lib.getExe curl}\' \
-  '' + lib.optionalString stdenv.isLinux ''
-    --replace xclip ${lib.getExe xclip} \
-    --replace wl-copy ${lib.getExe' wl-clipboard "wl-copy"}
-  '';
+  patchPhase =
+    ''
+      substituteInPlace platform.lua \
+      --replace \'curl\' \'${lib.getExe curl}\' \
+    ''
+    + lib.optionalString stdenv.isLinux ''
+      --replace xclip ${lib.getExe xclip} \
+      --replace wl-copy ${lib.getExe' wl-clipboard "wl-copy"}
+    '';
 
   scriptPath = ".";
   passthru.scriptName = "videoclip";

--- a/pkgs/applications/video/mpv/scripts/visualizer.nix
+++ b/pkgs/applications/video/mpv/scripts/visualizer.nix
@@ -14,11 +14,11 @@ buildLua {
     rev = "b4246984ba6dc6820adef5c8bbf793af85c9ab8e";
     sha256 = "ZNUzw4OW7z+yGTxim7CCWJdWmihDFOQAQk3bC5Ijcbs=";
   };
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = with lib; {
     description = "various audio visualization";
     homepage = "https://github.com/mfcc64/mpv-scripts";
-    maintainers = with maintainers; [kmein];
+    maintainers = with maintainers; [ kmein ];
   };
 }

--- a/pkgs/applications/video/mpv/scripts/vr-reversal.nix
+++ b/pkgs/applications/video/mpv/scripts/vr-reversal.nix
@@ -1,4 +1,10 @@
-{ lib, stdenvNoCC, fetchFromGitHub, gitUpdater, ffmpeg }:
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  gitUpdater,
+  ffmpeg,
+}:
 
 stdenvNoCC.mkDerivation rec {
   pname = "vr-reversal";
@@ -10,9 +16,7 @@ stdenvNoCC.mkDerivation rec {
     rev = "v${version}";
     sha256 = "1wn2ngcvn7wcsl3kmj782x5q9130qw951lj6ilrkafp6q6zscpqr";
   };
-  passthru.updateScript = gitUpdater {
-    rev-prefix = "v";
-  };
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   dontBuild = true;
 

--- a/pkgs/applications/video/mpv/scripts/webtorrent-mpv-hook.nix
+++ b/pkgs/applications/video/mpv/scripts/webtorrent-mpv-hook.nix
@@ -1,4 +1,11 @@
-{ lib, buildNpmPackage, fetchFromGitHub, gitUpdater, nodejs, python3 }:
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  gitUpdater,
+  nodejs,
+  python3,
+}:
 
 buildNpmPackage rec {
   pname = "webtorrent-mpv-hook";
@@ -10,9 +17,7 @@ buildNpmPackage rec {
     rev = "v${version}";
     hash = "sha256-/dMtXcIyfAs++Zgz2CxRW0tkzn5QjS+WVGChlCyrU0U=";
   };
-  passthru.updateScript = gitUpdater {
-    rev-prefix = "v";
-  };
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   postPatch = ''
     substituteInPlace src/webtorrent.ts --replace-fail "node_path: 'node'" "node_path: '${lib.getExe nodejs}'"

--- a/pkgs/applications/video/mpv/scripts/youtube-upnext.nix
+++ b/pkgs/applications/video/mpv/scripts/youtube-upnext.nix
@@ -1,4 +1,10 @@
-{ buildLua, fetchFromGitHub, curl, unstableGitUpdater, lib }:
+{
+  buildLua,
+  fetchFromGitHub,
+  curl,
+  unstableGitUpdater,
+  lib,
+}:
 
 buildLua rec {
   pname = "youtube-upnext";


### PR DESCRIPTION
## Description of changes

- format `mpvScripts` with nixfmt-rfc-style
- add `mpvScripts` directory to the `check-nix-format` workflow

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review`
  Nothing to be rebuilt
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
