### PR TITLE
libiff,libilbm: init at 0-unstable-2024-03-02

### DIFF
--- a/pkgs/by-name/li/libiff/package.nix
+++ b/pkgs/by-name/li/libiff/package.nix
@@ -1,0 +1,34 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  autoreconfHook,
+  help2man,
+}:
+
+stdenv.mkDerivation {
+  pname = "libiff";
+  version = "0-unstable-2024-03-02";
+  src = fetchFromGitHub {
+    owner = "svanderburg";
+    repo = "libiff";
+    rev = "b5f542a83c824f26e0816770c9a17c22bd388606";
+    sha256 = "sha256-Arh3Ihd5TWg5tdemodrxz2EDxh/hwz9b2/AvrTONFy8=";
+  };
+  nativeBuildInputs = [
+    autoreconfHook
+    help2man
+  ];
+  meta = with lib; {
+    description = "Parser for the Interchange File Format (IFF)";
+    longDescription = ''
+      libiff is a portable, extensible parser library implemented in
+      ANSI C, for EA-IFF 85: Electronic Arts' Interchange File Format
+      (IFF).
+    '';
+    homepage = "https://github.com/svanderburg/libiff";
+    maintainers = with maintainers; [ _414owen ];
+    platforms = platforms.all;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/by-name/li/libilbm/package.nix
+++ b/pkgs/by-name/li/libilbm/package.nix
@@ -1,0 +1,38 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  libiff,
+  autoreconfHook,
+  pkg-config,
+  help2man,
+}:
+
+stdenv.mkDerivation {
+  pname = "libilbm";
+  version = "0-unstable-2024-03-02";
+  src = fetchFromGitHub {
+    owner = "svanderburg";
+    repo = "libilbm";
+    rev = "586f5822275ef5780509a851cb90c7407b2633d9";
+    sha256 = "sha256-EcsrspL/N40yFE15UFWGienpJHhoq1zd8zZe6x4nK6o=";
+  };
+  buildInputs = [ libiff ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    help2man
+  ];
+  meta = with lib; {
+    description = "Parser for the ILBM: IFF Interleaved BitMap format";
+    longDescription = ''
+      libilbm is a portable parser library built on top of libiff,
+      for ILBM: IFF Interleaved BitMap format, which is used by programs
+      such as Deluxe Paint and Graphicraft to read and write images.
+    '';
+    homepage = "https://github.com/svanderburg/libilbm";
+    maintainers = with maintainers; [ _414owen ];
+    platforms = platforms.all;
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds the libiff, and libilbm libraries, which parse/render image formats. These are used in GIMP 2.99.x releases.

This extracts work done in https://github.com/jtojnar/nixpkgs/pull/2 into its own PR.
See also https://github.com/NixOS/nixpkgs/pull/67576

@jtojnar 
@svanderburg You have nix files in these repos. If you're willing, would you like to be listed as a package maintainer here?


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
