### PR TITLE
libvirt: apply patches for CVE-2024-2494 and CVE-2024-1441

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -9,6 +9,7 @@
 , dnsmasq
 , docutils
 , fetchFromGitLab
+, fetchpatch
 , gettext
 , glib
 , gnutls
@@ -126,6 +127,16 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
+    (fetchpatch {
+      name = "CVE-2024-2494.patch";
+      url = "https://gitlab.com/libvirt/libvirt/-/commit/8a3f8d957507c1f8223fdcf25a3ff885b15557f2.patch";
+      hash = "sha256-kxSIZ4bPOhN6PpJepoSF+EDTgdmazRWh3a3KSVfm1GU=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-1441.patch";
+      url = "https://gitlab.com/libvirt/libvirt/-/commit/c664015fe3a7bf59db26686e9ed69af011c6ebb8.patch";
+      hash = "sha256-Qi/gk7+NPz9s9OpWOnF8XW6A75C9BbVxBTE4KVwalo4=";
+    })
   ] ++ lib.optionals enableZfs [
     (substituteAll {
       src = ./0002-substitute-zfs-and-zpool-commands.patch;


### PR DESCRIPTION
## Description of changes

Applied the 2 security patches for the libvirt version we currently have.
I also took a look at upgrading to 10.2.0 (this work was started in #302247) but it currently breaks tests of `virt-manager` (you check https://github.com/LeSuisse/nixpkgs/commit/e587537e9b3d2e98112c729b238a4973616358d8). It looks like `virt-manager` upstream has not yet catch up with libvirt 10.2.0.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Result of `nixpkgs-review pr 308087` run on aarch64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>htcondor</li>
  </ul>
</details>
<details>
  <summary>4 packages failed to build:</summary>
  <ul>
    <li>nixops_unstablePlugins.nixops-libvirtd</li>
    <li>nixops_unstablePlugins.nixops-libvirtd.dist</li>
    <li>nixops_unstable_full</li>
    <li>nixops_unstable_full.dist</li>
  </ul>
</details>
<details>
  <summary>35 packages built:</summary>
  <ul>
    <li>appvm</li>
    <li>collectd</li>
    <li>diffoscope</li>
    <li>diffoscope.dist</li>
    <li>diffoscope.man</li>
    <li>docker-machine-kvm2</li>
    <li>gnome.gnome-boxes</li>
    <li>libguestfs</li>
    <li>librenms</li>
    <li>libvirt</li>
    <li>libvirt-glib</li>
    <li>libvirt-glib.dev</li>
    <li>libvirt-glib.devdoc</li>
    <li>mgmt</li>
    <li>minikube</li>
    <li>ocamlPackages.ocaml_libvirt</li>
    <li>perl536Packages.SysVirt</li>
    <li>perl536Packages.SysVirt.devdoc</li>
    <li>perl538Packages.SysVirt</li>
    <li>perl538Packages.SysVirt.devdoc</li>
    <li>python311Packages.guestfs</li>
    <li>python311Packages.guestfs.dist</li>
    <li>python311Packages.libvirt</li>
    <li>python311Packages.libvirt.dist</li>
    <li>python312Packages.guestfs</li>
    <li>python312Packages.guestfs.dist</li>
    <li>rubyPackages.ruby-libvirt</li>
    <li>rubyPackages_3_2.ruby-libvirt</li>
    <li>rubyPackages_3_3.ruby-libvirt</li>
    <li>vagrant</li>
    <li>virt-manager</li>
    <li>virt-manager-qt</li>
    <li>virt-manager.dist</li>
    <li>virt-top</li>
    <li>virt-viewer</li>
  </ul>
</details>

Result of `nixpkgs-review pr 308087` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages failed to build:</summary>
  <ul>
    <li>htcondor</li>
    <li>nixops_unstablePlugins.nixops-libvirtd</li>
    <li>nixops_unstablePlugins.nixops-libvirtd.dist</li>
    <li>nixops_unstable_full</li>
    <li>nixops_unstable_full.dist</li>
  </ul>
</details>
<details>
  <summary>38 packages built:</summary>
  <ul>
    <li>appvm</li>
    <li>collectd</li>
    <li>diffoscope</li>
    <li>diffoscope.dist</li>
    <li>diffoscope.man</li>
    <li>docker-machine-kvm2</li>
    <li>gnome.gnome-boxes</li>
    <li>guestfs-tools</li>
    <li>libguestfs</li>
    <li>libguestfs-with-appliance</li>
    <li>librenms</li>
    <li>libvirt</li>
    <li>libvirt-glib</li>
    <li>libvirt-glib.dev</li>
    <li>libvirt-glib.devdoc</li>
    <li>mgmt</li>
    <li>minikube</li>
    <li>multipass</li>
    <li>ocamlPackages.ocaml_libvirt</li>
    <li>perl536Packages.SysVirt</li>
    <li>perl536Packages.SysVirt.devdoc</li>
    <li>perl538Packages.SysVirt</li>
    <li>perl538Packages.SysVirt.devdoc</li>
    <li>python311Packages.guestfs</li>
    <li>python311Packages.guestfs.dist</li>
    <li>python311Packages.libvirt</li>
    <li>python311Packages.libvirt.dist</li>
    <li>python312Packages.guestfs</li>
    <li>python312Packages.guestfs.dist</li>
    <li>rubyPackages.ruby-libvirt</li>
    <li>rubyPackages_3_2.ruby-libvirt</li>
    <li>rubyPackages_3_3.ruby-libvirt</li>
    <li>vagrant</li>
    <li>virt-manager</li>
    <li>virt-manager-qt</li>
    <li>virt-manager.dist</li>
    <li>virt-top</li>
    <li>virt-viewer</li>
  </ul>
</details>

No new build failures.
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
