### PR TITLE
sage: Add as passthru.tests to critical dependencies

### DIFF
--- a/pkgs/applications/science/math/lrcalc/default.nix
+++ b/pkgs/applications/science/math/lrcalc/default.nix
@@ -1,6 +1,9 @@
 { lib, stdenv
 , fetchFromBitbucket
 , autoreconfHook
+
+# Reverse dependency
+, sage
 }:
 
 stdenv.mkDerivation rec {
@@ -19,6 +22,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoreconfHook
   ];
+
+  passthru.tests = { inherit sage; };
 
   meta = with lib; {
     description = "Littlewood-Richardson calculator";

--- a/pkgs/development/python-modules/cypari2/default.nix
+++ b/pkgs/development/python-modules/cypari2/default.nix
@@ -7,6 +7,9 @@
 , gmp
 , cython
 , cysignals
+
+# Reverse dependency
+, sage
 }:
 
 buildPythonPackage rec {
@@ -52,6 +55,8 @@ buildPythonPackage rec {
     test -f "$out/${python.sitePackages}/cypari2/auto_paridecl.pxd"
     make check
   '';
+
+  passthru.tests = { inherit sage; };
 
   meta = with lib; {
     description = "Cython bindings for PARI";

--- a/pkgs/development/python-modules/cysignals/default.nix
+++ b/pkgs/development/python-modules/cysignals/default.nix
@@ -4,6 +4,9 @@
 , buildPythonPackage
 , cython
 , pariSupport ? true, pari # for interfacing with the PARI/GP signal handler
+
+# Reverse dependency
+, sage
 }:
 
 assert pariSupport -> pari != null;
@@ -45,6 +48,8 @@ buildPythonPackage rec {
   nativeBuildInputs = [ autoreconfHook ];
 
   enableParallelBuilding = true;
+
+  passthru.tests = { inherit sage; };
 
   meta = with lib; {
     description = "Interrupt and signal handling for Cython";

--- a/pkgs/development/python-modules/cython/default.nix
+++ b/pkgs/development/python-modules/cython/default.nix
@@ -8,6 +8,9 @@
 , gdb
 , numpy
 , ncurses
+
+# Reverse dependency
+, sage
 }:
 
 let
@@ -56,6 +59,8 @@ in buildPythonPackage rec {
   # Temporary solution
   doCheck = false;
   # doCheck = !stdenv.isDarwin;
+
+  passthru.tests = { inherit sage; };
 
   # force regeneration of generated code in source distributions
   # https://github.com/cython/cython/issues/5089

--- a/pkgs/development/python-modules/fpylll/default.nix
+++ b/pkgs/development/python-modules/fpylll/default.nix
@@ -15,6 +15,9 @@
 , fplll
 , numpy
 
+# Reverse dependency
+, sage
+
 # tests
 , pytestCheckHook
 }:
@@ -71,6 +74,8 @@ buildPythonPackage rec {
     # should be identical anyway.
     export PY_IGNORE_IMPORTMISMATCH=1
   '';
+
+  passthru.tests = { inherit sage; };
 
   meta = with lib; {
     description = "A Python interface for fplll";

--- a/pkgs/development/python-modules/gmpy2/default.nix
+++ b/pkgs/development/python-modules/gmpy2/default.nix
@@ -5,6 +5,9 @@
 , gmp
 , mpfr
 , libmpc
+
+# Reverse dependency
+, sage
 }:
 
 let
@@ -28,6 +31,8 @@ buildPythonPackage {
   buildInputs = [ gmp mpfr libmpc ];
 
   pythonImportsCheck = [ "gmpy2" ];
+
+  passthru.tests = { inherit sage; };
 
   meta = with lib; {
     description = "GMP/MPIR, MPFR, and MPC interface to Python 2.6+ and 3.x";

--- a/pkgs/development/python-modules/importlib-metadata/default.nix
+++ b/pkgs/development/python-modules/importlib-metadata/default.nix
@@ -7,6 +7,9 @@
 , typing-extensions
 , toml
 , zipp
+
+# Reverse dependency
+, sage
 }:
 
 buildPythonPackage rec {
@@ -40,6 +43,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "importlib_metadata"
   ];
+
+  passthru.tests = { inherit sage; };
 
   meta = with lib; {
     description = "Read metadata from Python packages";

--- a/pkgs/development/python-modules/importlib-resources/default.nix
+++ b/pkgs/development/python-modules/importlib-resources/default.nix
@@ -10,6 +10,9 @@
 # dependencies
 , importlib-metadata
 
+# Reverse dependency
+, sage
+
 # tests
 , jaraco-collections
 , pytestCheckHook
@@ -45,6 +48,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "importlib_resources"
   ];
+
+  passthru.tests = { inherit sage; };
 
   meta = with lib; {
     description = "Read resources from Python packages";

--- a/pkgs/development/python-modules/ipykernel/default.nix
+++ b/pkgs/development/python-modules/ipykernel/default.nix
@@ -18,6 +18,9 @@
 , pyzmq
 , tornado
 , traitlets
+
+# Reverse dependency
+, sage
 }:
 
 buildPythonPackage rec {
@@ -63,6 +66,7 @@ buildPythonPackage rec {
 
   passthru.tests = {
     pytest = callPackage ./tests.nix { };
+    inherit sage;
   };
 
   meta = {

--- a/pkgs/development/python-modules/ipython/default.nix
+++ b/pkgs/development/python-modules/ipython/default.nix
@@ -29,6 +29,9 @@
 , notebook
 , qtconsole
 
+# Reverse dependency
+, sage
+
 # Test dependencies
 , pickleshare
 , pytest-asyncio
@@ -105,6 +108,8 @@ buildPythonPackage rec {
     # FileNotFoundError: [Errno 2] No such file or directory: 'pbpaste'
     "test_clipboard_get"
   ];
+
+  passthru.tests = { inherit sage; };
 
   meta = with lib; {
     description = "IPython: Productive Interactive Computing";

--- a/pkgs/development/python-modules/jinja2/default.nix
+++ b/pkgs/development/python-modules/jinja2/default.nix
@@ -12,6 +12,9 @@
 , setuptools
 , sphinxcontrib-log-cabinet
 , sphinx-issues
+
+# Reverse dependency
+, sage
 }:
 
 buildPythonPackage rec {
@@ -75,6 +78,8 @@ buildPythonPackage rec {
     inherit (python) pythonVersion;
     inherit meta;
   };
+
+  passthru.tests = { inherit sage; };
 
   meta = with lib; {
     changelog = "https://github.com/pallets/jinja/blob/${version}/CHANGES.rst";

--- a/pkgs/development/python-modules/jupyter-core/default.nix
+++ b/pkgs/development/python-modules/jupyter-core/default.nix
@@ -7,6 +7,9 @@
 , traitlets
 , pip
 , pytestCheckHook
+
+# Reverse dependency
+, sage
 }:
 
 buildPythonPackage rec {
@@ -60,6 +63,8 @@ buildPythonPackage rec {
   '';
 
   pythonImportsCheck = [ "jupyter_core" ];
+
+  passthru.tests = { inherit sage; };
 
   meta = with lib; {
     description = "Base package on which Jupyter projects rely";

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -69,6 +69,9 @@
 # required for headless detection
 , libX11
 , wayland
+
+# Reverse dependency
+, sage
 }:
 
 let
@@ -182,6 +185,8 @@ buildPythonPackage rec {
       enable_lto = !stdenv.isDarwin;
     };
   };
+
+  passthru.tests = { inherit sage; };
 
   env.MPLSETUPCFG = writeText "mplsetup.cfg" (lib.generators.toINI {} passthru.config);
 

--- a/pkgs/development/python-modules/memory-allocator/default.nix
+++ b/pkgs/development/python-modules/memory-allocator/default.nix
@@ -2,6 +2,9 @@
 , fetchPypi
 , buildPythonPackage
 , cython
+
+# Reverse dependency
+, sage
 }:
 
 buildPythonPackage rec {
@@ -18,6 +21,8 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ cython ];
 
   pythonImportsCheck = [ "memory_allocator" ];
+
+  passthru.tests = { inherit sage; };
 
   meta = with lib; {
     description = "An extension class to allocate memory easily with cython";

--- a/pkgs/development/python-modules/mpmath/default.nix
+++ b/pkgs/development/python-modules/mpmath/default.nix
@@ -5,6 +5,9 @@
 , isPyPy
 , setuptools
 , pytestCheckHook
+
+# Reverse dependency
+, sage
 }:
 
 buildPythonPackage rec {
@@ -28,6 +31,8 @@ buildPythonPackage rec {
       gmpy2
     ];
   };
+
+  passthru.tests = { inherit sage; };
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/networkx/default.nix
+++ b/pkgs/development/python-modules/networkx/default.nix
@@ -19,6 +19,9 @@
 # tests
 , pytest-xdist
 , pytestCheckHook
+
+# reverse dependency
+, sage
 }:
 
 buildPythonPackage rec {
@@ -52,6 +55,8 @@ buildPythonPackage rec {
       sympy
     ];
   };
+
+  passthru.tests = { inherit sage; };
 
   nativeCheckInputs = [
     pytest-xdist

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -19,6 +19,9 @@
 , blas
 , lapack
 
+# Reverse dependency
+, sage
+
 # tests
 , hypothesis
 , pytest-xdist
@@ -177,6 +180,7 @@ in buildPythonPackage rec {
     blas = blas.provider;
     blasImplementation = blas.implementation;
     inherit cfg;
+    tests = { inherit sage; };
   };
 
   # Disable test

--- a/pkgs/development/python-modules/pexpect/default.nix
+++ b/pkgs/development/python-modules/pexpect/default.nix
@@ -3,6 +3,9 @@
 , fetchPypi
 , setuptools
 , ptyprocess
+
+# Reverse dependency
+, sage
 }:
 
 buildPythonPackage (rec {
@@ -23,6 +26,8 @@ buildPythonPackage (rec {
   doCheck = false;
 
   propagatedBuildInputs = [ ptyprocess ];
+
+  passthru.tests = { inherit sage; };
 
   meta = with lib; {
     homepage = "http://www.noah.org/wiki/Pexpect";

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -7,7 +7,7 @@
 , defusedxml, olefile, freetype, libjpeg, zlib, libtiff, libwebp, libxcrypt, tcl, lcms2, tk, libX11
 , libxcb, openjpeg, libimagequant, numpy, pytestCheckHook, setuptools
 # for passthru.tests
-, imageio, matplotlib, pilkit, pydicom, reportlab
+, imageio, matplotlib, pilkit, pydicom, reportlab, sage
 }@args:
 
 import ./generic.nix (rec {
@@ -24,7 +24,7 @@ import ./generic.nix (rec {
   };
 
   passthru.tests = {
-    inherit imageio matplotlib pilkit pydicom reportlab;
+    inherit imageio matplotlib pilkit pydicom reportlab sage;
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pplpy/default.nix
+++ b/pkgs/development/python-modules/pplpy/default.nix
@@ -9,6 +9,9 @@
 , cysignals
 , gmpy2
 , sphinx
+
+# Reverse dependency
+, sage
 }:
 
 buildPythonPackage rec {
@@ -53,6 +56,8 @@ buildPythonPackage rec {
     mkdir -p "$doc/share/doc"
     mv docs/build/html "$doc/share/doc/pplpy"
   '';
+
+  passthru.tests = { inherit sage; };
 
   meta = with lib; {
     description = "A Python wrapper for ppl";

--- a/pkgs/development/python-modules/primecountpy/default.nix
+++ b/pkgs/development/python-modules/primecountpy/default.nix
@@ -4,6 +4,9 @@
 , primecount
 , cython
 , cysignals
+
+# Reverse dependency
+, sage
 }:
 
 buildPythonPackage rec {
@@ -24,6 +27,8 @@ buildPythonPackage rec {
   doCheck = false;
 
   pythonImportsCheck = [ "primecountpy" ];
+
+  passthru.tests = { inherit sage; };
 
   meta = with lib; {
     description = "Cython interface for C++ primecount library";

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -25,6 +25,9 @@
 , xsimd
 , blas
 , lapack
+
+# Reverse dependency
+, sage
 }:
 
 let
@@ -193,6 +196,7 @@ in buildPythonPackage {
     # Pass it the names of the datasets to update their hashes
     ++ (builtins.attrNames datasetsHashes)
     ;
+    tests = { inherit sage; };
   };
 
   SCIPY_USE_G77_ABI_WRAPPER = 1;

--- a/pkgs/development/python-modules/sympy/default.nix
+++ b/pkgs/development/python-modules/sympy/default.nix
@@ -3,6 +3,9 @@
 , fetchPypi
 , glibcLocales
 , mpmath
+
+# Reverse dependency
+, sage
 }:
 
 buildPythonPackage rec {
@@ -26,6 +29,8 @@ buildPythonPackage rec {
   preCheck = ''
     export LANG="en_US.UTF-8"
   '';
+
+  passthru.tests = { inherit sage; };
 
   meta = with lib; {
     description = "A Python library for symbolic mathematics";


### PR DESCRIPTION
## Description of changes

Adds `sage` to `passthru.tests` of its dependencies, so that frequent breakages occur less frequently.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
