### PR TITLE
python3.pkgs.pygobject3: propagate gobject-introspection setup hook and glib

### DIFF
--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -11,6 +11,7 @@
 , meson
 , ninja
 , pythonOlder
+, runCommandLocal
 , gnome
 , python
 }:
@@ -46,6 +47,15 @@ buildPythonPackage rec {
     glib
   ] ++ lib.optionals stdenv.isDarwin [
     ncurses
+  ];
+
+  depsBuildBuildPropagated = [
+    glib # TODO: Not sure why it works here, when the proper place is depsHostHostPropagated IMO.
+    gobject-introspection.setupHook
+  ];
+
+  depsHostHostPropagated = [
+    glib
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -50,7 +50,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     pycairo
-    gobject-introspection # e.g. try building: python3Packages.urwid python3Packages.pydbus
   ];
 
   mesonFlags = [


### PR DESCRIPTION
## Description of changes

Previously, if a package just depended on GLib (or other bindings shipped with gobject-introspection), wrapper was not needed since `${gobject-introspection}/lib/girepository-1.0` is implicitly on typelib path. Now that GLib bindings were moved to `glib` package, `${glib}/lib/girepository-1.0` must be added to `GI_TYPELIB_PATH` by the wrapper (or `gobject-introspection` setup hook for build time).

This broke packages like `power-profile-daemon` at runtime and `python3.pkgs.pydbus` at build time.

While we cannot sensibly propagate wrapping, we can at least fix the build time issues by propagating `glib` and the g-i setup hook.

---

I believe it should be possible to use `pygobject3` without `GLib` bindings in theory, so propagating `glib` is not exactly correct. But since all practical projects will probably need `GLib` or `GObject` anyway, it might still be a a good idea to propagate `glib` from `pygobject3`.

We probably want to propagate `gobject-introspection.setupHook` from `pygobject3` all the time because without the environment variables set by the setup hook, no bindings will be available.

I do not think we do not want to propagate `gobject-introspection` since it now just contains typelibs for bunch of third-party libraries (e.g. cairo, fontconfig, xrandr…) which are not needed most of the time, the old libgirepository (which is usually only linked against) and build tools (needed for producing bindings, not for consuming them).

---

If `pygobject3` goes to `buildInputs` (`(0,1)`), `gobject-introspection.setupHook` should go to `depsBuildBuildPropagated` (`(-1,-1)`) in `pygobject3` to result in `(-1,0)` (`nativeBuildInputs`) in dependents, and `glib` should go to `depsHostHostPropagated` (`(0,0)`), if we want it in `(0,1)` (`buildInputs`). We cannot propagate `setupHook` attribute directly, since it is not a package, though.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
