### PR TITLE
rsdkv5: init at 8278952

### DIFF
--- a/pkgs/by-name/rs/rsdkv5/package.nix
+++ b/pkgs/by-name/rs/rsdkv5/package.nix
@@ -57,5 +57,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.unfreeRedistributable;
     maintainers = [ lib.maintainers.puffnfresh ];
     platforms = lib.platforms.linux;
+    mainProgram = "RSDKv5U";
   };
 }

--- a/pkgs/by-name/rs/rsdkv5/package.nix
+++ b/pkgs/by-name/rs/rsdkv5/package.nix
@@ -1,0 +1,61 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, glew
+, glfw
+, libtheora
+, portaudio
+, libogg
+, zlib
+, SDL2
+, libXcursor
+, libXrandr
+, libXext
+, libXScrnSaver
+, libXi
+, libXfixes
+}:
+
+stdenv.mkDerivation rec {
+  pname = "RSDKv5";
+  version = lib.strings.substring 0 7 src.rev;
+
+  src = fetchFromGitHub {
+    owner = "Rubberduckycooly";
+    repo = "Sonic-Mania-Decompilation";
+    rev = "8278952deec0e5acbe3a0d5bd3a7bac4c297e65a";
+    fetchSubmodules = true;
+    sha256 = "sha256-q8aQxgu3ssqqNtNLKL4DbbsuddeXk5HoY+G79ep5/Sk=";
+  };
+
+  sourceRoot = "${src.name}/dependencies/RSDKv5";
+
+  postPatch = ''
+    substituteInPlace makefiles/Linux.cfg \
+      --replace-fail 'portaudio' 'portaudio-2.0'
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ glew glfw libtheora portaudio libogg zlib SDL2 libXcursor libXext libXScrnSaver libXrandr libXi libXfixes ];
+
+  makeFlags = [ "AUTOBUILD=1" ];
+
+  installPhase = ''
+    mkdir -p $out/share $out/bin
+    cp -r bin/Linux/OGL $out/share/rsdkv5
+    ln -s $out/share/rsdkv5/RSDKv5U $out/bin/
+  '';
+
+  postFixup = ''
+    patchelf --add-rpath $out/share/rsdkv5 $out/share/rsdkv5/RSDKv5U
+  '';
+
+  meta = {
+    description = "Decompilation of Sonic Mania";
+    homepage = "https://github.com/Rubberduckycooly/Sonic-Mania-Decompilation";
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = [ lib.maintainers.puffnfresh ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

https://github.com/Rubberduckycooly/Sonic-Mania-Decompilation

Very similar to #307384.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
