### PR TITLE
librecast: 0.7.0 ->  0.8.0, lcsync: 0.2.1 -> 0.3.0

### DIFF
--- a/pkgs/applications/networking/sync/lcsync/default.nix
+++ b/pkgs/applications/networking/sync/lcsync/default.nix
@@ -8,14 +8,14 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   name = "lcsync";
-  version = "0.2.1";
+  version = "0.3.0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "librecast";
     repo = "lcsync";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-RVfa0EmCPPT7ndy94YwD24S9pj7L11ztISaKHGcbTS8=";
+    hash = "sha256-eiYbS/LYnM2ZjDHO9KhBp1rrovbhm+OVVfmLtjxAE+Y=";
   };
   buildInputs = [ lcrq librecast libsodium ];
   configureFlags = [ "SETCAP_PROGRAM=true" ];

--- a/pkgs/development/libraries/librecast/default.nix
+++ b/pkgs/development/libraries/librecast/default.nix
@@ -7,14 +7,14 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   name = "librecast";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "librecast";
     repo = "librecast";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-NlwYJJn1yewx92y6UKJcj6R2MnPn+XuEiKOmsR2oE3g=";
+    hash = "sha256-8Qit1KFazVG+2TEmSGXiBNawvpc7Ihr/0mx4KCzBoAY=";
   };
   buildInputs = [ lcrq libsodium ];
   installFlags = [ "PREFIX=$(out)" ];


### PR DESCRIPTION
## Description of changes

- https://codeberg.org/librecast/librecast/src/branch/main/CHANGELOG.md#0-8-0-2023-11-07
- https://codeberg.org/librecast/lcsync/src/commit/89c15c85061caa719115ad505cb466429e4680bf/CHANGELOG.md#0-3-0-2023-11-07

NOTE: please let me know if splitting this into a PR per-package would preferred. These are coupled changes.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
