### PR TITLE
olympus{,-unwrapped}: init at 25.04.20.01

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17521,6 +17521,12 @@
     githubId = 28323;
     name = "Peter Simons";
   };
+  petingoso = {
+    email = "petingavasco@protonmail.com";
+    github = "Petingoso";
+    githubId = 92183955;
+    name = "Vasco Petinga";
+  };
   petrkozorezov = {
     email = "petr.kozorezov@gmail.com";
     github = "petrkozorezov";

--- a/pkgs/by-name/ol/olympus-unwrapped/deps.json
+++ b/pkgs/by-name/ol/olympus-unwrapped/deps.json
@@ -1,0 +1,317 @@
+[
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.0",
+    "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "1.1.0",
+    "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
+  },
+  {
+    "pname": "Mono.Cecil",
+    "version": "0.11.4",
+    "hash": "sha256-HrnRgFsOzfqAWw0fUxi/vkzZd8dMn5zueUeLQWA9qvs="
+  },
+  {
+    "pname": "MonoMod",
+    "version": "22.1.4.3",
+    "hash": "sha256-kindD5YUjBWsopvEnmOL4XsldgwE1zRrmMxIh6nDua8="
+  },
+  {
+    "pname": "MonoMod.RuntimeDetour",
+    "version": "22.1.4.3",
+    "hash": "sha256-m7FN3SGME4GRGuc7l5ClCT9W3mXqbbhAJHHpWwYqLi8="
+  },
+  {
+    "pname": "MonoMod.RuntimeDetour.HookGen",
+    "version": "22.1.4.3",
+    "hash": "sha256-DuOnuXQcS63Z/y5s3q5FHZiqWTPgayNpylkzRzl6pE4="
+  },
+  {
+    "pname": "MonoMod.Utils",
+    "version": "22.1.4.3",
+    "hash": "sha256-0KyqozOCC26+z5+Ah35iFvRwrPXvvxDlEq6gLl5lPNU="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.1",
+    "hash": "sha256-K2tSVW4n4beRPzPu3rlVaBEMdGvWSv/3Q1fxaDh4Mjo="
+  },
+  {
+    "pname": "runtime.any.System.Collections",
+    "version": "4.3.0",
+    "hash": "sha256-4PGZqyWhZ6/HCTF2KddDsbmTTjxs2oW79YfkberDZS8="
+  },
+  {
+    "pname": "runtime.any.System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-PaiITTFI2FfPylTEk7DwzfKeiA/g/aooSU1pDcdwWLU="
+  },
+  {
+    "pname": "runtime.any.System.IO",
+    "version": "4.3.0",
+    "hash": "sha256-vej7ySRhyvM3pYh/ITMdC25ivSd0WLZAaIQbYj/6HVE="
+  },
+  {
+    "pname": "runtime.any.System.Reflection",
+    "version": "4.3.0",
+    "hash": "sha256-ns6f++lSA+bi1xXgmW1JkWFb2NaMD+w+YNTfMvyAiQk="
+  },
+  {
+    "pname": "runtime.any.System.Reflection.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-Y2AnhOcJwJVYv7Rp6Jz6ma0fpITFqJW+8rsw106K2X8="
+  },
+  {
+    "pname": "runtime.any.System.Reflection.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-LkPXtiDQM3BcdYkAm5uSNOiz3uF4J45qpxn5aBiqNXQ="
+  },
+  {
+    "pname": "runtime.any.System.Resources.ResourceManager",
+    "version": "4.3.0",
+    "hash": "sha256-9EvnmZslLgLLhJ00o5MWaPuJQlbUFcUF8itGQNVkcQ4="
+  },
+  {
+    "pname": "runtime.any.System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-qwhNXBaJ1DtDkuRacgHwnZmOZ1u9q7N8j0cWOLYOELM="
+  },
+  {
+    "pname": "runtime.any.System.Runtime.Handles",
+    "version": "4.3.0",
+    "hash": "sha256-PQRACwnSUuxgVySO1840KvqCC9F8iI9iTzxNW0RcBS4="
+  },
+  {
+    "pname": "runtime.any.System.Runtime.InteropServices",
+    "version": "4.3.0",
+    "hash": "sha256-Kaw5PnLYIiqWbsoF3VKJhy7pkpoGsUwn4ZDCKscbbzA="
+  },
+  {
+    "pname": "runtime.any.System.Text.Encoding",
+    "version": "4.3.0",
+    "hash": "sha256-Q18B9q26MkWZx68exUfQT30+0PGmpFlDgaF0TnaIGCs="
+  },
+  {
+    "pname": "runtime.any.System.Threading.Tasks",
+    "version": "4.3.0",
+    "hash": "sha256-agdOM0NXupfHbKAQzQT8XgbI9B8hVEh+a/2vqeHctg4="
+  },
+  {
+    "pname": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-LXUPLX3DJxsU1Pd3UwjO1PO9NM2elNEDXeu2Mu/vNps="
+  },
+  {
+    "pname": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-qeSqaUI80+lqw5MK4vMpmO0CZaqrmYktwp6L+vQAb0I="
+  },
+  {
+    "pname": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-SrHqT9wrCBsxILWtaJgGKd6Odmxm8/Mh7Kh0CUkZVzA="
+  },
+  {
+    "pname": "runtime.native.System",
+    "version": "4.3.0",
+    "hash": "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y="
+  },
+  {
+    "pname": "runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-Jy01KhtcCl2wjMpZWH+X3fhHcVn+SyllWFY8zWlz/6I="
+  },
+  {
+    "pname": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-wyv00gdlqf8ckxEdV7E+Ql9hJIoPcmYEuyeWb5Oz3mM="
+  },
+  {
+    "pname": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-zi+b4sCFrA9QBiSGDD7xPV27r3iHGlV99gpyVUjRmc4="
+  },
+  {
+    "pname": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-gybQU6mPgaWV3rBG2dbH6tT3tBq8mgze3PROdsuWnX0="
+  },
+  {
+    "pname": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-VsP72GVveWnGUvS/vjOQLv1U80H2K8nZ4fDAmI61Hm4="
+  },
+  {
+    "pname": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-4yKGa/IrNCKuQ3zaDzILdNPD32bNdy6xr5gdJigyF5g="
+  },
+  {
+    "pname": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-HmdJhhRsiVoOOCcUvAwdjpMRiyuSwdcgEv2j9hxi+Zc="
+  },
+  {
+    "pname": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-pVFUKuPPIx0edQKjzRon3zKq8zhzHEzko/lc01V/jdw="
+  },
+  {
+    "pname": "runtime.unix.System.Diagnostics.Debug",
+    "version": "4.3.0",
+    "hash": "sha256-ReoazscfbGH+R6s6jkg5sIEHWNEvjEoHtIsMbpc7+tI="
+  },
+  {
+    "pname": "runtime.unix.System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-c5tXWhE/fYbJVl9rXs0uHh3pTsg44YD1dJvyOA0WoMs="
+  },
+  {
+    "pname": "runtime.unix.System.Runtime.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-l8S9gt6dk3qYG6HYonHtdlYtBKyPb29uQ6NDjmrt3V4="
+  },
+  {
+    "pname": "System.Collections",
+    "version": "4.3.0",
+    "hash": "sha256-afY7VUtD6w/5mYqrce8kQrvDIfS2GXDINDh73IjxJKc="
+  },
+  {
+    "pname": "System.Collections.NonGeneric",
+    "version": "4.3.0",
+    "hash": "sha256-8/yZmD4jjvq7m68SPkJZLBQ79jOTOyT5lyzX4SCYAx8="
+  },
+  {
+    "pname": "System.Collections.Specialized",
+    "version": "4.3.0",
+    "hash": "sha256-QNg0JJNx+zXMQ26MJRPzH7THdtqjrNtGLUgaR1SdvOk="
+  },
+  {
+    "pname": "System.ComponentModel",
+    "version": "4.3.0",
+    "hash": "sha256-i00uujMO4JEDIEPKLmdLY3QJ6vdSpw6Gh9oOzkFYBiU="
+  },
+  {
+    "pname": "System.ComponentModel.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-IOMJleuIBppmP4ECB3uftbdcgL7CCd56+oAD/Sqrbus="
+  },
+  {
+    "pname": "System.ComponentModel.TypeConverter",
+    "version": "4.3.0",
+    "hash": "sha256-PSDiPYt8PgTdTUBz+GH6lHCaM1YgfObneHnZsc8Fz54="
+  },
+  {
+    "pname": "System.Diagnostics.Debug",
+    "version": "4.3.0",
+    "hash": "sha256-fkA79SjPbSeiEcrbbUsb70u9B7wqbsdM9s1LnoKj0gM="
+  },
+  {
+    "pname": "System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-caL0pRmFSEsaoeZeWN5BTQtGrAtaQPwFi8YOZPZG5rI="
+  },
+  {
+    "pname": "System.Globalization.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-mmJWA27T0GRVuFP9/sj+4TrR4GJWrzNIk2PDrbr7RQk="
+  },
+  {
+    "pname": "System.IO",
+    "version": "4.3.0",
+    "hash": "sha256-ruynQHekFP5wPrDiVyhNiRIXeZ/I9NpjK5pU+HPDiRY="
+  },
+  {
+    "pname": "System.IO.FileSystem.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-LMnfg8Vwavs9cMnq9nNH8IWtAtSfk0/Fy4s4Rt9r1kg="
+  },
+  {
+    "pname": "System.Linq",
+    "version": "4.3.0",
+    "hash": "sha256-R5uiSL3l6a3XrXSSL6jz+q/PcyVQzEAByiuXZNSqD/A="
+  },
+  {
+    "pname": "System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM="
+  },
+  {
+    "pname": "System.Reflection",
+    "version": "4.3.0",
+    "hash": "sha256-NQSZRpZLvtPWDlvmMIdGxcVuyUnw92ZURo0hXsEshXY="
+  },
+  {
+    "pname": "System.Reflection.Emit.ILGeneration",
+    "version": "4.7.0",
+    "hash": "sha256-GUnQeGo/DtvZVQpFnESGq7lJcjB30/KnDY7Kd2G/ElE="
+  },
+  {
+    "pname": "System.Reflection.Emit.Lightweight",
+    "version": "4.7.0",
+    "hash": "sha256-V0Wz/UUoNIHdTGS9e1TR89u58zJjo/wPUWw6VaVyclU="
+  },
+  {
+    "pname": "System.Reflection.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-mMOCYzUenjd4rWIfq7zIX9PFYk/daUyF0A8l1hbydAk="
+  },
+  {
+    "pname": "System.Reflection.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-5ogwWB4vlQTl3jjk1xjniG2ozbFIjZTL9ug0usZQuBM="
+  },
+  {
+    "pname": "System.Reflection.TypeExtensions",
+    "version": "4.7.0",
+    "hash": "sha256-GEtCGXwtOnkYejSV+Tfl+DqyGq5jTUaVyL9eMupMHBM="
+  },
+  {
+    "pname": "System.Resources.ResourceManager",
+    "version": "4.3.0",
+    "hash": "sha256-idiOD93xbbrbwwSnD4mORA9RYi/D/U48eRUsn/WnWGo="
+  },
+  {
+    "pname": "System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg="
+  },
+  {
+    "pname": "System.Runtime.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-wLDHmozr84v1W2zYCWYxxj0FR0JDYHSVRaRuDm0bd/o="
+  },
+  {
+    "pname": "System.Runtime.Handles",
+    "version": "4.3.0",
+    "hash": "sha256-KJ5aXoGpB56Y6+iepBkdpx/AfaJDAitx4vrkLqR7gms="
+  },
+  {
+    "pname": "System.Runtime.InteropServices",
+    "version": "4.3.0",
+    "hash": "sha256-8sDH+WUJfCR+7e4nfpftj/+lstEiZixWUBueR2zmHgI="
+  },
+  {
+    "pname": "System.Text.Encoding",
+    "version": "4.3.0",
+    "hash": "sha256-GctHVGLZAa/rqkBNhsBGnsiWdKyv6VDubYpGkuOkBLg="
+  },
+  {
+    "pname": "System.Threading",
+    "version": "4.3.0",
+    "hash": "sha256-ZDQ3dR4pzVwmaqBg4hacZaVenQ/3yAF/uV7BXZXjiWc="
+  },
+  {
+    "pname": "System.Threading.Tasks",
+    "version": "4.3.0",
+    "hash": "sha256-Z5rXfJ1EXp3G32IKZGiZ6koMjRu0n8C1NGrwpdIen4w="
+  },
+  {
+    "pname": "YamlDotNet",
+    "version": "9.1.0",
+    "hash": "sha256-WbMPOLkbyN+SdMrBYuaXV2qKB+bLTV+6RdSFSy/iljk="
+  }
+]

