### PR TITLE
ratslap: make linux-only, use finalAttrs

### DIFF
--- a/pkgs/by-name/ra/ratslap/package.nix
+++ b/pkgs/by-name/ra/ratslap/package.nix
@@ -7,15 +7,15 @@
 , git
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ratslap";
   version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "krayon";
     repo = "ratslap";
-    rev = version;
-    sha256 = "sha256-PO/79tTiO4TBtojrEtkSf5W6zuG+Ml2iJGAtYHDwHEY=";
+    rev = finalAttrs.version;
+    hash = "sha256-PO/79tTiO4TBtojrEtkSf5W6zuG+Ml2iJGAtYHDwHEY=";
     leaveDotGit = true;
   };
 
@@ -33,9 +33,9 @@ stdenv.mkDerivation rec {
     makeFlagsArray+=(
       "-W gitup"
       "VDIRTY="
-      "MAJVER=${version}"
+      "MAJVER=${finalAttrs.version}"
       "APPBRANCH=main"
-      "BINNAME=${pname}"
+      "BINNAME=ratslap"
       "MARKDOWN_GEN="
       "BUILD_DATE=$(git show -s --date=format:'%Y-%m-%d %H:%M:%S%z' --format=%cd)"
       "BUILD_MONTH=$(git show -s --date=format:'%B' --format=%cd)"
@@ -49,8 +49,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cp ratslap $out/bin
 
-    mv manpage.1 ${pname}.1
-    installManPage ${pname}.1
+    mv manpage.1 ratslap.1
+    installManPage ratslap.1
 
     runHook postInstall
   '';
@@ -62,9 +62,9 @@ stdenv.mkDerivation rec {
       all buttons and configuring modes, DPI settings and the LED.
     '';
     homepage = "https://github.com/krayon/ratslap";
-    changelog = "https://github.com/krayon/ratslap/releases/tag/${version}";
+    changelog = "https://github.com/krayon/ratslap/releases/tag/${finalAttrs.version}";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ zebreus ];
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

ZHF: https://github.com/NixOS/nixpkgs/issues/309482

Hydra was failing to build this package on darwin. According to upstream the `ratslap` package is linux only.
This PR changes the supported platform list of `ratslap` to only have `platforms.linux`

The other changes in the PR should not cause any rebuilds, as I only did exact substitutions.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
