### PR TITLE
libdevil: fix compilation on Darwin with clang

### DIFF
--- a/pkgs/development/libraries/libdevil/default.nix
+++ b/pkgs/development/libraries/libdevil/default.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [ "--enable-ILU" "--enable-ILUT" ];
 
+  CXXFLAGS = lib.optionalString stdenv.isDarwin "-Wno-register";
+
   preConfigure = ''
     sed -i 's, -std=gnu99,,g' configure
     sed -i 's,malloc.h,stdlib.h,g' src-ILU/ilur/ilur.c

--- a/pkgs/development/libraries/libdevil/default.nix
+++ b/pkgs/development/libraries/libdevil/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [ "--enable-ILU" "--enable-ILUT" ];
 
-  CXXFLAGS = lib.optionalString stdenv.isDarwin "-Wno-register";
+  CXXFLAGS = lib.optionalString stdenv.cc.isClang "-Wno-register";
 
   preConfigure = ''
     sed -i 's, -std=gnu99,,g' configure


### PR DESCRIPTION
Compilation fails now that the default C++ standard is 17, because the (rather old) upstream code uses the "register" keyword.

```
./../src-IL/include/il_manip.h:63:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
        register int m =   i        & 0x007fffff;
        ^~~~~~~~~
```
We could selectively set -std=c++14, but it also seems sufficient to suppress the warning, so this commit chooses that option.

Fixes #309078. Fixes #309417.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
