### PR TITLE
kanji-stroke-order-font: 4.003 -> 4.004

### DIFF
--- a/pkgs/data/fonts/kanji-stroke-order-font/default.nix
+++ b/pkgs/data/fonts/kanji-stroke-order-font/default.nix
@@ -1,28 +1,36 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchzip }:
 
 let
-  version = "4.003";
-  debianVersion = "dfsg-1";
-in stdenv.mkDerivation {
-  name = "kanji-stroke-order-font-${version}";
+  font = "kanji-stroke-order";
+  version = "4.004";
+in
+stdenv.mkDerivation {
+  pname = "${font}-font";
+  inherit version;
 
-  src = fetchurl {
-    url = "https://salsa.debian.org/fonts-team/fonts-kanjistrokeorders/-/archive/debian/${version}_${debianVersion}/fonts-kanjistrokeorders-debian-${version}_${debianVersion}.tar.bz2";
-    sha256 = "1a8hxzkrfjz0h5gl9h0panzzsn7cldlklxryyzmpam23g32q6bg1";
+  src = fetchzip {
+    # https://github.com/NixOS/nixpkgs/issues/60157
+    url = "https://drive.google.com/uc?export=download&id=1snpD-IQmT6fGGQjEePHdDzE2aiwuKrz4#${font}.zip";
+    hash = "sha256-wQpurDS6APnpNMbMHofwW/UKeBF8FXeiCVx4wAOeRoE=";
+    stripRoot = false;
   };
 
   installPhase = ''
-    mkdir -p $out/share/fonts/kanji-stroke-order $out/share/doc/kanji-stroke-order
-    cp *.ttf $out/share/fonts/kanji-stroke-order
-    cp *.txt $out/share/doc/kanji-stroke-order
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/${font}
+    install -Dm644 *.txt -t $out/share/doc/${font}
+    install -Dm644 *.pdf -t $out/share/doc/${font}
+
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "Font containing stroke order diagrams for over 6500 kanji, 180 kana and other characters";
-    homepage = "https://sites.google.com/site/nihilistorguk/";
+    homepage = "https://www.nihilist.org.uk/";
 
     license = [ licenses.bsd3 ];
-    maintainers = with maintainers; [ ptrhlm ];
+    maintainers = with maintainers; [ ptrhlm stephen-huan ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
From `result/share/doc/kanji-stroke-order/readme_en_v4.004.txt`.

```
CHANGELOG
2020/09/09  4.004 Corrections and improvements reported by users.
                  Added more glyphs
                  Jōyō and other common use kanji that have changed:
                    U+96E2 離 Corrected appearance
                  Non-Jōyō kanji that have changed:
                    U+5699 嚙 Added
                    U+6372 捲 Corrected orientation of strokes 4 and 5. Improved appearance.
                    U+6414 搔 Added
                    U+6EBA 溺 Corrected start location of strokes 7, 8, 12 and 13
                    U+717D 煽 Corrected start location of strokes 11 and 14
                    U+7FDF 翟 Corrected appearance
                    U+7FF0 翰 Corrected start location of strokes 13 and 16
                    U+9019 這 Corrected appearance
```

Unfortunately the [Debian package](https://salsa.debian.org/fonts-team/fonts-kanjistrokeorders/) is still at `4.003`. Checking [repology](https://repology.org/project/fonts:kanjistrokeorders/versions) and going through the up-to-date packages
- [AUR](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=ttf-kanjistrokeorders)
- [Gentoo](https://gitweb.gentoo.org/repo/gentoo.git/tree/media-fonts/kanjistrokeorders/kanjistrokeorders-4.004.ebuild)
- [OpenBSD](https://github.com/openbsd/ports/blob/master/fonts/ja-kanjistrokeorders-ttf/Makefile)
- [Terra](https://github.com/terrapkg/packages/blob/f40/anda/fonts/kanjistrokeorders/kanjistrokeorders-fonts.spec)

show all of them either use the Google Drive or Dropbox link provided on the homepage. It seems relatively stable.

If necessary I can mirror on my personal website or GitHub.

Result of `nixpkgs-review pr 308702` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>kanji-stroke-order-font</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
