### PR TITLE
eternal-terminal: 6.2.4 -> 6.2.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10052,6 +10052,11 @@
     githubId = 107689;
     name = "Josh Holland";
   };
+  jshort = {
+    github = "jshort";
+    githubId = 1186444;
+    name = "James Short";
+  };
   jsierles = {
     email = "joshua@hey.com";
     matrix = "@jsierles:matrix.org";

--- a/pkgs/tools/networking/eternal-terminal/default.nix
+++ b/pkgs/tools/networking/eternal-terminal/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "eternal-terminal";
-  version = "6.2.4";
+  version = "6.2.8";
 
   src = fetchFromGitHub {
     owner = "MisterTea";
     repo = "EternalTerminal";
     rev = "refs/tags/et-v${version}";
-    hash = "sha256-9W9Pz0VrFU+HNpf98I3CLrn8+kpjjNLOUK8gGcDJcI8=";
+    hash = "sha256-7LhCP7zARpigsDJmA7y/ZIgN06l8aCszXryzPoa4aL0=";
   };
 
   nativeBuildInputs = [
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
   ];
 
   preBuild = ''
+    mkdir -p ../external_imported/Catch2/single_include/catch2
     cp ${catch2}/include/catch2/catch.hpp ../external_imported/Catch2/single_include/catch2/catch.hpp
   '';
 
@@ -54,7 +55,7 @@ stdenv.mkDerivation rec {
     homepage = "https://eternalterminal.dev/";
     changelog = "https://github.com/MisterTea/EternalTerminal/releases/tag/et-v${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ dezgeg ];
+    maintainers = with maintainers; [ dezgeg jshort ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
## Description of changes

https://github.com/MisterTea/EternalTerminal/releases/tag/et-v6.2.8

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

```
 ✔  ⚙  jwshort@LAPTOP  ~/gitworkspaces/nixpkgs/pkgs/tools/networking/eternal-terminal   6.2.8 
 ❯ nix-build -E 'with import <nixpkgs> {}; callPackage ./default.nix {}'
[ 98%] Linking CXX executable etserver
[100%] Linking CXX executable etterminal
[100%] Built target etserver
[100%] Built target etterminal
[100%] Linking CXX executable et
[100%] Built target et
[100%] Linking CXX executable et-test
[100%] Built target et-test
buildPhase completed in 49 seconds
Running phase: checkPhase
check flags: SHELL=/nix/store/lp3ginchcanhcj4dgw6yzdgv8bgdkm1v-bash-5.2p26/bin/bash VERBOSE=y test
Running tests...
/nix/store/m6r7cw90g4l3clba3fdl3fdvdfkm35gb-cmake-3.29.1/bin/ctest --force-new-ctest-process
Test project /tmp/nix-build-eternal-terminal-6.2.8.drv-0/source/build
    Start 1: et-test
1/1 Test #1: et-test ..........................   Passed  160.33 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) = 160.34 sec
checkPhase completed in 2 minutes 41 seconds
Running phase: installPhase
install flags: -j10 SHELL=/nix/store/lp3ginchcanhcj4dgw6yzdgv8bgdkm1v-bash-5.2p26/bin/bash install
[  1%] Built target generated-code
[ 14%] Built target et-lib
[ 20%] Built target HtmCommon
[ 29%] Built target TerminalCommon
[ 32%] Built target htmd
[ 32%] Built target htm
[ 37%] Built target et
[ 41%] Built target etterminal
[ 41%] Built target etserver
[ 94%] Built target Catch2
[ 94%] Built target Catch2WithMain
[100%] Built target et-test
Install the project...
-- Install configuration: "Release"
-- Installing: /nix/store/lqw2r44hp0c72p2gdzbjhsaqxsl2ayic-eternal-terminal-6.2.8/bin/etserver
-- Installing: /nix/store/lqw2r44hp0c72p2gdzbjhsaqxsl2ayic-eternal-terminal-6.2.8/bin/etterminal
-- Installing: /nix/store/lqw2r44hp0c72p2gdzbjhsaqxsl2ayic-eternal-terminal-6.2.8/bin/et
-- Installing: /nix/store/lqw2r44hp0c72p2gdzbjhsaqxsl2ayic-eternal-terminal-6.2.8/bin/htm
-- Installing: /nix/store/lqw2r44hp0c72p2gdzbjhsaqxsl2ayic-eternal-terminal-6.2.8/bin/htmd
-- Installing: /nix/store/lqw2r44hp0c72p2gdzbjhsaqxsl2ayic-eternal-terminal-6.2.8/include/httplib.h
-- Installing: /nix/store/lqw2r44hp0c72p2gdzbjhsaqxsl2ayic-eternal-terminal-6.2.8/lib/cmake/httplib/httplibConfig.cmake
-- Installing: /nix/store/lqw2r44hp0c72p2gdzbjhsaqxsl2ayic-eternal-terminal-6.2.8/lib/cmake/httplib/httplibConfigVersion.cmake
-- Installing: /nix/store/lqw2r44hp0c72p2gdzbjhsaqxsl2ayic-eternal-terminal-6.2.8/lib/cmake/httplib/FindBrotli.cmake
-- Installing: /nix/store/lqw2r44hp0c72p2gdzbjhsaqxsl2ayic-eternal-terminal-6.2.8/lib/cmake/httplib/httplibTargets.cmake
Running phase: fixupPhase
checking for references to /private/tmp/nix-build-eternal-terminal-6.2.8.drv-0/ in /nix/store/lqw2r44hp0c72p2gdzbjhsaqxsl2ayic-eternal-terminal-6.2.8...
patching script interpreter paths in /nix/store/lqw2r44hp0c72p2gdzbjhsaqxsl2ayic-eternal-terminal-6.2.8
stripping (with command strip and flags -S) in  /nix/store/lqw2r44hp0c72p2gdzbjhsaqxsl2ayic-eternal-terminal-6.2.8/lib /nix/store/lqw2r44hp0c72p2gdzbjhsaqxsl2ayic-eternal-terminal-6.2.8/bin
/nix/store/lqw2r44hp0c72p2gdzbjhsaqxsl2ayic-eternal-terminal-6.2.8

 ✔  ⚙  jwshort@LAPTOP  ~/gitworkspaces/nixpkgs/pkgs/tools/networking/eternal-terminal   6.2.8 
 ❯ result/bin/et --version                                                                                                                                                          16:39:18  05.03.24  100% █
et version 6.2.8

 ✔  ⚙  jwshort@LAPTOP  ~/gitworkspaces/nixpkgs/pkgs/tools/networking/eternal-terminal   6.2.8 
 ❯ result/bin/etserver --version                                                                                                                                                    16:41:27  05.03.24  100% █
et version 6.2.8

 ✔  ⚙  jwshort@LAPTOP  ~/gitworkspaces/nixpkgs/pkgs/tools/networking/eternal-terminal   6.2.8 
 ❯ result/bin/et dev:8080
```

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
