### PR TITLE
psysh: 0.11.21 -> 0.12.3 + build-support/php: update

### DIFF
--- a/pkgs/build-support/php/build-composer-project.nix
+++ b/pkgs/build-support/php/build-composer-project.nix
@@ -62,7 +62,7 @@ let
         runHook postInstallCheck
       '';
 
-      composerRepository = phpDrv.mkComposerRepository {
+      composerRepository = phpDrv.mkComposerRepository ({
         inherit composer composer-local-repo-plugin;
         inherit (finalAttrs) patches pname src vendorHash version;
 
@@ -71,7 +71,7 @@ let
         composerNoPlugins = previousAttrs.composerNoPlugins or true;
         composerNoScripts = previousAttrs.composerNoScripts or true;
         composerStrictValidation = previousAttrs.composerStrictValidation or true;
-      };
+      } // (previousAttrs.composerRepository or {}));
 
       COMPOSER_CACHE_DIR="/dev/null";
       COMPOSER_DISABLE_NETWORK="1";

--- a/pkgs/build-support/php/hooks/composer-install-hook.sh
+++ b/pkgs/build-support/php/hooks/composer-install-hook.sh
@@ -23,6 +23,10 @@ composerInstallConfigureHook() {
         cp "$composerLock" composer.lock
     fi
 
+    chmod +w composer.{json,lock}
+    cp ${composerRepository}/composer.{json,lock} .
+    chmod +w composer.{json,lock}
+
     if [[ ! -f "composer.lock" ]]; then
         setComposeRootVersion
 
@@ -70,8 +74,6 @@ composerInstallConfigureHook() {
 
         exit 1
     fi
-
-    chmod +w composer.json composer.lock
 
     echo "Finished composerInstallConfigureHook"
 }

--- a/pkgs/build-support/php/hooks/composer-repository-hook.sh
+++ b/pkgs/build-support/php/hooks/composer-repository-hook.sh
@@ -19,6 +19,8 @@ composerRepositoryConfigureHook() {
         cp $composerLock composer.lock
     fi
 
+    chmod +w composer.{json,lock}
+
     if [[ ! -f "composer.lock" ]]; then
         setComposeRootVersion
 
@@ -85,7 +87,7 @@ composerRepositoryInstallHook() {
 
     # Copy the composer.lock files to the output directory, to be able to validate consistency with
     # the src composer.lock file where this fixed-output derivation is used
-    cp composer.lock $out/
+    cp composer.{json,lock} $out/
 
     echo "Finished composerRepositoryInstallHook"
 }

--- a/pkgs/development/php-packages/composer/default.nix
+++ b/pkgs/development/php-packages/composer/default.nix
@@ -40,7 +40,7 @@ php.buildComposerProject (finalAttrs: {
       --prefix PATH : ${lib.makeBinPath [ _7zz cacert curl git unzip xz ]}
   '';
 
-  vendorHash = "sha256-dNNV9fTyGyRoGeDV/vBjn0aMgkaUMsrKQv5AOoiYokQ=";
+  vendorHash = "sha256-4s912b04PTPbK9+suni9uJ2Cx4qDb8CkMLy6y25a1eQ=";
 
   meta = {
     changelog = "https://github.com/composer/composer/releases/tag/${finalAttrs.version}";

--- a/pkgs/development/php-packages/psysh/default.nix
+++ b/pkgs/development/php-packages/psysh/default.nix
@@ -1,18 +1,22 @@
-{ fetchFromGitHub, lib, php }:
+{ fetchFromGitHub, fetchurl, lib, php }:
 
 php.buildComposerProject (finalAttrs: {
   pname = "psysh";
-  version = "0.11.21";
+  version = "0.12.3";
 
   src = fetchFromGitHub {
     owner = "bobthecow";
     repo = "psysh";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-YuBn4mrgOzGeMGfGcyZySAISmQdv3WRGn91PRozyxdI=";
+    hash = "sha256-v2UAhxnfnVwA05sxcqMU5vmQcwlBcc901PYJqYf+pCw=";
   };
 
-  composerLock = ./composer.lock;
-  vendorHash = "sha256-FZFeO7UiVssxTf0JX6wdjrAE+jucYnfQJA1eOng39lQ=";
+  composerLock = fetchurl {
+    name = "composer.lock";
+    url = "https://github.com/bobthecow/psysh/releases/download/v${finalAttrs.version}/composer-v${finalAttrs.version}.lock";
+    hash = "sha256-ur6mzla3uXeFL6aEHAPdpxGdvcgzOgTLW/CKPbNqeCg=";
+  };
+  vendorHash = "";
 
   meta = {
     changelog = "https://github.com/bobthecow/psysh/releases/tag/v${finalAttrs.version}";

--- a/pkgs/development/php-packages/psysh/default.nix
+++ b/pkgs/development/php-packages/psysh/default.nix
@@ -16,7 +16,18 @@ php.buildComposerProject (finalAttrs: {
     url = "https://github.com/bobthecow/psysh/releases/download/v${finalAttrs.version}/composer-v${finalAttrs.version}.lock";
     hash = "sha256-ur6mzla3uXeFL6aEHAPdpxGdvcgzOgTLW/CKPbNqeCg=";
   };
-  vendorHash = "";
+
+  composerRepository = {
+    preBuild = ''
+      setComposeRootVersion
+      composer config platform.php 7.4
+      composer require --no-update symfony/polyfill-iconv symfony/polyfill-mbstring
+      composer require --no-update --dev roave/security-advisories:dev-latest
+      composer update --no-interaction --no-progress --prefer-stable --no-dev --classmap-authoritative --prefer-dist --lock
+    '';
+  };
+
+  vendorHash = "sha256-vlEbehxy6xi2qLKG32fV0OJVSphWjqKUVHbWOhoWjoI=";
 
   meta = {
     changelog = "https://github.com/bobthecow/psysh/releases/tag/v${finalAttrs.version}";


### PR DESCRIPTION
Some projects in PHP are running `composer` commands on their CI before building a release.

Even if the project's `composer.lock` gets shipped along the PHAR release, running `composer validate` returns and error (https://github.com/bobthecow/psysh/issues/796).

This PR allows users to run a `preBuild` hook so that extra composer commands can be triggered just before building the composer repository (https://github.com/NixOS/nixpkgs/pull/308608/commits/017b29d988f4919321e82d4e9ca0bae5542f7806)

The downside of this is that all the PHP hashes needs to be regenerated. I don't know if there's a better way to do this yet.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
