### PR TITLE
[23.11] iwd: apply patches for CVE-2023-52161 and buffer overflows

### DIFF
--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , fetchgit
+, fetchpatch
 , autoreconfHook
 , pkg-config
 , ell
@@ -19,6 +20,24 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-i+2R8smgLXooApj0Z5e03FybhYgw1X/kIsJkrDzW8y4=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2023-52161.patch";
+      url = "https://git.kernel.org/pub/scm/network/wireless/iwd.git/patch/?id=6415420f1c92012f64063c131480ffcef58e60ca";
+      hash = "sha256-bN5mxdWDyKEC2IyyG2vlzTEAL57C4uC7GAJA3jSXJHg=";
+    })
+    (fetchpatch {
+      name = "netdev-buffer-overflow-32-byte-ssid.patch";
+      url = "https://git.kernel.org/pub/scm/network/wireless/iwd.git/patch/?id=8d68b33e763aced6d419df9f6534760d2c890279";
+      hash = "sha256-BSduzwVUTEcqjVwD88qJYgItApcQZwU43u9gbNMDs8I=";
+    })
+    (fetchpatch {
+      name = "erp-buffer-overflow-32-byte-ssid.patch";
+      url = "https://git.kernel.org/pub/scm/network/wireless/iwd.git/patch/?id=bdaae53cf828a1f6ea7a7b57d7d6ebcc7b70ac43";
+      hash = "sha256-K/Ib0azlZ0UlFqcqs+8dSfj0hh0j0dZYpfB9f6tEqc8=";
+    })
+  ];
 
   outputs = [ "out" "man" "doc" ]
     ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "test";


### PR DESCRIPTION
## Description of changes

AFAIK the buffer overflows did not get a CVE ID assigned and I'm not sure it can be exploited in a meaningful way. The patches are pretty small and self contained so it should be fine to include them "just in case".

`unstable` is using the latest version that include all the patches.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Result of `nixpkgs-review pr 308218` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>iwd</li>
    <li>iwd.doc</li>
    <li>iwd.man</li>
    <li>iwd.test</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
