### PR TITLE
wordpressPackages.plugins.hcaptcha-for-forms-and-more: init at 4.1.1

### DIFF
--- a/pkgs/servers/web-apps/wordpress/packages/languages.json
+++ b/pkgs/servers/web-apps/wordpress/packages/languages.json
@@ -1,20 +1,20 @@
 {
   "de_DE": {
     "path": "de_DE",
-    "rev": "1416209",
-    "sha256": "1ffs7qjn9qp6s40v7z4ngm062wapjbhg2fihp7p4nb4ki3gf2yh9",
+    "rev": "1436223",
+    "sha256": "0yc9h1c5pqqy7n3x5ss9vxizb1qyalx2srnwkfnhgl0f103ry7hc",
     "version": "6.5"
   },
   "fr_FR": {
     "path": "fr_FR",
-    "rev": "1412485",
-    "sha256": "06h4vg0kcybvf6v04sf6iyi8bw1bjjzpicdv90acdb049q5vc4x3",
+    "rev": "1436240",
+    "sha256": "014n9zk6adlzk2ayd5f5hm97ybn8b5l5h589576hsmv30crivqsq",
     "version": "6.5"
   },
   "ro_RO": {
     "path": "ro_RO",
-    "rev": "1410752",
-    "sha256": "1j4ypjgm1qghr18cll7iwr7qhdcffakzpj83lb391fyr2b3s7liq",
+    "rev": "1436218",
+    "sha256": "15issr2hnq9fci7kkw42aqqxj5vq154v91xy6mhppp2079g93c63",
     "version": "6.5"
   }
 }

