### PR TITLE
treewide: mark packages using librusty_v8 as binaryNativeCode

### DIFF
--- a/pkgs/by-name/wi/windmill/package.nix
+++ b/pkgs/by-name/wi/windmill/package.nix
@@ -74,7 +74,10 @@ rustPlatform.buildRustPackage {
             name = "librusty_v8-${args.version}";
             url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a";
             sha256 = args.shas.${stdenv.hostPlatform.system} or (throw "Unsupported platform ${stdenv.hostPlatform.system}");
-            meta = { inherit (args) version; };
+            meta = {
+              inherit (args) version;
+              sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+            };
           };
       in
       fetch_librusty_v8 {

--- a/pkgs/development/web/deno/librusty_v8.nix
+++ b/pkgs/development/web/deno/librusty_v8.nix
@@ -1,12 +1,15 @@
 # auto-generated file -- DO NOT EDIT!
-{ stdenv, fetchurl }:
+{ lib, stdenv, fetchurl }:
 
 let
   fetch_librusty_v8 = args: fetchurl {
     name = "librusty_v8-${args.version}";
     url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
     sha256 = args.shas.${stdenv.hostPlatform.system};
-    meta = { inherit (args) version; };
+    meta = {
+      inherit (args) version;
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    };
   };
 in
 fetch_librusty_v8 {

--- a/pkgs/development/web/deno/update/librusty_v8.ts
+++ b/pkgs/development/web/deno/update/librusty_v8.ts
@@ -40,14 +40,17 @@ fetchurl {
 
 const templateDeps = (version: string, deps: PrefetchResult[]) =>
   `# auto-generated file -- DO NOT EDIT!
-{ stdenv, fetchurl }:
+{ lib, stdenv, fetchurl }:
 
 let
   fetch_librusty_v8 = args: fetchurl {
     name = "librusty_v8-\${args.version}";
     url = "https://github.com/denoland/rusty_v8/releases/download/v\${args.version}/librusty_v8_release_\${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
     sha256 = args.shas.\${stdenv.hostPlatform.system};
-    meta = { inherit (args) version; };
+    meta = {
+      inherit (args) version;
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    };
   };
 in
 fetch_librusty_v8 {

--- a/pkgs/development/web/edge-runtime/librusty_v8.nix
+++ b/pkgs/development/web/edge-runtime/librusty_v8.nix
@@ -1,4 +1,3 @@
-# auto-generated file -- DO NOT EDIT!
 { stdenv, fetchurl }:
 
 let

--- a/pkgs/development/web/edge-runtime/librusty_v8.nix
+++ b/pkgs/development/web/edge-runtime/librusty_v8.nix
@@ -1,11 +1,14 @@
-{ stdenv, fetchurl }:
+{ lib, stdenv, fetchurl }:
 
 let
   fetch_librusty_v8 = args: fetchurl {
     name = "librusty_v8-${args.version}";
     url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a";
     sha256 = args.shas.${stdenv.hostPlatform.system};
-    meta = { inherit (args) version; };
+    meta = {
+      inherit (args) version;
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    };
   };
 in
 fetch_librusty_v8 {

--- a/pkgs/servers/http/router/librusty_v8.nix
+++ b/pkgs/servers/http/router/librusty_v8.nix
@@ -1,11 +1,14 @@
-{ stdenv, fetchurl }:
+{ lib, stdenv, fetchurl }:
 
 let
   fetch_librusty_v8 = args: fetchurl {
     name = "librusty_v8-${args.version}";
     url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a";
     sha256 = args.shas.${stdenv.hostPlatform.system};
-    meta = { inherit (args) version; };
+    meta = {
+      inherit (args) version;
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    };
   };
 in
 fetch_librusty_v8 {


### PR DESCRIPTION
## Description of changes

While these packages are primarily built from source, they include librusty_v8 which is binaryNativeCode.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
