### PR TITLE
nixos/ssh: disable `authorizedKeysInHomedir` by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -390,6 +390,9 @@
     * from `/var/log/private/gns3` to `/var/log/gns3`
   and to change the ownership of these directories and their contents to `gns3` (including `/etc/gns3`).
 
+- The `sshd` module now doesn't include `%h/.ssh/authorized_keys` as `AuthorizedKeysFile` unless
+  `services.openssh.authorizedKeysInHomedir` is set to `true` (the default is `false` for `stateVersion` 24.11 onwards).
+
 - Legacy package `stalwart-mail_0_6` was dropped, please note the
   [manual upgrade process](https://github.com/stalwartlabs/mail-server/blob/main/UPGRADING.md)
   before changing the package to `pkgs.stalwart-mail` in

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -302,7 +302,8 @@ in
 
       authorizedKeysInHomedir = lib.mkOption {
         type = lib.types.bool;
-        default = true;
+        default = lib.versionOlder config.system.stateVersion "24.11";
+        defaultText = lib.literalMD "`false` unless [](#opt-system.stateVersion) is 24.05 or older";
         description = ''
           Enables the use of the `~/.ssh/authorized_keys` file.
 

--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -14,7 +14,10 @@ in {
       { ... }:
 
       {
-        services.openssh.enable = true;
+        services.openssh = {
+          enable = true;
+          authorizedKeysInHomedir = true;
+        };
         security.pam.services.sshd.limits =
           [ { domain = "*"; item = "memlock"; type = "-"; value = 1024; } ];
         users.users.root.openssh.authorizedKeys.keys = [
@@ -39,7 +42,11 @@ in {
       { ... }:
 
       {
-        services.openssh = { enable = true; startWhenNeeded = true; };
+        services.openssh = {
+          enable = true;
+          startWhenNeeded = true;
+          authorizedKeysInHomedir = true;
+        };
         security.pam.services.sshd.limits =
           [ { domain = "*"; item = "memlock"; type = "-"; value = 1024; } ];
         users.users.root.openssh.authorizedKeys.keys = [


### PR DESCRIPTION
Split-off from #279894 to avoid a breaking change late in 24.05's release cycle.

~~**Do not merge before `staging` [stops being included](https://github.com/NixOS/nixpkgs/issues/303285) in the release (not before 2024-05-15 AoE)**~~


## Description of changes

- [x] Default `services.openssh.authorizedKeysInHomedir` to `false` **on `stateVersion` 24.11 and later**
  By request of maintainer, and would prevent future issues similar to #31611
- [x] Make the default depend on `stateVersion`, blocked on #325610
  see [eval failure](https://gist.github.com/GrahamcOfBorg/ddcd43987a6ce4cddfcdfbf24522ec39) on @ofborg
- [x] Document the ~~breaking~~ change in a release note.
  ~~The 24.11 release notes file doesn't exist yet.~~


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) `openssh`
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/staging/nixos/doc/manual/release-notes/rl-2411.section.md)
  - [x] (Module updates) Added a release notes entry if the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