--- a/pkgs/by-name/ol/olympus-unwrapped/package.nix
+++ b/pkgs/by-name/ol/olympus-unwrapped/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchzip,
+  buildDotnetModule,
+  dotnetCorePackages,
+  luajitPackages,
+  sqlite,
+  libarchive,
+  curl,
+  love,
+  xdg-utils,
+}:
+let
+  lua_cpath =
+    with luajitPackages;
+    lib.concatMapStringsSep ";" getLuaCPath [
+      (buildLuarocksPackage {
+        pname = "lsqlite3";
+        version = "0.9.6-1";
+        src = fetchzip {
+          url = "http://lua.sqlite.org/home/zip/lsqlite3_v096.zip";
+          hash = "sha256-Mq409A3X9/OS7IPI/KlULR6ZihqnYKk/mS/W/2yrGBg=";
+        };
+        buildInputs = [ sqlite.dev ];
+      })
+
+      lua-subprocess
+      nfd
+    ];
+
+  phome = "$out/lib/olympus";
+  # The following variables are to be updated by the update script.
+  version = "25.04.20.01";
+  buildId = "4758"; # IMPORTANT: This line is matched with regex in update.sh.
+  rev = "10e01bf182e51d1fc2b6060622108a1fb98ae7b7";
+in
+buildDotnetModule {
+  pname = "olympus-unwrapped";
+  inherit version;
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "EverestAPI";
+    repo = "Olympus";
+    fetchSubmodules = true; # Required. See upstream's README.
+    hash = "sha256-7Xdd6AdDpHQUmQ3ogEyir/OQwvOcVDMtweE3D/v4uuQ=";
+  };
+
+  nativeBuildInputs = [
+    libarchive # To create the .love file (zip format).
+  ];
+
+  nugetDeps = ./deps.json;
+  projectFile = "sharp/Olympus.Sharp.csproj";
+  executables = [ ];
+  installPath = "${placeholder "out"}/lib/olympus/sharp";
+
+  # See the 'Dist: Update src/version.txt' step in azure-pipelines.yml from upstream.
+  preConfigure = ''
+    echo ${version}-nixos-${buildId}-${builtins.substring 0 5 rev} > src/version.txt
+  '';
+
+  # The script find-love is hacked to use love from nixpkgs.
+  # It is used to launch Loenn from Olympus.
+  # I assume --fused is so saves are properly made (https://love2d.org/wiki/love.filesystem).
+  preInstall = ''
+    mkdir -p ${phome}
+    makeWrapper ${lib.getExe love} ${phome}/find-love \
+      --add-flags "--fused"
+
+    install -Dm755 suppress-output.sh ${phome}/suppress-output
+
+    mkdir -p $out/bin
+    makeWrapper ${phome}/find-love $out/bin/olympus \
+      --prefix LUA_CPATH ";" "${lua_cpath}" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ curl ]}" \
+      --suffix PATH : "${lib.makeBinPath [ xdg-utils ]}" \
+      --add-flags ${phome}/olympus.love \
+      --set DOTNET_ROOT ${dotnetCorePackages.runtime_8_0}/share/dotnet
+
+    bsdtar --format zip --strip-components 1 -cf ${phome}/olympus.love src
+  '';
+
+  postInstall = ''
+    install -Dm644 lib-linux/olympus.desktop $out/share/applications/olympus.desktop
+    install -Dm644 src/data/icon.png $out/share/icons/hicolor/128x128/apps/olympus.png
+    install -Dm644 LICENSE $out/share/licenses/olympus/LICENSE
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Cross-platform GUI Everest installer and Celeste mod manager";
+    homepage = "https://github.com/EverestAPI/Olympus";
+    downloadPage = "https://everestapi.github.io/#olympus";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      ulysseszhan
+      petingoso
+    ];
+    mainProgram = "olympus";
+    platforms = lib.platforms.unix;
+    badPlatforms = lib.platforms.aarch; # Celeste doesn't support aarch in the first place
+  };
+}

