### PR TITLE
[wip] k3s: update versions 1.29, 1.28, 1.27

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_27/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_27/chart-versions.nix
@@ -1,10 +1,10 @@
 {
     traefik-crd  = {
-        url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.2+up25.0.0.tgz";
-        sha256 = "0jygzsn5pxzf7423x5iqfffgx5xvm7c7hfck46y7vpv1fdkiipcq";
+        url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.3+up25.0.0.tgz";
+        sha256 = "1z693i4kd3jyf26ccnb0sxjyxadipl6k13n7jyg5v4y93fv1rpdw";
     };
     traefik = {
-        url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.2+up25.0.0.tgz";
-        sha256 = "1g9n19lnqdkmbbr3rnbwc854awha0kqqfwyxanyx1lg5ww8ldp89";
+        url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.3+up25.0.0.tgz";
+        sha256 = "1a24qlp7c6iri72ka1i37l1lzn13xibrd26dy295z2wzr55gg7if";
     };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_27/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_27/versions.nix
@@ -1,14 +1,14 @@
 {
-  k3sVersion = "1.27.12+k3s1";
-  k3sCommit = "78ad57567c9eb1fd1831986f5fd7b4024add1767";
-  k3sRepoSha256 = "1j6xb3af4ypqq5m6a8x2yc2515zvlgqzfsfindjm9cbmq5iisphq";
-  k3sVendorHash = "sha256-65cmpRwD9C+fcbBSv1YpeukO7bfGngsLv/rk6sM59gU=";
+  k3sVersion = "1.27.13+k3s1";
+  k3sCommit = "b23f142da8589854cc7ee45da08d96b5ad1ee1ff";
+  k3sRepoSha256 = "052998644il0qra7cdpvmy007gw16k2rvyg418m1j02pm9a3zn10";
+  k3sVendorHash = "sha256-rQZZnleRekkU1+I38LmFnnatZPuS+K1jbBwA+Dmc0jo=";
   chartVersions = import ./chart-versions.nix;
   k3sRootVersion = "0.12.2";
   k3sRootSha256 = "1gjynvr350qni5mskgm7pcc7alss4gms4jmkiv453vs8mmma9c9k";
   k3sCNIVersion = "1.4.0-k3s2";
   k3sCNISha256 = "17dg6jgjx18nrlyfmkv14dhzxsljz4774zgwz5dchxcf38bvarqa";
-  containerdVersion = "1.7.11-k3s2.27";
-  containerdSha256 = "0xjxc5dgh3drk2glvcabd885damjffp9r4cs0cm1zgnrrbhlipra";
+  containerdVersion = "1.7.15-k3s1.27";
+  containerdSha256 = "0bjxw174prhq8izmgrmpyljfxzrj0lh5d0w04g3lyn0rp3kwxqsl";
   criCtlVersion = "1.26.0-rc.0-k3s1";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_28/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_28/chart-versions.nix
@@ -1,10 +1,10 @@
 {
     traefik-crd  = {
-        url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.2+up25.0.0.tgz";
-        sha256 = "0jygzsn5pxzf7423x5iqfffgx5xvm7c7hfck46y7vpv1fdkiipcq";
+        url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.3+up25.0.0.tgz";
+        sha256 = "1z693i4kd3jyf26ccnb0sxjyxadipl6k13n7jyg5v4y93fv1rpdw";
     };
     traefik = {
-        url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.2+up25.0.0.tgz";
-        sha256 = "1g9n19lnqdkmbbr3rnbwc854awha0kqqfwyxanyx1lg5ww8ldp89";
+        url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.3+up25.0.0.tgz";
+        sha256 = "1a24qlp7c6iri72ka1i37l1lzn13xibrd26dy295z2wzr55gg7if";
     };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_28/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_28/versions.nix
@@ -1,14 +1,14 @@
 {
-  k3sVersion = "1.28.8+k3s1";
-  k3sCommit = "653dd61aaa2d0ef8bd83ac4dbc6d150dde792efc";
-  k3sRepoSha256 = "0pf8xw1m56m2s8i99vxj4i2l7fz7388kiynwzfrck43jb7v7kbbw";
-  k3sVendorHash = "sha256-wglwRW2RO9QJI6CRLgkVg5Upt6R0M3gX76zy0kT02ec=";
+  k3sVersion = "1.28.9+k3s1";
+  k3sCommit = "289a1a3edbc0f6ee5a7f91bf96aa1ed1b743bd1f";
+  k3sRepoSha256 = "0kms6r10k6v037r5lxxrp90bnynrgyrn61kqnzy2f5avny4blikh";
+  k3sVendorHash = "sha256-iUp2Maua3BnrC4Jq2ij0uOW5gYYZfz6e+TEdDtN0PT8=";
   chartVersions = import ./chart-versions.nix;
   k3sRootVersion = "0.12.2";
   k3sRootSha256 = "1gjynvr350qni5mskgm7pcc7alss4gms4jmkiv453vs8mmma9c9k";
   k3sCNIVersion = "1.4.0-k3s2";
   k3sCNISha256 = "17dg6jgjx18nrlyfmkv14dhzxsljz4774zgwz5dchxcf38bvarqa";
-  containerdVersion = "1.7.11-k3s2";
-  containerdSha256 = "0279sil02wz7310xhrgmdbc0r2qibj9lafy0i9k24jdrh74icmib";
+  containerdVersion = "1.7.15-k3s1";
+  containerdSha256 = "18hlj4ixjk7wvamfd66xyc0cax2hs9s7yjvlx52afxdc73194y0f";
   criCtlVersion = "1.26.0-rc.0-k3s1";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_29/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_29/chart-versions.nix
@@ -1,10 +1,10 @@
 {
     traefik-crd  = {
-        url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.2+up25.0.0.tgz";
-        sha256 = "0jygzsn5pxzf7423x5iqfffgx5xvm7c7hfck46y7vpv1fdkiipcq";
+        url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.3+up25.0.0.tgz";
+        sha256 = "1z693i4kd3jyf26ccnb0sxjyxadipl6k13n7jyg5v4y93fv1rpdw";
     };
     traefik = {
-        url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.2+up25.0.0.tgz";
-        sha256 = "1g9n19lnqdkmbbr3rnbwc854awha0kqqfwyxanyx1lg5ww8ldp89";
+        url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.3+up25.0.0.tgz";
+        sha256 = "1a24qlp7c6iri72ka1i37l1lzn13xibrd26dy295z2wzr55gg7if";
     };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_29/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_29/versions.nix
@@ -1,14 +1,14 @@
 {
-  k3sVersion = "1.29.3+k3s1";
-  k3sCommit = "8aecc26b0f167d5e9e4e9fbcfd5a471488bf5957";
-  k3sRepoSha256 = "12285mhwi6cifsw3gjxxmd1g2i5f7vkdgzdc6a78rkvnx7z1j3p3";
-  k3sVendorHash = "sha256-pID2h/rvvKyfHWoglYPbbliAby+9R2zoh7Ajd36qjVQ=";
+  k3sVersion = "1.29.4+k3s1";
+  k3sCommit = "94e29e2ef5d79904f730e2024c8d1682b901b2d5";
+  k3sRepoSha256 = "0kkhd2fnlmjanzvwgdclmbg6azw3r1a2lj5207716pavxmb9ld7y";
+  k3sVendorHash = "sha256-wOX+ktGPFYUKLZBK/bQhWWG+SnRCkNYnk3Tz8wpMo5A=";
   chartVersions = import ./chart-versions.nix;
-  k3sRootVersion = "0.12.2";
-  k3sRootSha256 = "1gjynvr350qni5mskgm7pcc7alss4gms4jmkiv453vs8mmma9c9k";
+  k3sRootVersion = "0.13.0";
+  k3sRootSha256 = "1jq5f0lm08abx5ikarf92z56fvx4kjpy2nmzaazblb34lajw87vj";
   k3sCNIVersion = "1.4.0-k3s2";
   k3sCNISha256 = "17dg6jgjx18nrlyfmkv14dhzxsljz4774zgwz5dchxcf38bvarqa";
-  containerdVersion = "1.7.11-k3s2";
-  containerdSha256 = "0279sil02wz7310xhrgmdbc0r2qibj9lafy0i9k24jdrh74icmib";
+  containerdVersion = "1.7.15-k3s1";
+  containerdSha256 = "18hlj4ixjk7wvamfd66xyc0cax2hs9s7yjvlx52afxdc73194y0f";
   criCtlVersion = "1.29.0-k3s1";
 }

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -185,15 +185,6 @@ let
     src = k3sRepo;
     vendorHash = k3sVendorHash;
 
-    patches =
-      # Disable: Add runtime checking of golang version
-      (fetchpatch {
-        # https://github.com/k3s-io/k3s/pull/9054
-        url = "https://github.com/k3s-io/k3s/commit/b297996b9252b02e56e9425f55f6becbf6bb7832.patch";
-        hash = "sha256-xBOY2jnLhT9dtVKtq26V9QUnuX1q6E/9UcO9IaU719U=";
-        revert = true;
-      });
-
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ libseccomp sqlite.dev ];
 


### PR DESCRIPTION
* k3s_1_29: 1.29.3+k3s1 -> 1.29.4+k3s1
* k3s_1_28: 1.28.8+k3s1 -> 1.28.9+k3s1
* k3s_1_27: 1.27.12+k3s1 -> 1.27.13+k3s1

Pending: As predicted by Euank, the patch that reverts go version pinning has conflicted. It needs adaptation.

<!--
https://github.com/ofborg build k3s_1_29.passthru.tests.single-node k3s_1_29.passthru.tests.multi-node k3s_1_29.passthru.tests.etcd k3s_1_28.passthru.tests.single-node k3s_1_28.passthru.tests.multi-node k3s_1_28.passthru.tests.etcd k3s_1_27.passthru.tests.single-node k3s_1_27.passthru.tests.multi-node k3s_1_27.passthru.tests.etcd
-->