### PR TITLE
ssh-mitm: 3.0.2 → 4.1.1

### DIFF
--- a/pkgs/tools/security/ssh-mitm/default.nix
+++ b/pkgs/tools/security/ssh-mitm/default.nix
@@ -1,18 +1,29 @@
-{ lib
-, fetchFromGitHub
-, python3
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  installShellFiles,
+  python3,
 }:
 
 let
   py = python3.override {
     packageOverrides = self: super: {
       paramiko = super.paramiko.overridePythonAttrs (oldAttrs: rec {
-        version = "3.1.0";
+        version = "3.3.1";
         src = oldAttrs.src.override {
           inherit version;
-          hash = "sha256-aVD6ymgZrNMhnUrmlKI8eofuONCE9wwXJLDA27i3V2k=";
+          hash = "sha256-ajd3qWGshtvvN1xfW41QAUoaltD9fwVKQ7yIATSw/3c=";
         };
-        patches = [ ];
+        patches = [
+          (fetchpatch {
+            name = "Use-pytest-s-setup_method-in-pytest-8-the-nose-method-setup-is-deprecated.patch";
+            url = "https://github.com/paramiko/paramiko/pull/2349.diff";
+            hash = "sha256-4CTIZ9BmzRdh+HOwxSzfM9wkUGJOnndctK5swqqsIvU=";
+          })
+
+        ];
         propagatedBuildInputs = oldAttrs.propagatedBuildInputs ++ [ python3.pkgs.icecream ];
       });
     };
@@ -20,17 +31,23 @@ let
 in
 with py.pkgs;
 
+
 buildPythonApplication rec {
   pname = "ssh-mitm";
-  version = "3.0.2";
-  format = "setuptools";
+  version = "4.1.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "ssh-mitm";
+    repo = "ssh-mitm";
     rev = "refs/tags/${version}";
-    hash = "sha256-koV7g6ZmrrXk60rrDP8BwrDZk3shiyJigQgNcb4BASE=";
+    hash = "sha256-Uf1B7oEZyNWj4TjrLvEfFdxsvsGeMLXFsSdxGLUV4ZU=";
   };
+
+  build-system = [
+    hatchling
+    hatch-requirements-txt
+  ];
 
   propagatedBuildInputs = [
     argcomplete
@@ -39,17 +56,25 @@ buildPythonApplication rec {
     paramiko
     pytz
     pyyaml
+    python-json-logger
     rich
+    tkinter
     setuptools
     sshpubkeys
-  ];
+    wrapt
+  ] ++ lib.optionals stdenv.isDarwin [ setuptools ];
+  # fix for darwin users
+
+  nativeBuildInputs = [ installShellFiles ];
 
   # Module has no tests
   doCheck = false;
+  # Install man page
+  postInstall = ''
+    installManPage man1/*
+  '';
 
-  pythonImportsCheck = [
-    "sshmitm"
-  ];
+  pythonImportsCheck = [ "sshmitm" ];
 
   meta = with lib; {
     description = "Tool for SSH security audits";


### PR DESCRIPTION
* Hash wasn't updated, updating the hash to the correct value seems to make the build fail with a very weird error. (EDIT : Hash was finally updated)
* Paramiko override necessary, (EDIT as last release needs Paramiko <3.4/>=3.3.0).

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

@fabaff 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
