### PR TITLE
platformsh: 4.17.0 -> 5.0.13

### DIFF
--- a/pkgs/by-name/pl/platformsh/package.nix
+++ b/pkgs/by-name/pl/platformsh/package.nix
@@ -52,10 +52,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "The unified tool for managing your Platform.sh services from the command line";
+    description = "The unified tool for managing your Platform.sh services from the command line.";
     homepage = "https://github.com/platformsh/cli";
     license = lib.licenses.mit;
-    mainProgram = "platformsh";
+    mainProgram = "platform";
     maintainers = with lib.maintainers; [ shyim spk ];
     platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/pl/platformsh/package.nix
+++ b/pkgs/by-name/pl/platformsh/package.nix
@@ -14,19 +14,19 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     {
       x86_64-darwin = fetchurl {
         url = "https://github.com/platformsh/cli/releases/download/${finalAttrs.version}/platformsh-cli_${finalAttrs.version}_darwin_all.tar.gz";
-        hash = "sha256-5JKXtAUnqrlufyNE05uZjEDfJv557auYPriTxvUbMJI=";
+        hash = "sha256-ABnfxLMtY8E5KqJkrtIlPB4ML7CSFvjizCabv7i7SbU=";
       };
       aarch64-darwin = fetchurl {
         url = "https://github.com/platformsh/cli/releases/download/${finalAttrs.version}/platformsh-cli_${finalAttrs.version}_darwin_all.tar.gz";
-        hash = "sha256-5JKXtAUnqrlufyNE05uZjEDfJv557auYPriTxvUbMJI=";
+        hash = "sha256-ABnfxLMtY8E5KqJkrtIlPB4ML7CSFvjizCabv7i7SbU=";
       };
       x86_64-linux = fetchurl {
         url = "https://github.com/platformsh/cli/releases/download/${finalAttrs.version}/platformsh-cli_${finalAttrs.version}_linux_amd64.tar.gz";
-        hash = "sha256-fjVL/sbO1wmaJ4qZpUMV/4Q4Jzf0p6qx0ElRdY5EUJU=";
+        hash = "sha256-ABnfxLMtY8E5KqJkrtIlPB4ML7CSFvjizCabv7i7SbU=";
       };
       aarch64-linux = fetchurl {
         url = "https://github.com/platformsh/cli/releases/download/${finalAttrs.version}/platformsh-cli_${finalAttrs.version}_linux_arm64.tar.gz";
-        hash = "sha256-MNlQkwsg5SuIQJBDy7yVtcda1odpaUZezCgrat6OW2Q=";
+        hash = "sha256-ABnfxLMtY8E5KqJkrtIlPB4ML7CSFvjizCabv7i7SbU=";
       };
     }
     .${stdenvNoCC.system}

--- a/pkgs/by-name/pl/platformsh/package.nix
+++ b/pkgs/by-name/pl/platformsh/package.nix
@@ -1,34 +1,63 @@
-{ stdenvNoCC, lib, fetchurl }:
+{
+  stdenvNoCC,
+  lib,
+  fetchurl,
+  testers,
+  platformsh
+}:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "platformsh";
-  version = "5.0.12";
+  version = "5.0.13";
 
-  src = {
-    x86_64-linux = fetchurl {
-      url = "https://github.com/platformsh/cli/releases/download/${version}/platformsh-cli_${version}_linux_amd64.tar.gz";
-      hash = "sha256-svEPMVY7r7pAoXwFIMYqCEduqR3Nkocaguf2nIGt+G8=";
-    };
-    aarch64-linux = fetchurl {
-      url = "https://github.com/platformsh/cli/releases/download/${version}/platformsh-cli_${version}_linux_arm64.tar.gz";
-      hash = "sha256-ZraS/PqSPL/kcj5o6hzDdL70IV2IWXOma6OHCiXIDQc=";
-    };
-  }.${stdenvNoCC.system} or (throw "${pname}-${version}: ${stdenvNoCC.system} is unsupported.");
+  src =
+    {
+      x86_64-darwin = fetchurl {
+        url = "https://github.com/platformsh/cli/releases/download/${finalAttrs.version}/platformsh-cli_${finalAttrs.version}_darwin_all.tar.gz";
+        hash = "sha256-5JKXtAUnqrlufyNE05uZjEDfJv557auYPriTxvUbMJI=";
+      };
+      aarch64-darwin = fetchurl {
+        url = "https://github.com/platformsh/cli/releases/download/${finalAttrs.version}/platformsh-cli_${finalAttrs.version}_darwin_all.tar.gz";
+        hash = "sha256-5JKXtAUnqrlufyNE05uZjEDfJv557auYPriTxvUbMJI=";
+      };
+      x86_64-linux = fetchurl {
+        url = "https://github.com/platformsh/cli/releases/download/${finalAttrs.version}/platformsh-cli_${finalAttrs.version}_linux_amd64.tar.gz";
+        hash = "sha256-fjVL/sbO1wmaJ4qZpUMV/4Q4Jzf0p6qx0ElRdY5EUJU=";
+      };
+      aarch64-linux = fetchurl {
+        url = "https://github.com/platformsh/cli/releases/download/${finalAttrs.version}/platformsh-cli_${finalAttrs.version}_linux_arm64.tar.gz";
+        hash = "sha256-MNlQkwsg5SuIQJBDy7yVtcda1odpaUZezCgrat6OW2Q=";
+      };
+    }
+    .${stdenvNoCC.system}
+      or (throw "${finalAttrs.pname}-${finalAttrs.version}: ${stdenvNoCC.system} is unsupported.");
 
   dontConfigure = true;
   dontBuild = true;
 
   sourceRoot = ".";
   installPhase = ''
