### PR TITLE
sphinxcontrib-ditaa: init at 1.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16835,6 +16835,15 @@
     githubId = 52847440;
     name = "Ryan Burns";
   };
+  rconybea = {
+    email = "n1xpkgs@hushmail.com";
+    github = "rconybea";
+    githubId = 8570969;
+    name = "Roland Conybeare";
+    keys = [{
+      fingerprint = "bw5Cr/4ul1C2UvxopphbZbFI1i5PCSnOmPID7mJ/Ogo";
+    }];
+  };
   rdnetto = {
     email = "rdnetto@gmail.com";
     github = "rdnetto";

--- a/pkgs/development/python-modules/sphinxcontrib-ditaa/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-ditaa/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, unittestCheckHook
+, mock
+, sphinx-testing
+, sphinx
+, ditaa
+}:
+
+buildPythonPackage rec {
+  pname = "sphinxcontrib-ditaa";
+  version = "1.0.2";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "57f2e13b059b38fde89580beca916ac6ca7456b2d706c3ddea9dd4890e5f5bd3";
+  };
+
+  buildInputs = [ mock sphinx-testing ];
+  propagatedBuildInputs = [ sphinx ditaa ];
+
+  # no tests provided 
+  doCheck = false;
+
+  nativeCheckInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "-s" "tests" ];
+
+  pythonNamespaces = [ "sphinxcontrib" ];
+
+  meta = with lib; {
+    description = "Sphinx ditaa extension";
+    homepage = "https://pypi.org/project/sphinxcontrib-ditaa";
+    maintainers = with maintainers; [ ];
+    license = licenses.bsd0;
+  };
+
+}

--- a/pkgs/development/python-modules/sphinxcontrib-ditaa/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-ditaa/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   buildInputs = [ mock sphinx-testing ];
   propagatedBuildInputs = [ sphinx ditaa ];
 
-  # no tests provided 
+  # no tests provided
   doCheck = false;
 
   nativeCheckInputs = [ unittestCheckHook ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14259,6 +14259,8 @@ self: super: with self; {
 
   sphinxcontrib-devhelp = callPackage ../development/python-modules/sphinxcontrib-devhelp { };
 
+  sphinxcontrib-ditaa = callPackage ../development/python-modules/sphinxcontrib-ditaa { };
+
   sphinxcontrib-excel-table = callPackage ../development/python-modules/sphinxcontrib-excel-table { };
 
   sphinxcontrib-fulltoc = callPackage ../development/python-modules/sphinxcontrib-fulltoc { };


### PR DESCRIPTION
## Description of changes

Add sphinx plugin to invoke ditaa.
1. ditaa (nixpkgs.ditaa) renders ascii art block diagrams to image formats like .svg
2. sphinx (nixpkgs.python3xxPackages.sphinx) generates documentation from .rst text files
3. sphinxcontrib-ditaa (https://pypi.org/project/sphinxcontrib-ditaa) adds sphinx markup to send a block of text to ditaa for rendering.  Analogous to existing packages such as nixpkgs.python3xxPackages.sphinxcontrib-plantuml.

Executable content comprises about 200 lines of python.
nix package adapted from sphinxcontrib-blockdiag

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Using successfully for sphinx-generated documentation in xo-unit (https://github.com/rconybea/xo-unit),
and user environment in xo-nix2 (https://github.com/rconybea/xo-nix2/flake.nix)

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
