### PR TITLE
onnxruntime-genai: init at 0.2.0-rc4

### DIFF
--- a/pkgs/by-name/on/onnxruntime-extensions/0001-patch-dependencies.patch
+++ b/pkgs/by-name/on/onnxruntime-extensions/0001-patch-dependencies.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 526b288..ebd1a11 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -384,8 +384,15 @@ endif()
+ # enable the opencv dependency if we have ops that require it
+ if(OCOS_ENABLE_CV2 OR OCOS_ENABLE_VISION)
+   set(_ENABLE_OPENCV ON)
+-  message(STATUS "Fetch opencv")
+-  include(opencv)
++  # message(STATUS "Fetch opencv")
++  # include(opencv)
++  find_package(OpenCV REQUIRED)
++  set(opencv_LIBS ${OpenCV_LIBS})
++  include_directories(${OpenCV_INCLUDE_DIRS})
++  if (OCOS_ENABLE_OPENCV_CODECS)
++      list(APPEND opencv_INCLUDE_DIRS ${OPENCV_MODULE_opencv_imgcodecs_LOCATION}/include)
++      list(APPEND opencv_LIBS opencv_imgcodecs)
++  endif()
+ endif()
+ 
+ if(OCOS_ENABLE_CV2)

--- a/pkgs/by-name/on/onnxruntime-extensions/0002-patch-dependencies.patch
+++ b/pkgs/by-name/on/onnxruntime-extensions/0002-patch-dependencies.patch
@@ -1,0 +1,28 @@
+diff --git a/cmake/externals/googlere2.cmake b/cmake/externals/googlere2.cmake
+index 296736d..e1e20c4 100644
+--- a/cmake/externals/googlere2.cmake
++++ b/cmake/externals/googlere2.cmake
+@@ -1,12 +1,12 @@
+-FetchContent_Declare(
+-  googlere2
+-  GIT_REPOSITORY https://github.com/google/re2.git
+-  GIT_TAG        2021-06-01
+-  EXCLUDE_FROM_ALL
+-)
++# FetchContent_Declare(
++#   googlere2
++#   GIT_REPOSITORY https://github.com/google/re2.git
++#   GIT_TAG        2021-06-01
++#   EXCLUDE_FROM_ALL
++# )
+ 
+-FetchContent_MakeAvailable(googlere2)
+-set_target_properties(re2
+-  PROPERTIES
+-      POSITION_INDEPENDENT_CODE ON
+-      FOLDER externals/google)
++# FetchContent_MakeAvailable(googlere2)
++# set_target_properties(re2
++#   PROPERTIES
++#       POSITION_INDEPENDENT_CODE ON
++#       FOLDER externals/google)

