### PR TITLE
 pkgs/development/tools: Fix some unstableGitUpdater users

### DIFF
--- a/pkgs/development/tools/analysis/tartan/default.nix
+++ b/pkgs/development/tools/analysis/tartan/default.nix
@@ -12,7 +12,7 @@
 
 stdenv.mkDerivation rec {
   pname = "tartan";
-  version = "unstable-2021-12-23";
+  version = "0.3.0-unstable-2021-12-23";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";

--- a/pkgs/development/tools/goperf/default.nix
+++ b/pkgs/development/tools/goperf/default.nix
@@ -8,7 +8,7 @@
 
 buildGoModule rec {
   pname = "goperf";
-  version = "unstable-2023-11-08";
+  version = "0-unstable-2023-11-08";
 
   src = fetchgit {
     url = "https://go.googlesource.com/perf";
@@ -22,8 +22,8 @@ buildGoModule rec {
     export UPDATE_NIX_ATTR_PATH=goperf
     ${lib.escapeShellArgs (unstableGitUpdater { inherit (src) url; })}
     set -x
-    oldhash="$(nix-instantiate . --eval --strict -A "goperf.go-modules.drvAttrs.outputHash" | cut -d'"' -f2)"
-    newhash="$(nix-build -A goperf.go-modules --no-out-link 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
+    oldhash="$(nix-instantiate . --eval --strict -A "goperf.goModules.drvAttrs.outputHash" | cut -d'"' -f2)"
+    newhash="$(nix-build -A goperf.goModules --no-out-link 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
     fname="$(nix-instantiate --eval -E 'with import ./. {}; (builtins.unsafeGetAttrPos "version" goperf).file' | cut -d'"' -f2)"
     ${lib.getExe sd} --string-mode "$oldhash" "$newhash" "$fname"
   '';

--- a/pkgs/development/tools/misc/c2ffi/default.nix
+++ b/pkgs/development/tools/misc/c2ffi/default.nix
@@ -24,6 +24,9 @@ llvmPackages.stdenv.mkDerivation {
   passthru.updateScript = unstableGitUpdater {
     url = "https://github.com/rpav/c2ffi.git";
     branch = c2ffiBranch;
+    # Tags only exist for older LLVM versions, so they would result in nonsense names
+    # like: c2ffi-llvm-16.0.0-11.0.0.0-unstable-YYYY-MM-DD
+    hardcodeZeroVersion = true;
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
+++ b/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
@@ -20,7 +20,9 @@ luarocks.overrideAttrs (old: {
     };
   };
 
-  meta = old.meta // {
+  # old.meta // { /* ... */ } doesn't update meta.position, which breaks the updateScript
+  meta = {
+    inherit (old.meta) description license maintainers platforms;
     mainProgram = "luarocks";
   };
 })

--- a/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
+++ b/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
@@ -2,7 +2,7 @@
 
 luarocks.overrideAttrs (old: {
   pname = "luarocks-nix";
-  version = "unstable-2023-10-19";
+  version = "0-unstable-2023-10-19";
 
   src = fetchFromGitHub {
     owner = "nix-community";
@@ -14,7 +14,10 @@ luarocks.overrideAttrs (old: {
   patches = [ ];
 
   passthru = {
-    updateScript = unstableGitUpdater { };
+    updateScript = unstableGitUpdater {
+      # tags incompletely inherited from regular luarocks
+      hardcodeZeroVersion = true;
+    };
   };
 
   meta = old.meta // {

--- a/pkgs/development/tools/misc/patchelf/unstable.nix
+++ b/pkgs/development/tools/misc/patchelf/unstable.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "patchelf";
-  version = "unstable-2024-01-15";
+  version = "0.18.0-unstable-2024-01-15";
 
   src = fetchFromGitHub {
     owner = "NixOS";

--- a/pkgs/development/tools/vala-lint/default.nix
+++ b/pkgs/development/tools/vala-lint/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation rec {
   pname = "vala-lint";
-  version = "unstable-2023-12-05";
+  version = "0-unstable-2023-12-05";
 
   src = fetchFromGitHub {
     owner = "vala-lang";


### PR DESCRIPTION
## Description of changes

#280501 now makes `unstableGitUpdater` produce versions that match our desired unstable version schema. Start fixing the versions of packages that use it, and their `unstableGitUpdater` arguments as needed.

Tackling packages in `pkgs/development/tools` here. Checked running the update script of everything, which results in either the same version & revs as corrected here, or newer versions.

`luaPackages.luarocks-nix` required an adjustment to `meta` to work. The way it overrode `luaPackages.luarocks.meta` caused `meta.position` to be off, so `update-source-version` was unable to find the file it should update:

```
+ update-source-version luaPackages.luarocks-nix 0-unstable-2024-04-29 --rev=a473a8f479711682f5b97a72362736d96efd463b
update-source-version: error: Couldn't locate old source hash 'sha256-dqFFYehBgK0RqH0/1GtZXq7XLGCcc3Kfadq8ICYNCWk=' (or it appeared more than once) in '<nixpkgs>/pkgs/development/tools/misc/luarocks/default.nix'!
```

Happy to implement a better fix if anyone can think of one. `nix-instantiate . --eval --strict -A "luaPackages.luarocks-nix.meta.position"` needs to point at `luarocks-nix.nix` instead of `default.nix`.

`nixpkgs-review rev HEAD` result, [`tartan`](https://hydra.nixos.org/eval/1806018?filter=tartan&compare=1806008) already fails on Hydra:

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>tartan</li>
  </ul>
</details>
<details>
  <summary>24 packages built:</summary>
  <ul>
    <li>bottles</li>
    <li>bottles-unwrapped</li>
    <li>dell-command-configure</li>
    <li>dropbox</li>
    <li>dropbox-cli</li>
    <li>dropbox-cli.nautilusExtension</li>
    <li>firefox-beta-bin</li>
    <li>firefox-beta-bin-unwrapped</li>
    <li>firefox-bin</li>
    <li>firefox-bin-unwrapped</li>
    <li>firefox-devedition-bin</li>
    <li>firefox-devedition-bin-unwrapped</li>
    <li>gamescope</li>
    <li>goperf</li>
    <li>hotspot</li>
    <li>lua51Packages.luarocks-nix</li>
    <li>lua52Packages.luarocks-nix</li>
    <li>lua53Packages.luarocks-nix</li>
    <li>lua54Packages.luarocks-nix</li>
    <li>luajitPackages.luarocks-nix</li>
    <li>luarocks-packages-updater</li>
    <li>mate.caja-dropbox</li>
    <li>patchelfUnstable</li>
    <li>vala-lint</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
