### PR TITLE
kratos: fix 'version' command

### DIFF
--- a/pkgs/applications/misc/kratos/default.nix
+++ b/pkgs/applications/misc/kratos/default.nix
@@ -1,8 +1,15 @@
-{ fetchFromGitHub, buildGoModule, lib, stdenv }:
-
-buildGoModule rec {
+{
+  fetchFromGitHub,
+  buildGoModule,
+  lib,
+  stdenv
+}:
+let
   pname = "kratos";
   version = "1.1.0";
+in
+buildGoModule {
+  inherit pname version;
 
   src = fetchFromGitHub {
     owner = "ory";
@@ -20,7 +27,6 @@ buildGoModule rec {
   # Pass versioning information via ldflags
   ldflags = [
     "-X github.com/ory/kratos/driver/config.Version=${version}"
-    "-X github.com/ory/kratos/driver/config.Commit=f47675b82012e0ff74b05b9b7e713b3aa2fdda54"
   ];
 
   doCheck = false;
@@ -36,14 +42,14 @@ buildGoModule rec {
     patchShebangs "''${files[@]}"
 
     # patchShebangs doesn't work for this Makefile, do it manually
-    substituteInPlace Makefile --replace '/bin/bash' '${stdenv.shell}'
+    substituteInPlace Makefile --replace-fail '/usr/bin/env bash' '${stdenv.shell}'
   '';
 
-  meta = with lib; {
-    maintainers = with maintainers; [ mrmebelman ];
-    homepage = "https://www.ory.sh/kratos/";
-    license = licenses.asl20;
-    description = "An API-first Identity and User Management system that is built according to cloud architecture best practices";
+  meta = {
     mainProgram = "kratos";
+    description = "An API-first Identity and User Management system that is built according to cloud architecture best practices";
+    homepage = "https://www.ory.sh/kratos/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mrmebelman ];
   };
 }

--- a/pkgs/applications/misc/kratos/default.nix
+++ b/pkgs/applications/misc/kratos/default.nix
@@ -17,6 +17,12 @@ buildGoModule rec {
 
   tags = [ "sqlite" ];
 
+  # Pass versioning information via ldflags
+  ldflags = [
+    "-X github.com/ory/kratos/driver/config.Version=${version}"
+    "-X github.com/ory/kratos/driver/config.Commit=f47675b82012e0ff74b05b9b7e713b3aa2fdda54"
+  ];
+
   doCheck = false;
 
   preBuild = ''


### PR DESCRIPTION
## Description of changes
This (finally!) fixes the `kratos version` command.

Before:
![image](https://github.com/NixOS/nixpkgs/assets/15896005/7bb4311d-dadf-4d83-a903-433894994990)


After:
![image](https://github.com/NixOS/nixpkgs/assets/15896005/b951ca99-8bc3-4633-864a-5d7a42f30833)


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
