### PR TITLE
added aarch64-darwin version of lmstudio + updated lmstudio to 0.2.22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5688,6 +5688,11 @@
     githubId = 54799;
     name = "Edward Tjörnhammar";
   };
+  eeedean = {
+    github = "eeedean";
+    githubId = 8173116;
+    name = "Dean Eckert";
+  };
   eelco = {
     email = "edolstra+nixpkgs@gmail.com";
     github = "edolstra";

--- a/pkgs/by-name/lm/lmstudio/darwin.nix
+++ b/pkgs/by-name/lm/lmstudio/darwin.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, fetchurl
+, undmg
+, lib
+, meta
+, pname
+, version
+}:
+stdenv.mkDerivation {
+  inherit meta pname version;
+
+  src = fetchurl {
+    url = "https://releases.lmstudio.ai/mac/arm64/${version}/b/latest/LM-Studio-${version}-arm64.dmg";
+    hash = "sha256-kb1XoTZjhCL1+CsV+r3/EN0srzIJ43H2VMZ779dVq1k=";
+  };
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/Applications
+    cp -r *.app $out/Applications
+    runHook postInstall
+  '';
+}
+

--- a/pkgs/by-name/lm/lmstudio/linux.nix
+++ b/pkgs/by-name/lm/lmstudio/linux.nix
@@ -1,0 +1,29 @@
+{ lib
+, appimageTools
+, fetchurl
+, version
+, pname
+, meta
+}:
+let
+  src = fetchurl {
+    url = "https://releases.lmstudio.ai/linux/${version}/beta/LM_Studio-${version}.AppImage";
+    hash = "sha256-hcV8wDhulFAxHDBDKicpEGovwcsn9RaIi/idUz+YzD8=";
+  };
+
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit meta pname version src;
+
+  extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs) ++ [ pkgs.ocl-icd ];
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications
+    cp -r ${appimageContents}/usr/share/icons $out/share
+    install -m 444 -D ${appimageContents}/lm-studio.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/lm-studio.desktop \
+      --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=lmstudio'
+  '';
+}
+

--- a/pkgs/by-name/lm/lmstudio/package.nix
+++ b/pkgs/by-name/lm/lmstudio/package.nix
@@ -5,10 +5,10 @@
 
 let
   pname = "lmstudio";
-  version = "0.2.20";
+  version = "0.2.22";
   src = fetchurl {
     url = "https://releases.lmstudio.ai/linux/${version}/beta/LM_Studio-${version}.AppImage";
-    hash = "sha256-T92ZDqGvxJfBkAWsK8EgHdQZnLefK3gDP2vCTL8X+eM=";
+    hash = "sha256-hcV8wDhulFAxHDBDKicpEGovwcsn9RaIi/idUz+YzD8=";
   };
 
   appimageContents = appimageTools.extractType2 { inherit pname version src; };

--- a/pkgs/by-name/lm/lmstudio/package.nix
+++ b/pkgs/by-name/lm/lmstudio/package.nix
@@ -1,38 +1,22 @@
 { lib
-, appimageTools
-, fetchurl
+, stdenv
+, callPackage
+, ...
 }:
-
 let
   pname = "lmstudio";
   version = "0.2.22";
-  src = fetchurl {
-    url = "https://releases.lmstudio.ai/linux/${version}/beta/LM_Studio-${version}.AppImage";
-    hash = "sha256-hcV8wDhulFAxHDBDKicpEGovwcsn9RaIi/idUz+YzD8=";
-  };
-
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
-
-  extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs) ++ [ pkgs.ocl-icd ];
-
-  extraInstallCommands = ''
-    mkdir -p $out/share/applications
-    cp -r ${appimageContents}/usr/share/icons $out/share
-    install -m 444 -D ${appimageContents}/lm-studio.desktop -t $out/share/applications
-    substituteInPlace $out/share/applications/lm-studio.desktop \
-      --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=lmstudio'
-  '';
-
   meta = {
     description = "LM Studio is an easy to use desktop app for experimenting with local and open-source Large Language Models (LLMs)";
     homepage = "https://lmstudio.ai/";
     license = lib.licenses.unfree;
     mainProgram = "lmstudio";
     maintainers = with lib.maintainers; [ drupol eeedean ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ [ "aarch64-darwin" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-}
+in
+  if stdenv.isDarwin
+    then callPackage ./darwin.nix { inherit pname version meta; }
+    else callPackage ./linux.nix  { inherit pname version meta; }
+

--- a/pkgs/by-name/lm/lmstudio/package.nix
+++ b/pkgs/by-name/lm/lmstudio/package.nix
@@ -31,7 +31,7 @@ appimageTools.wrapType2 {
     homepage = "https://lmstudio.ai/";
     license = lib.licenses.unfree;
     mainProgram = "lmstudio";
-    maintainers = with lib.maintainers; [ drupol ];
+    maintainers = with lib.maintainers; [ drupol eeedean ];
     platforms = lib.platforms.linux;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };


### PR DESCRIPTION
## Description of changes

### Packaging Change
 * Added packaging for macOS / `aarch64-darwin` (no `x86_64-darwin`-Support present)
 * Moved Linux packaging into own file

### Version bump

I don't have a reasonable NixOS device with a desktop environment. **Would therefore much appreciate someone trying it out.** @drupol do you have time for verifying functionality?

#### 🎉 What's New in 0.2.21
 * New models support! 🤖 🦙
   * Microsoft's "Phi-3" (small & fast with impressive capabilities)
   * Meta's "Llama 3" (incredibly powerful open model)
 * LM Studio "tray" status bar menu 👾
   * Quickly start/stop the server, see loaded models, and more
   * On Mac / Linux: find the tray icon in the top right corner
   * On Windows: find the tray icon in the bottom right corner
 * Advanced Information: 🤓
   * llama.cpp commit b4e4b8a9351d918a56831c73cf9f25c1837b80d1
   * To disable the tray menu, set "disableTray": true in settings.json

#### What's New in 0.2.22
 * ✨ NEW: Meet lms - LM Studio's command line interface!
    * With lms, you can...
      * Load/unload models, control the server programmatically, list models, and more, all from the command line
      * lms is MIT licensed! Check out the Github: https://github.com/lmstudio-ai/lmstudio-cli
 * 🛠️ How to setup lms on your machine:
    * On Windows, run:
cmd /c %USERPROFILE%/.cache/lm-studio/bin/lms.exe bootstrap
    * On Mac and Linux, run:
~/.cache/lm-studio/bin/lms bootstrap
 * 🤓 Advanced Information:
    * llama.cpp commit: a8f9b076316e16aadd0791015b3bfd446fe1e904
      * Includes Flash Attention! Turn it on under Advanced Configuration > Model Initialization

## Things done


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
