### PR TITLE
libnvme: 1.7.1 -> 1.9; nvme-cli: 2.7.1 -> 2.9.1

### DIFF
--- a/pkgs/os-specific/linux/libnvme/default.nix
+++ b/pkgs/os-specific/linux/libnvme/default.nix
@@ -1,4 +1,5 @@
 { fetchFromGitHub
+, bash
 , json_c
 , keyutils
 , lib
@@ -17,7 +18,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libnvme";
-  version = "1.7.1";
+  version = "1.9";
 
   outputs = [ "out" ] ++ lib.optionals withDocs [ "man" ];
 
@@ -25,11 +26,13 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "linux-nvme";
     repo = "libnvme";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-hCR/K8bPXj8HthayrnwwGfI+wxpUwcWkcx3S/8h+3m8=";
+    hash = "sha256-nXzYbj4BDxFii30yR+aTgqjQfyYMFiAIcV/OHI2y5Ws=";
   };
 
   postPatch = ''
     patchShebangs scripts
+    substituteInPlace test/sysfs/sysfs-tree-diff.sh \
+      --replace-fail /bin/bash ${bash}/bin/bash
   '';
 
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/nvme-cli/default.nix
+++ b/pkgs/os-specific/linux/nvme-cli/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nvme-cli";
-  version = "2.7.1";
+  version = "2.9.1";
 
   src = fetchFromGitHub {
     owner = "linux-nvme";
     repo = "nvme-cli";
     rev = "v${version}";
-    hash = "sha256-Gm+1tb/Nh+Yg2PgSUn/1hR4CZYnfTWRwcQU0A8UeQwI=";
+    hash = "sha256-zs7UksB5QkvCP29iELDGMJeObvMdKrs6ajQkEzCPzzQ=";
   };
 
   mesonFlags = [


### PR DESCRIPTION
## Description of changes

Updates nvme-cli from v2.7.1 -> v2.9.1:
https://github.com/linux-nvme/nvme-cli/releases/tag/v2.8
https://github.com/linux-nvme/nvme-cli/releases/tag/v2.9
https://github.com/linux-nvme/nvme-cli/releases/tag/v2.9.1

Updates libnvme from v1.7.1 -> v1.9:
https://github.com/linux-nvme/libnvme/releases/tag/v1.8
https://github.com/linux-nvme/libnvme/releases/tag/v1.9

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
