### PR TITLE
jetbrains.plugins: fix plugin discovery

### DIFF
--- a/pkgs/applications/editors/jetbrains/plugins/default.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/default.nix
@@ -63,8 +63,7 @@ let
       ids);
 
 
-in
-rec {
+in {
   # Only use if you know what youre doing
   raw = { inherit files byId byName; };
 
@@ -96,24 +95,19 @@ rec {
 
       inherit (ide) meta;
 
-      buildPhase =
-        let
-          pluginCmdsLines = map (plugin: "ln -s ${plugin} \"$out\"/${meta.mainProgram}/plugins/${baseNameOf plugin}") plugins;
-          pluginCmds = builtins.concatStringsSep "\n" pluginCmdsLines;
-        in
-        ''
-          cp -r ${ide} $out
-          chmod +w -R $out
-          rm -f $out/${meta.mainProgram}/plugins/plugin-classpath.txt
-          IFS=' ' read -ra pluginArray <<< "$newPlugins"
-          for plugin in "''${pluginArray[@]}"
-          do
-            ln -s "$plugin" -t $out/${meta.mainProgram}/plugins/
-          done
-          sed "s|${ide.outPath}|$out|" \
-            -i $(realpath $out/bin/${meta.mainProgram}) \
-            -i $(realpath $out/bin/${meta.mainProgram}-remote-dev-server)
-          autoPatchelf $out
-        '';
+      buildPhase = ''
+        cp -r ${ide} $out
+        chmod +w -R $out
+        rm -f $out/${meta.mainProgram}/plugins/plugin-classpath.txt
+        IFS=' ' read -ra pluginArray <<< "$newPlugins"
+        for plugin in "''${pluginArray[@]}"
+        do
+          ln -s "$plugin" -t $out/${meta.mainProgram}/plugins/
+        done
+        sed "s|${ide.outPath}|$out|" \
+          -i $(realpath $out/bin/${meta.mainProgram}) \
+          -i $(realpath $out/bin/${meta.mainProgram}-remote-dev-server)
+        autoPatchelf $out
+      '';
     };
 }

--- a/pkgs/applications/editors/jetbrains/plugins/default.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/default.nix
@@ -104,6 +104,7 @@ rec {
         ''
           cp -r ${ide} $out
           chmod +w -R $out
+          rm -f $out/${meta.mainProgram}/plugins/plugin-classpath.txt
           IFS=' ' read -ra pluginArray <<< "$newPlugins"
           for plugin in "''${pluginArray[@]}"
           do


### PR DESCRIPTION
## Description of changes

In recent JetBrains releases, a `plugin-classpath.txt` made its appearance. That file seems to be a cache of some kind that the IDEs use to discover which plugins are bundled with an IDE release.

If that file is removed, there seems to be a fallback mechanism that instead goes through the list of subdirectories in `plugins`. That works rather better for us, as we don’t know how to generate a `plugin-classpath.txt`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
