### PR TITLE
nixos/xkb: extract from xserver 

### DIFF
--- a/nixos/modules/config/console.nix
+++ b/nixos/modules/config/console.nix
@@ -120,16 +120,17 @@ in
   ###### implementation
 
   config = mkMerge [
-    { console.keyMap = with config.services.xserver;
-        mkIf cfg.useXkbConfig
-          (pkgs.runCommand "xkb-console-keymap" { preferLocalBuild = true; } ''
-            '${pkgs.buildPackages.ckbcomp}/bin/ckbcomp' \
-              ${optionalString (config.environment.sessionVariables ? XKB_CONFIG_ROOT)
-                "-I${config.environment.sessionVariables.XKB_CONFIG_ROOT}"
-              } \
-              -model '${xkb.model}' -layout '${xkb.layout}' \
-              -option '${xkb.options}' -variant '${xkb.variant}' > "$out"
-          '');
+    { console.keyMap = let
+      xkb = config.environment.xkb;
+    in mkIf cfg.useXkbConfig
+      (pkgs.runCommand "xkb-console-keymap" { preferLocalBuild = true; } ''
+        '${pkgs.buildPackages.ckbcomp}/bin/ckbcomp' \
+          ${optionalString (config.environment.sessionVariables ? XKB_CONFIG_ROOT)
+            "-I${config.environment.sessionVariables.XKB_CONFIG_ROOT}"
+          } \
+          -model '${xkb.model}' -layout '${xkb.layout}' \
+          -option '${xkb.options}' -variant '${xkb.variant}' > "$out"
+      '');
     }
 
     (mkIf (!cfg.enable) {

--- a/nixos/modules/config/xkb.nix
+++ b/nixos/modules/config/xkb.nix
@@ -17,7 +17,7 @@ in
       default = "${pkgs.xkeyboard_config}/etc/X11/xkb";
       defaultText = lib.literalExpression ''"''${pkgs.xkeyboard_config}/etc/X11/xkb"'';
       description = ''
-        Path used for -xkbdir xserver parameter.
+        Path to the xkb configs which are symlinked to /etc/X11/xkb and will be used for the `-xkbdir` xserver parameter.
       '';
     };
 

--- a/nixos/modules/config/xkb.nix
+++ b/nixos/modules/config/xkb.nix
@@ -7,6 +7,81 @@
 
 let
   cfg = config.environment.xkb;
+
+  layoutOpts = {
+    options = {
+      description = lib.mkOption {
+        type = lib.types.str;
+        description = "A short description of the layout.";
+      };
+
+      languages = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        description = ''
+          A list of languages provided by the layout.
+          (Use ISO 639-2 codes, for example: "eng" for english)
+        '';
+      };
+
+      compatFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          The path to the xkb compat file.
+          This file sets the compatibility state, used to preserve
+          compatibility with xkb-unaware programs.
+          It must contain a `xkb_compat "name" { ... }` block.
+        '';
+      };
+
+      geometryFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          The path to the xkb geometry file.
+          This (completely optional) file describes the physical layout of
+          keyboard, which maybe be used by programs to depict it.
+          It must contain a `xkb_geometry "name" { ... }` block.
+        '';
+      };
+
+      keycodesFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          The path to the xkb keycodes file.
+          This file specifies the range and the interpretation of the raw
+          keycodes sent by the keyboard.
+          It must contain a `xkb_keycodes "name" { ... }` block.
+        '';
+      };
+
+      symbolsFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          The path to the xkb symbols file.
+          This is the most important file: it defines which symbol or action
+          maps to each key and must contain a
+          `xkb_symbols "name" { ... }` block.
+        '';
+      };
+
+      typesFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          The path to the xkb types file.
+          This file specifies the key types that can be associated with
+          the various keyboard keys.
+          It must contain a `xkb_types "name" { ... }` block.
+        '';
+      };
+
+    };
+  };
+
+  xkb_patched = pkgs.xorg.xkeyboardconfig_custom { layouts = cfg.extraLayouts; };
 in
 {
   options.environment.xkb = {
@@ -26,6 +101,27 @@ in
       default = "us";
       description = ''
         X keyboard layout, or multiple keyboard layouts separated by commas.
+      '';
+    };
+
+    extraLayouts = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule layoutOpts);
+      default = { };
+      example = lib.literalExpression ''
+        {
+           mine = {
+            description = "My custom xkb layout.";
+            languages = [ "eng" ];
+            symbolsFile = /path/to/my/layout;
+          };
+        }
+      '';
+      description = ''
+        Extra custom layouts that will be included in the xkb configuration.
+        Information on how to create a new layout can be found here:
+        <https://www.x.org/releases/current/doc/xorg-docs/input/XKB-Enhancing.html#Defining_New_Layouts>.
+        For more examples see
+        <https://wiki.archlinux.org/index.php/X_KeyBoard_extension#Basic_examples>
       '';
     };
 
