### PR TITLE
llvmPackages_{12,13,14,15,16,17,18}.compiler-rt: fix build with clang 18

### DIFF
--- a/pkgs/development/compilers/llvm/12/compiler-rt/clang18-compat.patch
+++ b/pkgs/development/compilers/llvm/12/compiler-rt/clang18-compat.patch
@@ -1,0 +1,34 @@
+Adapted from the following patch.
+
+From 5c2b84b0963aa1af0c55c38afbc4080fd9f6a46f Mon Sep 17 00:00:00 2001
+From: Jon Roelofs <jonathan_roelofs@apple.com>
+Date: Fri, 17 Nov 2023 14:21:57 -0800
+Subject: [PATCH] [builtins] Move cfi start's after the symbol name [NFC]
+
+... in preparation for diagnosing improperly nested .cfi regions.
+
+See https://reviews.llvm.org/D155245
+---
+ compiler-rt/lib/builtins/assembly.h | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/compiler-rt/lib/builtins/assembly.h b/compiler-rt/lib/builtins/assembly.h
+index f6ce6a9fccff..f859ad8f6706 100644
+--- a/lib/builtins/assembly.h
++++ b/lib/builtins/assembly.h
+@@ -249,9 +249,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY(name) SEPARATOR                                    \
+-  CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  name:                                                                        \
++  SEPARATOR CFI_START                                                          \
++  SEPARATOR BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \
+-- 
+2.44.0
+

--- a/pkgs/development/compilers/llvm/12/default.nix
+++ b/pkgs/development/compilers/llvm/12/default.nix
@@ -305,6 +305,8 @@ let
         ../common/compiler-rt/armv6-mcr-dmb.patch
         ../common/compiler-rt/armv6-sync-ops-no-thumb.patch
         ../common/compiler-rt/armv6-no-ldrexd-strexd.patch
+        # Fix build with clang 18 due to https://github.com/llvm/llvm-project/commit/d506aa4edfa66074db3dc1fa84da9d9c80d71500.
+        ../12/compiler-rt/clang18-compat.patch
       ];
       inherit llvm_meta;
       stdenv = if stdenv.hostPlatform.useLLVM or false
@@ -327,6 +329,8 @@ let
         ../common/compiler-rt/armv6-mcr-dmb.patch
         ../common/compiler-rt/armv6-sync-ops-no-thumb.patch
         ../common/compiler-rt/armv6-no-ldrexd-strexd.patch
+        # Fix build with clang 18 due to https://github.com/llvm/llvm-project/commit/d506aa4edfa66074db3dc1fa84da9d9c80d71500.
+        ../12/compiler-rt/clang18-compat.patch
       ];
       inherit llvm_meta;
       stdenv = if stdenv.hostPlatform.useLLVM or false

--- a/pkgs/development/compilers/llvm/13/default.nix
+++ b/pkgs/development/compilers/llvm/13/default.nix
@@ -343,6 +343,12 @@ in let
         ../common/compiler-rt/armv6-no-ldrexd-strexd.patch
         ../common/compiler-rt/armv6-scudo-no-yield.patch
         ../common/compiler-rt/armv6-scudo-libatomic.patch
+        # Fix build with clang 18 due to https://github.com/llvm/llvm-project/commit/d506aa4edfa66074db3dc1fa84da9d9c80d71500.
+        (fetchpatch {
+          url = "https://github.com/llvm/llvm-project/commit/7939ce39dac0078fef7183d6198598b99c652c88.patch";
+          stripLen = 1;
+          hash = "sha256-tGqXsYvUllFrPa/r/dsKVlwx5IrcJGccuR1WAtUg7/o=";
+        })
       ];
       inherit llvm_meta;
       stdenv = if stdenv.hostPlatform.useLLVM or false
@@ -367,6 +373,12 @@ in let
         ../common/compiler-rt/armv6-no-ldrexd-strexd.patch
         ../common/compiler-rt/armv6-scudo-no-yield.patch
         ../common/compiler-rt/armv6-scudo-libatomic.patch
+        # Fix build with clang 18 due to https://github.com/llvm/llvm-project/commit/d506aa4edfa66074db3dc1fa84da9d9c80d71500.
+        (fetchpatch {
+          url = "https://github.com/llvm/llvm-project/commit/7939ce39dac0078fef7183d6198598b99c652c88.patch";
+          stripLen = 1;
+          hash = "sha256-tGqXsYvUllFrPa/r/dsKVlwx5IrcJGccuR1WAtUg7/o=";
+        })
       ];
       inherit llvm_meta;
       stdenv = if stdenv.hostPlatform.useLLVM or false

