### PR TITLE
`gnomeExtensions.system-monitor`: patch to add `GTop` to the extension's path

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -124,6 +124,15 @@ super: lib.trivial.pipe super [
     ];
   }))
 
+  (patchExtension "system-monitor@gnome-shell-extensions.gcampax.github.com" (old: {
+    patches = [
+      (substituteAll {
+        src = ./extensionOverridesPatches/system-monitor_at_gnome-shell-extensions.gcampax.github.com.patch;
+        gtop_path = "${libgtop}/lib/girepository-1.0";
+      })
+    ];
+  }))
+
   (patchExtension "system-monitor-next@paradoxxx.zero.gmail.com" (old: {
     patches = [
       (substituteAll {

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/system-monitor_at_gnome-shell-extensions.gcampax.github.com.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/system-monitor_at_gnome-shell-extensions.gcampax.github.com.patch
@@ -1,0 +1,25 @@
+diff --git a/extension.js b/extension.js
+index 37d2eb1..232d0d5 100644
+--- a/extension.js
++++ b/extension.js
+@@ -6,9 +6,9 @@
+ 
+ import Clutter from 'gi://Clutter';
+ import Gio from 'gi://Gio';
++import GIRepository from "gi://GIRepository";
+ import GLib from 'gi://GLib';
+ import GObject from 'gi://GObject';
+-import GTop from 'gi://GTop';
+ import Pango from 'gi://Pango';
+ import Shell from 'gi://Shell';
+ import St from 'gi://St';
+@@ -19,6 +19,9 @@ import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+ 
+ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+ 
++GIRepository.Repository.prepend_search_path('@gtop_path@');
++const GTop = (await import("gi://GTop")).default;
++
+ const THRESHOLD_HIGH = 0.80;
+ 
+ // adapted from load-graph.cpp in gnome-system-monitor


### PR DESCRIPTION
## Description of changes
This PR patches `gnomeExtensions.system-monitor`, an extension installed by default as of `GNOME 46`, so that `GTop` is within its path; otherwise, an error occurs when trying to enable this extension.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
