### PR TITLE
lxc: added option for unprivileged containers

### DIFF
--- a/nixos/modules/virtualisation/lxc.nix
+++ b/nixos/modules/virtualisation/lxc.nix
@@ -23,6 +23,8 @@ in
           '';
       };
 
+    unprivilegedContainers = lib.mkEnableOption "support for unprivileged users to launch containers";
+
     systemConfig =
       lib.mkOption {
         type = lib.types.lines;
@@ -53,6 +55,15 @@ in
             administration access in LXC. See {manpage}`lxc-usernet(5)`.
           '';
       };
+
+      bridgeConfig =
+        lib.mkOption {
+          type = lib.types.lines;
+          default = "";
+          description = ''
+              This is the config file for override lxc-net bridge default settings.
+            '';
+        };
   };
 
   ###### implementation
@@ -62,6 +73,8 @@ in
     environment.etc."lxc/lxc.conf".text = cfg.systemConfig;
     environment.etc."lxc/lxc-usernet".text = cfg.usernetConfig;
     environment.etc."lxc/default.conf".text = cfg.defaultConfig;
+    environment.etc."lxc/lxc-net".text = cfg.bridgeConfig;
+    environment.pathsToLink = [ "/share/lxc" ];
     systemd.tmpfiles.rules = [ "d /var/lib/lxc/rootfs 0755 root root -" ];
 
     security.apparmor.packages = [ cfg.package ];
@@ -72,6 +85,31 @@ in
       "lxc-containers".profile = ''
         include ${cfg.package}/etc/apparmor.d/lxc-containers
       '';
+    };
+
+    # We don't need the `lxc-user` group, unless the unprivileged containers are enabled.
+    users.groups = lib.mkIf cfg.unprivilegedContainers { lxc-user = {}; };
+
+    # `lxc-user-nic` needs suid to attach to bridge for unpriv containers.
+    security.wrappers = lib.mkIf cfg.unprivilegedContainers {
+      lxcUserNet = {
+        source = "${pkgs.lxc}/libexec/lxc/lxc-user-nic";
+        setuid = true;
+        owner = "root";
+        group = "lxc-user";
+        program = "lxc-user-nic";
+        permissions = "u+rx,g+x,o-rx";
+      };
+    };
+
+    # Add lxc-net service if unpriv mode is enabled.
+    systemd.packages = lib.mkIf cfg.unprivilegedContainers [ pkgs.lxc ];
+    systemd.services = lib.mkIf cfg.unprivilegedContainers {
+      lxc-net = {
+        enable = true;
+        wantedBy = [ "multi-user.target" ];
+        path = [ pkgs.iproute2 pkgs.iptables pkgs.getent pkgs.dnsmasq ];
+      };
     };
   };
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -538,6 +538,7 @@ in {
   loki = handleTest ./loki.nix {};
   luks = handleTest ./luks.nix {};
   lvm2 = handleTest ./lvm2 {};
+  lxc = handleTest ./lxc {};
   lxd = pkgs.recurseIntoAttrs (handleTest ./lxd { inherit handleTestOn; });
   lxd-image-server = handleTest ./lxd-image-server.nix {};
   #logstash = handleTest ./logstash.nix {};

--- a/nixos/tests/incus/container.nix
+++ b/nixos/tests/incus/container.nix
@@ -11,8 +11,8 @@ let
     extra;
   };
 
-  container-image-metadata = releases.incusContainerMeta.${pkgs.stdenv.hostPlatform.system};
-  container-image-rootfs = releases.incusContainerImage.${pkgs.stdenv.hostPlatform.system};
+  container-image-metadata = "${releases.incusContainerMeta.${pkgs.stdenv.hostPlatform.system}}/tarball/nixos-system-${pkgs.stdenv.hostPlatform.system}.tar.xz";
+  container-image-rootfs = "${releases.incusContainerImage.${pkgs.stdenv.hostPlatform.system}}/nixos-lxc-image-${pkgs.stdenv.hostPlatform.system}.squashfs";
 in
 {
   inherit name;
@@ -61,7 +61,7 @@ in
     machine.succeed("incus admin init --minimal")
 
     with subtest("Container image can be imported"):
-        machine.succeed("incus image import ${container-image-metadata}/*/*.tar.xz ${container-image-rootfs} --alias nixos")
+        machine.succeed("incus image import ${container-image-metadata} ${container-image-rootfs} --alias nixos")
 
     with subtest("Container can be launched and managed"):
         machine.succeed("incus launch nixos container")

--- a/nixos/tests/incus/incusd-options.nix
+++ b/nixos/tests/incus/incusd-options.nix
@@ -16,8 +16,8 @@ import ../make-test-python.nix (
       };
     };
 