--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -24,10 +24,10 @@
     "version": "2.21.08.31"
   },
   "breeze": {
-    "path": "breeze/tags/2.1.6",
-    "rev": "3051666",
-    "sha256": "0926fxbxkw06g6828s0yx017zp1sr60lh2b9cdgil0fxwc5ga26z",
-    "version": "2.1.6"
+    "path": "breeze/tags/2.1.7",
+    "rev": "3074984",
+    "sha256": "13alrv92p70ccg8xjybfzzikv35ff24zkc3dxlbrlr62ikczyyy0",
+    "version": "2.1.7"
   },
   "co-authors-plus": {
     "path": "co-authors-plus/tags/3.5.15",
@@ -36,10 +36,10 @@
     "version": "3.5.15"
   },
   "code-syntax-block": {
-    "path": "code-syntax-block/tags/3.1.1",
-    "rev": "2747615",
-    "sha256": "0dqdsl7f3ihshvly6cqd5l4cbimx5skmips514wvifspwggwmmjm",
-    "version": "3.1.1"
+    "path": "code-syntax-block/tags/3.2.1",
+    "rev": "3083143",
+    "sha256": "0hcvix71g2nh2yws0j3rll2dk3ybf39i04m7qz9yrnva6s17g6l6",
+    "version": "3.2.1"
   },
   "cookie-notice": {
     "path": "cookie-notice/tags/2.4.16",
@@ -60,10 +60,16 @@
     "version": "1.4.0"
   },
   "gutenberg": {
-    "path": "gutenberg/tags/18.1.0",
-    "rev": "3068196",
-    "sha256": "0ajkm54m4g6xg10263hjwdy2jigcaiqczg5dla7c457jqg8jv4nv",
-    "version": "18.1.0"
+    "path": "gutenberg/tags/18.2.0",
+    "rev": "3077097",
+    "sha256": "126zbp5ix94qrkrw4lwsiwk3mri7xd28f7zz4cqbv03wq7pzla6x",
+    "version": "18.2.0"
+  },
+  "hcaptcha-for-forms-and-more": {
+    "path": "hcaptcha-for-forms-and-more/tags/4.1.1",
+    "rev": "3081325",
+    "sha256": "1sw42qpy3qqz48a86fd5dc71iq6s1q44v5mgq7fa49makkn5fd4r",
+    "version": "4.1.1"
   },
   "hello-dolly": {
     "path": "hello-dolly/tags/1.7.2",
@@ -156,10 +162,10 @@
     "version": "0.25.9"
   },
   "wordpress-seo": {
-    "path": "wordpress-seo/tags/22.5",
-    "rev": "3071371",
-    "sha256": "0jwkicd8zf6ggf2qf2r1ndgj2k208n9bwvjrd7k3gg09jwsccgab",
-    "version": "22.5"
+    "path": "wordpress-seo/tags/22.6",
+    "rev": "3079171",
+    "sha256": "105646vkdvnrwa6kbk8vhvp40l5rg5dnd0rs21qg7byw7xv61nzs",
+    "version": "22.6"
   },
   "worker": {
     "path": "worker/tags/4.9.19",
@@ -174,10 +180,10 @@
     "version": "2.0"
   },
   "wp-fastest-cache": {
-    "path": "wp-fastest-cache/tags/1.2.5",
-    "rev": "3065036",
-    "sha256": "0q3ra4xry8jbvnx7nxj6a8jjyrni6faa8ys0s2ikaf6jf3r9skqa",
-    "version": "1.2.5"
+    "path": "wp-fastest-cache/tags/1.2.6",
+    "rev": "3081800",
+    "sha256": "0pp8di9jaj13k0qdpcnwx825nzx8cd9h336li8swg3jbr3sppvl7",
+    "version": "1.2.6"
   },
   "wp-gdpr-compliance": {
     "path": "wp-gdpr-compliance/tags/2.0.22",
@@ -192,10 +198,10 @@
     "version": "4.0.1"
   },
   "wp-statistics": {
-    "path": "wp-statistics/tags/14.6.1",
-    "rev": "3070028",
-    "sha256": "0qrhfqbn51cgyr0y3v4hxpnkhsk829i62c3ccy6a34gf5fxhrjnl",
-    "version": "14.6.1"
+    "path": "wp-statistics/tags/14.6.4",
+    "rev": "3081064",
+    "sha256": "03834h6vcczcbmw7h3db6bk39qr9yipgsn8q9mwa43rq7h7b7pvh",
+    "version": "14.6.4"
   },
   "wp-swiper": {
     "path": "wp-swiper/trunk",
@@ -210,9 +216,9 @@
     "version": "1.4.1"
   },
   "wpforms-lite": {
-    "path": "wpforms-lite/tags/1.8.7.2",
-    "rev": "3043142",
-    "sha256": "1na6vlvnvni9vqg99i1ab49z5cyy6kyqf197ph8r79nc46lyxa5a",
-    "version": "1.8.7.2"
+    "path": "wpforms-lite/tags/1.8.8.3",
+    "rev": "3077484",
+    "sha256": "03glhjxsrw6n884qkxrizbs6i4d7b1bl9m2zj7f32p0bq466hm6r",
+    "version": "1.8.8.3"
   }
 }

--- a/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
@@ -10,6 +10,7 @@
 , "disable-xml-rpc": "gpl2Plus"
 , "embed-extended": "gpl2Plus"
 , "gutenberg": "gpl2Plus"
+, "hcaptcha-for-forms-and-more": "gpl2Only"
 , "hello-dolly": "gpl2Plus"
 , "hkdev-maintenance-mode": "gpl2Plus"
 , "jetpack": "gpl2Plus"


### PR DESCRIPTION
## Description of changes
Adding the plugin [hcaptcha-for-forms-and-more](https://wordpress.org/plugins/hcaptcha-for-forms-and-more/)

## Things done
* Built on platform(s)
  
  * [x]  x86_64-linux
  * [ ]  aarch64-linux
  * [ ]  x86_64-darwin
  * [ ]  aarch64-darwin
* For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  
  * [ ]  `sandbox = relaxed`
  * [ ]  `sandbox = true`
* [ ]  Tested, as applicable:
  
  * [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  * and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  * or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  * made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
* [ ]  Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
* [ ]  Tested basic functionality of all binary files (usually in `./result/bin/`)
* [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  
  * [ ]  (Package updates) Added a release notes entry if the change is major or breaking
  * [ ]  (Module updates) Added a release notes entry if the change is significant
  * [ ]  (Module addition) Added a release notes entry if adding a new NixOS module
* [x]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Add a 👍 [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to [pull requests you find important](https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
