### PR TITLE
mpvScripts: scopewide fixups

### DIFF
--- a/pkgs/applications/video/mpv/scripts/convert.nix
+++ b/pkgs/applications/video/mpv/scripts/convert.nix
@@ -22,13 +22,13 @@ buildLua {
 
   postPatch = ''
     substituteInPlace convert_script.lua \
-      --replace 'mkvpropedit_exe = "mkvpropedit"' \
+      --replace-fail 'mkvpropedit_exe = "mkvpropedit"' \
                 'mkvpropedit_exe = "${mkvtoolnix-cli}/bin/mkvpropedit"' \
-      --replace 'mkvmerge_exe = "mkvmerge"' \
+      --replace-fail 'mkvmerge_exe = "mkvmerge"' \
                 'mkvmerge_exe = "${mkvtoolnix-cli}/bin/mkvmerge"' \
-      --replace 'yad_exe = "yad"' \
+      --replace-fail 'yad_exe = "yad"' \
                 'yad_exe = "${yad}/bin/yad"' \
-      --replace 'notify_send_exe = "notify-send"' \
+      --replace-fail 'notify_send_exe = "notify-send"' \
                 'notify_send_exe = "${libnotify}/bin/notify-send"' \
   '';
 

--- a/pkgs/applications/video/mpv/scripts/convert.nix
+++ b/pkgs/applications/video/mpv/scripts/convert.nix
@@ -23,13 +23,13 @@ buildLua {
   postPatch = ''
     substituteInPlace convert_script.lua \
       --replace-fail 'mkvpropedit_exe = "mkvpropedit"' \
-                'mkvpropedit_exe = "${mkvtoolnix-cli}/bin/mkvpropedit"' \
+                'mkvpropedit_exe = "${lib.getExe' mkvtoolnix-cli "mkvpropedit"}"' \
       --replace-fail 'mkvmerge_exe = "mkvmerge"' \
-                'mkvmerge_exe = "${mkvtoolnix-cli}/bin/mkvmerge"' \
+                'mkvmerge_exe = "${lib.getExe' mkvtoolnix-cli "mkvmerge"}"' \
       --replace-fail 'yad_exe = "yad"' \
-                'yad_exe = "${yad}/bin/yad"' \
+                'yad_exe = "${lib.getExe yad}"' \
       --replace-fail 'notify_send_exe = "notify-send"' \
-                'notify_send_exe = "${libnotify}/bin/notify-send"' \
+                'notify_send_exe = "${lib.getExe libnotify}"' \
   '';
 
   scriptPath = "convert_script.lua";

--- a/pkgs/applications/video/mpv/scripts/cutter.nix
+++ b/pkgs/applications/video/mpv/scripts/cutter.nix
@@ -16,13 +16,13 @@ buildLua {
 
   postPatch = ''
     substituteInPlace cutter.lua \
-      --replace '~/.config/mpv/scripts/c_concat.sh' '${placeholder "out"}/share/mpv/scripts/c_concat.sh'
+      --replace-fail '~/.config/mpv/scripts/c_concat.sh' '${placeholder "out"}/share/mpv/scripts/c_concat.sh'
 
     # needs to be ran separately so that we can replace everything, and not every single mention explicitly
     # original script places them in the scripts folder, just spawning unnecessary errors
     # i know that hardcoding .config and especially the .mpv directory isn't best practice, but I didn't want to deviate too much from upstream
     substituteInPlace cutter.lua \
-      --replace '~/.config/mpv/scripts' "''${XDG_CONFIG_HOME:-~/.config}/mpv/cutter"
+      --replace-fail '~/.config/mpv/scripts' "''${XDG_CONFIG_HOME:-~/.config}/mpv/cutter"
   '';
 
   passthru.scriptName = "cutter.lua";

--- a/pkgs/applications/video/mpv/scripts/mpris.nix
+++ b/pkgs/applications/video/mpv/scripts/mpris.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ glib mpv-unwrapped ffmpeg ];
 
   postPatch = ''
-    substituteInPlace Makefile --replace 'PKG_CONFIG =' 'PKG_CONFIG ?='
+    substituteInPlace Makefile --replace-fail 'PKG_CONFIG =' 'PKG_CONFIG ?='
   '';
 
   installFlags = [ "SCRIPTS_DIR=${placeholder "out"}/share/mpv/scripts" ];

--- a/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
@@ -15,7 +15,7 @@ buildLua rec {
   postPatch = ''
     substituteInPlace playlistmanager.lua \
       --replace-fail 'youtube_dl_executable = "youtube-dl",' \
-      'youtube_dl_executable = "${lib.getBin yt-dlp}/bin/yt-dlp"',
+      'youtube_dl_executable = "${lib.getExe yt-dlp}"',
   '';
 
   meta = with lib; {

--- a/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
@@ -14,7 +14,7 @@ buildLua rec {
 
   postPatch = ''
     substituteInPlace playlistmanager.lua \
-      --replace 'youtube_dl_executable = "youtube-dl",' \
+      --replace-fail 'youtube_dl_executable = "youtube-dl",' \
       'youtube_dl_executable = "${lib.getBin yt-dlp}/bin/yt-dlp"',
   '';
 

--- a/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-playlistmanager.nix
@@ -14,7 +14,7 @@ buildLua rec {
 
   postPatch = ''
     substituteInPlace playlistmanager.lua \
-      --replace-fail 'youtube_dl_executable = "youtube-dl",' \
+      --replace-fail 'youtube_dl_executable = "yt-dlp",' \
       'youtube_dl_executable = "${lib.getExe yt-dlp}"',
   '';
 

--- a/pkgs/applications/video/mpv/scripts/mpvacious.nix
+++ b/pkgs/applications/video/mpv/scripts/mpvacious.nix
@@ -23,11 +23,11 @@ buildLua rec {
 
   postPatch = ''
     substituteInPlace utils/forvo.lua \
-      --replace-fail "'curl" "'${curl}/bin/curl"
+      --replace-fail "'curl" "'${lib.getExe curl}"
     substituteInPlace platform/nix.lua \
-      --replace-fail "'curl" "'${curl}/bin/curl" \
-      --replace-fail "'wl-copy" "'${wl-clipboard}/bin/wl-copy" \
-      --replace-fail "'xclip" "'${xclip}/bin/xclip"
+      --replace-fail "'curl" "'${lib.getExe curl}" \
+      --replace-fail "'wl-copy" "'${lib.getExe' wl-clipboard "wl-copy"}" \
+      --replace-fail "'xclip" "'${lib.getExe xclip}"
   '';
 
   installPhase = ''

--- a/pkgs/applications/video/mpv/scripts/mpvacious.nix
+++ b/pkgs/applications/video/mpv/scripts/mpvacious.nix
@@ -23,11 +23,11 @@ buildLua rec {
 
   postPatch = ''
     substituteInPlace utils/forvo.lua \
-      --replace "'curl" "'${curl}/bin/curl"
+      --replace-fail "'curl" "'${curl}/bin/curl"
     substituteInPlace platform/nix.lua \
-      --replace "'curl" "'${curl}/bin/curl" \
-      --replace "'wl-copy" "'${wl-clipboard}/bin/wl-copy" \
-      --replace "'xclip" "'${xclip}/bin/xclip"
+      --replace-fail "'curl" "'${curl}/bin/curl" \
+      --replace-fail "'wl-copy" "'${wl-clipboard}/bin/wl-copy" \
+      --replace-fail "'xclip" "'${xclip}/bin/xclip"
   '';
 
   installPhase = ''

--- a/pkgs/applications/video/mpv/scripts/sponsorblock.nix
+++ b/pkgs/applications/video/mpv/scripts/sponsorblock.nix
@@ -28,8 +28,8 @@ buildLua {
 
   postPatch = ''
     substituteInPlace sponsorblock.lua \
-      --replace "python3" "${python3}/bin/python3" \
-      --replace 'mp.find_config_file("scripts")' "\"$out/share/mpv/scripts\""
+      --replace-fail "python3" "${python3}/bin/python3" \
+      --replace-fail 'mp.find_config_file("scripts")' "\"$out/share/mpv/scripts\""
   '';
 
   extraScripts = [ "sponsorblock_shared" ];

--- a/pkgs/applications/video/mpv/scripts/sponsorblock.nix
+++ b/pkgs/applications/video/mpv/scripts/sponsorblock.nix
@@ -28,7 +28,7 @@ buildLua {
 
   postPatch = ''
     substituteInPlace sponsorblock.lua \
-      --replace-fail "python3" "${python3}/bin/python3" \
+      --replace-fail "python3" "${lib.getExe python3}" \
       --replace-fail 'mp.find_config_file("scripts")' "\"$out/share/mpv/scripts\""
   '';
 

--- a/pkgs/applications/video/mpv/scripts/thumbfast.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbfast.nix
@@ -13,7 +13,7 @@ buildLua {
   passthru.updateScript = unstableGitUpdater {};
 
   passthru.extraWrapperArgs = [
-    "--prefix" "PATH" ":" "${lib.getBin mpv-unwrapped}/bin"
+    "--prefix" "PATH" ":" (lib.makeBinPath [ mpv-unwrapped ])
   ];
 
   meta = {

--- a/pkgs/applications/video/mpv/scripts/vr-reversal.nix
+++ b/pkgs/applications/video/mpv/scripts/vr-reversal.nix
@@ -18,7 +18,7 @@ stdenvNoCC.mkDerivation rec {
 
   # reset_rot is only available in ffmpeg 5.0, see 5bcc61ce87922ecccaaa0bd303a7e195929859a8
   postPatch = lib.optionalString (lib.versionOlder ffmpeg.version "5.0") ''
-    substituteInPlace 360plugin.lua --replace ":reset_rot=1:" ":"
+    substituteInPlace 360plugin.lua --replace-fail ":reset_rot=1:" ":"
   '';
 
   installPhase = ''

--- a/pkgs/applications/video/mpv/scripts/webtorrent-mpv-hook.nix
+++ b/pkgs/applications/video/mpv/scripts/webtorrent-mpv-hook.nix
@@ -15,7 +15,7 @@ buildNpmPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace src/webtorrent.ts --replace-fail "node_path: 'node'" "node_path: '${nodejs}/bin/node'"
+    substituteInPlace src/webtorrent.ts --replace-fail "node_path: 'node'" "node_path: '${lib.getExe nodejs}'"
     # This executable is just for telling non-Nix users how to install
     substituteInPlace package.json --replace-fail '"bin": "build/bin.mjs",' ""
     rm -rf src/bin.ts

--- a/pkgs/applications/video/mpv/scripts/webtorrent-mpv-hook.nix
+++ b/pkgs/applications/video/mpv/scripts/webtorrent-mpv-hook.nix
@@ -15,9 +15,9 @@ buildNpmPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace src/webtorrent.ts --replace "node_path: 'node'" "node_path: '${nodejs}/bin/node'"
+    substituteInPlace src/webtorrent.ts --replace-fail "node_path: 'node'" "node_path: '${nodejs}/bin/node'"
     # This executable is just for telling non-Nix users how to install
-    substituteInPlace package.json --replace '"bin": "build/bin.mjs",' ""
+    substituteInPlace package.json --replace-fail '"bin": "build/bin.mjs",' ""
     rm -rf src/bin.ts
   '';
 

--- a/pkgs/applications/video/mpv/scripts/youtube-upnext.nix
+++ b/pkgs/applications/video/mpv/scripts/youtube-upnext.nix
@@ -13,7 +13,7 @@ buildLua rec {
 
   postPatch = ''
     substituteInPlace youtube-upnext.lua \
-      --replace '"curl"' '"${lib.getExe curl}"'
+      --replace-fail '"curl"' '"${lib.getExe curl}"'
   '';
 
   passthru.updateScript = unstableGitUpdater { };

--- a/pkgs/tools/misc/yad/default.nix
+++ b/pkgs/tools/misc/yad/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
     '';
 
     license = licenses.gpl3;
+    mainProgram = "yad";
     maintainers = with maintainers; [ smironov ];
     platforms = with platforms; linux;
   };


### PR DESCRIPTION
## Description of changes

- `yad`: set `meta.mainProgram`, for use by `lib.getExe` ;
- `mpvScripts`:
  - scopewide: use `substituteInPlace --replace-fail` ;
  - `mpv-playlistmanager`: update an outdated replace patten in `postPatch` ;
  - replace all manual path construction with `lib.getExe` and `lib.makeBinPath`.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review`.
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
