### PR TITLE
add support for soft-reboot

### DIFF
--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -115,6 +115,8 @@ if (($ENV{"NIXOS_NO_SYNC"} // "") ne "1") {
 }
 
 if ($action eq "boot") {
+    # /run/next-system/activate is called when systemctl soft-reboot is called
+    system("@coreutils@/bin/ln", "-sfn", "$toplevel", "/run/next-system") == 0 or exit 1;
     exit(0);
 }
 

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -128,6 +128,8 @@ let
       "final.target"
       "kexec.target"
       "systemd-kexec.service"
+      "systemd-soft-reboot.service"
+      "soft-reboot.target"
     ] ++ lib.optional cfg.package.withUtmp "systemd-update-utmp.service" ++ [
 
       # Password entry.
@@ -695,6 +697,20 @@ in
         create = "0664 root ${config.users.groups.utmp.name}";
         minsize = "1M";
       };
+    };
+
+    # make sure /run/next-system isn't garbage collected before the next boot
+    systemd.tmpfiles.rules = [ "L+ /nix/var/nix/gcroots/next-system - - - - /run/next-system" ];
+
+    # if /run/next-system exists, activate it before  rebooting
+    systemd.services.systemd-soft-reboot-activate-next-system = {
+      wantedBy = [ "soft-reboot.target" ];
+      before = [ "systemd-soft-reboot.service" ];
+      unitConfig = {
+        DefaultDependencies = false;
+        ConditionPathExists = "/run/next-system/activate";
+      };
+      serviceConfig.ExecStart = "/run/next-system/activate";
     };
   };
 


### PR DESCRIPTION
## Description of changes

Usage:

```
sudo nixos-rebuild boot && sudo systemctl soft-reboot
```

`switch-to-configuration boot` will now prepare a symlink `/run/next-system`
and just before soft-reboot we will automatically call
`/run/next-system/activate` to activate the next system to be booted when
`systemctl soft-reboot` is called.

not only can soft-reboot can be used as an alternative to kexec and reboot, but
it can also be used as an alternative to `nixos-rebuild switch` in many cases.

Unlike kexec and reboot, soft-reboot can keep certain resources around across the reboot.
For example, socket units can be configured to stay around such that reboots can happen
without stopping accepting any connections. Furthermore file descriptors can be passed across
boots using FDSTORE to even keep existing connections intact.

Please see the man-page for more info: https://www.freedesktop.org/software/systemd/man/latest/systemd-soft-reboot.service.html#


from Systemd NEWS:

> A "soft reboot" is similar to a regular reboot, except that it affects
> userspace only: the service manager shuts down any running services and other
> units, then optionally switches into a new root file system (mounted to
> /run/nextroot/), and then passes control to a systemd instance in the new file
> system which then starts the system up again. The kernel is not rebooted and
> neither is the hardware, firmware or boot loader. This provides a fast,
> lightweight mechanism to quickly reset or update userspace, without the latency
> that a full system reset involves. Moreover, open file descriptors may be
> passed across the soft reboot into the new system where they will be passed
> back to the originating services. This allows pinning resources across the
> reboot, thus minimizing grey-out time further

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
