### PR TITLE
matrix-commander: 7.2.0 -> 7.6.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
@@ -17,13 +17,13 @@
 
 buildPythonApplication rec {
   pname = "matrix-commander";
-  version = "7.2.0";
+  version = "7.6.2";
 
   src = fetchFromGitHub {
     owner = "8go";
     repo = "matrix-commander";
     rev = "v${version}";
-    hash = "sha256-qL6ARkAWu0FEuYK2e9Z9hMSfK4TW0kGgoIFUfJ8Dgwk=";
+    hash = "sha256-BiQShJHCTvEdkhp21uxxCTxBZ1eezuWE6btMc/wkPlc=";
   };
 
   format = "pyproject";


### PR DESCRIPTION
## Description of changes

[release: v7.6.2](https://github.com/8go/matrix-commander/releases/tag/v7.6.2)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
