### PR TITLE
python3Packages: don't propagate build-platform cffi

### DIFF
--- a/pkgs/development/python-modules/brotlicffi/default.nix
+++ b/pkgs/development/python-modules/brotlicffi/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   buildInputs = [ brotli ];
 
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [ cffi ];
 
   propagatedBuildInputs = [ cffi ];
 

--- a/pkgs/development/python-modules/brotlipy/default.nix
+++ b/pkgs/development/python-modules/brotlipy/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [ cffi ];
 
   dependencies = [
     cffi

--- a/pkgs/development/python-modules/cairosvg/default.nix
+++ b/pkgs/development/python-modules/cairosvg/default.nix
@@ -22,7 +22,10 @@ buildPythonPackage rec {
     hash = "sha256-QyUx1yNHKRuanr+2d3AmtgdWP9hxnEbudC2wrvcnG6A=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  nativeBuildInputs = [
+    cairocffi
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     cairocffi
@@ -31,8 +34,6 @@ buildPythonPackage rec {
     pillow
     tinycss2
   ];
-
-  propagatedNativeBuildInputs = [ cairocffi ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/cmarkgfm/default.nix
+++ b/pkgs/development/python-modules/cmarkgfm/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     hash = "sha256-ogjBcm4SujhRJc7yxtN1xBxd6kzCZzp3r3ErHb8HTpA=";
   };
 
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [ cffi ];
 
   propagatedBuildInputs = [ cffi ];
 

--- a/pkgs/development/python-modules/cmsis-pack-manager/default.nix
+++ b/pkgs/development/python-modules/cmsis-pack-manager/default.nix
@@ -33,10 +33,10 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
+    cffi
     rustPlatform.cargoSetupHook
     rustPlatform.maturinBuildHook
   ];
-  propagatedNativeBuildInputs = [ cffi ];
   buildInputs = [
     libiconv
   ] ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Security;

--- a/pkgs/development/python-modules/editdistance-s/default.nix
+++ b/pkgs/development/python-modules/editdistance-s/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     sha256 = "0w2qd5b6a3c3ahd0xy9ykq4wzqk0byqwdqrr26dyn8j2425j46lg";
   };
 
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [ cffi ];
 
   propagatedBuildInputs = [ cffi ];
 

--- a/pkgs/development/python-modules/fastpbkdf2/default.nix
+++ b/pkgs/development/python-modules/fastpbkdf2/default.nix
@@ -22,12 +22,12 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ openssl ];
+  nativeBuildInputs = [ cffi ];
   nativeCheckInputs = [ pytest ];
   propagatedBuildInputs = [
     cffi
     six
   ];
-  propagatedNativeBuildInputs = [ cffi ];
 
   meta = with lib; {
     homepage = "https://github.com/Ayrx/python-fastpbkdf2";

--- a/pkgs/development/python-modules/liquidctl/default.nix
+++ b/pkgs/development/python-modules/liquidctl/default.nix
@@ -59,8 +59,6 @@ buildPythonPackage rec {
     pillow
   ];
 
-  propagatedNativeBuildInputs = [ smbus-cffi ];
-
   outputs = [
     "out"
     "man"

--- a/pkgs/development/python-modules/miniaudio/default.nix
+++ b/pkgs/development/python-modules/miniaudio/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     CoreAudio
   ];
 
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [ cffi ];
   dependencies = [ cffi ];
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/misaka/default.nix
+++ b/pkgs/development/python-modules/misaka/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     sha256 = "1mzc29wwyhyardclj1vg2xsfdibg2lzb7f1azjcxi580ama55wv2";
   };
 
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [ cffi ];
 
   propagatedBuildInputs = [ cffi ];
 

--- a/pkgs/development/python-modules/prox-tv/default.nix
+++ b/pkgs/development/python-modules/prox-tv/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage {
     lapack
   ];
 
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [ cffi ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/python-modules/pycares/default.nix
+++ b/pkgs/development/python-modules/pycares/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     idna
   ];
 
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [ cffi ];
 
   # Requires network access
   doCheck = false;

--- a/pkgs/development/python-modules/pycmarkgfm/default.nix
+++ b/pkgs/development/python-modules/pycmarkgfm/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     hash = "sha256-oPklCB54aHn33ewTiSlXgx38T0RzLure5OzGuFwsLNo=";
   };
 
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [ cffi ];
 
   propagatedBuildInputs = [ cffi ];
 

--- a/pkgs/development/python-modules/pygit2/default.nix
+++ b/pkgs/development/python-modules/pygit2/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     export DYLD_LIBRARY_PATH="${libgit2}/lib"
   '';
 
-  nativeBuildInputs = [ setuptools ];
+  nativeBuildInputs = [ setuptools ] ++ lib.optionals (!isPyPy) [ cffi ];
 
   buildInputs = [ libgit2 ];
 
