### PR TITLE
kodiPackages.pvr-iptvsimple: 20.13.0 -> 21.8.4

### DIFF
--- a/pkgs/applications/video/kodi/addons/pvr-iptvsimple/default.nix
+++ b/pkgs/applications/video/kodi/addons/pvr-iptvsimple/default.nix
@@ -6,13 +6,13 @@
 buildKodiBinaryAddon rec {
   pname = "pvr-iptvsimple";
   namespace = "pvr.iptvsimple";
-  version = "20.13.0";
+  version = "21.8.4";
 
   src = fetchFromGitHub {
     owner = "kodi-pvr";
     repo = "pvr.iptvsimple";
     rev = "${version}-${rel}";
-    sha256 = "sha256-W/tFM/WpWdSvLEf0iwQoH2JVDjyfr1l8CRQkOG5q4hk=";
+    sha256 = "sha256-uuqk1kJnioCaRWIkC5liPSVRQPpviuaE+wmE4rq6fJw=";
   };
 
   extraBuildInputs = [


### PR DESCRIPTION
## Description of changes

https://github.com/kodi-pvr/pvr.iptvsimple/compare/20.13.0-Nexus...21.8.4-Omega

### Release notes
https://github.com/kodi-pvr/pvr.iptvsimple/releases/tag/21.8.4-Omega
https://github.com/kodi-pvr/pvr.iptvsimple/releases/tag/21.8.3-Omega
https://github.com/kodi-pvr/pvr.iptvsimple/releases/tag/21.8.2-Omega
https://github.com/kodi-pvr/pvr.iptvsimple/releases/tag/21.8.1-Omega
https://github.com/kodi-pvr/pvr.iptvsimple/releases/tag/21.8.0-Omega
https://github.com/kodi-pvr/pvr.iptvsimple/releases/tag/21.7.2-Omega
https://github.com/kodi-pvr/pvr.iptvsimple/releases/tag/21.7.0-Omega
https://github.com/kodi-pvr/pvr.iptvsimple/releases/tag/21.6.0-Omega
https://github.com/kodi-pvr/pvr.iptvsimple/releases/tag/21.5.0-Omega

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
