### PR TITLE
Fix ebusd service argument passing

### DIFF
--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -90,7 +90,16 @@ rec {
     mkOption ?
       k: v: if v == null
             then []
-            else [ (mkOptionName k) (lib.generators.mkValueStringDefault {} v) ]
+            else if optionValueSeparator == null then
+              [ (mkOptionName k) (lib.generators.mkValueStringDefault {} v) ]
+            else
+              [ "${mkOptionName k}${optionValueSeparator}${lib.generators.mkValueStringDefault {} v}" ],
+
+    # how to separate an option from its flag;
+    # by default, there is no separator, so option `-c` and value `5`
+    # would become ["-c" "5"].
+    # This is useful if the command requires equals, for example, `-c=5`.
+    optionValueSeparator ? null
     }:
     options:
       let

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -1639,6 +1639,27 @@ runTests {
     ];
   };
 
+  testToGNUCommandLineSeparator = {
+    expr = cli.toGNUCommandLine { optionValueSeparator = "="; } {
+      data = builtins.toJSON { id = 0; };
+      X = "PUT";
+      retry = 3;
+      retry-delay = null;
+      url = [ "https://example.com/foo" "https://example.com/bar" ];
+      silent = false;
+      verbose = true;
+    };
+
+    expected = [
+      "-X=PUT"
+      "--data={\"id\":0}"
+      "--retry=3"
+      "--url=https://example.com/foo"
+      "--url=https://example.com/bar"
+      "--verbose"
+    ];
+  };
+
   testToGNUCommandLineShell = {
     expr = cli.toGNUCommandLineShell {} {
       data = builtins.toJSON { id = 0; };

--- a/nixos/modules/services/home-automation/ebusd.nix
+++ b/nixos/modules/services/home-automation/ebusd.nix
@@ -138,7 +138,7 @@ in
       after = [ "network.target" ];
       serviceConfig = {
         ExecStart = let
-          args = cli.toGNUCommandLineShell { } (foldr (a: b: a // b) { } [
+          args = cli.toGNUCommandLineShell { optionValueSeparator = "="; } (foldr (a: b: a // b) { } [
             {
               inherit (cfg) device port configpath scanconfig readonly;
               foreground = true;


### PR DESCRIPTION
## Description of changes

This resolves a bug introduced in #308500 / #264893, where ebusd arguments were changed from `--scanconfig=all` to `--scanconfig all` with the use of `cli.toGNUCommandLineShell`.

The bug is an unfortunate result of `ebusd`'s argument parsing - the arguments must be [separated by equals signs](https://github.com/john30/ebusd/blob/c084dd2cbb3411883bd1b048585724a93e1aff83/src/ebusd/main_args.cpp#L658).

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

