### PR TITLE
nixos/nomad: change dropPrivileges default to false

### DIFF
--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -25,7 +25,7 @@ in
 
       dropPrivileges = mkOption {
         type = types.bool;
-        default = true;
+        default = false;
         description = ''
           Whether the nomad agent should be run as a non-root nomad user.
         '';


### PR DESCRIPTION
## Description of changes

Rootless nomad is more appealing from an operational security perspective, but upstream indicates that rootless nomad is _not_ yet a supported mode of operation an may exhibit unexpected behavior. This change keeps the option available, but changes the default to [what upstream recommends][1].

I came across this because after updating my nomad deployment, the Docker driver suddenly stopped working, and this was the only way I was able to resolve it (despite ensuring appropriate group membership, correct cgroups, etc.). My deployment kept working after making the change in-place to an existing deployment, so it appears like the systemd `StateDirectory=` behavior (ensuring ownership is consistent with the `.service` unit's designed owner) is working as intended to make sure that the change will work with existing installations. (Annoyingly, upstream source code actually forcibly _disables_ the Docker driver entirely unless EUID is 0).

I haven't documented a related release note for this, since I wanted to consult with the folks marked as maintainers for the nomad package before committing with the associated release note changelog. But I definitely think it deserves a release note if we do make the change since it changes a default.

[1]: https://github.com/hashicorp/nomad/issues/13669

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- ~For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - ~(Package updates) Added a release notes entry if the change is major or breaking~
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - ~(Module addition) Added a release notes entry if adding a new NixOS module~
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
