### PR TITLE
Revert "python3Packages.mayavi: disable for python 3.11"

### DIFF
--- a/pkgs/development/python-modules/mayavi/default.nix
+++ b/pkgs/development/python-modules/mayavi/default.nix
@@ -10,6 +10,7 @@
 , pygments
 , pyqt5
 , pythonOlder
+, pythonAtLeast
 , traitsui
 , vtk
 , wrapQtAppsHook
@@ -17,6 +18,7 @@
 
 buildPythonPackage rec {
   pname = "mayavi";
+  # TODO: Remove meta.broken on next release.
   version = "4.8.1";
   format = "setuptools";
 
@@ -85,5 +87,8 @@ buildPythonPackage rec {
     homepage = "https://github.com/enthought/mayavi";
     license = licenses.bsdOriginal;
     maintainers = with maintainers; [ knedlsepp ];
+    # Should be fixed in a version from after March 26, see:
+    # https://github.com/enthought/mayavi/issues/1284#issuecomment-2020631244
+    broken = pythonAtLeast "3.12";
   };
 }

--- a/pkgs/development/python-modules/mayavi/default.nix
+++ b/pkgs/development/python-modules/mayavi/default.nix
@@ -10,7 +10,6 @@
 , pygments
 , pyqt5
 , pythonOlder
-, pythonAtLeast
 , traitsui
 , vtk
 , wrapQtAppsHook
@@ -20,7 +19,8 @@ buildPythonPackage rec {
   pname = "mayavi";
   version = "4.8.1";
   format = "setuptools";
-  disabled = pythonOlder "3.8" || pythonAtLeast "3.11";
+
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7253,7 +7253,8 @@ self: super: with self; {
   maya = callPackage ../development/python-modules/maya { };
 
   mayavi = pkgs.libsForQt5.callPackage ../development/python-modules/mayavi {
-    inherit (self) buildPythonPackage pythonOlder pythonAtLeast pyface pygments numpy packaging vtk traitsui envisage apptools pyqt5;
+    inherit buildPythonPackage pythonOlder;
+    inherit (self) pyface pygments numpy packaging vtk traitsui envisage apptools pyqt5;
   };
 
   mayim = callPackage ../development/python-modules/mayim { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7253,7 +7253,7 @@ self: super: with self; {
   maya = callPackage ../development/python-modules/maya { };
 
   mayavi = pkgs.libsForQt5.callPackage ../development/python-modules/mayavi {
-    inherit buildPythonPackage pythonOlder;
+    inherit buildPythonPackage pythonOlder pythonAtLeast;
     inherit (self) pyface pygments numpy packaging vtk traitsui envisage apptools pyqt5;
   };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