--- a/pkgs/development/compilers/llvm/14/default.nix
+++ b/pkgs/development/compilers/llvm/14/default.nix
@@ -317,6 +317,12 @@ in let
         ../common/compiler-rt/armv6-no-ldrexd-strexd.patch
         ../common/compiler-rt/armv6-scudo-no-yield.patch
         ../common/compiler-rt/armv6-scudo-libatomic.patch
+        # Fix build with clang 18 due to https://github.com/llvm/llvm-project/commit/d506aa4edfa66074db3dc1fa84da9d9c80d71500.
+        (fetchpatch {
+          url = "https://github.com/llvm/llvm-project/commit/7939ce39dac0078fef7183d6198598b99c652c88.patch";
+          stripLen = 1;
+          hash = "sha256-tGqXsYvUllFrPa/r/dsKVlwx5IrcJGccuR1WAtUg7/o=";
+        })
       ];
       inherit llvm_meta;
       stdenv = if stdenv.hostPlatform.useLLVM or false
@@ -342,6 +348,12 @@ in let
         ../common/compiler-rt/armv6-no-ldrexd-strexd.patch
         ../common/compiler-rt/armv6-scudo-no-yield.patch
         ../common/compiler-rt/armv6-scudo-libatomic.patch
+        # Fix build with clang 18 due to https://github.com/llvm/llvm-project/commit/d506aa4edfa66074db3dc1fa84da9d9c80d71500.
+        (fetchpatch {
+          url = "https://github.com/llvm/llvm-project/commit/7939ce39dac0078fef7183d6198598b99c652c88.patch";
+          stripLen = 1;
+          hash = "sha256-tGqXsYvUllFrPa/r/dsKVlwx5IrcJGccuR1WAtUg7/o=";
+        })
       ];
       inherit llvm_meta;
       stdenv = if stdenv.hostPlatform.useLLVM or false

--- a/pkgs/development/compilers/llvm/15/default.nix
+++ b/pkgs/development/compilers/llvm/15/default.nix
@@ -364,6 +364,12 @@ in let
         ../common/compiler-rt/darwin-plistbuddy-workaround.patch
         # See: https://github.com/NixOS/nixpkgs/pull/194634#discussion_r999829893
         ../common/compiler-rt/armv7l-15.patch
+        # Fix build with clang 18 due to https://github.com/llvm/llvm-project/commit/d506aa4edfa66074db3dc1fa84da9d9c80d71500.
+        (fetchpatch {
+          url = "https://github.com/llvm/llvm-project/commit/7939ce39dac0078fef7183d6198598b99c652c88.patch";
+          stripLen = 1;
+          hash = "sha256-tGqXsYvUllFrPa/r/dsKVlwx5IrcJGccuR1WAtUg7/o=";
+        })
       ];
       inherit llvm_meta;
       stdenv = if stdenv.hostPlatform.useLLVM or false
@@ -384,6 +390,12 @@ in let
         ../common/compiler-rt/darwin-plistbuddy-workaround.patch
         # See: https://github.com/NixOS/nixpkgs/pull/194634#discussion_r999829893
         ../common/compiler-rt/armv7l-15.patch
+        # Fix build with clang 18 due to https://github.com/llvm/llvm-project/commit/d506aa4edfa66074db3dc1fa84da9d9c80d71500.
+        (fetchpatch {
+          url = "https://github.com/llvm/llvm-project/commit/7939ce39dac0078fef7183d6198598b99c652c88.patch";
+          stripLen = 1;
+          hash = "sha256-tGqXsYvUllFrPa/r/dsKVlwx5IrcJGccuR1WAtUg7/o=";
+        })
       ];
       inherit llvm_meta;
       stdenv = if stdenv.hostPlatform.useLLVM or false

