### PR TITLE
craftos-pc: reduce closure size, install `.desktop` and icons

### DIFF
--- a/pkgs/applications/emulators/craftos-pc/default.nix
+++ b/pkgs/applications/emulators/craftos-pc/default.nix
@@ -40,7 +40,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-ozebHgUgwdqYtWAyL+EdwpjEvZC+PkWcLYCPWz2FjSw=";
   };
 
-  buildInputs = [ patchelf poco openssl SDL2 SDL2_mixer ncurses libpng pngpp libwebp ];
+  nativeBuildInputs = [ patchelf ];
+  buildInputs = [ poco openssl SDL2 SDL2_mixer ncurses libpng pngpp libwebp ];
 
   preBuild = ''
     cp -R ${craftos2-lua}/* ./craftos2-lua/

--- a/pkgs/applications/emulators/craftos-pc/default.nix
+++ b/pkgs/applications/emulators/craftos-pc/default.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ patchelf unzip ];
   buildInputs = [ poco openssl SDL2 SDL2_mixer ncurses libpng pngpp libwebp ];
+  strictDeps = true;
 
   preBuild = ''
     cp -R ${craftos2-lua}/* ./craftos2-lua/

--- a/pkgs/applications/emulators/craftos-pc/default.nix
+++ b/pkgs/applications/emulators/craftos-pc/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , callPackage
 , patchelf
+, unzip
 , poco
 , openssl
 , SDL2
@@ -40,7 +41,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-ozebHgUgwdqYtWAyL+EdwpjEvZC+PkWcLYCPWz2FjSw=";
   };
 
-  nativeBuildInputs = [ patchelf ];
+  nativeBuildInputs = [ patchelf unzip ];
   buildInputs = [ poco openssl SDL2 SDL2_mixer ncurses libpng pngpp libwebp ];
 
   preBuild = ''
@@ -64,6 +65,17 @@ stdenv.mkDerivation rec {
     patchelf --replace-needed craftos2-lua/src/liblua.so liblua.so $out/bin/craftos
     cp -R api $out/include/CraftOS-PC
     cp -R ${craftos2-rom}/* $out/share/craftos
+
+    mkdir -p resources/linux-icons
+    unzip resources/linux-icons.zip -d resources/linux-icons
+    for dim in 16 24 32 48 64 96 128 256 1024; do
+      dir="$out/share/icons/hicolor/$dimx$dim/apps"
+      mkdir -p "$dir"
+      cp "resources/linux-icons/$dim.png" "$dir/craftos.png"
+    done
+
+    mkdir -p $out/share/applications
+    cp resources/linux-icons/CraftOS-PC.desktop $out/share/applications/CraftOS-PC.desktop
   '';
 
   passthru.tests = {


### PR DESCRIPTION
## Description of changes

### Reduce runtime dependencies
patchelf is only used in the installPhase and is not used in the program itself, so we move it to nativeBuildInputs to reduce the closure size.

### Install icons and `.desktop` 

Upstream provides icons and a .desktop file in the resources/linux-icons.zip file.

This PR properly installs these assets, ~~as well as patching the .desktop file to be hardcoded to the binary path~~ (removed after seeing https://github.com/NixOS/nixpkgs/issues/308324).


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
