### PR TITLE
sgx-sdk: 2.23 -> 2.24

### DIFF
--- a/pkgs/os-specific/linux/sgx/azure-dcap-client/default.nix
+++ b/pkgs/os-specific/linux/sgx/azure-dcap-client/default.nix
@@ -16,7 +16,7 @@ let
     find "$out" -mindepth 1 -delete
     cp ${lib.concatStringsSep " " list} "$out/"
   '';
-  headers = linkFarmFromDrvs "azure-dcpa-client-intel-headers" [
+  headers = linkFarmFromDrvs "azure-dcap-client-intel-headers" [
     (fetchFromGitHub rec {
       name = "${repo}-headers";
       owner = "intel";
@@ -69,8 +69,8 @@ stdenv.mkDerivation rec {
     find -L '${headers}' -type f -exec ln -s {} src/Linux/ext/intel \;
 
     substitute src/Linux/Makefile{.in,} \
-      --replace '##CURLINC##' '${curl.dev}/include/curl/' \
-      --replace '$(TEST_SUITE): $(PROVIDER_LIB) $(TEST_SUITE_OBJ)' '$(TEST_SUITE): $(TEST_SUITE_OBJ)'
+      --replace-fail '##CURLINC##' '${curl.dev}/include/curl/' \
+      --replace-fail '$(TEST_SUITE): $(PROVIDER_LIB) $(TEST_SUITE_OBJ)' '$(TEST_SUITE): $(TEST_SUITE_OBJ)'
   '';
 
   env.NIX_CFLAGS_COMPILE = "-Wno-deprecated-declarations";
@@ -84,11 +84,11 @@ stdenv.mkDerivation rec {
   # $(nix-build -A sgx-azure-dcap-client.tests.suite)/bin/tests
   passthru.tests.suite = callPackage ./test-suite.nix { };
 
-  meta = with lib; {
+  meta = {
     description = "Interfaces between SGX SDKs and the Azure Attestation SGX Certification Cache";
     homepage = "https://github.com/microsoft/azure-dcap-client";
-    maintainers = with maintainers; [ phlip9 trundle veehaitch ];
+    maintainers = with lib.maintainers; [ phlip9 trundle veehaitch ];
     platforms = [ "x86_64-linux" ];
-    license = [ licenses.mit ];
+    license = [ lib.licenses.mit ];
   };
 }

--- a/pkgs/os-specific/linux/sgx/psw/default.nix
+++ b/pkgs/os-specific/linux/sgx/psw/default.nix
@@ -29,11 +29,11 @@ stdenv.mkDerivation rec {
       # Also include the Data Center Attestation Primitives (DCAP) platform
       # enclaves.
       dcap = rec {
-        version = "1.20";
+        version = "1.21";
         filename = "prebuilt_dcap_${version}.tar.gz";
         prebuilt = fetchurl {
           url = "https://download.01.org/intel-sgx/sgx-dcap/${version}/linux/${filename}";
-          hash = "sha256-nPsI89KSBA3cSNTMWyktZP5dkf+BwL3NZ4MuUf6G98o=";
+          hash = "sha256-/PPD2MyNxoCwzNljIFcpkFvItXbyvymsJ7+Uf4IyZuk=";
         };
       };
     in
@@ -158,31 +158,31 @@ stdenv.mkDerivation rec {
     # is helpful to have properly patched versions for non-NixOS distributions.
     echo "Fixing aesmd.service"
     substituteInPlace $out/lib/systemd/system/aesmd.service \
-      --replace '@aesm_folder@' \
-                "$out/aesm" \
-      --replace 'Type=forking' \
-                'Type=simple' \
-      --replace "ExecStart=$out/aesm/aesm_service" \
-                "ExecStart=$out/bin/aesm_service --no-daemon"\
-      --replace "/bin/mkdir" \
-                "${coreutils}/bin/mkdir" \
-      --replace "/bin/chown" \
-                "${coreutils}/bin/chown" \
-      --replace "/bin/chmod" \
-                "${coreutils}/bin/chmod" \
-      --replace "/bin/kill" \
-                "${coreutils}/bin/kill"
+      --replace-fail '@aesm_folder@' \
+                     "$out/aesm" \
+      --replace-fail 'Type=forking' \
+                     'Type=simple' \
+      --replace-fail "ExecStart=$out/aesm/aesm_service" \
+                     "ExecStart=$out/bin/aesm_service --no-daemon"\
+      --replace-fail "/bin/mkdir" \
+                     "${coreutils}/bin/mkdir" \
+      --replace-fail "/bin/chown" \
+                     "${coreutils}/bin/chown" \
+      --replace-fail "/bin/chmod" \
+                     "${coreutils}/bin/chmod" \
+      --replace-fail "/bin/kill" \
+                     "${coreutils}/bin/kill"
   '';
 
   passthru.tests = {
     service = nixosTests.aesmd;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Intel SGX Architectural Enclave Service Manager";
     homepage = "https://github.com/intel/linux-sgx";
-    maintainers = with maintainers; [ phlip9 veehaitch citadelcore ];
+    maintainers = with lib.maintainers; [ phlip9 veehaitch citadelcore ];
     platforms = [ "x86_64-linux" ];
-    license = with licenses; [ bsd3 ];
+    license = [ lib.licenses.bsd3 ];
   };
 }

--- a/pkgs/os-specific/linux/sgx/sdk/default.nix
+++ b/pkgs/os-specific/linux/sgx/sdk/default.nix
@@ -26,15 +26,15 @@
 stdenv.mkDerivation rec {
   pname = "sgx-sdk";
   # Version as given in se_version.h
-  version = "2.23.100.2";
+  version = "2.24.100.3";
   # Version as used in the Git tag
-  versionTag = "2.23";
+  versionTag = "2.24";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-sgx";
     rev = "sgx_${versionTag}";
-    hash = "sha256-i+fE6xKiuljG8LY8TIHgrW15DVpdp46bZdNo/BjgT/I=";
+    hash = "sha256-1urEdfMKNUqqyJ3wQ10+tvtlRuAKELpaCWIOzjCbYKw=";
     fetchSubmodules = true;
   };
 
@@ -121,8 +121,6 @@ stdenv.mkDerivation rec {
 
       pushd 'external/ippcp_internal'
 
-      cp -r ${ipp-crypto-no_mitigation}/include/. inc/
-
       install -D -m a+rw ${ipp-crypto-no_mitigation}/lib/intel64/libippcp.a \
         lib/linux/intel64/no_mitigation/libippcp.a
       install -D -m a+rw ${ipp-crypto-cve_2020_0551_load}/lib/intel64/libippcp.a \
@@ -130,8 +128,13 @@ stdenv.mkDerivation rec {
       install -D -m a+rw ${ipp-crypto-cve_2020_0551_cf}/lib/intel64/libippcp.a \
         lib/linux/intel64/cve_2020_0551_cf/libippcp.a
 
+      cp -r ${ipp-crypto-no_mitigation}/include/* inc/
+
+      mkdir inc/ippcp
+      cp ${ipp-crypto-no_mitigation}/include/fips_cert.h inc/ippcp/
+
       rm inc/ippcp.h
-      patch ${ipp-crypto-no_mitigation}/include/ippcp.h -i inc/ippcp21u7.patch -o inc/ippcp.h
+      patch ${ipp-crypto-no_mitigation}/include/ippcp.h -i ./inc/ippcp21u11.patch -o ./inc/ippcp.h
 
       install -D ${ipp-crypto-no_mitigation.src}/LICENSE license/LICENSE
 
@@ -285,11 +288,11 @@ stdenv.mkDerivation rec {
       '';
     };
 
-  meta = with lib; {
+  meta = {
     description = "Intel SGX SDK for Linux built with IPP Crypto Library";
     homepage = "https://github.com/intel/linux-sgx";
-    maintainers = with maintainers; [ phlip9 sbellem arturcygan veehaitch ];
+    maintainers = with lib.maintainers; [ phlip9 sbellem arturcygan veehaitch ];
     platforms = [ "x86_64-linux" ];
-    license = with licenses; [ bsd3 ];
+    license = [ lib.licenses.bsd3 ];
   };
 }

--- a/pkgs/os-specific/linux/sgx/sdk/disable-downloads.patch
+++ b/pkgs/os-specific/linux/sgx/sdk/disable-downloads.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile b/Makefile
-index 32433051..2e480efb 100644
+index 73502a7..f24bd11 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -50,8 +50,8 @@ tips:
+@@ -50,18 +50,18 @@ tips:
  preparation:
  # As SDK build needs to clone and patch openmp, we cannot support the mode that download the source from github as zip.
  # Only enable the download from git
@@ -12,8 +12,10 @@ index 32433051..2e480efb 100644
 +	# ./external/dcap_source/QuoteVerification/prepare_sgxssl.sh nobuild
  	cd external/openmp/openmp_code && git apply ../0001-Enable-OpenMP-in-SGX.patch >/dev/null 2>&1 ||  git apply ../0001-Enable-OpenMP-in-SGX.patch --check -R
  	cd external/protobuf/protobuf_code && git apply ../sgx_protobuf.patch >/dev/null 2>&1 ||  git apply ../sgx_protobuf.patch --check -R
+-	cd external/protobuf/protobuf_code && git submodule update --init --recursive && cd third_party/abseil-cpp && git apply ../../../sgx_abseil.patch>/dev/null 2>&1 || git apply ../../../sgx_abseil.patch --check -R
++	cd external/protobuf/protobuf_code && cd third_party/abseil-cpp && git apply ../../../sgx_abseil.patch>/dev/null 2>&1 || git apply ../../../sgx_abseil.patch --check -R
  	./external/sgx-emm/create_symlink.sh
-@@ -59,8 +59,8 @@ preparation:
+ 	cd external/mbedtls/mbedtls_code && git apply ../sgx_mbedtls.patch >/dev/null 2>&1 || git apply ../sgx_mbedtls.patch --check -R
  	cd external/cbor && cp -r libcbor sgx_libcbor
  	cd external/cbor/libcbor && git apply ../raw_cbor.patch >/dev/null 2>&1 || git apply ../raw_cbor.patch --check -R
  	cd external/cbor/sgx_libcbor && git apply ../sgx_cbor.patch >/dev/null 2>&1 || git apply ../sgx_cbor.patch --check -R

--- a/pkgs/os-specific/linux/sgx/sdk/ipp-crypto.nix
+++ b/pkgs/os-specific/linux/sgx/sdk/ipp-crypto.nix
@@ -8,16 +8,20 @@
 }:
 gcc11Stdenv.mkDerivation rec {
   pname = "ipp-crypto";
-  version = "2021.10.0";
+  version = "2021.11.1";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "ipp-crypto";
     rev = "ippcp_${version}";
-    hash = "sha256-DfXsJ+4XqyjCD+79LUD53Cx8D46o1a4fAZa2UxGI1Xg=";
+    hash = "sha256-OgNrrPE8jFVD/hcv7A43Bno96r4Z/lb7/SE6TEL7RDI=";
   };
 
-  cmakeFlags = [ "-DARCH=intel64" ] ++ extraCmakeFlags;
+  cmakeFlags = [
+    "-DARCH=intel64"
+    # sgx-sdk now requires FIPS-compliance mode turned on
+    "-DIPPCP_FIPS_MODE=on"
+  ] ++ extraCmakeFlags;
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/os-specific/linux/sgx/ssl/default.nix
+++ b/pkgs/os-specific/linux/sgx/ssl/default.nix
@@ -10,7 +10,7 @@
 }:
 let
   sgxVersion = sgx-sdk.versionTag;
-  opensslVersion = "3.0.12";
+  opensslVersion = "3.0.13";
 in
 stdenv.mkDerivation {
   pname = "sgx-ssl" + lib.optionalString debug "-debug";
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
     let
       opensslSourceArchive = fetchurl {
         url = "https://www.openssl.org/source/openssl-${opensslVersion}.tar.gz";
-        hash = "sha256-+Tyejt3l6RZhGd4xdV/Ie0qjSGNmL2fd/LoU0La2m2E=";
+        hash = "sha256-iFJXU/edO+wn0vp8ZqoLkrOqlJja/ZPXz6SzeAza4xM=";
       };
     in
     ''
@@ -39,8 +39,8 @@ stdenv.mkDerivation {
 
     # Skip the tests. Build and run separately (see below).
     substituteInPlace Linux/sgx/Makefile \
-      --replace '$(MAKE) -C $(TEST_DIR) all' \
-                'bash -c "true"'
+      --replace-fail '$(MAKE) -C $(TEST_DIR) all' \
+                     'bash -c "true"'
   '';
 
   nativeBuildInputs = [
@@ -71,11 +71,11 @@ stdenv.mkDerivation {
     SIM = callPackage ./tests.nix { sgxMode = "SIM"; inherit opensslVersion; };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Cryptographic library for Intel SGX enclave applications based on OpenSSL";
     homepage = "https://github.com/intel/intel-sgx-ssl";
-    maintainers = with maintainers; [ phlip9 trundle veehaitch ];
+    maintainers = with lib.maintainers; [ phlip9 trundle veehaitch ];
     platforms = [ "x86_64-linux" ];
-    license = [ licenses.bsd3 licenses.openssl ];
+    license = with lib.licenses; [ bsd3 openssl ];
   };
 }


### PR DESCRIPTION
## Description of changes

Updates the `sgx-*` package family to the [latest 2.24 release](https://github.com/intel/linux-sgx/releases/tag/sgx_2.24).


**Quick Glossary:**

- **Intel SGX** is a Confidential Computing technology for running enclaves and confidential VMs (Intel TDX) on Intel server CPUs alongside an untrusted hypervisor/Linux/userspace software stack.
- `sgx-sdk` is the top-level SDK for developing Intel SGX enclaves.
- `sgx-psw` (Platform SoftWare) includes the `aesmd` service (Architecture Enclave Service Manager Daemon), which simplifies running enclaves and getting remote attestation quotes.
- `ipp-crypto` is Intel's cryptography library.
- `sgx-azure-dcap-client` is an integration with `aesmd` and Azure cloud so that `aesmd` fetches PCK certs from the local Azure cloud cert cache.
- `sgx-ssl` is a patched version of OpenSSL that runs inside SGX, and is an alternative crypto backend to `ipp-crypto`.


**Commits:**

- sgx-sdk/ipp-crypto: 2021.10.0 -> 2021.11.1

    - gcc 12 and 13 are _still_ failing

    - sgx-sdk now requires FIPS-mode enabled

    - Diff: <https://github.com/intel/ipp-crypto/compare/ippcp_2021.10.0...ippcp_2021.11.1>

    - Changelog: <https://github.com/intel/ipp-crypto/blob/ippcp_2021.11.1/CHANGELOG.md>

- sgx-sdk: 2.23 -> 2.24

    - .patch out a `git submodule update` from `make preparation`.

    - Place the `ipp-crypto/fips_cert.h` header somewhere sgx-sdk can find it.

    - Diff: <https://github.com/intel/linux-sgx/compare/sgx_2.23...sgx_2.24>

    - Changelog: <https://github.com/intel/linux-sgx/releases/tag/sgx_2.24>

- sgx-psw: 2.23 -> 2.24

- sgx-azure-dcap-client: fix warnings

- sgx-ssl: openssl: 3.0.12 -> 3.0.13


These changes were tested on an SGX-enabled Azure gen2 VM (DCSv3) running NixOS.


## Previous update PRs

- [sgx-sdk: 2.21 -> 2.23](https://github.com/NixOS/nixpkgs/pull/283405)

- [sgx-sdk: 2.16 -> 2.21](https://github.com/NixOS/nixpkgs/pull/254845)


## Run simulator tests

```bash
$ nix run .#sgx-sdk.tests.sampleEnclave
$ nix run .#sgx-sdk.tests.localAttestation
$ nix run .#sgx-sdk.tests.remoteAttestation
$ nix run .#sgx-sdk.tests.sealUnseal

$ nix build .#sgx-psw.tests.service
$ nix build .#sgx-azure-dcap-client.tests.suite && ./result/bin/tests
$ nix run .#sgx-ssl.tests.SIM
```


## Run against real SGX hardware

Make sure you're running on a recent x86-64 Intel CPU, against a somewhat recent kernel with the in-tree kernel SGX driver (any NixOS config in the last few years should cover this).

If everything's setup properly, you should see:

```bash
$ journalctl --boot --dmesg --grep=sgx
kernel: sgx: EPC section 0x2c0000000-0x3bfffffff

$ find /dev -name "*sgx*" -ls
 83      0 crw-rw----   1 root     sgx_prv   10, 126 May  8 17:21 /dev/sgx_provision
 84      0 crw-rw----   1 root     sgx       10, 125 May  8 17:21 /dev/sgx_enclave
400      0 drwxr-xr-x   2 root     root           80 May  8 17:21 /dev/sgx
```

In the NixOS `configuration.nix`, add something like:

```nix
  services.aesmd = {
    enable = true;
    # Include this if you're running on Azure
    quoteProviderLibrary = pkgs.sgx-azure-dcap-client;
  };
```

After a quick `nixos-rebuild --switch`, the `aesmd` service should be running:

```bash
$ systemctl status aesmd.service
● aesmd.service - Intel Architectural Enclave Service Manager
     Loaded: loaded (/etc/systemd/system/aesmd.service; enabled; preset: enabled)
     Active: active (running)
    Process: 1469 ExecStartPre=/nix/store/yafphjdidfdanjd0w7p83zarls5248qw-copy-aesmd-data-files.sh (code=exited, status=0/SUCCESS)
   Main PID: 1472 (aesm_service)
         IP: 67.6K in, 13.0K out
         IO: 2.0M read, 64.0K written
      Tasks: 4 (limit: 9516)
     Memory: 4.8M (peak: 5.0M)
        CPU: 125ms
     CGroup: /system.slice/aesmd.service
             └─1472 /nix/store/8jgh6fxa0xkdvv1xbpc9gj7x8pf3fqic-sgx-psw-2.24.100.3/aesm/aesm_service --no-daemon

systemd[1]: Started Intel Architectural Enclave Service Manager.
aesm_service[1472]: The path of system bundle: System Bundle
aesm_service[1472]: ecdsa_quote_service_bundle_name:2.0.0
aesm_service[1472]: epid_quote_service_bundle_name:2.0.0
aesm_service[1472]: le_launch_service_bundle_name:2.0.0
aesm_service[1472]: linux_network_service_bundle_name:2.0.0
aesm_service[1472]: pce_service_bundle_name:2.0.0
aesm_service[1472]: quote_ex_service_bundle_name:2.0.0
aesm_service[1472]: system_bundle:4.0.0
aesm_service[1472]: Azure Quote Provider: libdcap_quoteprov.so [INFO]: Debug Logging Enabled
```

Run the tests:

```bash
$ nix run .#sgx-sdk.runTestsHW
$ nix run .#sgx-azure-dcap-client.tests.suite
$ nix run .#sgx-ssl.tests.HW
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
