### PR TITLE
bombsquad: init at 1.7.34

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19591,6 +19591,12 @@
     githubId = 12841859;
     name = "Syboxez Blank";
   };
+  syedahkam = {
+    email = "smahkam57@gmail.com";
+    github = "SyedAhkam";
+    githubId = 52673095;
+    name = "Syed Ahkam";
+  };
   symphorien = {
     email = "symphorien_nixpkgs@xlumurb.eu";
     matrix = "@symphorien:xlumurb.eu";

--- a/pkgs/by-name/bo/bombsquad/package.nix
+++ b/pkgs/by-name/bo/bombsquad/package.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  stdenv,
+  targetPlatform,
+  fetchurl,
+  python312,
+  SDL2,
+  libvorbis,
+  openal,
+  curl,
+  gnugrep,
+  libgcc,
+  makeWrapper,
+  makeDesktopItem,
+  autoPatchelfHook,
+  copyDesktopItems,
+  writeShellApplication,
+  commandLineArgs ? "",
+}:
+let
+  archive =
+    {
+      x86_64-linux = {
+        name = "BombSquad_Linux_x86_64";
+        hash = "sha256-VLNO0TxI/KBj8RkpGjo9Rx40f7fuV3pK2kIoKff9sRU=";
+      };
+      aarch-64-linux = {
+        name = "BombSquad_Linux_Arm64";
+        hash = "sha256-w42qhioZ9JRm004WEKzsJ3G1u09tLuPvTy8qV3DuglI=";
+      };
+    }
+    .${targetPlatform.system} or (throw "${targetPlatform.system} is unsupported.");
+in
+stdenv.mkDerivation (finalAttrs: {
+  name = "bombsquad";
+  version = "1.7.34";
+  sourceRoot = ".";
+  src = fetchurl {
+    url = "https://files.ballistica.net/bombsquad/builds/${archive.name}_${finalAttrs.version}.tar.gz";
+    inherit (archive) hash;
+  };
+
+  bombsquadIcon = fetchurl {
+    url = "https://files.ballistica.net/bombsquad/promo/BombSquadIcon.png";
+    hash = "sha256-MfOvjVmjhLejrJmdLo/goAM9DTGubnYGhlN6uF2GugA=";
+  };
+
+  nativeBuildInputs = [
+    python312
+    SDL2
+    libvorbis
+    openal
+    libgcc
+    makeWrapper
+    autoPatchelfHook
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "bombsquad";
+      genericName = "bombsquad";
+      desktopName = "BombSquad";
+      icon = "bombsquad";
+      exec = "bombsquad";
+      comment = "An explosive arcade-style party game.";
+      categories = [ "Game" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    base=${archive.name}_${finalAttrs.version}
+
+    install -m755 -D $base/bombsquad $out/bin/bombsquad
+    install -dm755 $base/ba_data $out/usr/share/bombsquad/ba_data
+    cp -r $base/ba_data $out/usr/share/bombsquad/
+
+    wrapProgram "$out/bin/bombsquad" \
+      --add-flags ${lib.escapeShellArg commandLineArgs} \
+      --add-flags "-d $out/usr/share/bombsquad"
+
+    install -Dm755 ${finalAttrs.bombsquadIcon} $out/usr/share/icons/hicolor/32x32/apps/bombsquad.png
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "bombsquad-versionLister";
+    runtimeInputs = [
+      curl
+      gnugrep
+    ];
+    text = ''
+      curl -sL "https://files.ballistica.net/bombsquad/builds/CHANGELOG.md" \
+          | grep -oP '^### \K\d+\.\d+\.\d+' \
+          | head -n 1
+    '';
+  });
+
+  meta = {
+    description = "A free, multiplayer, arcade-style game for up to eight players that combines elements of fighting games and first-person shooters (FPS)";
+    homepage = "https://ballistica.net";
+    changelog = "https://ballistica.net/downloads?display=changelog";
+    license = with lib.licenses; [
+      mit
+      unfree
+    ];
+    maintainers = with lib.maintainers; [ syedahkam ];
+    mainProgram = "bombsquad";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Derived new package `bombsquad` which is a *game* available [here](https://ballistica.net) ([source](https://github.com/efroemling/ballistica)) published by Eric Froemling.

Currently support is for Linux x86 & arm64. However I have plans to add support for deriving mac `.dmg`s soon.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

---

EDIT: If anyone stumbles here looking for a way to simply run the game on their NixOS machine (until this is merged), you may run this command, build & run directly from my forked version of nixpkgs:

```sh
NIXPKGS_ALLOW_UNFREE=1 nix run --impure github:SyedAhkam/nixpkgs/add-bombsquad-pkg#bombsquad
```