### PR TITLE
lollypop: 1.4.37 -> 1.4.39 and add kid3 as buildinput

### DIFF
--- a/pkgs/applications/audio/lollypop/default.nix
+++ b/pkgs/applications/audio/lollypop/default.nix
@@ -25,7 +25,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "lollypop";
-  version = "1.4.37";
+  version = "1.4.39";
 
   format = "other";
 
@@ -35,7 +35,7 @@ python3.pkgs.buildPythonApplication rec {
     repo = pname;
     rev = version;
     fetchSubmodules = true;
-    sha256 = "sha256-3GPmGNbbSxvLq0t3F9q1x64BwNQCEvFQWLb0bSO9KUY=";
+    sha256 = "sha256-VPHQwy2+XR9R7toIN5sNFB91ddROlL7Scr8AKLgUzuo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/audio/lollypop/default.nix
+++ b/pkgs/applications/audio/lollypop/default.nix
@@ -23,7 +23,7 @@
 , youtubeSupport ? true
 }:
 
-python3.pkgs.buildPythonApplication rec  {
+python3.pkgs.buildPythonApplication rec {
   pname = "lollypop";
   version = "1.4.37";
 
@@ -48,32 +48,28 @@ python3.pkgs.buildPythonApplication rec  {
     wrapGAppsHook
   ];
 
-  buildInputs = with gst_all_1; [
-    gdk-pixbuf
-    glib
-    glib-networking
-    gst-libav
-    gst-plugins-bad
-    gst-plugins-base
-    gst-plugins-good
-    gst-plugins-ugly
-    gstreamer
-    gtk3
-    libhandy
-    libsoup_3
-    pango
-    totem-pl-parser
-  ] ++ lib.optional lastFMSupport libsecret;
+  buildInputs = with gst_all_1;
+    [
+      gdk-pixbuf
+      glib
+      glib-networking
+      gst-libav
+      gst-plugins-bad
+      gst-plugins-base
+      gst-plugins-good
+      gst-plugins-ugly
+      gstreamer
+      gtk3
+      libhandy
+      libsoup_3
+      pango
+      totem-pl-parser
+    ] ++ lib.optional lastFMSupport libsecret;
 
-  propagatedBuildInputs = with python3.pkgs; [
-    beautifulsoup4
-    pillow
-    pycairo
-    pygobject3
-  ]
-  ++ lib.optional lastFMSupport pylast
-  ++ lib.optional youtubeSupport youtube-dl
-  ;
+  propagatedBuildInputs = with python3.pkgs;
+    [ beautifulsoup4 pillow pycairo pygobject3 ]
+    ++ lib.optional lastFMSupport pylast
+    ++ lib.optional youtubeSupport youtube-dl;
 
   postPatch = ''
     chmod +x meson_post_install.py
@@ -95,9 +91,7 @@ python3.pkgs.buildPythonApplication rec  {
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
-  passthru = {
-    updateScript = nix-update-script { };
-  };
+  passthru = { updateScript = nix-update-script { }; };
 
   meta = with lib; {
     changelog = "https://gitlab.gnome.org/World/lollypop/tags/${version}";

--- a/pkgs/applications/audio/lollypop/default.nix
+++ b/pkgs/applications/audio/lollypop/default.nix
@@ -21,6 +21,7 @@
 , wrapGAppsHook
 , lastFMSupport ? true
 , youtubeSupport ? true
+, kid3Support ? true
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -69,7 +70,8 @@ python3.pkgs.buildPythonApplication rec {
   propagatedBuildInputs = with python3.pkgs;
     [ beautifulsoup4 pillow pycairo pygobject3 ]
     ++ lib.optional lastFMSupport pylast
-    ++ lib.optional youtubeSupport youtube-dl;
+    ++ lib.optional youtubeSupport youtube-dl
+    ++ lib.optional kid3Support pkgs.kid3;
 
   postPatch = ''
     chmod +x meson_post_install.py


### PR DESCRIPTION
Lollypop allows for metadata editing through kid3, which was missing from its derivation.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
