### PR TITLE
exiftool: 12.82 -> 12.84

### DIFF
--- a/pkgs/development/perl-modules/ImageExifTool/default.nix
+++ b/pkgs/development/perl-modules/ImageExifTool/default.nix
@@ -1,11 +1,12 @@
-{ lib
-, stdenv
-, buildPerlPackage
-, exiftool
-, fetchurl
-, gitUpdater
-, shortenPerlShebang
-, testers
+{
+  buildPerlPackage,
+  exiftool,
+  fetchurl,
+  gitUpdater,
+  lib,
+  shortenPerlShebang,
+  stdenv,
+  testers,
 }:
 
 buildPerlPackage rec {
@@ -18,6 +19,7 @@ buildPerlPackage rec {
   };
 
   nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
+
   postInstall = lib.optionalString stdenv.isDarwin ''
     shortenPerlShebang $out/bin/exiftool
   '';
@@ -28,9 +30,7 @@ buildPerlPackage rec {
       command = "${lib.getExe exiftool} -ver";
       package = exiftool;
     };
-    updateScript = gitUpdater {
-      url = "https://github.com/exiftool/exiftool.git";
-    };
+    updateScript = gitUpdater { url = "https://github.com/exiftool/exiftool.git"; };
   };
 
   meta = {

--- a/pkgs/development/perl-modules/ImageExifTool/default.nix
+++ b/pkgs/development/perl-modules/ImageExifTool/default.nix
@@ -10,11 +10,11 @@
 
 buildPerlPackage rec {
   pname = "Image-ExifTool";
-  version = "12.82";
+  version = "12.84";
 
   src = fetchurl {
     url = "https://exiftool.org/Image-ExifTool-${version}.tar.gz";
-    hash = "sha256-1MfWz0AR+SaM2Ar7gAfLs38OJhOnP4cRekpe1uSjDD4=";
+    hash = "sha256-sfSnx5bS7vI0KIhBOpB5VYzP6g8oi0rR7mUTxxNWEA0=";
   };
 
   nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;


### PR DESCRIPTION
## Description of changes

https://github.com/exiftool/exiftool/compare/12.82...12.84

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
