### PR TITLE
python3Packages.curl-cffi: init at 0.6.3

### DIFF
--- a/pkgs/development/python-modules/curl-cffi/default.nix
+++ b/pkgs/development/python-modules/curl-cffi/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, curl-impersonate-chrome
+, cffi
+, certifi
+}:
+
+buildPythonPackage rec {
+  pname = "curl-cffi";
+  version = "0.6.3";
+
+  src = fetchFromGitHub {
+    owner = "yifeikong";
+    repo = "curl_cffi";
+    rev = "v${version}";
+    hash = "sha256-VeBh5wp/VEMDGR2YK06w34hBv9qHIyA+EiZHrhEhAGw=";
+  };
+
+  patches = [
+    ./use-system-libs.patch
+  ];
+  buildInputs = [
+    curl-impersonate-chrome
+  ];
+
+  format = "pyproject";
+  build-system = [
+    setuptools
+  ];
+
+  nativeBuildInputs = [
+    cffi
+  ];
+  propagatedBuildInputs = [
+    cffi
+    certifi
+  ];
+
+  pythonImportsCheck = [ "curl_cffi" ];
+
+  meta = with lib; {
+    description = "Python binding for curl-impersonate via cffi";
+    homepage = "https://curl-cffi.readthedocs.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ chuangzhu ];
+  };
+}

--- a/pkgs/development/python-modules/curl-cffi/use-system-libs.patch
+++ b/pkgs/development/python-modules/curl-cffi/use-system-libs.patch
@@ -1,0 +1,23 @@
+diff --git a/scripts/build.py b/scripts/build.py
+index b705a0d..9bfcaab 100644
+--- a/scripts/build.py
++++ b/scripts/build.py
+@@ -105,7 +105,6 @@ def get_curl_libraries():
+ ffibuilder = FFI()
+ system = platform.system()
+ root_dir = Path(__file__).parent.parent
+-download_libcurl()
+ 
+ 
+ ffibuilder.set_source(
+@@ -114,9 +113,7 @@ ffibuilder.set_source(
+         #include "shim.h"
+     """,
+     # FIXME from `curl-impersonate`
+-    libraries=get_curl_libraries(),
+-    extra_objects=get_curl_archives(),
+-    library_dirs=[arch["libdir"]],
++    libraries=["curl-impersonate-chrome"],
+     source_extension=".c",
+     include_dirs=[
+         str(root_dir / "include"),

--- a/pkgs/tools/networking/curl-impersonate/default.nix
+++ b/pkgs/tools/networking/curl-impersonate/default.nix
@@ -31,6 +31,8 @@ let
     pname = "curl-impersonate-${name}";
     version = "0.6.1";
 
+    outputs = [ "out" "dev" ];
+
     src = fetchFromGitHub {
       owner = "lwthiker";
       repo = "curl-impersonate";
@@ -130,6 +132,9 @@ let
 
       # Install zsh and fish completions
       installShellCompletion $TMPDIR/curl-impersonate-${name}.{zsh,fish}
+
+      # Install headers
+      make -C curl-*/include install
     '';
 
     preFixup = let

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2636,6 +2636,8 @@ self: super: with self; {
 
   curlify = callPackage ../development/python-modules/curlify { };
 
+  curl-cffi = callPackage ../development/python-modules/curl-cffi { };
+
   curtsies = callPackage ../development/python-modules/curtsies { };
 
   curve25519-donna = callPackage ../development/python-modules/curve25519-donna { };


### PR DESCRIPTION
## Description of changes

Python binding for curl-impersonate via cffi. A http client that can impersonate browser tls/ja3/http2 fingerprints.

https://curl-cffi.readthedocs.io/

Dependency of #309402, https://github.com/NixOS/nixpkgs/pull/309345#pullrequestreview-2039788592

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
