### PR TITLE
python312Packages.asdf: 2.13.0 -> 3.2.0, unbreak

### DIFF
--- a/pkgs/development/python-modules/asdf/default.nix
+++ b/pkgs/development/python-modules/asdf/default.nix
@@ -1,90 +1,67 @@
 { lib
 , asdf-standard
 , asdf-transform-schemas
-, astropy
+, attrs
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
-, importlib-resources
+, fsspec
+, importlib-metadata
 , jmespath
-, jsonschema
 , lz4
 , numpy
 , packaging
-, pytest-astropy
+, psutil
+, pytest-remotedata
 , pytestCheckHook
 , pythonOlder
 , pyyaml
 , semantic-version
+, setuptools
 , setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "asdf";
-  version = "2.13.0";
-  format = "pyproject";
+  version = "3.2.0";
+  pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
-    owner = "asdf-format/";
-    repo = pname;
+    owner = "asdf-format";
+    repo = "asdf";
     rev = "refs/tags/${version}";
-    hash = "sha256-u8e7ot5NDRqQFH0eLVnGinBQmQD73BlR5K9HVjA7SIg=";
+    hash = "sha256-r+cEv6g7fq3I/h2mlszzJRQcazy7qP9pg0hfYG/Sa9E=";
   };
 
-  patches = [
-    # Fix default validation, https://github.com/asdf-format/asdf/pull/1203
-    (fetchpatch {
-      name = "default-validation.patch";
-      url = "https://github.com/asdf-format/asdf/commit/6f79f620b4632e20178d9bd53528702605d3e976.patch";
-      hash = "sha256-h/dYhXRCf5oIIC+u6+8C91mJnmEzuNmlEzqc0UEhLy0=";
-      excludes = [
-          "CHANGES.rst"
-      ];
-    })
-  ];
-
-  postPatch = ''
-    # https://github.com/asdf-format/asdf/pull/1203
-    substituteInPlace pyproject.toml \
-      --replace "'jsonschema >=4.0.1, <4.10.0'," "'jsonschema >=4.0.1',"
-  '';
-
-  nativeBuildInputs = [
+  build-system = [
+    setuptools
     setuptools-scm
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     asdf-standard
     asdf-transform-schemas
+    importlib-metadata
     jmespath
-    jsonschema
     numpy
     packaging
     pyyaml
     semantic-version
-  ] ++ lib.optionals (pythonOlder "3.9") [
-    importlib-resources
+    attrs
   ];
 
   nativeCheckInputs = [
-    astropy
+    fsspec
     lz4
-    pytest-astropy
+    psutil
+    pytest-remotedata
     pytestCheckHook
   ];
 
-  preCheck = ''
-    export PY_IGNORE_IMPORTMISMATCH=1
-  '';
 
   pythonImportsCheck = [
     "asdf"
-  ];
-
-  disabledTests = [
-    "config.rst"
   ];
 
   meta = with lib; {
@@ -92,7 +69,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/asdf-format/asdf";
     license = licenses.bsd3;
     maintainers = with maintainers; [ ];
-    # Many tests fail, according to Hydra
-    broken = true;
   };
 }


### PR DESCRIPTION
## Description of changes

This PR unbreaks the `asdf` python package by updating to the latest version.
The newer version needs some different dependencies, so I included them.
I could remove all the patching that was done.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
