### PR TITLE
 warp-terminal: 0.2024.04.16.08.02.stable_00 -> 0.2024.05.07.08.02.stable_02

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/package.nix
+++ b/pkgs/by-name/wa/warp-terminal/package.nix
@@ -99,7 +99,7 @@ meta = with lib; {
   homepage = "https://www.warp.dev";
   license = licenses.unfree;
   sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-  maintainers = with maintainers; [ emilytrau Enzime imadnyc ];
+  maintainers = with maintainers; [ emilytrau Enzime imadnyc donteatoreo ];
   platforms = platforms.darwin ++ [ "x86_64-linux" ];
 };
 

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "darwin": {
-    "hash": "sha256-oIRZtj1BZWioO1ucEXnJQoz/FfDNHWLdYLExuLk+aJk=",
-    "version": "0.2024.04.23.08.01.stable_03"
+    "hash": "sha256-Ky5JyocpI9JKvhmmhk0Cg/Eo7icmo6FQAT639cGIGrA=",
+    "version": "0.2024.05.07.08.02.stable_02"
   },
   "linux": {
-    "hash": "sha256-R9//eoelQkH8OAhoU0ux+o1EpQozWhRJwCTTSY9LBGU=",
-    "version": "0.2024.04.23.08.01.stable_03"
+    "hash": "sha256-zUbWNgiupBoFWoN3I726FejGtGne9dctaiGlPBbj5KU=",
+    "version": "0.2024.05.07.08.02.stable_02"
   }
 }


### PR DESCRIPTION
## Description of changes

Fixes: https://github.com/NixOS/nixpkgs/issues/309938

Changelog: https://docs.warp.dev/getting-started/changelog#id-2024.05.02-v0.2024.04.30.08.02

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
