### PR TITLE
lib/gvariant: Fix error message for unsupported primitives

### DIFF
--- a/lib/gvariant.nix
+++ b/lib/gvariant.nix
@@ -53,6 +53,53 @@ rec {
 
   inherit type isGVariant;
 
+  intConstructors = [
+    {
+      name = "mkInt32";
+      type = type.int32;
+      min = -2147483648;
+      max = 2147483647;
+    }
+    {
+      name = "mkUint32";
+      type = type.uint32;
+      min = 0;
+      max = 4294967295;
+    }
+    {
+      name = "mkInt64";
+      type = type.int64;
+      # Nix does not support such large numbers.
+      min = null;
+      max = null;
+    }
+    {
+      name = "mkUint64";
+      type = type.uint64;
+      min = 0;
+      # Nix does not support such large numbers.
+      max = null;
+    }
+    {
+      name = "mkInt16";
+      type = type.int16;
+      min = -32768;
+      max = 32767;
+    }
+    {
+      name = "mkUint16";
+      type = type.uint16;
+      min = 0;
+      max = 65535;
+    }
+    {
+      name = "mkUchar";
+      type = type.uchar;
+      min = 0;
+      max = 255;
+    }
+  ];
+
   /* Returns the GVariant value that most closely matches the given Nix value.
      If no GVariant value can be found unambiguously then error is thrown.
 
@@ -70,6 +117,18 @@ rec {
       mkArray v
     else if isGVariant v then
       v
+    else if builtins.isInt v then
+      let
+        validConstructors = builtins.filter ({ min, max, ... }: (min == null || min <= v) && (max == null || v <= max)) intConstructors;
+      in
+      throw ''
+        The GVariant type for number “${builtins.toString v}” is unclear.
+        Please wrap the value with one of the following, depending on the value type in GSettings schema:
+
+        ${lib.concatMapStringsSep "\n" ({ name, type, ...}: "- `lib.gvariant.${name}` for `${type}`") validConstructors}
+      ''
+    else if builtins.isAttrs v then
+      throw "Cannot construct GVariant value from an attribute set. If you want to construct a dictionary, you will need to create an array containing items constructed with `lib.gvariant.mkDictionaryEntry`."
     else
       throw "The GVariant type of “${builtins.typeOf v}” can't be inferred.";
 

--- a/lib/gvariant.nix
+++ b/lib/gvariant.nix
@@ -71,7 +71,7 @@ rec {
     else if isGVariant v then
       v
     else
-      throw "The GVariant type of ${v} can't be inferred.";
+      throw "The GVariant type of “${builtins.typeOf v}” can't be inferred.";
 
   /* Returns the GVariant array from the given type of the elements and a Nix list.
 


### PR DESCRIPTION
## Description of changes

Without this, passing an integer to a setting will fail with a confusing error:

    error: cannot coerce an integer to a string

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
