### PR TITLE
mpvScripts: add missing `updateScript`s

### DIFF
--- a/pkgs/applications/video/mpv/scripts/mpv-cheatsheet.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-cheatsheet.nix
@@ -1,4 +1,9 @@
-{ lib, fetchFromGitHub, nodePackages, stdenvNoCC }:
+{ lib
+, fetchFromGitHub
+, gitUpdater
+, nodePackages
+, stdenvNoCC
+}:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mpv-cheatsheet";
   version = "0.30.0.2";
@@ -9,6 +14,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-MWK0CYto3zgn3fivmL43tvgZn6XrjPxKLp0lgTFdplM=";
   };
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   nativeBuildInputs = [
     nodePackages.browserify

--- a/pkgs/applications/video/mpv/scripts/mpv-slicing.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-slicing.nix
@@ -3,6 +3,7 @@
   buildLua,
   fetchFromGitHub,
   ffmpeg,
+  unstableGitUpdater,
 }:
 
 buildLua {
@@ -15,6 +16,7 @@ buildLua {
     rev = "d09c11227704c8d5bdaa2c799ef64dce881c63a7";
     hash = "sha256-MKoM0f74/XoctiHQVOB3LzFWtJXpsREfQh5icaebCJo=";
   };
+  passthru.updateScript = unstableGitUpdater { };
 
   postPatch = ''
     substituteInPlace slicing.lua \


### PR DESCRIPTION
## Description of changes

`mpvScripts.mpv-{cheatsheet, slicing}`: add `updateScript`


## Rationale

The update bot won't automatically deal with drvs that do not have an `updateScript` and aren't in Repology.
Mpv scripts typically aren't tracked by repology.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested `updateScript` with `maintainers/scripts/update.nix`
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