-    container-image-metadata = releases.incusContainerMeta.${pkgs.stdenv.hostPlatform.system};
-    container-image-rootfs = releases.incusContainerImage.${pkgs.stdenv.hostPlatform.system};
+    container-image-metadata = "${releases.incusContainerMeta.${pkgs.stdenv.hostPlatform.system}}/tarball/nixos-system-${pkgs.stdenv.hostPlatform.system}.tar.xz";
+    container-image-rootfs = "${releases.incusContainerImage.${pkgs.stdenv.hostPlatform.system}}/nixos-lxc-image-${pkgs.stdenv.hostPlatform.system}.squashfs";
   in
   {
     name = "incusd-options";
@@ -87,7 +87,7 @@ import ../make-test-python.nix (
       machine.wait_for_unit("incus-preseed.service")
 
       with subtest("Container image can be imported"):
-          machine.succeed("incus image import ${container-image-metadata}/*/*.tar.xz ${container-image-rootfs} --alias nixos")
+          machine.succeed("incus image import ${container-image-metadata} ${container-image-rootfs} --alias nixos")
 
       with subtest("Container can be launched and managed"):
           machine.succeed("incus launch nixos container")

--- a/nixos/tests/incus/incusd-options.nix
+++ b/nixos/tests/incus/incusd-options.nix
@@ -16,8 +16,12 @@ import ../make-test-python.nix (
       };
     };
 
-    container-image-metadata = "${releases.incusContainerMeta.${pkgs.stdenv.hostPlatform.system}}/tarball/nixos-system-${pkgs.stdenv.hostPlatform.system}.tar.xz";
-    container-image-rootfs = "${releases.incusContainerImage.${pkgs.stdenv.hostPlatform.system}}/nixos-lxc-image-${pkgs.stdenv.hostPlatform.system}.squashfs";
+    container-image-metadata = "${
+      releases.incusContainerMeta.${pkgs.stdenv.hostPlatform.system}
+    }/tarball/nixos-system-${pkgs.stdenv.hostPlatform.system}.tar.xz";
+    container-image-rootfs = "${
+      releases.incusContainerImage.${pkgs.stdenv.hostPlatform.system}
+    }/nixos-lxc-image-${pkgs.stdenv.hostPlatform.system}.squashfs";
   in
   {
     name = "incusd-options";

--- a/nixos/tests/lxc/default.nix
+++ b/nixos/tests/lxc/default.nix
@@ -1,0 +1,124 @@
+import ../make-test-python.nix (
+  { pkgs, lib, ... }:
+
+  let
+    releases = import ../../release.nix {
+      configuration = {
+        # Building documentation makes the test unnecessarily take a longer time:
+        documentation.enable = lib.mkForce false;
+      };
+    };
+
+    lxc-image-metadata = releases.lxdContainerMeta.${pkgs.stdenv.hostPlatform.system};
+    lxc-image-rootfs = releases.lxdContainerImage.${pkgs.stdenv.hostPlatform.system};
+
+  in
+  {
+    name = "lxc-container-unprivileged";
+
+    meta = {
+      maintainers = lib.teams.lxc.members;
+    };
+
+    nodes.machine =
+      { lib, pkgs, ... }:
+      {
+        virtualisation = {
+          diskSize = 6144;
+          cores = 2;
+          memorySize = 512;
+          writableStore = true;
+
+          lxc = {
+            enable = true;
+            unprivilegedContainers = true;
+            systemConfig = ''
+              lxc.lxcpath = /tmp/lxc
+            '';
+            defaultConfig = ''
+              lxc.net.0.type = veth
+              lxc.net.0.link = lxcbr0
+              lxc.net.0.flags = up
+              lxc.net.0.hwaddr = 00:16:3e:xx:xx:xx
+              lxc.idmap = u 0 100000 65536
+              lxc.idmap = g 0 100000 65536
+            '';
+            # Permit user alice to connect to bridge
+            usernetConfig = ''
+              @lxc-user veth lxcbr0 10
+            '';
+            bridgeConfig = ''
+              LXC_IPV6_ADDR=""
+              LXC_IPV6_MASK=""
+              LXC_IPV6_NETWORK=""
+              LXC_IPV6_NAT="false"
+            '';
+          };
+        };
+
+        # Needed for lxc
+        environment.systemPackages = with pkgs; [
+          pkgs.wget
+          pkgs.dnsmasq
+        ];
+
+        # Create user for test
+        users.users.alice = {
+          isNormalUser = true;
+          password = "test";
+          description = "Lxc unprivileged user with access to lxcbr0";
+          extraGroups = [ "lxc-user" ];
+          subGidRanges = [
+            {
+              startGid = 100000;
+              count = 65536;
+            }
+          ];
+          subUidRanges = [
+            {
+              startUid = 100000;
+              count = 65536;
+            }
+          ];
+        };
+
+        users.users.bob = {
+          isNormalUser = true;
+          password = "test";
+          description = "Lxc unprivileged user without access to lxcbr0";
+          subGidRanges = [
+            {
+              startGid = 100000;
+              count = 65536;
+            }
+          ];
+          subUidRanges = [
+            {
+              startUid = 100000;
+              count = 65536;
+            }
+          ];
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("lxc-net.service")
+
+      # Copy config files for alice
+      machine.execute("su -- alice -c 'mkdir -p ~/.config/lxc'")
+      machine.execute("su -- alice -c 'cp /etc/lxc/default.conf ~/.config/lxc/'")
+      machine.execute("su -- alice -c 'cp /etc/lxc/lxc.conf ~/.config/lxc/'")
+
+      machine.succeed("su -- alice -c 'lxc-create -t local -n test -- --metadata ${lxc-image-metadata}/*/*.tar.xz --fstree ${lxc-image-rootfs}/*/*.tar.xz'")
+      machine.succeed("su -- alice -c 'lxc-start test'")
+      machine.succeed("su -- alice -c 'lxc-stop test'")
+
+      # Copy config files for bob
+      machine.execute("su -- bob -c 'mkdir -p ~/.config/lxc'")
+      machine.execute("su -- bob -c 'cp /etc/lxc/default.conf ~/.config/lxc/'")
+      machine.execute("su -- bob -c 'cp /etc/lxc/lxc.conf ~/.config/lxc/'")
+
+      machine.fail("su -- bob -c 'lxc-start test'")
+    '';
+  }
+)

--- a/nixos/tests/lxd/container.nix
+++ b/nixos/tests/lxd/container.nix
@@ -64,7 +64,7 @@ in {
 
     with subtest("Squashfs image is functional"):
         machine.succeed(
-            "lxc image import ${lxd-image-metadata}/*/*.tar.xz ${lxd-image-rootfs-squashfs} --alias nixos-squashfs"
+            "lxc image import ${lxd-image-metadata}/*/*.tar.xz ${lxd-image-rootfs-squashfs}/nixos-lxc-image-${pkgs.stdenv.hostPlatform.system}.squashfs --alias nixos-squashfs"
         )
         machine.succeed("lxc launch nixos-squashfs container")
         with machine.nested("Waiting for instance to start and be usable"):

--- a/pkgs/by-name/lx/lxc/package.nix
+++ b/pkgs/by-name/lx/lxc/package.nix
@@ -48,15 +48,36 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # fix docbook2man version detection
     ./docbook-hack.patch
+
+    # Fix hardcoded path of lxc-user-nic
+    # This is needed to use unprivileged containers
+    ./user-nic.diff
   ];
 
   mesonFlags = [
-    "-Dinstall-init-files=false"
+    "-Dinstall-init-files=true"
     "-Dinstall-state-dirs=false"
     "-Dspecfile=false"
     "-Dtools-multicall=true"
     "-Dtools=false"
+    "-Dusernet-config-path=/etc/lxc/lxc-usernet"
+    "-Ddistrosysconfdir=${placeholder "out"}/etc/lxc"
+    "-Dsystemd-unitdir=${placeholder "out"}/lib/systemd/system"
   ];
+
+  # /run/current-system/sw/share
+  postInstall = ''
+    substituteInPlace $out/etc/lxc/lxc --replace-fail "$out/etc/lxc" "/etc/lxc"
+    substituteInPlace $out/libexec/lxc/lxc-net --replace-fail "$out/etc/lxc" "/etc/lxc"
+
+    substituteInPlace $out/share/lxc/templates/lxc-download --replace-fail "$out/share" "/run/current-system/sw/share"
+    substituteInPlace $out/share/lxc/templates/lxc-local --replace-fail "$out/share" "/run/current-system/sw/share"
+    substituteInPlace $out/share/lxc/templates/lxc-oci --replace-fail "$out/share" "/run/current-system/sw/share"
+
+    substituteInPlace $out/share/lxc/config/common.conf --replace-fail "$out/share" "/run/current-system/sw/share"
+    substituteInPlace $out/share/lxc/config/userns.conf --replace-fail "$out/share" "/run/current-system/sw/share"
+    substituteInPlace $out/share/lxc/config/oci.common.conf --replace-fail "$out/share" "/run/current-system/sw/share"
+  '';
 
   enableParallelBuilding = true;
 
@@ -66,6 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
     tests = {
       incus-legacy-init = nixosTests.incus.container-legacy-init;
       incus-systemd-init = nixosTests.incus.container-systemd-init;
+      lxc = nixosTests.lxc;
       lxd = nixosTests.lxd.container;
     };
 

--- a/pkgs/by-name/lx/lxc/user-nic.diff
+++ b/pkgs/by-name/lx/lxc/user-nic.diff
@@ -1,0 +1,13 @@
+diff --git a/src/lxc/network.c b/src/lxc/network.c
+index 0a99d32..850e975 100644
+--- a/src/lxc/network.c
++++ b/src/lxc/network.c
+@@ -2940,7 +2940,7 @@ int lxc_find_gateway_addresses(struct lxc_handler *handler)
+ 
+ #ifdef IN_LIBLXC
+ 
+-#define LXC_USERNIC_PATH LIBEXECDIR "/lxc/lxc-user-nic"
++#define LXC_USERNIC_PATH "/run/wrappers/bin/lxc-user-nic"
+ static int lxc_create_network_unpriv_exec(const char *lxcpath,
+ 					  const char *lxcname,
+ 					  struct lxc_netdev *netdev, pid_t pid,


### PR DESCRIPTION
## Description of changes
Added extra option to enable unprivileged containers.
This includes:
 - a patch to remove the hard-coded path to `lxc-user-nic`;
 - a new security wrapper to set SUID to `lxc-user-nic`;
 - changes to build flags to add missing files.

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
