### PR TITLE
python311Packages.filedate: init at 3.0

### DIFF
--- a/pkgs/development/python-modules/filedate/default.nix
+++ b/pkgs/development/python-modules/filedate/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  python-dateutil,
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "filedate";
+  version = "3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "kubinka0505";
+    repo = "filedate";
+    rev = version;
+    hash = "sha256-HvuGP+QlUlfAUfFmaVVvtPHGdrbWVxghQipnqTTvAQc=";
+  };
+
+  sourceRoot = "${src.name}/Files";
+
+  # The repo stores everything in "src" and uses setup.py to move "src" ->
+  # "filedate" before calling setup() and then tries to rename "filedate" back
+  # to "src" after.
+  postPatch = ''
+    mv src filedate
+    substituteInPlace setup.py \
+      --replace-fail "__title__ = os.path.basename(os.path.dirname(os.path.dirname(__file__)))" '__title__ = "filedate"'
+    substituteInPlace setup.py \
+      --replace-fail "cleanup = True" "cleanup = False"
+
+    # Disable renaming "filedate" dir back to "src"
+    substituteInPlace setup.py \
+      --replace-fail "if os.path.exists(__title__):" ""
+    substituteInPlace setup.py \
+      --replace-fail "	os.rename(__title__, directory)" ""
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [ python-dateutil ];
+
+  pythonImportsCheck = [ "filedate" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pytestFlagsArray = [ "tests/unit.py" ];
+
+  disabledTests = [ "test_created" ];
+
+  meta = {
+    description = "Simple, convenient and cross-platform file date changing library";
+    homepage = "https://github.com/kubinka0505/filedate";
+    changelog = "https://github.com/kubinka0505/filedate/blob/${src.rev}/Documents/ChangeLog.md";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ thornycrackers ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4183,6 +4183,8 @@ self: super: with self; {
 
   filecheck = callPackage ../development/python-modules/filecheck { };
 
+  filedate = callPackage ../development/python-modules/filedate { };
+
   filedepot = callPackage ../development/python-modules/filedepot { };
 
   filelock = callPackage ../development/python-modules/filelock { };


### PR DESCRIPTION
## Description of changes

fildate is one of the [requirements](https://github.com/Jules-WinnfieldX/CyberDropDownloader/blob/master/pyproject.toml#L22) for the [cyberdrop-dl](https://github.com/NixOS/nixpkgs/issues/306050) request. The package itself does some non standard operations.  The [github repo](https://github.com/kubinka0505/filedate) stores the source code in a directory called [src](https://github.com/kubinka0505/filedate/tree/master/Files/src). Then `setup.py` tries to rename that directory to `filedate` before calling `setup()`. After it tries to rename `filedate` back to `src`. I'm not sure it this is the cleanest way to handle the situation but it works. Open to feedback on how to improve.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
