### PR TITLE
Luau: installs libraries + headers

### DIFF
--- a/pkgs/development/interpreters/luau/add-pkgconfig.patch
+++ b/pkgs/development/interpreters/luau/add-pkgconfig.patch
@@ -1,0 +1,13 @@
+--- /dev/null
++++ b/Luau.pc
+@@ -0,0 +1,10 @@
++prefix=@out@
++exec_prefix=${prefix}
++includedir=${prefix}/include/
++libdir=${prefix}/lib
++
++Name: Luau
++Description: A fast, small, safe, gradually typed embeddable scripting language derived from Lua
++Version: @version@
++Cflags: -I${includedir}/Luau
++Libs: -L${libdir} -lLuau.Analysis -lLuau.Ast -lLuau.Compiler -lLuau.VM

--- a/pkgs/development/interpreters/luau/default.nix
+++ b/pkgs/development/interpreters/luau/default.nix
@@ -15,12 +15,61 @@ stdenv.mkDerivation rec {
 
   buildInputs = lib.optionals stdenv.cc.isClang [ llvmPackages.libunwind ];
 
+  patches = [
+    ./add-pkgconfig.patch
+  ];
+
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 -t $out/bin luau
-    install -Dm755 -t $out/bin luau-analyze
-    install -Dm755 -t $out/bin luau-compile
+    mkdir -pv "$out/bin" "$dev/lib/pkgconfig" "$dev/include/Luau"
+
+    local execs=(
+      luau
+      luau-analyze
+      luau-ast
+      luau-bytecode
+      luau-compile
+      luau-reduce
+    )
+    for exec in "''${execs[@]}"; do
+      install -Dm755 -t "$out/bin" "$exec"
+    done
+
+    local libs=(
+      libLuau.Analysis.a
+      libLuau.Ast.a
+      libLuau.CodeGen.a
+      libLuau.Compiler.a
+      libLuau.Config.a
+      libLuau.VM.a
+      libisocline.a
+    )
+    for lib in "''${libs[@]}"; do
+      install -Dm644 -t "$dev/lib" "$lib"
+    done
+
+    local headers=(
+      $TEMPDIR/source/Analysis/include/Luau/*.h
+      $TEMPDIR/source/Ast/include/Luau/*.h
+      $TEMPDIR/source/CodeGen/include/*.h
+      $TEMPDIR/source/CodeGen/include/Luau/*.h
+      $TEMPDIR/source/Common/include/Luau/*.h
+      $TEMPDIR/source/Compiler/include/*.h
+      $TEMPDIR/source/Compiler/include/Luau/*.h
+      $TEMPDIR/source/Config/include/Luau/*.h
+      $TEMPDIR/source/VM/include/*.h
+      $TEMPDIR/source/extern/isocline/include/*.h
+    )
+
+    for header in "''${headers[@]}"; do
+      install -Dm644 -t "$dev/include/Luau" "$header"
+    done
+
+    cp -v "$TEMPDIR/source/Luau.pc" "Luau.pc"
+    substituteInPlace Luau.pc --replace-fail "@out@" "$dev"
+    substituteInPlace Luau.pc --replace-fail "@version@" "${version}"
+    install -Dm644 -t "$dev/lib/pkgconfig" Luau.pc
 
     runHook postInstall
   '';
@@ -37,6 +86,7 @@ stdenv.mkDerivation rec {
   '';
 
   passthru.updateScript = gitUpdater { };
+  outputs = [ "out" "dev" ];
 
   meta = with lib; {
     description = "A fast, small, safe, gradually typed embeddable scripting language derived from Lua";
@@ -46,5 +96,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = [ ];
     mainProgram = "luau";
+    pkgConfigModules = [ "Luau" ];
   };
 }


### PR DESCRIPTION
## Description of changes

I've added a `.pc` file and made it so the library and headers are included in the package. I had a hard time copying the headers and `.pc` files over to `$out`, so my solution probably isn't perfect. If there's a better way of doing it, feel free to let me know. I also wasn't sure if the libraries should be installed in the `$dev` output instead of the default, but I can change that if it's needed.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
