### PR TITLE
ocamlPackages.odoc: 2.2.1 → 2.4.2

### DIFF
--- a/pkgs/development/ocaml-modules/odoc-parser/default.nix
+++ b/pkgs/development/ocaml-modules/odoc-parser/default.nix
@@ -1,23 +1,22 @@
-{ lib, fetchurl, buildDunePackage, ocaml, astring, result, camlp-streams, version ? "2.0.0" }:
+{ lib, fetchurl, buildDunePackage, ocaml, astring, result, camlp-streams, version ? "2.4.2" }:
 
 let param = {
+  "2.4.2" = {
+    sha256 = "sha256-Vjz9uybsijDnN6nPKFoG4LuulT9I4lu7D2n3qZwrpAs=";
+  };
   "2.0.0" = {
     sha256 = "sha256-QHkZ+7DrlXYdb8bsZ3dijZSqGQc0O9ymeLGIC6+zOSI=";
-    extraBuildInputs = [ camlp-streams ];
   };
   "1.0.1" = {
     sha256 = "sha256-orvo5CAbYOmAurAeluQfK6CwW6P1C0T3WDfoovuQfSw=";
-    extraBuildInputs = [ camlp-streams ];
   };
   "1.0.0" = {
     sha256 = "sha256-tqoI6nGp662bK+vE2h7aDXE882dObVfRBFnZNChueqE=";
     max_version = "5.0";
-    extraBuildInputs = [];
   };
   "0.9.0" = {
     sha256 = "sha256-3w2tG605v03mvmZsS2O5c71y66O3W+n3JjFxIbXwvXk=";
     max_version = "5.0";
-    extraBuildInputs = [];
   };
 }."${version}"; in
 
@@ -31,11 +30,14 @@ buildDunePackage rec {
   minimalOCamlVersion = "4.02";
 
   src = fetchurl {
-    url = "https://github.com/ocaml-doc/odoc-parser/releases/download/${version}/odoc-parser-${version}.tbz";
+    url = if lib.versionAtLeast version "2.4"
+      then "https://github.com/ocaml/odoc/releases/download/${version}/odoc-${version}.tbz"
+      else "https://github.com/ocaml-doc/odoc-parser/releases/download/${version}/odoc-parser-${version}.tbz";
     inherit (param) sha256;
   };
 
-  propagatedBuildInputs = [ astring result ] ++ param.extraBuildInputs;
+  propagatedBuildInputs = [ astring result ] ++
+    lib.optional (lib.versionAtLeast version "1.0.1") camlp-streams;
 
   meta = {
     description = "Parser for Ocaml documentation comments";

--- a/pkgs/development/ocaml-modules/odoc/default.nix
+++ b/pkgs/development/ocaml-modules/odoc/default.nix
@@ -1,4 +1,5 @@
 { lib, fetchurl, buildDunePackage, ocaml
+, ocaml-crunch
 , astring, cmdliner, cppo, fpath, result, tyxml
 , markup, yojson, sexplib0, jq
 , odoc-parser, ppx_expect, bash, fmt
@@ -6,14 +7,9 @@
 
 buildDunePackage rec {
   pname = "odoc";
-  version = "2.2.1";
+  inherit (odoc-parser) version src;
 
-  src = fetchurl {
-    url = "https://github.com/ocaml/odoc/releases/download/${version}/odoc-${version}.tbz";
-    sha256 = "sha256-F4blO/CCT+HHx7gdKn2EaEal0RZ3lp5jljYfd6OBaAM=";
-  };
-
-  nativeBuildInputs = [ cppo ];
+  nativeBuildInputs = [ cppo ocaml-crunch ];
   buildInputs = [ astring cmdliner fpath result tyxml odoc-parser fmt ];
 
   nativeCheckInputs = [ bash jq ];


### PR DESCRIPTION
## Description of changes

Support for OCaml 5.2: https://raw.githubusercontent.com/ocaml/odoc/2.4.2/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
