### PR TITLE
spicetify-cli: rename bin

### DIFF
--- a/pkgs/by-name/sp/spicetify-cli/package.nix
+++ b/pkgs/by-name/sp/spicetify-cli/package.nix
@@ -1,4 +1,10 @@
-{ lib, buildGoModule, fetchFromGitHub, testers, spicetify-cli }:
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  testers,
+  spicetify-cli,
+}:
 
 buildGoModule rec {
   pname = "spicetify-cli";
@@ -20,6 +26,8 @@ buildGoModule rec {
 
   # used at runtime, but not installed by default
   postInstall = ''
+    mv $out/bin/spicetify-cli $out/bin/spicetify
+    ln -s $out/bin/spicetify $out/bin/spicetify-cli
     cp -r ${src}/jsHelper $out/bin/jsHelper
     cp -r ${src}/CustomApps $out/bin/CustomApps
     cp -r ${src}/Extensions $out/bin/Extensions
@@ -28,19 +36,19 @@ buildGoModule rec {
 
   doInstallCheck = true;
   installCheckPhase = ''
-    $out/bin/spicetify-cli --help > /dev/null
+    $out/bin/spicetify --help > /dev/null
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = spicetify-cli;
-    command = "spicetify-cli -v";
-  };
+  passthru.tests.version = testers.testVersion { package = spicetify-cli; };
 
   meta = with lib; {
     description = "Command-line tool to customize Spotify client";
     homepage = "https://github.com/spicetify/spicetify-cli/";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ jonringer mdarocha ];
-    mainProgram = "spicetify-cli";
+    maintainers = with maintainers; [
+      jonringer
+      mdarocha
+    ];
+    mainProgram = "spicetify";
   };
 }


### PR DESCRIPTION
## Description of changes

Changes the `meta.mainProgram` and output bin from `spicetify-cli` to `spicetify`. The CLI is intended to be used under the `spicetify` command: see https://spicetify.app/docs/advanced-usage/command-line-interface/, https://spicetify.app/docs/getting-started#updating. I believe Homebrew also renames the binary to `spicetify`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
