### PR TITLE
pkgs/development/libraries: Fix some unstableGitUpdater users

### DIFF
--- a/pkgs/development/libraries/cegui/default.nix
+++ b/pkgs/development/libraries/cegui/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, writeShellScript
 , cmake
 , ogre
 , freetype
@@ -13,7 +14,7 @@
 
 stdenv.mkDerivation {
   pname = "cegui";
-  version = "unstable-2023-03-18";
+  version = "0-unstable-2023-03-18";
 
   src = fetchFromGitHub {
     owner = "paroj";
@@ -47,6 +48,12 @@ stdenv.mkDerivation {
 
   passthru.updateScript = unstableGitUpdater {
     branch = "v0";
+    # The above branch is separate from the branch with the latest tags, so the updater doesn't pick them up
+    # This is what would be used to handle upstream's format, if it was able to see the tags
+    # tagConverter = writeShellScript "cegui-tag-converter.sh" ''
+    #   sed -e 's/^v//g' -e 's/-/./g'
+    # '';
+    hardcodeZeroVersion = true;
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/crossguid/default.nix
+++ b/pkgs/development/libraries/crossguid/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "crossguid";
-  version = "unstable-2019-05-29";
+  version = "0.2.2-unstable-2019-05-29";
 
   src = fetchFromGitHub {
     owner = "graeme-hill";
@@ -24,7 +24,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = lib.optional stdenv.isLinux libuuid;
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
 
   meta = with lib; {
     description = "Lightweight cross platform C++ GUID/UUID library";

--- a/pkgs/development/libraries/gl3w/default.nix
+++ b/pkgs/development/libraries/gl3w/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "gl3w";
-  version = "unstable-2023-10-10";
+  version = "0-unstable-2023-10-10";
 
   src = fetchFromGitHub {
     owner = "skaslev";

--- a/pkgs/development/libraries/gtk-frdp/default.nix
+++ b/pkgs/development/libraries/gtk-frdp/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation rec {
   pname = "gtk-frdp";
-  version = "unstable-2024-03-01";
+  version = "3.37.1-unstable-2024-03-01";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
@@ -41,7 +41,9 @@ stdenv.mkDerivation rec {
   ];
 
   passthru = {
-    updateScript = unstableGitUpdater { };
+    updateScript = unstableGitUpdater {
+      tagPrefix = "v";
+    };
   };
 
   env.NIX_CFLAGS_COMPILE = toString (lib.optionals stdenv.isDarwin [

--- a/pkgs/development/libraries/hax11/default.nix
+++ b/pkgs/development/libraries/hax11/default.nix
@@ -9,7 +9,7 @@
 
 multiStdenv.mkDerivation (finalAttrs: {
   pname = "hax11";
-  version = "unstable-2023-09-25";
+  version = "0-unstable-2023-09-25";
 
   src = fetchFromGitHub {
     owner = "CyberShadow";

--- a/pkgs/development/libraries/libcxxrt/default.nix
+++ b/pkgs/development/libraries/libcxxrt/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
   pname = "libcxxrt";
-  version = "unstable-2024-04-15";
+  version = "4.0.10-unstable-2024-04-15";
 
   src = fetchFromGitHub {
     owner = "libcxxrt";

--- a/pkgs/development/libraries/libsegfault/default.nix
+++ b/pkgs/development/libraries/libsegfault/default.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libsegfault";
-  version = "unstable-2022-11-13";
+  version = "0-unstable-2022-11-13";
 
   src = fetchFromGitHub {
     owner = "jonathanpoelen";

--- a/pkgs/development/libraries/libvgm/default.nix
+++ b/pkgs/development/libraries/libvgm/default.nix
@@ -42,7 +42,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "libvgm";
-  version = "unstable-2024-04-24";
+  version = "0-unstable-2024-04-24";
 
   src = fetchFromGitHub {
     owner = "ValleyBell";

--- a/pkgs/development/libraries/libz/default.nix
+++ b/pkgs/development/libraries/libz/default.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libz";
-  version = "unstable-2018-03-31";
+  version = "1.2.8.2015.12.26-unstable-2018-03-31";
 
   src = fetchFromGitLab {
     owner = "sortix";
@@ -18,7 +18,9 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [ "out" "dev" ];
   outputDoc = "dev"; # single tiny man3 page
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "libz-";
+  };
 
   meta = {
     homepage = "https://sortix.org/libz/";

--- a/pkgs/development/libraries/minilibx/default.nix
+++ b/pkgs/development/libraries/minilibx/default.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation {
   pname = "minilibx";
-  version = "unstable-2021-10-30";
+  version = "0-unstable-2021-10-30";
 
   src = fetchFromGitHub {
     owner = "42Paris";

--- a/pkgs/development/libraries/rapidcheck/default.nix
+++ b/pkgs/development/libraries/rapidcheck/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rapidcheck";
-  version = "unstable-2023-12-14";
+  version = "0-unstable-2023-12-14";
 
   src = fetchFromGitHub {
     owner = "emil-e";


### PR DESCRIPTION
## Description of changes

#280501 now makes `unstableGitUpdater` produce versions that match our desired unstable version schema. Start fixing the versions of packages that use it, and their `unstableGitUpdater` arguments as needed.

Tackling `pkgs/development/libraries` here. The only directory left after this from the initial treewide PR is `pkgs/development/libraries`, where I expect the amount of rebuilds to shoot up abit. Checked running the update script of everything, which results in either the same version & revs as corrected here, or newer versions.

The review shell wouldn't get built properly:
```
error: The store path /nix/store/b8v5azw991mibnqirpq44jzn2mig2jgr-update-python-libraries is a file and can't be merged into an environment using pkgs.buildEnv! at /nix/store/62vdaz1lphcpz98192ljywh8s9dknq4m-builder.pl line 122.
error: builder for '/nix/store/gkbj8ailg3zrvsfkknjw1d2j3y0hmnd2-env.drv' failed with exit code 2;
```

But running it with `--no-shell --print-result` shows the results just fine:

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>152 packages built:</summary>
  <ul>
    <li>appvm</li>
    <li>attic-client</li>
    <li>attic-server</li>
    <li>bundix</li>
    <li>cabal2nix</li>
    <li>cached-nix-shell</li>
    <li>cachix (cachix.bin ,cachix.doc)</li>
    <li>cegui</li>
    <li>colmena</li>
    <li>common-updater-scripts</li>
    <li>crate2nix</li>
    <li>crossguid</li>
    <li>crystal2nix</li>
    <li>dep2nix</li>
    <li>devenv</li>
    <li>disko</li>
    <li>dub-to-nix</li>
    <li>dydisnix</li>
    <li>fusionInventory</li>
    <li>gl3w</li>
    <li>gnome-connections</li>
    <li>gtk-frdp</li>
    <li>harmonia</li>
    <li>hax11</li>
    <li>hax11.doc</li>
    <li>hci</li>
    <li>hercules-ci-agent</li>
    <li>hercules-ci-agent.data</li>
    <li>home-manager</li>
    <li>hydra_unstable</li>
    <li>libcxxrt</li>
    <li>libnixxml</li>
    <li>libsegfault</li>
    <li>libvgm</li>
    <li>libvgm.dev</li>
    <li>libz</li>
    <li>libz.dev</li>
    <li>lua51Packages.luarocks-nix</li>
    <li>lua52Packages.luarocks-nix</li>
    <li>lua53Packages.luarocks-nix</li>
    <li>lua54Packages.luarocks-nix</li>
    <li>luajitPackages.luarocks-nix</li>
    <li>luarocks-packages-updater</li>
    <li>minilibx</li>
    <li>minilibx.dev</li>
    <li>minilibx.man</li>
    <li>mmlgui</li>
    <li>nil</li>
    <li>nim_lk</li>
    <li>niv (niv.bin ,niv.data)</li>
    <li>nix (nixVersions.nix_2_18)</li>
    <li>nix-binary-cache</li>
    <li>nix-bundle</li>
    <li>nix-direnv</li>
    <li>nix-doc</li>
    <li>nix-du</li>
    <li>nix-eval-jobs</li>
    <li>nix-index</li>
    <li>nix-init</li>
    <li>nix-inspect</li>
    <li>nix-pin</li>
    <li>nix-plugins</li>
    <li>nix-prefetch</li>
    <li>nix-prefetch-bzr</li>
    <li>nix-prefetch-cvs</li>
    <li>nix-prefetch-docker</li>
    <li>nix-prefetch-git</li>
    <li>nix-prefetch-hg</li>
    <li>nix-prefetch-scripts</li>
    <li>nix-prefetch-svn</li>
    <li>nix-serve</li>
    <li>nix-serve-ng</li>
    <li>nix-simple-deploy</li>
    <li>nix-template</li>
    <li>nix-unit</li>
    <li>nix-update</li>
    <li>nix-update-source</li>
    <li>nix-update-source.dist</li>
    <li>nix-update.dist</li>
    <li>nix-visualize</li>
    <li>nix-visualize.dist</li>
    <li>nix-web</li>
    <li>nix.debug (nixVersions.nix_2_18.debug)</li>
    <li>nix.dev (nixVersions.nix_2_18.dev)</li>
    <li>nix.doc (nixVersions.nix_2_18.doc)</li>
    <li>nix.man (nixVersions.nix_2_18.man)</li>
    <li>nixStatic</li>
    <li>nixStatic.dev</li>
    <li>nixVersions.git</li>
    <li>nixVersions.git.debug</li>
    <li>nixVersions.git.dev</li>
    <li>nixVersions.git.doc</li>
    <li>nixVersions.git.man</li>
    <li>nixVersions.latest</li>
    <li>nixVersions.latest.debug</li>
    <li>nixVersions.latest.dev</li>
    <li>nixVersions.latest.doc</li>
    <li>nixVersions.latest.man</li>
    <li>nixVersions.nix_2_19</li>
    <li>nixVersions.nix_2_19.debug</li>
    <li>nixVersions.nix_2_19.dev</li>
    <li>nixVersions.nix_2_19.doc</li>
    <li>nixVersions.nix_2_19.man</li>
    <li>nixVersions.nix_2_20</li>
    <li>nixVersions.nix_2_20.debug</li>
    <li>nixVersions.nix_2_20.dev</li>
    <li>nixVersions.nix_2_20.doc</li>
    <li>nixVersions.nix_2_20.man</li>
    <li>nixVersions.nix_2_21</li>
    <li>nixVersions.nix_2_21.debug</li>
    <li>nixVersions.nix_2_21.dev</li>
    <li>nixVersions.nix_2_21.doc</li>
    <li>nixVersions.nix_2_21.man</li>
    <li>nixd</li>
    <li>nixos-anywhere</li>
    <li>nixos-generators</li>
    <li>nixos-option</li>
    <li>nixos-rebuild</li>
    <li>nixos-shell</li>
    <li>nixpkgs-hammering</li>
    <li>nixpkgs-review</li>
    <li>nixpkgs-review.dist</li>
    <li>node2nix</li>
    <li>npins</li>
    <li>nuget-to-nix</li>
    <li>nurl</li>
    <li>nvfetcher</li>
    <li>opendungeons</li>
    <li>outline</li>
    <li>prefetch-yarn-deps</li>
    <li>python311Packages.nix-kernel</li>
    <li>python311Packages.nix-kernel.dist</li>
    <li>python312Packages.nix-kernel</li>
    <li>python312Packages.nix-kernel.dist</li>
    <li>rapidcheck</li>
    <li>rapidcheck.dev</li>
    <li>sbomnix</li>
    <li>sbomnix.dist</li>
    <li>sonic-pi</li>
    <li>swiftpm2nix</li>
    <li>terranix</li>
    <li>update-nix-fetchgit</li>
    <li>update-python-libraries</li>
    <li>vgmplay-libvgm</li>
    <li>vimPluginsUpdater</li>
    <li>vulnix</li>
    <li>vulnix.dist</li>
    <li>vulnix.doc</li>
    <li>vulnix.man</li>
    <li>wp4nix</li>
    <li>yarn2nix</li>
    <li>zon2nix</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
