### PR TITLE
criterion: 2.4.1 -> 2.4.2, add maintainer, migrate by-name, add version check

### DIFF
--- a/pkgs/by-name/cr/criterion/package.nix
+++ b/pkgs/by-name/cr/criterion/package.nix
@@ -16,6 +16,9 @@
   nanomsg,
   nanopbMalloc,
   python3Packages,
+  testers,
+  criterion,
+  callPackage
 }:
 
 let
@@ -89,6 +92,16 @@ stdenv.mkDerivation rec {
     "out"
     "dev"
   ];
+
+  passthru.tests.version =
+    let
+      tester = callPackage ./tests/001-version.nix {};
+    in
+    testers.testVersion {
+      package = criterion;
+      command = "${lib.getExe tester} --version";
+      version = "v${version}";
+    };
 
   meta = {
     description = "A cross-platform C and C++ unit testing framework for the 21th century";

--- a/pkgs/by-name/cr/criterion/package.nix
+++ b/pkgs/by-name/cr/criterion/package.nix
@@ -1,6 +1,22 @@
-{ lib, stdenv, fetchFromGitHub, boxfort, meson, libcsptr, pkg-config, gettext
-, cmake, ninja, protobuf, libffi, libgit2, dyncall, nanomsg, nanopbMalloc
-, python3Packages }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  boxfort,
+  meson,
+  libcsptr,
+  pkg-config,
+  gettext,
+  cmake,
+  ninja,
+  protobuf,
+  libffi,
+  libgit2,
+  dyncall,
+  nanomsg,
+  nanopbMalloc,
+  python3Packages,
+}:
 
 let
   # follow revisions defined in .wrap files
@@ -8,17 +24,17 @@ let
     owner = "MrAnno";
     repo = "debugbreak";
     rev = "83bf7e933311b88613cbaadeced9c2e2c811054a";
-    sha256 = "sha256-OPrPGBUZN73Nl5NMEf/nME843yTolt913yjut3rAos0=";
+    hash = "sha256-OPrPGBUZN73Nl5NMEf/nME843yTolt913yjut3rAos0=";
   };
 
   klib = fetchFromGitHub {
     owner = "attractivechaos";
     repo = "klib";
     rev = "cdb7e9236dc47abf8da7ebd702cc6f7f21f0c502";
-    sha256 = "sha256-+GaI5nXz4jYI0rO17xDhNtFpLlGL2WzeSVLMfB6Cl6E=";
+    hash = "sha256-+GaI5nXz4jYI0rO17xDhNtFpLlGL2WzeSVLMfB6Cl6E=";
   };
-
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "criterion";
   version = "2.4.2";
 
@@ -26,14 +42,20 @@ in stdenv.mkDerivation rec {
     owner = "Snaipe";
     repo = "Criterion";
     rev = "v${version}";
-    sha256 = "sha256-5GH7AYjrnBnqiSmp28BoaM1Xmy8sPs1atfqJkGy3Yf0=";
     fetchSubmodules = true;
+    hash = "sha256-5GH7AYjrnBnqiSmp28BoaM1Xmy8sPs1atfqJkGy3Yf0=";
   };
 
