### PR TITLE
magic-wormhole: fix build

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13399,6 +13399,12 @@
     matrix = "@mjm:beeper.com";
     name = "Matt Moriarity";
   };
+  mjoerg = {
+    name = "Martin Joerg";
+    email = "martin.joerg@gmail.com";
+    github = "mjoerg";
+    githubId = 147256;
+  };
   mjp = {
     email = "mike@mythik.co.uk";
     github = "MikePlayle";

--- a/pkgs/development/python-modules/iterable-io/default.nix
+++ b/pkgs/development/python-modules/iterable-io/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "iterable-io";
+  version = "1.0.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "pR0Ps";
+    repo = "iterable-io";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-+PSINKS7/FeGHYvkOASA5m+1pBpKfURfylZ8CwKijgA=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  pythonImportsCheck = [ "iterableio" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Library to adapt iterables to a file-like interface";
+    homepage = "https://github.com/pR0Ps/iterable-io";
+    changelog = "https://github.com/pR0Ps/iterable-io/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.lgpl3Only;
+    maintainers = [ lib.maintainers.mjoerg ];
+  };
+}

--- a/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
@@ -1,33 +1,40 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , autobahn
 , mock
 , twisted
+, pythonOlder
+, pythonAtLeast
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "magic-wormhole-transit-relay";
   version = "0.2.1";
-  format = "setuptools";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7" || pythonAtLeast "3.12";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0ppsx2s1ysikns1h053x67z2zmficbn3y3kf52bzzslhd2s02j6b";
+    hash = "sha256-y0gBtGiQ6v+XKG4OP+xi0dUv/jF9FACDtjNqH7To+l4=";
   };
+
+  nativeBuildInputs = [ setuptools ];
 
   propagatedBuildInputs = [ autobahn twisted ];
 
-  nativeCheckInputs = [ mock twisted ];
+  pythonImportsCheck = [ "wormhole_transit_relay" ];
 
-  checkPhase = ''
-    trial -j$NIX_BUILD_CORES wormhole_transit_relay
-  '';
+  nativeCheckInputs = [ pytestCheckHook mock twisted ];
 
-  meta = with lib; {
+  meta = {
     description = "Transit Relay server for Magic-Wormhole";
     homepage = "https://github.com/magic-wormhole/magic-wormhole-transit-relay";
-    license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    changelog = "https://github.com/magic-wormhole/magic-wormhole-transit-relay/blob/${version}/NEWS.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.mjoerg ];
   };
 }

--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -17,7 +17,9 @@
 , tqdm
 , click
 , humanize
+, iterable-io
 , txtorcon
+, zipstream-ng
 
 # optional-dependencies
 , noiseprotocol
@@ -34,7 +36,7 @@
 buildPythonPackage rec {
   pname = "magic-wormhole";
   version = "0.14.0";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -56,7 +58,9 @@ buildPythonPackage rec {
     tqdm
     click
     humanize
+    iterable-io
     txtorcon
+    zipstream-ng
   ]
   ++ autobahn.optional-dependencies.twisted
   ++ twisted.optional-dependencies.tls;
@@ -111,12 +115,12 @@ buildPythonPackage rec {
     install -Dm644 docs/wormhole.1 $out/share/man/man1/wormhole.1
   '';
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/magic-wormhole/magic-wormhole/blob/${version}/NEWS.md";
     description = "Securely transfer data between computers";
     homepage = "https://github.com/magic-wormhole/magic-wormhole";
-    license = licenses.mit;
-    maintainers = with maintainers; [ asymmetric ];
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.mjoerg ];
     mainProgram = "wormhole";
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5941,6 +5941,8 @@ self: super: with self; {
 
   itemloaders = callPackage ../development/python-modules/itemloaders { };
 
+  iterable-io = callPackage ../development/python-modules/iterable-io { };
+
   iteration-utilities = callPackage ../development/python-modules/iteration-utilities { };
 
   iterative-telemetry = callPackage ../development/python-modules/iterative-telemetry { };


### PR DESCRIPTION
## Description of changes

This adds the missing dependencies required for magic-wormhole 0.14.0, and also improves dependencies
magic-wormhole-mailbox-server and magic-wormhole-transit-relay.

Fixes #309210.

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>12 packages built:</summary>
  <ul>
    <li>gnome-keysign</li>
    <li>gnome-keysign.dist</li>
    <li>magic-wormhole (python311Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python311Packages.magic-wormhole.dist)</li>
    <li>python311Packages.iterable-io</li>
    <li>python311Packages.iterable-io.dist</li>
    <li>python312Packages.iterable-io</li>
    <li>python312Packages.iterable-io.dist</li>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc