### PR TITLE
k3s: enforce rfc 0166 format

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -111,3 +111,6 @@ fb0e5be84331188a69b3edd31679ca6576edb75a
 
 # pkgs/os-specific/bsd: Reformat with nixfmt-rfc-style 2024-03-01
 3fe3b055adfc020e6a923c466b6bcd978a13069a
+
+# k3s: format with nixfmt-rfc-style
+0b7900d5e8e0bcac89e14a52d3e840f9201e9f47

--- a/.github/workflows/check-nix-format.yml
+++ b/.github/workflows/check-nix-format.yml
@@ -39,6 +39,10 @@ jobs:
             pkgs/development/cuda-modules
             pkgs/test/cuda
             pkgs/top-level/cuda-packages.nix
+          NIX_FMT_PATHS_K3S: |
+            nixos/modules/services/cluster/k3s
+            nixos/tests/k3s
+            pkgs/applications/networking/cluster/k3s
           NIX_FMT_PATHS_VSCODE_EXTS: pkgs/applications/editors/vscode/extensions
           NIX_FMT_PATHS_PHP_PACKAGES: pkgs/development/php-packages
           NIX_FMT_PATHS_BUILD_SUPPORT_PHP: pkgs/build-support/php

--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -1,15 +1,25 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 with lib;
 let
   cfg = config.services.k3s;
