### PR TITLE
mpvScripts.evafast: Specify upstream branch in `updateScript`

### DIFF
--- a/pkgs/applications/video/mpv/scripts/evafast.nix
+++ b/pkgs/applications/video/mpv/scripts/evafast.nix
@@ -16,7 +16,8 @@ buildLua {
     hash = "sha256-BGWD2XwVu8zOSiDJ+9oWi8aPN2Wkw0Y0gF58X4f+tdI=";
   };
 
-  passthru.updateScript = unstableGitUpdater { };
+  # Drop the `branch` parameter once upstream merges `rewrite` back into `master`
+  passthru.updateScript = unstableGitUpdater { branch = "rewrite"; };
 
   meta = with lib; {
     description = "Seeking and hybrid fastforwarding like VHS";


### PR DESCRIPTION
## Description of changes

Specified `mpvScripts.evafast.updateScript`'s `branch` argument.

The upstream repo's `HEAD` points to branch `master`,
whereas the currently-packaged version comes from branch `rewrite`

@purrpurrn This will need updating once upstream merges `rewrite` into `master`.


## Things done

- [x] Ran `nix-shell maintainers/scripts/update.nix --argstr package mpvScripts.evafast`
  confirmed the `updateScript` now behaves as desired
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
