### PR TITLE
pytr: init at 0.1.9-unstable-2024-04-01

### DIFF
--- a/pkgs/by-name/py/pytr/package.nix
+++ b/pkgs/by-name/py/pytr/package.nix
@@ -1,0 +1,36 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+}:
+python3Packages.buildPythonApplication {
+  pname = "pytr";
+  version = "0.1.9-unstable-2024-04-01";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "marzzzello";
+    repo = "pytr";
+    rev = "843ba364fb61116effe230a5a65a4116e03e1f34";
+    hash = "sha256-GQHNk1BaJLLse8eEELwzgJ/c7f1cpbYJFIkWSaT2yhU=";
+  };
+
+  dependencies = with python3Packages; [
+    certifi
+    coloredlogs
+    ecdsa
+    packaging
+    pathvalidate
+    pygments
+    requests-futures
+    shtab
+    websockets
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/marzzzello/pytr";
+    description = "Use Trade Republic in terminal and mass download all documents";
+    maintainers = with maintainers; [ juliusrickert ];
+    platforms = with platforms; linux ++ darwin;
+  };
+}
+


### PR DESCRIPTION
## Description of changes

_pytr_ is a CLI to mass-download documents from the broker _Trade Republic_.

https://github.com/marzzzello/pytr

I added the version based on the latest commit on the `master` branch as there are [important additions and fixes](https://github.com/marzzzello/pytr/compare/0.1.9...843ba364fb61116effe230a5a65a4116e03e1f34) that are not released (yet). In general, the project [seems to encourage](https://github.com/marzzzello/pytr/blob/843ba364fb61116effe230a5a65a4116e03e1f34/README.md#installation) using the latest version of the `master` branch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