-  removeOption = config: instruction:
-    lib.mkRemovedOptionModule ([ "services" "k3s" ] ++ config) instruction;
+  removeOption =
+    config: instruction:
+    lib.mkRemovedOptionModule (
+      [
+        "services"
+        "k3s"
+      ]
+      ++ config
+    ) instruction;
 in
 {
-  imports = [
-    (removeOption [ "docker" ] "k3s docker option is no longer supported.")
-  ];
+  imports = [ (removeOption [ "docker" ] "k3s docker option is no longer supported.") ];
 
   # interface
   options.services.k3s = {
@@ -33,7 +43,10 @@ in
         - `serverAddr` is required.
       '';
       default = "server";
-      type = types.enum [ "server" "agent" ];
+      type = types.enum [
+        "server"
+        "agent"
+      ];
     };
 
     serverAddr = mkOption {
@@ -125,7 +138,8 @@ in
         message = "serverAddr or configPath (with 'server' key) should be set if role is 'agent'";
       }
       {
-        assertion = cfg.role == "agent" -> cfg.configPath != null || cfg.tokenFile != null || cfg.token != "";
+        assertion =
+          cfg.role == "agent" -> cfg.configPath != null || cfg.tokenFile != null || cfg.token != "";
         message = "token or tokenFile or configPath (with 'token' or 'token-file' keys) should be set if role is 'agent'";
       }
       {
@@ -142,8 +156,14 @@ in
 
     systemd.services.k3s = {
       description = "k3s service";
-      after = [ "firewall.service" "network-online.target" ];
-      wants = [ "firewall.service" "network-online.target" ];
+      after = [
+        "firewall.service"
+        "network-online.target"
+      ];
+      wants = [
+        "firewall.service"
+        "network-online.target"
+      ];
       wantedBy = [ "multi-user.target" ];
       path = optional config.boot.zfs.enabled config.boot.zfs.package;
       serviceConfig = {
@@ -159,9 +179,7 @@ in
         TasksMax = "infinity";
         EnvironmentFile = cfg.environmentFile;
         ExecStart = concatStringsSep " \\\n " (
-          [
-            "${cfg.package}/bin/k3s ${cfg.role}"
-          ]
+          [ "${cfg.package}/bin/k3s ${cfg.role}" ]
           ++ (optional cfg.clusterInit "--cluster-init")
           ++ (optional cfg.disableAgent "--disable-agent")
           ++ (optional (cfg.serverAddr != "") "--server ${cfg.serverAddr}")

--- a/nixos/tests/k3s/default.nix
+++ b/nixos/tests/k3s/default.nix
@@ -1,16 +1,20 @@
-{ system ? builtins.currentSystem
-, pkgs ? import ../../.. { inherit system; }
-, lib ? pkgs.lib
+{
+  system ? builtins.currentSystem,
+  pkgs ? import ../../.. { inherit system; },
+  lib ? pkgs.lib,
 }:
 let
   allK3s = lib.filterAttrs (n: _: lib.strings.hasPrefix "k3s_" n) pkgs;
 in
 {
   # Testing K3s with Etcd backend
-  etcd = lib.mapAttrs (_: k3s: import ./etcd.nix {
-    inherit system pkgs k3s;
-    inherit (pkgs) etcd;
-  }) allK3s;
+  etcd = lib.mapAttrs (
+    _: k3s:
+    import ./etcd.nix {
+      inherit system pkgs k3s;
+      inherit (pkgs) etcd;
+    }
+  ) allK3s;
   # Run a single node k3s cluster and verify a pod can run
   single-node = lib.mapAttrs (_: k3s: import ./single-node.nix { inherit system pkgs k3s; }) allK3s;
   # Run a multi-node k3s cluster and verify pod networking works across nodes

--- a/nixos/tests/k3s/etcd.nix
+++ b/nixos/tests/k3s/etcd.nix
@@ -1,100 +1,130 @@
-import ../make-test-python.nix ({ pkgs, lib, k3s, etcd, ... }:
+import ../make-test-python.nix (
+  {
+    pkgs,
+    lib,
+    k3s,
+    etcd,
+    ...
+  }:
 
-{
-  name = "${k3s.name}-etcd";
+  {
+    name = "${k3s.name}-etcd";
 
-  nodes = {
+    nodes = {
 
-    etcd = { ... }: {
-      services.etcd = {
-        enable = true;
-        openFirewall = true;
-        listenClientUrls = [ "http://192.168.1.1:2379" "http://127.0.0.1:2379" ];
-        listenPeerUrls = [ "http://192.168.1.1:2380" ];
-        initialAdvertisePeerUrls = [ "http://192.168.1.1:2380" ];
-        initialCluster = [ "etcd=http://192.168.1.1:2380" ];
-      };
-      networking = {
-        useDHCP = false;
-        defaultGateway = "192.168.1.1";
-        interfaces.eth1.ipv4.addresses = pkgs.lib.mkForce [
-          { address = "192.168.1.1"; prefixLength = 24; }
-        ];
-      };
-    };
-
-    k3s = { pkgs, ... }: {
-      environment.systemPackages = with pkgs; [ jq ];
-      # k3s uses enough resources the default vm fails.
-      virtualisation.memorySize = 1536;
-      virtualisation.diskSize = 4096;
-
-      services.k3s = {
-        enable = true;
-        role = "server";
-        extraFlags = builtins.toString [
-          "--datastore-endpoint=\"http://192.168.1.1:2379\""
-          "--disable" "coredns"
-          "--disable" "local-storage"
-          "--disable" "metrics-server"
-          "--disable" "servicelb"
-          "--disable" "traefik"
-          "--node-ip" "192.168.1.2"
-        ];
-      };
-
-      networking = {
-        firewall = {
-          allowedTCPPorts = [ 2379 2380 6443 ];
-          allowedUDPPorts = [ 8472 ];
+      etcd =
+        { ... }:
+        {
+          services.etcd = {
+            enable = true;
+            openFirewall = true;
+            listenClientUrls = [
+              "http://192.168.1.1:2379"
+              "http://127.0.0.1:2379"
+            ];
+            listenPeerUrls = [ "http://192.168.1.1:2380" ];
+            initialAdvertisePeerUrls = [ "http://192.168.1.1:2380" ];
+            initialCluster = [ "etcd=http://192.168.1.1:2380" ];
+          };
+          networking = {
+            useDHCP = false;
+            defaultGateway = "192.168.1.1";
+            interfaces.eth1.ipv4.addresses = pkgs.lib.mkForce [
+              {
+                address = "192.168.1.1";
+                prefixLength = 24;
+              }
+            ];
+          };
         };
-        useDHCP = false;
-        defaultGateway = "192.168.1.2";
-        interfaces.eth1.ipv4.addresses = pkgs.lib.mkForce [
-          { address = "192.168.1.2"; prefixLength = 24; }
-        ];
-      };
+
+      k3s =
+        { pkgs, ... }:
+        {
+          environment.systemPackages = with pkgs; [ jq ];
+          # k3s uses enough resources the default vm fails.
+          virtualisation.memorySize = 1536;
+          virtualisation.diskSize = 4096;
+
+          services.k3s = {
+            enable = true;
+            role = "server";
+            extraFlags = builtins.toString [
+              "--datastore-endpoint=\"http://192.168.1.1:2379\""
+              "--disable"
+              "coredns"
+              "--disable"
+              "local-storage"
+              "--disable"
+              "metrics-server"
+              "--disable"
+              "servicelb"
+              "--disable"
+              "traefik"
+              "--node-ip"
+              "192.168.1.2"
+            ];
+          };
+
+          networking = {
+            firewall = {
+              allowedTCPPorts = [
+                2379
+                2380
+                6443
+              ];
+              allowedUDPPorts = [ 8472 ];
+            };
+            useDHCP = false;
+            defaultGateway = "192.168.1.2";
+            interfaces.eth1.ipv4.addresses = pkgs.lib.mkForce [
+              {
+                address = "192.168.1.2";
+                prefixLength = 24;
+              }
+            ];
+          };
+        };
     };
 
-  };
+    testScript = ''
+      with subtest("should start etcd"):
+          etcd.start()
+          etcd.wait_for_unit("etcd.service")
 
-  testScript = ''
-    with subtest("should start etcd"):
-        etcd.start()
-        etcd.wait_for_unit("etcd.service")
+      with subtest("should wait for etcdctl endpoint status to succeed"):
+          etcd.wait_until_succeeds("etcdctl endpoint status")
 
-    with subtest("should wait for etcdctl endpoint status to succeed"):
-        etcd.wait_until_succeeds("etcdctl endpoint status")
+      with subtest("should start k3s"):
+          k3s.start()
+          k3s.wait_for_unit("k3s")
 
-    with subtest("should start k3s"):
-        k3s.start()
-        k3s.wait_for_unit("k3s")
+      with subtest("should test if kubectl works"):
+          k3s.wait_until_succeeds("k3s kubectl get node")
 
-    with subtest("should test if kubectl works"):
-        k3s.wait_until_succeeds("k3s kubectl get node")
+      with subtest("should wait for service account to show up; takes a sec"):
+          k3s.wait_until_succeeds("k3s kubectl get serviceaccount default")
 
-    with subtest("should wait for service account to show up; takes a sec"):
-        k3s.wait_until_succeeds("k3s kubectl get serviceaccount default")
+      with subtest("should create a sample secret object"):
+          k3s.succeed("k3s kubectl create secret generic nixossecret --from-literal thesecret=abacadabra")
 
-    with subtest("should create a sample secret object"):
-        k3s.succeed("k3s kubectl create secret generic nixossecret --from-literal thesecret=abacadabra")
+      with subtest("should check if secret is correct"):
+          k3s.wait_until_succeeds("[[ $(kubectl get secrets nixossecret -o json | jq -r .data.thesecret | base64 -d) == abacadabra ]]")
 
-    with subtest("should check if secret is correct"):
-        k3s.wait_until_succeeds("[[ $(kubectl get secrets nixossecret -o json | jq -r .data.thesecret | base64 -d) == abacadabra ]]")
+      with subtest("should have a secret in database"):
+          etcd.wait_until_succeeds("[[ $(etcdctl get /registry/secrets/default/nixossecret | head -c1 | wc -c) -ne 0 ]]")
 
-    with subtest("should have a secret in database"):
-        etcd.wait_until_succeeds("[[ $(etcdctl get /registry/secrets/default/nixossecret | head -c1 | wc -c) -ne 0 ]]")
+      with subtest("should delete the secret"):
+          k3s.succeed("k3s kubectl delete secret nixossecret")
 
-    with subtest("should delete the secret"):
-        k3s.succeed("k3s kubectl delete secret nixossecret")
+      with subtest("should not have a secret in database"):
+          etcd.wait_until_fails("[[ $(etcdctl get /registry/secrets/default/nixossecret | head -c1 | wc -c) -ne 0 ]]")
 
-    with subtest("should not have a secret in database"):
-        etcd.wait_until_fails("[[ $(etcdctl get /registry/secrets/default/nixossecret | head -c1 | wc -c) -ne 0 ]]")
+      with subtest("should shutdown k3s and etcd"):
+          k3s.shutdown()
+          etcd.shutdown()
+    '';
 
-    with subtest("should shutdown k3s and etcd"):
-        k3s.shutdown()
-        etcd.shutdown()
-  '';
-
-  meta.maintainers = etcd.meta.maintainers ++ k3s.meta.maintainers;
-})
+    meta.maintainers = etcd.meta.maintainers ++ k3s.meta.maintainers;
+  }
+)

--- a/nixos/tests/k3s/multi-node.nix
+++ b/nixos/tests/k3s/multi-node.nix
@@ -1,14 +1,30 @@
-import ../make-test-python.nix ({ pkgs, lib, k3s, ... }:
+import ../make-test-python.nix (
+  {
+    pkgs,
+    lib,
+    k3s,
+    ...
+  }:
   let
     imageEnv = pkgs.buildEnv {
       name = "k3s-pause-image-env";
-      paths = with pkgs; [ tini bashInteractive coreutils socat ];
+      paths = with pkgs; [
+        tini
+        bashInteractive
+        coreutils
+        socat
+      ];
     };
     pauseImage = pkgs.dockerTools.streamLayeredImage {
       name = "test.local/pause";
       tag = "local";
       contents = imageEnv;
-      config.Entrypoint = [ "/bin/tini" "--" "/bin/sleep" "inf" ];
+      config.Entrypoint = [
+        "/bin/tini"
+        "--"
+        "/bin/sleep"
+        "inf"
+      ];
     };
     # A daemonset that responds 'server' on port 8000
     networkTestDaemonset = pkgs.writeText "test.yml" ''
@@ -42,90 +58,135 @@ import ../make-test-python.nix ({ pkgs, lib, k3s, ... }:
     name = "${k3s.name}-multi-node";
 
     nodes = {
-      server = { pkgs, ... }: {
-        environment.systemPackages = with pkgs; [ gzip jq ];
-        # k3s uses enough resources the default vm fails.
-        virtualisation.memorySize = 1536;
-        virtualisation.diskSize = 4096;
+      server =
+        { pkgs, ... }:
+        {
+          environment.systemPackages = with pkgs; [
+            gzip
+            jq
+          ];
+          # k3s uses enough resources the default vm fails.
+          virtualisation.memorySize = 1536;
+          virtualisation.diskSize = 4096;
 
-        services.k3s = {
-          inherit tokenFile;
-          enable = true;
-          role = "server";
-          package = k3s;
-          clusterInit = true;
-          extraFlags = builtins.toString [
-            "--disable" "coredns"
-            "--disable" "local-storage"
-            "--disable" "metrics-server"
-            "--disable" "servicelb"
-            "--disable" "traefik"
-            "--node-ip" "192.168.1.1"
-            "--pause-image" "test.local/pause:local"
+          services.k3s = {
+            inherit tokenFile;
+            enable = true;
+            role = "server";
+            package = k3s;
+            clusterInit = true;
+            extraFlags = builtins.toString [
+              "--disable"
+              "coredns"
+              "--disable"
+              "local-storage"
+              "--disable"
+              "metrics-server"
+              "--disable"
+              "servicelb"
+              "--disable"
+              "traefik"
+              "--node-ip"
+              "192.168.1.1"
+              "--pause-image"
+              "test.local/pause:local"
+            ];
+          };
+          networking.firewall.allowedTCPPorts = [
+            2379
+            2380
+            6443
+          ];
+          networking.firewall.allowedUDPPorts = [ 8472 ];
+          networking.firewall.trustedInterfaces = [ "flannel.1" ];
+          networking.useDHCP = false;
+          networking.defaultGateway = "192.168.1.1";
+          networking.interfaces.eth1.ipv4.addresses = pkgs.lib.mkForce [
+            {
+              address = "192.168.1.1";
+              prefixLength = 24;
+            }
           ];
         };
-        networking.firewall.allowedTCPPorts = [ 2379 2380 6443 ];
-        networking.firewall.allowedUDPPorts = [ 8472 ];
-        networking.firewall.trustedInterfaces = [ "flannel.1" ];
-        networking.useDHCP = false;
-        networking.defaultGateway = "192.168.1.1";
-        networking.interfaces.eth1.ipv4.addresses = pkgs.lib.mkForce [
-          { address = "192.168.1.1"; prefixLength = 24; }
-        ];
-      };
 
-      server2 = { pkgs, ... }: {
-        environment.systemPackages = with pkgs; [ gzip jq ];
-        virtualisation.memorySize = 1536;
-        virtualisation.diskSize = 4096;
+      server2 =
+        { pkgs, ... }:
+        {
+          environment.systemPackages = with pkgs; [
+            gzip
+            jq
+          ];
+          virtualisation.memorySize = 1536;
+          virtualisation.diskSize = 4096;
 
-        services.k3s = {
-          inherit tokenFile;
-          enable = true;
-          serverAddr = "https://192.168.1.1:6443";
-          clusterInit = false;
-          extraFlags = builtins.toString [
-            "--disable" "coredns"
-            "--disable" "local-storage"
-            "--disable" "metrics-server"
-            "--disable" "servicelb"
-            "--disable" "traefik"
-            "--node-ip" "192.168.1.3"
-            "--pause-image" "test.local/pause:local"
+          services.k3s = {
+            inherit tokenFile;
+            enable = true;
+            serverAddr = "https://192.168.1.1:6443";
+            clusterInit = false;
+            extraFlags = builtins.toString [
+              "--disable"
+              "coredns"
+              "--disable"
+              "local-storage"
+              "--disable"
+              "metrics-server"
+              "--disable"
+              "servicelb"
+              "--disable"
+              "traefik"
+              "--node-ip"
+              "192.168.1.3"
+              "--pause-image"
+              "test.local/pause:local"
+            ];
+          };
+          networking.firewall.allowedTCPPorts = [
+            2379
+            2380
+            6443
+          ];
+          networking.firewall.allowedUDPPorts = [ 8472 ];
+          networking.firewall.trustedInterfaces = [ "flannel.1" ];
+          networking.useDHCP = false;
+          networking.defaultGateway = "192.168.1.3";
+          networking.interfaces.eth1.ipv4.addresses = pkgs.lib.mkForce [
+            {
+              address = "192.168.1.3";
+              prefixLength = 24;
+            }
           ];
         };
-        networking.firewall.allowedTCPPorts = [ 2379 2380 6443 ];
-        networking.firewall.allowedUDPPorts = [ 8472 ];
-        networking.firewall.trustedInterfaces = [ "flannel.1" ];
-        networking.useDHCP = false;
-        networking.defaultGateway = "192.168.1.3";
-        networking.interfaces.eth1.ipv4.addresses = pkgs.lib.mkForce [
-          { address = "192.168.1.3"; prefixLength = 24; }
-        ];
-      };
 
-      agent = { pkgs, ... }: {
-        virtualisation.memorySize = 1024;
-        virtualisation.diskSize = 2048;
-        services.k3s = {
-          inherit tokenFile;
-          enable = true;
-          role = "agent";
-          serverAddr = "https://192.168.1.3:6443";
-          extraFlags = lib.concatStringsSep " " [
-            "--pause-image" "test.local/pause:local"
-            "--node-ip" "192.168.1.2"
+      agent =
+        { pkgs, ... }:
+        {
+          virtualisation.memorySize = 1024;
+          virtualisation.diskSize = 2048;
+          services.k3s = {
+            inherit tokenFile;
+            enable = true;
+            role = "agent";
+            serverAddr = "https://192.168.1.3:6443";
+            extraFlags = lib.concatStringsSep " " [
+              "--pause-image"
+              "test.local/pause:local"
+              "--node-ip"
+              "192.168.1.2"
+            ];
+          };
+          networking.firewall.allowedTCPPorts = [ 6443 ];
+          networking.firewall.allowedUDPPorts = [ 8472 ];
+          networking.firewall.trustedInterfaces = [ "flannel.1" ];
+          networking.useDHCP = false;
+          networking.defaultGateway = "192.168.1.2";
+          networking.interfaces.eth1.ipv4.addresses = pkgs.lib.mkForce [
+            {
+              address = "192.168.1.2";
+              prefixLength = 24;
+            }
           ];
         };
-        networking.firewall.allowedTCPPorts = [ 6443 ];
-        networking.firewall.allowedUDPPorts = [ 8472 ];
-        networking.firewall.trustedInterfaces = [ "flannel.1" ];
-        networking.useDHCP = false;
-        networking.defaultGateway = "192.168.1.2";
-        networking.interfaces.eth1.ipv4.addresses = pkgs.lib.mkForce [
-          { address = "192.168.1.2"; prefixLength = 24; }
-        ];
-      };
     };
 
     meta.maintainers = k3s.meta.maintainers;
@@ -178,4 +239,5 @@ import ../make-test-python.nix ({ pkgs, lib, k3s, ... }:
       for m in machines:
           m.shutdown()
     '';
-  })
+  }
+)

--- a/nixos/tests/k3s/single-node.nix
+++ b/nixos/tests/k3s/single-node.nix
@@ -1,14 +1,29 @@
-import ../make-test-python.nix ({ pkgs, lib, k3s, ... }:
+import ../make-test-python.nix (
+  {
+    pkgs,
+    lib,
+    k3s,
+    ...
+  }:
   let
     imageEnv = pkgs.buildEnv {
       name = "k3s-pause-image-env";
-      paths = with pkgs; [ tini (hiPrio coreutils) busybox ];
+      paths = with pkgs; [
+        tini
+        (hiPrio coreutils)
+        busybox
+      ];
     };
     pauseImage = pkgs.dockerTools.streamLayeredImage {
       name = "test.local/pause";
       tag = "local";
       contents = imageEnv;
-      config.Entrypoint = [ "/bin/tini" "--" "/bin/sleep" "inf" ];
+      config.Entrypoint = [
+        "/bin/tini"
+        "--"
+        "/bin/sleep"
+        "inf"
+      ];
     };
     testPodYaml = pkgs.writeText "test.yml" ''
       apiVersion: v1
@@ -27,69 +42,83 @@ import ../make-test-python.nix ({ pkgs, lib, k3s, ... }:
     name = "${k3s.name}-single-node";
     meta.maintainers = k3s.meta.maintainers;
 
-    nodes.machine = { pkgs, ... }: {
-      environment.systemPackages = with pkgs; [ k3s gzip ];
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = with pkgs; [
+          k3s
+          gzip
+        ];
 
-      # k3s uses enough resources the default vm fails.
-      virtualisation.memorySize = 1536;
-      virtualisation.diskSize = 4096;
+        # k3s uses enough resources the default vm fails.
+        virtualisation.memorySize = 1536;
+        virtualisation.diskSize = 4096;
 
-      services.k3s.enable = true;
-      services.k3s.role = "server";
-      services.k3s.package = k3s;
-      # Slightly reduce resource usage
-      services.k3s.extraFlags = builtins.toString [
-        "--disable" "coredns"
-        "--disable" "local-storage"
-        "--disable" "metrics-server"
-        "--disable" "servicelb"
-        "--disable" "traefik"
-        "--pause-image" "test.local/pause:local"
-      ];
+        services.k3s.enable = true;
+        services.k3s.role = "server";
+        services.k3s.package = k3s;
+        # Slightly reduce resource usage
+        services.k3s.extraFlags = builtins.toString [
+          "--disable"
+          "coredns"
+          "--disable"
+          "local-storage"
+          "--disable"
+          "metrics-server"
+          "--disable"
+          "servicelb"
+          "--disable"
+          "traefik"
+          "--pause-image"
+          "test.local/pause:local"
+        ];
 
-      users.users = {
-        noprivs = {
-          isNormalUser = true;
-          description = "Can't access k3s by default";
-          password = "*";
+        users.users = {
+          noprivs = {
+            isNormalUser = true;
+            description = "Can't access k3s by default";
+            password = "*";
+          };
         };
       };
-    };
 
-    testScript = ''
-      start_all()
+    testScript =
+      ''
+        start_all()
 
-      machine.wait_for_unit("k3s")
-      machine.succeed("kubectl cluster-info")
-      machine.fail("sudo -u noprivs kubectl cluster-info")
+        machine.wait_for_unit("k3s")
+        machine.succeed("kubectl cluster-info")
+        machine.fail("sudo -u noprivs kubectl cluster-info")
       '' # Fix-Me: Tests fail for 'aarch64-linux' as: "CONFIG_CGROUP_FREEZER: missing (fail)"
-      + lib.optionalString (!pkgs.stdenv.isAarch64) ''machine.succeed("k3s check-config")'' + ''
+      + lib.optionalString (!pkgs.stdenv.isAarch64) ''machine.succeed("k3s check-config")''
+      + ''
 
-      machine.succeed(
-          "${pauseImage} | ctr image import -"
-      )
+        machine.succeed(
+            "${pauseImage} | ctr image import -"
+        )
 
-      # Also wait for our service account to show up; it takes a sec
-      machine.wait_until_succeeds("kubectl get serviceaccount default")
-      machine.succeed("kubectl apply -f ${testPodYaml}")
-      machine.succeed("kubectl wait --for 'condition=Ready' pod/test")
-      machine.succeed("kubectl delete -f ${testPodYaml}")
+        # Also wait for our service account to show up; it takes a sec
+        machine.wait_until_succeeds("kubectl get serviceaccount default")
+        machine.succeed("kubectl apply -f ${testPodYaml}")
+        machine.succeed("kubectl wait --for 'condition=Ready' pod/test")
+        machine.succeed("kubectl delete -f ${testPodYaml}")
 
-      # regression test for #176445
-      machine.fail("journalctl -o cat -u k3s.service | grep 'ipset utility not found'")
+        # regression test for #176445
+        machine.fail("journalctl -o cat -u k3s.service | grep 'ipset utility not found'")
 
-      with subtest("Run k3s-killall"):
-          # Call the killall script with a clean path to assert that
-          # all required commands are wrapped
-          output = machine.succeed("PATH= ${k3s}/bin/k3s-killall.sh 2>&1 | tee /dev/stderr")
-          assert "command not found" not in output, "killall script contains unknown command"
+        with subtest("Run k3s-killall"):
+            # Call the killall script with a clean path to assert that
+            # all required commands are wrapped
+            output = machine.succeed("PATH= ${k3s}/bin/k3s-killall.sh 2>&1 | tee /dev/stderr")
+            assert "command not found" not in output, "killall script contains unknown command"
 
-          # Check that killall cleaned up properly
-          machine.fail("systemctl is-active k3s.service")
-          machine.fail("systemctl list-units | grep containerd")
-          machine.fail("ip link show | awk -F': ' '{print $2}' | grep -e flannel -e cni0")
-          machine.fail("ip netns show | grep cni-")
+            # Check that killall cleaned up properly
+            machine.fail("systemctl is-active k3s.service")
+            machine.fail("systemctl list-units | grep containerd")
+            machine.fail("ip link show | awk -F': ' '{print $2}' | grep -e flannel -e cni0")
+            machine.fail("ip netns show | grep cni-")
 
-      machine.shutdown()
-    '';
-  })
+        machine.shutdown()
+      '';
+  }
+)

--- a/pkgs/applications/networking/cluster/k3s/1_26/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_26/chart-versions.nix
@@ -1,10 +1,10 @@
 {
-    traefik-crd  = {
-        url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.2+up25.0.0.tgz";
-        sha256 = "0jygzsn5pxzf7423x5iqfffgx5xvm7c7hfck46y7vpv1fdkiipcq";
-    };
-    traefik = {
-        url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.2+up25.0.0.tgz";
-        sha256 = "1g9n19lnqdkmbbr3rnbwc854awha0kqqfwyxanyx1lg5ww8ldp89";
-    };
+  traefik-crd = {
+    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.2+up25.0.0.tgz";
+    sha256 = "0jygzsn5pxzf7423x5iqfffgx5xvm7c7hfck46y7vpv1fdkiipcq";
+  };
+  traefik = {
+    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.2+up25.0.0.tgz";
+    sha256 = "1g9n19lnqdkmbbr3rnbwc854awha0kqqfwyxanyx1lg5ww8ldp89";
+  };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_27/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_27/chart-versions.nix
@@ -1,10 +1,10 @@
 {
-    traefik-crd  = {
-        url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.3+up25.0.0.tgz";
-        sha256 = "1z693i4kd3jyf26ccnb0sxjyxadipl6k13n7jyg5v4y93fv1rpdw";
-    };
-    traefik = {
-        url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.3+up25.0.0.tgz";
-        sha256 = "1a24qlp7c6iri72ka1i37l1lzn13xibrd26dy295z2wzr55gg7if";
-    };
+  traefik-crd = {
+    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.3+up25.0.0.tgz";
+    sha256 = "1z693i4kd3jyf26ccnb0sxjyxadipl6k13n7jyg5v4y93fv1rpdw";
+  };
+  traefik = {
+    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.3+up25.0.0.tgz";
+    sha256 = "1a24qlp7c6iri72ka1i37l1lzn13xibrd26dy295z2wzr55gg7if";
+  };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_28/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_28/chart-versions.nix
@@ -1,10 +1,10 @@
 {
-    traefik-crd  = {
-        url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.3+up25.0.0.tgz";
-        sha256 = "1z693i4kd3jyf26ccnb0sxjyxadipl6k13n7jyg5v4y93fv1rpdw";
-    };
-    traefik = {
-        url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.3+up25.0.0.tgz";
-        sha256 = "1a24qlp7c6iri72ka1i37l1lzn13xibrd26dy295z2wzr55gg7if";
-    };
+  traefik-crd = {
+    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.3+up25.0.0.tgz";
+    sha256 = "1z693i4kd3jyf26ccnb0sxjyxadipl6k13n7jyg5v4y93fv1rpdw";
+  };
+  traefik = {
+    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.3+up25.0.0.tgz";
+    sha256 = "1a24qlp7c6iri72ka1i37l1lzn13xibrd26dy295z2wzr55gg7if";
+  };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_29/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_29/chart-versions.nix
@@ -1,10 +1,10 @@
 {
-    traefik-crd  = {
-        url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.3+up25.0.0.tgz";
-        sha256 = "1z693i4kd3jyf26ccnb0sxjyxadipl6k13n7jyg5v4y93fv1rpdw";
-    };
-    traefik = {
-        url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.3+up25.0.0.tgz";
-        sha256 = "1a24qlp7c6iri72ka1i37l1lzn13xibrd26dy295z2wzr55gg7if";
-    };
+  traefik-crd = {
+    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.3+up25.0.0.tgz";
+    sha256 = "1z693i4kd3jyf26ccnb0sxjyxadipl6k13n7jyg5v4y93fv1rpdw";
+  };
+  traefik = {
+    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.3+up25.0.0.tgz";
+    sha256 = "1a24qlp7c6iri72ka1i37l1lzn13xibrd26dy295z2wzr55gg7if";
+  };
 }

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -29,41 +29,42 @@ lib:
 # currently.
 # It is likely we will have to split out additional builders for additional
 # versions in the future, or customize this one further.
-{ lib
-, makeWrapper
-, socat
-, iptables
-, iproute2
-, ipset
-, bridge-utils
-, btrfs-progs
-, conntrack-tools
-, buildGoModule
-, runc
-, rsync
-, kmod
-, libseccomp
-, pkg-config
-, ethtool
-, util-linux
-, fetchFromGitHub
-, fetchurl
-, fetchzip
-, fetchgit
-, zstd
-, yq-go
-, sqlite
-, nixosTests
-, pkgsBuildBuild
-, go
-, runCommand
-, bash
-, procps
-, coreutils
-, gnugrep
-, findutils
-, gnused
-, systemd
+{
+  lib,
+  makeWrapper,
+  socat,
+  iptables,
+  iproute2,
+  ipset,
+  bridge-utils,
+  btrfs-progs,
+  conntrack-tools,
+  buildGoModule,
+  runc,
+  rsync,
+  kmod,
+  libseccomp,
+  pkg-config,
+  ethtool,
+  util-linux,
+  fetchFromGitHub,
+  fetchurl,
+  fetchzip,
+  fetchgit,
+  zstd,
+  yq-go,
+  sqlite,
+  nixosTests,
+  pkgsBuildBuild,
+  go,
+  runCommand,
+  bash,
+  procps,
+  coreutils,
+  gnugrep,
+  findutils,
+  gnused,
+  systemd,
 }:
 
 # k3s is a kinda weird derivation. One of the main points of k3s is the
@@ -91,7 +92,13 @@ let
     description = "A lightweight Kubernetes distribution";
     license = licenses.asl20;
     homepage = "https://k3s.io";
-    maintainers = with maintainers; [ euank mic92 superherointj wrmilling yajo ];
+    maintainers = with maintainers; [
+      euank
+      mic92
+      superherointj
+      wrmilling
+      yajo
+    ];
     platforms = platforms.linux;
 
     # resolves collisions with other installations of kubectl, crictl, ctr
@@ -231,12 +238,19 @@ let
     vendorHash = k3sVendorHash;
 
     nativeBuildInputs = [ pkg-config ];
-    buildInputs = [ libseccomp sqlite.dev ];
+    buildInputs = [
+      libseccomp
+      sqlite.dev
+    ];
 
     subPackages = [ "cmd/server" ];
     ldflags = versionldflags;
 
-    tags = [ "ctrd" "libsqlite3" "linux" ];
+    tags = [
+      "ctrd"
+      "libsqlite3"
+      "linux"
+    ];
 
     # create the multicall symlinks for k3s
     postInstall = ''
@@ -282,7 +296,11 @@ buildGoModule rec {
   pname = "k3s";
   version = k3sVersion;
 
-  tags = [ "libsqlite3" "linux" "ctrd" ];
+  tags = [
+    "libsqlite3"
+    "linux"
+    "ctrd"
+  ];
   src = k3sRepo;
   vendorHash = k3sVendorHash;
 
@@ -400,15 +418,17 @@ buildGoModule rec {
 
   passthru.updateScript = updateScript;
 
-  passthru.mkTests = version:
-    let k3s_version = "k3s_" + lib.replaceStrings ["."] ["_"] (lib.versions.majorMinor version);
-    in {
+  passthru.mkTests =
+    version:
+    let
+      k3s_version = "k3s_" + lib.replaceStrings [ "." ] [ "_" ] (lib.versions.majorMinor version);
+    in
+    {
       etcd = nixosTests.k3s.etcd.${k3s_version};
       single-node = nixosTests.k3s.single-node.${k3s_version};
       multi-node = nixosTests.k3s.multi-node.${k3s_version};
     };
   passthru.tests = passthru.mkTests k3sVersion;
-
 
   meta = baseMeta;
 }

--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -12,22 +12,46 @@ let
   extraArgs = builtins.removeAttrs args [ "callPackage" ];
 in
 {
-  k3s_1_26 = common ((import ./1_26/versions.nix) // {
-    updateScript = [ ./update-script.sh "26" ];
-  }) extraArgs;
+  k3s_1_26 = common (
+    (import ./1_26/versions.nix)
+    // {
+      updateScript = [
+        ./update-script.sh
+        "26"
+      ];
+    }
+  ) extraArgs;
 
   # 1_27 can be built with the same builder as 1_26
-  k3s_1_27 = common ((import ./1_27/versions.nix) // {
-    updateScript = [ ./update-script.sh "27" ];
-  }) extraArgs;
+  k3s_1_27 = common (
+    (import ./1_27/versions.nix)
+    // {
+      updateScript = [
+        ./update-script.sh
+        "27"
+      ];
+    }
+  ) extraArgs;
 
   # 1_28 can be built with the same builder as 1_26
-  k3s_1_28 = common ((import ./1_28/versions.nix) // {
-    updateScript = [ ./update-script.sh "28" ];
-  }) extraArgs;
+  k3s_1_28 = common (
+    (import ./1_28/versions.nix)
+    // {
+      updateScript = [
+        ./update-script.sh
+        "28"
+      ];
+    }
+  ) extraArgs;
 
   # 1_29 can be built with the same builder as 1_26
-  k3s_1_29 = common ((import ./1_29/versions.nix) // {
-    updateScript = [ ./update-script.sh "29" ];
-  }) extraArgs;
+  k3s_1_29 = common (
+    (import ./1_29/versions.nix)
+    // {
+      updateScript = [
+        ./update-script.sh
+        "29"
+      ];
+    }
+  ) extraArgs;
 }

--- a/pkgs/applications/networking/cluster/k3s/update-script.sh
+++ b/pkgs/applications/networking/cluster/k3s/update-script.sh
@@ -57,14 +57,14 @@ CHARTS_URL=https://k3s.io/k3s-charts/assets
 rm -f chart-versions.nix.update
 cat > chart-versions.nix.update <<EOF
 {
-    traefik-crd  = {
-        url = "${CHARTS_URL}/traefik-crd/${CHART_FILES[0]}";
-        sha256 = "$(nix-prefetch-url --quiet "${CHARTS_URL}/traefik-crd/${CHART_FILES[0]}")";
-    };
-    traefik = {
-        url = "${CHARTS_URL}/traefik/${CHART_FILES[1]}";
-        sha256 = "$(nix-prefetch-url --quiet "${CHARTS_URL}/traefik/${CHART_FILES[1]}")";
-    };
+  traefik-crd  = {
+    url = "${CHARTS_URL}/traefik-crd/${CHART_FILES[0]}";
+    sha256 = "$(nix-prefetch-url --quiet "${CHARTS_URL}/traefik-crd/${CHART_FILES[0]}")";
+  };
+  traefik = {
+    url = "${CHARTS_URL}/traefik/${CHART_FILES[1]}";
+    sha256 = "$(nix-prefetch-url --quiet "${CHARTS_URL}/traefik/${CHART_FILES[1]}")";
+  };
 }
 EOF
 mv chart-versions.nix.update chart-versions.nix


### PR DESCRIPTION
k3s: enforce RFC 0166 format

* k3s: format with nixfmt-rfc-style
* k3s: update update-script for nixfmt-rfc-style
* github/workflows: add k3s to check-nix-format
* git-blame-ignore-revs: format k3s with nixfmt-rfc-style