### PR TITLE
caligula: init at 0.4.5

### DIFF
--- a/pkgs/by-name/ca/caligula/package.nix
+++ b/pkgs/by-name/ca/caligula/package.nix
@@ -1,0 +1,39 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, stdenv
+, darwin
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "caligula";
+  version = "0.4.5";
+
+  src = fetchFromGitHub {
+    owner = "ifd3f";
+    repo = "caligula";
+    rev = "v${version}";
+    hash = "sha256-9+aLpxmMP76CsLFFmr1mhKgbaT7Zz0lx4D2jQCUA9VY=";
+  };
+
+  cargoHash = "sha256-VwtmU5jTQPn3hpNuLckPQl6joEFPfuax1gRVG0/nceg=";
+
+  buildInputs = lib.optionals stdenv.isDarwin (
+    with darwin.apple_sdk.frameworks; [
+      Cocoa
+      IOKit
+      Foundation
+      DiskArbitration
+    ]
+  );
+
+  RUSTFLAGS = "--cfg tracing_unstable";
+
+  meta = with lib; {
+    description = "A user-friendly, lightweight TUI for disk imaging";
+    homepage = "https://github.com/ifd3f/caligula/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ sodiboo ];
+    mainProgram = "caligula";
+  };
+}

--- a/pkgs/by-name/ca/caligula/package.nix
+++ b/pkgs/by-name/ca/caligula/package.nix
@@ -34,6 +34,9 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/ifd3f/caligula/";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ sodiboo ];
+    platforms = platforms.linux ++ platforms.darwin;
+    # https://github.com/ifd3f/caligula/issues/105
+    broken = stdenv.hostPlatform.isDarwin;
     mainProgram = "caligula";
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Caligula is a user-friendly, lightweight TUI for disk imaging.

https://github.com/ifd3f/caligula

While it works on my machine, which is an `x86_64-linux`, Caligula also supports macOS. I've copied the required frameworks from [the official flake](https://github.com/ifd3f/caligula/blob/edd8b153479302e8f7f613d9fc81169555a54299/nix/cross-helpers.nix#L53-L56), but it is important to note that **i do not own an `{x86_64,aarch64}-darwin` machine to test on**.


cc @ifd3f; you said on mastodon that you were interested in also maintaining the package? can you test that it works on macOS?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
