### PR TITLE
rstudio: 2023.12.1+402 -> 2024.04.1+738

### DIFF
--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , mkDerivation
 , fetchurl
+, fetchpatch
 , fetchFromGitHub
 , makeDesktopItem
 , copyDesktopItems
@@ -39,7 +40,7 @@
 
 let
   pname = "RStudio";
-  version = "2023.12.1+402";
+  version = "2024.04.1+748";
   RSTUDIO_VERSION_MAJOR = lib.versions.major version;
   RSTUDIO_VERSION_MINOR = lib.versions.minor version;
   RSTUDIO_VERSION_PATCH = lib.versions.patch version;
@@ -50,8 +51,8 @@ let
   src = fetchFromGitHub {
     owner = "rstudio";
     repo = "rstudio";
-    rev = version;
-    hash = "sha256-ecMzkpHazg8jEBz9wh8hqRX2UdziOC8b6F+3xxdugy0=";
+    rev = "v" + version;
+    hash = "sha256-fzxbhN9NdM0E2rxezj2BMEZ8obUbX0Zw8haDNmfAkWs=";
   };
 
   mathJaxSrc = fetchurl {
@@ -62,8 +63,8 @@ let
   rsconnectSrc = fetchFromGitHub {
     owner = "rstudio";
     repo = "rsconnect";
-    rev = "v1.2.0";
-    hash = "sha256-ghRz4Frd+I9ShRNNOE/kdk9KjRCj0Z1mPnThueriiUY=";
+    rev = "v1.2.2";
+    hash = "sha256-wvM9Bm7Nb6yU9z0o+uF5lB2kdgjOW5wZSk6y48NPF2U=";
   };
 
   # Ideally, rev should match the rstudio release name.
@@ -118,6 +119,7 @@ in
       "-DRSTUDIO_USE_SYSTEM_SOCI=ON"
       "-DRSTUDIO_USE_SYSTEM_BOOST=ON"
       "-DRSTUDIO_USE_SYSTEM_YAML_CPP=ON"
+      "-DRSTUDIO_DISABLE_CHECK_FOR_UPDATES=ON"
       "-DQUARTO_ENABLED=TRUE"
       "-DPANDOC_VERSION=${pandoc.version}"
       "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}/lib/rstudio"
@@ -134,6 +136,13 @@ in
       ./pandoc-nix-path.patch
       ./use-system-quarto.patch
       ./ignore-etc-os-release.patch
+
+      (fetchpatch {
+        name = "use-system-yaml-patch";
+        url = "https://github.com/rstudio/rstudio/commit/04de8ca8b83dcc7fee9fd65e6ef58c372489d5ef.patch";
+        hash = "sha256-FHSSOPsw6AAYBj/fgNT6idyxvRj3SG+fbla0UDjug1Y=";
+      })
+
     ];
 
     postPatch = ''
@@ -181,6 +190,11 @@ in
       done
 
       unzip -q ${mathJaxSrc} -d dependencies/mathjax-27
+
+     # As of Chocolate Cosmos, node 18.19.1 is used for runtime
+     # 18.18.2 is still used for build
+     # see https://github.com/rstudio/rstudio/commit/facb5cf1ab38fe77813aaf36590804e4f865d780
+     mkdir -p dependencies/common/node/18.19.1
 
       mkdir -p dependencies/pandoc/${pandoc.version}
       cp ${pandoc}/bin/pandoc dependencies/pandoc/${pandoc.version}/pandoc

--- a/pkgs/applications/editors/rstudio/use-system-node.patch
+++ b/pkgs/applications/editors/rstudio/use-system-node.patch
@@ -11,21 +11,6 @@ index d18362b..98cdd4c 100644
  
  # enable copilot
  copilot-enabled=1
-diff --git a/src/cpp/server/CMakeLists.txt b/src/cpp/server/CMakeLists.txt
-index 30dd638..cb4a645 100644
---- a/src/cpp/server/CMakeLists.txt
-+++ b/src/cpp/server/CMakeLists.txt
-@@ -250,10 +250,6 @@ if (UNIX AND NOT APPLE)
-            DESTINATION ${RSERVER_SYSTEMD_DIR})
- 
-    # install node
--   install(
--      DIRECTORY "${RSTUDIO_DEPENDENCIES_DIR}/common/node/${RSTUDIO_NODE_VERSION}/"
--      DESTINATION "${RSTUDIO_INSTALL_BIN}/node"
--      USE_SOURCE_PERMISSIONS)
- 
- elseif(APPLE)
- 
 diff --git a/src/gwt/build.xml b/src/gwt/build.xml
 index 033d605..f1ee63d 100644
 --- a/src/gwt/build.xml


### PR DESCRIPTION
## Description of changes

Updated Rstudio to the latest version. Now, two versions of Node are needed, one for building, and one as a runtime dependency. It was enough to create the appropriate directory. I also refer to the commit in question in the default.nix file.

There was also a regression that was introduced that made yaml-cpp not be found, but this was solved this morning with https://github.com/rstudio/rstudio/commit/04de8ca8b83dcc7fee9fd65e6ef58c372489d5ef so I've backported the patch. This will need to be removed for the next release.

Builds and runs on x86 linux. Visual mode for editing markdown documents still loading forever though.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
