### PR TITLE
python312Packages.phunspell: init at 0.1.6

### DIFF
--- a/pkgs/development/python-modules/phunspell/default.nix
+++ b/pkgs/development/python-modules/phunspell/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+
+  setuptools,
+
+  spylls,
+}:
+
+buildPythonPackage rec {
+  pname = "phunspell";
+  version = "0.1.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "dvwright";
+    repo = "phunspell";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-TlO9Ccr2iRN+s3JV+3P36RF9oFY32fj+24sKslZZCVk=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-package-data-warning.patch";
+      url = "https://github.com/dvwright/phunspell/commit/70a0ee8af8442797e03916cea31637c21e6d32d9.patch";
+      hash = "sha256-kSaKHd7dVJM8+2dqxjs26Hv0feNXAXXymUE97DNVBFM=";
+    })
+    (fetchpatch {
+      name = "replace-description-file-deprecated-option.patch";
+      url = "https://github.com/dvwright/phunspell/commit/331c593b486cebe1a9b72befa568de9b51033f15.patch";
+      hash = "sha256-gdYfeG1vBtjnDDCjmg+ZSuToqVe0hrzB3RIqBLGNvBQ=";
+    })
+  ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [ spylls ];
+
+  # for tests need lots of RAM, just skip...
+  doCheck = false;
+
+  pythonImportsCheck = [ "phunspell" ];
+
+  meta = with lib; {
+    description = "Pure Python spell checker, wrapping spylls a port of Hunspell";
+    homepage = "https://github.com/dvwright/phunspell";
+    changelog = "https://github.com/dvwright/phunspell/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ vizid ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9717,6 +9717,8 @@ self: super: with self; {
 
   phpserialize = callPackage ../development/python-modules/phpserialize { };
 
+  phunspell = callPackage ../development/python-modules/phunspell { };
+
   phx-class-registry = callPackage ../development/python-modules/phx-class-registry { };
 
   pi1wire = callPackage ../development/python-modules/pi1wire { };


### PR DESCRIPTION
## Description of changes
Pure Python spell checker, wrapping spylls a port of Hunspell
https://github.com/dvwright/phunspell

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
