### PR TITLE
recipes-archive-melpa: fix incorrect source hashes

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -260,7 +260,7 @@
     "s"
    ],
    "commit": "966bfcfdd3b2e288576ffe363d676ad282902090",
-   "sha256": "0apcbfaa70kgrpjjsfbr0lg9lcfiijpx5bms4sbzc606vlnxxn0d"
+   "sha256": "0zmzn8rdn1q0dfql3awivhrxd1nrvqr6mb8gv2ynaldyidgsb487"
   }
  },
  {
@@ -1610,7 +1610,7 @@
     "keyfreq"
    ],
    "commit": "5c3c430b21bcf685c412cf5ceb3769f630082e4f",
-   "sha256": "14p9lmnrpsnx94ycvsqmfxnk5kws0cman4a6fbnikl35ma8zc01x"
+   "sha256": "0zjncby2884cv8nz2ss7i0p17l15lsk88zwvb7b0gr3apbfpcpa3"
   }
  },
  {
@@ -1895,7 +1895,7 @@
     1033
    ],
    "commit": "04fed0ef795bfe2482998c5b6f87c37c13fe8c50",
-   "sha256": "0klzdgicxfsfwg66a5lnlsfv4mpli6fikplk3qldpwz21652xsz9"
+   "sha256": "0kk571d7ww6j8y6krfsr9v5yvssz8gvfjq4xc3vsgvpzl6bdh8rl"
   },
   "stable": {
    "version": [
@@ -1904,7 +1904,7 @@
     0
    ],
    "commit": "0907961986a582ded514d54a8bfdf691f7bfaf86",
-   "sha256": "0klzdgicxfsfwg66a5lnlsfv4mpli6fikplk3qldpwz21652xsz9"
+   "sha256": "10hm8anw78n37pl9rz3dnjphrnsxf3fy00d008gayn70jfjl1433"
   }
  },
  {
@@ -2442,7 +2442,7 @@
     0
    ],
    "commit": "97c20b1fd9ad3f138e1100e3a837d05108c4c564",
-   "sha256": "1x4apig2hrvvy6pjciklmz5afpq5l4rmfjahc2wvyzs79abh0icx"
+   "sha256": "1wsvs756cbwbxlaxij352kman7196m39684m6sqnfb685cfrwzdj"
   }
  },
  {
@@ -3318,7 +3318,7 @@
     806
    ],
    "commit": "6ad8c6be4f44de0c33eab012e507320b732d4800",
-   "sha256": "0cq960q11lpic6zcw71z2ap80jzrzgcwwy2vwhgc1zwi8k8l9i4q"
+   "sha256": "1pg0xqzixw3nq68hsy263q7j76fggy6wqgmcl5yd0wfhbzd23qqz"
   }
  },
  {
@@ -3628,7 +3628,7 @@
     0
    ],
    "commit": "785f0bad0c73069e6c41ca543c29675785b614a8",
-   "sha256": "05q548dyb620kg12mgkmw6jpwbr2y2aqs5p7314y2c37khvw5irg"
+   "sha256": "1ja0q2z9kqkz3ycclgaw1ib83cjh6kym9lrikni0if3spbb0df3w"
   }
  },
  {
@@ -6746,7 +6746,7 @@
     1821
    ],
    "commit": "927257e97a602b6979a75028e8417bf1499582d4",
-   "sha256": "1vw1vpnxa4qxbdsmis8d0df3qhwr1c5h0q04rvwmyviixd729mlr"
+   "sha256": "1jbpf28918pjiqhw8rackv9r8iq9ydd3jw1zwwifznglmpyca7jk"
   },
   "stable": {
    "version": [
@@ -6754,7 +6754,7 @@
     1
    ],
    "commit": "927257e97a602b6979a75028e8417bf1499582d4",
-   "sha256": "1vw1vpnxa4qxbdsmis8d0df3qhwr1c5h0q04rvwmyviixd729mlr"
+   "sha256": "1jbpf28918pjiqhw8rackv9r8iq9ydd3jw1zwwifznglmpyca7jk"
   }
  },
  {
@@ -6835,7 +6835,7 @@
     "flycheck"
    ],
    "commit": "5bfd5f91b9f91e46158e0419c6bb5c350e7684a1",
-   "sha256": "0mb85g7bydd0nv3hjzvqb3d01cs4hg5846ibcznaqhsqk93pgm2h"
+   "sha256": "0nb6dbk8aclkq7jki52y4lwgbxg61xh1598l08yfv2l1ykhgg0n0"
   }
  },
  {
@@ -9075,7 +9075,7 @@
     2201
    ],
    "commit": "587b39ea7a1d786df5c04796d51bf2a5a4eda0d7",
-   "sha256": "14nxqlrza35l955zgc4yi9yaymd9slyyyjmbnbd831v8jlddngm9"
+   "sha256": "0bvg2vpak2bv3s7wc0zzrqb3pys5s7vi6rs7k7l4fmaj5amaq9vb"
   }
  },
  {
@@ -16469,7 +16469,7 @@
     "seq"
    ],
    "commit": "b2bcf2e6997a5ab3502baba9143af44ac2cc2eb3",
