### PR TITLE
eww: 0.6.0 -> 0.6.0-unstable-2024-04-26

### DIFF
--- a/pkgs/by-name/ew/eww/package.nix
+++ b/pkgs/by-name/ew/eww/package.nix
@@ -26,7 +26,10 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-ClnIW7HxbQcC85OyoMhBLFjVtdEUCOARuimfS4uRi+E=";
 
-  nativeBuildInputs = [ pkg-config wrapGAppsHook3 ];
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook3
+  ];
 
   buildInputs = [
     gtk3
@@ -35,7 +38,10 @@ rustPlatform.buildRustPackage rec {
     librsvg
   ];
 
-  cargoBuildFlags = [ "--bin" "eww" ];
+  cargoBuildFlags = [
+    "--bin"
+    "eww"
+  ];
 
   cargoTestFlags = cargoBuildFlags;
 
@@ -43,10 +49,23 @@ rustPlatform.buildRustPackage rec {
   RUSTC_BOOTSTRAP = 1;
 
   meta = {
-    description = "ElKowars wacky widgets";
+    description = "A widget system made in Rust to create widgets for any WM";
+    longDescription = ''
+      Eww (ElKowar's Wacky Widgets) is a widget system made in Rust which lets
+      you create your own widgets similarly to how you can in AwesomeWM.
+      The key difference: It is independent of your window manager!
+      It can be configured in yuck and themed using CSS, is very easy
+      to customize and provides all the flexibility you need!
+    '';
     homepage = "https://github.com/elkowar/eww";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ coffeeispower eclairevoyant figsoda lom w-lfchen ];
+    maintainers = with lib.maintainers; [
+      coffeeispower
+      eclairevoyant
+      figsoda
+      lom
+      w-lfchen
+    ];
     mainProgram = "eww";
     broken = stdenv.isDarwin;
   };

--- a/pkgs/by-name/ew/eww/package.nix
+++ b/pkgs/by-name/ew/eww/package.nix
@@ -12,16 +12,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "eww";
-  version = "0.6.0";
+  version = "0.6.0-unstable-2024-04-26";
 
   src = fetchFromGitHub {
     owner = "elkowar";
     repo = "eww";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-rzDnplFJNiHe+XbxbhZMEhPJMiJsmdVqtZxlxhzzpTk=";
+    # FIXME: change to a release tag once a new release is available
+    # https://github.com/elkowar/eww/pull/1084
+    # using the revision to fix string truncation issue in eww config
+    rev = "2c8811512460ce6cc75e021d8d081813647699dc";
+    hash = "sha256-eDOg5Ink3iWT/B1WpD9po5/UxS4DEaVO4NPIRyjSheM=";
   };
 
-  cargoHash = "sha256-n9nd5E/VO+0BgkhrfQpeihlIkoVQRf6CMiPCK5opvvw=";
+  cargoHash = "sha256-ClnIW7HxbQcC85OyoMhBLFjVtdEUCOARuimfS4uRi+E=";
 
   nativeBuildInputs = [ pkg-config wrapGAppsHook3 ];
 


### PR DESCRIPTION
## Description of changes
This PR merely backports the upstream patch (https://github.com/elkowar/eww/commit/2c8811512460ce6cc75e021d8d081813647699dc) to fix the problem in current release.
Also reformats the file using `nixfmt-rfc-style`.
Fixes https://github.com/NixOS/nixpkgs/issues/308473

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
