### PR TITLE
workflows/backport: Add checkboxes for acceptable and unacceptable changes

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -31,5 +31,26 @@ jobs:
           pull_description: |-
             Bot-based backport to `${target_branch}`, triggered by a label in #${pull_number}.
 
-            * [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
-              * Even as a non-commiter, if you find that it is not acceptable, leave a comment.
+            Before merging, ensure that this backport is [acceptable for the stable release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases), and tick all boxes that apply.
+            As a non-committer unable to tick the checkboxes: if you find that this backport is not acceptable, do leave a comment and consider closing this PR.
+
+            Backwards-compatible changes that are generally okay to backport:
+
+            * [ ] The PR adds new packages, modules and functions
+            * [ ] The PR adds security fixes
+            * [ ] The PR contains patch version updates
+            * [ ] The PR contains minor version updates, which have been verified to include no breaking changes
+
+            Breaking changes that are _not_ okay to backport:
+
+            * [ ] The PR contains major version updates
+            * [ ] The PR changes or removes existing functionality
+            * [ ] The PR contains backward-incompatible changes to the `.override*` interface of a derivation
+            * [ ] The PR deserves an addition to the release notes
+            * [ ] The PR will cause a state migration which risks the loss of user data
+
+            Reasons why a breaking change still needs to be backported:
+
+            * [ ] The PR updates security critical applications, such as `firefox` and `chromium`
+            * [ ] The PR is required to continue interoperating with external services, such as `spotify`, `steam`, and `discord`
+            * [ ] Other, detailed in a comment below

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -484,13 +484,15 @@ The oldest supported release (`YYMM`) can be found using
 nix-instantiate --eval -A lib.trivial.oldestSupportedRelease
 ```
 
-The release branches should generally only receive backwards-compatible changes, both for the Nix expressions and derivations.
+Users should be confident tracking the stable release channels for updates worry-free from breaking changes that will affect them.
+The release branches should only receive backwards-compatible changes, both for the Nix expressions and derivations.
+
 Here are some examples of backwards-compatible changes that are okay to backport:
 - ✔️ New packages, modules and functions
 - ✔️ Security fixes
 - ✔️ Package version updates
   - ✔️ Patch versions with fixes
-  - ✔️ Minor versions with new functionality, but no breaking changes
+  - ✔️ Minor versions with new functionality, verified to include no breaking changes
 
 In addition, major package version updates with breaking changes are also acceptable for:
 - ✔️ Services that would fail without up-to-date client software, such as `spotify`, `steam`, and `discord`


### PR DESCRIPTION
## Description of changes

Our backport guidelines are vague, too permissive, and often ignored/forgotten. 
This PR addresses primarily the latter.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
