### PR TITLE
GNOME updates 2024-05-04

### DIFF
--- a/pkgs/desktops/gnome/core/evince/default.nix
+++ b/pkgs/desktops/gnome/core/evince/default.nix
@@ -42,13 +42,13 @@
 
 stdenv.mkDerivation rec {
   pname = "evince";
-  version = "46.0";
+  version = "46.1";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/evince/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-r/avaTksBJVr+tl23sXRWDtB1aM06TeZX3w8oHQN4iE=";
+    hash = "sha256-lLtSU2WwYKKML2AX0iy/KvURVQclSqQum/wAC7wYq2I=";
   };
 
   depsBuildBuild = [
@@ -109,8 +109,6 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (!supportMultimedia) [
     "-Dmultimedia=disabled"
   ];
-
-  env.NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 
   preFixup = ''
     gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${shared-mime-info}/share")

--- a/pkgs/desktops/gnome/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-software/default.nix
@@ -45,11 +45,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "gnome-software";
-  version = "46.0";
+  version = "46.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-software/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-EYkwAru1QIKJZoNwe8OZGuVaLzBAgRp2DjqSyWVE+G4=";
+    hash = "sha256-tu63iRAN6UtQ6+Lnfxaya+TC2xVImQXxmNBgxCXhkHY=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/core/gnome-terminal/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-terminal/default.nix
@@ -6,7 +6,6 @@
 , pkg-config
 , python3
 , libxml2
-, gnome
 , gitUpdater
 , nautilus
 , glib
@@ -30,14 +29,14 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-terminal";
-  version = "3.52.0";
+  version = "3.52.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = "gnome-terminal";
     rev = version;
-    hash = "sha256-6+6/fgGlSM/57+n0SopuF0ZY9htma5usIgxy2BBAC+M=";
+    hash = "sha256-npoQfe5+HTn7CsrW6MuOoiYBc3rYMAMv4apC6dFR8O4=";
   };
 
   nativeBuildInputs = [
@@ -69,13 +68,7 @@ stdenv.mkDerivation rec {
     nautilus # For extension
   ];
 
-  # Silly build system, it looks for dbus file from gnome-shell in the
-  # installation tree of the package it is configuring.
   postPatch = ''
-    substituteInPlace src/meson.build \
-       --replace "gt_prefix / gt_dbusinterfacedir / 'org.gnome.ShellSearchProvider2.xml'" \
-       "'${gnome.gnome-shell}/share/dbus-1/interfaces/org.gnome.ShellSearchProvider2.xml'"
-
     patchShebangs \
       data/icons/meson_updateiconcache.py \
       data/meson_desktopfile.py \

--- a/pkgs/desktops/gnome/misc/gnome-tweaks/default.nix
+++ b/pkgs/desktops/gnome/misc/gnome-tweaks/default.nix
@@ -23,12 +23,12 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "gnome-tweaks";
-  version = "46.0";
+  version = "46.1";
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-Fnh4Y0H2ZKxFgHhCIqFkCfqb9cx6XxtG3O/SqhPdujE=";
+    hash = "sha256-LxkqcIX71oQ+z4JXFtnaIeyScgKRSeo18+FZ4Kwwm4A=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/vte/default.nix
+++ b/pkgs/development/libraries/vte/default.nix
@@ -31,14 +31,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vte";
-  version = "0.76.0";
+  version = "0.76.1";
 
   outputs = [ "out" "dev" ]
     ++ lib.optional (gtkVersion != null) "devdoc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/vte/${lib.versions.majorMinor finalAttrs.version}/vte-${finalAttrs.version}.tar.xz";
-    hash = "sha256-u84wuPUENwsS1kOcB6gpk+l9fpr+LdNngXzVj/Ap/9o=";
+    hash = "sha256-CE6D73ZXdCaaSynfl8oi7cNDuaHYFDPTALjLLQh6HsI=";
   };
 
   patches = [
@@ -101,7 +101,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs perf/*
-    patchShebangs src/box_drawing_generate.sh
     patchShebangs src/parser-seq.py
     patchShebangs src/modes.py
   '';


### PR DESCRIPTION
Plus some cleanups, see the commit messages.

There is a confidential (?) issue mentioned in https://gitlab.gnome.org/GNOME/vte/-/commit/aa405e4b0b2bf28bef2f7fd741881eaff92d1739 but [the code](https://gitlab.gnome.org/GNOME/vte/-/commit/07ca9e0da93ab69fdc9b9eb284afa163ee59fa74) does not seem to appear in vte-0-74.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
