### PR TITLE
openlierox: 0.58rc3 -> 0.58_rc5, unbreak, refactor, adopt

### DIFF
--- a/pkgs/games/openlierox/default.nix
+++ b/pkgs/games/openlierox/default.nix
@@ -1,42 +1,79 @@
-{ lib, stdenv, fetchurl, libX11, xorgproto, gd, SDL, SDL_image, SDL_mixer, zlib
-, libxml2, pkg-config, curl, cmake, libzip }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  curl,
+  gd,
+  libX11,
+  libxml2,
+  libzip,
+  SDL,
+  SDL_image,
+  SDL_mixer,
+  zlib,
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openlierox";
-  version = "0.58rc3";
+  version = "0.58_rc5";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/openlierox/OpenLieroX_0.58_rc3.src.tar.bz2";
-    sha256 = "1k35xppfqi3qfysv81xq3hj4qdy9j2ciinbkfdcmwclcsf3nh94z";
+  src = fetchFromGitHub {
+    owner = "albertz";
+    repo = "openlierox";
+    rev = finalAttrs.version;
+    hash = "sha256-4ofjroEHlfrQitc7M+YTNWut0LGgntgQoOeBWU8nscY=";
   };
 
-  env.NIX_CFLAGS_COMPILE = "-I${libxml2.dev}/include/libxml2 -std=c++98 -Wno-error";
-
-  # The breakpad fails to build on x86_64, and it's only to report bugs upstream
-  cmakeFlags = [ "-DBREAKPAD=0" ];
-
-  preConfigure = ''
-    cmakeFlags="$cmakeFlags -DSYSTEM_DATA_DIR=$out/share"
+  postPatch = ''
+    sed 1i'#include <cstdint>' -i src/common/s*x.cpp
+    sed 1i'#include <libxml/parser.h>' -i include/XMLutils.h
+    substituteInPlace src/common/StringUtils.cpp \
+        --replace-fail "xmlErrorPtr" "const xmlError*"
   '';
 
-  patchPhase = ''
-    sed -i s,curl/types.h,curl/curl.h, include/HTTP.h src/common/HTTP.cpp
-  '';
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    SDL
+  ];
+
+  buildInputs = [
+    curl
+    gd
+    libX11
+    libxml2
+    libzip
+    SDL
+    SDL_image
+    SDL_mixer
+    zlib
+  ];
+
+  cmakeFlags = [ "-DSYSTEM_DATA_DIR=${placeholder "out"}/share" ];
+
+  env.NIX_CFLAGS_COMPILE = "-I${lib.getDev libxml2}/include/libxml2";
 
   installPhase = ''
-    mkdir -p $out/bin $out/share/OpenLieroX
-    cp bin/* $out/bin
-    cp -R ../share/gamedir/* $out/share/OpenLieroX
+    runHook preInstall
+
+    install -Dm755 bin/* -t $out/bin
+
+    mkdir -p $out/share/OpenLieroX
+    cp -r ../share/gamedir/* $out/share/OpenLieroX
+
+    runHook postInstall
   '';
 
-  nativeBuildInputs = [ cmake pkg-config curl ];
-  buildInputs = [ libX11 xorgproto gd SDL SDL_image SDL_mixer zlib libxml2
-    libzip ];
-
   meta = {
-    homepage = "http://openlierox.net";
     description = "Real-time game with Worms-like shooting";
+    homepage = "http://openlierox.net";
     license = lib.licenses.lgpl2Plus;
+    mainProgram = "openlierox";
+    maintainers = with lib.maintainers; [ tomasajt ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

ZHF: https://github.com/NixOS/nixpkgs/issues/309482

I formatted the code and moved the locations of the dependencies around so the diff is pretty big, so here are the most important things done:
- format with nixfmt
- bump version
- use github source
- patch some files that had issues related to `libxml2` and `gcc13`
  - I censored a word here with glob expansion :)
- set `strictDeps`
- run appropriate hooks


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
