### PR TITLE
python3Packages.pyrad: fix build failing

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5383,6 +5383,12 @@
     githubId = 472846;
     name = "Sebastian Krohn";
   };
+  drawbu = {
+    email = "clement21.boillot@gmail.com";
+    github = "drawbu";
+    githubId = 69208565;
+    name = "Clément Boillot";
+  };
   drets = {
     email = "dmitryrets@gmail.com";
     github = "drets";

--- a/pkgs/development/python-modules/pyrad/default.nix
+++ b/pkgs/development/python-modules/pyrad/default.nix
@@ -6,7 +6,19 @@
 , netaddr
 , six
 , unittestCheckHook
+, fetchPypi
 }:
+let
+  netaddr_0_8_0 = netaddr.overridePythonAttrs (oldAttrs: rec {
+    version = "0.8.0";
+
+    src = fetchPypi {
+      pname = "netaddr";
+      inherit version;
+      hash = "sha256-1sxXx6B7HZ0ukXqos2rozmHDW6P80bg8oxxaDuK1okM=";
+    };
+  });
+in
 
 buildPythonPackage rec {
   pname = "pyrad";
@@ -33,14 +45,21 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    netaddr
+    netaddr_0_8_0
     six
   ];
-
   preCheck = ''
     substituteInPlace tests/testServer.py \
-      --replace "def testBind(self):" "def dontTestBind(self):" \
-      --replace "def testBindv6(self):" "def dontTestBindv6(self):"
+      --replace-warn "def testBind(self):" "def dontTestBind(self):" \
+      --replace-warn "def testBindv6(self):" "def dontTestBindv6(self):" \
+
+    # A lot of test methods have been deprecated since Python 3.1
+    # and have been removed in Python 3.12.
+    # https://docs.python.org/3/whatsnew/3.11.html#pending-removal-in-python-3-12
+    substituteInPlace tests/*.py \
+      --replace-quiet "self.failUnless"   "self.assertTrue" \
+      --replace-quiet "self.failIf"       "self.assertFalse" \
+      --replace-quiet "self.assertEquals" "self.assertEqual"
   '';
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pyrad/default.nix
+++ b/pkgs/development/python-modules/pyrad/default.nix
@@ -1,12 +1,13 @@
-{ buildPythonPackage
-, fetchFromGitHub
-, fetchpatch
-, lib
-, poetry-core
-, netaddr
-, six
-, unittestCheckHook
-, fetchPypi
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  lib,
+  poetry-core,
+  netaddr,
+  six,
+  unittestCheckHook,
+  fetchPypi,
 }:
 let
   netaddr_0_8_0 = netaddr.overridePythonAttrs (oldAttrs: rec {
@@ -40,9 +41,7 @@ buildPythonPackage rec {
     })
   ];
 
-  nativeBuildInputs = [
-    poetry-core
-  ];
+  nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs = [
     netaddr_0_8_0
@@ -62,13 +61,9 @@ buildPythonPackage rec {
       --replace-quiet "self.assertEquals" "self.assertEqual"
   '';
 
-  nativeCheckInputs = [
-    unittestCheckHook
-  ];
+  nativeCheckInputs = [ unittestCheckHook ];
 
-  pythonImportsCheck = [
-    "pyrad"
-  ];
+  pythonImportsCheck = [ "pyrad" ];
 
   meta = {
     description = "Python RADIUS Implementation";

--- a/pkgs/development/python-modules/pyrad/default.nix
+++ b/pkgs/development/python-modules/pyrad/default.nix
@@ -70,10 +70,10 @@ buildPythonPackage rec {
     "pyrad"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Python RADIUS Implementation";
     homepage = "https://github.com/pyradius/pyrad";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ drawbu ];
   };
 }

--- a/pkgs/development/python-modules/pyrad/default.nix
+++ b/pkgs/development/python-modules/pyrad/default.nix
@@ -1,7 +1,6 @@
 {
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   lib,
   poetry-core,
   netaddr,
@@ -23,23 +22,15 @@ in
 
 buildPythonPackage rec {
   pname = "pyrad";
-  version = "2.4";
+  version = "2.4-unstable-2023-06-13";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "pyradius";
     repo = pname;
-    rev = version;
-    hash = "sha256-oqgkE0xG/8cmLeRZdGoHkaHbjtByeJwzBJwEdxH8oNY=";
+    rev = "dd34c5a29b46d83b0bea841e85fd72b79f315b87";
+    hash = "sha256-U4VVGkDDyN4J/tRDaDGSr2TSA4JmqIoQj5qn9qBAvQU=";
   };
-
-  patches = [
-    (fetchpatch {
-      # Migrate to poetry-core
-      url = "https://github.com/pyradius/pyrad/commit/a4b70067dd6269e14a2f9530d820390a8a454231.patch";
-      hash = "sha256-1We9wrVY3Or3GLIKK6hZvEjVYv6JOaahgP9zOMvgErE=";
-    })
-  ];
 
   nativeBuildInputs = [ poetry-core ];
 
@@ -47,18 +38,11 @@ buildPythonPackage rec {
     netaddr_0_8_0
     six
   ];
+
   preCheck = ''
     substituteInPlace tests/testServer.py \
       --replace-warn "def testBind(self):" "def dontTestBind(self):" \
       --replace-warn "def testBindv6(self):" "def dontTestBindv6(self):" \
-
-    # A lot of test methods have been deprecated since Python 3.1
-    # and have been removed in Python 3.12.
-    # https://docs.python.org/3/whatsnew/3.11.html#pending-removal-in-python-3-12
-    substituteInPlace tests/*.py \
-      --replace-quiet "self.failUnless"   "self.assertTrue" \
-      --replace-quiet "self.failIf"       "self.assertFalse" \
-      --replace-quiet "self.assertEquals" "self.assertEqual"
   '';
 
   nativeCheckInputs = [ unittestCheckHook ];


### PR DESCRIPTION
ZHF: #309482


## Description of changes

- Failing on ZHF https://hydra.nixos.org/build/258464455
- Fix `python3Packages.netaddr` to use the correct version
- Fix use of deleted methods in python312 causing build fail


## Things done

`2.4` to `2.4-unstable-2023-06-13`

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