@@ -58,7 +154,14 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    environment.etc."X11/xkb".source = cfg.dir;
+    environment = {
+      etc."X11/xkb".source = cfg.dir;
+      # runtime override supported by multiple libraries e. g. libxkbcommon
+      # https://xkbcommon.org/doc/current/group__include-path.html
+      sessionVariables.XKB_CONFIG_ROOT = cfg.dir;
+
+      xkb.dir = lib.mkIf (cfg.extraLayouts != { }) "${xkb_patched}/etc/X11/xkb";
+    };
 
     system.checks = lib.singleton (
       pkgs.runCommand "xkb-validated"

--- a/nixos/modules/config/xkb.nix
+++ b/nixos/modules/config/xkb.nix
@@ -1,0 +1,73 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.environment.xkb;
+in
+{
+  options.environment.xkb = {
+    enable = lib.mkEnableOption "XKB - X Keyboard Extension";
+
+    dir = lib.mkOption {
+      type = lib.types.path;
+      default = "${pkgs.xkeyboard_config}/etc/X11/xkb";
+      defaultText = lib.literalExpression ''"''${pkgs.xkeyboard_config}/etc/X11/xkb"'';
+      description = ''
+        Path used for -xkbdir xserver parameter.
+      '';
+    };
+
+    layout = lib.mkOption {
+      type = lib.types.str;
+      default = "us";
+      description = ''
+        X keyboard layout, or multiple keyboard layouts separated by commas.
+      '';
+    };
+
+    model = lib.mkOption {
+      type = lib.types.str;
+      default = "pc104";
+      example = "presario";
+      description = ''
+        X keyboard model.
+      '';
+    };
+
+    options = lib.mkOption {
+      type = lib.types.commas;
+      default = "terminate:ctrl_alt_bksp";
+      example = "grp:caps_toggle,grp_led:scroll";
+      description = ''
+        X keyboard options; layout switching goes here.
+      '';
+    };
+
+    variant = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      example = "colemak";
+      description = ''
+        X keyboard variant.
+      '';
+    };
+  };
+
+  config = {
+    system.checks = lib.singleton (pkgs.runCommand "xkb-validated" {
+      inherit (cfg) dir model layout variant options;
+      nativeBuildInputs = with pkgs.buildPackages; [ xkbvalidate ];
+      preferLocalBuild = true;
+    } ''
+      ${lib.optionalString (config.environment.sessionVariables ? XKB_CONFIG_ROOT)
+        "export XKB_CONFIG_ROOT=${config.environment.sessionVariables.XKB_CONFIG_ROOT}"
+      }
+      XKB_CONFIG_ROOT="$dir" xkbvalidate "$model" "$layout" "$variant" "$options"
+      touch "$out"
+    '');
+  };
+}

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -169,9 +169,9 @@ in
       $xserverConfig
 
       $desktopConfiguration
-        # Configure keymap in X11
-        # services.xserver.xkb.layout = "us";
-        # services.xserver.xkb.options = "eurosign:e,caps:escape";
+        # Configure keymap in X11 and Wayland
+        # environment.xkb.layout = "us";
+        # environment.xkb.options = "eurosign:e,caps:escape";
 
         # Enable CUPS to print documents.
         # services.printing.enable = true;

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -46,6 +46,7 @@
   ./config/xdg/portals/wlr.nix
   ./config/xdg/sounds.nix
   ./config/xdg/terminal-exec.nix
