### PR TITLE
cargo-shear: cleanup and set build env var

### DIFF
--- a/pkgs/by-name/ca/cargo-shear/package.nix
+++ b/pkgs/by-name/ca/cargo-shear/package.nix
@@ -1,24 +1,38 @@
-{ fetchFromGitHub, lib, rustPlatform }:
-
-rustPlatform.buildRustPackage rec {
-  pname = "cargo-shear";
+{
+  fetchFromGitHub,
+  lib,
+  rustPlatform,
+  testers,
+  cargo-shear,
+}:
+let
   version = "0.0.25";
+in
+rustPlatform.buildRustPackage {
+  pname = "cargo-shear";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "Boshen";
     repo = "cargo-shear";
     rev = "v${version}";
-    sha256 = "sha256-4NnCUe4DrnSeveicxvvDF49hrc4NdRx/N10PH7Q0k8k=";
+    hash = "sha256-4NnCUe4DrnSeveicxvvDF49hrc4NdRx/N10PH7Q0k8k=";
   };
 
   cargoHash = "sha256-gHXJz3Xw9vC04q001kd6AgEKKaRtAK3oGMn7JJh+Neo=";
 
-  meta = with lib; {
+  # https://github.com/Boshen/cargo-shear/blob/a0535415a3ea94c86642f39f343f91af5cdc3829/src/lib.rs#L20-L23
+  SHEAR_VERSION = version;
+  passthru.tests.version = testers.testVersion {
+    package = cargo-shear;
+  };
+
+  meta = {
     description = "Detect and remove unused dependencies from Cargo.toml";
     mainProgram = "cargo-shear";
     homepage = "https://github.com/Boshen/cargo-shear";
-    changelog = "https://github.com/Boshen/cargo-shear/blob/${src.rev}/CHANGELOG.md";
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [ uncenter ];
+    changelog = "https://github.com/Boshen/cargo-shear/blob/v${version}/CHANGELOG.md";
+    license = [ lib.licenses.mit ];
+    maintainers = with lib.maintainers; [ uncenter ];
   };
 }


### PR DESCRIPTION
## Description of changes

Sets the `SHEAR_VERSION` environment variable during build for `cargo-build --version` (see https://github.com/Boshen/cargo-shear/blob/a0535415a3ea94c86642f39f343f91af5cdc3829/src/lib.rs#L20-L23, https://github.com/Boshen/cargo-shear/blob/a0535415a3ea94c86642f39f343f91af5cdc3829/.github/workflows/release-binaries.yml#L39). Adds tests to confirm this as well.

![Screenshot 2024-05-06 at 06 53 20 (Code)](https://github.com/NixOS/nixpkgs/assets/47499684/c0502f90-8fde-4358-96ba-74ef14f07f42)

Also cleans up generally to better match Nixpkgs conventions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ x Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
