### PR TITLE
lua51Packages.nfd: fix module not loading

### DIFF
--- a/pkgs/development/lua-modules/nfd/default.nix
+++ b/pkgs/development/lua-modules/nfd/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, fetchFromGitHub, buildLuarocksPackage, lua, pkg-config, lib
-, substituteAll, zenity, AppKit }:
+{ stdenv, fetchFromGitHub, buildLuarocksPackage, lua51Packages, lua, pkg-config, lib, substituteAll, zenity, AppKit}:
 
 buildLuarocksPackage {
   pname = "nfd";
@@ -27,9 +26,16 @@ buildLuarocksPackage {
 
   buildInputs = lib.optionals stdenv.isDarwin [ AppKit ];
 
-  fixupPhase = ''
+  postInstall = ''
     find $out -name nfd_zenity.so -execdir mv {} nfd.so \;
   '';
+
+  doInstallCheck = true;
+  installCheckInputs = [ lua.pkgs.busted ];
+  installCheckPhase= ''
+    busted lua/spec/
+ '';
+
 
   meta = {
     description =

--- a/pkgs/development/lua-modules/nfd/default.nix
+++ b/pkgs/development/lua-modules/nfd/default.nix
@@ -22,7 +22,7 @@ buildLuarocksPackage {
   ];
   knownRockspec = "lua/nfd-scm-1.rockspec";
 
-  luarocksConfig.LUA_LIBDIR = "${lua}/lib";
+  luarocksConfig.variables.LUA_LIBDIR = "${lua}/lib";
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = lib.optionals stdenv.isDarwin [ AppKit ];


### PR DESCRIPTION
As #295022 complains, it wasn't finding symbols properly. 
This PR fixes #295022 .

I traced it to the [migration](https://github.com/NixOS/nixpkgs/pull/288669) from buildLuarocksPackage.extraVariables to buildLuarocksPackage.luarocksConfig.variables where someone forgot to add .variables.

It now launches the dialogue properly.

## Description of changes
Added a missing property
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
