### PR TITLE
copilot: unstable-2023-12-26 -> unstable-2024-05-01

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/copilot/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/copilot/default.nix
@@ -2,6 +2,7 @@
   lib,
   dash,
   editorconfig,
+  f,
   fetchFromGitHub,
   nodejs,
   s,
@@ -9,13 +10,13 @@
 }:
 melpaBuild {
   pname = "copilot";
-  version = "0-unstable-2023-12-26";
+  version = "0-unstable-2024-05-01";
 
   src = fetchFromGitHub {
-    owner = "zerolfx";
+    owner = "copilot-emacs";
     repo = "copilot.el";
-    rev = "d4fa14cea818e041b4a536c5052cf6d28c7223d7";
-    sha256 = "sha256-Tzs0Dawqa+OD0RSsf66ORbH6MdBp7BMXX7z+5UuNwq4=";
+    rev = "733bff26450255e092c10873580e9abfed8a81b8";
+    sha256 = "sha256-Knp36PtgA73gtYO+W1clQfr570bKCxTFsGW3/iH86A0=";
   };
 
   files = ''(:defaults "dist")'';
@@ -23,6 +24,7 @@ melpaBuild {
   packageRequires = [
     dash
     editorconfig
+    f
     s
   ];
 
@@ -30,8 +32,9 @@ melpaBuild {
 
   meta = {
     description = "Unofficial copilot plugin for Emacs";
-    homepage = "https://github.com/zerolfx/copilot.el";
+    homepage = "https://github.com/copilot-emacs/copilot.el";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bbigras ];
     platforms = [
       "x86_64-darwin"
       "x86_64-linux"


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

@samuelrivas 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
