### PR TITLE
nix-bisect: 0.4.1 -> 0.4.1-unstable-2024-04-19

### DIFF
--- a/pkgs/development/tools/misc/nix-bisect/default.nix
+++ b/pkgs/development/tools/misc/nix-bisect/default.nix
@@ -6,7 +6,7 @@
 
 let
   pname = "nix-bisect";
-  version = "0.4.1";
+  version = "0.4.1-unstable-2024-04-19";
 in
 python3.pkgs.buildPythonApplication {
   inherit pname version;
@@ -15,22 +15,9 @@ python3.pkgs.buildPythonApplication {
   src = fetchFromGitHub {
     owner = "timokau";
     repo = pname;
-    rev = "v${version}";
-    hash = "sha256-01vj35mMakqKi5zbMIPQ+R8xdkOWbzpnigd3/SU+svw=";
+    rev = "4f26082fec0817acbfa8cc6ca4c25caaf77ddcd2";
+    hash = "sha256-zyeE1jYo/9NEG8fB4gQBAR01siP4tyLvjjHN1yUS4Ug=";
   };
-
-  patches = [
-    (fetchpatch {
-      # Fixes compatibility with recent nix versions
-      url = "https://github.com/timokau/nix-bisect/commit/01eefe174b740cb90e48b06d67d5582d51786b96.patch";
-      hash = "sha256-Gls/NtHH7LujdEgLbcIRZ12KsJDrasXIMcHeeBVns4A=";
-    })
-    (fetchpatch {
-      # Fixes TypeError crashes associated with drvs_failed inconsistency
-      url = "https://github.com/timokau/nix-bisect/commit/9f3a17783046baae64c16f9e2be917c2603977fc.patch";
-      hash = "sha256-U9NUtgwslcgIf/wvH/WE7t0HGs2OP3wvYDKrb5j+lp0=";
-    })
-  ];
 
   propagatedBuildInputs = with python3.pkgs; [
     appdirs


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`nix-bisect` is currently broken when using the nix binary >= 2.15: https://github.com/timokau/nix-bisect/issues/25

Fix which was merged: https://github.com/timokau/nix-bisect/pull/27 And this works as expected from my testing.

`nix-bisect` hasnt had a major release since 2020 (0.4.1) so Im proposing to just use `master` and move to `unstable` instead of carrying patches.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