-   "sha256": "1gjdmdg496lkgm7xkgvfl4b4xir91kzn7sizyrgwdj845i9lfjmp"
+   "sha256": "0mfs261nzi5svxliy2yaxwhzgfb8my5f4580jizll1vkxi33c358"
   },
   "stable": {
    "version": [
@@ -16483,7 +16483,7 @@
     "seq"
    ],
    "commit": "1334f44725bd80a265de858d652f3fde4ae401fa",
-   "sha256": "1milqql0p9gp4dn9phn4fw1izf37wizpirvmzh5s71rwzrr6a9ix"
+   "sha256": "1h1lqrl3p9qgkicds8v44vdry19g53rya56hdj3cz5q8xj1nisn1"
   }
  },
  {
@@ -16713,7 +16713,7 @@
     "s"
    ],
    "commit": "0e6941e1832faafb2176238339667edd482acd95",
-   "sha256": "0xw475spfwq32nn5qz3gk22cggj1f5y245da9030vzi2jfb9vvid"
+   "sha256": "1ri022shrwiw10gdydm66c2xya1qxl449r5f8qadals7m4crczp2"
   },
   "stable": {
    "version": [
@@ -16728,7 +16728,7 @@
     "s"
    ],
    "commit": "0e6941e1832faafb2176238339667edd482acd95",
-   "sha256": "0xw475spfwq32nn5qz3gk22cggj1f5y245da9030vzi2jfb9vvid"
+   "sha256": "1ri022shrwiw10gdydm66c2xya1qxl449r5f8qadals7m4crczp2"
   }
  },
  {
@@ -21363,7 +21363,7 @@
     0
    ],
    "commit": "2ecd466ffa7a3157b9ddcd7545b6fb8ad308c976",
-   "sha256": "1y8rsc63nl4n43pvn283f1vcpqyjnv6xl60fwyscwrqaz19bsnl1"
+   "sha256": "1h5lssnc1am54hkprnp61bsj5fnm8j556q2gbhljfjgrdwnqv8ky"
   }
  },
  {
@@ -21985,7 +21985,7 @@
     "ht"
    ],
    "commit": "5123477396a562fae350a89fbed79464cc498bc9",
-   "sha256": "1bkiwg1wp3l904159gycdr83xkb3i0h2k0da7akzkwc957abvp8w"
+   "sha256": "0xd94cpqpv0yw70ajrvs69ygds62m40fk0m4s59zvdn5qs7ivj4k"
   }
  },
  {
@@ -23098,7 +23098,7 @@
     0
    ],
    "commit": "6d0c4203eb192d73d89261b3a9bad52951e394af",
-   "sha256": "0a89bp9vz8lzg5klhmzpfmc0mhqmx667ivr86ckkjhiwr2mmzq0s"
+   "sha256": "1rdmhsrlqn19a140i3099fp7f9wnlglp760rnrjp5p840wzfm74q"
   }
  },
  {
@@ -24019,7 +24019,7 @@
     5
    ],
    "commit": "dbace8d2250f84487d31b39050fcdc260fcde804",
-   "sha256": "0r9qmr2l5kjwh1frp0k87nyaf13f7f9fjjf9yf9z92djqapfm9dd"
+   "sha256": "1d9105ibaw858gqp19rx2m6xm3hl57vzsmdqir883cy46qpvwhki"
   }
  },
  {
@@ -24221,7 +24221,7 @@
     "hydra"
    ],
    "commit": "79e422be55c72bfe36d2ec8a838f19d1cc8d101a",
-   "sha256": "01zdha3p7wsf98yayvwgpd4arcs7yhz62yk1nyq9n13hvmqg7dvk"
+   "sha256": "14hb3d76y4n8qvfl74v9hzgl6774bqdcmsa0npv3gs144fbx9prk"
   }
  },
  {
@@ -28860,7 +28860,7 @@
     "spinner"
    ],
    "commit": "b80b773238719fa7160e598219f300dfbc4db06d",
-   "sha256": "1w2xh207rm4a242iykhzsp3r3s8gv1cw8qr3cvwfbkxqrzmki7z4"
+   "sha256": "1whgbwdv3zrhxq2casxj784bx95j0vzlpnvi51i4xdxpdf77g521"
   },
   "stable": {
    "version": [
@@ -31629,7 +31629,7 @@
     0
    ],
    "commit": "f0add6820d250875f7d7c21aa5d813dc73dbcf96",
-   "sha256": "0zg52b3hl0rp9hjz04546kngssxs0l64dm01bwp9hapy7pichbci"
+   "sha256": "18bnw6yb41ki1xvkhi07v7fqx3var928majgd6613ra9nirnyqnj"
   }
  },
  {
@@ -32979,7 +32979,7 @@
     "dash"
    ],
    "commit": "7aa2e1715e6ea286b08bb446d2d9915afa0fdf03",
-   "sha256": "0b2a9qvqxhm2z4zb4qg6d5h0pp82hdmjl8qnk03zr1awi5angiyv"
+   "sha256": "11wag6sgfr62yj4zjr9n71kxd3kfa105l0rpbag47qmac2wsg7h5"
   }
  },
  {
@@ -33125,7 +33125,7 @@
     "switch-buffer-functions"
    ],
    "commit": "feb0fbf1fd4bdf220ae2d31ea7c066d8e62089f9",
