### PR TITLE
github: add k3s label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -113,6 +113,14 @@
         - pkgs/applications/editors/jupyter-kernels/**/*
         - pkgs/applications/editors/jupyter/**/*
 
+"6.topic: k3s":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - nixos/modules/services/cluster/k3s/**/*
+        - nixos/tests/k3s/**/*
+        - pkgs/applications/networking/cluster/k3s/**/*
+
 "6.topic: kernel":
   - any:
     - changed-files:


### PR DESCRIPTION
github: add k3s label

* Enables linking issues and PRs to K3s label.
* Automatically adds K3s label to PRs changing K3s files.