+    runHook preInstall
+
     install -Dm755 platformsh $out/bin/platformsh
+
+    runHook postInstall
   '';
 
+  passthru = {
+    tests.version = testers.testVersion {
+      inherit (finalAttrs) version;
+      package = platformsh;
+    };
+  };
+
   meta = {
-    homepage = "https://github.com/platformsh/cli";
     description = "The unified tool for managing your Platform.sh services from the command line";
-    maintainers = with lib.maintainers; [ spk ];
+    homepage = "https://github.com/platformsh/cli";
     license = lib.licenses.mit;
-    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    mainProgram = "platformsh";
+    maintainers = with lib.maintainers; [ shyim spk ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-}
+})

--- a/pkgs/by-name/pl/platformsh/package.nix
+++ b/pkgs/by-name/pl/platformsh/package.nix
@@ -13,20 +13,20 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   src =
     {
       x86_64-darwin = fetchurl {
-        url = "https://github.com/platformsh/cli/releases/download/${finalAttrs.version}/platformsh-cli_${finalAttrs.version}_darwin_all.tar.gz";
-        hash = "sha256-ABnfxLMtY8E5KqJkrtIlPB4ML7CSFvjizCabv7i7SbU=";
+        url = "https://github.com/platformsh/cli/releases/download/${finalAttrs.version}/platform_${finalAttrs.version}_darwin_all.tar.gz";
+        hash = "sha256-dCo5+de+9hXxrv+uPn0UoAh4UfSv+PyR2z/ytpfby0g=";
       };
       aarch64-darwin = fetchurl {
-        url = "https://github.com/platformsh/cli/releases/download/${finalAttrs.version}/platformsh-cli_${finalAttrs.version}_darwin_all.tar.gz";
-        hash = "sha256-ABnfxLMtY8E5KqJkrtIlPB4ML7CSFvjizCabv7i7SbU=";
+        url = "https://github.com/platformsh/cli/releases/download/${finalAttrs.version}/platform_${finalAttrs.version}_darwin_all.tar.gz";
+        hash = "sha256-dCo5+de+9hXxrv+uPn0UoAh4UfSv+PyR2z/ytpfby0g=";
       };
       x86_64-linux = fetchurl {
-        url = "https://github.com/platformsh/cli/releases/download/${finalAttrs.version}/platformsh-cli_${finalAttrs.version}_linux_amd64.tar.gz";
-        hash = "sha256-ABnfxLMtY8E5KqJkrtIlPB4ML7CSFvjizCabv7i7SbU=";
+        url = "https://github.com/platformsh/cli/releases/download/${finalAttrs.version}/platform_${finalAttrs.version}_linux_amd64.tar.gz";
+        hash = "sha256-JP0RCqNQ8V4sFP3645MW+Pd9QfPFRAuTbVPIK6WD6PQ=";
       };
       aarch64-linux = fetchurl {
-        url = "https://github.com/platformsh/cli/releases/download/${finalAttrs.version}/platformsh-cli_${finalAttrs.version}_linux_arm64.tar.gz";
-        hash = "sha256-ABnfxLMtY8E5KqJkrtIlPB4ML7CSFvjizCabv7i7SbU=";
+        url = "https://github.com/platformsh/cli/releases/download/${finalAttrs.version}/platform_${finalAttrs.version}_linux_arm64.tar.gz";
+        hash = "sha256-vpk093kpGAmMevd4SVr3KSIjUXUqt3yWDZFHOVxu9rw=";
       };
     }
     .${stdenvNoCC.system}

--- a/pkgs/by-name/pl/platformsh/package.nix
+++ b/pkgs/by-name/pl/platformsh/package.nix
@@ -52,7 +52,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "The unified tool for managing your Platform.sh services from the command line.";
+    description = "The unified tool for managing your Platform.sh services from the command line";
     homepage = "https://github.com/platformsh/cli";
     license = lib.licenses.mit;
     mainProgram = "platform";

--- a/pkgs/by-name/pl/platformsh/package.nix
+++ b/pkgs/by-name/pl/platformsh/package.nix
@@ -20,7 +20,7 @@ stdenvNoCC.mkDerivation rec {
 
   sourceRoot = ".";
   installPhase = ''
-    install -Dm755 platformsh-cli $out/bin/platformsh
+    install -Dm755 platformsh $out/bin/platformsh
   '';
 
   meta = {


### PR DESCRIPTION
## Description of changes

Remove the deprecated [legacy cli](https://github.com/platformsh/legacy-cli) in favor of the [new version](https://github.com/platformsh/cli).

## Things done

This script is a copy of the [Upsun CLI package](https://github.com/NixOS/nixpkgs/commit/6805bd7bb0f15118dd44ad7ece298153ef2392bd) which is released under the same repository.

I have modified the binary to use **platform** instead of **upsun**