### PR TITLE
nixos/ebusd: clean up module

### DIFF
--- a/nixos/modules/services/home-automation/ebusd.nix
+++ b/nixos/modules/services/home-automation/ebusd.nix
@@ -4,47 +4,14 @@ with lib;
 
 let
   cfg = config.services.ebusd;
-
-  package = pkgs.ebusd;
-
-  arguments = [
-    "${package}/bin/ebusd"
-    "--foreground"
-    "--updatecheck=off"
-    "--device=${cfg.device}"
-    "--port=${toString cfg.port}"
-    "--configpath=${cfg.configpath}"
-    "--scanconfig=${cfg.scanconfig}"
-    "--log=all:${cfg.logs.all}"
-    "--log=main:${cfg.logs.main}"
-    "--log=network:${cfg.logs.network}"
-    "--log=bus:${cfg.logs.bus}"
-    "--log=update:${cfg.logs.update}"
-    "--log=other:${cfg.logs.other}"
-  ] ++ lib.optionals cfg.readonly [
-    "--readonly"
-  ] ++ lib.optionals cfg.mqtt.enable [
-    "--mqtthost=${cfg.mqtt.host}"
-    "--mqttport=${toString cfg.mqtt.port}"
-    "--mqttuser=${cfg.mqtt.user}"
-    "--mqttpass=${cfg.mqtt.password}"
-  ] ++ lib.optionals cfg.mqtt.home-assistant [
-    "--mqttint=${package}/etc/ebusd/mqtt-hassio.cfg"
-    "--mqttjson"
-  ] ++ lib.optionals cfg.mqtt.retain [
-    "--mqttretain"
-  ] ++ cfg.extraArguments;
-
-  usesDev = hasPrefix "/" cfg.device;
-
-  command = concatStringsSep " " arguments;
-
 in
 {
   meta.maintainers = with maintainers; [ nathan-gs ];
 
   options.services.ebusd = {
     enable = mkEnableOption "ebusd, a daemon for communication with eBUS heating systems";
+
+    package = mkPackageOptionMD pkgs "ebusd" { };
 
     device = mkOption {
       type = types.str;
@@ -57,7 +24,8 @@ in
           ens:DEVICE for enhanced high speed serial device (only adapter v3 and newer with firmware since 20220731),
           DEVICE for serial device (normal speed, for all other serial adapters like adapter v2 as well as adapter v3 in non-enhanced mode), or
           [udp:]IP:PORT for network device.
-        https://github.com/john30/ebusd/wiki/2.-Run#device-options
+
+        Source: <https://github.com/john30/ebusd/wiki/2.-Run#device-options>
       '';
     };
 
@@ -81,7 +49,7 @@ in
       type = types.str;
       default = "https://cfg.ebusd.eu/";
       description = ''
-        Read CSV config files from PATH (local folder or HTTPS URL) [https://cfg.ebusd.eu/]
+        Directory to read CSV config files from. This can be a local folder or a URL.
       '';
     };
 
@@ -95,65 +63,21 @@ in
       '';
     };
 
-    logs = {
-      main = mkOption {
-        type = types.enum [ "none" "error" "notice" "info" "debug"];
-        default = "info";
-        description = ''
-          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (none|error|notice|info|debug) [all:notice].
-        '';
-      };
-
-      network = mkOption {
-        type = types.enum [ "none" "error" "notice" "info" "debug"];
-        default = "info";
-        description = ''
-          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (none|error|notice|info|debug) [all:notice].
-        '';
-      };
-
-      bus = mkOption {
-        type = types.enum [ "none" "error" "notice" "info" "debug"];
-        default = "info";
-        description = ''
-          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (none|error|notice|info|debug) [all:notice].
-        '';
-      };
-
-      update = mkOption {
-        type = types.enum [ "none" "error" "notice" "info" "debug"];
-        default = "info";
-        description = ''
-          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (none|error|notice|info|debug) [all:notice].
-        '';
-      };
-
-      other = mkOption {
-        type = types.enum [ "none" "error" "notice" "info" "debug"];
-        default = "info";
-        description = ''
-          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (none|error|notice|info|debug) [all:notice].
-        '';
-      };
-
-      all = mkOption {
-        type = types.enum [ "none" "error" "notice" "info" "debug"];
-        default = "info";
-        description = ''
-          Only write log for matching AREAs (main|network|bus|update|other|all) below or equal to LEVEL (none|error|notice|info|debug) [all:notice].
-        '';
-      };
-    };
+    logs = let
+      # "all" must come first so it can be overridden by more specific areas
+      areas = [ "all" "main" "network" "bus" "update" "other" ];
+      levels = [ "none" "error" "notice" "info" "debug" ];
+    in listToAttrs (map (area: nameValuePair area (mkOption {
+      type = types.enum levels;
+      default = "notice";
+      example = "debug";
+      description = ''
+        Only write log for matching `AREA`s (${concatStringsSep "|" areas}) below or equal to `LEVEL` (${concatStringsSep "|" levels})
+      '';
+    })) areas);
 
     mqtt = {
-
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Adds support for MQTT
-        '';
-      };
+      enable = mkEnableOption "support for MQTT";
 
       host = mkOption {
         type = types.str;
@@ -179,13 +103,7 @@ in
         '';
       };
 
-      retain = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Set the retain flag on all topics instead of only selected global ones
-        '';
-      };
+      retain = mkEnableOption "set the retain flag on all topics instead of only selected global ones";
 
       user = mkOption {
         type = types.str;
@@ -200,7 +118,6 @@ in
           The MQTT password.
         '';
       };
