### PR TITLE
Revert "tailscale: apply basic systemd hardening"

### DIFF
--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -9,7 +9,6 @@
 , shadow
 , procps
 , nixosTests
-, fetchpatch
 }:
 
 let
@@ -26,15 +25,6 @@ buildGoModule {
     hash = "sha256-DS7C/G1Nj9gIjYwXaEeCLbtH9HbB0tRoJBDjZc/nq5g=";
   };
   vendorHash = "sha256-pYeHqYd2cCOVQlD1r2lh//KC+732H0lj1fPDBr+W8qA=";
-
-  patches = [
-    # Reverts "cmd/tailscaled/tailscaled.service: revert recent hardening"
-    (fetchpatch {
-      url = "https://github.com/tailscale/tailscale/commit/2889fabaefc50040507ead652d6d2b212f476c2b.patch";
-      hash = "sha256-DPBrv7kjSVXhmptUGGzOkaP4iXi/Bym3lvqy4otL9HE=";
-      revert = true;
-    })
-  ];
 
   nativeBuildInputs = lib.optionals stdenv.isLinux [ makeWrapper ];
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#306241

This breaks core tailscale features (Tailscale SSH) and was dropped from upstream for good reasons (beyond "just" breaking on older systemd). Upstream Documentation includes an alternative unit file (https://tailscale.com/kb/1279/security-node-hardening) that can provide the same protections a little more sensibly if someone wishes to take the time to implement that in nix.

closes #308913