### PR TITLE
python312Packages.glymur: 0.12.5 -> 0.13.2, unbreak, refactor

### DIFF
--- a/pkgs/development/python-modules/glymur/default.nix
+++ b/pkgs/development/python-modules/glymur/default.nix
@@ -1,10 +1,13 @@
 { lib
 , stdenv
 , buildPythonPackage
+, substituteAll
+, glibc
+, libtiff
+, openjpeg
 , fetchFromGitHub
 , lxml
 , numpy
-, openjpeg
 , pytestCheckHook
 , pythonOlder
 , scikit-image
@@ -13,54 +16,66 @@
 
 buildPythonPackage rec {
   pname = "glymur";
-  version = "0.12.5";
-  format = "pyproject";
+  version = "0.13.2";
+  pyproject = true;
 
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "quintusdias";
-    repo = pname;
+    repo = "glymur";
     rev = "refs/tags/v${version}";
-    hash = "sha256-9NMSAt5yFRnlCUDP37/ozhDsS8FTdRkfjUz8kQwWzVc=";
+    hash = "sha256-GUqe9mdMm2O/cbZw8Reohh4X1kO+xOMWHb83PjNvdu8=";
   };
 
-  nativeBuildInputs = [
+  patches = [
+    (substituteAll {
+      src = ./set-lib-paths.patch;
+      openjp2_lib = "${lib.getLib openjpeg}/lib/libopenjp2${stdenv.hostPlatform.extensions.sharedLibrary}";
+      tiff_lib = "${lib.getLib libtiff}/lib/libtiff${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+  ];
+
+  postPatch = lib.optionalString (!stdenv.isDarwin) ''
+    substituteInPlace glymur/lib/tiff.py \
+        --replace-fail "glymur_config('c')" "ctypes.CDLL('${lib.getLib glibc}/lib/libc.so.6')"
+  '';
+
+  __propagatedImpureHostDeps = lib.optional stdenv.isDarwin "/usr/lib/libc.dylib";
+
+  build-system = [
     setuptools
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
+    lxml
     numpy
   ];
 
   nativeCheckInputs = [
-    lxml
     pytestCheckHook
     scikit-image
   ];
 
-  postConfigure = ''
-    substituteInPlace glymur/config.py \
-    --replace "path = read_config_file(libname)" "path = '${openjpeg}/lib/lib' + libname + ${if stdenv.isDarwin then "'.dylib'" else "'.so'"}"
+  preCheck = ''
+    export PATH="$out/bin:$PATH"
   '';
 
   disabledTestPaths = [
     # this test involves glymur's different ways of finding the openjpeg path on
     # fsh systems by reading an .rc file and such, and is obviated by the patch
-    # in postConfigure
     "tests/test_config.py"
-    "tests/test_tiff2jp2.py"
   ];
 
   pythonImportsCheck = [
     "glymur"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tools for accessing JPEG2000 files";
     homepage = "https://github.com/quintusdias/glymur";
     changelog = "https://github.com/quintusdias/glymur/blob/v${version}/CHANGES.txt";
-    license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tomasajt ];
   };
 }

--- a/pkgs/development/python-modules/glymur/set-lib-paths.patch
+++ b/pkgs/development/python-modules/glymur/set-lib-paths.patch
@@ -1,0 +1,16 @@
+diff --git a/glymur/config.py b/glymur/config.py
+index 962e299..dab44ba 100644
+--- a/glymur/config.py
++++ b/glymur/config.py
+@@ -53,6 +53,11 @@ def _determine_full_path(libname):
+     if path is not None:
+         return path
+ 
++    if libname == "openjp2":
++        return "@openjp2_lib@"
++    if libname == "tiff":
++        return "@tiff_lib@"
++
+     # No joy on config file.  Cygwin?  Cygwin is a bit of an odd case.
+     if platform.system().startswith('CYGWIN'):
+         g = pathlib.Path('/usr/bin').glob('cygopenjp2*.dll')


### PR DESCRIPTION
## Description of changes

ZHF: https://github.com/NixOS/nixpkgs/issues/309482

Main changes:
- bump version, fixes most of the problems (libxml2 breaking change was addressed)
- use `.patch` file to specify runtime library load paths
  - let's wait for OfBorg to run on darwin
- move `lxml` dependency to its proper place
- add `$out/bin` to path for testing
- adopt package

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