-   "sha256": "0pfnp7gw75hfhsy7jizp622s6yv61h3k2s0l2g33i801ar6abwm5"
+   "sha256": "1wb3xm45g77daw2ncs8a8w0m8d2hi591jmzwy5xli1zgrr5mm8h3"
   },
   "stable": {
    "version": [
@@ -33137,7 +33137,7 @@
     "switch-buffer-functions"
    ],
    "commit": "7539654e4a72edcc5bba07a101961e5bf0a9d449",
-   "sha256": "0pfnp7gw75hfhsy7jizp622s6yv61h3k2s0l2g33i801ar6abwm5"
+   "sha256": "11zpqwh1mlfifbgnvhc63bvnhg340jgxssm3m43hr1sxsyb52lh6"
   }
  },
  {
@@ -37773,7 +37773,7 @@
     "xelb"
    ],
    "commit": "047c83aa6b54bfb6ca8cac4d3ea18542611cef77",
-   "sha256": "1bwnw6qacdrm54lx4hc36f9lnidfw1wl399n7wasa24n9wrbr8z0"
+   "sha256": "08g7ly2syvmjgnj8qjgw5cva3wk08jmqnd85h49f76y0clcx6dsx"
   }
  },
  {
@@ -39486,7 +39486,7 @@
     4
    ],
    "commit": "ba63f0591c3be1644ee7ee972430c74b5d346579",
-   "sha256": "1yjfvb2vn5pmrq5fw4sfx1lfkbnkwlc160izpvkrf9ww9xsas6al"
+   "sha256": "014vbzxz1jmm83a5mg4zsyxm8nw96n8s2l7h3myhrn880d9xnqgg"
   }
  },
  {
@@ -39578,7 +39578,7 @@
     929
    ],
    "commit": "608dd1120d35b02a02570f024c585f7569508586",
-   "sha256": "08yq6hncy8vqa2plpxa4gkq244wig2pd05w4ws0j8nmpwcwl6zki"
+   "sha256": "1gcqllsdlkkmgrwxwczxsj4zllwpprw7df479j6sj563j6qds53r"
   }
  },
  {
@@ -40412,7 +40412,7 @@
     "flycheck"
    ],
    "commit": "0eb3dd630391e4d8a26e09c9032cfb9f4bd71e08",
-   "sha256": "1zk3rjabmpfl37zrnnim4h6cbnwp9vg8yjwirw8hjsayfh1pp0kk"
+   "sha256": "1nrhybhpkv3rvks1vqzahfjg0vva76kakd99wpdqsa60ylb5i4jw"
   },
   "stable": {
    "version": [
@@ -41583,7 +41583,7 @@
     "flycheck"
    ],
    "commit": "54744a78d06373404933fedc3ca836916e83de51",
-   "sha256": "1vvsswadiks9mpb49vz2q8z69wq0jalsvgalhn10k3pyz7p0abnd"
+   "sha256": "1zdvan6l2s97s7swnccq21z1ja8vl64l757j3hg50ipq8j5yy9dl"
   },
   "stable": {
    "version": [
@@ -41594,7 +41594,7 @@
     "flycheck"
    ],
    "commit": "54744a78d06373404933fedc3ca836916e83de51",
-   "sha256": "1vvsswadiks9mpb49vz2q8z69wq0jalsvgalhn10k3pyz7p0abnd"
+   "sha256": "1zdvan6l2s97s7swnccq21z1ja8vl64l757j3hg50ipq8j5yy9dl"
   }
  },
  {
@@ -46888,7 +46888,7 @@
     14
    ],
    "commit": "362f1d1189c090ece8b94f6a51680f74b1ff40f9",
-   "sha256": "1gsvl0r6r385lkv0z4gkxirz9as6k0ghmk402zsyz8gvdpl0f3jw"
+   "sha256": "15bmrhpg4kh6dv6bwzxs15wf4rm7a3g09z6ram762hf2kinfiihy"
   }
  },
  {
@@ -46949,7 +46949,7 @@
     "geiser"
    ],
    "commit": "f76b53dbc1465dbd799e29bdcd2be34cc1603f50",
-   "sha256": "1i4ywb4ggq884p2lbpmp6y53l8ys5ajma7sk21zxi1jx28nb01nm"
+   "sha256": "097gyi299fyjy4v22l2l95mzs319ljr9jas4n6893vghac3rf1r6"
   }
  },
  {
@@ -47007,7 +47007,7 @@
     "geiser"
    ],
    "commit": "42376b74ae0ad84d02c26560dfd9181493dcccd7",
-   "sha256": "1aqsvmk1hi7kc3j4h8xlza7c6rwm71v98fv5wpw8kmyj9vsp49wx"
+   "sha256": "04gwd9qa0785zfr6m9a5443ilgvyz05l06cb1waicf83sgp8xl32"
   }
  },
  {
@@ -47621,7 +47621,7 @@
     2
    ],
    "commit": "fa81e915c256271fa10b807a2935d5eaa4700dff",
