### PR TITLE
inotify-info: unstable-2024-01-05 -> 0.0.1

### DIFF
--- a/pkgs/by-name/in/inotify-info/package.nix
+++ b/pkgs/by-name/in/inotify-info/package.nix
@@ -1,14 +1,17 @@
-{ lib, stdenv, fetchFromGitHub }:
-
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
 stdenv.mkDerivation (finalAttrs: {
   pname = "inotify-info";
-  version = "unstable-2024-01-05";
+  version = "0.0.1";
 
   src = fetchFromGitHub {
     owner = "mikesart";
     repo = "inotify-info";
-    rev = "a7ff6fa62ed96ec5d2195ef00756cd8ffbf23ae1";
-    hash = "sha256-yY+hjdb5J6dpFkIMMUWvZlwoGT/jqOuQIcFp3Dv+qB8=";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-fsUvIXWnP6Iy9Db0wDG+ntSw6mUt0MQOTJA5vFxhH+U=";
   };
 
   installPhase = ''


### PR DESCRIPTION
## Description of changes

Bump version. No changes in functionality, just started creating releases.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
