### PR TITLE
dssp: 4.4.5 -> 4.4.7, libcifpp: 7.0.3 -> 7.0.4

### DIFF
--- a/pkgs/applications/science/biology/dssp/default.nix
+++ b/pkgs/applications/science/biology/dssp/default.nix
@@ -3,39 +3,20 @@
 , cmake
 , eigen
 , fetchFromGitHub
-, fetchpatch
 , libcifpp
 , libmcfp
 , zlib
 }:
-let
-  libcifpp' = libcifpp.overrideAttrs (oldAttrs: {
-    # dssp 4.4.3 requires specific version "5.2.0" of libcifpp
-    version = "5.2.0";
-    src = fetchFromGitHub {
-      inherit (oldAttrs.src) owner repo rev;
-      hash = "sha256-Sj10j6HxUoUvQ66cd2B8CO7CVBRd7w9CTovxkwPDOvs=";
-    };
-    patches = [
-      (fetchpatch {
-        # https://github.com/PDB-REDO/libcifpp/issues/51
-        name = "fix-build-on-darwin.patch";
-        url = "https://github.com/PDB-REDO/libcifpp/commit/641f06a7e7c0dc54af242b373820f2398f59e7ac.patch";
-        hash = "sha256-eWNfp9nA/+2J6xjZR6Tj+5OM3L5MxdfRi0nBzyaqvS0=";
-      })
-    ];
-  });
-in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dssp";
-  version = "4.4.5";
+  version = "4.4.7";
 
   src = fetchFromGitHub {
     owner = "PDB-REDO";
     repo = "dssp";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-X0aMWqoMhmQVRHWKVm2S6JAOYiBuBBMzMoivMdpNx0M=";
+    hash = "sha256-qePoZYkzzWuK6j1NM+q6fPuWVRDEe4OkPmXc9Nbqobo=";
   };
 
   nativeBuildInputs = [
@@ -44,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     eigen
-    libcifpp'
+    libcifpp
     libmcfp
     zlib
   ];

--- a/pkgs/development/libraries/libcifpp/default.nix
+++ b/pkgs/development/libraries/libcifpp/default.nix
@@ -3,20 +3,19 @@
 , boost
 , cmake
 , fetchFromGitHub
-, fetchpatch
 , eigen
 , zlib
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libcifpp";
-  version = "7.0.3";
+  version = "7.0.4";
 
   src = fetchFromGitHub {
     owner = "PDB-REDO";
     repo = "libcifpp";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-YRK648gJ2UlgeG5GHMjTid1At0lYt7Zqu4/+O5WG/OM=";
+    hash = "sha256-/dX77KRYmTIj8jxRzQRlpG/ktqDL1jjySux/JqHnE3I=";
   };
 
   nativeBuildInputs = [
@@ -33,6 +32,11 @@ stdenv.mkDerivation (finalAttrs: {
     eigen
     zlib
   ];
+
+  # cmake requires the existence of this directory when building dssp
+  postInstall = ''
+    mkdir -p $out/share/libcifpp
+  '';
 
   meta = with lib; {
     description = "Manipulate mmCIF and PDB files";


### PR DESCRIPTION
## Description of changes

- dssp
Diff: https://github.com/PDB-REDO/dssp/compare/refs/tags/v4.4.5...v4.4.7
Changelog: https://github.com/PDB-REDO/libcifpp/releases/tag/refs/tags/v4.4.7

- libcifpp
Diff: https://github.com/PDB-REDO/libcifpp/compare/refs/tags/v7.0.3...v7.0.4
Changelog: https://github.com/PDB-REDO/libcifpp/releases/tag/refs/tags/v7.0.4

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