-  nativeBuildInputs = [ meson ninja cmake pkg-config protobuf ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    cmake
+    pkg-config
+    protobuf
+  ];
 
   buildInputs = [
-    boxfort.dev
+    (lib.getDev boxfort)
     dyncall
     gettext
     libcsptr
@@ -63,17 +85,20 @@ in stdenv.mkDerivation rec {
     patchShebangs ci/isdir.py src/protocol/gen-pb.py
   '';
 
-  outputs = [ "dev" "out" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
-  meta = with lib; {
+  meta = {
     description = "A cross-platform C and C++ unit testing framework for the 21th century";
     homepage = "https://github.com/Snaipe/Criterion";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       thesola10
       Yumasi
       sigmanificient
     ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/cr/criterion/tests/001-version.nix
+++ b/pkgs/by-name/cr/criterion/tests/001-version.nix
@@ -1,0 +1,25 @@
+{
+  stdenv,
+  pkg-config,
+  criterion,
+}:
+stdenv.mkDerivation rec {
+  name = "version-tester";
+  version = "v${criterion.version}";
+  src = ./test_dummy.c;
+
+  dontUnpack = true;
+  buildInputs = [ criterion ];
+  nativeBuildInputs = [ pkg-config ];
+
+  buildPhase = ''
+    cc -o ${name} $src `pkg-config --libs criterion`
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${name} $out/bin/${name}
+  '';
+
+  meta.mainProgram = name;
+}

--- a/pkgs/by-name/cr/criterion/tests/test_dummy.c
+++ b/pkgs/by-name/cr/criterion/tests/test_dummy.c
@@ -1,0 +1,7 @@
+#include <stdbool.h>
+#include <criterion/criterion.h>
+
+Test(test_dummy, always_succeed)
+{
+    cr_assert(true);
+}

--- a/pkgs/development/libraries/criterion/default.nix
+++ b/pkgs/development/libraries/criterion/default.nix
@@ -2,15 +2,31 @@
 , cmake, ninja, protobuf, libffi, libgit2, dyncall, nanomsg, nanopbMalloc
 , python3Packages }:
 
-stdenv.mkDerivation rec {
+let
+  # follow revisions defined in .wrap files
+  debugbreak = fetchFromGitHub {
+    owner = "MrAnno";
+    repo = "debugbreak";
+    rev = "83bf7e933311b88613cbaadeced9c2e2c811054a";
+    sha256 = "sha256-OPrPGBUZN73Nl5NMEf/nME843yTolt913yjut3rAos0=";
+  };
+
+  klib = fetchFromGitHub {
+    owner = "attractivechaos";
+    repo = "klib";
+    rev = "cdb7e9236dc47abf8da7ebd702cc6f7f21f0c502";
+    sha256 = "sha256-+GaI5nXz4jYI0rO17xDhNtFpLlGL2WzeSVLMfB6Cl6E=";
+  };
+
+in stdenv.mkDerivation rec {
   pname = "criterion";
-  version = "2.4.1";
+  version = "2.4.2";
 
   src = fetchFromGitHub {
     owner = "Snaipe";
     repo = "Criterion";
     rev = "v${version}";
-    sha256 = "KT1XvhT9t07/ubsqzrVUp4iKcpVc1Z+saGF4pm2RsgQ=";
+    sha256 = "sha256-5GH7AYjrnBnqiSmp28BoaM1Xmy8sPs1atfqJkGy3Yf0=";
     fetchSubmodules = true;
   };
 
@@ -30,6 +46,18 @@ stdenv.mkDerivation rec {
   nativeCheckInputs = with python3Packages; [ cram ];
 
   doCheck = true;
+
+  prePatch = ''
+    cp -r ${debugbreak} subprojects/debugbreak
+    cp -r ${klib} subprojects/klib
+
+    for dep in "debugbreak" "klib"; do
+      local meson="$dep/meson.build"
+
+      chmod +w subprojects/$dep
+      cp subprojects/packagefiles/$meson subprojects/$meson
+    done
+  '';
 
   postPatch = ''
     patchShebangs ci/isdir.py src/protocol/gen-pb.py

--- a/pkgs/development/libraries/criterion/default.nix
+++ b/pkgs/development/libraries/criterion/default.nix
@@ -72,6 +72,7 @@ in stdenv.mkDerivation rec {
     maintainers = with maintainers; [
       thesola10
       Yumasi
+      sigmanificient
     ];
     platforms = platforms.unix;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20520,8 +20520,6 @@ with pkgs;
 
   cre2 = callPackage ../development/libraries/cre2 { };
 
-  criterion = callPackage ../development/libraries/criterion { };
-
   croaring = callPackage ../development/libraries/croaring { };
 
   crocoddyl = callPackage ../development/libraries/crocoddyl { };


### PR DESCRIPTION
## Description of changes

- update criterion: `2.4.1` -> `2.4.2` (fix #283639)
- add myself as maintainer
- migrate to by-name
- add version check
- formatted with newer `nixfmt-rfc-style`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
