### PR TITLE
cups-brother-dcpt310: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9366,6 +9366,13 @@
     githubId = 37965;
     name = "Léo Stefanesco";
   };
+  inexcode = {
+    name = "Inex Code";
+    email = "nixpkgs@inex.dev";
+    matrix = "@inexcode:inex.rocks";
+    github = "inexcode";
+    githubId = 13254627;
+  };
   infinidoge = {
     name = "Infinidoge";
     email = "infinidoge@inx.moe";

--- a/pkgs/by-name/cu/cups-brother-dcpt310/package.nix
+++ b/pkgs/by-name/cu/cups-brother-dcpt310/package.nix
@@ -1,0 +1,152 @@
+{
+  stdenv,
+  stdenvNoCC,
+  lib,
+  fetchurl,
+  perl,
+  gnused,
+  dpkg,
+  makeWrapper,
+  autoPatchelfHook,
+  libredirect,
+  gnugrep,
+  coreutils,
+  ghostscript,
+  file,
+  pkgsi686Linux,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "cups-brother-dcpt310";
+  version = "1.0.1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf103618/dcpt310pdrv-${finalAttrs.version}-0.i386.deb";
+    sha256 = "0g9hylmpgmzd6k9lxjy32c7pxbzj6gr9sfaahxj3xzqyar05amdx";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    perl
+    gnused
+    libredirect
+    pkgsi686Linux.stdenv.cc.cc.lib
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    dpkg-deb -x $src .
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"
+    cp -pr opt "$out"
+    cp -pr usr/bin "$out/bin"
+    rm "$out/opt/brother/Printers/dcpt310/cupswrapper/cupswrapperdcpt310"
+
+    mkdir -p "$out/lib/cups/filter" "$out/share/cups/model"
+
+    ln -s "../../../opt/brother/Printers/dcpt310/cupswrapper/brother_lpdwrapper_dcpt310" \
+      "$out/lib/cups/filter/brother_lpdwrapper_dcpt310"
+    ln -s "../../../opt/brother/Printers/dcpt310/cupswrapper/brother_dcpt310_printer_en.ppd" \
+      "$out/share/cups/model/brother_dcpt310_printer_en.ppd"
+
+    runHook postInstall
+  '';
+
+  # Fix global references and replace auto discovery mechanism
+  # with hardcoded values.
+  #
+  # The configuration binary 'brprintconf_dcpt310' and lpd filter
+  # 'brdcpt310filter' has hardcoded /opt format strings.  There isn't
+  # sufficient space in the binaries to substitute a path in the store, so use
+  # libredirect to get it to see the correct path.  The configuration binary
+  # also uses this format string to print configuration locations.  Here the
+  # wrapper output is processed to point into the correct location in the
+  # store.
+
+  postFixup = ''
+    interpreter=${pkgsi686Linux.glibc.out}/lib/ld-linux.so.2
+
+    substituteInPlace $out/opt/brother/Printers/dcpt310/lpd/filter_dcpt310 \
+      --replace "my \$BR_PRT_PATH =" "my \$BR_PRT_PATH = \"$out/opt/brother/Printers/dcpt310/\"; #" \
+      --replace /usr/bin/pdf2ps "${ghostscript}/bin/pdf2ps" \
+      --replace "my \$GHOST_SCRIPT" "my \$GHOST_SCRIPT = \"${ghostscript}/bin/gs\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"dcpt310\"; #"
+
+    substituteInPlace $out/opt/brother/Printers/dcpt310/cupswrapper/brother_lpdwrapper_dcpt310 \
+      --replace "PRINTER =~" "PRINTER = \"dcpt310\"; #" \
+      --replace "my \$basedir = \`readlink \$0\`" "my \$basedir = \"$out/opt/brother/Printers/dcpt310/\"" \
+      --replace "my \$lpdconf = \$LPDCONFIGEXE.\$PRINTER;" "my \$lpdconf = \"$out/bin/brprintconf_dcpt310\";"
+
+
+    patchelf --set-interpreter "$interpreter" "$out/opt/brother/Printers/dcpt310/lpd/brdcpt310filter" \
+      --set-rpath ${lib.makeLibraryPath [ pkgsi686Linux.stdenv.cc.cc ]}
+    patchelf --set-interpreter "$interpreter" "$out/bin/brprintconf_dcpt310"
+
+
+    wrapProgram $out/bin/brprintconf_dcpt310 \
+      --set LD_PRELOAD "${pkgsi686Linux.libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS /opt=$out/opt
+
+    wrapProgram $out/opt/brother/Printers/dcpt310/lpd/brdcpt310filter \
+      --set PATH ${
+        lib.makeBinPath [
+          coreutils
+          gnugrep
+          gnused
+          ghostscript
+        ]
+      } \
+      --set LD_PRELOAD "${pkgsi686Linux.libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS /opt=$out/opt
+
+    for f in \
+      $out/opt/brother/Printers/dcpt310/cupswrapper/brother_lpdwrapper_dcpt310 \
+      $out/opt/brother/Printers/dcpt310/lpd/filter_dcpt310 \
+    ; do
+      wrapProgram $f \
+        --set PATH ${
+          lib.makeBinPath [
+            coreutils
+            ghostscript
+            gnugrep
+            gnused
+            file
+          ]
+        }
+    done
+
+    substituteInPlace $out/bin/brprintconf_dcpt310 \
+      --replace \"\$"@"\" \"\$"@\" | LD_PRELOAD= ${gnused}/bin/sed -E '/^(function list :|resource file :).*/{s#/opt#$out/opt#}'"
+  '';
+
+  meta = {
+    description = "Brother DCP-T310 printer driver";
+    license = with lib.licenses; [
+      unfree
+      gpl2Plus
+    ];
+    sourceProvenance = with lib.sourceTypes; [
+      binaryNativeCode
+      fromSource
+    ];
+    maintainers = with lib.maintainers; [ inexcode ];
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+    ];
+    homepage = "https://www.brother.com/";
+    downloadPage = "https://support.brother.com/g/b/downloadhowto.aspx?c=us_ot&lang=en&prod=dcpt310_all&os=128&dlid=dlf103618_000&flang=4&type3=10283";
+  };
+})


### PR DESCRIPTION
## Description of changes

Adds driver for Brother DCP-T310 printer. Based on the `cups-brother-hll3230cdw` package, but with patches specific for this printer applied.

https://support.brother.com/g/b/producttop.aspx?c=us_ot&lang=en&prod=dcpt310_all

Works with `services.printing.drivers = [ pkgs.cups-brother-dcpt310 ];`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (able to print over USB)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