--- a/pkgs/by-name/on/onnxruntime-extensions/0003-patch-dependencies.patch
+++ b/pkgs/by-name/on/onnxruntime-extensions/0003-patch-dependencies.patch
@@ -1,0 +1,80 @@
+diff --git a/cmake/externals/sentencepieceproject.cmake b/cmake/externals/sentencepieceproject.cmake
+index dfef576..1556a47 100644
+--- a/cmake/externals/sentencepieceproject.cmake
++++ b/cmake/externals/sentencepieceproject.cmake
+@@ -1,37 +1,37 @@
+ # spm is abbreviation of sentencepiece to meet the path length limits on Windows
+-if(NOT _ONNXRUNTIME_EMBEDDED)
+-  # If extensions wasn't built in ORT, we create fetchcontent the same 3rd party library as ORT
+-  # So extensions is always consistent on the 3rd party libraries whether its build in ORT or not
++# if(NOT _ONNXRUNTIME_EMBEDDED)
++#   # If extensions wasn't built in ORT, we create fetchcontent the same 3rd party library as ORT
++#   # So extensions is always consistent on the 3rd party libraries whether its build in ORT or not
+ 
+-  # TOOD: migrate to external abseil library
+-  # include(abseil-cpp)
+-  message(STATUS "Fetch protobuf")
+-  FetchContent_Declare(
+-    protobuf
+-    GIT_REPOSITORY https://github.com/protocolbuffers/protobuf.git
+-    GIT_TAG v21.12
+-    EXCLUDE_FROM_ALL
+-    PATCH_COMMAND git checkout . && git apply --ignore-space-change --ignore-whitespace ${PROJECT_SOURCE_DIR}/cmake/externals/protobuf_cmake.patch
+-  )
++#   # TOOD: migrate to external abseil library
++#   # include(abseil-cpp)
++#   message(STATUS "Fetch protobuf")
++#   FetchContent_Declare(
++#     protobuf
++#     GIT_REPOSITORY https://github.com/protocolbuffers/protobuf.git
++#     GIT_TAG v21.12
++#     EXCLUDE_FROM_ALL
++#     PATCH_COMMAND git checkout . && git apply --ignore-space-change --ignore-whitespace ${PROJECT_SOURCE_DIR}/cmake/externals/protobuf_cmake.patch
++#   )
+   
+-  set(protobuf_BUILD_TESTS OFF CACHE BOOL "Build tests")
+-  set(protobuf_WITH_ZLIB OFF CACHE BOOL "Use zlib")
++#   set(protobuf_BUILD_TESTS OFF CACHE BOOL "Build tests")
++#   set(protobuf_WITH_ZLIB OFF CACHE BOOL "Use zlib")
+ 
+-  if(CMAKE_SYSTEM_NAME STREQUAL "Android")
+-    set(protobuf_BUILD_PROTOC_BINARIES OFF CACHE BOOL "")
+-  endif()
+-  set(protobuf_BUILD_SHARED_LIBS OFF CACHE BOOL "")
+-  if("${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL "" OR "${CMAKE_MSVC_RUNTIME_LIBRARY}" MATCHES "DLL$")
+-    set(protobuf_MSVC_STATIC_RUNTIME OFF CACHE BOOL "")
+-  else()
+-    set(protobuf_MSVC_STATIC_RUNTIME ON CACHE BOOL "")
+-  endif()
+-  set(protobuf_DISABLE_RTTI ON CACHE BOOL "Disable RTTI")
++#   if(CMAKE_SYSTEM_NAME STREQUAL "Android")
++#     set(protobuf_BUILD_PROTOC_BINARIES OFF CACHE BOOL "")
++#   endif()
++#   set(protobuf_BUILD_SHARED_LIBS OFF CACHE BOOL "")
++#   if("${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL "" OR "${CMAKE_MSVC_RUNTIME_LIBRARY}" MATCHES "DLL$")
++#     set(protobuf_MSVC_STATIC_RUNTIME OFF CACHE BOOL "")
++#   else()
++#     set(protobuf_MSVC_STATIC_RUNTIME ON CACHE BOOL "")
++#   endif()
++#   set(protobuf_DISABLE_RTTI ON CACHE BOOL "Disable RTTI")
+ 
+-  FetchContent_MakeAvailable(protobuf)
+-  set_target_properties(libprotobuf-lite PROPERTIES
+-    FOLDER externals/google)
+-endif()
++#   FetchContent_MakeAvailable(protobuf)
++#   set_target_properties(libprotobuf-lite PROPERTIES
++#     FOLDER externals/google)
++# endif()
+ 
+ # To avoid creating complicated logic to build protoc, especially for mobile platforms, we use the pre-generated pb files
+ # Uses the following command line in _deps/spm-src folder to generate the PB patch file if protobuf version is updated
+@@ -63,7 +63,7 @@ if(NOT protobuf_SOURCE_DIR)
+ endif()
+ 
+ FetchContent_MakeAvailable(spm)
+-target_link_libraries(sentencepiece-static PUBLIC protobuf::libprotobuf-lite)
++target_link_libraries(sentencepiece-static PUBLIC libprotobuf-lite)
+ set_target_properties(sentencepiece-static PROPERTIES
+   FOLDER externals/google)
+ 

--- a/pkgs/by-name/on/onnxruntime-extensions/package.nix
+++ b/pkgs/by-name/on/onnxruntime-extensions/package.nix
@@ -1,0 +1,266 @@
+{ config
+, stdenv
+, lib
+, fetchFromGitHub
+# , Foundation
+, abseil-cpp
+, cmake
+, eigen
+, gtest
+, libpng
+, nlohmann_json
+, nsync
+, pkg-config
+, python3Packages
+, re2
+, zlib
+, microsoft-gsl
+, dlib
+# , iconv
+, protobuf_21
+, pythonSupport ? true
+, cudaSupport ? config.cudaSupport
+, cudaPackages ? {}
+, onnxruntime
+, buildEnv
+, simdjson
+, opencv
+, sentencepiece
+, tree
+, coreutils
+}@inputs:
+
+
+let
+  version = "0.12.0";
+
+  stdenv = throw "Use effectiveStdenv instead";
+  effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else inputs.stdenv;
+
+  cudaCapabilities = cudaPackages.cudaFlags.cudaCapabilities;
+  # E.g. [ "80" "86" "90" ]
+  cudaArchitectures = (builtins.map cudaPackages.cudaFlags.dropDot cudaCapabilities);
+  cudaArchitecturesString = lib.strings.concatStringsSep ";" cudaArchitectures;
+
+  ort = buildEnv { name = "ort"; paths = [  onnxruntime  onnxruntime.dev ]; };
+
+
+  # Provide latest dr_libs.
+  dr_libs = fetchFromGitHub {
+    owner = "mackron";
+    repo = "dr_libs";
+    rev = "dd762b861ecadf5ddd5fb03e9ca1db6707b54fbb";
+    hash = "sha256-DkE9wTwqvOkEauMqlkijvljPlpoEG5LZRKxMffkfg3c=";
+  };
+  # sentencepiece-static = fetchFromGitHub {
+  #   owner = "google";
+  #   repo = "sentencepiece";
+  #   rev = "v0.1.96";
+  #   hash = "sha256-jo8XlQJsnWpeeezDjNNhh6T473XMqe8fsApUr82Y3BU=";
+  # };
+  blingfire =  fetchFromGitHub {
+    owner = "microsoft";
+    repo = "blingfire";
+    rev = "0831265c1aca95ca02eca5bf1155e4251e545328";
+    hash = "sha256-NNS+ggDx3NYLYqyWWwP8dAtV/fTJgp4EHTJwRMgOmzQ=";
+  };
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "onnxruntime-extensions";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-snFGnCHvHMX8IdiNzvvm8wB1LHBecUFTgDRMzVnKZxA=";
+  };
+  # sentencepiece_patched = sentencepiece.overrideAttrs(old: {
+  #   version = "v0.1.96";
+  #   src = fetchFromGitHub {
+  #     owner = "google";
+  #     repo = "sentencepiece";
+  #     rev = "refs/tags/v0.1.96";
+  #     sha256 = "sha256-jo8XlQJsnWpeeezDjNNhh6T473XMqe8fsApUr82Y3BU=";
+  #   };
+  #   patches = [
+  #     "${src}/cmake/externals/sentencepieceproject_cmake.patch"
+  #     "${src}/cmake/externals/sentencepieceproject_pb.patch"
+  #   ];
+  # });
+
+ sentencepiece_patched =
+ let patches = [
+        "${src}/cmake/externals/sentencepieceproject_cmake.patch"
+        "${src}/cmake/externals/sentencepieceproject_pb.patch"
+      ]; in
+  effectiveStdenv.mkDerivation {
+      inherit patches;
+      pname = "sentencepiece_patched";
+      version = "v0.1.96";
+      src = fetchFromGitHub {
+        owner = "google";
+        repo = "sentencepiece";
+        rev = "refs/tags/v0.1.96";
+        sha256 = "sha256-jo8XlQJsnWpeeezDjNNhh6T473XMqe8fsApUr82Y3BU=";
+      };
+      # Disable build and install phases
+      # buildPhase = "true";
+      dontConfigure = true;
+      dontBuild = true;
+      installPhase = ''
+        mkdir -p $out
+        cp -r * $out
+      '';
+    };
+
+in
+effectiveStdenv.mkDerivation rec {
+  pname = "onnxruntime-extensions";
+  inherit version src;
+
+
+  patches = [
+    ./0001-patch-dependencies.patch
+    ./0002-patch-dependencies.patch
+    ./0003-patch-dependencies.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    python3Packages.python
+    protobuf_21
+    ort
+    simdjson
+  ] ++ lib.optionals pythonSupport (with python3Packages; [
+    pip
+    python
+    # pythonOutputDistHook
+    # setuptools
+    # wheel
+    # python3Packages.onnxruntime
+  ]) ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_nvcc
+  ];
+
+  buildInputs = [
+    eigen
+    libpng
+    zlib
+    nlohmann_json
+    microsoft-gsl
+    ort
+    dlib
+    opencv
+    # opencv.cxxdev
+    abseil-cpp
+    protobuf_21
+    re2
+    # sentencepiece_patched
+
+
+  ] ++ lib.optionals pythonSupport (with python3Packages; [
+    numpy
+    pybind11
+    packaging
+  ])
+  # ++ lib.optionals effectiveStdenv.isDarwin [
+  #   Foundation
+  #   iconv
+  # ]
+   ++ lib.optionals cudaSupport (with cudaPackages; [
+    cuda_cccl # cub/cub.cuh
+    libcublas # cublas_v2.h
+    libcurand # curand.h
+    libcusparse # cusparse.h
+    libcufft # cufft.h
+    cudnn # cudnn.h
+    cuda_cudart
+  ]);
+
+  nativeCheckInputs = [
+    gtest
+  ] ++ lib.optionals pythonSupport (with python3Packages; [
+    pytest
+    sympy
+    onnx
+  ]);
+
+  # Python's wheel is stored in a separate dist output
+  outputs = [ "out" "dev"] ;
+
+  enableParallelBuilding = true;
+
+  cmakeDir = "cmake";
+
+  cmakeFlags = [
+    "-S .."
+    "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"
+    "-DFETCHCONTENT_QUIET=OFF"
+    "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+    "-DOCOS_ENABLE_STATIC_LIB=ON"
+    "-DOCOS_ENABLE_C_API=ON"
+    "-DOCOS_BUILD_PRESET=ort_genai"
+    "-DOCOS_BUILD_PYTHON=${if pythonSupport then "ON" else "OFF"}"
+    "-DONNXRUNTIME_PKG_DIR=${ort}"
+    "-DOCOS_ONNXRUNTIME_VERSION=${onnxruntime.version}"
+    "-DCMAKE_PREFIX_PATH=${protobuf_21}/lib/cmake"
+    "-DFETCHCONTENT_SOURCE_DIR_GSL=${microsoft-gsl.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_DR_LIBS=${dr_libs}"
+    "-DFETCHCONTENT_SOURCE_DIR_DLIB=${dlib.src}"
+  ]
+  ++ lib.optionals cudaSupport [
+    "-DOCOS_USE_CUDA=ON"
+    (lib.cmakeFeature "onnxruntime_CUDNN_HOME" "${cudaPackages.cudnn}")
+    (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cudaArchitecturesString)
+    (lib.cmakeFeature "onnxruntime_NVCC_THREADS" "1")
+    "-DCUDA_HOME=${cudaPackages.cuda_nvcc}"
+    (lib.cmakeFeature "CMAKE_CUDA_COMPILER" "${cudaPackages.cuda_nvcc}/bin/nvcc")
+
+  ];
+
+  env = lib.optionalAttrs effectiveStdenv.cc.isClang {
+    NIX_CFLAGS_COMPILE = toString [
+      "-Wno-error=deprecated-declarations"
+      "-Wno-error=unused-but-set-variable"
+    ];
+  };
+
+  doCheck = !cudaSupport;
+
+  requiredSystemFeatures = lib.optionals cudaSupport [ "big-parallel" ];
+
+  postInstall = ''
+    cp lib/libortcustomops.a $out/lib/
+    cp lib/libocos_operators.a $out/lib/
+    cp lib/libnoexcep_operators.a $out/lib/
+    cp lib/libextensions_pydll.so $out/lib/
+
+    ln -s $out/lib/libortextensions.so  $out/lib/libonnxruntime_extensions.so
+
+    cp -r $src/include $out/
+    chmod +w $out/include
+    cp $src/shared/api/*.h $out/include/
+    cp $src/shared/api/*.hpp $out/include/
+    cp $src/base/*.h $out/include/
+  '';
+
+  passthru = {
+    inherit cudaSupport cudaPackages onnxruntime; # for the python module
+    protobuf = protobuf_21;
+    # tests = lib.optionalAttrs pythonSupport {
+    #   python = python3Packages.onnxruntime-genai;
+    # };
+  };
+
+  meta = with lib; {
+    description = "A specialized pre- and post- processing library for ONNX Runtime ";
+    longDescription = ''
+      ONNXRuntime-Extensions is a C/C++ library that extends the capability of the ONNX models and inference with ONNX Runtime, via ONNX Runtime Custom Operator ABIs.
+      It includes a set of ONNX Runtime Custom Operator to support the common pre- and post-processing operators for vision, text, and nlp models.
+    '';
+    homepage = "https://github.com/microsoft/onnxruntime-extensions";
+    changelog = "https://github.com/microsoft/onnxruntime-extensions/releases/tag/v${version}";
+    # https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#architectures
+    platforms = platforms.unix;
+    license = licenses.mit;
+    maintainers = with maintainers; [ anpin ];
+  };
+}

--- a/pkgs/by-name/on/onnxruntime-genai/0001-dont-copy-files-into-wheel.patch
+++ b/pkgs/by-name/on/onnxruntime-genai/0001-dont-copy-files-into-wheel.patch
@@ -1,0 +1,19 @@
+diff --git a/src/python/CMakeLists.txt b/src/python/CMakeLists.txt
+index bc85d8b..b76f7f4 100644
+--- a/src/python/CMakeLists.txt
++++ b/src/python/CMakeLists.txt
+@@ -44,14 +44,6 @@ if(BUILD_WHEEL)
+ 
+   # Copy over any additional python files
+   file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/py/" DESTINATION ${WHEEL_TARGET_NAME}/)
+-  file(COPY "${CMAKE_SOURCE_DIR}/ThirdPartyNotices.txt" DESTINATION ${WHEEL_TARGET_NAME}/)
+-
+-  add_custom_command(TARGET python POST_BUILD
+-    COMMAND ${CMAKE_COMMAND} -E copy
+-    ${onnxruntime_libs} $<TARGET_FILE:python>
+-    ${WHEEL_TARGET_NAME}
+-    COMMENT "Copying files to wheel directory: ${WHEEL_TARGET_NAME}"
+-  )
+   set(auditwheel_exclude_list
+     "libcublas.so.11"
+     "libcublas.so.12"

--- a/pkgs/by-name/on/onnxruntime-genai/0001-dont-copy-files-into-wheel.patch
+++ b/pkgs/by-name/on/onnxruntime-genai/0001-dont-copy-files-into-wheel.patch
@@ -1,16 +1,17 @@
 diff --git a/src/python/CMakeLists.txt b/src/python/CMakeLists.txt
-index bc85d8b..b76f7f4 100644
+index 6472fe3a..fa029df1 100644
 --- a/src/python/CMakeLists.txt
 +++ b/src/python/CMakeLists.txt
-@@ -44,14 +44,6 @@ if(BUILD_WHEEL)
+@@ -55,15 +55,6 @@ if(BUILD_WHEEL)
  
    # Copy over any additional python files
    file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/py/" DESTINATION ${WHEEL_TARGET_NAME}/)
+-  file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/package_description.md" DESTINATION ${WHEEL_FILES_DIR}/)
 -  file(COPY "${CMAKE_SOURCE_DIR}/ThirdPartyNotices.txt" DESTINATION ${WHEEL_TARGET_NAME}/)
--
+-  file(COPY "${CMAKE_SOURCE_DIR}/LICENSE" DESTINATION ${WHEEL_TARGET_NAME}/)
 -  add_custom_command(TARGET python POST_BUILD
 -    COMMAND ${CMAKE_COMMAND} -E copy
--    ${onnxruntime_libs} $<TARGET_FILE:python>
+-    ${ortgenai_embed_libs} $<TARGET_FILE:python>
 -    ${WHEEL_TARGET_NAME}
 -    COMMENT "Copying files to wheel directory: ${WHEEL_TARGET_NAME}"
 -  )

--- a/pkgs/by-name/on/onnxruntime-genai/0002-update-link.patch
+++ b/pkgs/by-name/on/onnxruntime-genai/0002-update-link.patch
@@ -1,0 +1,58 @@
+diff --git a/benchmark/c/CMakeLists.txt b/benchmark/c/CMakeLists.txt
+index 98501f20..ad100551 100644
+--- a/benchmark/c/CMakeLists.txt
++++ b/benchmark/c/CMakeLists.txt
+@@ -24,9 +24,13 @@ add_executable(model_benchmark ${model_benchmark_srcs})
+ target_include_directories(model_benchmark PRIVATE
+   ${CMAKE_CURRENT_SOURCE_DIR}
+   ${CMAKE_SOURCE_DIR}/src  # directory containing the ort_genai headers
++  ${onnxruntime_extensions_SOURCE_DIR}/include
++  ${onnxruntime_extensions_SOURCE_DIR}/shared/api
+ )
+ 
+ target_link_libraries(model_benchmark PRIVATE onnxruntime-genai-static ${ONNXRUNTIME_LIB})
++target_link_libraries(model_benchmark PUBLIC onnxruntime_extensions)
++target_link_libraries(model_benchmark PRIVATE onnxruntime_extensions)
+ 
+ target_link_directories(model_benchmark PRIVATE ${ORT_LIB_DIR})
+ 
+diff --git a/src/python/CMakeLists.txt b/src/python/CMakeLists.txt
+index 6472fe3a..aee8abe9 100644
+--- a/src/python/CMakeLists.txt
++++ b/src/python/CMakeLists.txt
+@@ -102,20 +102,4 @@ if(BUILD_WHEEL)
+     list(APPEND modified_exclude_list "--exclude" ${item})
+   endforeach()
+ 
+-  if(MANYLINUX)
+-    add_custom_target(PyPackageBuild ALL
+-      COMMAND ${PYTHON_EXECUTABLE} -m pip wheel --no-deps .
+-      COMMAND ${CMAKE_COMMAND} -E remove ${WHEEL_TARGET_NAME}/onnxruntime_genai.cpython-*
+-      COMMAND auditwheel repair onnxruntime_genai*linux_x86_64.whl -w ${WHEEL_FILES_DIR} ${modified_exclude_list}
+-      WORKING_DIRECTORY "${WHEEL_FILES_DIR}"
+-      COMMENT "Building wheel with MANYLINUX on ${WHEEL_FILES_DIR}"
+-    )
+-  else()
+-    add_custom_target(PyPackageBuild ALL
+-      COMMAND ${PYTHON_EXECUTABLE} -m pip wheel --no-deps .
+-      WORKING_DIRECTORY "${WHEEL_FILES_DIR}"
+-      COMMENT "Building wheel on ${WHEEL_FILES_DIR}"
+-    )
+-  endif()
+-  add_dependencies(PyPackageBuild python)
+ endif()
+\ No newline at end of file
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index da3502bb..e500b1b3 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -25,6 +25,9 @@ target_link_libraries(unit_tests PRIVATE
+   onnxruntime-genai-static
+   GTest::gtest_main
+ )
++target_link_libraries(unit_tests PRIVATE onnxruntime_extensions)
++target_link_libraries(unit_tests PUBLIC onnxruntime_extensions)
++
+ 
+ if(NOT (CMAKE_SYSTEM_NAME STREQUAL "Android" OR CMAKE_SYSTEM_NAME STREQUAL "Linux"))
+ target_link_libraries(unit_tests PRIVATE ${ONNXRUNTIME_LIB})

--- a/pkgs/by-name/on/onnxruntime-genai/package.nix
+++ b/pkgs/by-name/on/onnxruntime-genai/package.nix
@@ -191,7 +191,7 @@ effectiveStdenv.mkDerivation rec {
   '';
 
   passthru = {
-    inherit cudaSupport cudaPackages onnxruntime; # for the python module
+    inherit cudaSupport cudaPackages onnxruntime onnxruntime-extensions; # for the python module
     protobuf = protobuf_21;
     tests = lib.optionalAttrs pythonSupport {
       python = python3Packages.onnxruntime-genai;

--- a/pkgs/by-name/on/onnxruntime-genai/package.nix
+++ b/pkgs/by-name/on/onnxruntime-genai/package.nix
@@ -1,0 +1,208 @@
+{ config
+, stdenv
+, lib
+, fetchFromGitHub
+, Foundation
+, abseil-cpp
+, cmake
+, eigen
+, gtest
+, libpng
+, nlohmann_json
+, nsync
+, pkg-config
+, python3Packages
+, re2
+, zlib
+, microsoft-gsl
+, iconv
+, protobuf_21
+, pythonSupport ? true
+, cudaSupport ? config.cudaSupport
+, cudaPackages ? {}
+, onnxruntime
+, buildEnv
+, simdjson
+}@inputs:
+
+
+let
+  version = "0.2.0-rc4";
+
+  stdenv = throw "Use effectiveStdenv instead";
+  effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else inputs.stdenv;
+
+  cudaCapabilities = cudaPackages.cudaFlags.cudaCapabilities;
+  # E.g. [ "80" "86" "90" ]
+  cudaArchitectures = (builtins.map cudaPackages.cudaFlags.dropDot cudaCapabilities);
+  cudaArchitecturesString = lib.strings.concatStringsSep ";" cudaArchitectures;
+
+  ort = buildEnv { name = "ort"; paths = [  onnxruntime  onnxruntime.dev ]; };
+in
+effectiveStdenv.mkDerivation rec {
+  pname = "onnxruntime-genai";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "onnxruntime-genai";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-BTVJSa4ltcy9sURQ/Q2ou9h3bLphh01va9bogoobxAs=";
+  };
+
+  patches = [
+    # If you stumble on these patches trying to update onnxruntime, check
+    # `git blame` and ping the introducers.
+
+    # Context: we want the upstream to
+    # - during nix build target directory doesn't have write permissions, so we do these actions in postBuild phase
+    ./0001-dont-copy-files-into-wheel.patch
+  ] ++ lib.optionals cudaSupport [
+    # This patch is copied from onnxruntime main package
+    # We apply the referenced 1064.patch ourselves to our nix dependency.
+    #  FIND_PACKAGE_ARGS for CUDA was added in https://github.com/microsoft/onnxruntime/commit/87744e5 so it might be possible to delete this patch after upgrading to 1.17.0
+    # ./nvcc-gsl.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    python3Packages.python
+    protobuf_21
+    ort
+    simdjson
+  ] ++ lib.optionals pythonSupport (with python3Packages; [
+    pip
+    python
+    pythonOutputDistHook
+    setuptools
+    wheel
+    python3Packages.onnxruntime
+  ]) ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_nvcc
+  ];
+
+  buildInputs = [
+    eigen
+    libpng
+    zlib
+    nlohmann_json
+    microsoft-gsl
+    ort
+  ] ++ lib.optionals pythonSupport (with python3Packages; [
+    numpy
+    pybind11
+    packaging
+  ]) ++ lib.optionals effectiveStdenv.isDarwin [
+    Foundation
+    iconv
+  ] ++ lib.optionals cudaSupport (with cudaPackages; [
+    cuda_cccl # cub/cub.cuh
+    libcublas # cublas_v2.h
+    libcurand # curand.h
+    libcusparse # cusparse.h
+    libcufft # cufft.h
+    cudnn # cudnn.h
+    cuda_cudart
+  ]);
+
+  nativeCheckInputs = [
+    gtest
+  ] ++ lib.optionals pythonSupport (with python3Packages; [
+    pytest
+    sympy
+    onnx
+  ]);
+
+  # Python's wheel is stored in a separate dist output
+  outputs = [ "out" ] ++ lib.optionals pythonSupport [ "dist" ];
+
+  enableParallelBuilding = true;
+
+  cmakeDir = "cmake";
+
+  cmakeFlags = [
+    "-S .."
+    "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"
+    "-DFETCHCONTENT_QUIET=OFF"
+    "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+    "-DBUILD_WHEEL=${if pythonSupport then "ON" else "OFF"}"
+    "-DUSE_DML=OFF"
+    "-DORT_HOME=${ort}"
+    (lib.cmakeBool "USE_CUDA" cudaSupport)
+    "-DFETCHCONTENT_SOURCE_DIR_SIMDJSON=${simdjson.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_GSL=${microsoft-gsl.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_GOOGLETEST=${gtest.src}"
+  ]
+  ++ lib.optionals cudaSupport [
+    (lib.cmakeFeature "onnxruntime_CUDNN_HOME" "${cudaPackages.cudnn}")
+    (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cudaArchitecturesString)
+    (lib.cmakeFeature "onnxruntime_NVCC_THREADS" "1")
+    "-DCUDA_HOME=${cudaPackages.cuda_nvcc}"
+    (lib.cmakeFeature "CMAKE_CUDA_COMPILER" "${cudaPackages.cuda_nvcc}/bin/nvcc")
+
+  ];
+
+  env = lib.optionalAttrs effectiveStdenv.cc.isClang {
+    NIX_CFLAGS_COMPILE = toString [
+      "-Wno-error=deprecated-declarations"
+      "-Wno-error=unused-but-set-variable"
+    ];
+  };
+
+  doCheck = !cudaSupport;
+
+  requiredSystemFeatures = lib.optionals cudaSupport [ "big-parallel" ];
+
+  postPatch = lib.optionalString (!cudaSupport) ''
+    substituteInPlace cmake/options.cmake \
+      --replace-fail  'option(USE_CUDA "Build with CUDA support" ON)' 'option(USE_CUDA "Build with CUDA support" OFF)'
+  '' + lib.optionalString (!pythonSupport) ''
+    substituteInPlace cmake/options.cmake \
+      --replace-fail  'option(ENABLE_PYTHON "Build the Python API." ON)' 'option(ENABLE_PYTHON "Build the Python API." OFF)'
+  '';
+
+  postBuild = lib.optionalString pythonSupport ''
+    cd wheel
+    chmod +w onnxruntime_genai
+    cp ../src/python/onnxruntime_genai.cpython-311-x86_64-linux-gnu.so onnxruntime_genai/
+    cp $src/ThirdPartyNotices.txt onnxruntime_genai/
+    ${python3Packages.python.interpreter} setup.py bdist_wheel
+    cd ..
+  '';
+
+  postInstall = ''
+    pwd
+    mkdir -p $out/lib
+    cp libonnxruntime-genai.so $out/lib/
+    mkdir -p dist
+    cp -r wheel/dist/. dist/
+  '';
+
+  passthru = {
+    inherit cudaSupport cudaPackages onnxruntime; # for the python module
+    protobuf = protobuf_21;
+    tests = lib.optionalAttrs pythonSupport {
+      python = python3Packages.onnxruntime-genai;
+    };
+  };
+
+  meta = with lib; {
+    description = "Cross-platform, high performance scoring engine for ML models";
+    longDescription = ''
+      ONNX Runtime is a performance-focused complete scoring engine
+      for Open Neural Network Exchange (ONNX) models, with an open
+      extensible architecture to continually address the latest developments
+      in AI and Deep Learning. ONNX Runtime stays up to date with the ONNX
+      standard with complete implementation of all ONNX operators, and
+      supports all ONNX releases (1.2+) with both future and backwards
+      compatibility.
+    '';
+    homepage = "https://github.com/microsoft/onnxruntime-genai";
+    changelog = "https://github.com/microsoft/onnxruntime-genai/releases/tag/v${version}";
+    # https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#architectures
+    platforms = platforms.unix;
+    license = licenses.mit;
+    maintainers = with maintainers; [ anpin ];
+  };
+}

--- a/pkgs/development/python-modules/onnxruntime-genai/default.nix
+++ b/pkgs/development/python-modules/onnxruntime-genai/default.nix
@@ -54,6 +54,7 @@ buildPythonPackage {
     re2
     onnxruntime-genai.protobuf
     onnxruntime-genai.onnxruntime
+    onnxruntime-genai.onnxruntime-extensions
   ] ++ lib.optionals onnxruntime-genai.passthru.cudaSupport (with onnxruntime-genai.passthru.cudaPackages; [
     libcublas # libcublasLt.so.XX libcublas.so.XX
     libcurand # libcurand.so.XX

--- a/pkgs/development/python-modules/onnxruntime-genai/default.nix
+++ b/pkgs/development/python-modules/onnxruntime-genai/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, autoPatchelfHook
+, pythonRelaxDepsHook
+, onnxruntime-genai
+, coloredlogs
+, numpy
+, packaging
+, oneDNN
+, re2
+
+}:
+
+# onnxruntime requires an older protobuf.
+# Doing an override in protobuf in the python-packages set
+# can give you a functioning Python package but note not
+# all Python packages will be compatible then.
+#
+# Because protobuf is not always needed we remove it
+# as a runtime dependency from our wheel.
+#
+# We do include here the non-Python protobuf so the shared libs
+# link correctly. If you do also want to include the Python
+# protobuf, you can add it to your Python env, but be aware
+# the version likely mismatches with what is used here.
+
+buildPythonPackage {
+  inherit (onnxruntime-genai) pname version;
+  format = "wheel";
+  src = onnxruntime-genai.dist;
+
+  unpackPhase = ''
+    cp -r $src dist
+    chmod +w dist
+  '';
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ] ++ lib.optionals stdenv.isLinux [
+    autoPatchelfHook
+  ];
+
+  # This project requires fairly large dependencies such as sympy which we really don't always need.
+  pythonRemoveDeps = [
+    "flatbuffers"
+    "protobuf"
+    "sympy"
+  ];
+
+  # Libraries are not linked correctly.
+  buildInputs = [
+    oneDNN
+    re2
+    onnxruntime-genai.protobuf
+    onnxruntime-genai.onnxruntime
+  ] ++ lib.optionals onnxruntime-genai.passthru.cudaSupport (with onnxruntime-genai.passthru.cudaPackages; [
+    libcublas # libcublasLt.so.XX libcublas.so.XX
+    libcurand # libcurand.so.XX
+    libcufft # libcufft.so.XX
+    cudnn # libcudnn.soXX
+    cuda_cudart # libcudart.so.XX
+  ]);
+
+  propagatedBuildInputs = [
+    coloredlogs
+    # flatbuffers
+    numpy
+    packaging
+    # protobuf
+    # sympy
+  ];
+
+  meta = onnxruntime-genai.meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5607,6 +5607,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };
 
+  onnxruntime-genai = callPackage ../by-name/on/onnxruntime-genai/package.nix {
+    inherit (darwin.apple_sdk.frameworks) Foundation;
+  };
+
   xkbd = callPackage ../applications/misc/xkbd { };
 
   libpsm2 = callPackage ../os-specific/linux/libpsm2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9423,6 +9423,13 @@ self: super: with self; {
     };
   };
 
+  onnxruntime-genai = callPackage ../development/python-modules/onnxruntime-genai {
+    onnxruntime-genai = pkgs.onnxruntime-genai.override {
+      python3Packages = self;
+      pythonSupport = true;
+    };
+  };
+
   onnxruntime-tools = callPackage ../development/python-modules/onnxruntime-tools { };
 
   onvif-zeep = callPackage ../development/python-modules/onvif-zeep { };


### PR DESCRIPTION
## Description of changes

This PR adds [microsoft/onnxruntime-genai](https://github.com/microsoft/onnxruntime-genai) library

This library provides the generative AI loop for ONNX models, including inference with ONNX Runtime, logits processing, search and sampling, and KV cache management. 

I'm not really a C or python person, so this code was largely adapted from existing onnxruntime package. Not sure if I should include original maintainers. 

While building the library I was faced with some weird issue where resulting wheel folder won't have write permissions and the only workaround I was able to find was to remove these steps via patch and perform them manually in postbuild

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
