### PR TITLE
pkgs/by-name: Fix some unstableGitUpdater users

### DIFF
--- a/pkgs/by-name/an/ansel/package.nix
+++ b/pkgs/by-name/an/ansel/package.nix
@@ -77,7 +77,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "ansel";
-  version = "unstable-2024-02-23";
+  version = "0-unstable-2024-02-23";
 
   src = fetchFromGitHub {
     owner = "aurelienpierreeng";
@@ -160,7 +160,10 @@ stdenv.mkDerivation {
     )
   '';
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = unstableGitUpdater {
+    # Tags inherited from Darktable, + a "nightly" 0.0.0 tag that new artefacts get attached to
+    hardcodeZeroVersion = true;
+  };
 
   meta = {
     description = "A darktable fork minus the bloat plus some design vision";

--- a/pkgs/by-name/bl/bluez-tools/package.nix
+++ b/pkgs/by-name/bl/bluez-tools/package.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bluez-tools";
-  version = "unstable-2020-10-25";
+  version = "0-unstable-2020-10-24";
 
   src = fetchFromGitHub {
     owner = "khvzak";

--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -92,7 +92,7 @@ let
 
   test-firmware =
     let
-      version = "unstable-2022-04-02";
+      version = "0-unstable-2022-04-02";
       src = fetchFromGitHub {
         name = "fwupd-test-firmware-${version}";
         owner = "fwupd";

--- a/pkgs/by-name/la/labwc-gtktheme/package.nix
+++ b/pkgs/by-name/la/labwc-gtktheme/package.nix
@@ -9,7 +9,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "labwc-gtktheme";
-  version = "unstable-2022-07-17";
+  version = "0-unstable-2022-07-17";
   pyproject = false;
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/la/labwc-menu-generator/package.nix
+++ b/pkgs/by-name/la/labwc-menu-generator/package.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "labwc-menu-generator";
-  version = "unstable-2024-03-27";
+  version = "0-unstable-2024-03-27";
 
   src = fetchFromGitHub {
     owner = "labwc";

--- a/pkgs/by-name/li/libui-ng/package.nix
+++ b/pkgs/by-name/li/libui-ng/package.nix
@@ -12,7 +12,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libui-ng";
-  version = "unstable-2024-02-05";
+  version = "4.1-unstable-2024-02-05";
 
   src = fetchFromGitHub {
     owner = "libui-ng";
@@ -47,7 +47,9 @@ stdenv.mkDerivation rec {
     (lib.mesonBool "examples" (!stdenv.isDarwin))
   ];
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "alpha";
+  };
 
   meta = with lib; {
     description = "A portable GUI library for C";

--- a/pkgs/by-name/lo/louvain-community/package.nix
+++ b/pkgs/by-name/lo/louvain-community/package.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "louvain-community";
-  version = "unstable-2024-01-30";
+  version = "0-unstable-2024-01-30";
 
   src = fetchFromGitHub {
     owner = "meelgroup";

--- a/pkgs/by-name/ni/nitter/package.nix
+++ b/pkgs/by-name/ni/nitter/package.nix
@@ -8,7 +8,7 @@
 
 buildNimPackage (finalAttrs: prevAttrs: {
   pname = "nitter";
-  version = "unstable-2024-02-26";
+  version = "0-unstable-2024-02-26";
 
   src = fetchFromGitHub {
     owner = "zedeus";

--- a/pkgs/by-name/ni/nix-search-cli/package.nix
+++ b/pkgs/by-name/ni/nix-search-cli/package.nix
@@ -6,7 +6,7 @@
 
 buildGoModule {
   pname = "nix-search-cli";
-  version = "unstable-2023-09-12";
+  version = "0-unstable-2023-09-12";
 
   src = fetchFromGitHub {
     owner = "peterldowns";
@@ -17,7 +17,11 @@ buildGoModule {
 
   vendorHash = "sha256-JDOu7YdX9ztMZt0EFAMz++gD7n+Mn1VOe5g6XwrgS5M=";
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = unstableGitUpdater {
+    # Almost every commit is tagged as "release-<unix-time>-<commit>", software doesn't keep track of its version
+    # Using 0 feels closer to what the tagging is trying to express
+    hardcodeZeroVersion = true;
+  };
 
   meta = with lib; {
     description = "CLI for searching packages on search.nixos.org";

--- a/pkgs/by-name/re/renode-dts2repl/package.nix
+++ b/pkgs/by-name/re/renode-dts2repl/package.nix
@@ -6,7 +6,7 @@
 
 python3.pkgs.buildPythonApplication {
   pname = "renode-dts2repl";
-  version = "unstable-2024-04-16";
+  version = "0-unstable-2024-04-16";
   pyproject = true;
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/ri/river-bnf/package.nix
+++ b/pkgs/by-name/ri/river-bnf/package.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "river-bnf";
-  version = "unstable-2023-10-10";
+  version = "0-unstable-2023-10-10";
 
   src = fetchFromSourcehut {
     owner = "~leon_plickat";

--- a/pkgs/by-name/sa/samrewritten/package.nix
+++ b/pkgs/by-name/sa/samrewritten/package.nix
@@ -11,7 +11,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "samrewritten";
-  version = "unstable-2023-05-23";
+  version = "202008-unstable-2023-05-22";
 
   src = fetchFromGitHub {
     owner = "PaulCombal";

--- a/pkgs/by-name/te/tecoc/package.nix
+++ b/pkgs/by-name/te/tecoc/package.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tecoc";
-  version = "unstable-2023-06-21";
+  version = "0-unstable-2023-06-21";
 
   src = fetchFromGitHub {
     owner = "blakemcbride";


### PR DESCRIPTION
## Description of changes

#280501 now makes `unstableGitUpdater` produce versions that match our desired unstable version schema. Start fixing the versions of packages that use it, and their `unstableGitUpdater` arguments as needed.

Tackling packages in `pkgs/by-name` here. Checked running the update script of everything, which results in either the same version & revs as corrected here, or newer versions.

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>40 packages built:</summary>
  <ul>
    <li>ansel</li>
    <li>approxmc</li>
    <li>arjun-cnf</li>
    <li>blueberry</li>
    <li>bluez-tools</li>
    <li>fwupd</li>
    <li>fwupd.debug</li>
    <li>fwupd.dev</li>
    <li>fwupd.devdoc</li>
    <li>fwupd.installedTests</li>
    <li>fwupd.lib</li>
    <li>fwupd.man</li>
    <li>gnome-firmware</li>
    <li>gnome.gnome-software</li>
    <li>kdePackages.discover</li>
    <li>kdePackages.discover.debug</li>
    <li>kdePackages.discover.dev</li>
    <li>kdePackages.discover.devtools</li>
    <li>labwc-gtktheme</li>
    <li>labwc-menu-generator</li>
    <li>libsForQt5.discover</li>
    <li>libsForQt5.kinfocenter</li>
    <li>libui-ng</li>
    <li>louvain-community</li>
    <li>nitter</li>
    <li>nix-search-cli</li>
    <li>pantheon.elementary-greeter</li>
    <li>pantheon.elementary-onboarding</li>
    <li>pantheon.elementary-settings-daemon</li>
    <li>pantheon.switchboard-plug-about</li>
    <li>pantheon.switchboard-plug-pantheon-shell</li>
    <li>pantheon.switchboard-plug-security-privacy</li>
    <li>pantheon.switchboard-with-plugs</li>
    <li>pantheon.wingpanel-applications-menu</li>
    <li>pantheon.wingpanel-with-indicators</li>
    <li>renode-dts2repl</li>
    <li>renode-dts2repl.dist</li>
    <li>river-bnf</li>
    <li>samrewritten</li>
    <li>tecoc</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