-   "sha256": "1jiglrlhrph57p5kkm1qlqihwl6z7h9qh16qmmd5783ynksnbxp3"
+   "sha256": "1yf6yipvhhna29mzaan5vb3d5qvbrkp2awr5diyf381mvxgk8akh"
   }
  },
  {
@@ -48001,7 +48001,7 @@
     "s"
    ],
    "commit": "8a403005ea7f7611bb1bfd829eeefe5a4f10bb40",
-   "sha256": "02hag6jd55mqf0n90p0hvihmqjvd0cdlpm5knsxk3cll7fp0kkkr"
+   "sha256": "0w5xl9r7sbhlwxzg391x50pnsjmjjakn761v3qg0lj6xhv23sdl5"
   }
  },
  {
@@ -48224,7 +48224,7 @@
     0
    ],
    "commit": "ea49e2e005af977a08331f8caa8f64d102b3b932",
-   "sha256": "05bkpg7xz8644np9imsj5ms821sbsb784ap5fjdnnn69kllz0d33"
+   "sha256": "0prx0xbnhhp46c09nnzpz07jgr3s5ngrw8zjksf48abr8acwywfv"
   }
  },
  {
@@ -48914,7 +48914,7 @@
     "yaml-mode"
    ],
    "commit": "2651e831aed84ee2512245952fac94901b086549",
-   "sha256": "0yd6s5vy5afkigm87xyh1nnwljplx1wdn5h02224ica0py48fzhd"
+   "sha256": "16fb4r3vq8xkzl911v7gaky95w1agfxjlpaxpjmidwx48rbcar59"
   }
  },
  {
@@ -48945,7 +48945,7 @@
     "gitlab-ci-mode"
    ],
    "commit": "30ea0eab74b24818f187242b079845785035e967",
-   "sha256": "1w1simnlffg56j79gal1qf1nlav9f8fmr2zfswfrmcv6cac6fhj9"
+   "sha256": "0awv24znkxs0h8pkj4b5jwjajxkf1agam09m5glr8zn5g3xbj798"
   }
  },
  {
@@ -48994,7 +48994,7 @@
     "helm"
    ],
    "commit": "5fe0a66642da6f4e7ba9e1e3a96572c7f1876e37",
-   "sha256": "1mxkcnjgazc1pyjbqqfnhc9phpyrgah960avm2fmi7m9n5v8cf0w"
+   "sha256": "1c5js19zyb1z61hapvbfcl5jhrjqij46cxldgqij6al0scw44dga"
   },
   "stable": {
    "version": [
@@ -49007,7 +49007,7 @@
     "helm"
    ],
    "commit": "5fe0a66642da6f4e7ba9e1e3a96572c7f1876e37",
-   "sha256": "1mxkcnjgazc1pyjbqqfnhc9phpyrgah960avm2fmi7m9n5v8cf0w"
+   "sha256": "1c5js19zyb1z61hapvbfcl5jhrjqij46cxldgqij6al0scw44dga"
   }
  },
  {
@@ -49548,7 +49548,7 @@
     "gnus"
    ],
    "commit": "44ebe0241a19f4052cd427dff408206542aa3c8f",
-   "sha256": "0h7w5wrkrd0jw8nmgbkzq8wam7ynvy7flhjg4frphzmimlhysli2"
+   "sha256": "1fqkclbddwfqywvkrb7l2cpibapxrk82ikdpbxapj09iwyn3ijlz"
   },
   "stable": {
    "version": [
@@ -49559,7 +49559,7 @@
     "gnus"
    ],
    "commit": "210c70f0021ee78e724f1d8e00ca96e1e99928ca",
-   "sha256": "0h7w5wrkrd0jw8nmgbkzq8wam7ynvy7flhjg4frphzmimlhysli2"
+   "sha256": "08j8x0iaz5s9q0b68d8h3153w0z6vak5l8qgw3dd1drz5p9xnvyw"
   }
  },
  {
@@ -62193,7 +62193,7 @@
     "islisp-mode"
    ],
    "commit": "423b84fe4cc6944e36971225b3e19c888e7e4690",
-   "sha256": "174zjlgcikaydgx5npsbwqblzc61pxnnpw50nia8jhh8175j2sbl"
+   "sha256": "0m3vxm4q5kbdn3q524z50zvwdk63gixaqxw9qxa6d175iv0xfwv8"
   },
   "stable": {
    "version": [
@@ -62205,7 +62205,7 @@
     "islisp-mode"
    ],
    "commit": "18258f7134cfd8e0bd12538351b3cd23ae44cec1",
-   "sha256": "174zjlgcikaydgx5npsbwqblzc61pxnnpw50nia8jhh8175j2sbl"
+   "sha256": "1s6alrv1hfi1plj5lh826j0h71xvm2v092kglj3yvy34g73dgrna"
   }
  },
  {
@@ -62700,7 +62700,7 @@
     2108
    ],
    "commit": "8f13262ebcb3f271f1d188584d04ca6d87214111",
-   "sha256": "0cqc23y9n63a7kl2p1zrfcsxnclfxcszfmbh2hmbrs6q05ys0kzg"
+   "sha256": "1aa6c9rswwgxyh8js0bnjrzcmyqc1az7vr5m68lbbmsbjb495awq"
   }
  },
  {
@@ -63394,7 +63394,7 @@
     1
    ],
    "commit": "18258f7134cfd8e0bd12538351b3cd23ae44cec1",
