### PR TITLE
plantuml-server: remove unnecessary systemd option path

### DIFF
--- a/nixos/modules/services/web-apps/plantuml-server.nix
+++ b/nixos/modules/services/web-apps/plantuml-server.nix
@@ -97,7 +97,6 @@ in
     systemd.services.plantuml-server = {
       description = "PlantUML server";
       wantedBy = [ "multi-user.target" ];
-      path = [ cfg.home ];
 
       environment = {
         PLANTUML_LIMIT_SIZE = builtins.toString cfg.plantumlLimitSize;


### PR DESCRIPTION
## Description of changes

@nh2 pointed out that adding `/var/lib/plantuml/bin` to `PATH` is odd.
https://github.com/NixOS/nixpkgs/commit/e340e24d3a8c5f0579928d30c88695b7d821910a#r141697434

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`

- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

I tested the functionality of the module locally by  adding this to mys system flake

```diff
index 2a7049c..7ef8433 100644
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-23.11";
+    nixpkgs-plantuml.url = "github:truh/nixpkgs/patch-1";
     agenix.url = "github:ryantm/agenix?ref=0.13.0";
     attic = {
       url = "github:zhaofengli/attic";
@@ -26,6 +27,7 @@
     attic,
     flake-utils,
     home-manager,
+    nixpkgs-plantuml,
     slackfeeder,
   }:
     {
@@ -46,6 +48,12 @@
           {
             environment.systemPackages = [agenix.packages.${system}.agenix];
           }
+          {
+            disabledModules = ["services/web-apps/plantuml-server.nix"];
+            imports = ["${nixpkgs-plantuml}/nixos/modules/services/web-apps/plantuml-server.nix"];
+            services.plantuml-server.enable = true;
+            services.plantuml-server.package = (import nixpkgs-plantuml {inherit system;}).plantuml-server;
+          }
         ];
       };
```

- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module

- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
