### PR TITLE
buildFHSEnv: Add capability support

### DIFF
--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -123,6 +123,12 @@ let
     exec ${run} "$@"
   '';
 
+  bwrap-patched = if lib.isDerivation bubblewrap then bubblewrap.overrideAttrs (oldAttrs: {
+    patches = (oldAttrs.patches or []) ++ [
+      ./disable_setuid_sandbox.patch
+    ];
+  }) else bubblewrap;
+
   indentLines = str: concatLines (map (s: "  " + s) (filter (s: s != "") (splitString "\n" str)));
   bwrapCmd = { initArgs ? "" }: ''
     ${extraPreBwrapCmds}
@@ -225,7 +231,7 @@ let
     ''}
 
     cmd=(
-      ${bubblewrap}/bin/bwrap
+      ${bwrap-patched}/bin/bwrap
       --dev-bind /dev /dev
       --proc /proc
       --chdir "$(pwd)"

--- a/pkgs/build-support/build-fhsenv-bubblewrap/disable_setuid_sandbox.patch
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/disable_setuid_sandbox.patch
@@ -1,0 +1,93 @@
+diff --git a/bubblewrap.c b/bubblewrap.c
+index c414bb0..56db2cb 100644
+--- a/bubblewrap.c
++++ b/bubblewrap.c
+@@ -812,8 +812,6 @@ drop_cap_bounding_set (bool drop_all)
+ static void
+ set_ambient_capabilities (void)
+ {
+-  if (is_privileged)
+-    return;
+   prctl_caps (requested_caps, FALSE, TRUE);
+ }
+ 
+@@ -870,14 +868,7 @@ acquire_privs (void)
+       /* Keep only the required capabilities for setup */
+       set_required_caps ();
+     }
+-  else if (real_uid != 0 && has_caps ())
+-    {
+-      /* We have some capabilities in the non-setuid case, which should not happen.
+-         Probably caused by the binary being setcap instead of setuid which we
+-         don't support anymore */
+-      die ("Unexpected capabilities but not setuid, old file caps config?");
+-    }
+-  else if (real_uid == 0)
++  else if (real_uid == 0 || has_caps ())
+     {
+       /* If our uid is 0, default to inheriting all caps; the caller
+        * can drop them via --cap-drop.  This is used by at least rpm-ostree.
+@@ -2466,9 +2457,6 @@ parse_args_recurse (int          *argcp,
+           unsigned long long size;
+           char *endptr = NULL;
+ 
+-          if (is_privileged)
+-            die ("The --size option is not permitted in setuid mode");
+-
+           if (argc < 2)
+             die ("--size takes an argument");
+ 
+@@ -2707,9 +2695,6 @@ main (int    argc,
+   args_data = opt_args_data;
+   opt_args_data = NULL;
+ 
+-  if ((requested_caps[0] || requested_caps[1]) && is_privileged)
+-    die ("--cap-add in setuid mode can be used only by root");
+-
+   if (opt_userns_block_fd != -1 && !opt_unshare_user)
+     die ("--userns-block-fd requires --unshare-user");
+ 
+@@ -2728,24 +2713,6 @@ main (int    argc,
+   if (opt_disable_userns && opt_userns_block_fd != -1)
+     die ("--disable-userns is not compatible with  --userns-block-fd");
+ 
+-  /* Technically using setns() is probably safe even in the privileged
+-   * case, because we got passed in a file descriptor to the
+-   * namespace, and that can only be gotten if you have ptrace
+-   * permissions against the target, and then you could do whatever to
+-   * the namespace anyway.
+-   *
+-   * However, for practical reasons this isn't possible to use,
+-   * because (as described in acquire_privs()) setuid bwrap causes
+-   * root to own the namespaces that it creates, so you will not be
+-   * able to access these namespaces anyway. So, best just not support
+-   * it anyway.
+-   */
+-  if (opt_userns_fd != -1 && is_privileged)
+-    die ("--userns doesn't work in setuid mode");
+-
+-  if (opt_userns2_fd != -1 && is_privileged)
+-    die ("--userns2 doesn't work in setuid mode");
+-
+   /* We have to do this if we weren't installed setuid (and we're not
+    * root), so let's just DWIM */
+   if (!is_privileged && getuid () != 0 && opt_userns_fd == -1)
+@@ -3256,7 +3223,7 @@ main (int    argc,
+     }
+ 
+   /* All privileged ops are done now, so drop caps we don't need */
+-  drop_privs (!is_privileged, TRUE);
++  drop_privs (TRUE, TRUE);
+ 
+   if (opt_block_fd != -1)
+     {
+@@ -3361,8 +3328,7 @@ main (int    argc,
+   /* Optionally bind our lifecycle */
+   handle_die_with_parent ();
+ 
+-  if (!is_privileged)
+-    set_ambient_capabilities ();
++  set_ambient_capabilities ();
+ 
+   /* Should be the last thing before execve() so that filters don't
+    * need to handle anything above */


### PR DESCRIPTION
## Description of changes

Theoretically, this should allow fhsenv applications to acquire capabilities if they have a setuid wrapper.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
