### PR TITLE
llvmPackages_{17,18,git}.compiler-rt: revert to dynamic checks on older SDKs

### DIFF
--- a/pkgs/development/compilers/llvm/17/default.nix
+++ b/pkgs/development/compilers/llvm/17/default.nix
@@ -358,7 +358,23 @@ in let
         ../common/compiler-rt/darwin-plistbuddy-workaround.patch
         # See: https://github.com/NixOS/nixpkgs/pull/194634#discussion_r999829893
         # ../common/compiler-rt/armv7l-15.patch
-      ];
+      ]
+      ++ lib.optionals
+        (
+          stdenv.hostPlatform.isDarwin
+          && lib.versionAtLeast release_version "17"
+          && lib.versionOlder stdenv.hostPlatform.darwinSdkVersion "10.15"
+        )
+        [
+          # As of LLVM 17, compiler-rt weakly links `_availability_version_check` instead of looking it up at runtime.
+          # That causes link failures on older SDKs, so revert to using `dlsym` when the SDK isn’t new enough.
+          (fetchpatch {
+            url = "https://github.com/llvm/llvm-project/commit/b653a2823fe4b4c9c6d85cfe119f31d8e70c2fa0.patch";
+            hash = "sha256-OknHXQGalj7400ESm9wjmKFohpLyYmbwUdNCiQsp9sY=";
+            stripLen = 1;
+            revert = true;
+          })
+        ];
       inherit llvm_meta;
       stdenv = if stdenv.hostPlatform.useLLVM or false || (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isStatic)
                then overrideCC stdenv buildLlvmTools.clangNoCompilerRtWithLibc
@@ -378,7 +394,23 @@ in let
         ../common/compiler-rt/darwin-plistbuddy-workaround.patch
         # See: https://github.com/NixOS/nixpkgs/pull/194634#discussion_r999829893
         # ../common/compiler-rt/armv7l-15.patch
-      ];
+      ]
+      ++ lib.optionals
+        (
+          stdenv.hostPlatform.isDarwin
+          && lib.versionAtLeast release_version "17"
+          && lib.versionOlder stdenv.hostPlatform.darwinSdkVersion "10.15"
+        )
+        [
+          # As of LLVM 17, compiler-rt weakly links `_availability_version_check` instead of looking it up at runtime.
+          # That causes link failures on older SDKs, so revert to using `dlsym` when the SDK isn’t new enough.
+          (fetchpatch {
+            url = "https://github.com/llvm/llvm-project/commit/b653a2823fe4b4c9c6d85cfe119f31d8e70c2fa0.patch";
+            hash = "sha256-OknHXQGalj7400ESm9wjmKFohpLyYmbwUdNCiQsp9sY=";
+            stripLen = 1;
+            revert = true;
+          })
+        ];
       inherit llvm_meta;
       stdenv = if stdenv.hostPlatform.useLLVM or false
                then overrideCC stdenv buildLlvmTools.clangNoCompilerRt

--- a/pkgs/development/compilers/llvm/18/default.nix
+++ b/pkgs/development/compilers/llvm/18/default.nix
@@ -1,6 +1,6 @@
 { lowPrio, newScope, pkgs, lib, stdenv, cmake, ninja
 , preLibcCrossHeaders
-, libxml2, python3, fetchFromGitHub, substituteAll, overrideCC, wrapCCWith, wrapBintoolsWith
+, libxml2, python3, fetchFromGitHub, fetchpatch, substituteAll, overrideCC, wrapCCWith, wrapBintoolsWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
 , targetLlvm
@@ -354,7 +354,23 @@ in let
         ../common/compiler-rt/darwin-plistbuddy-workaround.patch
         # See: https://github.com/NixOS/nixpkgs/pull/194634#discussion_r999829893
         # ../common/compiler-rt/armv7l-15.patch
-      ];
+      ]
+      ++ lib.optionals
+        (
+          stdenv.hostPlatform.isDarwin
+          && lib.versionAtLeast release_version "17"
+          && lib.versionOlder stdenv.hostPlatform.darwinSdkVersion "10.15"
+        )
+        [
+          # As of LLVM 17, compiler-rt weakly links `_availability_version_check` instead of looking it up at runtime.
+          # That causes link failures on older SDKs, so revert to using `dlsym` when the SDK isn’t new enough.
+          (fetchpatch {
+            url = "https://github.com/llvm/llvm-project/commit/b653a2823fe4b4c9c6d85cfe119f31d8e70c2fa0.patch";
+            hash = "sha256-OknHXQGalj7400ESm9wjmKFohpLyYmbwUdNCiQsp9sY=";
+            stripLen = 1;
+            revert = true;
+          })
+        ];
       inherit llvm_meta;
       stdenv = if stdenv.hostPlatform.useLLVM or false || (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isStatic)
                then overrideCC stdenv buildLlvmTools.clangNoCompilerRtWithLibc
@@ -371,7 +387,22 @@ in let
         ../common/compiler-rt/darwin-plistbuddy-workaround.patch
         # See: https://github.com/NixOS/nixpkgs/pull/194634#discussion_r999829893
         # ../common/compiler-rt/armv7l-15.patch
-      ];
+      ]++ lib.optionals
+        (
+          stdenv.hostPlatform.isDarwin
+          && lib.versionAtLeast release_version "17"
+          && lib.versionOlder stdenv.hostPlatform.darwinSdkVersion "10.15"
+        )
+        [
+          # As of LLVM 17, compiler-rt weakly links `_availability_version_check` instead of looking it up at runtime.
+          # That causes link failures on older SDKs, so revert to using `dlsym` when the SDK isn’t new enough.
+          (fetchpatch {
+            url = "https://github.com/llvm/llvm-project/commit/b653a2823fe4b4c9c6d85cfe119f31d8e70c2fa0.patch";
+            hash = "sha256-OknHXQGalj7400ESm9wjmKFohpLyYmbwUdNCiQsp9sY=";
+            stripLen = 1;
+            revert = true;
+          })
+        ];
       inherit llvm_meta;
       stdenv = if stdenv.hostPlatform.useLLVM or false
                then overrideCC stdenv buildLlvmTools.clangNoCompilerRt


### PR DESCRIPTION
## Description of changes

compiler-rt uses weak linkage for `_availability_version_check` as of LLVM 17, but that means it requires the 10.15 SDK to link. Revert the change on older SDKs, so they can continue using availability checks.

Testing was done by confirming that Python 3 compiles with clang 18 on x86_64-darwin. Without the patch, it fails due to missing symbols.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
