### PR TITLE
adding mirrord dev tool

### DIFF
--- a/pkgs/development/tools/mirrord/default.nix
+++ b/pkgs/development/tools/mirrord/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchurl, lib, unzip }:
+let
+  inherit (stdenv.hostPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
+
+  plat = {
+    x86_64-linux = "linux_x86_64";
+    x86_64-darwin = "mac_universal";
+    aarch64-linux = "linux_aarch64";
+    aarch64-darwin = "mac_universal";
+  }.${system} or throwSystem;
+
+  sha256 = {
+    x86_64-linux = "0iqmgvbjpsls28ky1r3milzy44jjz7hf70b0vvhby5xnwbc38bx2";
+    x86_64-darwin = "1w2bhsh8q9yqbp4y9a1g3rzf9b5nby42qas2531pkf1jzl06di44";
+    aarch64-linux = "0vj8wv8plm1pj10p2p1g5g50h9l7i5qzag5n3frgpsaz4dd53rkj";
+    aarch64-darwin = "1w2bhsh8q9yqbp4y9a1g3rzf9b5nby42qas2531pkf1jzl06di44";
+  }.${system} or throwSystem;
+in
+  stdenv.mkDerivation rec {
+    pname = "mirrord";
+    version = "3.100.1";
+
+    src = fetchurl {
+      url = "https://github.com/metalbear-co/${pname}/releases/download/${version}/${pname}_${plat}.zip";
+      inherit sha256;
+    };
+
+    nativeBuildInputs = [ unzip ];
+    dontBuild = true;
+    dontConfigure = true;
+    noDumpEnvVars = true;
+
+    unpackPhase = ''
+      mkdir -p $out/unpacked
+      unzip $src -d $out/unpacked
+    '';
+
+    installPhase = ''
+      mkdir -p $out/bin
+      mv $out/unpacked/* $out/bin/
+      chmod +x $out/bin/*
+    '';
+
+    meta = {
+      description = "mirrord lets developers run local processes in the context of their Kubernetes environment";
+      homepage = "https://github.com/metalbear-co/mirrord";
+      license = lib.licenses.mit;
+      platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+    };
+  }


### PR DESCRIPTION
## Description of changes

[mirrord lets developers run local processes in the context of their Kubernetes environment](https://mirrord.dev/). It’s meant to provide the benefits of running your service on a cloud environment (e.g. staging) without actually going through the hassle of deploying it there, and without disrupting the environment by deploying untested code. It comes as a Visual Studio Code extension, an IntelliJ plugin and a CLI tool. You can read more about it [here](https://mirrord.dev/docs/overview/introduction/).

https://github.com/metalbear-co/mirrord

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
