### PR TITLE
[Backport release-23.11] zfs_2_2: 2.2.3 -> 2.2.4; zfs_unstable: 2.2.3-unstable-2024-04-09 -> 2.2.4

### DIFF
--- a/pkgs/development/python-modules/py-libzfs/default.nix
+++ b/pkgs/development/python-modules/py-libzfs/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , cython
+, fetchpatch2
 , zfs
 }:
 
@@ -16,6 +17,13 @@ buildPythonPackage rec {
     rev = "TS-${version}";
     hash = "sha256-vBLbjP1gQEQNsTLc2W6uRzCFHQXZp+jGiwE0Pe8VTuw=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/truenas/py-libzfs/commit/b5ffe1f1d6097df6e2f5cc6dd3c968872ec60804.patch";
+      hash = "sha256-6r5hQ/o7c4vq4Tfh0l1WbeK3AuPvi+1wzkwkIn1qEes=";
+    })
+  ];
 
   nativeBuildInputs = [ cython ];
   buildInputs = [ zfs ];

--- a/pkgs/os-specific/linux/zfs/stable.nix
+++ b/pkgs/os-specific/linux/zfs/stable.nix
@@ -14,17 +14,17 @@ callPackage ./generic.nix args {
   # this attribute is the correct one for this package.
   kernelModuleAttribute = "zfs";
   # check the release notes for compatible kernels
-  kernelCompatible = kernel.kernelOlder "6.8";
+  kernelCompatible = kernel.kernelOlder "6.9";
 
-  latestCompatibleLinuxPackages = linuxKernel.packages.linux_6_6;
+  latestCompatibleLinuxPackages = linuxKernel.packages.linux_6_8;
 
   # this package should point to the latest release.
-  version = "2.2.3";
+  version = "2.2.4";
 
   tests = [
     nixosTests.zfs.installer
     nixosTests.zfs.stable
   ];
 
-  hash = "sha256-Bzkow15OitUUQ+mTYhCXgTrQl+ao/B4feleHY/rSSjg=";
+  hash = "sha256-SSp/1Tu1iGx5UDcG4j0k2fnYxK05cdE8gzfSn8DU5Z4=";
 }

--- a/pkgs/os-specific/linux/zfs/unstable.nix
+++ b/pkgs/os-specific/linux/zfs/unstable.nix
@@ -17,18 +17,19 @@ callPackage ./generic.nix args {
   # check the release notes for compatible kernels
   kernelCompatible = kernel.kernelOlder "6.9";
 
-  latestCompatibleLinuxPackages = linuxKernel.packages.linux_6_6;
+  latestCompatibleLinuxPackages = linuxKernel.packages.linux_6_8;
 
   # this package should point to a version / git revision compatible with the latest kernel release
   # IMPORTANT: Always use a tagged release candidate or commits from the
   # zfs-<version>-staging branch, because this is tested by the OpenZFS
   # maintainers.
-  version = "2.2.2";
+  version = "2.2.4";
+  # rev = "";
 
   isUnstable = true;
   tests = [
     nixosTests.zfs.unstable
   ];
 
-  hash = "sha256-CqhETAwhWMhbld5ib3Rz1dxms+GQbLwjEZw/V7U/2nE=";
+  hash = "sha256-SSp/1Tu1iGx5UDcG4j0k2fnYxK05cdE8gzfSn8DU5Z4=";
 }


### PR DESCRIPTION
## Description of changes

Manual backport of #308642 to 23.11 since Linux 6.8 was backported too.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

`nix-build zfsUnstable.passthru.tests -A zfs.passthru.tests`

`nix-build -A python3Packages.py-libzfs`

More tests pending.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
