### PR TITLE
jwhois: fix darwin build, format, refactor

### DIFF
--- a/pkgs/tools/networking/jwhois/default.nix
+++ b/pkgs/tools/networking/jwhois/default.nix
@@ -1,22 +1,37 @@
-{lib, stdenv, lynx, fetchurl}:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  lynx,
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "jwhois";
   version = "4.0";
 
   src = fetchurl {
-    url = "mirror://gnu/jwhois/jwhois-${version}.tar.gz";
-    sha256 = "0knn7iaj5v0n6jpmldyv2yk4bcy9dn3kywmv63bwc5drh9kvi6zs";
+    url = "mirror://gnu/jwhois/jwhois-${finalAttrs.version}.tar.gz";
+    hash = "sha256-+pu4Z4K5FcbXMLtyP4dtybNFphfbN1qvNBbsIlU81k4=";
   };
 
-  postInstall = ''
-    ln -s jwhois $out/bin/whois
-    sed -i -e "s|/usr/bin/lynx|${lynx}/bin/lynx|g" $out/etc/jwhois.conf
+  patches = [
+    ./connect.patch
+    ./service-name.patch
+  ];
+
+  postPatch = ''
+    # avoids error on darwin where `-Werror=implicit-function-declaration` is set by default
+    sed 1i'void timeout_init();' -i src/jwhois.c
+
+    substituteInPlace example/jwhois.conf \
+        --replace-fail "/usr/bin/lynx" ${lib.getExe lynx}
   '';
 
-  patches = [ ./connect.patch ./service-name.patch ];
-
   makeFlags = [ "AR=${stdenv.cc.bintools.targetPrefix}ar" ];
+
+  postInstall = ''
+    ln -s $out/bin/jwhois $out/bin/whois
+  '';
 
   # Work around error from <stdio.h> on aarch64-darwin:
   #     error: 'TARGET_OS_IPHONE' is not defined, evaluates to 0 [-Werror,-Wundef-prefix=TARGET_OS_]
@@ -26,7 +41,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A client for the WHOIS protocol allowing you to query the owner of a domain name";
     homepage = "https://www.gnu.org/software/jwhois/";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Only;
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

ZHF: #309482

This PR adds a `postPatch` patch which adds a missing function declaration that was causing build issues on darwin.

Other changes:
- format with `nixfmt`
- use `finalAttrs`
- subsitute `pname`
- use `hash`
- use `substituteInPlace` instead of `sed` when possible
- clear up possible confusion with `ln`
  - (it's not obvious that `pwd` is `$out/bin`)
- set license to `gpl3Only` (not sure what it is exactly, but using `gpl3Only` should be safe)


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
