### PR TITLE
tracexec: Packaging improvements

### DIFF
--- a/pkgs/by-name/tr/tracexec/package.nix
+++ b/pkgs/by-name/tr/tracexec/package.nix
@@ -1,37 +1,68 @@
 {
   lib,
-  rustPlatform,
+  stdenv,
   fetchFromGitHub,
+  rustPlatform,
+  cargo-about,
+  nix-update-script,
 }:
-
-rustPlatform.buildRustPackage rec {
+let
   pname = "tracexec";
   version = "0.2.2";
+in
+rustPlatform.buildRustPackage {
+  inherit pname version;
 
   src = fetchFromGitHub {
     owner = "kxxt";
     repo = "tracexec";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-X2hLaBndeYLBMnDe2MT4pgZiPj0COHG2uTvAbW+JVd4=";
   };
 
   cargoHash = "sha256-3xANOv+A4soDcKMINy+RnI8l6uS3koZpw3CMIUCmK5A=";
 
-  # Remove test binaries and only retain tracexec
-  postInstall = ''
-    find "$out/bin" -type f \! -name tracexec -print0 | xargs -0 rm -v
+  nativeBuildInputs = [
+    cargo-about
+  ];
+
+  # Remove RiscV64 specialisation when this is fixed:
+  # * https://github.com/NixOS/nixpkgs/pull/310158#pullrequestreview-2046944158
+  # * https://github.com/rust-vmm/seccompiler/pull/72
+  cargoBuildFlags = lib.optional stdenv.hostPlatform.isRiscV64 "--no-default-features";
+
+  preBuild = ''
+    sed -i '1ino-clearly-defined = true' about.toml  # disable network requests
+    cargo about generate --config about.toml -o THIRD_PARTY_LICENSES.HTML about.hbs
   '';
 
-  # ptrace is not allowed in sandbox
-  doCheck = false;
+  # Tests don't work for native non-x86 compilation
+  # because upstream overrides the name of the linker executables,
+  # see https://github.com/NixOS/nixpkgs/pull/310158#issuecomment-2118845043
+  doCheck = stdenv.hostPlatform.isx86_64;
+
+  checkFlags = [
+    "--skip=cli::test::log_mode_without_args_works" # `Permission denied` (needs `CAP_SYS_PTRACE`)
+    "--skip=tracer::test::tracer_emits_exec_event" # needs `/bin/true`
+  ];
+
+  postInstall = ''
+    # Remove test binaries (e.g. `empty-argv`, `corrupted-envp`) and only retain `tracexec`
+    find "$out/bin" -type f \! -name tracexec -print0 | xargs -0 rm -v
+
+    install -Dm644 LICENSE -t "$out/share/licenses/${pname}/"
+    install -Dm644 THIRD_PARTY_LICENSES.HTML -t "$out/share/licenses/${pname}/"
+  '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
+    changelog = "https://github.com/kxxt/tracexec/blob/v${version}/CHANGELOG.md";
     description = "A small utility for tracing execve{,at} and pre-exec behavior";
     homepage = "https://github.com/kxxt/tracexec";
-    changelog = "https://github.com/kxxt/tracexec/blob/${src.rev}/CHANGELOG.md";
-    license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ fpletz ];
+    license = lib.licenses.gpl2Plus;
     mainProgram = "tracexec";
+    maintainers = with lib.maintainers; [ fpletz nh2 ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
Original PR title: `tracexec: init at 0.1.0`

## Description of changes

See https://github.com/kxxt/tracexec

:heart: co-maintainers would be very appreciated!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
