### PR TITLE
fastahack: init at 1.0.0

### DIFF
--- a/pkgs/by-name/fa/fastahack/package.nix
+++ b/pkgs/by-name/fa/fastahack/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  runCommand,
+  fastahack,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fastahack";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "ekg";
+    repo = "fastahack";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-SWu2iRwNgdhsn4sH9/3jPNG3+l1xFAHXPq5/ODVd4WY=";
+  };
+
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  passthru.tests = {
+    simple = runCommand "${finalAttrs.pname}-test" { } ''
+      mkdir $out
+      cp ${fastahack.src}/tests/* $out
+      grep -v ERROR <(${lib.getExe fastahack} $out/correct.fasta 2>&1)
+      grep -v ERROR <(${lib.getExe fastahack} $out/crlf.fasta 2>&1)
+      grep "ERROR: embedded newline " <(${lib.getExe fastahack} $out/embedded_newline.fasta 2>&1)
+      grep "ERROR: mismatched line lengths" <(${lib.getExe fastahack} $out/mismatched_lines.fasta 2>&1)
+      grep -v ERROR <(${lib.getExe fastahack} $out/trailing_newlines.fasta 2>&1)
+    '';
+  };
+
+  meta = {
+    description = "Utilities for indexing and sequence extraction from FASTA files";
+    homepage = "https://github.com/ekg/fastahack";
+    changelog = "https://github.com/ekg/fastahack/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ natsukium ];
+    mainProgram = "fastahack";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

utilities for indexing and sequence extraction from FASTA files

https://github.com/ekg/fastahack

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
