### PR TITLE
fw-ectool: unstable-2022-12-03 -> 0-unstable-2024-04-24

### DIFF
--- a/pkgs/os-specific/linux/fw-ectool/default.nix
+++ b/pkgs/os-specific/linux/fw-ectool/default.nix
@@ -1,40 +1,48 @@
-{ stdenv
-, lib
-, fetchFromGitHub
-, pkg-config
-, hostname
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  cmake,
+  pkg-config,
+  hostname,
+  libusb1,
+  libftdi1,
 }:
 
 stdenv.mkDerivation {
   pname = "fw-ectool";
-  version = "unstable-2022-12-03";
+  version = "0-unstable-2024-04-24";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitLab {
     owner = "DHowett";
-    repo = "fw-ectool";
-    rev = "54c140399bbc3e6a3dce6c9f842727c4128367be";
-    hash = "sha256-2teJFz4zcA+USpbVPXMEIHLdmMLem8ik7YrmrSxr/n0=";
+    repo = "ectool";
+    rev = "39d64fb0e79e874cfe9877af69158fc2520b1a80";
+    hash = "sha256-SHRnyqicFlviBDu3aH+uKVUstVxpIhZV6JSuZOgOwXU=";
+    domain = "gitlab.howett.net";
   };
 
   nativeBuildInputs = [
+    cmake
     pkg-config
     hostname
   ];
-
-  buildPhase = ''
-    patchShebangs util
-    make out=out utils
-  '';
+  buildInputs = [
+    libusb1
+    libftdi1
+  ];
 
   installPhase = ''
-    install -D out/util/ectool $out/bin/ectool
+    install -D src/ectool $out/bin/ectool
   '';
 
   meta = with lib; {
     description = "EC-Tool adjusted for usage with framework embedded controller";
-    homepage = "https://github.com/DHowett/framework-ec";
+    homepage = "https://gitlab.howett.net/DHowett/ectool";
     license = licenses.bsd3;
-    maintainers = [ maintainers.mkg20001 ];
+    maintainers = [
+      maintainers.mkg20001
+      maintainers.ericthemagician
+    ];
     platforms = platforms.linux;
     mainProgram = "ectool";
   };


### PR DESCRIPTION
## Description of changes

I was having issues with the ectool to set my framework's battery charge to 80. Turns out, the issue is that I have the new AMD model.
According to the [forum discussion post](https://community.frame.work/t/exploring-the-embedded-controller/12846/122?u=eric_yen), the project has moved to: https://gitlab.howett.net/DHowett/ectool

I've updated the source, dependencies and formatted it with the new formatter.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