-   "sha256": "174zjlgcikaydgx5npsbwqblzc61pxnnpw50nia8jhh8175j2sbl"
+   "sha256": "1s6alrv1hfi1plj5lh826j0h71xvm2v092kglj3yvy34g73dgrna"
   }
  },
  {
@@ -64631,7 +64631,7 @@
     1017
    ],
    "commit": "c2ad37e2ada14b5551a83211cc4692b39be4e5fb",
-   "sha256": "18ibnf995yymgxv7xz7xql6lnix3sxn6pn659b1vp00g5d5yl2jf"
+   "sha256": "05izmyp875pfbpygy54ybwkxnjv3fmam024pkjd70i5m6xmg4wi6"
   },
   "stable": {
    "version": [
@@ -70952,7 +70952,7 @@
     2206
    ],
    "commit": "2b719baf0ccba79e28fcb3c2633c4849d976ac23",
-   "sha256": "1hlqairbjlrcbzb4r5fjm80znr9hdgny3vgm27dwwxxa340m0r6i"
+   "sha256": "0rxqam6cgi404m8n45mw73j3jdd2gb3iwpmyyixbv3cxfb7y1b0l"
   },
   "stable": {
    "version": [
@@ -70961,7 +70961,7 @@
     4
    ],
    "commit": "2b719baf0ccba79e28fcb3c2633c4849d976ac23",
-   "sha256": "1hlqairbjlrcbzb4r5fjm80znr9hdgny3vgm27dwwxxa340m0r6i"
+   "sha256": "0rxqam6cgi404m8n45mw73j3jdd2gb3iwpmyyixbv3cxfb7y1b0l"
   }
  },
  {
@@ -75866,7 +75866,7 @@
     "test-simple"
    ],
    "commit": "1334f44725bd80a265de858d652f3fde4ae401fa",
-   "sha256": "1milqql0p9gp4dn9phn4fw1izf37wizpirvmzh5s71rwzrr6a9ix"
+   "sha256": "1h1lqrl3p9qgkicds8v44vdry19g53rya56hdj3cz5q8xj1nisn1"
   }
  },
  {
@@ -77593,7 +77593,7 @@
     1
    ],
    "commit": "beb22e85f6073a930f7338a78bd186e3090abdd7",
-   "sha256": "1yf21gm4ziplmgx8yn7jqq45mwfiindbrman7fc5b9ifq78x9ryn"
+   "sha256": "1dhljrh44dsnixd8hbb11k6dgap8r8n7jknhfy2afdzq889fih74"
   }
  },
  {
@@ -78457,7 +78457,7 @@
     1309
    ],
    "commit": "d1c024fdf9543fbc0101cd2c6e8b248378f591cd",
-   "sha256": "1xvx26xbd0ylih6xyvwylzjl7z5dbw9sv828p5zykr6fg2kz9nb3"
+   "sha256": "11r54zj0q14f88wl6bp46gz4j2wv6cb37d42b2hfvhkgh88a71c5"
   },
   "stable": {
    "version": [
@@ -78466,7 +78466,7 @@
     1
    ],
    "commit": "d5b6b5b3552a5b84f4f887e2f805d9e72747fab2",
-   "sha256": "1xvx26xbd0ylih6xyvwylzjl7z5dbw9sv828p5zykr6fg2kz9nb3"
+   "sha256": "19yh93kkyailczv1yyg7jhmzwl768sg0rk4as5kgqays87h9bnfn"
   }
  },
  {
@@ -79386,7 +79386,7 @@
     812
    ],
    "commit": "98110bb9c300fc9866dee8e0023355f9f79c9b96",
-   "sha256": "1ysj9x9m1lxg1gy0z7y07qsi3g26qfqdwwa8kjkf40pchb2wxg0s"
+   "sha256": "080s96jkcw2p288sp1vgds91rgl693iz6hi2dv56p2ih0nnivwlg"
   }
  },
  {
@@ -82329,7 +82329,7 @@
     0
    ],
    "commit": "7825f88cb881a84eaa5cd1689772819a18eb2943",
-   "sha256": "0f8s7mhcs1ym4an8d4dabfvhin30xs2d0c5gv875hsgz8p3asgxs"
+   "sha256": "009did3i3i8yi0virq606l02w1mw0gdyiqablqg7m368gx0gfvh5"
   }
  },
  {
@@ -82407,7 +82407,7 @@
     0
    ],
    "commit": "dfe065acdd06be176fce3ab150fae699b2ad1a13",
-   "sha256": "1nqxw9s41ln91gjrglrbyhqasakgk0542ymhbwivw9l19yyizmaz"
+   "sha256": "0m5rfwp2y8iz7lrshdy09nk6dhrd7bgwb0761cmz1ky8w6f3di7v"
   }
  },
  {
@@ -83168,7 +83168,7 @@
     1249
    ],
    "commit": "44d506105989873dc1725e0cfc675925b35c9c98",
