### PR TITLE
xfce.xfce4-panel-profiles: Fix missing typelib

### DIFF
--- a/pkgs/desktops/xfce/applications/xfce4-panel-profiles/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-panel-profiles/default.nix
@@ -1,31 +1,63 @@
-{ mkXfceDerivation, lib, python3, intltool, gettext,
- gtk3, libxfce4ui, libxfce4util, pango, harfbuzz, gdk-pixbuf, atk }:
+{ stdenv
+, lib
+, fetchFromGitLab
+, gettext
+, gobject-introspection
+, intltool
+, wrapGAppsHook3
+, glib
+, gtk3
+, libxfce4ui
+, python3
+, gitUpdater
+}:
 
 let
-  pythonEnv = python3.withPackages(ps: [ ps.pygobject3 ps.psutil ]);
-  makeTypelibPath = lib.makeSearchPathOutput "lib/girepository-1.0" "lib/girepository-1.0";
-in mkXfceDerivation {
-  category = "apps";
+  pythonEnv = python3.withPackages (ps: [
+    ps.pygobject3
+    ps.psutil
+  ]);
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-panel-profiles";
   version = "1.0.14";
 
-  sha256 = "sha256-mGA70t2U4mqEbcrj/DDsPl++EKWyZ8YXzKzzVOrH5h8=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "apps";
+    repo = "xfce4-panel-profiles";
+    rev = "xfce4-panel-profiles-${finalAttrs.version}";
+    sha256 = "sha256-mGA70t2U4mqEbcrj/DDsPl++EKWyZ8YXzKzzVOrH5h8=";
+  };
 
-  nativeBuildInputs = [ intltool gettext ];
-  propagatedBuildInputs = [ pythonEnv ];
+  nativeBuildInputs = [
+    gettext
+    gobject-introspection
+    intltool
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    libxfce4ui
+    pythonEnv
+  ];
 
   configurePhase = ''
+    runHook preConfigure
+    # This is just a handcrafted script and does not accept additional arguments.
     ./configure --prefix=$out
+    runHook postConfigure
   '';
 
-  postFixup = ''
-    wrapProgram $out/bin/xfce4-panel-profiles \
-      --set GI_TYPELIB_PATH ${makeTypelibPath [ gtk3 libxfce4ui libxfce4util pango harfbuzz gdk-pixbuf atk ]}
-  '';
+  passthru.updateScript = gitUpdater { rev-prefix = "xfce4-panel-profiles-"; };
 
   meta = with lib; {
+    homepage = "https://docs.xfce.org/apps/xfce4-panel-profiles/start";
     description = "Simple application to manage Xfce panel layouts";
     mainProgram = "xfce4-panel-profiles";
     maintainers = with maintainers; [ ] ++ teams.xfce.members;
+    platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
This does not launch on master due to gobject-introspection 1.79 not installing GLib introspection data: `ImportError: Typelib file for namespace 'Gio', version '2.0' not found`. Use setupHook to set up the proper `GI_TYPELIB_PATH`.

It does not make sense for me to use `mkXfceDerivation` here as `xfce4-dev-tools` is not even used here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

