### PR TITLE
typesense: add darwin support

### DIFF
--- a/pkgs/servers/search/typesense/default.nix
+++ b/pkgs/servers/search/typesense/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     inherit hash;
   };
 
-  nativeBuildInputs = [
+  nativeBuildInputs = lib.optionals stdenv.isLinux [
     autoPatchelfHook
   ];
 
@@ -59,7 +59,7 @@ stdenv.mkDerivation {
     #     This is where I stopped trying for now.
     # XXX: retry once typesense has officially released their bazel based build.
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
     maintainers = with maintainers; [ oddlama ];
   };
 }

--- a/pkgs/servers/search/typesense/default.nix
+++ b/pkgs/servers/search/typesense/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation {
     #     This is where I stopped trying for now.
     # XXX: retry once typesense has officially released their bazel based build.
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with maintainers; [ oddlama ];
   };
 }

--- a/pkgs/servers/search/typesense/sources.json
+++ b/pkgs/servers/search/typesense/sources.json
@@ -12,6 +12,10 @@
     "x86_64-darwin": {
       "arch": "darwin-amd64",
       "hash": "sha256-FkWie6DgIhgojrn48rt9/GT0Lmu7jt74q2rzw1MI2Ws="
+    },
+    "aarch64-darwin": {
+      "arch": "darwin-arm64",
+      "hash": "sha256-ejw8B+DmCQs6cUSiLueY9tSdWnrFSFvLMS36U4+v8N4="
     }
   }
 }

--- a/pkgs/servers/search/typesense/update.sh
+++ b/pkgs/servers/search/typesense/update.sh
@@ -15,6 +15,7 @@ fi
 
 declare -A platforms=(
     [aarch64-linux]="linux-arm64"
+    [aarch64-darwin]="darwin-arm64"
     [x86_64-darwin]="darwin-amd64"
     [x86_64-linux]="linux-amd64"
 )


### PR DESCRIPTION
## Description of changes

Typesense now builds too on darwin

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