-   "sha256": "1g030806d2l238sr173ypdkkq0g8kf8qdp7a1ls5d3rw0bng4ds1"
+   "sha256": "0lgz0sknnrxmc7iy4lniday1nwpz4q841c3w2hm72aiwn5z21h22"
   }
  },
  {
@@ -87315,7 +87315,7 @@
     "seq"
    ],
    "commit": "e55415221eedba2f2bd37a30cb71c842e344b5ee",
-   "sha256": "079x6rcz50rpw0vdq5q2kjpixz95k9f3j9dwk91r5111vvr428w3"
+   "sha256": "0gjkl8j8jrimg45z9bsfkkbvmxsplh3nyqgr8g8d5mqm0w9b4pn3"
   },
   "stable": {
    "version": [
@@ -87329,7 +87329,7 @@
     "seq"
    ],
    "commit": "4c114489e682e514e79701045d541ab6f3dc3fb4",
-   "sha256": "079x6rcz50rpw0vdq5q2kjpixz95k9f3j9dwk91r5111vvr428w3"
+   "sha256": "13y302lyscdqrba1sfx60yf5ji2xi7fbsvjsjbw7hiz63kg6rccy"
   }
  },
  {
@@ -88091,7 +88091,7 @@
     "jami-bot"
    ],
    "commit": "020b03f299dad438f65d7bcbf93553b273fd7c33",
-   "sha256": "0fj166qawhnjbc14237fj8ph4f4xdjka7p8r2gxkfq6h0z101nr2"
+   "sha256": "18nhkmmrzs6i6px23c88wlml0gn43b38zfvpwq8bnabq3ak6q7j2"
   },
   "stable": {
    "version": [
@@ -88444,7 +88444,7 @@
     9
    ],
    "commit": "edf9f6f7254f72be939daf92942f76f44b72d32d",
-   "sha256": "0ijlmfq6dbdmk3jpl87g4knk4l76yxf63nmk3n2nll3v3swbk22g"
+   "sha256": "0jmavx9cd49y7lqb0zjpfyslqfd21a1anhpb6n6ksrxn65q6pf9q"
   }
  },
  {
@@ -88947,7 +88947,7 @@
     "ov"
    ],
    "commit": "b95b6a7ed9289637cb512232470633b330ca9713",
-   "sha256": "0gjvd7xd9kl06cgdyya2qbl7r4a9y4zfq1ci0109w5axs3zjin1m"
+   "sha256": "03x3n2ywgk2x7slpzy26bw3l9l000pd964z0yifvf9fqhpbk5d0r"
   }
  },
  {
@@ -89179,7 +89179,7 @@
     2
    ],
    "commit": "549fa6969660dcf0cf9bca5b7341d0cb48ec3b77",
-   "sha256": "0ksj6hssyr44qnvb32qj9lrq825ivvndhck9gzx4h7gbxmvq12a4"
+   "sha256": "12s74if74vw8q5awgrk0d1244ysfgb9kw3dxhypsccsbf413jmii"
   }
  },
  {
@@ -89556,7 +89556,7 @@
     "org-ref"
    ],
    "commit": "abcd622e4edaa5e4480bcd1e7e4953f67c90e036",
-   "sha256": "1467vskijg2n8k7fa2jj2hz8xr2s04r8a89521wmz54cza21g5j4"
+   "sha256": "08ia6gn0x0yydl28dhghifyxz0mrn0asllqg4s449gaz729cxqkd"
   }
  },
  {
@@ -90949,7 +90949,7 @@
     "org-ql"
    ],
    "commit": "a7c386ff134c71fd4f1f042e320751f077d57ddb",
-   "sha256": "11xbm6161rd5kv2bffqw678a7bymclvhpmm1qjxsvmi8bhfk1ls0"
+   "sha256": "1xc9g82pmd6fl48bbibwp5rb044cj2j0gw9d6qvn73pqdg8mj9jy"
   }
  },
  {
@@ -93021,7 +93021,7 @@
     "s"
    ],
    "commit": "e8cd440632fd46812d7311360f565828a12380b7",
-   "sha256": "0v2lrmak1lhaccwm2a68z4w554ng38wpk0sbw2qaj8qn03gv9dn4"
+   "sha256": "118km0hgxf1nss765cnykqyymjhg30pim9qjyxl31v07khr1d373"
   }
  },
  {
@@ -101079,7 +101079,7 @@
     2031
    ],
    "commit": "d76c5d5589a4f8a94cc5537686d9a3b46ea7cc59",
-   "sha256": "1bkkgs2agy00wivilljkj3a9fsb2ba935icjmhbk46zjc6yf3y6q"
+   "sha256": "03872n1v5qqqblviq9sf2ml6ibs50mcjrh0i35sb0m7l202nh52b"
   },
   "stable": {
    "version": [
@@ -101087,7 +101087,7 @@
     8
    ],
    "commit": "708cae8e67dbae293c7c4be0ca5e49d76fac6714",
-   "sha256": "1bkkgs2agy00wivilljkj3a9fsb2ba935icjmhbk46zjc6yf3y6q"
+   "sha256": "1v48i37iqrrwbyy3bscicfq66vbbml4sg0f0n950bnk0qagjx8py"
   }
  },
  {
@@ -102188,7 +102188,7 @@
     0
    ],
    "commit": "906b0a107f7bcfe6e32bcfedb977e6f0f99fda59",