-
     };
 
     extraArguments = mkOption {
@@ -210,25 +127,44 @@ in
         Extra arguments to the ebus daemon
       '';
     };
-
   };
 
-  config = mkIf (cfg.enable) {
-
+  config = let
+    usesDev = hasPrefix "/" cfg.device;
+  in mkIf cfg.enable {
     systemd.services.ebusd = {
       description = "EBUSd Service";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       serviceConfig = {
-        ExecStart = command;
+        ExecStart = let
+          args = cli.toGNUCommandLineShell { } (foldr (a: b: a // b) { } [
+            {
+              inherit (cfg) device port configpath scanconfig readonly;
+              foreground = true;
+              updatecheck = "off";
+              log = mapAttrsToList (name: value: "${name}:${value}") cfg.logs;
+              mqttretain = cfg.mqtt.retain;
+            }
+            (optionalAttrs cfg.mqtt.enable {
+              mqtthost  = cfg.mqtt.host;
+              mqttport  = cfg.mqtt.port;
+              mqttuser  = cfg.mqtt.user;
+              mqttpass  = cfg.mqtt.password;
+            })
+            (optionalAttrs cfg.mqtt.home-assistant {
+              mqttint = "${cfg.package}/etc/ebusd/mqtt-hassio.cfg";
+              mqttjson = true;
+            })
+          ]);
+        in "${cfg.package}/bin/ebusd ${args} ${escapeShellArgs cfg.extraArguments}";
+
         DynamicUser = true;
         Restart = "on-failure";
 
         # Hardening
         CapabilityBoundingSet = "";
-        DeviceAllow = lib.optionals usesDev [
-          cfg.device
-        ] ;
+        DeviceAllow = optionals usesDev [ cfg.device ];
         DevicePolicy = "closed";
         LockPersonality = true;
         MemoryDenyWriteExecute = false;
@@ -254,9 +190,7 @@ in
         RestrictNamespaces = true;
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
-        SupplementaryGroups = [
-          "dialout"
-        ];
+        SupplementaryGroups = [ "dialout" ];
         SystemCallArchitectures = "native";
         SystemCallFilter = [
           "@system-service @pkey"
@@ -265,6 +199,5 @@ in
         UMask = "0077";
       };
     };
-
   };
 }


### PR DESCRIPTION
## Description of changes

This is a rebase of #264893 with conflicts with other changes to `ebusd.nix` resolved.

### Original PR description

This PR only cleans up the code of the `ebusd` module, with the intention of not changing the outcome.

In general, I've cleaned up a bunch of descriptions, inlined a few single element lists, removed some extra space. The two big changes are the automatic generation of the `services.ebusd.logs` options, and the use of `cli.toGNUCommandLineShell` for constructing the string of arguments. The latter has also been moved from the top of the file, closer to the `ExecStart` where it is used.

I've tested that the code evalutates manually, but it would be nice if this had a basic test. Not sure how easy that would be to make though, considering it's a hardware related program.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
