### PR TITLE
rocmPackages.rocgdb: Ensure build with AMDPGU support, plus various improvements

### DIFF
--- a/pkgs/development/rocm-modules/6/default.nix
+++ b/pkgs/development/rocm-modules/6/default.nix
@@ -115,8 +115,7 @@ in rec {
   };
 
   rocgdb = callPackage ./rocgdb {
-    inherit rocmUpdateScript;
-    elfutils = elfutils.override { enableDebuginfod = true; };
+    inherit rocmUpdateScript rocdbgapi;
     stdenv = llvm.rocmClangStdenv;
   };
 

--- a/pkgs/development/rocm-modules/6/rocgdb/default.nix
+++ b/pkgs/development/rocm-modules/6/rocgdb/default.nix
@@ -6,11 +6,16 @@
 , texinfo
 , bison
 , flex
+, glibc
 , zlib
-, elfutils
 , gmp
+, mpfr
 , ncurses
 , expat
+, rocdbgapi
+, python3
+, babeltrace
+, sourceHighlight
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -33,11 +38,52 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     zlib
-    elfutils
     gmp
+    mpfr
     ncurses
     expat
+    rocdbgapi
+    python3
+    babeltrace
+    sourceHighlight
   ];
+
+  configureFlags = [
+    # Ensure we build the amdgpu traget
+    "--enable-targets=${stdenv.targetPlatform.config},amdgcn-amd-amdhsa"
+    "--with-amd-dbgapi=yes"
+
+    "--with-iconv-path=${glibc.bin}"
+    "--enable-tui"
+    "--with-babeltrace"
+    "--with-python=python3"
+    "--with-system-zlib"
+    "--enable-64-bit-bfd"
+    "--with-gmp=${gmp.dev}"
+    "--with-mpfr=${mpfr.dev}"
+    "--with-expat"
+    "--with-libexpat-prefix=${expat.dev}"
+
+    # So the installed binary is called "rocgdb" instead on plain "gdb"
+    "--program-prefix=roc"
+
+    # Disable building many components not used or incompatible with the amdgcn target
+    "--disable-sim"
+    "--disable-gdbserver"
+    "--disable-ld"
+    "--disable-gas"
+    "--disable-gdbserver"
+    "--disable-sim"
+    "--disable-gdbtk"
+    "--disable-gprofng"
+    "--disable-shared"
+  ];
+
+  # The source directory for ROCgdb (based on upstream GDB) contains multiple project
+  # of GNU’s toolchain (binutils and onther), we only need to install the GDB part.
+  installPhase = ''
+    make install-gdb
+  '';
 
   # `-Wno-format-nonliteral` doesn't work
   env.NIX_CFLAGS_COMPILE = "-Wno-error=format-security";

--- a/pkgs/development/rocm-modules/6/rocgdb/default.nix
+++ b/pkgs/development/rocm-modules/6/rocgdb/default.nix
@@ -97,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "ROCm source-level debugger for Linux, based on GDB";
     homepage = "https://github.com/ROCm/ROCgdb";
-    license = with licenses; [ gpl2 gpl3 bsd3 ];
+    license = licenses.gpl3Plus;
     maintainers = teams.rocm.members;
     platforms = platforms.linux;
     broken = versionAtLeast finalAttrs.version "7.0.0";


### PR DESCRIPTION
## Description of changes

The current ROCgdb project is built without AMDGPU support.  The current patch mostly aim at fixing this, plus other various improvements:

- Review dependencies ROCgdb is built against (I mostly use those recommended [here](https://rocm.docs.amd.com/projects/ROCgdb/en/latest/build.html))
- Add the `--program-prefix` configure option so the `gdb` is installed as `rocgdb`.
- The source repo contains GDB + various other GNU toolchain projects (binutils. ,,,).  This package is only interested in installing ROCgdb, so I use `make install-gdb` to avoid installing other unrelated components.
- Disable building many components that we do not need (binutils, as, ld), or which are not compatible with the amdgpu target (gdbserver, gprofng, ...).
- Those patches also adjust the ROCgdb license to GPLv3+.

I have tested the resulting `result/bin/rocgdb` against a gfx1031 card.

I am aware there are quite a few changes here, I am happy splitting those patch further if needed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