--- a/pkgs/by-name/ol/olympus-unwrapped/update.sh
+++ b/pkgs/by-name/ol/olympus-unwrapped/update.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+
+set -eu -o pipefail
+
+attr=olympus-unwrapped
+nix_file=$(nix-instantiate --eval --strict -A "$attr.meta.position" | sed -re 's/^"(.*):[0-9]+"$/\1/')
+
+api() {
+  curl -s "https://dev.azure.com/EverestAPI/Olympus/_apis/$1?api-version=7.1"
+}
+
+pipeline_id=$(api pipelines | jq -r '
+  .value
+  | map(select(.name == "EverestAPI.Olympus"))
+  | .[0].id
+')
+
+run_id=$(api pipelines/$pipeline_id/runs | jq -r '
+  .value
+  | map(select(.result == "succeeded"))
+  | max_by(.finishedDate)
+  | .id
+')
+sed -i 's|buildId\s*=\s*".*";|buildId = "'$run_id'";|' $nix_file
+
+run=$(api pipelines/$pipeline_id/runs/$run_id)
+commit=$(echo "$run" | jq -r '.resources.repositories.self.version')
+version=$(echo "$run" | jq -r '.name')
+update-source-version $attr $version --rev=$commit
+
+"$(nix-build --attr $attr.fetch-deps --no-out-link)"

--- a/pkgs/by-name/ol/olympus/package.nix
+++ b/pkgs/by-name/ol/olympus/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  makeWrapper,
+  olympus-unwrapped,
+  symlinkJoin,
+  buildFHSEnv,
+  writeShellScript,
+  # These need overriding if you launch Celeste/Loenn/MiniInstaller from Olympus.
+  # Some examples:
+  # - null: Use default wrapper.
+  # - "": Do not use wrapper.
+  # - steam-run: Use steam-run.
+  # - "steam-run": Use steam-run command available from PATH.
+  # - writeShellScriptBin { ... }: Use a custom script.
+  # - ./my-wrapper.sh: Use a custom script.
+  # In any case, it can be overridden at runtime by OLYMPUS_{CELESTE,LOENN,MINIINSTALLER}_WRAPPER.
+  celesteWrapper ? null,
+  loennWrapper ? null,
+  miniinstallerWrapper ? null,
+  skipHandlerCheck ? false, # whether to skip olympus xdg-mime check, true will override it
+}:
+let
+
+  wrapper-to-env =
+    wrapper:
+    if lib.isDerivation wrapper then
+      lib.getExe wrapper
+    else if wrapper != null then
+      wrapper
+    else
+      "";
+
+  # When installing Everest, Olympus uses MiniInstaller, which is dynamically linked.
+  miniinstaller-fhs = buildFHSEnv {
+    pname = "olympus-miniinstaller-fhs";
+    version = "1.0.0"; # remains constant, just to prevent complains
+    targetPkgs =
+      pkgs:
+      (with pkgs; [
+        icu
+        openssl
+        dotnet-runtime # Without this, MiniInstaller will install dotnet itself.
+      ]);
+  };
+
+  miniinstaller-wrapper =
+    if miniinstallerWrapper == null then
+      (writeShellScript "miniinstaller-wrapper" "exec ${lib.getExe miniinstaller-fhs} -c \"$@\"")
+    else
+      (wrapper-to-env miniinstallerWrapper);
+
+in
+symlinkJoin {
+
+  inherit (olympus-unwrapped) version meta;
+  pname = "olympus";
+
+  paths = [
+    olympus-unwrapped
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram $out/bin/olympus \
+      --set OLYMPUS_CELESTE_WRAPPER "${wrapper-to-env celesteWrapper}" \
+      --set OLYMPUS_LOENN_WRAPPER "${wrapper-to-env loennWrapper}"  \
+      --set OLYMPUS_MINIINSTALLER_WRAPPER "${miniinstaller-wrapper}" \
+      --set OLYMPUS_SKIP_SCHEME_HANDLER_CHECK "${if skipHandlerCheck then "1" else "0"}"
+  '';
+}


### PR DESCRIPTION
This is an attempt to package [Olympus](https://everestapi.github.io/), a GUI for installing Everest and managing Celeste mods.
This is based on this [draft](https://github.com/NixOS/nixpkgs/pull/295258), with the original authors permission.

It is able to launch from the app but for proper use depends on overriding celesteWrapper. See package.nix for details.

I only have to note that it has a popup complaining about finishing the installation but that's due to xdg-mime x-scheme-handler/everest not being set.

Needs [this](https://github.com/NixOS/nixpkgs/pull/309026) which was merged.

Finally, [Lönn](https://github.com/CelestialCartographers/Loenn) works as expected, being the installation managed by the program.

Ahorn is deprecated(in favor of Loenn) and it crashes over trying to run dynamic executables, wontfix.

fixes #162887
Closes #295258

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
