### PR TITLE
Revert "ffmpeg-full: disable avisynth on Darwin"

### DIFF
--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -40,7 +40,7 @@
 , withAss ? withHeadlessDeps && stdenv.hostPlatform == stdenv.buildPlatform # (Advanced) SubStation Alpha subtitle rendering
 , withAudioToolbox ? withHeadlessDeps && stdenv.isDarwin # Apple AudioToolbox
 , withAvFoundation ? withHeadlessDeps && stdenv.isDarwin # Apple AVFoundation framework
-, withAvisynth ? withFullDeps && !stdenv.isDarwin # AviSynth script files reading; Darwin currently broken because libdevil fails to build
+, withAvisynth ? withFullDeps # AviSynth script files reading
 , withBluray ? withFullDeps # BluRay reading
 , withBs2b ? withFullDeps # bs2b DSP library
 , withBzlib ? withHeadlessDeps


### PR DESCRIPTION
Reverts NixOS/nixpkgs#309423

The reason has passed.  I expect it's better to be more consistent.