### PR TITLE
prometheus-nvidia-gpu-exporter: initial version 1.2.1

### DIFF
--- a/pkgs/by-name/pr/prometheus-nvidia-gpu-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-nvidia-gpu-exporter/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "prometheus-nvidia-gpu-exporter";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "utkuozdemir";
+    repo = "nvidia_gpu_exporter";
+    rev = "v${version}";
+    hash = "sha256-+YmZ25OhOeIulkOH/Apqh3jGQ4Vanv0GIuc/EjBiZ+w=";
+  };
+
+  vendorHash = "sha256-Dsp98EWRiRaawYmdr3KR2YTteeD9cmHUHQoq5CnH9gA=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/prometheus/common/version.Version=${version}"
+    "-X=github.com/prometheus/common/version.Revision=${src.rev}"
+    "-X=github.com/prometheus/common/version.Branch=${src.rev}"
+    "-X=github.com/prometheus/common/version.BuildUser=goreleaser"
+    "-X=github.com/prometheus/common/version.BuildDate=1970-01-01T00:00:00Z"
+  ];
+
+  meta = {
+    description = "Nvidia GPU exporter for prometheus using nvidia-smi binary";
+    homepage = "https://github.com/utkuozdemir/nvidia_gpu_exporter";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ck3d ];
+    mainProgram = "nvidia_gpu_exporter";
+  };
+}


### PR DESCRIPTION
## Description of changes

Add prometheus-nvidia-gpu-exporter initial version 1.2.1. Package was created with nix-init.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
