### PR TITLE
podman: improve runtime patching

### DIFF
--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -19,11 +19,10 @@
 , symlinkJoin
 , substituteAll
 , extraPackages ? [ ]
-, runc
 , crun
-, gvisor
-, youki
+, runc
 , conmon
+, extraRuntimes ? lib.optionals stdenv.isLinux [ runc ]  # e.g.: runc, gvisor, youki
 , slirp4netns
 , fuse-overlayfs
 , util-linux
@@ -59,7 +58,9 @@ let
       netavark
       slirp4netns
       passt
-    ];
+      conmon
+      crun
+    ] ++ extraRuntimes;
   };
 in
 buildGoModule rec {
@@ -74,13 +75,13 @@ buildGoModule rec {
   };
 
   patches = [
-    # we intentionally don't build and install the helper so we shouldn't display messages to users about it
-    ./rm-podman-mac-helper-msg.patch
-  ] ++ lib.optionals stdenv.isLinux [
     (substituteAll {
       src = ./hardcode-paths.patch;
-      inherit crun runc gvisor youki conmon;
+      bin_path = helpersBin;
     })
+
+    # we intentionally don't build and install the helper so we shouldn't display messages to users about it
+    ./rm-podman-mac-helper-msg.patch
   ];
 
   vendorHash = null;

--- a/pkgs/applications/virtualization/podman/hardcode-paths.patch
+++ b/pkgs/applications/virtualization/podman/hardcode-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/vendor/github.com/containers/common/pkg/config/default.go b/vendor/github.com/containers/common/pkg/config/default.go
-index 19c4bb6bf..2743de4b2 100644
+index 3a6d804ad..5628e2bf6 100644
 --- a/vendor/github.com/containers/common/pkg/config/default.go
 +++ b/vendor/github.com/containers/common/pkg/config/default.go
-@@ -364,75 +364,34 @@ func defaultEngineConfig() (*EngineConfig, error) {
+@@ -366,75 +366,34 @@ func defaultEngineConfig() (*EngineConfig, error) {
  	c.Retry = 3
  	c.OCIRuntimes = map[string][]string{
  		"crun": {
@@ -13,7 +13,7 @@ index 19c4bb6bf..2743de4b2 100644
 -			"/sbin/crun",
 -			"/bin/crun",
 -			"/run/current-system/sw/bin/crun",
-+			"@crun@/bin/crun",
++			"@bin_path@/bin/crun",
  		},
  		"crun-vm": {
 -			"/usr/bin/crun-vm",
@@ -22,7 +22,7 @@ index 19c4bb6bf..2743de4b2 100644
 -			"/sbin/crun-vm",
 -			"/bin/crun-vm",
 -			"/run/current-system/sw/bin/crun-vm",
-+			// TODO: "@crun-vm@/bin/crun-vm",
++			"@bin_path@/bin/crun-vm",
  		},
  		"crun-wasm": {
 -			"/usr/bin/crun-wasm",
@@ -32,7 +32,7 @@ index 19c4bb6bf..2743de4b2 100644
 -			"/sbin/crun-wasm",
 -			"/bin/crun-wasm",
 -			"/run/current-system/sw/bin/crun-wasm",
-+			// TODO: "@crun-wasm@/bin/crun-wasm",
++			"@bin_path@/bin/crun-wasm",
  		},
  		"runc": {
 -			"/usr/bin/runc",
@@ -43,11 +43,11 @@ index 19c4bb6bf..2743de4b2 100644
 -			"/bin/runc",
 -			"/usr/lib/cri-o-runc/sbin/runc",
 -			"/run/current-system/sw/bin/runc",
-+			"@runc@/bin/runc",
++			"@bin_path@/bin/runc",
  		},
  		"runj": {
 -			"/usr/local/bin/runj",
-+			// TODO: "@runj@/bin/runj",
++			"@bin_path@/bin/runj",
  		},
  		"kata": {
 -			"/usr/bin/kata-runtime",
@@ -58,7 +58,7 @@ index 19c4bb6bf..2743de4b2 100644
 -			"/bin/kata-runtime",
 -			"/usr/bin/kata-qemu",
 -			"/usr/bin/kata-fc",
-+			// TODO: "@kata@/bin/kata",
++			"@bin_path@/bin/kata-runtime",
  		},
  		"runsc": {
 -			"/usr/bin/runsc",
@@ -68,27 +68,27 @@ index 19c4bb6bf..2743de4b2 100644
 -			"/bin/runsc",
 -			"/sbin/runsc",
 -			"/run/current-system/sw/bin/runsc",
-+			"@gvisor@/bin/runsc",
++			"@bin_path@/bin/runsc",
  		},
  		"youki": {
 -			"/usr/local/bin/youki",
 -			"/usr/bin/youki",
 -			"/bin/youki",
 -			"/run/current-system/sw/bin/youki",
-+			"@youki@/bin/youki",
++			"@bin_path@/bin/youki",
  		},
  		"krun": {
 -			"/usr/bin/krun",
 -			"/usr/local/bin/krun",
-+			// TODO: "@krun@/bin/krun",
++			"@bin_path@/bin/krun",
  		},
  		"ocijail": {
 -			"/usr/local/bin/ocijail",
-+			// TODO: "@ocijail@/bin/ocijail",
++			"@bin_path@/bin/ocijail",
  		},
  	}
  	c.PlatformToOCIRuntime = map[string]string{
-@@ -443,16 +402,9 @@ func defaultEngineConfig() (*EngineConfig, error) {
+@@ -445,26 +404,12 @@ func defaultEngineConfig() (*EngineConfig, error) {
  	// Needs to be called after populating c.OCIRuntimes.
  	c.OCIRuntime = c.findRuntime()
  
@@ -103,7 +103,18 @@ index 19c4bb6bf..2743de4b2 100644
 -		"/usr/local/bin/conmon",
 -		"/usr/local/sbin/conmon",
 -		"/run/current-system/sw/bin/conmon",
-+		"@conmon@/bin/conmon",
++		"@bin_path@/bin/conmon",
  	})
  	c.ConmonRsPath.Set([]string{
- 		"/usr/libexec/podman/conmonrs",
+-		"/usr/libexec/podman/conmonrs",
+-		"/usr/local/libexec/podman/conmonrs",
+-		"/usr/local/lib/podman/conmonrs",
+-		"/usr/bin/conmonrs",
+-		"/usr/sbin/conmonrs",
+-		"/usr/local/bin/conmonrs",
+-		"/usr/local/sbin/conmonrs",
+-		"/run/current-system/sw/bin/conmonrs",
++		"@bin_path@/bin/conmonrs",
+ 	})
+ 	c.PullPolicy = DefaultPullPolicy
+ 	c.RuntimeSupportsJSON.Set([]string{


### PR DESCRIPTION
## Description of changes

Change the approach used to integrate runtimes, in order to:

- Better support macOS
- Make obscure OCI runtimes optional
- Work around a panic due to runtimes having no paths

Fixes #306398.

Context:
- https://github.com/containers/podman/issues/22561
- https://github.com/NixOS/nixpkgs/pull/301553#discussion_r1569433767
- https://github.com/NixOS/nixpkgs/pull/301553#issuecomment-2067548846

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
