### PR TITLE
python312Packages.upb-lib: 0.5.4 -> 0.5.6

### DIFF
--- a/pkgs/development/python-modules/upb-lib/default.nix
+++ b/pkgs/development/python-modules/upb-lib/default.nix
@@ -1,37 +1,51 @@
 { lib
 , buildPythonPackage
+, fetchFromGitHub
+, pyserial-asyncio-fast
+, pytestCheckHook
 , pythonOlder
-, fetchPypi
-, pyserial-asyncio
 , pytz
+, poetry-core
 }:
 
 buildPythonPackage rec {
   pname = "upb-lib";
-  version = "0.5.4";
-  format = "setuptools";
+  version = "0.5.6";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.11";
 
-  src = fetchPypi {
-    pname = "upb_lib";
-    inherit version;
-    hash = "sha256-KEnSADj+sQtz37Xbi6fXoe2TN+F5Z9SYnlvCgXtxVnk=";
+  src = fetchFromGitHub {
+    owner = "gwww";
+    repo = "upb-lib";
+    rev = "refs/tags/${version}";
+    hash = "sha256-e8LYywKA5lNZ4UYFZTwcfePDWB4cTNz38Tiy4xzOxOs=";
   };
 
-  propagatedBuildInputs = [
-    pyserial-asyncio
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    pyserial-asyncio-fast
     pytz
   ];
 
-  # no tests on PyPI, no tags on GitHub
-  doCheck = false;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "upb_lib" ];
+
+  disabledTests = [
+    # AssertionError
+    "test_create_control_word_all"
+  ];
 
   meta = with lib; {
     description = "Library for interacting with UPB PIM";
     homepage = "https://github.com/gwww/upb-lib";
+    changelog = "https://github.com/gwww/upb-lib/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ dotlambda ];
   };


### PR DESCRIPTION
Diff: https://github.com/gwww/upb-lib/compare/refs/tags/0.5.4...0.5.6

Changelog: https://github.com/gwww/upb-lib/releases/tag/0.5.6

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
