### PR TITLE
fetchNpmRegistry: init

### DIFF
--- a/pkgs/build-support/fetchnpmregistry/default.nix
+++ b/pkgs/build-support/fetchnpmregistry/default.nix
@@ -1,0 +1,23 @@
+# `fetchPypi` function for fetching artifacts from PyPI.
+{ fetchurl
+, lib
+}:
+let
+  calculateUrl = { pname, version, workspace }:
+    let
+      endpoint =
+        if workspace != "" then "${workspace}/${pname}/-/${pname}-${version}"
+        else "${pname}/-/${pname}-${version}";
+    in
+    "https://registry.npmjs.org/${endpoint}.tgz";
+in
+lib.makeOverridable ({ pname
+                     , version
+                     , workspace ? ""
+                     , hash
+                     , ...
+                     }@args:
+let
+  url = calculateUrl { inherit pname version workspace; };
+in
+fetchurl { inherit url hash; } // args)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1239,6 +1239,8 @@ with pkgs;
 
   fetchgx = callPackage ../build-support/fetchgx { };
 
+  fetchNpmRegistry = callPackage ../build-support/fetchnpmregistry { };
+
   fetchPypi = callPackage ../build-support/fetchpypi { };
 
   fetchPypiLegacy = callPackage ../build-support/fetchpypilegacy { };


### PR DESCRIPTION
## Description of changes

This is a prototype implementation of a potential `fetchNpmRegistry` function, which could be used to design node builders for any package manager. Currently, each package manager does the fetching separately, so factoring this out would make it easier to maintain and build upon the current ecosystem in nixpkgs. 

This is mostly meant as an example at the moment; the npm registry [api docs](https://github.com/npm/registry/blob/main/docs/REGISTRY-API.md) mention that the url format I have currently only for *most* packages. The more robust way would be to have make a more custom FOD(rather than piggybacking off of fetchurl) and make a curl call to https://registry.npmjs.org/<pname>/<version> first in order to get the tarball url from there. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
