### PR TITLE
circt: fix darwin linking issues

### DIFF
--- a/pkgs/development/compilers/circt/circt-llvm.nix
+++ b/pkgs/development/compilers/circt/circt-llvm.nix
@@ -1,4 +1,5 @@
-{ stdenv
+{ lib
+, stdenv
 , cmake
 , ninja
 , circt
@@ -31,6 +32,14 @@
 
   outputs = [ "out" "lib" "dev" ];
 
+  # Get rid of ${extra_libdir} (which ends up containing a path to circt-llvm.dev
+  # in circt) so that we only have to remove the one fixed rpath.
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace llvm/llvm/cmake/modules/AddLLVM.cmake \
+      --replace-fail 'set(_install_rpath "@loader_path/../lib''${LLVM_LIBDIR_SUFFIX}" ''${extra_libdir})' \
+        'set(_install_rpath "@loader_path/../lib''${LLVM_LIBDIR_SUFFIX}")'
+  '';
+
   postInstall = ''
     # move llvm-config to $dev to resolve a circular dependency
     moveToOutput "bin/llvm-config*" "$dev"
@@ -48,6 +57,30 @@
       --replace "\''${_IMPORT_PREFIX}/lib/lib" "$lib/lib/lib" \
       --replace "\''${_IMPORT_PREFIX}/lib/objects-Release" "$lib/lib/objects-Release" \
       --replace "$out/bin/llvm-config" "$dev/bin/llvm-config" # patch path for llvm-config
+  '';
+
+  # Replace all references to @rpath with absolute paths and remove the rpaths.
+  #
+  # This is different from what the regular LLVM package does, which is to make
+  # everything absolute from the start: however, that doesn't work for us because
+  # we have `-DBUILD_SHARED_LIBS=ON`, meaning that many more things are
+  # dynamically rather than statically linked. This includes TableGen, which then
+  # fails to run halfway through the build because it tries to reference $lib when
+  # it hasn't been populated yet.
+  #
+  # Inspired by fixDarwinDylibNames.
+  postFixup = lib.optionalString stdenv.isDarwin ''
+    local flags=(-delete_rpath @loader_path/../lib)
+    for file in "$lib"/lib/*.dylib; do
+      flags+=(-change @rpath/"$(basename "$file")" "$file")
+    done
+
+    for file in "$out"/bin/* "$lib"/lib/*.dylib; do
+      if [ -L "$file" ]; then continue; fi
+      echo "$file: fixing dylib references"
+      # note that -id does nothing on binaries
+      install_name_tool -id "$file" "''${flags[@]}" "$file"
+    done
   '';
 
   # circt only use the mlir part of llvm, occasionally there are some unrelated failure from llvm,

--- a/pkgs/development/compilers/circt/default.nix
+++ b/pkgs/development/compilers/circt/default.nix
@@ -66,6 +66,13 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "lib" "dev" ];
 
+  # Copy circt-llvm's postFixup stage so that it can make all our dylib references
+  # absolute as well.
+  #
+  # We don't need `postPatch` because circt seems to be automatically inheriting
+  # the config somehow, presumably via. `-DMLIR_DIR`.
+  postFixup = circt-llvm.postFixup;
+
   postInstall = ''
     moveToOutput lib "$lib"
   '';


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR gets CIRCT to build successfully on Darwin.

While `circt-llvm` technically already builds, the output is unusable because the binaries try to reference libraries in ../lib, which doesn't work because the libraries are in another derivation. This causes `circt` itself to fail to build.

This PR fixes that by adding a `postFixup` step that changes all the libraries to be referenced by their absolute paths.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin (I tried to via. Rosetta, and it seemed to build but then Rosetta started throwing errors during check phase (which is a first!))
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
