### PR TITLE
eid-mw: replace libbeidpkcs11.so with opensc-pkcs11.so library

### DIFF
--- a/pkgs/tools/security/eid-mw/default.nix
+++ b/pkgs/tools/security/eid-mw/default.nix
@@ -13,6 +13,7 @@
 , libproxy
 , libxml2
 , nssTools
+, opensc
 , openssl
 , p11-kit
 , pcsclite
@@ -38,7 +39,7 @@ stdenv.mkDerivation rec {
 
 
   nativeBuildInputs = [ wrapGAppsHook3 autoreconfHook autoconf-archive pkg-config makeWrapper ];
-  buildInputs = [ curl gtk3 libassuan libbsd libproxy libxml2 openssl p11-kit pcsclite ];
+  buildInputs = [ curl gtk3 libassuan libbsd libproxy libxml2 opensc openssl p11-kit pcsclite ];
 
   preConfigure = ''
     mkdir openssl

--- a/pkgs/tools/security/eid-mw/eid-nssdb.in
+++ b/pkgs/tools/security/eid-mw/eid-nssdb.in
@@ -3,7 +3,7 @@
 rootdb="/etc/pki/nssdb"
 userdb="$HOME/.pki/nssdb"
 dbentry="Belgium eID"
-libfile="/run/current-system/sw/lib/libbeidpkcs11.so"
+libfile="/run/current-system/sw/lib/opensc-pkcs11.so"
 
 dbdir="$userdb"
 


### PR DESCRIPTION
To solve following issues:
https://github.com/ValveSoftware/steam-runtime/issues/667#issuecomment-2093093716
https://github.com/NixOS/nixpkgs/issues/298662

An issue with libpcsclite_real.so.1 is causing the build of eid-mw version 5.1.16 to fail:
https://hydra.nixos.org/build/258123099/nixlog/1/tail
See also:
https://github.com/NixOS/nixpkgs/issues/309158
Should hopefully get resolved via following merge request for pcsclite:
https://github.com/NixOS/nixpkgs/pull/308884

## Description of changes

<!--
This library change from  

 libfile="/run/current-system/sw/lib/libbeidpkcs11.so" 
to
libfile="/run/current-system/sw/lib/opensc-pkcs11.so"
is to avoid crashloop of steamwebhelper (part of steam package) due to steamwebhelper reading from /run/current-system/sw/lib/libbeidpkcs11.so 
There is a bug in /run/current-system/sw/lib/libbeidpkcs11.so causing steamwebhelper to crashloop.

/run/current-system/sw/lib/opensc-pkcs11.so does not cause a crashloop of steamwebhelper
/run/current-system/sw/lib/opensc-pkcs11.so supports the use of Belgian eid card readers.

According to https://wiki.debian.org/BeID, the Belgian-eID-specific fork of OpenSC was merged back into mainline OpenSC, so it is not necessary to use libbeidpkcs11.so any more: the more generic opensc-pkcs11.so should be sufficient.

-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)  
Successfully tested modified version of eid-nssdb script
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
