### PR TITLE
yofi: init at 0.2.2

### DIFF
--- a/pkgs/by-name/yo/yofi/package.nix
+++ b/pkgs/by-name/yo/yofi/package.nix
@@ -1,0 +1,50 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, autoPatchelfHook
+, fontconfig
+, libxkbcommon
+, pkg-config
+, libgcc
+, wayland
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "yofi";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "l4l";
+    repo = "yofi";
+    rev = "refs/tags/${version}";
+    hash = "sha256-cepAZyA4RBgqeF20g6YOlZTM0aRqErw17yuQ3U24UEg=";
+  };
+
+  cargoHash = "sha256-iSy/y1iwhR8x3wDIfazMeROSrJ8uRyA10hoNo6y2OQc=";
+  nativeBuildInputs = [
+    autoPatchelfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    libgcc
+    libxkbcommon
+  ];
+
+  appendRunpaths = [
+    (lib.makeLibraryPath [ fontconfig wayland ])
+  ];
+
+  checkFlags = [
+    # Fail to run in sandbox environment.
+    "--skip=screen::context::test"
+  ];
+
+  meta = {
+    description = "A minimalist app launcher in Rust";
+    homepage = "https://github.com/l4l/yofi";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ rayslash ];
+    mainProgram = "yofi";
+  };
+}


### PR DESCRIPTION
## Description of changes

Homepage: [https://github.com/l4l/yofi](https://github.com/l4l/yofi)
yofi is a minimalistic menu for wayland written in rust.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
