### PR TITLE
nixos/miniflux: allow port bind < 1024

### DIFF
--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -103,12 +103,13 @@ in
         RuntimeDirectoryMode = "0750";
         EnvironmentFile = cfg.adminCredentialsFile;
         # Hardening
-        CapabilityBoundingSet = [ "" ];
+        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+        CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
         DeviceAllow = [ "" ];
         LockPersonality = true;
         MemoryDenyWriteExecute = true;
         PrivateDevices = true;
-        PrivateUsers = true;
+        PrivateUsers = false; # true is incompatible with CAP_NET_BIND_SERVICE
         ProcSubset = "pid";
         ProtectClock = true;
         ProtectControlGroups = true;

--- a/nixos/tests/miniflux.nix
+++ b/nixos/tests/miniflux.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ pkgs, lib, ... }:
 
 let
-  port = 3142;
+  port = 80;
   username = "alice";
   password = "correcthorsebatterystaple";
   defaultPort = 8080;


### PR DESCRIPTION
## Description of changes

I am not particularly happy how this turned out.

miniflux wants to bind on :80 for acme http-01, when `CERT_DOMAIN` is set to something.

Unfortunately, we cannot test the built-in acme client in `nixos/tests/miniflux`, because miniflux inherits
`golang.org/x/crypto/acme/autocert`'s default CA
(`acme-v02.api.letsencrypt.org`), making it extremely difficult to use `nixos/tests/common/acme/server/default.nix`.

Additionally, we cannot make `CAP_NET_BIND_SERVICE` conditional. While checking for `CERT_DOMAIN` and `PORT` is trivial, we also would also have to parse and extract the port from `LISTEN_ADDRESS`.

In summary, this fixes two issues in the module:
 1. Use of `CERT_DOMAIN` (for https:// when not running behind a proxy).
 2. Use of a port below 1024 (not necessarily related to acme).

Closes #291532

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
