### PR TITLE
maker-panel: bump dependency to fix compilation error

### DIFF
--- a/pkgs/tools/misc/maker-panel/default.nix
+++ b/pkgs/tools/misc/maker-panel/default.nix
@@ -16,7 +16,9 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0dlsy0c46781sb652kp80pvga7pzx6xla64axir92fcgg8k803bi";
   };
 
-  cargoSha256 = "1ar62dn0khlbm47chakrsrxd1y76gpq0sql4g9j7dqqrvkavgd7w";
+  cargoHash = "sha256-Ygya/9keRyIQyjrO6medtcXww9LMG3ne6I/8q35lJPo=";
+
+  cargoPatches = [ ./update-gerber-types-to-0.3.patch ];
 
   nativeBuildInputs = [ go-md2man installShellFiles ];
 

--- a/pkgs/tools/misc/maker-panel/update-gerber-types-to-0.3.patch
+++ b/pkgs/tools/misc/maker-panel/update-gerber-types-to-0.3.patch
@@ -1,0 +1,109 @@
+From e616648213b75f60703bd68e028f0af78199a565 Mon Sep 17 00:00:00 2001
+From: Leah Amelia Chen <hi@pluie.me>
+Date: Mon, 6 May 2024 10:43:56 +0200
+Subject: [PATCH] Update gerber-types to 0.3.0
+
+Required to update num-bigint to ^0.3.3, in order to compile on modern
+Rust versions with a native `div_ceil` on unsigned integers.
+---
+ Cargo.lock | 26 ++++++++++++++++----------
+ Cargo.toml |  2 +-
+ 2 files changed, 17 insertions(+), 11 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 1b15393..41cd500 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -387,7 +387,7 @@ dependencies = [
+  "log",
+  "memmap2",
+  "ttf-parser",
+- "uuid",
++ "uuid 0.8.2",
+ ]
+
+ [[package]]
+@@ -471,15 +471,15 @@ dependencies = [
+
+ [[package]]
+ name = "gerber-types"
+-version = "0.2.0"
++version = "0.3.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c7badd25c55b207eb6607600b73293d9627587b2dc0608031aa8de50e63810d3"
++checksum = "aecf78a269d7b4f73953f30174b18f52c1bb44f7d58f4d830a76c0ea023ad8bc"
+ dependencies = [
+  "chrono",
+  "conv",
+  "num-rational",
+  "thiserror",
+- "uuid",
++ "uuid 1.8.0",
+ ]
+
+ [[package]]
+@@ -780,9 +780,9 @@ dependencies = [
+
+ [[package]]
+ name = "num-bigint"
+-version = "0.3.2"
++version = "0.4.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
++checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+ dependencies = [
+  "autocfg",
+  "num-integer",
+@@ -801,9 +801,9 @@ dependencies = [
+
+ [[package]]
+ name = "num-rational"
+-version = "0.3.2"
++version = "0.4.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
++checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+ dependencies = [
+  "autocfg",
+  "num-bigint",
+@@ -813,9 +813,9 @@ dependencies = [
+
+ [[package]]
+ name = "num-traits"
+-version = "0.2.14"
++version = "0.2.19"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
++checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+ dependencies = [
+  "autocfg",
+ ]
+@@ -1379,6 +1379,12 @@ dependencies = [
+  "getrandom 0.2.2",
+ ]
+
++[[package]]
++name = "uuid"
++version = "1.8.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
++
+ [[package]]
+ name = "vec_map"
+ version = "0.8.2"
+diff --git a/Cargo.toml b/Cargo.toml
+index 2f9e8ea..09f0410 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -13,7 +13,7 @@ geo-booleanop = "0.3.2"
+ geo = "0.16"
+ usvg = { version = "0.12", default-features = false }
+ resvg = { version = "0.12", default-features = false }
+-gerber-types = "0.2"
++gerber-types = "0.3"
+ #{ git = "https://github.com/twitchyliquid64/gerber-types-rs", rev = "e927ed2ff68d9e8629dbc36d5f1e5626da472376" }
+ structopt = "0.3"
+ zip = { version = "0.5", default-features = false }
+--
+2.44.0
+


### PR DESCRIPTION
## Description of changes

One of the dependencies of this crate, `num-bigint`, fails to compile on Rust versions >=1.73 due to a name conflict (see rust-num/num-bigint#219).

This commit fixes the compilation failure by bumping the `gerber-types` dependency to 0.3, which includes a newer version of `num-bigint` that compiles with the latest `rustc`.

This is part of [the ongoing ZHF campaign for 24.05](https://github.com/NixOS/nixpkgs/issues/309482).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
