### PR TITLE
treewide: make some unmaintained python packages use the pypa builder

### DIFF
--- a/pkgs/development/python-modules/accessible-pygments/default.nix
+++ b/pkgs/development/python-modules/accessible-pygments/default.nix
@@ -2,13 +2,14 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
+, setuptools
 , pygments
 }:
 
 buildPythonPackage rec {
   pname = "accessible-pygments";
   version = "0.0.4";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -17,7 +18,11 @@ buildPythonPackage rec {
     hash = "sha256-57V6mxWVjpYBx+nrB6RAyBMoNUWiCXPyV0pfRT0OlT4=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     pygments
   ];
 

--- a/pkgs/development/python-modules/accupy/default.nix
+++ b/pkgs/development/python-modules/accupy/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
+, setuptools
 , mpmath
 , numpy
 , pybind11
@@ -18,17 +19,19 @@
 buildPythonPackage rec {
   pname = "accupy";
   version = "0.3.6";
-  format = "setuptools";
+  pyproject = true;
+
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "nschloe";
-    repo = pname;
+    repo = "accupy";
     rev = version;
-    sha256 = "0sxkwpp2xy2jgakhdxr4nh1cspqv8l89kz6s832h05pbpyc0n767";
+    hash = "sha256-xxwLmL/rFgDFQNr8mRBFG1/NArQk9wanelL4Lu7ls2s=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
+    setuptools
     pybind11
   ];
 
@@ -36,7 +39,7 @@ buildPythonPackage rec {
     eigen
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     mpmath
     numpy
     pyfma
@@ -51,7 +54,7 @@ buildPythonPackage rec {
 
   postConfigure = ''
    substituteInPlace setup.py \
-     --replace "/usr/include/eigen3/" "${eigen}/include/eigen3/"
+     --replace-fail "/usr/include/eigen3/" "${eigen}/include/eigen3/"
   '';
 
   preBuild = ''
@@ -66,10 +69,12 @@ buildPythonPackage rec {
   # decouple ourselves from an unnecessary build dep
   preCheck = ''
     for f in test/test*.py ; do
-      substituteInPlace $f --replace 'import perfplot' ""
+      substituteInPlace $f --replace-quiet 'import perfplot' ""
     done
   '';
+
   disabledTests = [ "test_speed_comparison1" "test_speed_comparison2" ];
+
   pythonImportsCheck = [ "accupy" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/adal/default.nix
+++ b/pkgs/development/python-modules/adal/default.nix
@@ -6,12 +6,13 @@
 , pytestCheckHook
 , python-dateutil
 , requests
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "adal";
   version = "1.2.7";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "AzureAD";
@@ -24,7 +25,11 @@ buildPythonPackage rec {
     sed -i '/cryptography/d' setup.py
   '';
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     pyjwt
     python-dateutil
     requests

--- a/pkgs/development/python-modules/aioamqp/default.nix
+++ b/pkgs/development/python-modules/aioamqp/default.nix
@@ -3,23 +3,28 @@
 , fetchFromGitHub
 , pamqp
 , pythonOlder
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "aioamqp";
   version = "0.15.0";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "Polyconseil";
-    repo = pname;
-    rev = "${pname}-${version}";
+    repo = "aioamqp";
+    rev = "aioamqp-${version}";
     hash = "sha256-fssPknJn1tLtzb+2SFyZjfdhUdD8jqkwlInoi5uaplk=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     pamqp
   ];
 

--- a/pkgs/development/python-modules/aiocontextvars/default.nix
+++ b/pkgs/development/python-modules/aiocontextvars/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 , pytestCheckHook
 , pytest-asyncio
 , isPy27
@@ -9,20 +10,23 @@
 buildPythonPackage rec {
   pname = "aiocontextvars";
   version = "0.2.2";
-  format = "setuptools";
+  pyproject = true;
+
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "fantix";
-    repo = pname;
+    repo = "aiocontextvars";
     rev = "v${version}";
-    sha256 = "0a2gmrm9csiknc8n3si67sgzffkydplh9d7ga1k87ygk2aj22mmk";
+    hash = "sha256-s1YhpBLz+YNmUO+0BOltfjr3nz4m6mERszNqlmquTyg=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'," ""
+      --replace-fail "'pytest-runner'," ""
   '';
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/aiohttp-jinja2/default.nix
+++ b/pkgs/development/python-modules/aiohttp-jinja2/default.nix
@@ -6,12 +6,13 @@
 , pytest-aiohttp
 , pytestCheckHook
 , pythonOlder
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "aiohttp-jinja2";
   version = "1.6";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -20,7 +21,11 @@ buildPythonPackage rec {
     hash = "sha256-o6f/UmTlvKUuiuVHu/0HYbcklSMNQ40FtsCRW+YZsOI=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     aiohttp
     jinja2
   ];
@@ -31,8 +36,8 @@ buildPythonPackage rec {
   ];
 
   postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace " --cov=aiohttp_jinja2 --cov-report xml --cov-report html --cov-report term" ""
+    substituteInPlace pytest.ini \
+      --replace-fail "--cov=aiohttp_jinja2/ --cov=tests/ --cov-report term" ""
   '';
 
   pytestFlagsArray = [
@@ -43,10 +48,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "aiohttp_jinja2"
   ];
-
-  # Tests are outdated (1.5)
-  # pytest.PytestUnhandledCoroutineWarning: async def functions...
-  doCheck = false;
 
   meta = with lib; {
     description = "Jinja2 support for aiohttp";

--- a/pkgs/development/python-modules/aiohttp-openmetrics/default.nix
+++ b/pkgs/development/python-modules/aiohttp-openmetrics/default.nix
@@ -4,12 +4,13 @@
 , aiohttp
 , prometheus-client
 , pythonOlder
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "aiohttp-openmetrics";
   version = "0.0.12";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -18,7 +19,11 @@ buildPythonPackage rec {
     hash = "sha256-/ZRngcMlroCVTvIl+30DR4SI8LsSnTovuzg3YduWgWA=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     aiohttp
     prometheus-client
   ];

--- a/pkgs/development/python-modules/aiokafka/default.nix
+++ b/pkgs/development/python-modules/aiokafka/default.nix
@@ -9,6 +9,7 @@
 , packaging
 , python-snappy
 , pythonOlder
+, setuptools
 , zlib
 , zstandard
 }:
@@ -16,32 +17,33 @@
 buildPythonPackage rec {
   pname = "aiokafka";
   version = "0.10.0";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "aio-libs";
-    repo = pname;
+    repo = "aiokafka";
     rev = "refs/tags/v${version}";
     hash = "sha256-G9Q77nWUUW+hG/wm9z/S8gea4U1wHZdj7WdK2LsKBos=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     cython
+    setuptools
   ];
 
   buildInputs = [
     zlib
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     async-timeout
     kafka-python
     packaging
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     snappy = [
       python-snappy
     ];

--- a/pkgs/development/python-modules/aiomqtt/default.nix
+++ b/pkgs/development/python-modules/aiomqtt/default.nix
@@ -13,7 +13,7 @@
 buildPythonPackage rec {
   pname = "aiomqtt";
   version = "2.0.1";
-  format = "pyproject";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
@@ -24,12 +24,12 @@ buildPythonPackage rec {
     hash = "sha256-bV1elEO1518LVLwNDN5pzjxRgcG34K1XUsK7fTw8h+8=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     poetry-core
     poetry-dynamic-versioning
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     paho-mqtt
     typing-extensions
   ];

--- a/pkgs/development/python-modules/aiomysql/default.nix
+++ b/pkgs/development/python-modules/aiomysql/default.nix
@@ -4,6 +4,7 @@
 , fetchpatch
 , pymysql
 , pythonOlder
+, setuptools
 , setuptools-scm
 , wheel
 }:
@@ -11,13 +12,13 @@
 buildPythonPackage rec {
   pname = "aiomysql";
   version = "0.2.0";
-  format = "pyproject";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "aio-libs";
-    repo = pname;
+    repo = "aiomysql";
     rev = "refs/tags/v${version}";
     hash = "sha256-m/EgoBU3e+s3soXyYtACMDSjJfMLBOk/00qPtgawwQ8=";
   };
@@ -33,6 +34,7 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
+    setuptools
     setuptools-scm
     wheel
   ];

--- a/pkgs/development/python-modules/aiorun/default.nix
+++ b/pkgs/development/python-modules/aiorun/default.nix
@@ -12,13 +12,13 @@
 buildPythonPackage rec {
   pname = "aiorun";
   version = "2023.7.2";
-  format = "pyproject";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "cjrh";
-    repo = pname;
+    repo = "aiorun";
     rev = "refs/tags/v${version}";
     hash = "sha256-3AGsT8IUNi5SZHBsBfd7akj8eQ+xb0mrR7ydIr3T8gs=";
   };
@@ -31,11 +31,11 @@ buildPythonPackage rec {
     })
   ];
 
-  nativeBuildInputs = [
+  build-system = [
     flit-core
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     pygments
   ];
 

--- a/pkgs/development/python-modules/alembic/default.nix
+++ b/pkgs/development/python-modules/alembic/default.nix
@@ -22,7 +22,7 @@
 buildPythonPackage rec {
   pname = "alembic";
   version = "1.13.1";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.6";
 
@@ -31,11 +31,11 @@ buildPythonPackage rec {
     hash = "sha256-STLIVYv2jy7pK5u8uCGGccYnBk1bCJOUN69td9wF5ZU=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     mako
     sqlalchemy
     typing-extensions

--- a/pkgs/development/python-modules/ansible-compat/default.nix
+++ b/pkgs/development/python-modules/ansible-compat/default.nix
@@ -6,6 +6,7 @@
 , pytest-mock
 , pytestCheckHook
 , pyyaml
+, setuptools
 , setuptools-scm
 , subprocess-tee
 , pythonOlder
@@ -14,7 +15,7 @@
 buildPythonPackage rec {
   pname = "ansible-compat";
   version = "4.1.11";
-  format = "pyproject";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -24,10 +25,11 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
+    setuptools
     setuptools-scm
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     pyyaml
     subprocess-tee
   ];

--- a/pkgs/development/python-modules/ansible-kernel/default.nix
+++ b/pkgs/development/python-modules/ansible-kernel/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , writeText
+, setuptools
 , ipywidgets
 , six
 , docopt
@@ -25,14 +26,16 @@ in
 buildPythonPackage rec {
   pname = "ansible-kernel";
   version = "1.0.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-UJjm9FpmXSznXtaIR2rVv5YJS/H83FvRkNz09vwoe0c=";
   };
 
-  propagatedBuildInputs = [ ipywidgets six docopt tqdm jupyter psutil pyyaml ansible-runner ansible ];
+  build-system = [ setuptools ];
+
+  dependencies = [ ipywidgets six docopt tqdm jupyter psutil pyyaml ansible-runner ansible ];
 
   postPatch = ''
    # remove when merged

--- a/pkgs/development/python-modules/ansible-runner/default.nix
+++ b/pkgs/development/python-modules/ansible-runner/default.nix
@@ -18,13 +18,14 @@
 , pythonOlder
 , python-daemon
 , pyyaml
+, setuptools
 , six
 }:
 
 buildPythonPackage rec {
   pname = "ansible-runner";
   version = "2.3.6";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
@@ -42,11 +43,12 @@ buildPythonPackage rec {
     })
   ];
 
-  nativeBuildInputs = [
+  build-system = [
+    setuptools
     pbr
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     ansible-core
     psutil
     pexpect

--- a/pkgs/development/python-modules/ansiwrap/default.nix
+++ b/pkgs/development/python-modules/ansiwrap/default.nix
@@ -5,36 +5,37 @@
 , pytestCheckHook
 , pythonAtLeast
 , pythonOlder
+, setuptools
 , textwrap3
 }:
 
 buildPythonPackage rec {
   pname = "ansiwrap";
   version = "0.8.4";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7" || pythonAtLeast "3.12";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "ca0c740734cde59bf919f8ff2c386f74f9a369818cdc60efe94893d01ea8d9b7";
+    hash = "sha256-ygx0BzTN5Zv5Gfj/LDhvdPmjaYGM3GDv6UiT0B6o2bc=";
   };
 
   postPatch = ''
     # https://github.com/jonathaneunice/ansiwrap/issues/18
     substituteInPlace test/test_ansiwrap.py \
-      --replace "set(range(20, 120)).difference(LINE_LENGTHS)" "sorted(set(range(20, 120)).difference(LINE_LENGTHS))" \
-      --replace "set(range(120, 400)).difference(LINE_LENGTHS)" "sorted(set(range(120, 400)).difference(LINE_LENGTHS))"
+      --replace-fail "set(range(20, 120)).difference(LINE_LENGTHS)" "sorted(set(range(20, 120)).difference(LINE_LENGTHS))" \
+      --replace-fail "set(range(120, 400)).difference(LINE_LENGTHS)" "sorted(set(range(120, 400)).difference(LINE_LENGTHS))"
   '';
 
-  checkInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [ textwrap3 ];
+
+  nativeCheckInputs = [
     ansicolors
     pytestCheckHook
-  ];
-
-  propagatedBuildInputs = [
-    textwrap3
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/apipkg/default.nix
+++ b/pkgs/development/python-modules/apipkg/default.nix
@@ -9,16 +9,16 @@
 buildPythonPackage rec {
   pname = "apipkg";
   version = "3.0.2";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pytest-dev";
-    repo = pname;
+    repo = "apipkg";
     rev = "refs/tags/v${version}";
     hash = "sha256-ANLD7fUMKN3RmAVjVkcpwUH6U9ASalXdwKtPpoC8Urs=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     hatch-vcs
     hatchling
   ];

--- a/pkgs/development/python-modules/apprise/default.nix
+++ b/pkgs/development/python-modules/apprise/default.nix
@@ -15,12 +15,13 @@
 , pyyaml
 , requests
 , requests-oauthlib
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "apprise";
   version = "1.7.6";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -33,6 +34,11 @@ buildPythonPackage rec {
     installShellFiles
   ];
 
+  build-system = [
+    babel
+    setuptools
+  ];
+
   propagatedBuildInputs = [
     click
     cryptography
@@ -43,7 +49,6 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    babel
     gntp
     paho-mqtt
     pytest-mock

--- a/pkgs/development/python-modules/apscheduler/default.nix
+++ b/pkgs/development/python-modules/apscheduler/default.nix
@@ -19,7 +19,7 @@
 buildPythonPackage rec {
   pname = "apscheduler";
   version = "3.10.4";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -29,11 +29,12 @@ buildPythonPackage rec {
     hash = "sha256-5t8HGyfZvomOSGvHlAp75QtK8unafAjwdEqW1L1M70o=";
   };
 
-  buildInputs = [
+  build-system = [
+    setuptools
     setuptools-scm
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     pytz
     setuptools
     six
@@ -51,7 +52,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace " --cov --tb=short" ""
+      --replace-fail " --cov --tb=short" ""
   '';
 
   disabledTests = [

--- a/pkgs/development/python-modules/asana/default.nix
+++ b/pkgs/development/python-modules/asana/default.nix
@@ -1,18 +1,19 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pytestCheckHook
 , pythonOlder
-, requests
-, requests-oauthlib
-, responses
+, setuptools
+, certifi
 , six
+, python-dateutil
+, urllib3
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "asana";
   version = "5.0.3";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -23,15 +24,17 @@ buildPythonPackage rec {
     hash = "sha256-9F63DvwMh9NwlTqFuhiXfgRRRxAFjjRYmYzsuOhlQJ0=";
   };
 
-  propagatedBuildInputs = [
-    requests
-    requests-oauthlib
+  build-system = [ setuptools ];
+
+  dependencies = [
+    certifi
     six
+    python-dateutil
+    urllib3
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
-    responses
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/asciitree/default.nix
+++ b/pkgs/development/python-modules/asciitree/default.nix
@@ -1,28 +1,29 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pytest
+, setuptools
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "asciitree";
   version = "0.3.3";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mbr";
-    repo = pname;
+    repo = "asciitree";
     rev = version;
-    sha256 = "071wlpyi8pa262sj9xdy0zbj163z84dasxad363z3sfndqxw78h1";
+    hash = "sha256-AaLDO27W6fGHGU11rRpBf5gg1we+9SS1MEJdFP2lPBw=";
   };
 
-  nativeCheckInputs = [
-    pytest
+  build-system = [
+    setuptools
   ];
 
-  checkPhase = ''
-    pytest
-  '';
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   meta = with lib; {
     description = "Draws ASCII trees";

--- a/pkgs/development/python-modules/ase/default.nix
+++ b/pkgs/development/python-modules/ase/default.nix
@@ -2,18 +2,24 @@
 , fetchPypi
 , buildPythonPackage
 , isPy27
+, pythonAtLeast
+, setuptools
 , numpy
 , scipy
 , matplotlib
 , flask
 , pillow
 , psycopg2
+, pytestCheckHook
+, pytest-mock
+, pytest-xdist
 }:
 
 buildPythonPackage rec {
   pname = "ase";
   version = "3.22.1";
-  format = "setuptools";
+  pyproject = true;
+
   disabled = isPy27;
 
   src = fetchPypi {
@@ -21,14 +27,28 @@ buildPythonPackage rec {
     hash = "sha256-AE32sOoEsRFMeQ+t/kXUEl6w5TElxmqTQlr4U9gqtDI=";
   };
 
-  propagatedBuildInputs = [ numpy scipy matplotlib flask pillow psycopg2 ];
+  build-system = [ setuptools ];
 
-  checkPhase = ''
-    $out/bin/ase test
+  dependencies = [ numpy scipy matplotlib flask pillow psycopg2 ];
+
+  nativeCheckInputs = [ pytestCheckHook pytest-mock pytest-xdist ];
+
+  disabledTests = [
+    "test_fundamental_params"
+    "test_ase_bandstructure"
+    "test_imports"
+    "test_units"
+    "test_favicon"
+    "test_vibrations_methods" # missing attribute
+    "test_jmol_roundtrip" # missing attribute
+  ]
+  ++ lib.optionals (pythonAtLeast "3.12") [
+    "test_info_calculators"
+  ];
+
+  preCheck = ''
+    export PATH="$out/bin:$PATH"
   '';
-
-  # tests just hang most likely due to something with subprocesses and cli
-  doCheck = false;
 
   pythonImportsCheck = [ "ase" ];
 

--- a/pkgs/development/python-modules/aspell-python/default.nix
+++ b/pkgs/development/python-modules/aspell-python/default.nix
@@ -6,12 +6,13 @@
 , isPy27
 , pytestCheckHook
 , pythonAtLeast
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "aspell-python";
   version = "1.15";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = isPy27;
 
@@ -21,6 +22,10 @@ buildPythonPackage rec {
     extension = "tar.bz2";
     hash = "sha256-IEKRDmQY5fOH9bQk0dkUAy7UzpBOoZW4cNtVvLMcs40=";
   };
+
+  build-system = [
+    setuptools
+  ];
 
   buildInputs = [
     aspell

--- a/pkgs/development/python-modules/asyncssh/default.nix
+++ b/pkgs/development/python-modules/asyncssh/default.nix
@@ -1,5 +1,4 @@
 { lib
-, stdenv
 , bcrypt
 , buildPythonPackage
 , cryptography
@@ -15,13 +14,14 @@
 , pytestCheckHook
 , python-pkcs11
 , pythonOlder
+, setuptools
 , typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "asyncssh";
   version = "2.14.2";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.6";
 
@@ -30,14 +30,19 @@ buildPythonPackage rec {
     hash = "sha256-6Va/iYjQega6MwX2YE4mH0ygFMSiMvCHPxx2kvvjz8I=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     cryptography
-    libsodium
     nettle
     typing-extensions
   ];
 
-  passthru.optional-dependencies = {
+  buildInputs = [
+    libsodium
+  ];
+
+  optional-dependencies = {
     bcrypt = [
       bcrypt
     ];
@@ -64,7 +69,7 @@ buildPythonPackage rec {
     openssh
     openssl
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   patches = [
     # Reverts https://github.com/ronf/asyncssh/commit/4b3dec994b3aa821dba4db507030b569c3a32730

--- a/pkgs/development/python-modules/atomman/default.nix
+++ b/pkgs/development/python-modules/atomman/default.nix
@@ -22,10 +22,10 @@
 , pythonRelaxDepsHook
 }:
 
-buildPythonPackage rec {
-  version = "unstable-2023-07-28";
+buildPythonPackage {
   pname = "atomman";
-  format = "pyproject";
+  version = "1.4.6-unstable-2023-07-28";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -36,14 +36,16 @@ buildPythonPackage rec {
     hash = "sha256-WfB+OY61IPprT6OCVHl8VA60p7lLVkRGuyYX+nm7bbA=";
   };
 
-  nativeBuildInputs = [
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+
+  build-system = [
     setuptools
     wheel
-    pythonRelaxDepsHook
+    numpy
+    cython
   ];
 
-  propagatedBuildInputs = [
-    cython
+  dependencies = [
     datamodeldict
     matplotlib
     numericalunits

--- a/pkgs/development/python-modules/atsim-potentials/default.nix
+++ b/pkgs/development/python-modules/atsim-potentials/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
+, pythonAtLeast
 , fetchFromGitHub
+, setuptools
 , configparser
 , pyparsing
 , pytestCheckHook
@@ -14,23 +16,22 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.4.1";
-  format = "setuptools";
   pname = "atsim-potentials";
+  version = "0.4.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mjdrushton";
-    repo = pname;
+    repo = "atsim-potentials";
     rev = "refs/tags/${version}";
     hash = "sha256-G7lNqwEUwAT0f7M2nUTCxpXOAl6FWKlh7tcsvbur1eM=";
   };
 
-  postPatch = ''
-    # Remove conflicting openpyxl dependency version check
-    sed -i '/openpyxl==2.6.4/d' setup.py
-  '';
+  build-system = [
+    setuptools
+  ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     cexprtk
     configparser
     future
@@ -46,10 +47,21 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  # these files try to import `distutils` removed in Python 3.12
+  disabledTestPaths = lib.optionals (pythonAtLeast "3.12") [
+    "tests/config/test_configuration_eam.py"
+    "tests/config/test_configuration_eam_fs.py"
+    "tests/config/test_configuration_pair.py"
+    "tests/test_dlpoly_writeTABEAM.py"
+    "tests/test_documentation_examples.py"
+    "tests/test_eam_adp_writer.py"
+    "tests/test_gulp_writer.py"
+    "tests/test_lammpsWriteEAM.py"
+  ];
+
   disabledTests = [
     # Missing lammps executable
     "eam_tabulate_example2TestCase"
-    "test_pymath"
   ];
 
   pythonImportsCheck = [ "atsim.potentials" ];

--- a/pkgs/development/python-modules/aubio/default.nix
+++ b/pkgs/development/python-modules/aubio/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 , numpy
 , pytestCheckHook
 , stdenv
@@ -10,18 +11,22 @@
 buildPythonPackage rec {
   pname = "aubio";
   version = "0.4.9";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "aubio";
+    repo = "aubio";
     rev = version;
-    sha256 = "0fhxikvlr010nbh02g455d5y8bq6j5yw180cdh4gsd0hb43y3z26";
+    hash = "sha256-RvzhB1kQNP0IbAygwH2RBi/kSyuFPAHgsiCATPeMHTo=";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Accelerate AudioToolbox CoreVideo CoreGraphics ]);
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     numpy
   ];
 

--- a/pkgs/development/python-modules/audiotools/default.nix
+++ b/pkgs/development/python-modules/audiotools/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 , stdenv
 , AudioToolbox
 , AudioUnit
@@ -10,7 +11,9 @@
 buildPythonPackage rec {
   pname = "audiotools";
   version = "3.1.1";
-  format = "setuptools";
+  pyproject = true;
+
+  build-system = [ setuptools ];
 
   buildInputs = lib.optionals stdenv.isDarwin [
     AudioToolbox

--- a/pkgs/development/python-modules/autobahn/default.nix
+++ b/pkgs/development/python-modules/autobahn/default.nix
@@ -34,6 +34,7 @@
   # , pytrie
 , rlp
 , service-identity
+, setuptools
 , spake2
 , twisted
 , txaio
@@ -49,7 +50,7 @@
 buildPythonPackage rec {
   pname = "autobahn";
   version = "23.6.2";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.9";
 
@@ -60,10 +61,14 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "pytest>=2.8.6,<3.3.0" "pytest"
+      --replace-fail "pytest>=2.8.6,<3.3.0" "pytest"
   '';
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     cryptography
     hyperlink
     pynacl
@@ -74,9 +79,9 @@ buildPythonPackage rec {
     mock
     pytest-asyncio_0_21
     pytestCheckHook
-  ] ++ passthru.optional-dependencies.scram
-  ++ passthru.optional-dependencies.serialization
-  ++ passthru.optional-dependencies.xbr;
+  ] ++ optional-dependencies.scram
+  ++ optional-dependencies.serialization
+  ++ optional-dependencies.xbr;
 
   preCheck = ''
     # Run asyncio tests (requires twisted)
@@ -91,7 +96,7 @@ buildPythonPackage rec {
     "autobahn"
   ];
 
-  passthru.optional-dependencies = rec {
+  optional-dependencies = rec {
     all = accelerate ++ compress ++ encryption ++ nvx ++ serialization ++ scram ++ twisted ++ ui ++ xbr;
     accelerate = [ /* wsaccel */ ];
     compress = [ python-snappy ];

--- a/pkgs/tools/admin/aws-mfa/default.nix
+++ b/pkgs/tools/admin/aws-mfa/default.nix
@@ -2,13 +2,14 @@
 , buildPythonApplication
 , fetchFromGitHub
 , fetchpatch
+, setuptools
 , boto3
 }:
 
 buildPythonApplication rec {
   pname = "aws-mfa";
   version = "0.0.12";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "broamski";
@@ -26,7 +27,11 @@ buildPythonApplication rec {
     })
   ];
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     boto3
   ];
 

--- a/pkgs/tools/networking/apc-temp-fetch/default.nix
+++ b/pkgs/tools/networking/apc-temp-fetch/default.nix
@@ -3,12 +3,13 @@
 , fetchPypi
 , pythonOlder
 , requests
+, setuptools
 }:
 
 buildPythonApplication rec {
   pname = "apc-temp-fetch";
   version = "0.0.2";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.6";
 
@@ -18,7 +19,11 @@ buildPythonApplication rec {
     hash = "sha256-lXGj/xrOkdMMYvuyVVSCojjQlzISFUT14VTn//iOARo=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     requests
   ];
 


### PR DESCRIPTION
## Description of changes

- some criteria I gave myself for which python packages to go through
  - package has no maintainers
  - packages has a name starting with the letter `a`
  - package is still using `format = ...`
  - `rg 'format = "' -l | xargs rg 'maintainers\s*=*.+\[\s*\]' -l | xargs rg 'pname\s*=\s*"a'`
- changes done to each package:
  - use `pyproject = true`
  - move python packages in `nativeBuildInputs` to `build-system`
  - move python packages in `propagatedBuildInputs` to `dependencies`
  - rename `passthru.optional-dependencies` to `optional-dependencies`
  - when previously using `format = "setuptools"`, add `setuptools` to `build-system`
  - use `--replace-fail` instead of `--replace` when needed
  - remove mentions of `pname`, substitute it with string literal
  - change `sha256` to `hash`
  - when needed also do some refactoring to make tests for or fix a previously uncaught issue
- packages not done because of large rebuilds
  - `asgiref` (django, flask, etc)
  - `anytree` (glib)
  - `ansible`, `ansible-core`
  - `attrs`
  - `automat`
  - `aws-sam-translator` (aiobotocore packages)
  - `aiosqlite`

---
Notes:
- this PR triggers ~500 rebuilds
- I'm not yet sure what the commit messages should really be
- TODO: `ase` tests need reasoning for being disabled

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
