### PR TITLE
Add electron-chromedriver

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11426,6 +11426,12 @@
     githubId = 1769386;
     name = "Liam Diprose";
   };
+  liammurphy14 = {
+    email = "liam.murphy137@gmail.com";
+    github = "liam-murphy14";
+    githubId = 54590679;
+    name = "Liam Murphy";
+  };
   liarokapisv = {
     email = "liarokapis.v@gmail.com";
     github = "liarokapisv";

--- a/pkgs/development/tools/electron/chromedriver/default.nix
+++ b/pkgs/development/tools/electron/chromedriver/default.nix
@@ -1,0 +1,14 @@
+let
+  infoJson = builtins.fromJSON (builtins.readFile ./info.json);
+in
+
+{ lib, callPackage }:
+
+let
+  mkElectronChromedriver = callPackage ./generic.nix { };
+in
+lib.mapAttrs' (majorVersion: info:
+  lib.nameValuePair
+    "electron-chromedriver_${majorVersion}"
+    (mkElectronChromedriver info.version info.hashes)
+) infoJson

--- a/pkgs/development/tools/electron/chromedriver/generic.nix
+++ b/pkgs/development/tools/electron/chromedriver/generic.nix
@@ -1,0 +1,96 @@
+{ lib
+, stdenv
+, fetchurl
+, glib
+, xorg
+, nspr
+, nss
+, autoPatchelfHook
+, unzip
+}:
+
+version: hashes:
+let
+  pname = "electron-chromedriver";
+
+  meta = with lib; {
+    homepage = "https://www.electronjs.org/";
+    description = "WebDriver server for running Selenium tests on Chrome";
+    longDescription = ''
+      WebDriver is an open source tool for automated testing of webapps across
+      many browsers. It provides capabilities for navigating to web pages, user
+      input, JavaScript execution, and more. ChromeDriver is a standalone
+      server that implements the W3C WebDriver standard. This is
+      an unofficial build of ChromeDriver compiled by the Electronjs
+      project.
+    '';
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ liammurphy14 yayayayaka ];
+    platforms = ["x86_64-darwin" "x86_64-linux" "armv7l-linux" "aarch64-linux" "aarch64-darwin"];
+    mainProgram = "chromedriver";
+  };
+
+  fetcher = vers: tag: hash: fetchurl {
+    url = "https://github.com/electron/electron/releases/download/v${vers}/chromedriver-v${vers}-${tag}.zip";
+    sha256 = hash;
+  };
+
+  tags = {
+    x86_64-linux = "linux-x64";
+    aarch64-linux = "linux-arm64";
+    armv7l-linux = "linux-armv7l";
+    x86_64-darwin = "darwin-x64";
+    aarch64-darwin = "darwin-arm64";
+  };
+
+  get = as: platform: as.${platform.system} or (throw "Unsupported system: ${platform.system}");
+
+  common = platform: {
+    inherit pname version meta;
+    src = fetcher version (get tags platform) (get hashes platform);
+
+    buildInputs = [
+      stdenv.cc.cc.lib
+      glib
+      xorg.libxcb
+      nspr
+      nss
+    ];
+  };
+
+  linux = {
+    nativeBuildInputs = [ autoPatchelfHook unzip ];
+
+    dontUnpack = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+      unzip $src
+      install -m777 -D chromedriver $out/bin/chromedriver
+      runHook postInstall
+    '';
+  };
+
+  darwin = {
+    nativeBuildInputs = [ unzip ];
+
+    dontUnpack = true;
+    dontBuild = true;
+
+    # darwin distributions come with libffmpeg dependecy + icudtl.dat file
+    installPhase = ''
+      runHook preInstall
+      unzip $src
+      install -m777 -D chromedriver $out/bin/chromedriver
+      cp libffmpeg.dylib $out/bin/libffmpeg.dylib
+      cp icudtl.dat $out/bin/icudtl.dat
+      runHook postInstall
+    '';
+  };
+in
+  stdenv.mkDerivation (
+    (common stdenv.hostPlatform) //
+    (if stdenv.isDarwin then darwin else linux)
+  )

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -1,0 +1,35 @@
+{
+    "29": {
+        "hashes": {
+            "aarch64-darwin": "82e4158d2fc3f854911d665643d8fe9dfa90795c9599df797d01044d7381501b",
+            "aarch64-linux": "14ac2a9db3b183d51ed967700c93d56d38868695a180d40d8427a860162d6d2c",
+            "armv7l-linux": "7f35fa76df7c0e02c424b1461622c0620d45e7f4e56611626045136d9fa4ff04",
+            "headers": "194vq6lcppf76ly7cz4b1299h8wfw6xvwfgfndqsqm1sg6g1hrmg",
+            "x86_64-darwin": "b80fed41b99d4713fe7b44edbac0a74e5a6aafcfb019ae564c03b1380c6b8ac1",
+            "x86_64-linux": "b64425fe356aec15f4c8adf1e6a8b2caaccd989378bbe9d19632dd77a020ddfe"
+        },
+        "version": "29.4.4"
+    },
+    "30": {
+        "hashes": {
+            "aarch64-darwin": "12447d8fca855c84b2fe23e6db80beb2ba37780ed0ddf42025e1981d9eaf4939",
+            "aarch64-linux": "df9072d486e86451e37e7bf680a9a7ab744b41e5ccdf1121a91ad9cc02166a8d",
+            "armv7l-linux": "25f5406e0dfa05fd8a0bc5fbcb6c7377dd7fec9d17f5a39554f1f39cb4ce5fba",
+            "headers": "1y8nyib0a9k5q01smy55ddkj9sl01rj625afx32h5pf815r5asmf",
+            "x86_64-darwin": "a00dd14044bef8383bbdeaf11ad049876a1d545ee8e39c953d8053d4efbce8fe",
+            "x86_64-linux": "a7def33c6d32555acb0eb299c839d1f609b31877ba53f8d82dd12aae29924fb7"
+        },
+        "version": "30.2.0"
+    },
+    "31": {
+        "hashes": {
+            "aarch64-darwin": "6335fb15beeaaa6601a325a9b616b059a289063fc560ff66efd5353d4ab4fcbe",
+            "aarch64-linux": "de793d036dbce9dbda8603992db8d57d40e37f97ee9bc5808fcb5ec492cb1e10",
+            "armv7l-linux": "fe4ab8af208fd5d882c9b1cc25f33a0816a6eec4d75f0911b8fa320e9c8cadcc",
+            "headers": "00i9y8ya03drd5hdhv1pmlai66bjmh04zfc39g65skbgz9yjihmj",
+            "x86_64-darwin": "5423016c84cde9513ace0d68d06fecd376ab945bae22e2cb39eaf2a6e83813a8",
+            "x86_64-linux": "70182bd0980458607ed7d1684ded9de88bfd00793e680bb23b9cef595a24a5d6"
+        },
+        "version": "31.2.0"
+    }
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17799,6 +17799,11 @@ with pkgs;
     electron_29-bin
     electron_30-bin;
 
+  inherit (callPackages ../development/tools/electron/chromedriver { })
+    electron-chromedriver_29
+    electron-chromedriver_30
+    electron-chromedriver_31;
+
   electron_24 = electron_24-bin;
   electron_27 = electron_27-bin;
   electron_28 = electron_28-bin;
@@ -17806,6 +17811,7 @@ with pkgs;
   electron_30 = if lib.meta.availableOn stdenv.hostPlatform electron-source.electron_30 then electron-source.electron_30 else electron_30-bin;
   electron = electron_30;
   electron-bin = electron_30-bin;
+  electron-chromedriver = electron-chromedriver_30;
 
   autobuild = callPackage ../development/tools/misc/autobuild { };
 


### PR DESCRIPTION
## Description of changes

add a wrapper for the electron-built chromedriver binaries for all nixpkgs supported versions of electron (30, 29, 28, 27, 24). This allows NixOS users to easily install chromedriver binaries that are compatible with specific electron versions, for use during [electron automated testing](https://www.electronjs.org/docs/latest/tutorial/automated-testing).

See [the electron github page](https://github.com/electron/electron) as well as the [electron-chromedriver NPM package](https://www.npmjs.com/package/electron-chromedriver) for more details.

Notes
1. this chromedriver binary is not already included in the release tarballs of electron/electron-bin packages
2. I modeled the nix code here after the electron-bin package, so shout out to the maintainers for providing a super nice template :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
