### PR TITLE
mysql84: init at 8.4.0

### DIFF
--- a/pkgs/by-name/my/mysql84/no-force-outline-atomics.patch
+++ b/pkgs/by-name/my/mysql84/no-force-outline-atomics.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 727d66011f9..acae1aada57 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1338,19 +1338,6 @@ IF(UNIX AND MY_COMPILER_IS_GNU_OR_CLANG
+   ENDIF()
+ ENDIF()
+ 
+-# For aarch64 some sub-architectures support LSE atomics and some don't. Thus,
+-# compiling for the common denominator (-march=armv8-a) means LSE is not used.
+-# The -moutline-atomics switch enables run-time detection of LSE support.
+-# There are compilers (gcc 9.3.1 for example) which support this switch, but
+-# do not enable it by default, even though it seems to help. So, we force it.
+-IF(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+-  MY_CHECK_CXX_COMPILER_FLAG( "-moutline-atomics" HAVE_OUTLINE_ATOMICS)
+-  IF(HAVE_OUTLINE_ATOMICS)
+-    STRING_APPEND(CMAKE_C_FLAGS   " -moutline-atomics")
+-    STRING_APPEND(CMAKE_CXX_FLAGS " -moutline-atomics")
+-  ENDIF()
+-ENDIF()
+-
+ IF(LINUX)
+   OPTION(LINK_RANDOMIZE "Randomize the order of all symbols in the binary" OFF)
+   SET(LINK_RANDOMIZE_SEED "mysql"

--- a/pkgs/by-name/my/mysql84/package.nix
+++ b/pkgs/by-name/my/mysql84/package.nix
@@ -1,0 +1,78 @@
+{ lib, stdenv, fetchurl, bison, cmake, pkg-config
+, icu, libedit, libevent, lz4, ncurses, openssl, protobuf_21, re2, readline, zlib, zstd, libfido2
+, darwin, numactl, libtirpc, rpcsvc-proto, curl
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mysql";
+  version = "8.4.0";
+
+  src = fetchurl {
+    url = "https://dev.mysql.com/get/Downloads/MySQL-${lib.versions.majorMinor finalAttrs.version}/mysql-${finalAttrs.version}.tar.gz";
+    hash = "sha256-R6VDP83WOduDa5nhtUWcK4E8va0j/ytd1K0n95K6kY4=";
+  };
+
+  nativeBuildInputs = [ bison cmake pkg-config ]
+    ++ lib.optionals (!stdenv.isDarwin) [ rpcsvc-proto ];
+
+  patches = [
+    ./no-force-outline-atomics.patch # Do not force compilers to turn on -moutline-atomics switch
+  ];
+
+  ## NOTE: MySQL upstream frequently twiddles the invocations of libtool. When updating, you might proactively grep for libtool references.
+  postPatch = ''
+    substituteInPlace cmake/libutils.cmake --replace /usr/bin/libtool libtool
+    substituteInPlace cmake/os/Darwin.cmake --replace /usr/bin/libtool libtool
+  '';
+
+  buildInputs = [
+    (curl.override { inherit openssl; }) icu libedit libevent lz4 ncurses openssl protobuf_21 re2 readline zlib
+    zstd libfido2
+  ] ++ lib.optionals stdenv.isLinux [
+    numactl libtirpc
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.cctools darwin.apple_sdk.frameworks.CoreServices darwin.developer_cmds darwin.DarwinTools
+  ];
+
+  outputs = [ "out" "static" ];
+
+  cmakeFlags = [
+    "-DFORCE_UNSUPPORTED_COMPILER=1" # To configure on Darwin.
+    "-DWITH_ROUTER=OFF" # It may be packaged separately.
+    "-DWITH_SYSTEM_LIBS=ON"
+    "-DWITH_UNIT_TESTS=OFF"
+    "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
+    "-DMYSQL_DATADIR=/var/lib/mysql"
+    "-DINSTALL_INFODIR=share/mysql/docs"
+    "-DINSTALL_MANDIR=share/man"
+    "-DINSTALL_PLUGINDIR=lib/mysql/plugin"
+    "-DINSTALL_INCLUDEDIR=include/mysql"
+    "-DINSTALL_DOCREADMEDIR=share/mysql"
+    "-DINSTALL_SUPPORTFILESDIR=share/mysql"
+    "-DINSTALL_MYSQLSHAREDIR=share/mysql"
+    "-DINSTALL_MYSQLTESTDIR="
+    "-DINSTALL_DOCDIR=share/mysql/docs"
+    "-DINSTALL_SHAREDIR=share/mysql"
+  ];
+
+  postInstall = ''
+    moveToOutput "lib/*.a" $static
+    so=${stdenv.hostPlatform.extensions.sharedLibrary}
+    ln -s libmysqlclient$so $out/lib/libmysqlclient_r$so
+  '';
+
+  passthru = {
+    client = finalAttrs.finalPackage;
+    connector-c = finalAttrs.finalPackage;
+    server = finalAttrs.finalPackage;
+    mysqlVersion = lib.versions.majorMinor finalAttrs.version;
+  };
+
+  meta = with lib; {
+    homepage = "https://www.mysql.com/";
+    description = "The world's most popular open source database";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ orivej shyim ];
+    platforms = platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

MySQL 8.4 new major is out as LTS. 

## Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
