### PR TITLE
python3Packages.h5py: lift requirement for mpi4py version

### DIFF
--- a/pkgs/development/python-modules/h5py/default.nix
+++ b/pkgs/development/python-modules/h5py/default.nix
@@ -31,6 +31,12 @@ in buildPythonPackage rec {
     hash = "sha256-e36PeAcqLt7IfJg28l80ID/UkqRHVwmhi0F6M8+yH6k=";
   };
 
+  patches = [
+    # Unlock an overly strict locking of mpi4py version (seems not to be necessary).
+    # See also: https://github.com/h5py/h5py/pull/2418/files#r1589372479
+    ./mpi4py-requirement.patch
+  ];
+
   # avoid strict pinning of numpy
   postPatch = ''
     substituteInPlace pyproject.toml \

--- a/pkgs/development/python-modules/h5py/mpi4py-requirement.patch
+++ b/pkgs/development/python-modules/h5py/mpi4py-requirement.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index b1463422..7f0c7b10 100755
+--- a/setup.py
++++ b/setup.py
+@@ -47,7 +47,7 @@ if setup_configure.mpi_enabled():
+     # incompatible with newer setuptools.
+     RUN_REQUIRES.append('mpi4py >=3.1.1')
+     SETUP_REQUIRES.append("mpi4py ==3.1.1; python_version<'3.11'")
+-    SETUP_REQUIRES.append("mpi4py ==3.1.4; python_version>='3.11'")
++    SETUP_REQUIRES.append("mpi4py >=3.1.4; python_version>='3.11'")
+ 
+ # Set the environment variable H5PY_SETUP_REQUIRES=0 if we need to skip
+ # setup_requires for any reason.


### PR DESCRIPTION
## Description of changes

Unbreak the build for python 3.11 and python 3.12.

@sheepforce this also fixes meep.
ZHF: #309482

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
