### PR TITLE
siril: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/applications/science/astronomy/siril/default.nix
+++ b/pkgs/applications/science/astronomy/siril/default.nix
@@ -1,27 +1,20 @@
-{ lib, stdenv, fetchFromGitLab, fetchpatch, pkg-config, meson, ninja, cmake
+{ lib, stdenv, fetchFromGitLab, pkg-config, meson, ninja, cmake
 , git, criterion, gtk3, libconfig, gnuplot, opencv, json-glib
 , fftwFloat, cfitsio, gsl, exiv2, librtprocess, wcslib, ffmpeg
 , libraw, libtiff, libpng, libjpeg, libheif, ffms, wrapGAppsHook3
+, curl
 }:
 
 stdenv.mkDerivation rec {
   pname = "siril";
-  version = "1.2.0";
+  version = "1.2.1";
 
   src = fetchFromGitLab {
     owner = "free-astro";
     repo = "siril";
     rev = version;
-    hash = "sha256-lCoFQ7z6cZbyNPEm5s40DNdvTwFonHK3KCd8RniqQWs=";
+    hash = "sha256-njvByA8nbG3qHKfv8eX20TrIhngVI0nzIHmhYIN6htE=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "siril-1.2-exiv2-0.28.patch";
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sci-astronomy/siril/files/siril-1.2-exiv2-0.28.patch?id=002882203ad6a2b08ce035a18b95844a9f4b85d0";
-      hash = "sha256-R1yslW6hzvJHKo0/IqBxkCuqcX6VrdRSz68gpAExxVE=";
-    })
-  ];
 
   nativeBuildInputs = [
     meson ninja cmake pkg-config git criterion wrapGAppsHook3
@@ -30,14 +23,16 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gtk3 cfitsio gsl exiv2 gnuplot opencv fftwFloat librtprocess wcslib
     libconfig libraw libtiff libpng libjpeg libheif ffms ffmpeg json-glib
+    curl
   ];
 
   # Necessary because project uses default build dir for flatpaks/snaps
   dontUseMesonConfigure = true;
   dontUseCmakeConfigure = true;
 
+  # Meson fails to find libcurl unless the option is specifically enabled
   configureScript = ''
-    ${meson}/bin/meson --buildtype release nixbld .
+    ${meson}/bin/meson setup -Denable-libcurl=yes --buildtype release nixbld .
   '';
 
   postConfigure = ''


### PR DESCRIPTION
## Description of changes

Upgrade to latest upstream release: https://siril.org/download/2024-01-26-siril-1.2.1/

Add support for libcurl to enable features such as [photometric color calibration](https://siril.readthedocs.io/en/stable/processing/colors.html#photometric-color-calibration).

Remove exiv patch which has since been [merged](https://gitlab.com/free-astro/siril/-/commit/713b1d9c6edd9c7e0e00bd4ed05101cede6590bf) upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux

- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
