### PR TITLE
igvm-tooling: init at 1.5.0

### DIFF
--- a/pkgs/by-name/ig/igvm-tooling/package.nix
+++ b/pkgs/by-name/ig/igvm-tooling/package.nix
@@ -1,0 +1,78 @@
+{ lib
+, python3
+, fetchFromGitHub
+, fetchpatch
+, which
+, acpica-tools
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "igvm-tooling";
+  version = "1.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "igvm-tooling";
+    rev = "igvm-${version}";
+    hash = "sha256-13TtiJv2w9WXSW6oPMfo+rRah+Q1wHV14aBaFGfz9CE=";
+  };
+
+  patches = [
+    # drop unused libclang dependency
+    # remove once https://github.com/microsoft/igvm-tooling/pull/53 is merged
+    (fetchpatch {
+      name = "0001-setup.py-remove-unused-libclang-dependency.patch";
+      url = "https://github.com/microsoft/igvm-tooling/commit/7182e925de9b5e9f5c8c3a3ce6e3942a92506064.patch";
+      sha256 = "sha256-tcVxcuLxknyEdo2YjeHOqSG9xQna8US+YyvlcfX+Htw=";
+      stripLen = 1;
+    })
+    # write updated acpi files to tempdir (instead of nix store path) at runtime
+    # remove once https://github.com/microsoft/igvm-tooling/pull/54 is merged
+    (fetchpatch {
+      name = "0002-acpi-update-dsl-files-in-tempdir.patch";
+      url = "https://github.com/microsoft/igvm-tooling/commit/20f8d123ec6531d8540074b7df2ee12de60e73b8.patch";
+      sha256 = "sha256-hNfkclxaYViy66TPHqLV3mqD7wqBuBN9MnMLaDOeRNM=";
+      stripLen = 1;
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace igvm/acpi.py \
+      --replace-fail 'os.path.join(os.path.dirname(__file__), "acpi", "acpi.zip")' "\"$out/share/igvm-tooling/acpi/acpi.zip\""
+  '';
+
+  sourceRoot = "${src.name}/src";
+
+  nativeBuildInputs = [ acpica-tools ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    setuptools
+    ecdsa
+    cstruct
+    pyelftools
+    pytest
+    cached-property
+    frozendict
+  ] ++ [
+    acpica-tools
+    which
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/igvm-tooling/acpi/acpi-clh
+    cp -rT igvm/acpi/acpi-clh $out/share/igvm-tooling/acpi/acpi-clh
+    cp igvm/acpi/acpi.zip $out/share/igvm-tooling/acpi/acpi.zip
+    find $out/share/igvm-tooling/acpi -name "*.dsl" -exec iasl -f {} \;
+  '';
+
+  meta = {
+    description = "IGVM Image Generator";
+    homepage = "https://github.com/microsoft/igvm-tooling";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.malt3 ];
+    changelog = "https://github.com/microsoft/igvm-tooling/releases/tag/igvm-${version}";
+    mainProgram = "igvmgen";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The igvm-tooling repository contains `igvmgen`, a build tool for the igvm image format.
This format is used in the Confidential Containers and Kata Containers world to describe the initial memory contents of a pod virtual machine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
