### PR TITLE
textadept: 12.1 -> 12.4

### DIFF
--- a/pkgs/applications/editors/textadept/default.nix
+++ b/pkgs/applications/editors/textadept/default.nix
@@ -3,7 +3,7 @@
 , withCurses ? false, ncurses
 }:
 stdenv.mkDerivation rec {
-  version = "12.1";
+  version = "12.4";
   pname = "textadept";
 
   src = fetchFromGitHub {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "orbitalquark";
     repo = "textadept";
     rev = "textadept_${version}";
-    sha256 = "sha256-ce7U/GR/4zkjnRN3fx3FLecc9vuvFqCONy275SWnpNc=";
+    sha256 = "sha256-nPgpQeBq5Stv2o0Ke4W2Ltnx6qLe5TIC5a8HSYVkmfI=";
   };
 
   nativeBuildInputs = [ cmake ]

--- a/pkgs/applications/editors/textadept/deps.nix
+++ b/pkgs/applications/editors/textadept/deps.nix
@@ -1,8 +1,8 @@
 {
   # scintilla
-  "scintilla536.tgz" = {
-    url = "https://www.scintilla.org/scintilla536.tgz";
-    sha256 = "sha256-ib6CeKg+eBOSWq/il32quH0r1r69F7AXn+cq/dVIyyQ=";
+  "scintilla550.tgz" = {
+    url = "https://www.scintilla.org/scintilla550.tgz";
+    sha256 = "sha256-5VPpVQnwH5KqFX+gLQanEmQuE9aaEewaAqfd8ixAYjE=";
   };
   # lexilla
   "lexilla510.tgz" = {
@@ -15,9 +15,9 @@
     sha256 = "sha256-l1qeLMCrhyoZA/GfmXFR20rY5EsUoO5e+1vZJtYdb24=";
   };
   # scintillua
-  "e88bbcfecae46b48b79d8156ea7129411b5c847d.zip" = {
-    url = "https://github.com/orbitalquark/scintillua/archive/e88bbcfecae46b48b79d8156ea7129411b5c847d.zip";
-    sha256 = "sha256-sWqpVtcAwysGn86XFwaEkKSPemk2247SydOQi6klFrQ=";
+  "scintillua_6.3.zip" = {
+    url = "https://github.com/orbitalquark/scintillua/archive/scintillua_6.3.zip";
+    sha256 = "sha256-SAFmu3q8T1UtVjdUcFy9NPu0DOLqewvU/Vb9b7XjgQM=";
   };
   # lua
   "lua-5.4.6.tar.gz" = {
@@ -48,6 +48,11 @@
   "1.0.zip" = {
     url = "https://github.com/orbitalquark/lua-std-regex/archive/1.0.zip";
     sha256 = "sha256-W2hKHOfqYyo3qk+YvPJlzZfZ1wxZmMVphSlcaql+dOE=";
+  };
+  # singleapp
+  "v3.4.0.zip" = {
+    url = "https://github.com/itay-grudev/SingleApplication/archive/refs/tags/v3.4.0.zip";
+    sha256 = "sha256-FwyzM+R9ALpGH9u2RXab4Sqi4Q+p3Qs+8EdfhjPGcXY=";
   };
 }
 


### PR DESCRIPTION
## Description of changes

updated textadept: 12.1 -> 12.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
