### PR TITLE
mpvScripts.evafast: init at 0-unstable-2024-02-09

### DIFF
--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -99,6 +99,7 @@ let
       convert = callPackage ./convert.nix { };
       cutter = callPackage ./cutter.nix { };
       dynamic-crop = callPackage ./dynamic-crop.nix { };
+      evafast = callPackage ./evafast.nix { };
       inhibit-gnome = callPackage ./inhibit-gnome.nix { };
       memo = callPackage ./memo.nix { };
       manga-reader = callPackage ./manga-reader.nix { };

--- a/pkgs/applications/video/mpv/scripts/evafast.nix
+++ b/pkgs/applications/video/mpv/scripts/evafast.nix
@@ -21,7 +21,7 @@ buildLua {
   meta = with lib; {
     description = "Seeking and hybrid fastforwarding like VHS";
     homepage = "https://github.com/po5/evafast";
-    license = licenses.unfree; # no explicit licensing information available
+    license = licenses.unfree; # no license; see https://github.com/po5/evafast/issues/15
     maintainers = with lib.maintainers; [ purrpurrn ];
   };
 }

--- a/pkgs/applications/video/mpv/scripts/evafast.nix
+++ b/pkgs/applications/video/mpv/scripts/evafast.nix
@@ -1,0 +1,27 @@
+{
+  fetchFromGitHub,
+  buildLua,
+  lib,
+  unstableGitUpdater,
+}:
+
+buildLua {
+  pname = "evafast";
+  version = "0-unstable-2024-02-09";
+
+  src = fetchFromGitHub {
+    owner = "po5";
+    repo = "evafast";
+    rev = "92af3e2e1c756ce83f9d0129c780caeef1131a0b";
+    hash = "sha256-BGWD2XwVu8zOSiDJ+9oWi8aPN2Wkw0Y0gF58X4f+tdI=";
+  };
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = with lib; {
+    description = "Seeking and Hybrid fastforwarding like VHS";
+    homepage = "https://github.com/po5/evafast";
+    license = licenses.unfree; # no explicit licensing information available
+    maintainers = with lib.maintainers; [ purrpurrn ];
+  };
+}

--- a/pkgs/applications/video/mpv/scripts/evafast.nix
+++ b/pkgs/applications/video/mpv/scripts/evafast.nix
@@ -19,7 +19,7 @@ buildLua {
   passthru.updateScript = unstableGitUpdater { };
 
   meta = with lib; {
-    description = "Seeking and Hybrid fastforwarding like VHS";
+    description = "Seeking and hybrid fastforwarding like VHS";
     homepage = "https://github.com/po5/evafast";
     license = licenses.unfree; # no explicit licensing information available
     maintainers = with lib.maintainers; [ purrpurrn ];


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
