### PR TITLE
glm: 0.9.9.8 -> 1.0.1, opensplat: 1.1.2 -> 1.1.3, fix frogatto's engine's build

### DIFF
--- a/pkgs/by-name/op/opencomposite/package.nix
+++ b/pkgs/by-name/op/opencomposite/package.nix
@@ -41,8 +41,9 @@ stdenv.mkDerivation {
   ];
 
   cmakeFlags = [
-    "-DUSE_SYSTEM_OPENXR=ON"
-    "-DUSE_SYSTEM_GLM=ON"
+    (lib.cmakeBool "USE_SYSTEM_OPENXR" true)
+    (lib.cmakeBool "USE_SYSTEM_GLM" true)
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-DGLM_ENABLE_EXPERIMENTAL")
   ];
 
   installPhase = ''

--- a/pkgs/by-name/op/opensplat/package.nix
+++ b/pkgs/by-name/op/opensplat/package.nix
@@ -4,13 +4,13 @@
   cmake,
   ninja,
   fetchFromGitHub,
-  fetchpatch,
   python3,
   opencv,
   nlohmann_json,
   nanoflann,
   glm,
   cxxopts,
+  nix-update-script,
   config,
   # Upstream has rocm/hip support, too. anyone?
   cudaSupport ? config.cudaSupport,
@@ -18,7 +18,7 @@
   autoAddDriverRunpath,
 }:
 let
-  version = "1.1.2";
+  version = "1.1.3";
   torch = python3.pkgs.torch.override { inherit cudaSupport; };
   # Using a normal stdenv with cuda torch gives
   # ld: /nix/store/k1l7y96gv0nc685cg7i3g43i4icmddzk-python3.11-torch-2.2.1-lib/lib/libc10.so: undefined reference to `std::ios_base_library_init()@GLIBCXX_3.4.32'
@@ -32,25 +32,12 @@ stdenv'.mkDerivation {
     owner = "pierotofy";
     repo = "OpenSplat";
     rev = "refs/tags/v${version}";
-    hash = "sha256-3tk62b5fSf6wzuc5TwkdfAKgUMrw3ZxetCJa2RVMS/s=";
+    hash = "sha256-2NcKb2SWU/vNsnd2KhdU85J60fJPuc44ZxIle/1UT6g=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "install-executables.patch";
-      url = "https://github.com/pierotofy/OpenSplat/commit/b4c4176819b508978583b7ebf66306171807a8e6.patch";
-      hash = "sha256-BUgPMcO3lt3ZEzv24u36k3aTEIoloOhxrCGi1KQ5Epk=";
-    })
-  ];
-
   postPatch = ''
