### PR TITLE
treewide: Fix some unstableGitUpdater users

### DIFF
--- a/pkgs/data/documentation/scheme-manpages/default.nix
+++ b/pkgs/data/documentation/scheme-manpages/default.nix
@@ -2,7 +2,7 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "scheme-manpages";
-  version = "unstable-2024-02-11";
+  version = "0-unstable-2024-02-11";
 
   src = fetchFromGitHub {
     owner = "schemedoc";

--- a/pkgs/data/themes/dracula-theme/default.nix
+++ b/pkgs/data/themes/dracula-theme/default.nix
@@ -2,7 +2,7 @@
 
 let
   themeName = "Dracula";
-  version = "unstable-2024-04-24";
+  version = "4.0.0-unstable-2024-04-24";
 in
 stdenvNoCC.mkDerivation {
   pname = "dracula-theme";
@@ -38,7 +38,9 @@ stdenvNoCC.mkDerivation {
     runHook postInstall
   '';
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
 
   meta = with lib; {
     description = "Dracula variant of the Ant theme";

--- a/pkgs/data/themes/material-kwin-decoration/default.nix
+++ b/pkgs/data/themes/material-kwin-decoration/default.nix
@@ -17,7 +17,7 @@
 
 mkDerivation rec {
   pname = "material-kwin-decoration";
-  version = "unstable-2023-01-15";
+  version = "7-unstable-2023-01-15";
 
   src = fetchFromGitHub {
     owner = "Zren";
@@ -47,7 +47,9 @@ mkDerivation rec {
   ];
 
   passthru = {
-    updateScript = unstableGitUpdater { };
+    updateScript = unstableGitUpdater {
+      tagPrefix = "v";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/data/themes/nixos-bgrt-plymouth/default.nix
+++ b/pkgs/data/themes/nixos-bgrt-plymouth/default.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   name = "nixos-bgrt-plymouth";
-  version = "unstable-2023-03-10";
+  version = "0-unstable-2023-03-10";
 
   src = fetchFromGitHub {
     repo = "plymouth-theme-nixos-bgrt";

--- a/pkgs/desktops/pantheon/desktop/file-roller-contract/default.nix
+++ b/pkgs/desktops/pantheon/desktop/file-roller-contract/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "file-roller-contract";
-  version = "unstable-2021-02-22";
+  version = "0-unstable-2021-02-22";
 
   src = fetchFromGitHub {
     owner = "elementary";

--- a/pkgs/desktops/pantheon/third-party/wingpanel-indicator-ayatana/default.nix
+++ b/pkgs/desktops/pantheon/third-party/wingpanel-indicator-ayatana/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation rec {
   pname = "wingpanel-indicator-ayatana";
-  version = "unstable-2023-04-18";
+  version = "2.0.7-unstable-2023-04-18";
 
   src = fetchFromGitHub {
     owner = "Lafydev";

--- a/pkgs/development/compilers/c0/default.nix
+++ b/pkgs/development/compilers/c0/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation rec {
   pname = "c0";
-  version = "unstable-2023-09-05";
+  version = "0-unstable-2023-09-05";
 
   src = fetchFromBitbucket {
     owner = "c0-lang";

--- a/pkgs/development/compilers/open-watcom/v2.nix
+++ b/pkgs/development/compilers/open-watcom/v2.nix
@@ -13,7 +13,7 @@
 stdenv.mkDerivation rec {
   pname = "${passthru.prettyName}-unwrapped";
   # nixpkgs-update: no auto update
-  version = "unstable-2023-11-24";
+  version = "0-unstable-2023-11-24";
 
   src = fetchFromGitHub {
     owner = "open-watcom";
@@ -89,6 +89,8 @@ stdenv.mkDerivation rec {
     prettyName = "open-watcom-v2";
     updateScript = unstableGitUpdater {
       url = "https://github.com/open-watcom/open-watcom-v2.git";
+      # no numerical releases, monthly "YYYY-MM-DD-Build" tags and daily "Current-build", "Last-CI-build" & "Coverity-scan" retagging
+      hardcodeZeroVersion = true;
     };
   };
 

--- a/pkgs/development/compilers/zig/shell-completions.nix
+++ b/pkgs/development/compilers/zig/shell-completions.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zig-shell-completions";
-  version = "unstable-2023-11-18";
+  version = "0-unstable-2023-11-18";
 
   src = fetchFromGitHub {
     owner = "ziglang";

--- a/pkgs/development/interpreters/femtolisp/default.nix
+++ b/pkgs/development/interpreters/femtolisp/default.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "femtolisp";
-  version = "unstable-2023-07-12";
+  version = "0-unstable-2023-07-12";
 
   src = fetchFromSourcehut {
     owner = "~ft";

--- a/pkgs/development/interpreters/nelua/default.nix
+++ b/pkgs/development/interpreters/nelua/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "nelua";
-  version = "unstable-2024-04-20";
+  version = "0-unstable-2024-04-20";
 
   src = fetchFromGitHub {
     owner = "edubart";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace lualib/nelua/version.lua \
       --replace "NELUA_GIT_HASH = nil" "NELUA_GIT_HASH = '${src.rev}'" \
-      --replace "NELUA_GIT_DATE = nil" "NELUA_GIT_DATE = '${lib.removePrefix "unstable-" version}'"
+      --replace "NELUA_GIT_DATE = nil" "NELUA_GIT_DATE = '${lib.removePrefix "0-unstable-" version}'"
   '';
 
   makeFlags = [ "PREFIX=$(out)" ];
@@ -23,7 +23,10 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = unstableGitUpdater {
+    # no releases, only stale "latest" tag
+    hardcodeZeroVersion = true;
+  };
 
   meta = with lib; {
     description = "Minimal, efficient, statically-typed and meta-programmable systems programming language heavily inspired by Lua, which compiles to C and native code";

--- a/pkgs/games/doom-ports/slade/git.nix
+++ b/pkgs/games/doom-ports/slade/git.nix
@@ -20,7 +20,7 @@
 
 stdenv.mkDerivation rec {
   pname = "slade";
-  version = "unstable-2023-09-30";
+  version = "3.2.4-unstable-2023-09-30";
 
   src = fetchFromGitHub {
     owner = "sirjuddington";

--- a/pkgs/games/nile/default.nix
+++ b/pkgs/games/nile/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonApplication rec {
   pname = "nile";
-  version = "unstable-2024-03-09";
+  version = "1.0.2-unstable-2024-03-09";
   format = "pyproject";
 
   src = fetchFromGitHub {
@@ -56,5 +56,7 @@ buildPythonApplication rec {
     maintainers = with maintainers; [ aidalgol ];
   };
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
 }

--- a/pkgs/servers/bloat/default.nix
+++ b/pkgs/servers/bloat/default.nix
@@ -6,7 +6,7 @@
 
 buildGoModule {
   pname = "bloat";
-  version = "unstable-2024-02-12";
+  version = "0-unstable-2024-02-12";
 
   src = fetchgit {
     url = "git://git.freesoftwareextremist.com/bloat";

--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "klipper";
-  version = "unstable-2024-04-20";
+  version = "0.12.0-unstable-2024-04-20";
 
   src = fetchFromGitHub {
     owner = "KevinOConnor";
@@ -63,7 +63,10 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = unstableGitUpdater { url = meta.homepage; };
+  passthru.updateScript = unstableGitUpdater {
+    url = meta.homepage;
+    tagPrefix = "v";
+  };
 
   meta = with lib; {
     description = "The Klipper 3D printer firmware";

--- a/pkgs/servers/moonraker/default.nix
+++ b/pkgs/servers/moonraker/default.nix
@@ -24,7 +24,7 @@ let
   );
 in stdenvNoCC.mkDerivation rec {
   pname = "moonraker";
-  version = "unstable-2023-12-27";
+  version = "0.8.0-unstable-2023-12-27";
 
   src = fetchFromGitHub {
     owner = "Arksine";
@@ -44,7 +44,10 @@ in stdenvNoCC.mkDerivation rec {
   '';
 
   passthru = {
-    updateScript = unstableGitUpdater { url = meta.homepage; };
+    updateScript = unstableGitUpdater {
+      url = meta.homepage;
+      tagPrefix = "v";
+    };
     tests.moonraker = nixosTests.moonraker;
   };
 

--- a/pkgs/servers/sql/postgresql/ext/pgjwt.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgjwt.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
   pname = "pgjwt";
-  version = "unstable-2023-03-02";
+  version = "0-unstable-2023-03-02";
 
   src = fetchFromGitHub {
     owner  = "michelp";

--- a/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   pname = "tds_fdw";
   # Move to stable version when it's released.
-  version = "unstable-2024-02-10";
+  version = "2.0.3-unstable-2024-02-10";
 
   buildInputs = [ postgresql freetds ];
 
@@ -21,7 +21,9 @@ stdenv.mkDerivation rec {
     install -D tds_fdw.control -t $out/share/postgresql/extension
   '';
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
 
   meta = with lib; {
     description = "A PostgreSQL foreign data wrapper to connect to TDS databases (Sybase and Microsoft SQL Server)";

--- a/pkgs/shells/nushell/plugins/net.nix
+++ b/pkgs/shells/nushell/plugins/net.nix
@@ -9,7 +9,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "nu-plugin-net";
-  version = "unstable-2024-04-05";
+  version = "0-unstable-2024-04-05";
 
   src = fetchFromGitHub {
     owner = "fennewald";
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage {
     hash = "sha256-uKLYTRR2tThSvwWbvEePOLZ9ehNPfCYruZxTKSIxpEA=";
   };
 
-  cargoHash = "sha256-2A9RalZhXigLq/6w738G6PnkV3FyK+3HHXPDQRHTIm0=";
+  cargoHash = "sha256-BsCOej31vfTf+Wca4+AjxkhXz6wpMRFJmGBsUqOj2U0=";
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook

--- a/pkgs/shells/rc-9front/default.nix
+++ b/pkgs/shells/rc-9front/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation {
   pname = "rc-9front";
-  version = "unstable-2022-11-01";
+  version = "0-unstable-2022-11-01";
 
   src = fetchFrom9Front {
     domain = "shithub.us";

--- a/pkgs/shells/zsh/zsh-prezto/default.nix
+++ b/pkgs/shells/zsh/zsh-prezto/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "zsh-prezto";
-  version = "unstable-2024-04-15";
+  version = "0-unstable-2024-04-15";
 
   src = fetchFromGitHub {
     owner = "sorin-ionescu";


### PR DESCRIPTION
## Description of changes

#280501 now makes `unstableGitUpdater` produce versions that match our desired unstable version schema. Start fixing the versions of packages that use it, and their `unstableGitUpdater` arguments as needed.

Tackling abunch of mostly self-contained packages here. The only directory left after this from the initial treewide PR is `pkgs/development/libraries`, where I expect the amount of rebuilds to shoot up abit. Checked running the update script of everything, which results in either the same version & revs as corrected here, or newer versions.

I *think* the `klipper-*` failures are also present on [Hydra](https://hydra.nixos.org/eval/1806092?filter=klipper&compare=1806084), though the only information there is that the output limit was exceeded? Failure from the review reproduces locally on master at least: [klipper-firmware-mcu-0.12.0-unstable-2024-04-20.log](https://github.com/NixOS/nixpkgs/files/15213746/klipper-firmware-mcu-0.12.0-unstable-2024-04-20.log)

(If you wish to run the review locally, then I *really* recommend excluding `open-watcom-v2*` from it. It's a very slow, single-core build with a very low impact. As its package maintainer feel free to not waste your time on it :slightly_smiling_face:)

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>c0</li>
  </ul>
</details>
<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>klipper-firmware</li>
    <li>klipper-flash</li>
  </ul>
</details>
<details>
  <summary>31 packages built:</summary>
  <ul>
    <li>bloat</li>
    <li>dracula-theme</li>
    <li>femtolisp</li>
    <li>heroic</li>
    <li>heroic-unwrapped</li>
    <li>klipper</li>
    <li>material-kwin-decoration</li>
    <li>moonraker</li>
    <li>nelua</li>
    <li>nile</li>
    <li>nile.dist</li>
    <li>nixos-bgrt-plymouth</li>
    <li>nushellPlugins.net</li>
    <li>pantheon.file-roller-contract</li>
    <li>postgresql12JitPackages.pgjwt (postgresql13JitPackages.pgjwt ,postgresql14JitPackages.pgjwt ,postgresql15JitPackages.pgjwt ,postgresql16JitPackages.pgjwt)</li>
    <li>postgresql12JitPackages.tds_fdw</li>
    <li>postgresql12Packages.pgjwt (postgresql13Packages.pgjwt ,postgresql14Packages.pgjwt ,postgresql15Packages.pgjwt ,postgresql16Packages.pgjwt)</li>
    <li>postgresql12Packages.tds_fdw</li>
    <li>postgresql13JitPackages.tds_fdw</li>
    <li>postgresql13Packages.tds_fdw</li>
    <li>postgresql14JitPackages.tds_fdw</li>
    <li>postgresql14Packages.tds_fdw</li>
    <li>postgresql15JitPackages.tds_fdw</li>
    <li>postgresql15Packages.tds_fdw</li>
    <li>postgresql16JitPackages.tds_fdw</li>
    <li>postgresql16Packages.tds_fdw</li>
    <li>rc-9front</li>
    <li>scheme-manpages</li>
    <li>wingpanel-indicator-ayatana</li>
    <li>zig-shell-completions</li>
    <li>zsh-prezto</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
