### PR TITLE
libiio: 0.24 -> 0.25

### DIFF
--- a/pkgs/development/libraries/libiio/cmake-fix-libxml2-find-package.patch
+++ b/pkgs/development/libraries/libiio/cmake-fix-libxml2-find-package.patch
@@ -1,13 +1,13 @@
-diff --color -ur a/CMakeLists.txt b/CMakeLists.txt
---- a/CMakeLists.txt	2022-06-02 02:57:01.503340155 +0300
-+++ b/CMakeLists.txt	2022-06-02 02:54:33.726941188 +0300
-@@ -378,7 +378,7 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 858cb239..50e6fac1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -408,7 +408,7 @@ if (WITH_XML_BACKEND)
  	# So, try first to find the CMake module provided by libxml2 package, then fallback
  	# on the CMake's FindLibXml2.cmake module (which can lack some definition, especially
  	# in static build case).
--	find_package(LibXml2 QUIET NO_MODULE)
+-	find_package(LibXml2 QUIET NO_MODULE NO_SYSTEM_ENVIRONMENT_PATH)
 +	find_package(LibXml2 QUIET MODULE)
  	if(DEFINED LIBXML2_VERSION_STRING)
  		set(LIBXML2_FOUND ON)
  		set(LIBXML2_INCLUDE_DIR ${LIBXML2_INCLUDE_DIRS})
-Seulement dans b: good.patch

--- a/pkgs/development/libraries/libiio/default.nix
+++ b/pkgs/development/libraries/libiio/default.nix
@@ -17,7 +17,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libiio";
-  version = "0.24";
+  version = "0.25";
 
   outputs = [ "out" "lib" "dev" ]
     ++ lib.optional pythonSupport "python";
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     owner = "analogdevicesinc";
     repo = "libiio";
     rev = "v${version}";
-    sha256 = "sha256-c5HsxCdp1cv5BGTQ/8dc8J893zk9ntbfAudLpqoQ1ow=";
+    sha256 = "sha256-s+5zuw3nAxnE8LVreCdrLGVrEUzzXmfIfPXW5iH6auM=";
   };
 
   # Revert after https://github.com/NixOS/nixpkgs/issues/125008 is
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace libiio.rules.cmakein \
-      --replace /bin/sh ${runtimeShell}
+      --replace-fail /bin/sh ${runtimeShell}
   '' + lib.optionalString pythonSupport ''
     # Hardcode path to the shared library into the bindings.
     sed "s#@libiio@#$lib/lib/libiio${stdenv.hostPlatform.extensions.sharedLibrary}#g" ${./hardcode-library-path.patch} | patch -p1

--- a/pkgs/development/libraries/libiio/hardcode-library-path.patch
+++ b/pkgs/development/libraries/libiio/hardcode-library-path.patch
@@ -1,38 +1,13 @@
-diff --git a/bindings/python/iio.py b/bindings/python/iio.py
-index 5306daa..f8962ee 100644
---- a/bindings/python/iio.py
-+++ b/bindings/python/iio.py
-@@ -229,9 +229,9 @@ if "Windows" in _system():
-     _iiolib = "libiio.dll"
- else:
-     # Non-windows, possibly Posix system
--    _iiolib = "iio"
-+    _iiolib = "@libiio@"
- 
--_lib = _cdll(find_library(_iiolib), use_errno=True, use_last_error=True)
-+_lib = _cdll(_iiolib, use_errno=True, use_last_error=True)
- 
- _get_backends_count = _lib.iio_get_backends_count
- _get_backends_count.restype = c_uint
 diff --git a/bindings/python/setup.py.cmakein b/bindings/python/setup.py.cmakein
-index cd14e2e..516c409 100644
+index 33a4eb91..74cc50ab 100644
 --- a/bindings/python/setup.py.cmakein
 +++ b/bindings/python/setup.py.cmakein
-@@ -62,7 +62,7 @@ class InstallWrapper(install):
-             _iiolib = "libiio.dll"
-         else:
-             # Non-windows, possibly Posix system
--            _iiolib = "iio"
-+            _iiolib = "@libiio@"
-         try:
-             import os
+@@ -66,7 +66,7 @@ class InstallWrapper(install):
  
-@@ -72,7 +72,7 @@ class InstallWrapper(install):
-                 fulllibpath = find_recursive(destdir, "libiio.so")
-                 _lib = _cdll(fulllibpath, use_errno=True, use_last_error=True)
-             else:
--                _lib = _cdll(find_library(_iiolib), use_errno=True, use_last_error=True)
-+                _lib = _cdll(_iiolib, use_errno=True, use_last_error=True)
+         try:
+ 
+-            _lib = _cdll(fulllibpath, use_errno=True, use_last_error=True)
++            _lib = _cdll("@libiio@", use_errno=True, use_last_error=True)
              if not _lib._name:
                  raise OSError
          except OSError:


### PR DESCRIPTION
## Description of changes

Update libiio to version 0.25.
See [libiio release](https://github.com/analogdevicesinc/libiio/releases/tag/v0.25) for changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


## nixpkgs-review
```bash
[nix-shell:~/.cache/nixpkgs-review/rev-6ada5a82dbfd2cabcbeec3d6715d2efe14a80597]$ cat ./report.json 
{
    "blacklisted": [],
    "broken": [],
    "built": [
        "gnuradio",
        "gnuradioMinimal",
        "gnuradioPackages.osmosdr",
        "gnuradioPackages.osmosdr.dev",
        "libad9361",
        "libiio",
        "libiio.dev",
        "libiio.lib",
        "libiio.python",
        "python312Packages.libiio",
        "sdrangel",
        "urh",
        "urh.dist"
    ],
    "extra-nixpkgs-config": null,
    "failed": [],
    "non-existent": [],
    "pr": null,
    "system": "aarch64-darwin",
    "tests": []
}
```

## iio executables
### iio_attr
```bash
(base) user@host> /nix/store/s91fch9hllkchqangqp33mhwmnabfbzc-libiio-0.25/bin/iio_attr -u 'usb:' -D                                            ~/nixpkgs
IIO context has 5 devices:
        iio:device0, adm1177: found 0 debug attributes
        iio:device1, ad9361-phy: found 179 debug attributes
        iio:device2, xadc: found 0 debug attributes
        iio:device3, cf-ad9361-dds-core-lpc: found 1 debug attributes
        iio:device4, cf-ad9361-lpc: found 2 debug attributes
```
### iio_info
```bash
(base) seedart@cdmbp> /nix/store/s91fch9hllkchqangqp33mhwmnabfbzc-libiio-0.25/bin/iio_attr -u 'usb:' -D                                            ~/nixpkgs
IIO context has 5 devices:
        iio:device0, adm1177: found 0 debug attributes
        iio:device1, ad9361-phy: found 179 debug attributes
        iio:device2, xadc: found 0 debug attributes
        iio:device3, cf-ad9361-dds-core-lpc: found 1 debug attributes
        iio:device4, cf-ad9361-lpc: found 2 debug attributes
```