### PR TITLE
nixos/dockerTools: fixup proot/fakeroot code - exclude also dev

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -958,6 +958,7 @@ rec {
                 eval "$fakeRootCommands"
                 tar \
                   --sort name \
+                  --exclude=./dev \
                   --exclude=./proc \
                   --exclude=./sys \
                   --exclude=.${builtins.storeDir} \


### PR DESCRIPTION
Finish work of commit 49119155125e4ce346e2881eb5dd2f79515b8e18 of @Mic92, avoid to arhive also /dev which can fail and never usefull in containers

## Description of changes

Fix issues with docker build include unnecessary /dev directory