+  ./config/xkb.nix
   ./config/zram.nix
   ./hardware/acpilight.nix
   ./hardware/all-firmware.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1544,7 +1544,6 @@
   ./services/x11/display-managers/startx.nix
   ./services/x11/display-managers/sx.nix
   ./services/x11/display-managers/xpra.nix
-  ./services/x11/extra-layouts.nix
   ./services/x11/fractalart.nix
   ./services/x11/hardware/cmt.nix
   ./services/x11/hardware/digimend.nix

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -187,8 +187,6 @@ in {
       "/libexec" # for drkonqi
     ];
 
-    environment.etc."X11/xkb".source = config.services.xserver.xkb.dir;
-
     # Add ~/.config/kdedefaults to XDG_CONFIG_DIRS for shells, since Plasma sets that.
     # FIXME: maybe we should append to XDG_CONFIG_DIRS in /etc/set-environment instead?
     environment.sessionVariables.XDG_CONFIG_DIRS = ["$HOME/.config/kdedefaults"];

--- a/nixos/modules/services/display-managers/sddm.nix
+++ b/nixos/modules/services/display-managers/sddm.nix
@@ -115,11 +115,13 @@ let
             enable-tap = config.services.libinput.mouse.tapping;
             left-handed = config.services.libinput.mouse.leftHanded;
           };
-          keyboard = {
-            keymap_model = xcfg.xkb.model;
-            keymap_layout = xcfg.xkb.layout;
-            keymap_variant = xcfg.xkb.variant;
-            keymap_options = xcfg.xkb.options;
+          keyboard = let
+            inherit (config.environment) xkb;
+          in {
+            keymap_model = xkb.model;
+            keymap_layout = xkb.layout;
+            keymap_variant = xkb.variant;
+            keymap_options = xkb.options;
           };
         };
       in

--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -90,8 +90,6 @@ in
         };
     };
 
-    environment.etc."X11/xkb".source = xcfg.xkb.dir;
-
     fonts.packages = [ pkgs.dejavu_fonts ];
 
     services.udisks2.enable = true;

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -311,8 +311,6 @@ in
         "/share"
       ];
 
