### PR TITLE
xml-security-c: fix build on darwin, format, small clean up

### DIFF
--- a/pkgs/development/libraries/xml-security-c/default.nix
+++ b/pkgs/development/libraries/xml-security-c/default.nix
@@ -2,19 +2,23 @@
   lib,
   stdenv,
   fetchurl,
+  pkg-config,
   xalanc,
   xercesc,
   openssl,
-  pkg-config,
+  darwin,
 }:
 
-stdenv.mkDerivation rec {
+let
+  inherit (darwin.apple_sdk.frameworks) CoreFoundation CoreServices SystemConfiguration;
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "xml-security-c";
   version = "2.0.4";
 
   src = fetchurl {
-    url = "mirror://apache/santuario/c-library/${pname}-${version}.tar.gz";
-    sha256 = "sha256-p42mcg9sK6FBANJCYTHg0z6sWi26XMEb3QSXS364kAM=";
+    url = "mirror://apache/santuario/c-library/xml-security-c-${finalAttrs.version}.tar.gz";
+    hash = "sha256-p42mcg9sK6FBANJCYTHg0z6sWi26XMEb3QSXS364kAM=";
   };
 
   configureFlags = [
@@ -25,11 +29,17 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [
-    xalanc
-    xercesc
-    openssl
-  ];
+  buildInputs =
+    [
+      xalanc
+      xercesc
+      openssl
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      CoreFoundation
+      CoreServices
+      SystemConfiguration
+    ];
 
   meta = {
     homepage = "https://santuario.apache.org/";
@@ -38,4 +48,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.jagajaga ];
   };
-}
+})

--- a/pkgs/development/libraries/xml-security-c/default.nix
+++ b/pkgs/development/libraries/xml-security-c/default.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, fetchurl, xalanc, xercesc, openssl, pkg-config }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  xalanc,
+  xercesc,
+  openssl,
+  pkg-config,
+}:
 
 stdenv.mkDerivation rec {
   pname = "xml-security-c";
@@ -16,7 +24,12 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ xalanc xercesc openssl ];
+
+  buildInputs = [
+    xalanc
+    xercesc
+    openssl
+  ];
 
   meta = {
     homepage = "https://santuario.apache.org/";


### PR DESCRIPTION
## Description of changes

ZHF: #309482

I don't have a darwin machine, so I'm just working based on logs, but in theory this PR should fix the build on darwin.

Let's wait for OfBorg or someone who has a darwin machine to test compilation.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