-   "sha256": "17clkgs94dgq5nsjlwkr52m5s446ibfss3qc8a8m0zaz6j4f8l1m"
+   "sha256": "0d7hc2llr9dkjyfgyyjb2k72rny0j395a29pqgqgqyrwcn8b1py1"
   }
  },
  {
@@ -102305,7 +102305,7 @@
     "python"
    ],
    "commit": "e606469aafec2e6beda8c589540b88a5a6f6f33f",
-   "sha256": "0vyipfsppissa87pdnbksamdby0yl2q8nzawqivv6smn33jp6vsn"
+   "sha256": "00i7cc4r7275l22k3708xi4hqw2j44yivdb1madzrpf314v3kabr"
   }
  },
  {
@@ -105645,7 +105645,7 @@
     1940
    ],
    "commit": "4aab5a5be16b69b47ef5e67d02782df5e41dbd7b",
-   "sha256": "1zq4nnp3yqv46129kazm76bvdqvjjhlrfg95bkdxvkd7qrdjc9a3"
+   "sha256": "1pancvhm4g4010814jy1cdhdrjh5hlig2j31fcsa5jn331d7rj6g"
   },
   "stable": {
    "version": [
@@ -105654,7 +105654,7 @@
     0
    ],
    "commit": "4aab5a5be16b69b47ef5e67d02782df5e41dbd7b",
-   "sha256": "1zq4nnp3yqv46129kazm76bvdqvjjhlrfg95bkdxvkd7qrdjc9a3"
+   "sha256": "1pancvhm4g4010814jy1cdhdrjh5hlig2j31fcsa5jn331d7rj6g"
   }
  },
  {
@@ -105802,7 +105802,7 @@
     0
    ],
    "commit": "c7c6b726806df7e8cb25a41b213a207850c91cb7",
-   "sha256": "18rba101m9vmjl4mf3x0k7wvbgn6qmay9la745vzpr3lx1f4nn98"
+   "sha256": "0p044wg9d4i6f5x7bdshmisgwvw424y16lixac93q6v5bh3xmab5"
   }
  },
  {
@@ -105999,7 +105999,7 @@
     "web-mode"
    ],
    "commit": "6cf58cf04fee933113857af07414b3f27c24b505",
-   "sha256": "0b3gqs1lsk80shirsc41zajzjbg1sgzksmnfazffx88h612p7ygd"
+   "sha256": "0s3hs0w6hz8vx4172mfraiqfjhd1a9h1w61ra6fklc5fjf3y8pn8"
   },
   "stable": {
    "version": [
@@ -106011,7 +106011,7 @@
     "web-mode"
    ],
    "commit": "6cf58cf04fee933113857af07414b3f27c24b505",
-   "sha256": "0b3gqs1lsk80shirsc41zajzjbg1sgzksmnfazffx88h612p7ygd"
+   "sha256": "0s3hs0w6hz8vx4172mfraiqfjhd1a9h1w61ra6fklc5fjf3y8pn8"
   }
  },
  {
@@ -106269,7 +106269,7 @@
     4
    ],
    "commit": "71e475ab35555e0a1eca26d73acf1ced911e422e",
-   "sha256": "0y18i4ly61jyvxymvgjr99arhxfn5y5s659jnqf4gvyp3d671dkf"
+   "sha256": "0x3mmf4gq4d0cqfqbkrrpwhayvmplacck0zc9nlzcn35y17jzpcz"
   }
  },
  {
@@ -108372,7 +108372,7 @@
     "s"
    ],
    "commit": "91c56311b48a26aa6ef5a113b0a828e174059b0a",
-   "sha256": "10ikd6ksz5adpldyx9h8s3qnwc488rqixzwnd0rjjwqigmllj9lb"
+   "sha256": "1iyq8m75gzyx2ww919i4zl63gajsaczgwax214a1jgf8x91j590k"
   }
  },
  {
@@ -110039,7 +110039,7 @@
     "s"
    ],
    "commit": "9b8cfb59a2dcee8b39b680ab9adad5ecb1f53c0b",
-   "sha256": "1xnby24gpxij1z03wvx89s459jw0f8bwhgi80xvdq8gxhbbz2w7a"
+   "sha256": "0kx0c4syd7k6ff9j463bib32pz4wq0rzjlg6b0yqnymlzfr1mbki"
   }
  },
  {
@@ -110666,7 +110666,7 @@
     "rtm"
    ],
    "commit": "37c5feffea7c9b571279b6f549d06cf9c0720273",
-   "sha256": "1kkhnsxr8zrb21k4ckyg69nsndwy4zdkvfw2drk4v1vnbgx8144f"
+   "sha256": "0rwvlhwg66ny0rm972wjfz41ck9kqmbax49wkagrkimm1cdrjfia"
   }
  },
  {
@@ -111983,7 +111983,7 @@
     "dash"
    ],
    "commit": "d3b616843167f04b8a9f53dd25e84818c9f6fbce",
