### PR TITLE
hyprpaper: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprpaper/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprpaper/default.nix
@@ -2,14 +2,24 @@
 , stdenv
 , fetchFromGitHub
 , cmake
+, cairo
+, expat
 , file
+, fribidi
 , hyprlang
+, libdatrie
 , libGL
 , libjpeg
+, libselinux
+, libsepol
+, libthai
 , libwebp
-, mesa
+, libXdmcp
 , pango
+, pcre
+, pcre2
 , pkg-config
+, util-linux
 , wayland
 , wayland-protocols
 , wayland-scanner
@@ -17,13 +27,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hyprpaper";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = finalAttrs.pname;
     rev = "v${finalAttrs.version}";
-    hash = "sha256-mqxnaNiCVJS88Dk4V1v2wdS0RaCbOk8HFOUUbp0Uiy0=";
+    hash = "sha256-l13c8ALA7ZKDgluYA1C1OfkDGYD6e1/GR6LJnxCLRhA=";
   };
 
   nativeBuildInputs = [
@@ -33,13 +43,23 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    cairo
+    expat
     file
+    fribidi
     hyprlang
+    libdatrie
     libGL
     libjpeg
+    libselinux
+    libsepol
+    libthai
     libwebp
-    mesa
+    libXdmcp
     pango
+    pcre
+    pcre2
+    util-linux
     wayland
     wayland-protocols
   ];
@@ -47,18 +67,6 @@ stdenv.mkDerivation (finalAttrs: {
   prePatch = ''
     substituteInPlace src/main.cpp \
       --replace GIT_COMMIT_HASH '"${finalAttrs.src.rev}"'
-  '';
-
-  preConfigure = ''
-    make protocols
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm755 ./hyprpaper -t $out/bin
-
-    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

[CHANGELOG](https://github.com/hyprwm/hyprpaper/releases/tag/v0.7.0)

Closes #309164.

Depends on #309075, due to the `XDG_RUNTIME_DIR` changes.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
