### PR TITLE
elfutils: Unconditionally include error.h in system.h on musl

### DIFF
--- a/pkgs/development/tools/misc/elfutils/musl-error_h.patch
+++ b/pkgs/development/tools/misc/elfutils/musl-error_h.patch
@@ -1,66 +1,80 @@
-diff -crb --new-file a/lib/error.h b/lib/error.h
-*** a/lib/error.h	1969-12-31 19:00:00.000000000 -0500
---- b/lib/error.h	2021-01-21 04:38:25.000000000 -0500
-***************
-*** 0 ****
---- 1,27 ----
-+ #ifndef _ERROR_H_
-+ #define _ERROR_H_
-+ 
-+ #include <stdarg.h>
-+ #include <stdio.h>
-+ #include <stdlib.h>
-+ #include <string.h>
-+ #include <errno.h>
-+ 
-+ static unsigned int error_message_count = 0;
-+ 
-+ static inline void error(int status, int errnum, const char* format, ...)
-+ {
-+ 	va_list ap;
-+ 	fprintf(stderr, "%s: ", program_invocation_name);
-+ 	va_start(ap, format);
-+ 	vfprintf(stderr, format, ap);
-+ 	va_end(ap);
-+ 	if (errnum)
-+ 		fprintf(stderr, ": %s", strerror(errnum));
-+ 	fprintf(stderr, "\n");
-+ 	error_message_count++;
-+ 	if (status)
-+ 		exit(status);
-+ }
-+ 
-+ #endif	/* _ERROR_H_ */
-diff -crb --new-file a/src/error.h b/src/error.h
-*** a/src/error.h	1969-12-31 19:00:00.000000000 -0500
---- b/src/error.h	2021-01-21 04:38:29.000000000 -0500
-***************
-*** 0 ****
---- 1,27 ----
-+ #ifndef _ERROR_H_
-+ #define _ERROR_H_
-+ 
-+ #include <stdarg.h>
-+ #include <stdio.h>
-+ #include <stdlib.h>
-+ #include <string.h>
-+ #include <errno.h>
-+ 
-+ static unsigned int error_message_count = 0;
-+ 
-+ static inline void error(int status, int errnum, const char* format, ...)
-+ {
-+ 	va_list ap;
-+ 	fprintf(stderr, "%s: ", program_invocation_name);
-+ 	va_start(ap, format);
-+ 	vfprintf(stderr, format, ap);
-+ 	va_end(ap);
-+ 	if (errnum)
-+ 		fprintf(stderr, ": %s", strerror(errnum));
-+ 	fprintf(stderr, "\n");
-+ 	error_message_count++;
-+ 	if (status)
-+ 		exit(status);
-+ }
-+ 
-+ #endif	/* _ERROR_H_ */
+diff '--color=auto' -Naur elfutils-0.191.orig/lib/error.h elfutils-0.191/lib/error.h
+--- elfutils-0.191.orig/lib/error.h	1970-01-01 00:00:00.000000000 +0000
++++ elfutils-0.191/lib/error.h	2024-05-05 14:18:10.885500254 +0000
+@@ -0,0 +1,27 @@
++#ifndef _ERROR_H_
++#define _ERROR_H_
++
++#include <stdarg.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <errno.h>
++
++static unsigned int error_message_count = 0;
++
++static inline void error(int status, int errnum, const char* format, ...)
++{
++	va_list ap;
++	fprintf(stderr, "%s: ", program_invocation_name);
++	va_start(ap, format);
++	vfprintf(stderr, format, ap);
++	va_end(ap);
++	if (errnum)
++		fprintf(stderr, ": %s", strerror(errnum));
++	fprintf(stderr, "\n");
++	error_message_count++;
++	if (status)
++		exit(status);
++}
++
++#endif	/* _ERROR_H_ */
+diff '--color=auto' -Naur elfutils-0.191.orig/lib/system.h elfutils-0.191/lib/system.h
+--- elfutils-0.191.orig/lib/system.h	2024-03-01 20:12:17.000000000 +0000
++++ elfutils-0.191/lib/system.h	2024-05-05 14:21:46.657242872 +0000
+@@ -47,14 +47,7 @@
+ #include <sys/param.h>
+ #include <unistd.h>
+ 
+-#if defined(HAVE_ERROR_H)
+ #include <error.h>
+-#elif defined(HAVE_ERR_H)
+-extern int error_message_count;
+-void error(int status, int errnum, const char *format, ...);
+-#else
+-#error "err.h or error.h must be available"
+-#endif
+ 
+ /* error (EXIT_FAILURE, ...) should be noreturn but on some systems it
+    isn't.  This may cause warnings about code that should not be reachable.
+diff '--color=auto' -Naur elfutils-0.191.orig/src/error.h elfutils-0.191/src/error.h
+--- elfutils-0.191.orig/src/error.h	1970-01-01 00:00:00.000000000 +0000
++++ elfutils-0.191/src/error.h	2024-05-05 14:18:10.885500254 +0000
+@@ -0,0 +1,27 @@
++#ifndef _ERROR_H_
++#define _ERROR_H_
++
++#include <stdarg.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <errno.h>
++
++static unsigned int error_message_count = 0;
++
++static inline void error(int status, int errnum, const char* format, ...)
++{
++	va_list ap;
++	fprintf(stderr, "%s: ", program_invocation_name);
++	va_start(ap, format);
++	vfprintf(stderr, format, ap);
++	va_end(ap);
++	if (errnum)
++		fprintf(stderr, ": %s", strerror(errnum));
++	fprintf(stderr, "\n");
++	error_message_count++;
++	if (status)
++		exit(status);
++}
++
++#endif	/* _ERROR_H_ */


### PR DESCRIPTION
The patched implementation of `error` for musl based builds uses a static inline function. If some parts of the code don't correctly include this implementation, lingering undefined references to `error` are produced.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
