### PR TITLE
python311Packages.scikit-bio: unbreak, refactor, run tests, adopt

### DIFF
--- a/pkgs/development/python-modules/biom-format/default.nix
+++ b/pkgs/development/python-modules/biom-format/default.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  setuptools,
+  cython,
+  click,
+  numpy,
+  scipy,
+  pandas,
+  h5py,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "biom-format";
+  version = "2.1.15";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "biocore";
+    repo = "biom-format";
+    rev = "refs/tags/${version}";
+    hash = "sha256-WRBc+C/UWme7wYogy4gH4KTIdIqU3KmBm2jWzGNxGQg=";
+  };
+
+  patches = [
+    # fixes a test, can be removed in next version after 2.1.15
+    (fetchpatch {
+      name = "fix-dataframe-comparison.patch";
+      url = "https://github.com/biocore/biom-format/commit/5d1c921ca2cde5d7332508503ce990a7209d1fdc.patch";
+      hash = "sha256-nyHi469ivjJSQ01yIk/6ZMXFdoo9wVuazJHnFdy2nBg=";
+    })
+  ];
+
+  build-system = [
+    setuptools
+    cython
+    numpy
+  ];
+
+  dependencies = [
+    click
+    numpy
+    scipy
+    pandas
+    h5py
+  ];
+
+  # make pytest resolve the package from $out
+  # some tests don't work if we change the level of directory nesting
+  preCheck = ''
+    mkdir biom_tests
+    mv biom/tests biom_tests/tests
+    rm -r biom
+  '';
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pytestFlagsArray = [ "biom_tests/tests" ];
+
+  pythonImportsCheck = [ "biom" ];
+
+  meta = {
+    homepage = "http://biom-format.org/";
+    description = "Biological Observation Matrix (BIOM) format";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}

--- a/pkgs/development/python-modules/scikit-bio/default.nix
+++ b/pkgs/development/python-modules/scikit-bio/default.nix
@@ -1,22 +1,23 @@
-{ lib
-, buildPythonPackage
-, fetchPypi
-, cython
-, lockfile
-, cachecontrol
-, decorator
-, h5py
-, ipython
-, matplotlib
-, natsort
-, numpy
-, pandas
-, scipy
-, hdmedians
-, scikit-learn
-, coverage
-, python
-, isPy3k
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  cython,
+  lockfile,
+  cachecontrol,
+  decorator,
+  h5py,
+  ipython,
+  matplotlib,
+  natsort,
+  numpy,
+  pandas,
+  scipy,
+  hdmedians,
+  scikit-learn,
+  coverage,
+  python,
+  isPy3k,
 }:
 
 buildPythonPackage rec {
@@ -32,7 +33,20 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ cython ];
   nativeCheckInputs = [ coverage ];
-  propagatedBuildInputs = [ lockfile cachecontrol decorator ipython matplotlib natsort numpy pandas scipy h5py hdmedians scikit-learn ];
+  propagatedBuildInputs = [
+    lockfile
+    cachecontrol
+    decorator
+    ipython
+    matplotlib
+    natsort
+    numpy
+    pandas
+    scipy
+    h5py
+    hdmedians
+    scikit-learn
+  ];
 
   # cython package not included for tests
   doCheck = false;
@@ -47,7 +61,10 @@ buildPythonPackage rec {
     homepage = "http://scikit-bio.org/";
     description = "Data structures, algorithms and educational resources for bioinformatics";
     license = licenses.bsd3;
-    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+    ];
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/scikit-bio/default.nix
+++ b/pkgs/development/python-modules/scikit-bio/default.nix
@@ -1,70 +1,64 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
+  setuptools,
   cython,
-  lockfile,
-  cachecontrol,
+  oldest-supported-numpy,
+  requests,
   decorator,
-  h5py,
-  ipython,
-  matplotlib,
   natsort,
   numpy,
   pandas,
   scipy,
+  h5py,
   hdmedians,
-  scikit-learn,
-  coverage,
+  biom-format,
   python,
-  isPy3k,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
-  version = "0.6.0";
-  format = "setuptools";
   pname = "scikit-bio";
-  disabled = !isPy3k;
+  version = "0.6.0";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-EBBafDwVrlkQJEkn8punqjUjSxnr5lE7hIRUc0OywQ8=";
+  src = fetchFromGitHub {
+    owner = "scikit-bio";
+    repo = "scikit-bio";
+    rev = "refs/tags/${version}";
+    hash = "sha256-v8/r52pJpMi34SekPQBf7CqRbs+ZEyPR3WO5RBB7uKg=";
   };
 
-  nativeBuildInputs = [ cython ];
-  nativeCheckInputs = [ coverage ];
-  propagatedBuildInputs = [
-    lockfile
-    cachecontrol
+  build-system = [
+    setuptools
+    cython
+    oldest-supported-numpy
+  ];
+
+  dependencies = [
+    requests
     decorator
-    ipython
-    matplotlib
     natsort
     numpy
     pandas
     scipy
     h5py
     hdmedians
-    scikit-learn
+    biom-format
   ];
 
-  # cython package not included for tests
-  doCheck = false;
+  nativeCheckInputs = [ pytestCheckHook ];
 
-  checkPhase = ''
-    ${python.interpreter} -m skbio.test
-  '';
+  # only the $out dir contains the built cython extensions, so we run the tests inside there
+  pytestFlagsArray = [ "${placeholder "out"}/${python.sitePackages}/skbio" ];
 
   pythonImportsCheck = [ "skbio" ];
 
-  meta = with lib; {
+  meta = {
     homepage = "http://scikit-bio.org/";
     description = "Data structures, algorithms and educational resources for bioinformatics";
-    license = licenses.bsd3;
-    platforms = [
-      "x86_64-linux"
-      "x86_64-darwin"
-    ];
-    maintainers = [ ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ tomasajt ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1529,6 +1529,8 @@ self: super: with self; {
 
   binwalk-full = self.binwalk.override { visualizationSupport = true; };
 
+  biom-format = callPackage ../development/python-modules/biom-format { };
+
   biopandas = callPackage ../development/python-modules/biopandas { };
 
   biopython = callPackage ../development/python-modules/biopython { };


### PR DESCRIPTION
## Description of changes

Last version bump broke the `scikit-bio` package, some dependencies were missing. This PR adds the missing dependency (`bio-format`), and refactors a lot of the code of the `scikit-bio` package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