@@ -38,8 +38,6 @@ buildPythonPackage rec {
     cached-property
     pycparser
   ] ++ lib.optionals (!isPyPy) [ cffi ];
-
-  propagatedNativeBuildInputs = lib.optionals (!isPyPy) [ cffi ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/pykeepass/default.nix
+++ b/pkgs/development/python-modules/pykeepass/default.nix
@@ -32,8 +32,6 @@ buildPythonPackage rec {
     pycryptodomex
   ];
 
-  propagatedNativeBuildInputs = [ argon2-cffi ];
-
   nativeCheckInputs = [
     pyotp
     unittestCheckHook

--- a/pkgs/development/python-modules/pynacl/default.nix
+++ b/pkgs/development/python-modules/pynacl/default.nix
@@ -27,11 +27,12 @@ buildPythonPackage rec {
     sha256 = "8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba";
   };
 
-  nativeBuildInputs = [ sphinxHook ];
+  nativeBuildInputs = [
+    cffi
+    sphinxHook
+  ];
 
   buildInputs = [ libsodium ];
-
-  propagatedNativeBuildInputs = [ cffi ];
 
   propagatedBuildInputs = [ cffi ];
 

--- a/pkgs/development/python-modules/python-olm/default.nix
+++ b/pkgs/development/python-modules/python-olm/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage {
     future
   ];
 
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [ cffi ];
 
   pythonImportsCheck = [ "olm" ];
 

--- a/pkgs/development/python-modules/pywayland/default.nix
+++ b/pkgs/development/python-modules/pywayland/default.nix
@@ -21,8 +21,10 @@ buildPythonPackage rec {
   };
 
   depsBuildBuild = [ pkg-config ];
-  nativeBuildInputs = [ wayland-scanner ];
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [
+    cffi
+    wayland-scanner
+  ];
   buildInputs = [ wayland ];
   propagatedBuildInputs = [ cffi ];
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/pywlroots/default.nix
+++ b/pkgs/development/python-modules/pywlroots/default.nix
@@ -31,8 +31,10 @@ buildPythonPackage rec {
     hash = "sha256-cssr4UBIwMvInM8bV4YwE6mXf9USSMMAzMcgAefEPbs=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [
+    cffi
+    pkg-config
+  ];
   buildInputs = [
     libinput
     libxkbcommon

--- a/pkgs/development/python-modules/reflink/default.nix
+++ b/pkgs/development/python-modules/reflink/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ cffi ];
 
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [ cffi ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/smbus-cffi/default.nix
+++ b/pkgs/development/python-modules/smbus-cffi/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     })
   ];
 
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [ cffi ];
 
   propagatedBuildInputs = [ cffi ];
 

--- a/pkgs/development/python-modules/soundfile/default.nix
+++ b/pkgs/development/python-modules/soundfile/default.nix
@@ -29,12 +29,12 @@ buildPythonPackage rec {
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];
+  nativeBuildInputs = [ cffi ];
   propagatedBuildInputs = [
     numpy
     libsndfile
     cffi
   ];
-  propagatedNativeBuildInputs = [ cffi ];
 
   meta = {
     description = "Audio library based on libsndfile, CFFI and NumPy";

--- a/pkgs/development/python-modules/xcffib/default.nix
+++ b/pkgs/development/python-modules/xcffib/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     sed -e 's,ffi\.dlopen(,&"${xorg.libxcb.out}/lib/" + ,' -i xcffib/__init__.py
   '';
 
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [ cffi ];
 
   propagatedBuildInputs = [ cffi ];
 

--- a/pkgs/development/python-modules/xkbcommon/default.nix
+++ b/pkgs/development/python-modules/xkbcommon/default.nix
@@ -19,8 +19,10 @@ buildPythonPackage rec {
     hash = "sha256-rBdICNv2HTXZ2oBL8zuqx0vG8r4MEIWUrpPHnNFd3DY=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [
+    cffi
+    pkg-config
+  ];
   buildInputs = [ libxkbcommon ];
   propagatedBuildInputs = [ cffi ];
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/xpybutil/default.nix
+++ b/pkgs/development/python-modules/xpybutil/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     xcffib
   ];
 
-  propagatedNativeBuildInputs = [ xcffib ];
+  nativeBuildInputs = [ xcffib ];
 
   # no tests
   doCheck = false;

--- a/pkgs/development/python-modules/zstandard/default.nix
+++ b/pkgs/development/python-modules/zstandard/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     hash = "sha256-stjGLQjnJV9o96dAuuhbPJuOVGa6qcv39X8c3grGvAk=";
   };
 
-  propagatedNativeBuildInputs = [ cffi ];
+  nativeBuildInputs = [ cffi ];
 
   propagatedBuildInputs = [ cffi ];
 


### PR DESCRIPTION
## Description of changes

This PR revives #221951 by @lopsided98. I've successfully cross-compiled all of the packages changed in this PR except `pywayland` and `pywlroots` which appear to have deeper issues when being cross-compiled.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
