### PR TITLE
openvas-smb: init at 22.5.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13011,6 +13011,12 @@
     githubId = 20536514;
     name = "Magdalena Haselsteiner";
   };
+  mi-ael = {
+    email = "miael.oss.1970@gmail.com";
+    name = "mi-ael";
+    github = "mi-ael";
+    githubId = 12199265;
+  };
   miangraham = {
     github = "miangraham";
     githubId = 704580;

--- a/pkgs/by-name/op/openvas-smb/package.nix
+++ b/pkgs/by-name/op/openvas-smb/package.nix
@@ -1,0 +1,71 @@
+{ fetchFromGitHub
+, fetchurl
+, lib
+, stdenv
+, cmake
+, git
+, pkg-config
+, glib
+, gnutls
+, perl
+, heimdal
+, popt
+, libunistring
+}:
+let
+  heimdalConfigHeader = fetchurl {
+    url = "https://raw.githubusercontent.com/heimdal/heimdal/d8c10e68a61f10c8fca62b227a0766d294bda4a0/include/heim_threads.h";
+    sha256 = "08345hkb5jbdcgh2cx3d624w4c8wxmnnsjxlw46wsnm39k4l0ihw";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "openvas-smb";
+  version = "22.5.6";
+
+  src = fetchFromGitHub {
+    owner = "greenbone";
+    repo = "openvas-smb";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-wnlBOHYOTWNbwzoHCpsXbuhp0uH3wBH6+Oo4Y+zSsfg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    git
+    pkg-config
+  ];
+
+  buildInputs = [
+    glib
+    gnutls
+    perl
+    heimdal
+    popt
+    libunistring
+  ];
+
+  # The pkg expects the heimdal headers to be in a "heimdal" folder, which is the case on
+  # debian, but not on nix. Additionally some heimdal header names have the same names
+  # as kerberos header names, so the old include path is removed.
+  preConfigure = ''
+    mkdir -p include
+
+    # symlink to change include path for heimdal headers from "heim_etc.h" to "heimdal/heim_etc.h"
+    ln -s ${heimdal.dev}/include include/heimdal
+    remove="-isystem ${heimdal.dev}/include "
+    NIX_CFLAGS_COMPILE=''${NIX_CFLAGS_COMPILE//"''$remove"/}
+    NIX_CFLAGS_COMPILE+=" -isystem $(pwd)/include";
+
+    # add default config header for heimdal
+    cp ${heimdalConfigHeader} include/heim_threads.h
+  '';
+
+  meta = with lib; {
+    description = "SMB module for Greenbone Community Edition";
+    homepage = "https://github.com/greenbone/openvas-smb";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ mi-ael ];
+    mainProgram = "wmic";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

SMB module for Greenbone Community Edition
https://github.com/greenbone/openvas-smb

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
