### PR TITLE
nixos/ipa: Enable sudo, authorized_keys, and netgroups integration

### DIFF
--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -85,6 +85,18 @@ with lib;
         '';
         default = [];
       };
+
+      sudoers = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          List of sudoers entries to configure in {file}`/etc/nsswitch.conf`.
+
+          Note that "files" is always prepended.
+
+          This option only takes effect if both nscd and sudo are enabled.
+        '';
+        default = [];
+      };
     };
   };
 
@@ -120,6 +132,8 @@ with lib;
       services:  ${concatStringsSep " " config.system.nssDatabases.services}
       protocols: files
       rpc:       files
+
+      sudoers:   ${concatStringsSep " " config.system.nssDatabases.sudoers}
     '';
 
     system.nssDatabases = {
@@ -131,6 +145,7 @@ with lib;
         (mkOrder 1499 [ "dns" ])
       ];
       services = mkBefore [ "files" ];
+      sudoers = mkBefore [ "files" ];
     };
   };
 }

--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -50,6 +50,18 @@ with lib;
         default = [];
       };
 
+      netgroup = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          List of netgroup entries to configure in {file}`/etc/nsswitch.conf`.
+
+          Note that "files" is always prepended.
+
+          This option only takes effect if nscd is enabled.
+        '';
+        default = [];
+      };
+
       shadow = mkOption {
         type = types.listOf types.str;
         description = ''
@@ -134,6 +146,7 @@ with lib;
       rpc:       files
 
       sudoers:   ${concatStringsSep " " config.system.nssDatabases.sudoers}
+      netgroup:  ${concatStringsSep " " config.system.nssDatabases.netgroup}
     '';
 
     system.nssDatabases = {
@@ -146,6 +159,7 @@ with lib;
       ];
       services = mkBefore [ "files" ];
       sudoers = mkBefore [ "files" ];
+      netgroup = mkBefore [ "files" ];
     };
   };
 }

--- a/nixos/modules/security/ipa.nix
+++ b/nixos/modules/security/ipa.nix
@@ -257,9 +257,12 @@ in {
       allowed_uids = ${concatStringsSep ", " cfg.ifpAllowedUids}
     '';
 
-    services.ntp.servers = singleton cfg.server;
-    services.sssd.enable = true;
     services.ntp.enable = true;
+    services.ntp.servers = singleton cfg.server;
+
+    services.sssd.enable = true;
+    services.sssd.sshAuthorizedKeysIntegration = true;
+    services.sssd.sudoIntegration = true;
 
     security.pki.certificateFiles = singleton cfg.certificate;
   };

--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -132,6 +132,7 @@ in {
         passwd = [ "sss" ];
         services = [ "sss" ];
         shadow = [ "sss" ];
+        netgroup = [ "sss" ];
       };
       services.dbus.packages = [ pkgs.sssd ];
     })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13294,6 +13294,10 @@ with pkgs;
 
   sudo = callPackage ../tools/security/sudo { };
 
+  sudoWithSssd = sudo.override {
+    withSssd = true;
+  };
+
   sudo-rs = callPackage ../tools/security/sudo-rs { };
 
   suidChroot = callPackage ../tools/system/suid-chroot { };


### PR DESCRIPTION
## Description of changes

- Add sudoWithSssd variant to all-packages.nix
- nixos/nsswitch: Add sudoers and netgroup nssDatabases options
- nixos/sssd: Add sudoIntegration option, enable nss netgroup lookups
- nixos/ipa: Enable sudo and authorized_keys integration when freeipa client is enabled

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
