### PR TITLE
notmuch: install the vim plugin

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -15,12 +15,12 @@
 , withVim ? true
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "notmuch";
   version = "0.38.3";
 
   src = fetchurl {
-    url = "https://notmuchmail.org/releases/notmuch-${version}.tar.xz";
+    url = "https://notmuchmail.org/releases/notmuch-${finalAttrs.version}.tar.xz";
     hash = "sha256-mvRsyA2li0MByiuu/MJaQNES0DFVB+YywPPw8IMo0FQ=";
   };
 
@@ -141,9 +141,8 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    pythonSourceRoot = "notmuch-${version}/bindings/python";
+    pythonSourceRoot = "notmuch-${finalAttrs.version}/bindings/python";
     tests.version = testers.testVersion { package = notmuch; };
-    inherit version;
 
     updateScript = gitUpdater {
       url = "https://git.notmuchmail.org/git/notmuch";
@@ -160,4 +159,4 @@ stdenv.mkDerivation rec {
     platforms   = platforms.unix;
     mainProgram = "notmuch";
   };
-}
+})

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -12,6 +12,7 @@
 , withEmacs ? true
 , withRuby ? true
 , withSfsexp ? true # also installs notmuch-git, which requires sexp-support
+, withVim ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -133,6 +134,10 @@ stdenv.mkDerivation rec {
   + lib.optionalString withSfsexp ''
     cp notmuch-git $out/bin/notmuch-git
     wrapProgram $out/bin/notmuch-git --prefix PATH : $out/bin:${lib.getBin git}/bin
+  '' + lib.optionalString withVim ''
+    make -C vim DESTDIR="$out/share/vim-plugins/notmuch" prefix="" install
+    mkdir -p $out/share/nvim
+    ln -s $out/share/vim-plugins/notmuch $out/share/nvim/site
   '';
 
   passthru = {


### PR DESCRIPTION
Seems I messed up squashing https://github.com/NixOS/nixpkgs/pull/308318

> Changes look good, but I haven't tested them. In any case, could you squash the commits please into 1 notmuch: install the vim plugin?

That's fixed now @doronbehar.

I'm still thinking about how to pick up the Ruby bindings. It would make it easier if they were in the same output. It doesn't look like there were any strong reasons against this https://github.com/NixOS/nixpkgs/pull/155056. 