### PR TITLE
dwarf-fortress: 50.12 -> 50.13

### DIFF
--- a/pkgs/games/dwarf-fortress/default.nix
+++ b/pkgs/games/dwarf-fortress/default.nix
@@ -49,7 +49,7 @@ let
   # The latest Dwarf Fortress version. Maintainers: when a new version comes
   # out, ensure that (unfuck|dfhack|twbt) are all up to date before changing
   # this. Note that unfuck and twbt are not required for 50.
-  latestVersion = "50.12";
+  latestVersion = "50.13";
 
   # Converts a version to a package name.
   versionToName = version: "dwarf-fortress_${replaceStrings ["."] ["_"] version}";

--- a/pkgs/games/dwarf-fortress/default.nix
+++ b/pkgs/games/dwarf-fortress/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, stdenvNoCC, gccStdenv, lib, recurseIntoAttrs, libsForQt5, newScope, texliveBasic, perlPackages, jdk8, jre8 }:
+{ stdenv, stdenvNoCC, gccStdenv, lib, recurseIntoAttrs, libsForQt5, newScope, perlPackages, jdk8, jre8 }:
 
 # To whomever it may concern:
 #
@@ -79,9 +79,7 @@ let
 
           dwarf-therapist = libsForQt5.callPackage ./dwarf-therapist/wrapper.nix {
             inherit dwarf-fortress;
-            dwarf-therapist = (libsForQt5.callPackage ./dwarf-therapist {
-              texlive = texliveBasic.withPackages (ps: with ps; [ float caption wrapfig adjmulticol sidecap preprint enumitem ]);
-            }).override (optionalAttrs (!isAtLeast50) {
+            dwarf-therapist = (libsForQt5.callPackage ./dwarf-therapist {}).override (optionalAttrs (!isAtLeast50) {
               # 41.2.5 is the last version to support Dwarf Fortress 0.47.
               version = "41.2.5";
               hash = "sha256-xfYBtnO1n6OcliVt07GsQ9alDJIfWdVhtuyWwuvXSZs=";

--- a/pkgs/games/dwarf-fortress/dfhack/default.nix
+++ b/pkgs/games/dwarf-fortress/dfhack/default.nix
@@ -89,6 +89,11 @@ let
       hash = "sha256-2mO8DpNmZRCV7IRY0arf3SMvlO4Pxs61Kxfh3q3k3HU=";
       xmlRev = "980b1af13acc31660dce632f913c968f52e2b275";
     };
+    "50.13" = {
+      dfHackRelease = "50.13-r1.1";
+      hash = "sha256-FiXanXflszTr4ogz+EoDAUxzE2U9ODeZIJJ1u6Xm4Mo=";
+      xmlRev = "3507715fd07340de5a6c47064220f6e17343e5d5";
+    };
   };
 
   release =

--- a/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
@@ -6,8 +6,8 @@
 , cmake
 , texlive
 , ninja
-, version ? "42.1.5"
-, hash ? "sha256-aUakfUjnIZWNDhCkG3A6u7BaaCG8kPMV/Fu2S73CoDg="
+, version ? "42.1.6"
+, hash ? "sha256-VjCXT4sl3HsFILrqTc3JJSeRedZaOXUbf4KvSzTo0uc="
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
@@ -4,7 +4,6 @@
 , qtbase
 , qtdeclarative
 , cmake
-, texlive
 , ninja
 , version ? "42.1.6"
 , hash ? "sha256-VjCXT4sl3HsFILrqTc3JJSeRedZaOXUbf4KvSzTo0uc="
@@ -22,7 +21,7 @@ stdenv.mkDerivation rec {
     inherit hash;
   };
 
-  nativeBuildInputs = [ texlive cmake ninja ];
+  nativeBuildInputs = [ cmake ninja ];
   buildInputs = [ qtbase qtdeclarative ];
 
   enableParallelBuilding = true;

--- a/pkgs/games/dwarf-fortress/game.json
+++ b/pkgs/games/dwarf-fortress/game.json
@@ -144,5 +144,8 @@
   },
   "50.12": {
     "linux": "070014fzwszfgjyxjyij0k0hadah6s62lpi91ykp3vs220azya1m"
+  },
+  "50.13": {
+    "linux": "19wzgsdgv0vq7v2dxhypr9hayky3nm3lbra1kk9vn8ri96jdkfkw"
   }
 }


### PR DESCRIPTION
## Description of changes

- dwarf-fortress: 50.12 -> 50.13
- dfhack: init 50.13-r1.1
- dwarf-therapist: 42.1.5 -> 42.1.6

Sadly does not fix game audio (which was reported upstream).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

`NIXPKGS_ALLOW_UNFREE=1 nix build .#dwarf-fortress-packages.dwarf-fortress-full --impure -L`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
