### PR TITLE
cve-util-bin: restructure build inputs

### DIFF
--- a/pkgs/development/python-modules/lib4sbom/default.nix
+++ b/pkgs/development/python-modules/lib4sbom/default.nix
@@ -1,9 +1,13 @@
 { lib
-, python3Packages
+, buildPythonPackage
 , fetchFromGitHub
+, pyyaml
+, semantic-version
+, defusedxml
+, pytestCheckHook
 }:
 
-python3Packages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "lib4sbom";
   version = "0.7.1";
   format = "setuptools";
@@ -15,13 +19,13 @@ python3Packages.buildPythonPackage rec {
     hash = "sha256-UQZZYTRDbUqSH6F8hjhp9L70025cRO3zXQ8Aoznotg4=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  dependencies = [
     pyyaml
     semantic-version
     defusedxml
   ];
 
-  nativeCheckInputs = with python3Packages; [
+  nativeCheckInputs = [
     pytestCheckHook
   ];
 

--- a/pkgs/tools/security/cve-bin-tool/default.nix
+++ b/pkgs/tools/security/cve-bin-tool/default.nix
@@ -1,35 +1,31 @@
 { lib
 , buildPythonApplication
 , fetchFromGitHub
+  # aiohttp[speedups]
+, aiodns
+, aiohttp
+, beautifulsoup4
+, brotlipy
+, cvss
+, distro
 , filetype
+, google-cloud-sdk
+, jinja2
 , jsonschema
 , lib4sbom
 , packageurl-python
-, python-gnupg
-, plotly
-, beautifulsoup4
-, pyyaml
-, isort
-, py
-, jinja2
-, rpmfile
-, reportlab
-, zstandard
-, rich
-, aiohttp
-, toml
-, distro
-  # aiohttp[speedups]
-, aiodns
-, brotlipy
-, faust-cchardet
-, pillow
-, pytestCheckHook
-, xmlschema
-, setuptools
 , packaging
-, cvss
-, google-cloud-sdk
+, plotly
+, pytestCheckHook
+, python-gnupg
+, pyyaml
+, rich
+, rpmfile
+, setuptools
+, toml
+, xmlschema
+, zstandard
+, reportlab
 , pip
 , testers
 , cve-bin-tool
@@ -50,45 +46,45 @@ buildPythonApplication rec {
   # Wants to open a sqlite database, access the internet, etc
   doCheck = false;
 
-  propagatedNativeBuildInputs = [
-    pip
-  ];
-
-  propagatedBuildInputs = [
-    google-cloud-sdk
+  dependencies = [
+    # aiohttp[speedups]
+    aiodns
+    aiohttp
+    beautifulsoup4
+    brotlipy
+    cvss
+    distro
     filetype
+    google-cloud-sdk # gsutil
+    jinja2
     jsonschema
     lib4sbom
     packageurl-python
-    python-gnupg
-    plotly
-    beautifulsoup4
-    pyyaml
-    isort
-    py
-    jinja2
-    rpmfile
-    reportlab
-    zstandard
-    rich
-    aiohttp
-    toml
-    distro
-    # aiohttp[speedups]
-    aiodns
-    brotlipy
-    faust-cchardet
-    # needed by brotlipy
-    pillow
-    setuptools
-    xmlschema
-    cvss
     packaging
+    plotly
+    python-gnupg
+    pyyaml
+    rich
+    rpmfile
+    setuptools
+    toml
+    xmlschema
+    zstandard
+  ];
+
+  optional-dependencies = {
+    pdf = [
+      reportlab
+    ];
+  };
+
+  propagatedBuildInputs = [
+    pip
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
-  ];
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   pythonImportsCheck = [
     "cve_bin_tool"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6564,6 +6564,8 @@ self: super: with self; {
 
   pa-ringbuffer = callPackage ../development/python-modules/pa-ringbuffer { };
 
+  lib4sbom = callPackage ../development/python-modules/lib4sbom { };
+
   libais = callPackage ../development/python-modules/libais { };
 
   libarchive-c = callPackage ../development/python-modules/libarchive-c {


### PR DESCRIPTION
## Description of changes

* Moved `lib4sbom` to `development/python-modules` (https://github.com/NixOS/nixpkgs/pull/308858#discussion_r1589853817)
* Updated dependencies in `cve-bin-util` to remove some unused ones and move `pip` to `propagatesBuildInputs` so it can actually be found (https://github.com/NixOS/nixpkgs/pull/308858#discussion_r1589853964)
* To match the upstream package, `reportlab` is now an optional dependency

Tested database update, SBOM scanning and scanning of `requirements.txt`.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