--- a/pkgs/development/compilers/llvm/16/default.nix
+++ b/pkgs/development/compilers/llvm/16/default.nix
@@ -1,6 +1,6 @@
 { lowPrio, newScope, pkgs, lib, stdenv, cmake, ninja
 , preLibcCrossHeaders
-, libxml2, python3, fetchFromGitHub, substituteAll, overrideCC, wrapCCWith, wrapBintoolsWith
+, libxml2, python3, fetchFromGitHub, fetchpatch, substituteAll, overrideCC, wrapCCWith, wrapBintoolsWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
 , targetLlvm
@@ -373,6 +373,12 @@ in let
         ../common/compiler-rt/darwin-plistbuddy-workaround.patch
         # See: https://github.com/NixOS/nixpkgs/pull/194634#discussion_r999829893
         # ../common/compiler-rt/armv7l-15.patch
+        # Fix build with clang 18 due to https://github.com/llvm/llvm-project/commit/d506aa4edfa66074db3dc1fa84da9d9c80d71500.
+        (fetchpatch {
+          url = "https://github.com/llvm/llvm-project/commit/7939ce39dac0078fef7183d6198598b99c652c88.patch";
+          stripLen = 1;
+          hash = "sha256-tGqXsYvUllFrPa/r/dsKVlwx5IrcJGccuR1WAtUg7/o=";
+        })
       ];
       inherit llvm_meta;
       stdenv = if stdenv.hostPlatform.useLLVM or false || (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isStatic)
@@ -393,6 +399,12 @@ in let
         ../common/compiler-rt/darwin-plistbuddy-workaround.patch
         # See: https://github.com/NixOS/nixpkgs/pull/194634#discussion_r999829893
         # ../common/compiler-rt/armv7l-15.patch
+        # Fix build with clang 18 due to https://github.com/llvm/llvm-project/commit/d506aa4edfa66074db3dc1fa84da9d9c80d71500.
+        (fetchpatch {
+          url = "https://github.com/llvm/llvm-project/commit/7939ce39dac0078fef7183d6198598b99c652c88.patch";
+          stripLen = 1;
+          hash = "sha256-tGqXsYvUllFrPa/r/dsKVlwx5IrcJGccuR1WAtUg7/o=";
+        })
       ];
       inherit llvm_meta;
       stdenv = if stdenv.hostPlatform.useLLVM or false

--- a/pkgs/development/compilers/llvm/17/default.nix
+++ b/pkgs/development/compilers/llvm/17/default.nix
@@ -358,6 +358,12 @@ in let
         ../common/compiler-rt/darwin-plistbuddy-workaround.patch
         # See: https://github.com/NixOS/nixpkgs/pull/194634#discussion_r999829893
         # ../common/compiler-rt/armv7l-15.patch
+        # Fix build with clang 18 due to https://github.com/llvm/llvm-project/commit/d506aa4edfa66074db3dc1fa84da9d9c80d71500.
+        (fetchpatch {
+          url = "https://github.com/llvm/llvm-project/commit/7939ce39dac0078fef7183d6198598b99c652c88.patch";
+          stripLen = 1;
+          hash = "sha256-tGqXsYvUllFrPa/r/dsKVlwx5IrcJGccuR1WAtUg7/o=";
+        })
       ];
       inherit llvm_meta;
       stdenv = if stdenv.hostPlatform.useLLVM or false || (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isStatic)
@@ -378,6 +384,12 @@ in let
         ../common/compiler-rt/darwin-plistbuddy-workaround.patch
         # See: https://github.com/NixOS/nixpkgs/pull/194634#discussion_r999829893
         # ../common/compiler-rt/armv7l-15.patch
+        # Fix build with clang 18 due to https://github.com/llvm/llvm-project/commit/d506aa4edfa66074db3dc1fa84da9d9c80d71500.
+        (fetchpatch {
+          url = "https://github.com/llvm/llvm-project/commit/7939ce39dac0078fef7183d6198598b99c652c88.patch";
+          stripLen = 1;
+          hash = "sha256-tGqXsYvUllFrPa/r/dsKVlwx5IrcJGccuR1WAtUg7/o=";
+        })
       ];
       inherit llvm_meta;
       stdenv = if stdenv.hostPlatform.useLLVM or false


### PR DESCRIPTION
## Description of changes

Clang 18 rejects assembly code that used to be accepted because it can cause runtime crashes. This change prevents older versions of compiler-rt from building on Darwin with a clang 18 stdenv.

The fix is to apply or backport https://github.com/llvm/llvm-project/commit/7939ce39dac0078fef7183d6198598b99c652c88.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