-      environment.etc."X11/xkb".source = xcfg.xkb.dir;
-
       environment.sessionVariables = {
         PLASMA_USE_QT_SCALING = mkIf cfg.useQtScaling "1";
 

--- a/nixos/modules/services/x11/extra-layouts.nix
+++ b/nixos/modules/services/x11/extra-layouts.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-  layouts = config.services.xserver.xkb.extraLayouts;
+  layouts = config.environment.xkb.extraLayouts;
 
   layoutOpts = {
     options = {
@@ -79,7 +79,7 @@ let
   };
 
   xkb_patched = pkgs.xorg.xkeyboardconfig_custom {
-    layouts = config.services.xserver.xkb.extraLayouts;
+    layouts = config.environment.xkb.extraLayouts;
   };
 
 in
@@ -88,15 +88,14 @@ in
 
   imports = [
     (lib.mkRenamedOptionModuleWith {
-      sinceRelease = 2311;
       from = [ "services" "xserver" "extraLayouts" ];
-      to = [ "services" "xserver" "xkb" "extraLayouts" ];
+      to = [ "services" "xkb" "extraLayouts" ];
     })
   ];
 
   ###### interface
 
-  options.services.xserver.xkb = {
+  options.environment.xkb = {
     extraLayouts = mkOption {
       type = types.attrsOf (types.submodule layoutOpts);
       default = { };
@@ -125,18 +124,16 @@ in
 
   config = mkIf (layouts != { }) {
 
-    environment.sessionVariables = {
-      # runtime override supported by multiple libraries e. g. libxkbcommon
-      # https://xkbcommon.org/doc/current/group__include-path.html
-      XKB_CONFIG_ROOT = config.services.xserver.xkb.dir;
-    };
-
-    services.xserver = {
+    environment = {
       xkb.dir = "${xkb_patched}/etc/X11/xkb";
-      exportConfiguration = config.services.xserver.displayManager.startx.enable
-        || config.services.xserver.displayManager.sx.enable;
+      sessionVariables = {
+        # runtime override supported by multiple libraries e. g. libxkbcommon
+        # https://xkbcommon.org/doc/current/group__include-path.html
+        XKB_CONFIG_ROOT = config.environment.xkb.dir;
+      };
     };
 
+    services.xserver.exportConfiguration = config.services.xserver.displayManager.startx.enable
+        || config.services.xserver.displayManager.sx.enable;
   };
-
 }

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -173,31 +173,16 @@ in
         "Use services.xserver.fontPath instead of useXFS")
       (mkRemovedOptionModule [ "services" "xserver" "useGlamor" ]
         "Option services.xserver.useGlamor was removed because it is unnecessary. Drivers that uses Glamor will use it automatically.")
-      (lib.mkRenamedOptionModuleWith {
-        sinceRelease = 2311;
-        from = [ "services" "xserver" "layout" ];
-        to = [ "services" "xserver" "xkb" "layout" ];
-      })
-      (lib.mkRenamedOptionModuleWith {
-        sinceRelease = 2311;
-        from = [ "services" "xserver" "xkbModel" ];
-        to = [ "services" "xserver" "xkb" "model" ];
-      })
-      (lib.mkRenamedOptionModuleWith {
-        sinceRelease = 2311;
-        from = [ "services" "xserver" "xkbOptions" ];
-        to = [ "services" "xserver" "xkb" "options" ];
-      })
-      (lib.mkRenamedOptionModuleWith {
-        sinceRelease = 2311;
-        from = [ "services" "xserver" "xkbVariant" ];
-        to = [ "services" "xserver" "xkb" "variant" ];
-      })
-      (lib.mkRenamedOptionModuleWith {
-        sinceRelease = 2311;
-        from = [ "services" "xserver" "xkbDir" ];
-        to = [ "services" "xserver" "xkb" "dir" ];
-      })
+      (lib.mkRenamedOptionModule [ "services" "xserver" "layout" ] [ "environment" "xkb" "layout" ])
+      (lib.mkRenamedOptionModule [ "services" "xserver" "xkb" "layout" ] [ "environment" "xkb" "layout" ])
+      (lib.mkRenamedOptionModule [ "services" "xserver" "xkb" "dir" ] [ "environment" "xkb" "dir" ])
+      (lib.mkRenamedOptionModule [ "services" "xserver" "xkb" "model" ] [ "environment" "xkb" "model" ])
+      (lib.mkRenamedOptionModule [ "services" "xserver" "xkb" "options" ] [ "environment" "xkb" "options" ])
+      (lib.mkRenamedOptionModule [ "services" "xserver" "xkb" "variant" ] [ "environment" "xkb" "variant" ])
+      (lib.mkRenamedOptionModule [ "services" "xserver" "xkbDir" ] [ "environment" "xkb" "dir" ])
+      (lib.mkRenamedOptionModule [ "services" "xserver" "xkbModel" ] [ "environment" "xkb" "model" ])
+      (lib.mkRenamedOptionModule [ "services" "xserver" "xkbOptions" ] [ "environment" "xkb" "options" ])
+      (lib.mkRenamedOptionModule [ "services" "xserver" "xkbVariant" ] [ "environment" "xkb" "variant" ])
     ];
 
 
@@ -360,52 +345,6 @@ in
           Whether to update the DBus activation environment after launching the
           desktop manager.
         '';
-      };
-
-      xkb = {
-        layout = mkOption {
-          type = types.str;
-          default = "us";
-          description = ''
-            X keyboard layout, or multiple keyboard layouts separated by commas.
-          '';
-        };
-
-        model = mkOption {
-          type = types.str;
-          default = "pc104";
-          example = "presario";
-          description = ''
-            X keyboard model.
-          '';
-        };
-
-        options = mkOption {
-          type = types.commas;
-          default = "terminate:ctrl_alt_bksp";
-          example = "grp:caps_toggle,grp_led:scroll";
-          description = ''
-            X keyboard options; layout switching goes here.
-          '';
-        };
-
-        variant = mkOption {
-          type = types.str;
-          default = "";
-          example = "colemak";
-          description = ''
-            X keyboard variant.
-          '';
-        };
-
-        dir = mkOption {
-          type = types.path;
-          default = "${pkgs.xkeyboard_config}/etc/X11/xkb";
-          defaultText = literalExpression ''"''${pkgs.xkeyboard_config}/etc/X11/xkb"'';
-          description = ''
-            Path used for -xkbdir xserver parameter.
-          '';
-        };
       };
 
       config = mkOption {
@@ -639,6 +578,8 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
+    environment.xkb.enable = true;
+
     services.displayManager.enable = true;
 
     services.xserver.displayManager.lightdm.enable =
@@ -683,7 +624,7 @@ in
         {
           "X11/xorg.conf".source = "${configFile}";
           # -xkbdir command line option does not seems to be passed to xkbcomp.
-          "X11/xkb".source = "${cfg.xkb.dir}";
+          "X11/xkb".source = "${config.environment.xkb.dir}";
         })
       # Needed since 1.18; see https://bugs.freedesktop.org/show_bug.cgi?id=89023#c5
       // (let cfgPath = "X11/xorg.conf.d/10-evdev.conf"; in
@@ -739,7 +680,7 @@ in
 
     services.xserver.displayManager.xserverArgs =
       [ "-config ${configFile}"
-        "-xkbdir" "${cfg.xkb.dir}"
+        "-xkbdir" "${config.environment.xkb.dir}"
       ] ++ optional (cfg.display != null) ":${toString cfg.display}"
         ++ optional (cfg.tty     != null) "vt${toString cfg.tty}"
         ++ optional (cfg.dpi     != null) "-dpi ${toString cfg.dpi}"
@@ -755,18 +696,6 @@ in
       [ xorg.xorgserver.out
         xorg.xf86inputevdev.out
       ];
-
-    system.checks = singleton (pkgs.runCommand "xkb-validated" {
-      inherit (cfg.xkb) dir model layout variant options;
-      nativeBuildInputs = with pkgs.buildPackages; [ xkbvalidate ];
-      preferLocalBuild = true;
-    } ''
-      ${optionalString (config.environment.sessionVariables ? XKB_CONFIG_ROOT)
-        "export XKB_CONFIG_ROOT=${config.environment.sessionVariables.XKB_CONFIG_ROOT}"
-      }
-      XKB_CONFIG_ROOT="$dir" xkbvalidate "$model" "$layout" "$variant" "$options"
-      touch "$out"
-    '');
 
     services.xserver.config =
       ''

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -174,6 +174,7 @@ in
       (mkRemovedOptionModule [ "services" "xserver" "useGlamor" ]
         "Option services.xserver.useGlamor was removed because it is unnecessary. Drivers that uses Glamor will use it automatically.")
       (lib.mkRenamedOptionModule [ "services" "xserver" "layout" ] [ "environment" "xkb" "layout" ])
+      (lib.mkRenamedOptionModule [ "services" "xserver" "xkb" "extraLayouts" ] [ "environment" "xkb" "extraLayouts" ])
       (lib.mkRenamedOptionModule [ "services" "xserver" "xkb" "layout" ] [ "environment" "xkb" "layout" ])
       (lib.mkRenamedOptionModule [ "services" "xserver" "xkb" "dir" ] [ "environment" "xkb" "dir" ])
       (lib.mkRenamedOptionModule [ "services" "xserver" "xkb" "model" ] [ "environment" "xkb" "model" ])

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -664,7 +664,7 @@ self: super:
   });
 
   # xkeyboardconfig variant extensible with custom layouts.
-  # See nixos/modules/services/x11/extra-layouts.nix
+  # See nixos/modules/config/xkb.nix
   xkeyboardconfig_custom = { layouts ? { } }:
   let
     patchIn = name: layout:


### PR DESCRIPTION


## Description of changes

I did not test this yet.

@Shawn8901 @alois31 can you help me review this, again? That would be lovely.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