-    # the two vendored gsplats are so heavily modified they may be considered a fork
-    find vendor ! -name 'gsplat*' -maxdepth 1 -mindepth 1 -exec rm -rf {} +
-    mkdir vendor/{nanoflann,glm}
-    ln -s ${glm}/include/glm vendor/glm/glm
-    ln -s ${nanoflann}/include/nanoflann.hpp vendor/nanoflann/nanoflann.hpp
-    ln -s ${nlohmann_json}/include/nlohmann vendor/json
-    ln -s ${cxxopts}/include/cxxopts.hpp vendor/cxxopts.hpp
+    substituteInPlace CMakeLists.txt \
+      --replace-fail glm::glm-header-only glm::glm
   '';
 
   nativeBuildInputs = [
@@ -63,6 +50,9 @@ stdenv'.mkDerivation {
 
   buildInputs = [
     nlohmann_json
+    nanoflann
+    glm
+    cxxopts
     torch.cxxdev
     torch
     opencv
@@ -74,15 +64,23 @@ stdenv'.mkDerivation {
 
   cmakeFlags = [
     (lib.cmakeBool "CMAKE_SKIP_RPATH" true)
+    (lib.cmakeFeature "FETCHCONTENT_TRY_FIND_PACKAGE_MODE" "ALWAYS")
   ] ++ lib.optionals cudaSupport [
     (lib.cmakeFeature "GPU_RUNTIME" "CUDA")
     (lib.cmakeFeature "CUDA_TOOLKIT_ROOT_DIR" "${cudaPackages.cudatoolkit}/")
   ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Production-grade 3D gaussian splatting";
     homepage = "https://github.com/pierotofy/OpenSplat/";
-    license = lib.licenses.mit;
+    license = [
+      # main
+      lib.licenses.agpl3Only
+      # vendored+modified gsplat
+      lib.licenses.asl20
+    ];
     maintainers = [ lib.maintainers.jcaesar ];
     platforms = lib.platforms.linux ++ lib.optionals (!cudaSupport) lib.platforms.darwin;
   };

--- a/pkgs/by-name/op/opensplat/package.nix
+++ b/pkgs/by-name/op/opensplat/package.nix
@@ -35,11 +35,6 @@ stdenv'.mkDerivation {
     hash = "sha256-2NcKb2SWU/vNsnd2KhdU85J60fJPuc44ZxIle/1UT6g=";
   };
 
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail glm::glm-header-only glm::glm
-  '';
-
   nativeBuildInputs = [
     cmake
     ninja

--- a/pkgs/games/empty-epsilon/default.nix
+++ b/pkgs/games/empty-epsilon/default.nix
@@ -33,7 +33,8 @@ let
     buildInputs = [ sfml libX11 glm SDL2 ];
 
     cmakeFlags = [
-      "-DFETCHCONTENT_SOURCE_DIR_BASIS=${basis-universal}"
+      (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_BASIS" "${basis-universal}")
+      (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-DGLM_ENABLE_EXPERIMENTAL")
     ];
 
     meta = with lib; {
@@ -63,15 +64,16 @@ stdenv.mkDerivation {
   buildInputs = [ serious-proton sfml glew libX11 python3 glm SDL2 ninja ];
 
   cmakeFlags = [
-    "-DSERIOUS_PROTON_DIR=${serious-proton.src}"
-    "-DCPACK_PACKAGE_VERSION=${version.emptyepsilon}"
-    "-DCPACK_PACKAGE_VERSION_MAJOR=${major}"
-    "-DCPACK_PACKAGE_VERSION_MINOR=${minor}"
-    "-DCPACK_PACKAGE_VERSION_PATCH=${patch.emptyepsilon}"
-    "-DFETCHCONTENT_SOURCE_DIR_BASIS=${basis-universal}"
-    "-DFETCHCONTENT_SOURCE_DIR_MESHOPTIMIZER=${meshoptimizer.src}"
-    "-DCMAKE_AR=${stdenv.cc.cc}/bin/gcc-ar"
-    "-DCMAKE_RANLIB=${stdenv.cc.cc}/bin/gcc-ranlib"
+    (lib.cmakeFeature "SERIOUS_PROTON_DIR" "${serious-proton.src}")
+    (lib.cmakeFeature "CPACK_PACKAGE_VERSION" "${version.emptyepsilon}")
+    (lib.cmakeFeature "CPACK_PACKAGE_VERSION_MAJOR" "${major}")
+    (lib.cmakeFeature "CPACK_PACKAGE_VERSION_MINOR" "${minor}")
+    (lib.cmakeFeature "CPACK_PACKAGE_VERSION_PATCH" "${patch.emptyepsilon}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_BASIS" "${basis-universal}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_MESHOPTIMIZER" "${meshoptimizer.src}")
+    (lib.cmakeFeature "CMAKE_AR" "${stdenv.cc.cc}/bin/gcc-ar")
+    (lib.cmakeFeature "CMAKE_RANLIB" "${stdenv.cc.cc}/bin/gcc-ranlib")
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-DGLM_ENABLE_EXPERIMENTAL")
     "-G Ninja"
   ];
 

--- a/pkgs/games/frogatto/engine.nix
+++ b/pkgs/games/frogatto/engine.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation {
     glm
   ];
 
+  env.CXXFLAGS = "-DGLM_ENABLE_EXPERIMENTAL";
+
   enableParallelBuilding = true;
 
   installPhase = ''

--- a/pkgs/games/frogatto/engine.nix
+++ b/pkgs/games/frogatto/engine.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
     glm
   ];
 
-  env.CXXFLAGS = "-DGLM_ENABLE_EXPERIMENTAL";
+  env.CXXFLAGS = "-DGLM_ENABLE_EXPERIMENTAL -Wno-error=deprecated-declarations";
 
   enableParallelBuilding = true;
 

--- a/pkgs/games/solarus/default.nix
+++ b/pkgs/games/solarus/default.nix
@@ -22,6 +22,10 @@ mkDerivation rec {
     openal libmodplug libvorbis
     qtbase glm ];
 
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-DGLM_ENABLE_EXPERIMENTAL")
+  ];
+
   preFixup = ''
     mkdir $lib/
     mv $out/lib $lib


### PR DESCRIPTION
## Description of changes

* glm
  * changelog: [1.0.0](https://github.com/g-truc/glm/releases/tag/1.0.0) [1.0.1](https://github.com/g-truc/glm/releases/tag/1.0.1)
   * The 1.0 "release" seems to have put some features behind "experimental" [gates](https://github.com/g-truc/glm/blob/45008b225e28eb700fa0f7d3ff69b7c1db94fadf/glm/gtx/matrix_decompose.hpp#L24), so a define is necessary to avoid build failures on some dependent packages
    
 * opensplat
   * changelog: [1.1.3](https://github.com/pierotofy/OpenSplat/releases/tag/v1.1.3)
   * The license change corrects an error on my part in the init pr
 * frogatto / anura-engine:
   * The glm update broke its build, but it also already contained an unrelated `-Werror` build failure . Cleanup en passant.
   * I don't plan on testing whether this actually runs
   
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
