### PR TITLE
dotnet: fix aot compilation

### DIFF
--- a/pkgs/development/compilers/dotnet/build-dotnet.nix
+++ b/pkgs/development/compilers/dotnet/build-dotnet.nix
@@ -52,7 +52,8 @@ let
   sigtool = callPackage ./sigtool.nix {};
   signAppHost = callPackage ./sign-apphost.nix {};
 
-  hasILCompiler = lib.versionAtLeast version "7";
+  hasILCompiler =
+    lib.versionAtLeast version (if targetRid == "osx-arm64" then "8" else "7");
 
   extraTargets = writeText "extra.targets" (''
     <Project>

--- a/pkgs/development/compilers/dotnet/build-dotnet.nix
+++ b/pkgs/development/compilers/dotnet/build-dotnet.nix
@@ -18,6 +18,7 @@ assert if type == "sdk" then packages != null else true;
 , libuuid
 , zlib
 , libkrb5
+, openssl
 , curl
 , lttng-ust_2_12
 , testers
@@ -51,6 +52,20 @@ let
   sigtool = callPackage ./sigtool.nix {};
   signAppHost = callPackage ./sign-apphost.nix {};
 
+  hasILCompiler = lib.versionAtLeast version "7";
+
+  extraTargets = writeText "extra.targets" (''
+    <Project>
+  '' + lib.optionalString hasILCompiler ''
+      <ItemGroup>
+        <CustomLinkerArg Include="-Wl,-rpath,'${lib.makeLibraryPath [ icu zlib openssl ]}'" />
+      </ItemGroup>
+  '' + lib.optionalString stdenv.isDarwin ''
+      <Import Project="${signAppHost}" />
+  '' + ''
+    </Project>
+  '');
+
 in
 mkCommon type rec {
   inherit pname version;
@@ -70,6 +85,7 @@ mkCommon type rec {
     icu
     libkrb5
     curl
+    xmlstarlet
   ] ++ lib.optional stdenv.isLinux lttng-ust_2_12;
 
   src = fetchurl (
@@ -79,15 +95,15 @@ mkCommon type rec {
 
   sourceRoot = ".";
 
-  postPatch = if type == "sdk" && stdenv.isDarwin then ''
+  postPatch = if type == "sdk" then (''
     xmlstarlet ed \
       --inplace \
       -s //_:Project -t elem -n Import \
-      -i \$prev -t attr -n Project -v "${signAppHost}" \
+      -i \$prev -t attr -n Project -v "${extraTargets}" \
       sdk/*/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets
-
+  '' + lib.optionalString stdenv.isDarwin ''
     codesign --remove-signature packs/Microsoft.NETCore.App.Host.osx-*/*/runtimes/osx-*/native/{apphost,singlefilehost}
-  '' else null;
+  '') else null;
 
   dontPatchELF = true;
   noDumpEnvVars = true;
@@ -135,7 +151,7 @@ mkCommon type rec {
   '';
 
   passthru = {
-    inherit icu;
+    inherit icu hasILCompiler;
   } // lib.optionalAttrs (type == "sdk") {
     packages = mkNugetDeps {
       name = "${pname}-${version}-deps";

--- a/pkgs/development/compilers/dotnet/common.nix
+++ b/pkgs/development/compilers/dotnet/common.nix
@@ -113,8 +113,8 @@
       publish = mkDotnetTest {
         name = "publish";
         template = "console";
-        build = "dotnet publish -o $out";
-        run = checkConsoleOutput "$src/test";
+        build = "dotnet publish -o $out/bin";
+        run = checkConsoleOutput "$src/bin/test";
       };
 
       self-contained = mkDotnetTest {
@@ -130,20 +130,20 @@
         name = "single-file";
         template = "console";
         usePackageSource = true;
-        build = "dotnet publish --use-current-runtime -p:PublishSingleFile=true -o $out";
+        build = "dotnet publish --use-current-runtime -p:PublishSingleFile=true -o $out/bin";
         runtime = null;
-        run = checkConsoleOutput "$src/test";
+        run = checkConsoleOutput "$src/bin/test";
       };
 
       web = mkDotnetTest {
         name = "web";
         template = "web";
-        build = "dotnet publish -o $out";
+        build = "dotnet publish -o $out/bin";
         runInputs = [ expect curl ];
         run = ''
           expect <<"EOF"
             set status 1
-            spawn $env(src)/test
+            spawn $env(src)/bin/test
             proc abort { } { exit 2 }
             expect_before default abort
             expect -re {Now listening on: ([^\r]+)\r} {

--- a/pkgs/development/compilers/dotnet/common.nix
+++ b/pkgs/development/compilers/dotnet/common.nix
@@ -1,12 +1,19 @@
 # TODO: switch to stdenvNoCC
 { stdenv
+, stdenvNoCC
 , lib
 , writeText
 , testers
 , runCommand
+, runCommandWith
 , expect
 , curl
 , installShellFiles
+, callPackage
+, zlib
+, swiftPackages
+, darwin
+, icu
 }: type: args: stdenv.mkDerivation (finalAttrs: args // {
   doInstallCheck = true;
 
@@ -43,9 +50,11 @@
       mkDotnetTest =
         {
           name,
+          stdenv ? stdenvNoCC,
           template,
           usePackageSource ? false,
           build,
+          buildInputs ? [],
           # TODO: use correct runtimes instead of sdk
           runtime ? finalAttrs.finalPackage,
           runInputs ? [],
@@ -54,19 +63,20 @@
         }:
         let
           sdk = finalAttrs.finalPackage;
-          built = runCommand "dotnet-test-${name}" {
-            buildInputs = [ sdk ];
-            # make sure ICU works in a sandbox
-            propagatedSandboxProfile = toString sdk.__propagatedSandboxProfile + ''
-              (allow network-inbound (local ip))
-              (allow mach-lookup (global-name "com.apple.FSEvents"))
-            '';
+          built = runCommandWith  {
+            name = "dotnet-test-${name}";
+            inherit stdenv;
+            derivationArgs = {
+              buildInputs = [ sdk ] ++ buildInputs;
+              # make sure ICU works in a sandbox
+              propagatedSandboxProfile = toString sdk.__propagatedSandboxProfile;
+            };
           } (''
             HOME=$PWD/.home
             dotnet new nugetconfig
             dotnet nuget disable source nuget
           '' + lib.optionalString usePackageSource ''
-            dotnet nuget add source ${finalAttrs.finalPackage.packages}
+            dotnet nuget add source ${sdk.packages}
           '' + ''
             dotnet new ${template} -n test -o .
           '' + build);
@@ -96,6 +106,8 @@
         [[ "$output" =~ Hello,?\ World! ]] && touch "$out"
       '';
 
+      patchNupkgs = callPackage ./patch-nupkgs.nix {};
+
     in {
       version = testers.testVersion ({
         package = finalAttrs.finalPackage;
@@ -103,7 +115,7 @@
         command = "dotnet --info";
       });
     }
-    // lib.optionalAttrs (type == "sdk") {
+    // lib.optionalAttrs (type == "sdk") ({
       console = mkDotnetTest {
         name = "console";
         template = "console";
@@ -165,6 +177,30 @@
         '';
         runAllowNetworking = true;
       };
-    } // args.passthru.tests or {};
+    } // lib.optionalAttrs finalAttrs.finalPackage.hasILCompiler {
+      aot = mkDotnetTest {
+        name = "aot";
+        stdenv = if stdenv.isDarwin then swiftPackages.stdenv else stdenv;
+        template = "console";
+        usePackageSource = true;
+        buildInputs =
+          [ patchNupkgs
+            zlib
+          ] ++ lib.optional stdenv.isDarwin (with darwin; with apple_sdk.frameworks; [
+            swiftPackages.swift
+            Foundation
+            CryptoKit
+            GSS
+            ICU
+          ]);
+        build = ''
+          dotnet restore -p:PublishAot=true
+          patch-nupkgs .home/.nuget/packages
+          dotnet publish -p:PublishAot=true -o $out/bin
+        '';
+        runtime = null;
+        run = checkConsoleOutput "$src/bin/test";
+      };
+    }) // args.passthru.tests or {};
   } // args.passthru or {};
 })

--- a/pkgs/development/compilers/dotnet/packages.nix
+++ b/pkgs/development/compilers/dotnet/packages.nix
@@ -37,6 +37,8 @@ in {
 
     passthru = {
       inherit (vmr) icu targetRid;
+      # ilcompiler is currently broken: https://github.com/dotnet/source-build/issues/1215
+      hasILCompiler = false;
     };
 
     meta = vmr.meta // {

--- a/pkgs/development/compilers/dotnet/update.sh
+++ b/pkgs/development/compilers/dotnet/update.sh
@@ -300,6 +300,7 @@ sdk_packages () {
     if ! version_older "$version" "8"; then
         pkgs+=(
             "Microsoft.NET.ILLink.Tasks"
+            "runtime.osx-arm64.Microsoft.DotNet.ILCompiler"
         )
     fi
 

--- a/pkgs/development/compilers/dotnet/update.sh
+++ b/pkgs/development/compilers/dotnet/update.sh
@@ -282,6 +282,7 @@ sdk_packages () {
     # Packages that only apply to .NET 7 and up
     if ! version_older "$version" "7"; then
         pkgs+=(
+          "Microsoft.DotNet.ILCompiler"
           "runtime.linux-arm64.Microsoft.DotNet.ILCompiler"
           "runtime.linux-musl-arm64.Microsoft.DotNet.ILCompiler"
           "runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler"

--- a/pkgs/development/compilers/dotnet/update.sh
+++ b/pkgs/development/compilers/dotnet/update.sh
@@ -7,46 +7,46 @@ set -Eeuo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 release () {
-  local content="$1"
-  local version="$2"
+    local content="$1"
+    local version="$2"
 
-  jq -r '.releases[] | select(."release-version" == "'"$version"'")' <<< "$content"
+    jq -r '.releases[] | select(."release-version" == "'"$version"'")' <<< "$content"
 }
 
 release_files () {
-  local release="$1"
-  local expr="$2"
+    local release="$1"
+    local expr="$2"
 
-  jq -r '[('"$expr"').files[] | select(.name | test("^.*.tar.gz$"))]' <<< "$release"
+    jq -r '[('"$expr"').files[] | select(.name | test("^.*.tar.gz$"))]' <<< "$release"
 }
 
 release_platform_attr () {
-  local release_files="$1"
-  local platform="$2"
-  local attr="$3"
+    local release_files="$1"
+    local platform="$2"
+    local attr="$3"
 
-  jq -r '.[] | select((.rid == "'"$platform"'") and (.name | contains("composite") | not)) | ."'"$attr"'"' <<< "$release_files"
+    jq -r '.[] | select((.rid == "'"$platform"'") and (.name | contains("composite") | not)) | ."'"$attr"'"' <<< "$release_files"
 }
 
 platform_sources () {
-  local release_files="$1"
-  local platforms=(
-    "x86_64-linux   linux-x64"
-    "aarch64-linux  linux-arm64"
-    "x86_64-darwin  osx-x64"
-    "aarch64-darwin osx-arm64"
-  )
+    local release_files="$1"
+    local platforms=(
+        "x86_64-linux   linux-x64"
+        "aarch64-linux  linux-arm64"
+        "x86_64-darwin  osx-x64"
+        "aarch64-darwin osx-arm64"
+    )
 
-  echo "srcs = {"
-  for kv in "${platforms[@]}"; do
-    local nix_platform=${kv%% *}
-    local ms_platform=${kv##* }
+    echo "srcs = {"
+    for kv in "${platforms[@]}"; do
+        local nix_platform=${kv%% *}
+        local ms_platform=${kv##* }
 
-    local url=$(release_platform_attr "$release_files" "$ms_platform" url)
-    local hash=$(release_platform_attr "$release_files" "$ms_platform" hash)
+        local url=$(release_platform_attr "$release_files" "$ms_platform" url)
+        local hash=$(release_platform_attr "$release_files" "$ms_platform" hash)
 
-    [[ -z "$url" || -z "$hash" ]] && continue
-    echo "      $nix_platform = {
+        [[ -z "$url" || -z "$hash" ]] && continue
+        echo "      $nix_platform = {
         url     = \"$url\";
         sha512  = \"$hash\";
       };"
@@ -112,15 +112,15 @@ aspnetcore_packages () {
     # This should not happend in minor or bugfix updates, but probably happens
     # with every new major .NET release.
     local pkgs=(
-      "Microsoft.AspNetCore.App.Runtime.linux-arm"
-      "Microsoft.AspNetCore.App.Runtime.linux-arm64"
-      "Microsoft.AspNetCore.App.Runtime.linux-musl-arm64"
-      "Microsoft.AspNetCore.App.Runtime.linux-musl-x64"
-      "Microsoft.AspNetCore.App.Runtime.linux-x64"
-      "Microsoft.AspNetCore.App.Runtime.osx-x64"
-      "Microsoft.AspNetCore.App.Runtime.win-arm64"
-      "Microsoft.AspNetCore.App.Runtime.win-x64"
-      "Microsoft.AspNetCore.App.Runtime.win-x86"
+        "Microsoft.AspNetCore.App.Runtime.linux-arm"
+        "Microsoft.AspNetCore.App.Runtime.linux-arm64"
+        "Microsoft.AspNetCore.App.Runtime.linux-musl-arm64"
+        "Microsoft.AspNetCore.App.Runtime.linux-musl-x64"
+        "Microsoft.AspNetCore.App.Runtime.linux-x64"
+        "Microsoft.AspNetCore.App.Runtime.osx-x64"
+        "Microsoft.AspNetCore.App.Runtime.win-arm64"
+        "Microsoft.AspNetCore.App.Runtime.win-x64"
+        "Microsoft.AspNetCore.App.Runtime.win-x86"
     )
 
     # These packages are currently broken on .NET 8
@@ -133,9 +133,9 @@ aspnetcore_packages () {
     # Packages that only apply to .NET 6 and up
     if ! version_older "$version" "6"; then
         pkgs+=(
-          "Microsoft.AspNetCore.App.Ref"
-          "Microsoft.AspNetCore.App.Runtime.linux-musl-arm"
-          "Microsoft.AspNetCore.App.Runtime.osx-arm64"
+            "Microsoft.AspNetCore.App.Ref"
+            "Microsoft.AspNetCore.App.Runtime.linux-musl-arm"
+            "Microsoft.AspNetCore.App.Runtime.osx-arm64"
         )
     fi
 
@@ -168,102 +168,102 @@ sdk_packages () {
     # This should not happend in minor or bugfix updates, but probably happens
     # with every new major .NET release.
     local pkgs=(
-      "Microsoft.NETCore.App.Host.linux-arm"
-      "Microsoft.NETCore.App.Host.linux-arm64"
-      "Microsoft.NETCore.App.Host.linux-musl-arm64"
-      "Microsoft.NETCore.App.Host.linux-musl-x64"
-      "Microsoft.NETCore.App.Host.linux-x64"
-      "Microsoft.NETCore.App.Host.osx-x64"
-      "Microsoft.NETCore.App.Host.win-arm64"
-      "Microsoft.NETCore.App.Host.win-x64"
-      "Microsoft.NETCore.App.Host.win-x86"
-      "Microsoft.NETCore.App.Runtime.linux-arm"
-      "Microsoft.NETCore.App.Runtime.linux-arm64"
-      "Microsoft.NETCore.App.Runtime.linux-musl-arm64"
-      "Microsoft.NETCore.App.Runtime.linux-musl-x64"
-      "Microsoft.NETCore.App.Runtime.linux-x64"
-      "Microsoft.NETCore.App.Runtime.osx-x64"
-      "Microsoft.NETCore.App.Runtime.win-arm64"
-      "Microsoft.NETCore.App.Runtime.win-x64"
-      "Microsoft.NETCore.App.Runtime.win-x86"
-      "Microsoft.NETCore.DotNetAppHost"
-      "Microsoft.NETCore.DotNetHost"
-      "Microsoft.NETCore.DotNetHostPolicy"
-      "Microsoft.NETCore.DotNetHostResolver"
-      "runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost"
-      "runtime.linux-arm64.Microsoft.NETCore.DotNetHost"
-      "runtime.linux-arm64.Microsoft.NETCore.DotNetHostPolicy"
-      "runtime.linux-arm64.Microsoft.NETCore.DotNetHostResolver"
-      "runtime.linux-arm.Microsoft.NETCore.DotNetAppHost"
-      "runtime.linux-arm.Microsoft.NETCore.DotNetHost"
-      "runtime.linux-arm.Microsoft.NETCore.DotNetHostPolicy"
-      "runtime.linux-arm.Microsoft.NETCore.DotNetHostResolver"
-      "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetAppHost"
-      "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHost"
-      "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostPolicy"
-      "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostResolver"
-      "runtime.linux-musl-x64.Microsoft.NETCore.DotNetAppHost"
-      "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHost"
-      "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostPolicy"
-      "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostResolver"
-      "runtime.linux-x64.Microsoft.NETCore.DotNetAppHost"
-      "runtime.linux-x64.Microsoft.NETCore.DotNetHost"
-      "runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy"
-      "runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver"
-      "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost"
-      "runtime.osx-x64.Microsoft.NETCore.DotNetHost"
-      "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy"
-      "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver"
-      "runtime.win-arm64.Microsoft.NETCore.DotNetAppHost"
-      "runtime.win-arm64.Microsoft.NETCore.DotNetHost"
-      "runtime.win-arm64.Microsoft.NETCore.DotNetHostPolicy"
-      "runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver"
-      "runtime.win-x64.Microsoft.NETCore.DotNetAppHost"
-      "runtime.win-x64.Microsoft.NETCore.DotNetHost"
-      "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy"
-      "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver"
-      "runtime.win-x86.Microsoft.NETCore.DotNetAppHost"
-      "runtime.win-x86.Microsoft.NETCore.DotNetHost"
-      "runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy"
-      "runtime.win-x86.Microsoft.NETCore.DotNetHostResolver"
-      "Microsoft.NETCore.App.Host.linux-musl-arm"
-      "Microsoft.NETCore.App.Host.osx-arm64"
-      "Microsoft.NETCore.App.Runtime.linux-musl-arm"
-      "Microsoft.NETCore.App.Runtime.osx-arm64"
-      "Microsoft.NETCore.App.Ref"
-      "Microsoft.NETCore.App.Runtime.Mono.linux-arm"
-      "Microsoft.NETCore.App.Runtime.Mono.linux-arm64"
-      "Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64"
-      "Microsoft.NETCore.App.Runtime.Mono.linux-x64"
-      "Microsoft.NETCore.App.Runtime.Mono.osx-arm64"
-      "Microsoft.NETCore.App.Runtime.Mono.osx-x64"
-      "Microsoft.NETCore.App.Runtime.Mono.win-x64"
-      "Microsoft.NETCore.App.Runtime.Mono.win-x86"
-      "runtime.linux-musl-arm.Microsoft.NETCore.DotNetAppHost"
-      "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHost"
-      "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHostPolicy"
-      "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHostResolver"
-      "runtime.osx-arm64.Microsoft.NETCore.DotNetAppHost"
-      "runtime.osx-arm64.Microsoft.NETCore.DotNetHost"
-      "runtime.osx-arm64.Microsoft.NETCore.DotNetHostPolicy"
-      "runtime.osx-arm64.Microsoft.NETCore.DotNetHostResolver"
-      "Microsoft.NETCore.App.Crossgen2.linux-musl-arm"
-      "Microsoft.NETCore.App.Crossgen2.linux-musl-arm64"
-      "Microsoft.NETCore.App.Crossgen2.linux-musl-x64"
-      "Microsoft.NETCore.App.Crossgen2.linux-arm"
-      "Microsoft.NETCore.App.Crossgen2.linux-arm64"
-      "Microsoft.NETCore.App.Crossgen2.linux-x64"
-      "Microsoft.NETCore.App.Crossgen2.osx-x64"
-      "Microsoft.NETCore.App.Crossgen2.osx-arm64"
+        "Microsoft.NETCore.App.Host.linux-arm"
+        "Microsoft.NETCore.App.Host.linux-arm64"
+        "Microsoft.NETCore.App.Host.linux-musl-arm64"
+        "Microsoft.NETCore.App.Host.linux-musl-x64"
+        "Microsoft.NETCore.App.Host.linux-x64"
+        "Microsoft.NETCore.App.Host.osx-x64"
+        "Microsoft.NETCore.App.Host.win-arm64"
+        "Microsoft.NETCore.App.Host.win-x64"
+        "Microsoft.NETCore.App.Host.win-x86"
+        "Microsoft.NETCore.App.Runtime.linux-arm"
+        "Microsoft.NETCore.App.Runtime.linux-arm64"
+        "Microsoft.NETCore.App.Runtime.linux-musl-arm64"
+        "Microsoft.NETCore.App.Runtime.linux-musl-x64"
+        "Microsoft.NETCore.App.Runtime.linux-x64"
+        "Microsoft.NETCore.App.Runtime.osx-x64"
+        "Microsoft.NETCore.App.Runtime.win-arm64"
+        "Microsoft.NETCore.App.Runtime.win-x64"
+        "Microsoft.NETCore.App.Runtime.win-x86"
+        "Microsoft.NETCore.DotNetAppHost"
+        "Microsoft.NETCore.DotNetHost"
+        "Microsoft.NETCore.DotNetHostPolicy"
+        "Microsoft.NETCore.DotNetHostResolver"
+        "runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost"
+        "runtime.linux-arm64.Microsoft.NETCore.DotNetHost"
+        "runtime.linux-arm64.Microsoft.NETCore.DotNetHostPolicy"
+        "runtime.linux-arm64.Microsoft.NETCore.DotNetHostResolver"
+        "runtime.linux-arm.Microsoft.NETCore.DotNetAppHost"
+        "runtime.linux-arm.Microsoft.NETCore.DotNetHost"
+        "runtime.linux-arm.Microsoft.NETCore.DotNetHostPolicy"
+        "runtime.linux-arm.Microsoft.NETCore.DotNetHostResolver"
+        "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetAppHost"
+        "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHost"
+        "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostPolicy"
+        "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostResolver"
+        "runtime.linux-musl-x64.Microsoft.NETCore.DotNetAppHost"
+        "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHost"
+        "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostPolicy"
+        "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostResolver"
+        "runtime.linux-x64.Microsoft.NETCore.DotNetAppHost"
+        "runtime.linux-x64.Microsoft.NETCore.DotNetHost"
+        "runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy"
+        "runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver"
+        "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost"
+        "runtime.osx-x64.Microsoft.NETCore.DotNetHost"
+        "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy"
+        "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver"
+        "runtime.win-arm64.Microsoft.NETCore.DotNetAppHost"
+        "runtime.win-arm64.Microsoft.NETCore.DotNetHost"
+        "runtime.win-arm64.Microsoft.NETCore.DotNetHostPolicy"
+        "runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver"
+        "runtime.win-x64.Microsoft.NETCore.DotNetAppHost"
+        "runtime.win-x64.Microsoft.NETCore.DotNetHost"
+        "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy"
+        "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver"
+        "runtime.win-x86.Microsoft.NETCore.DotNetAppHost"
+        "runtime.win-x86.Microsoft.NETCore.DotNetHost"
+        "runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy"
+        "runtime.win-x86.Microsoft.NETCore.DotNetHostResolver"
+        "Microsoft.NETCore.App.Host.linux-musl-arm"
+        "Microsoft.NETCore.App.Host.osx-arm64"
+        "Microsoft.NETCore.App.Runtime.linux-musl-arm"
+        "Microsoft.NETCore.App.Runtime.osx-arm64"
+        "Microsoft.NETCore.App.Ref"
+        "Microsoft.NETCore.App.Runtime.Mono.linux-arm"
+        "Microsoft.NETCore.App.Runtime.Mono.linux-arm64"
+        "Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64"
+        "Microsoft.NETCore.App.Runtime.Mono.linux-x64"
+        "Microsoft.NETCore.App.Runtime.Mono.osx-arm64"
+        "Microsoft.NETCore.App.Runtime.Mono.osx-x64"
+        "Microsoft.NETCore.App.Runtime.Mono.win-x64"
+        "Microsoft.NETCore.App.Runtime.Mono.win-x86"
+        "runtime.linux-musl-arm.Microsoft.NETCore.DotNetAppHost"
+        "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHost"
+        "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHostPolicy"
+        "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHostResolver"
+        "runtime.osx-arm64.Microsoft.NETCore.DotNetAppHost"
+        "runtime.osx-arm64.Microsoft.NETCore.DotNetHost"
+        "runtime.osx-arm64.Microsoft.NETCore.DotNetHostPolicy"
+        "runtime.osx-arm64.Microsoft.NETCore.DotNetHostResolver"
+        "Microsoft.NETCore.App.Crossgen2.linux-musl-arm"
+        "Microsoft.NETCore.App.Crossgen2.linux-musl-arm64"
+        "Microsoft.NETCore.App.Crossgen2.linux-musl-x64"
+        "Microsoft.NETCore.App.Crossgen2.linux-arm"
+        "Microsoft.NETCore.App.Crossgen2.linux-arm64"
+        "Microsoft.NETCore.App.Crossgen2.linux-x64"
+        "Microsoft.NETCore.App.Crossgen2.osx-x64"
+        "Microsoft.NETCore.App.Crossgen2.osx-arm64"
     )
 
     # These packages were removed on .NET 9
     if ! version_older "$version" "9"; then
-      local newpkgs=()
-      for pkg in "${pkgs[@]}"; do
-        [[ "$pkg" = *Microsoft.NETCore.DotNetHost* ]] || newpkgs+=("$pkg")
-      done
-      pkgs=("${newpkgs[@]}")
+        local newpkgs=()
+        for pkg in "${pkgs[@]}"; do
+            [[ "$pkg" = *Microsoft.NETCore.DotNetHost* ]] || newpkgs+=("$pkg")
+        done
+        pkgs=("${newpkgs[@]}")
     fi
 
     # These packages were removed on .NET 8
@@ -282,14 +282,14 @@ sdk_packages () {
     # Packages that only apply to .NET 7 and up
     if ! version_older "$version" "7"; then
         pkgs+=(
-          "Microsoft.DotNet.ILCompiler"
-          "runtime.linux-arm64.Microsoft.DotNet.ILCompiler"
-          "runtime.linux-musl-arm64.Microsoft.DotNet.ILCompiler"
-          "runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler"
-          "runtime.linux-x64.Microsoft.DotNet.ILCompiler"
-          "runtime.osx-x64.Microsoft.DotNet.ILCompiler"
-          "runtime.win-arm64.Microsoft.DotNet.ILCompiler"
-          "runtime.win-x64.Microsoft.DotNet.ILCompiler"
+            "Microsoft.DotNet.ILCompiler"
+            "runtime.linux-arm64.Microsoft.DotNet.ILCompiler"
+            "runtime.linux-musl-arm64.Microsoft.DotNet.ILCompiler"
+            "runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler"
+            "runtime.linux-x64.Microsoft.DotNet.ILCompiler"
+            "runtime.osx-x64.Microsoft.DotNet.ILCompiler"
+            "runtime.win-arm64.Microsoft.DotNet.ILCompiler"
+            "runtime.win-x64.Microsoft.DotNet.ILCompiler"
         )
     fi
 
@@ -304,74 +304,74 @@ sdk_packages () {
 }
 
 main () {
-  pname=$(basename "$0")
-  if [[ ! "$*" =~ ^.*[0-9]{1,}\.[0-9]{1,}.*$ ]]; then
-    echo "Usage: $pname [sem-versions]
+    pname=$(basename "$0")
+    if [[ ! "$*" =~ ^.*[0-9]{1,}\.[0-9]{1,}.*$ ]]; then
+        echo "Usage: $pname [sem-versions]
 Get updated dotnet src (platform - url & sha512) expressions for specified versions
 
 Examples:
   $pname 6.0.14 7.0.201    - specific x.y.z versions
   $pname 6.0 7.0           - latest x.y versions
 " >&2
-    exit 1
-  fi
-
-  for sem_version in "$@"; do
-    echo "Generating ./versions/${sem_version}.nix"
-    patch_specified=false
-    # Check if a patch was specified as an argument.
-    # If so, generate file for the specific version.
-    # If only x.y version was provided, get the latest patch
-    # version of the given x.y version.
-    if [[ "$sem_version" =~ ^[0-9]{1,}\.[0-9]{1,}\.[0-9]{1,} ]]; then
-        patch_specified=true
-    elif [[ ! "$sem_version" =~ ^[0-9]{1,}\.[0-9]{1,}$ ]]; then
-        continue
+        exit 1
     fi
 
-    # Make sure the x.y version is properly passed to .NET release metadata url.
-    # Then get the json file and parse it to find the latest patch release.
-    major_minor=$(sed 's/^\([0-9]*\.[0-9]*\).*$/\1/' <<< "$sem_version")
-    content=$(curl -sL https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/"$major_minor"/releases.json)
-    major_minor_patch=$([ "$patch_specified" == true ] && echo "$sem_version" || jq -r '."latest-release"' <<< "$content")
-    major_minor_underscore=${major_minor/./_}
+    for sem_version in "$@"; do
+        echo "Generating ./versions/${sem_version}.nix"
+        patch_specified=false
+        # Check if a patch was specified as an argument.
+        # If so, generate file for the specific version.
+        # If only x.y version was provided, get the latest patch
+        # version of the given x.y version.
+        if [[ "$sem_version" =~ ^[0-9]{1,}\.[0-9]{1,}\.[0-9]{1,} ]]; then
+            patch_specified=true
+        elif [[ ! "$sem_version" =~ ^[0-9]{1,}\.[0-9]{1,}$ ]]; then
+            continue
+        fi
 
-    release_content=$(release "$content" "$major_minor_patch")
-    aspnetcore_version=$(jq -r '."aspnetcore-runtime".version' <<< "$release_content")
-    runtime_version=$(jq -r '.runtime.version' <<< "$release_content")
-    mapfile -t sdk_versions < <(jq -r '.sdks[] | .version' <<< "$release_content" | sort -rn)
+        # Make sure the x.y version is properly passed to .NET release metadata url.
+        # Then get the json file and parse it to find the latest patch release.
+        major_minor=$(sed 's/^\([0-9]*\.[0-9]*\).*$/\1/' <<< "$sem_version")
+        content=$(curl -sL https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/"$major_minor"/releases.json)
+        major_minor_patch=$([ "$patch_specified" == true ] && echo "$sem_version" || jq -r '."latest-release"' <<< "$content")
+        major_minor_underscore=${major_minor/./_}
 
-    # If patch was not specified, check if the package is already the latest version
-    # If it is, exit early
-    if [ "$patch_specified" == false ] && [ -f "./versions/${sem_version}.nix" ]; then
-        current_version=$(nix-instantiate --eval -E "(import ./versions/${sem_version}.nix { \
+        release_content=$(release "$content" "$major_minor_patch")
+        aspnetcore_version=$(jq -r '."aspnetcore-runtime".version' <<< "$release_content")
+        runtime_version=$(jq -r '.runtime.version' <<< "$release_content")
+        mapfile -t sdk_versions < <(jq -r '.sdks[] | .version' <<< "$release_content" | sort -rn)
+
+        # If patch was not specified, check if the package is already the latest version
+        # If it is, exit early
+        if [ "$patch_specified" == false ] && [ -f "./versions/${sem_version}.nix" ]; then
+            current_version=$(nix-instantiate --eval -E "(import ./versions/${sem_version}.nix { \
             buildAspNetCore = { ... }: {}; \
             buildNetSdk = { ... }: {}; \
             buildNetRuntime = { ... }: {}; \
             }).release_${major_minor_underscore}" | jq -r)
 
-        if [[ "$current_version" == "$major_minor_patch" ]]; then
-            echo "Nothing to update."
-            continue
+            if [[ "$current_version" == "$major_minor_patch" ]]; then
+                echo "Nothing to update."
+                continue
+            fi
         fi
-    fi
 
-    aspnetcore_files="$(release_files "$release_content" .\"aspnetcore-runtime\")"
-    runtime_files="$(release_files "$release_content" .runtime)"
+        aspnetcore_files="$(release_files "$release_content" .\"aspnetcore-runtime\")"
+        runtime_files="$(release_files "$release_content" .runtime)"
 
-    channel_version=$(jq -r '."channel-version"' <<< "$content")
-    support_phase=$(jq -r '."support-phase"' <<< "$content")
+        channel_version=$(jq -r '."channel-version"' <<< "$content")
+        support_phase=$(jq -r '."support-phase"' <<< "$content")
 
-    aspnetcore_sources="$(platform_sources "$aspnetcore_files")"
-    runtime_sources="$(platform_sources "$runtime_files")"
+        aspnetcore_sources="$(platform_sources "$aspnetcore_files")"
+        runtime_sources="$(platform_sources "$runtime_files")"
 
-    sdk_packages="$(sdk_packages "${runtime_version}")"
-    aspnetcore_packages="$(aspnetcore_packages "${aspnetcore_version}")"
+        sdk_packages="$(sdk_packages "${runtime_version}")"
+        aspnetcore_packages="$(aspnetcore_packages "${aspnetcore_version}")"
 
-    result=$(mktemp)
-    trap "rm -f $result" TERM INT EXIT
+        result=$(mktemp)
+        trap "rm -f $result" TERM INT EXIT
 
-    echo "{ buildAspNetCore, buildNetRuntime, buildNetSdk }:
+        echo "{ buildAspNetCore, buildNetRuntime, buildNetSdk }:
 
 # v$channel_version ($support_phase)
 
@@ -393,35 +393,35 @@ in rec {
     $runtime_sources
   };" > "${result}"
 
-    declare -A feature_bands
-    unset latest_sdk
+        declare -A feature_bands
+        unset latest_sdk
 
-    for sdk_version in "${sdk_versions[@]}"; do
-      sdk_base_version=${sdk_version%-*}
-      feature_band=${sdk_base_version:0:-2}xx
-      # sometimes one release has e.g. both 8.0.202 and 8.0.203
-      [[ ! ${feature_bands[$feature_band]+true} ]] || continue
-      feature_bands[$feature_band]=$sdk_version
-      sdk_files="$(release_files "$release_content" ".sdks[] | select(.version == \"$sdk_version\")")"
-      sdk_sources="$(platform_sources "$sdk_files")"
-      sdk_attrname=sdk_${feature_band//./_}
-      [[ -v latest_sdk ]] || latest_sdk=$sdk_attrname
+        for sdk_version in "${sdk_versions[@]}"; do
+            sdk_base_version=${sdk_version%-*}
+            feature_band=${sdk_base_version:0:-2}xx
+            # sometimes one release has e.g. both 8.0.202 and 8.0.203
+            [[ ! ${feature_bands[$feature_band]+true} ]] || continue
+            feature_bands[$feature_band]=$sdk_version
+            sdk_files="$(release_files "$release_content" ".sdks[] | select(.version == \"$sdk_version\")")"
+            sdk_sources="$(platform_sources "$sdk_files")"
+            sdk_attrname=sdk_${feature_band//./_}
+            [[ -v latest_sdk ]] || latest_sdk=$sdk_attrname
 
-      echo "
+            echo "
   $sdk_attrname = buildNetSdk {
     version = \"${sdk_version}\";
     $sdk_sources
     inherit packages;
   };" >> "${result}"
-    done
+        done
 
-    echo "
+        echo "
   sdk_$major_minor_underscore = $latest_sdk;
 }" >> "${result}"
 
-    cp "${result}" "./versions/${sem_version}.nix"
-    echo "Generated ./versions/${sem_version}.nix"
-  done
+        cp "${result}" "./versions/${sem_version}.nix"
+        echo "Generated ./versions/${sem_version}.nix"
+    done
 }
 
 main "$@"

--- a/pkgs/development/compilers/dotnet/versions/7.0.nix
+++ b/pkgs/development/compilers/dotnet/versions/7.0.nix
@@ -111,6 +111,7 @@ let
       (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHostPolicy"; version = "7.0.20"; sha256 = "18sarln3kbkqc1ab9jnadcqqxs8iicf7jqldxzbjzhdpmf96vwna"; })
       (fetchNuGet { pname = "runtime.win-arm.Microsoft.NETCore.DotNetHostResolver"; version = "7.0.20"; sha256 = "1vh3ymhv33qysc4vj4gb3g1rgajy4jr4kxfjcsq2myn96aan84i1"; })
       (fetchNuGet { pname = "Microsoft.NETCore.App.Composite"; version = "7.0.20"; sha256 = "12w9hlq70ynkrgqbr555lnqmbf67iz3kaci2vi07zsn3mmak3z6j"; })
+      (fetchNuGet { pname = "Microsoft.DotNet.ILCompiler"; version = "7.0.20"; sha256 = "0c966243j6m22hy3n922rl64vi6y1l7ljn69bwydm5clyh7zvn0a"; })
       (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.DotNet.ILCompiler"; version = "7.0.20"; sha256 = "11c31fzq4qfxcsz3p6vzdfnaqs29saf1dnmzq7l90p6ylwsblc7f"; })
       (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.DotNet.ILCompiler"; version = "7.0.20"; sha256 = "087q3p57snmvvzzqpxp3vwvi2q21kzlk8qh1w6axrcjdci31xmji"; })
       (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler"; version = "7.0.20"; sha256 = "1nc8m38jsqai934nn26f6dkl3c0r4sabssjiizcixdyypzlv3hcf"; })

--- a/pkgs/development/compilers/dotnet/versions/8.0.nix
+++ b/pkgs/development/compilers/dotnet/versions/8.0.nix
@@ -103,6 +103,7 @@ let
       (fetchNuGet { pname = "Microsoft.NETCore.App.Crossgen2.linux-x64"; version = "8.0.6"; sha256 = "1628i25saxmny4k8zzhh6nkz0njlvmi05f1m2sx976flqd3kxr78"; })
       (fetchNuGet { pname = "Microsoft.NETCore.App.Crossgen2.osx-x64"; version = "8.0.6"; sha256 = "0fz0a4hm8lf56r5hff4vcz6pfmwfqygddm6cyxj04x63wqd16sl8"; })
       (fetchNuGet { pname = "Microsoft.NETCore.App.Crossgen2.osx-arm64"; version = "8.0.6"; sha256 = "1bg9d8fcwr7808vbakkgrzry4wf0l7r28xn9hsnh14awsqprngid"; })
+      (fetchNuGet { pname = "Microsoft.DotNet.ILCompiler"; version = "8.0.6"; sha256 = "0wvdsmpriwvzf53n8sp7vda0996s8vhv83nis45sz1imwm7gxn4r"; })
       (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.DotNet.ILCompiler"; version = "8.0.6"; sha256 = "0l3pibk6q4hhinf2ki42vcc6kvvi5x4icm8bpcnm9iss6kafchry"; })
       (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.DotNet.ILCompiler"; version = "8.0.6"; sha256 = "19wwim19f1aqscvya85chbycj30ns5cxr2ga5jfrkxbyni9q557m"; })
       (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler"; version = "8.0.6"; sha256 = "1bggciasdgh7yr9vjkfq8fjxzg8lbcj4cd16slcr8kkpqy1lj79s"; })

--- a/pkgs/development/compilers/dotnet/versions/8.0.nix
+++ b/pkgs/development/compilers/dotnet/versions/8.0.nix
@@ -112,6 +112,7 @@ let
       (fetchNuGet { pname = "runtime.win-arm64.Microsoft.DotNet.ILCompiler"; version = "8.0.6"; sha256 = "0cqm5183as2m3nsl9as00qm9928bani6gflndg0fv73r799k5raz"; })
       (fetchNuGet { pname = "runtime.win-x64.Microsoft.DotNet.ILCompiler"; version = "8.0.6"; sha256 = "0yjji845ngsaqxyg2cmngj3vba8v4wyriv0qz4hgn1wbrramml6b"; })
       (fetchNuGet { pname = "Microsoft.NET.ILLink.Tasks"; version = "8.0.6"; sha256 = "0slfrm65izibsxg505vr8m4k6n2a2kl4iqyyr9xkgr8541g7rrs5"; })
+      (fetchNuGet { pname = "runtime.osx-arm64.Microsoft.DotNet.ILCompiler"; version = "8.0.6"; sha256 = "07y19lzkfr0i122gqbvfwi87jipjvrw4wrm68z01k4k0yh0mk1lj"; })
   ];
 in rec {
   release_8_0 = "8.0.6";

--- a/pkgs/development/compilers/dotnet/versions/9.0.nix
+++ b/pkgs/development/compilers/dotnet/versions/9.0.nix
@@ -67,6 +67,7 @@ let
       (fetchNuGet { pname = "Microsoft.NETCore.App.Crossgen2.linux-x64"; version = "9.0.0-preview.5.24306.7"; sha256 = "0hxf3xk6yn8n04fwj9j7c6a70y9apf31aafn2nhd3yykvvf7618d"; })
       (fetchNuGet { pname = "Microsoft.NETCore.App.Crossgen2.osx-x64"; version = "9.0.0-preview.5.24306.7"; sha256 = "1pw27c0czrrgp0vqnlcz6zhyrhbjbqh14wbcknrcn1smlm6fl77x"; })
       (fetchNuGet { pname = "Microsoft.NETCore.App.Crossgen2.osx-arm64"; version = "9.0.0-preview.5.24306.7"; sha256 = "14k0sd0b6rpngw8s1gz833kq89qghnhszgvk9v2rabncb1qlhanv"; })
+      (fetchNuGet { pname = "Microsoft.DotNet.ILCompiler"; version = "9.0.0-preview.5.24306.7"; sha256 = "1qmshjgd3wpal5gbsq5ajanissr237bjgfpxg7sp5bqjb20yg4hp"; })
       (fetchNuGet { pname = "runtime.linux-arm64.Microsoft.DotNet.ILCompiler"; version = "9.0.0-preview.5.24306.7"; sha256 = "0c2spsh6m236cmpf6c2hafcrr4w2ks433g024cmpa93a3s6dfvcp"; })
       (fetchNuGet { pname = "runtime.linux-musl-arm64.Microsoft.DotNet.ILCompiler"; version = "9.0.0-preview.5.24306.7"; sha256 = "0wla1jr95b7hm6wa2yx080wgy8iaqr7r3q83jp3qdnp3k2y0rgpk"; })
       (fetchNuGet { pname = "runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler"; version = "9.0.0-preview.5.24306.7"; sha256 = "00mkrwlx48dis7fg73gxj1c99zs1na4k6y11q1908a674hni8qlx"; })

--- a/pkgs/development/compilers/dotnet/versions/9.0.nix
+++ b/pkgs/development/compilers/dotnet/versions/9.0.nix
@@ -76,6 +76,7 @@ let
       (fetchNuGet { pname = "runtime.win-arm64.Microsoft.DotNet.ILCompiler"; version = "9.0.0-preview.5.24306.7"; sha256 = "1s8m140xbwc2pmyhrrmgfd4r2lppld26m6x3k1kz9gfn7kk4ayjx"; })
       (fetchNuGet { pname = "runtime.win-x64.Microsoft.DotNet.ILCompiler"; version = "9.0.0-preview.5.24306.7"; sha256 = "1f9hn43fs25fbzzhrawfjgz56mknsnmhmdgf1f1pqlpfzwb2bvvn"; })
       (fetchNuGet { pname = "Microsoft.NET.ILLink.Tasks"; version = "9.0.0-preview.5.24306.7"; sha256 = "0ck2agia8lmhvwvzh73yh2ydkqfz4g21404cv4qxjj28l618cjl5"; })
+      (fetchNuGet { pname = "runtime.osx-arm64.Microsoft.DotNet.ILCompiler"; version = "9.0.0-preview.5.24306.7"; sha256 = "1xdnyrbxdm9acnldinb4xcdk0jy32jx6rgrqwcsqh4a6xzdz7y05"; })
   ];
 in rec {
   release_9_0 = "9.0.0-preview.5";


### PR DESCRIPTION
## Description of changes

This adds the missing package and linker args so that `-p:PublishAot=true` works.  This is available on binary sdks version 7+, but not currently on the source built sdks, because ilcompiler is broken upstream.

FYI @NixOS/dotnet 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
