### PR TITLE
google-chrome: move independently of `chromium`, add jnsgruk as maintainer, remove leftover `google-chrome-{beta,dev}` code paths

### DIFF
--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -28,9 +28,6 @@
 ## Gentoo
 , bzip2, libcap
 
-# Which distribution channel to use.
-, channel ? "stable"
-
 # Necessary for USB audio devices.
 , pulseSupport ? true, libpulseaudio
 
@@ -70,16 +67,10 @@ let
     ++ lib.optional libvaSupport libva
     ++ [ gtk3 gtk4 ];
 
-  suffix = lib.optionalString (channel != "stable") "-${channel}";
-
-  crashpadHandlerBinary = if lib.versionAtLeast version "94"
-    then "chrome_crashpad_handler"
-    else "crashpad_handler";
-
 in stdenv.mkDerivation {
   inherit version;
 
-  name = "google-chrome${suffix}-${version}";
+  pname = "google-chrome";
 
   src = chromium.chromeSrc;
 
@@ -103,11 +94,8 @@ in stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    case ${channel} in
-      beta) appname=chrome-beta      dist=beta     ;;
-      dev)  appname=chrome-unstable  dist=unstable ;;
-      *)    appname=chrome           dist=stable   ;;
-    esac
+    appname=chrome
+    dist=stable
 
     exe=$out/bin/google-chrome-$dist
 
@@ -149,7 +137,7 @@ in stdenv.mkDerivation {
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
 
-    for elf in $out/share/google/$appname/{chrome,chrome-sandbox,${crashpadHandlerBinary}}; do
+    for elf in $out/share/google/$appname/{chrome,chrome-sandbox,chrome_crashpad_handler}; do
       patchelf --set-rpath $rpath $elf
       patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $elf
     done
@@ -167,8 +155,6 @@ in stdenv.mkDerivation {
     # will try to merge PRs and respond to issues but I'm not actually using
     # Google Chrome.
     platforms = [ "x86_64-linux" ];
-    mainProgram =
-      if (channel == "dev") then "google-chrome-unstable"
-      else "google-chrome-${channel}";
+    mainProgram = "google-chrome-stable";
   };
 }

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -147,7 +147,7 @@ in stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.google.com/chrome/browser/";
     license = licenses.unfree;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ jnsgruk ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "google-chrome-stable";
   };

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, patchelf, makeWrapper
+{ lib, stdenv, patchelf, makeWrapper, fetchurl
 
 # Linked dynamic libraries.
 , glib, fontconfig, freetype, pango, cairo, libX11, libXi, atk, nss, nspr
@@ -31,9 +31,6 @@
 # Necessary for USB audio devices.
 , pulseSupport ? true, libpulseaudio
 
-# Only needed for getting information about upstream binaries
-, chromium
-
 , gsettings-desktop-schemas
 , gnome
 
@@ -48,8 +45,6 @@ let
   opusWithCustomModes = libopus.override {
     withCustomModes = true;
   };
-
-  version = chromium.upstream-info.version;
 
   deps = [
     glib fontconfig freetype pango cairo libX11 libXi atk nss nspr
@@ -67,12 +62,14 @@ let
     ++ lib.optional libvaSupport libva
     ++ [ gtk3 gtk4 ];
 
-in stdenv.mkDerivation {
-  inherit version;
-
+in stdenv.mkDerivation (finalAttrs: {
   pname = "google-chrome";
+  version = "124.0.6367.118";
 
-  src = chromium.chromeSrc;
+  src = fetchurl {
+    url = "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${finalAttrs.version}-1_amd64.deb";
+    hash = "sha256-H3bv6WiVBl4j38ROZ80+SD9UO9ok+xxcKFxDd9yjWNY=";
+  };
 
   nativeBuildInputs = [ patchelf makeWrapper ];
   buildInputs = [
@@ -150,11 +147,8 @@ in stdenv.mkDerivation {
     homepage = "https://www.google.com/chrome/browser/";
     license = licenses.unfree;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    maintainers = with maintainers; [ primeos ];
-    # Note from primeos: By updating Chromium I also update Google Chrome and
-    # will try to merge PRs and respond to issues but I'm not actually using
-    # Google Chrome.
+    maintainers = with maintainers; [ ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "google-chrome-stable";
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Please see the commit message bodies for details.

Security label, because this also contains the security fixes from #308358 (version 124.0.6367.118).

Thanks a lot @jnsgruk! :)
Feel free to ping me from time to time if you need help. I can't promise I'll respond (something something already at capacity) but don't feel like you are completely on your own.

I believe this will be extremely low maintenance (e.g. build fixes), besides the very frequent version bumps.

And @r-ryantm will likely help you as well :)

Though please keep in mind, that you need to add the backport label to all update PRs.

Ref #306010

cc @jnsgruk @primeos

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) 
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
