### PR TITLE
darwin.stdenv: propagate sdkRoot via extraBuildInputs

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk/sdkRoot.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/sdkRoot.nix
@@ -41,18 +41,14 @@ runCommand "sdkroot-${sdkVersion}" { } ''
 
   install -D '${../../../build-support/setup-hooks/role.bash}' "$out/nix-support/setup-hook"
   cat >> "$out/nix-support/setup-hook" <<-hook
-  #
-  # See comments in cc-wrapper's setup hook. This works exactly the same way.
-  #
-  [[ -z \''${strictDeps-} ]] || (( "\$hostOffset" < 0 )) || return 0
-
   sdkRootHook() {
     # See ../../../build-support/setup-hooks/role.bash
     local role_post
     getHostRoleEnvHook
 
     # Only set the SDK root if one has not been set via this hook or some other means.
-    if [[ ! \$NIX_CFLAGS_COMPILE =~ isysroot ]]; then
+    local cflagsVar=NIX_CFLAGS_COMPILE\''${role_post}
+    if [[ ! \''${!cflagsVar} =~ isysroot ]]; then
       export NIX_CFLAGS_COMPILE\''${role_post}+=' -isysroot $out/${sdkName}.sdk'
     fi
   }
@@ -60,9 +56,9 @@ runCommand "sdkroot-${sdkVersion}" { } ''
   # See ../../../build-support/setup-hooks/role.bash
   getTargetRole
 
-  addEnvHooks "\$targetOffset" sdkRootHook
+  addEnvHooks "\$hostOffset" sdkRootHook
 
   # No local scope in sourced file
-  unset -v role_post
+  unset -v cflagsVar role_post
   hook
 ''

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -138,9 +138,8 @@ let
 
         inherit config;
 
-        extraBuildInputs = [ prevStage.darwin.CF ];
-        extraNativeBuildInputs = extraNativeBuildInputs
-          ++ [ prevStage.darwin.apple_sdk.sdkRoot ];
+        extraBuildInputs = [ prevStage.darwin.CF prevStage.darwin.apple_sdk.sdkRoot ];
+        extraNativeBuildInputs = extraNativeBuildInputs;
 
         preHook = lib.optionalString (!isBuiltByNixpkgsCompiler bash) ''
           # Don't patch #!/interpreter because it leads to retained
@@ -671,7 +670,7 @@ in
           # libc++, and libc++abi do not need CoreFoundation. Avoid propagating the CF from prior
           # stages to the final stdenv via rpath by dropping it from `extraBuildInputs`.
           stdenvNoCF = self.stdenv.override {
-            extraBuildInputs = [ ];
+            extraBuildInputs = [ prevStage.darwin.apple_sdk.sdkRoot ];
           };
 
           libcxxBootstrapStdenv = self.overrideCC stdenvNoCF (self.llvmPackages.clangNoCompilerRtWithLibc.override {
@@ -885,7 +884,7 @@ in
             compiler-rt = superLib.compiler-rt.override ({
               inherit (self.llvmPackages) libllvm;
               stdenv = self.stdenv.override {
-                extraBuildInputs = [ self.darwin.CF ];
+                extraBuildInputs = [ self.darwin.CF prevStage.darwin.apple_sdk.sdkRoot ];
               };
             });
           });
@@ -899,7 +898,7 @@ in
       stdenv =
         let
           stdenvNoCF = super.stdenv.override {
-            extraBuildInputs = [ ];
+            extraBuildInputs = [ prevStage.darwin.apple_sdk.sdkRoot ];
           };
         in
         self.overrideCC stdenvNoCF (self.llvmPackages.clangNoCompilerRtWithLibc.override {
@@ -1230,9 +1229,9 @@ in
 
       extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
         prevStage.updateAutotoolsGnuConfigScriptsHook
-      ] ++ [ prevStage.darwin.apple_sdk.sdkRoot ];
+      ];
 
-      extraBuildInputs = [ prevStage.darwin.CF ];
+      extraBuildInputs = [ prevStage.darwin.CF prevStage.darwin.apple_sdk.sdkRoot ];
 
       inherit cc;
 

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -79,7 +79,7 @@ impure-cmds // appleSourcePackages // chooseLibs // {
   inherit apple_sdk apple_sdk_10_12 apple_sdk_11_0;
 
   stdenvNoCF = stdenv.override {
-    extraBuildInputs = [];
+    extraBuildInputs = [ apple_sdk.sdkRoot ];
   };
 
   binutils-unwrapped = callPackage ../os-specific/darwin/binutils {


### PR DESCRIPTION
## Description of changes

This ensures it is properly dropped when cross-compiling.

I tested by building the Darwin bootstrap on aarch64-darwin and building psutil in the bootstrap to confirm the sdk root is being propagated correctly. It should have an SDK version of 11.0 (and did).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
