### PR TITLE
imposm: init at 0.12.0

### DIFF
--- a/pkgs/by-name/im/imposm/package.nix
+++ b/pkgs/by-name/im/imposm/package.nix
@@ -1,0 +1,34 @@
+{ lib, buildGoModule, fetchFromGitHub, leveldb, geos }:
+
+buildGoModule rec {
+  pname = "imposm";
+  version = "0.12.0";
+
+  src = fetchFromGitHub {
+    owner = "omniscale";
+    repo = "imposm3";
+    rev = "v${version}";
+    hash = "sha256-xX4cV/iU7u/g9n7dtkkkCtNOPZK5oyprNHGDUuW+ees=";
+  };
+
+  vendorHash = null;
+
+  buildInputs = [ leveldb geos ];
+
+  ldflags = [
+    "-s -w"
+    "-X github.com/omniscale/imposm3.Version=${version}"
+  ];
+
+  # requires network access
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Imposm imports OpenStreetMap data into PostGIS";
+    homepage = "https://imposm.org/";
+    changelog = "https://github.com/omniscale/imposm3/releases/tag/${src.rev}";
+    license = licenses.apsl20;
+    maintainers = with maintainers; [ sikmir ];
+    mainProgram = "imposm";
+  };
+}


### PR DESCRIPTION
## Description of changes
[Imposm](https://github.com/omniscale/imposm3) is an importer for OpenStreetMap data.

Another attempt #254023

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
