### PR TITLE
bitcoin: reenable bdb legacy wallet support on non-Darwin platforms

### DIFF
--- a/pkgs/applications/blockchains/bitcoin/default.nix
+++ b/pkgs/applications/blockchains/bitcoin/default.nix
@@ -13,6 +13,7 @@
 , miniupnpc
 , zeromq
 , zlib
+, db48
 , sqlite
 , qrencode
 , qtbase ? null
@@ -51,6 +52,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ boost libevent miniupnpc zeromq zlib ]
     ++ lib.optionals withWallet [ sqlite ]
+    # building with db48 (for legacy descriptor wallet support) is broken on Darwin
+    ++ lib.optionals (withWallet && !stdenv.isDarwin) [ db48 ]
     ++ lib.optionals withGui [ qrencode qtbase qttools ];
 
   postInstall = ''


### PR DESCRIPTION
#### Copy of commit msg

Joinmarket requires legacy wallet support:
https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/79e5c3d0a79fb4456fbd8929fa5de9c5b8361a34/docs/USAGE.md#:~:text=legacy%20wallets

Also, this removes breakage for other legacy wallet users on non-Darwin platforms.

#### Things done

- [x] Built on x86_64-linux

cc @prusnak