### PR TITLE
libreswan: 4.15 -> 5.0

### DIFF
--- a/nixos/tests/libreswan.nix
+++ b/nixos/tests/libreswan.nix
@@ -119,11 +119,11 @@ in
       with subtest("Libreswan is ready"):
           alice.wait_for_unit("ipsec")
           bob.wait_for_unit("ipsec")
-          alice.succeed("ipsec verify 1>&2")
+          alice.succeed("ipsec checkconfig")
 
       with subtest("Alice and Bob can start the tunnel"):
-          alice.execute("ipsec auto --start tunnel >&2 &")
-          bob.succeed("ipsec auto --start tunnel")
+          alice.execute("ipsec start tunnel >&2 &")
+          bob.succeed("ipsec start tunnel")
           # apparently this is needed to "wake" the tunnel
           bob.execute("ping -c1 alice")
 

--- a/pkgs/tools/networking/libreswan/default.nix
+++ b/pkgs/tools/networking/libreswan/default.nix
@@ -28,7 +28,7 @@
 , libselinux
 , ldns
 , xmlto
-, docbook_xml_dtd_412
+, docbook_xml_dtd_45
 , docbook_xsl
 , findXMLCatalogs
 , dns-root-data
@@ -45,11 +45,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "libreswan";
-  version = "4.15";
+  version = "5.0";
 
   src = fetchurl {
     url = "https://download.libreswan.org/${pname}-${version}.tar.gz";
-    hash = "sha256-/mDX2zmMjuIlBV2zZeyWiiSuvLxcNQYRMfz/2tG+BK8=";
+    hash = "sha256-ELwK3JC56YGjDf77p9r/IAhB7LmRD51nHxN//BQUKGo=";
   };
 
   strictDeps = true;
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     flex
     pkg-config
     xmlto
-    docbook_xml_dtd_412
+    docbook_xml_dtd_45
     docbook_xsl
     findXMLCatalogs
   ];
@@ -73,51 +73,15 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional stdenv.isLinux libselinux;
 
   prePatch = ''
-    # Correct iproute2 and iptables path
-    sed -e 's|/sbin/ip|${iproute2}/bin/ip|g' \
-        -e 's|/sbin/\(ip6\?tables\)|${iptables}/bin/\1|' \
-        -e 's|/bin/bash|${runtimeShell}|g' \
-        -i initsystems/systemd/ipsec.service.in \
-           programs/barf/barf.in \
-           programs/verify.linux/verify.in
-    sed -e 's|\([[:blank:]]\)\(ip6\?tables\(-save\)\? -\)|\1${iptables}/bin/\2|' \
-        -i programs/verify.linux/verify.in
-
-    # Prevent the makefile from trying to
-    # reload the systemd daemon or create tmpfiles
-    sed -e 's|systemctl|true|g' \
-        -e 's|systemd-tmpfiles|true|g' \
-        -i initsystems/systemd/Makefile
-
-    # Fix systemd detection on NixOS
-    sed -e 's|\(-a ! -x /bin/journalctl\)|\1 -a ! -x /run/current-system/sw/bin/journalctl|g' \
-        -e 's|\(-o ! -x /bin/journalctl\)|\1 -o ! -x /run/current-system/sw/bin/journalctl|g' \
-        -i programs/barf/barf.in
-
-    # Fix the ipsec program from crushing the PATH
-    sed -e 's|\(PATH=".*"\):.*$|\1:$PATH|' -i programs/ipsec/ipsec.in
-
-    # Fix python script to use the correct python
-    sed -e 's/^\(\W*\)installstartcheck()/\1sscmd = "ss"\n\0/' \
-        -i programs/verify.linux/verify.in
-
     # Replace wget with curl to save a dependency
-    curlArgs='-s --remote-name-all --output-dir'
-    sed -e "s|wget -q -P|${curl}/bin/curl $curlArgs|g" \
-        -i programs/letsencrypt/letsencrypt.in
-
-    # Patch the Makefile:
-    # 1. correct the pam.d directory install path
-    # 2. do not create the /var/lib/ directory
-    sed -e 's|$(DESTDIR)/etc/pam.d|$(out)/etc/pam.d|' \
-        -e '/test ! -d $(NSSDIR)/,+3d' \
-        -i configs/Makefile
+    substituteInPlace programs/letsencrypt/letsencrypt.in \
+      --replace-fail 'wget -q -P' '${curl}/bin/curl -s --remote-name-all --output-dir'
   '';
 
   makeFlags = [
     "PREFIX=$(out)"
     "INITSYSTEM=systemd"
-    "UNITDIR=$(out)/etc/systemd/system/"
+    "SYSTEMUNITDIR=$(out)/etc/systemd/system/"
     "TMPFILESDIR=$(out)/lib/tmpfiles.d/"
     "LINUX_VARIANT=nixos"
     "DEFAULT_DNSSEC_ROOTKEY_FILE=${dns-root-data}/root.key"
@@ -125,13 +89,13 @@ stdenv.mkDerivation rec {
 
   # Hack to make install work
   installFlags = [
-    "FINALVARDIR=\${out}/var"
-    "FINALSYSCONFDIR=\${out}/etc"
+    "VARDIR=\${out}/var"
+    "SYSCONFDIR=\${out}/etc"
   ];
 
   postInstall = ''
-    # Install examples directory (needed for letsencrypt)
-    cp -r docs/examples $out/share/doc/libreswan/examples
+    # Install letsencrypt config files
+    install -m644 -Dt "$out/share/doc/libreswan/letsencrypt" docs/examples/*
   '';
 
   postFixup = ''


### PR DESCRIPTION

## Description of changes

Major update

Notes:

  - barf went into contrib/ and officially unsupported.
  - verify was removed entirely.
  - the makefile is a bit smarter now and doesn't require many of the previous workarounds.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested via `nixosTests.libreswan`.
- [x] Tested compilation of all packages that depend on this change
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
