### PR TITLE
nixos/plasma6: add CAP_SYS_NICE for kwin_wayland

### DIFF
--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -286,6 +286,15 @@ in {
       kde-smartcard = lib.mkIf config.security.pam.p11.enable { p11Auth = true; };
     };
 
+    security.wrappers = {
+      kwin_wayland = {
+        owner = "root";
+        group = "root";
+        capabilities = "cap_sys_nice+ep";
+        source = "${lib.getBin pkgs.kdePackages.kwin}/bin/kwin_wayland";
+      };
+    };
+
     programs.dconf.enable = true;
 
     programs.firefox.nativeMessagingHosts.packages = [kdePackages.plasma-browser-integration];

--- a/pkgs/kde/plasma/kwin/0001-Lower-CAP_SYS_NICE-from-the-ambient-set.patch
+++ b/pkgs/kde/plasma/kwin/0001-Lower-CAP_SYS_NICE-from-the-ambient-set.patch
@@ -1,0 +1,40 @@
+From 232e480ab1303f37d37d295b57fdcbb6b6648bca Mon Sep 17 00:00:00 2001
+From: Alois Wohlschlager <alois1@gmx-topmail.de>
+Date: Sun, 7 Aug 2022 16:12:31 +0200
+Subject: [PATCH] Lower CAP_SYS_NICE from the ambient set
+
+The capabilities wrapper raises CAP_SYS_NICE into the ambient set so it
+is inherited by the wrapped program. However, we don't want it to leak
+into the entire desktop environment.
+
+Lower the capability again at startup so that the kernel will clear it
+on exec.
+---
+ src/main_wayland.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/main_wayland.cpp b/src/main_wayland.cpp
+index 1720e14e7..f2bb446b0 100644
+--- a/src/main_wayland.cpp
++++ b/src/main_wayland.cpp
+@@ -39,7 +39,9 @@
+ #include <QWindow>
+ #include <qplatformdefs.h>
+ 
++#include <linux/capability.h>
+ #include <sched.h>
++#include <sys/prctl.h>
+ #include <sys/resource.h>
+ 
+ #include <iomanip>
+@@ -285,6 +287,7 @@ static QString automaticBackendSelection()
+ 
+ int main(int argc, char *argv[])
+ {
++    prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_LOWER, CAP_SYS_NICE, 0, 0);
+     KWin::Application::setupMalloc();
+     KWin::Application::setupLocalizedString();
+     KWin::gainRealTime();
+-- 
+2.37.1
+

--- a/pkgs/kde/plasma/kwin/default.nix
+++ b/pkgs/kde/plasma/kwin/default.nix
@@ -26,6 +26,7 @@ mkKdeDerivation {
     # The rest are NixOS-specific hacks
     ./0003-plugins-qpa-allow-using-nixos-wrapper.patch
     ./0001-NixOS-Unwrap-executable-name-for-.desktop-search.patch
+    ./0001-Lower-CAP_SYS_NICE-from-the-ambient-set.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

This makes kwin_wayland successfully gain SCHED_RR priority, which significantly improves the rendering lag, ie. cursor movement and desktop animations, under heavy CPU load like on compilation. This was already enabled for plasma5 but is not for plasma6 somehow.

The capability lowering patch is copied unchanged [from plasma5](https://github.com/NixOS/nixpkgs/blob/def8d7e2549f2b2eb54d1115833cd814ffb0ba14/pkgs/desktops/plasma-5/kwin/0001-Lower-CAP_SYS_NICE-from-the-ambient-set.patch). With the patch, it seems that applications launched by global shortcuts having this:
```
$ getpcaps $(pgrep alacritty)
2607: cap_setpcap,cap_sys_nice=i
```

So these capabilities are inheritable but not effective nor permitted. I guess it means nothing? cc the original patch author @alois31

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - Tested with plasma6 desktop environment.
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
