### PR TITLE
litmusctl: init at 1.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17760,6 +17760,12 @@
       fingerprint = "E628 C811 6FB8 1657 F706  4EA4 F251 ADDC 9D04 1C7E";
     }];
   };
+  sailord = {
+    name = "Sailord";
+    email = "sailord328@gmail.com";
+    github = "Sail0rd";
+    githubId = 55802415;
+  };
   samalws = {
     email = "sam@samalws.com";
     name = "Sam Alws";

--- a/pkgs/by-name/li/litmusctl/package.nix
+++ b/pkgs/by-name/li/litmusctl/package.nix
@@ -1,0 +1,43 @@
+{ buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, kubectl
+, lib
+}:
+
+buildGoModule rec {
+  pname = "litmusctl";
+  version = "1.5.0";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  buildInputs = [
+    kubectl
+  ];
+
+  src = fetchFromGitHub {
+    owner = "litmuschaos";
+    repo = "litmusctl";
+    rev = "${version}";
+    hash = "sha256-FORrvPKDTG48WV03+HbXiBJa1IHfHV7yMDhQX64kn6U=";
+  };
+
+  vendorHash = "sha256-U4dp2E2TZ3rds63PS6GzUVhb2qDSv92bf9JCkWpdLew=";
+
+  postInstall = ''
+    installShellCompletion --cmd litmusctl \
+      --bash <($out/bin/litmusctl completion bash) \
+      --fish <($out/bin/listmusctl completion fish) \
+      --zsh <($out/bin/litmusctl completion zsh)
+  '';
+
+  meta = {
+    description = "Command-Line tool to manage Litmuschaos's agent plane";
+    homepage = "https://github.com/litmuschaos/litmusctl";
+    license = lib.licenses.asl20;
+    mainProgram = "litmusctl";
+    maintainers = with lib.maintainers; [ vinetos sailord ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Creation of the litmusctl package, which is a command line tool to manager litmus chaos agent's plane
homepage: https://github.com/litmuschaos/litmusctl

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
