### PR TITLE
pkgs/tools: Fix some unstableGitUpdater users

### DIFF
--- a/pkgs/tools/admin/drawterm/default.nix
+++ b/pkgs/tools/admin/drawterm/default.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation {
   pname = "drawterm";
-  version = "unstable-2024-04-23";
+  version = "0-unstable-2024-04-23";
 
   src = fetchFrom9Front {
     owner = "plan9front";

--- a/pkgs/tools/audio/kaldi/default.nix
+++ b/pkgs/tools/audio/kaldi/default.nix
@@ -19,7 +19,7 @@
 assert blas.implementation == "openblas" && lapack.implementation == "openblas";
 stdenv.mkDerivation (finalAttrs: {
   pname = "kaldi";
-  version = "unstable-2024-01-31";
+  version = "0-unstable-2024-01-31";
 
   src = fetchFromGitHub {
     owner = "kaldi-asr";

--- a/pkgs/tools/audio/vgmtools/default.nix
+++ b/pkgs/tools/audio/vgmtools/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "vgmtools";
-  version = "unstable-2023-08-27";
+  version = "0.1-unstable-2023-08-27";
 
   src = fetchFromGitHub {
     owner = "vgmrips";

--- a/pkgs/tools/misc/cht.sh/default.nix
+++ b/pkgs/tools/misc/cht.sh/default.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation {
   pname = "cht.sh";
-  version = "unstable-2022-04-18";
+  version = "0-unstable-2022-04-18";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/tools/misc/edid-decode/default.nix
+++ b/pkgs/tools/misc/edid-decode/default.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "edid-decode";
-  version = "unstable-2024-04-02";
+  version = "0-unstable-2024-04-02";
 
   outputs = [
     "out"

--- a/pkgs/tools/misc/ipxe/default.nix
+++ b/pkgs/tools/misc/ipxe/default.nix
@@ -33,7 +33,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "ipxe";
-  version = "unstable-2024-02-08";
+  version = "1.21.1-unstable-2024-02-08";
 
   nativeBuildInputs = [ gnu-efi mtools openssl perl xorriso xz ] ++ lib.optional stdenv.hostPlatform.isx86 syslinux;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
@@ -101,7 +101,9 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  passthru.updateScript = unstableGitUpdater {};
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
 
   meta = with lib;
     { description = "Network boot firmware";

--- a/pkgs/tools/misc/tewisay/default.nix
+++ b/pkgs/tools/misc/tewisay/default.nix
@@ -6,7 +6,7 @@
 
 buildGoModule rec {
   pname = "tewisay";
-  version = "unstable-2022-11-04";
+  version = "0-unstable-2022-11-04";
 
   # lucy deleted the old repo, this is a fork/mirror
   src = fetchFromGitHub {

--- a/pkgs/tools/misc/urn-timer/default.nix
+++ b/pkgs/tools/misc/urn-timer/default.nix
@@ -12,7 +12,7 @@
 
 stdenv.mkDerivation {
   pname = "urn-timer";
-  version = "unstable-2024-03-05";
+  version = "0-unstable-2024-03-05";
 
   src = fetchFromGitHub {
     owner = "paoloose";

--- a/pkgs/tools/security/bash-supergenpass/default.nix
+++ b/pkgs/tools/security/bash-supergenpass/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation {
   pname = "bash-supergenpass";
-  version = "unstable-2024-03-24";
+  version = "0-unstable-2024-03-24";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/tools/security/pass/rofi-pass.nix
+++ b/pkgs/tools/security/pass/rofi-pass.nix
@@ -29,7 +29,7 @@ assert lib.assertOneOf "backend" backend [ "x11" "wayland" ];
 
 stdenv.mkDerivation {
   pname = "rofi-pass";
-  version = "unstable-2024-02-13";
+  version = "2.0.2-unstable-2024-02-13";
 
   src = fetchFromGitHub {
     owner = "carnager";

--- a/pkgs/tools/video/untrunc-anthwlock/default.nix
+++ b/pkgs/tools/video/untrunc-anthwlock/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
   pname = "untrunc-anthwlock";
-  version = "unstable-2021-11-21";
+  version = "0-unstable-2021-11-21";
 
   src = fetchFromGitHub {
     owner = "anthwlock";
@@ -30,7 +30,10 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = unstableGitUpdater {
+    # Only stale "latest" tag
+    hardcodeZeroVersion = true;
+  };
 
   meta = with lib; {
     description = "Restore a truncated mp4/mov (improved version of ponchio/untrunc)";

--- a/pkgs/tools/wayland/wayland-proxy-virtwl/default.nix
+++ b/pkgs/tools/wayland/wayland-proxy-virtwl/default.nix
@@ -8,7 +8,7 @@
 
 ocamlPackages.buildDunePackage rec {
   pname = "wayland-proxy-virtwl";
-  version = "unstable-2024-04-08";
+  version = "0-unstable-2024-04-08";
 
   src = fetchFromGitHub {
     owner = "talex5";


### PR DESCRIPTION
## Description of changes

#280501 now makes `unstableGitUpdater` produce versions that match our desired unstable version schema. Start fixing the versions of packages that use it, and their `unstableGitUpdater` arguments as needed.

Tackling packages in `pkgs/tools` here. Checked running the update script of everything, which results in either the same version & revs as corrected here, or newer versions.

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>115 packages built:</summary>
  <ul>
    <li>bash-supergenpass</li>
    <li>bottles</li>
    <li>bottles-unwrapped</li>
    <li>cagebreak</li>
    <li>cht-sh</li>
    <li>drawterm</li>
    <li>drawterm-wayland</li>
    <li>dwl</li>
    <li>dwl.man</li>
    <li>edid-decode</li>
    <li>edid-decode.man</li>
    <li>edid-generator</li>
    <li>gamescope</li>
    <li>grimblast</li>
    <li>hdrop</li>
    <li>hw-probe</li>
    <li>hyprland</li>
    <li>hyprland.dev</li>
    <li>hyprland.man</li>
    <li>hyprlandPlugins.hy3</li>
    <li>hyprshade</li>
    <li>hyprshade.dist</li>
    <li>hyprshot</li>
    <li>ipxe</li>
    <li>kaldi</li>
    <li>kdePackages.kdeplasma-addons</li>
    <li>kdePackages.kdeplasma-addons.debug</li>
    <li>kdePackages.kdeplasma-addons.dev</li>
    <li>kdePackages.kdeplasma-addons.devtools</li>
    <li>kdePackages.kwin</li>
    <li>kdePackages.kwin.debug</li>
    <li>kdePackages.kwin.dev</li>
    <li>kdePackages.kwin.devtools</li>
    <li>kdePackages.plasma-browser-integration</li>
    <li>kdePackages.plasma-browser-integration.debug</li>
    <li>kdePackages.plasma-browser-integration.dev</li>
    <li>kdePackages.plasma-browser-integration.devtools</li>
    <li>kdePackages.plasma-desktop</li>
    <li>kdePackages.plasma-desktop.debug</li>
    <li>kdePackages.plasma-desktop.dev</li>
    <li>kdePackages.plasma-desktop.devtools</li>
    <li>kdePackages.plasma-mobile</li>
    <li>kdePackages.plasma-mobile.debug</li>
    <li>kdePackages.plasma-mobile.dev</li>
    <li>kdePackages.plasma-mobile.devtools</li>
    <li>kdePackages.plasma-pa</li>
    <li>kdePackages.plasma-pa.debug</li>
    <li>kdePackages.plasma-pa.dev</li>
    <li>kdePackages.plasma-pa.devtools</li>
    <li>kdePackages.plasma-workspace</li>
    <li>kdePackages.plasma-workspace.debug</li>
    <li>kdePackages.plasma-workspace.dev</li>
    <li>kdePackages.plasma-workspace.devtools</li>
    <li>kdePackages.powerdevil</li>
    <li>kdePackages.powerdevil.debug</li>
    <li>kdePackages.powerdevil.dev</li>
    <li>kdePackages.powerdevil.devtools</li>
    <li>kdePackages.qwlroots</li>
    <li>kdePackages.sierra-breeze-enhanced</li>
    <li>kdePackages.waylib</li>
    <li>kdePackages.waylib.bin</li>
    <li>kdePackages.waylib.dev</li>
    <li>kodi-gbm</li>
    <li>labwc</li>
    <li>labwc.man</li>
    <li>libdisplay-info</li>
    <li>louvre</li>
    <li>louvre.dev</li>
    <li>mate.mate-gsettings-overrides</li>
    <li>mate.mate-wayland-session</li>
    <li>nwg-panel</li>
    <li>nwg-panel.dist</li>
    <li>phoc</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
    <li>river</li>
    <li>river.man</li>
    <li>rivercarro</li>
    <li>rofi-pass</li>
    <li>rofi-pass-wayland</li>
    <li>scenefx</li>
    <li>srm-cuarzo</li>
    <li>srm-cuarzo.dev</li>
    <li>sway</li>
    <li>sway-contrib.grimshot</li>
    <li>sway-contrib.grimshot.man</li>
    <li>sway-unwrapped</li>
    <li>swayfx</li>
    <li>swayfx-unwrapped</li>
    <li>tewisay</li>
    <li>tinywl</li>
    <li>untrunc-anthwlock</li>
    <li>urn-timer</li>
    <li>vgmtools</li>
    <li>waybar</li>
    <li>waybox</li>
    <li>wayfire</li>
    <li>wayfire-with-plugins</li>
    <li>wayfirePlugins.firedecor</li>
    <li>wayfirePlugins.focus-request</li>
    <li>wayfirePlugins.wayfire-plugins-extra</li>
    <li>wayfirePlugins.wayfire-shadows</li>
    <li>wayfirePlugins.wcm</li>
    <li>wayfirePlugins.wf-shell</li>
    <li>wayfirePlugins.windecor</li>
    <li>wayfirePlugins.wwp-switcher</li>
    <li>wayland-proxy-virtwl</li>
    <li>weston</li>
    <li>wio</li>
    <li>wlprop</li>
    <li>wlroots (wlroots_0_17)</li>
    <li>wlroots.examples (wlroots_0_17.examples)</li>
    <li>xdg-desktop-portal-hyprland</li>
    <li>xwayland-run</li>
    <li>xwayland-run.man</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