-   "sha256": "0gadjaq39g8zsh3lvbx29nm2lgyzna2x435xyf7rb89ly4v22wa6"
+   "sha256": "04vv9swkn3l2lcdb4ncmc6vr3967mglfgiabn1978gyhv4xp9nwm"
   },
   "stable": {
    "version": [
@@ -119401,7 +119401,7 @@
     9
    ],
    "commit": "0505a7c0d306632972f29e584e83e0cd58eba2ce",
-   "sha256": "04b6lyrn9hj754ykb07ks60c602h5gla11scyisnzga662li16ib"
+   "sha256": "0k4jpfc9m6834gng6w4zab8jh0d4i3dh5yvn89mlznsb9r9d6148"
   }
  },
  {
@@ -120012,7 +120012,7 @@
     "s"
    ],
    "commit": "a715f7f2df416b8a6c827a9493ce7004180a3a4f",
-   "sha256": "188cdgic25wrb4jdgdcj070a0pxsh3m0rd9d2r6i1s1n1nalrs6g"
+   "sha256": "08awv1vbqg0x0h7f036sh07vypm8lq6b5g36gq9dmyfaqci9ccw6"
   }
  },
  {
@@ -120056,7 +120056,7 @@
     "base32"
    ],
    "commit": "927257e97a602b6979a75028e8417bf1499582d4",
-   "sha256": "1vw1vpnxa4qxbdsmis8d0df3qhwr1c5h0q04rvwmyviixd729mlr"
+   "sha256": "1jbpf28918pjiqhw8rackv9r8iq9ydd3jw1zwwifznglmpyca7jk"
   }
  },
  {
@@ -122342,7 +122342,7 @@
     0
    ],
    "commit": "c2f4870aff70efe70a8d1b089e56d3a2d6d048b9",
-   "sha256": "14ybav1f82m2gsxkciwlc0pm01ihqqaqq6arnjqvgxdnw0z6qniq"
+   "sha256": "0i6jfr4l7mr8gpavmfblr5d41ck8aqzaf4iv1qk5fyzsb6yi0nla"
   }
  },
  {
@@ -124707,7 +124707,7 @@
     "outshine"
    ],
    "commit": "9cb2354874608d971be407ad9299ed918a6c061a",
-   "sha256": "1qfjwsxi3w2gdl258jbk5d3z645gs6zccxx2iah54zbgql17pgj9"
+   "sha256": "0gak3gvqw1pvall2rx82npil283z83aq79w5pw2a5rhi8a3imha4"
   },
   "stable": {
    "version": [
@@ -124720,7 +124720,7 @@
     "outshine"
    ],
    "commit": "5202db4c6a511a90a950a723293d11d55ec05264",
-   "sha256": "1qfjwsxi3w2gdl258jbk5d3z645gs6zccxx2iah54zbgql17pgj9"
+   "sha256": "1ygx8g9cxyyhhpcqan1ca4g741s3dd141bcmp6jjqbjfn2gqraz6"
   }
  },
  {
@@ -131180,7 +131180,7 @@
     "request"
    ],
    "commit": "98323098c37a444de49cfef44f1506e9386e8c5f",
-   "sha256": "18hi6m2ngl9yz599q5bhifafi4vz1adc06bjl0bhb3rs62vbkwk2"
+   "sha256": "1zr67h0w49rsi84mgf6jdili28h8782q6vjl8za0iq1hcx9zqxyf"
   }
  },
  {


### PR DESCRIPTION

## Description of changes

Here is how I produce this patch:
1. Cherry-pick the update[1] to my system's Nixpkgs commit to avoid
building many staging packages
2. Build sources for each elisp package set denoted as EPKGS.  EPKGS
can be elpaDevelPackages, elpaPackages, nongnuPackages,
melpaStablePackages and melpaPackages.
   nix build --include nixpkgs=$PWD --file source-hash.nix EPKGS --keep-going
3. Check log for hash mismatch:
   error: hash mismatch in fixed-output derivation '/nix/store/lg6jmfbqmkp261dwk25ji9n8sxd180rm-source-vhdl-tools-20200330.1819.drv':
         specified: sha256-QsEah0IR5qIEv4Wng9VAfyBB47UC9SwoVfsGjvcbUz0=
         got:    sha256-RMEah0IR5qIEv4Wng9VAfyBB47UC9SwoVfsGjvcbUz0=
4. Convert the correct hash if needed
   nix hash to-base32 sha256-RMEah0IR5qIEv4Wng9VAfyBB47UC9SwoVfsGjvcbUz0=

Here is the content of source-hash.nix:

```nix

let
  pkgs = import <nixpkgs> { };
  lib = pkgs.lib;
  mkSrcSet =
    epkgs:
    lib.mapAttrs (
      name: package: package.src.overrideAttrs { name = "source-" + name + "-" + package.version; }
    ) (lib.filterAttrs (_: package: lib.isDerivation package && (package ? src)) epkgs);
in
{
  elpaDevelPackages = mkSrcSet pkgs.emacsPackages.elpaDevelPackages;
  elpaPackages = mkSrcSet pkgs.emacsPackages.elpaPackages;
  nongnuPackages = mkSrcSet pkgs.emacsPackages.nongnuPackages;
  melpaStablePackages = mkSrcSet pkgs.emacsPackages.melpaStablePackages;
  melpaPackages = mkSrcSet pkgs.emacsPackages.melpaPackages;
}

```

[1]: https://github.com/NixOS/nixpkgs/pull/308258


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
