### PR TITLE
python311Packages.gradio-client: 0.14.0 -> 0.16.1, python311Packages.gradio: 4.27.0 -> 4.29.0

### DIFF
--- a/pkgs/development/python-modules/gradio/client.nix
+++ b/pkgs/development/python-modules/gradio/client.nix
@@ -28,8 +28,8 @@
 
 buildPythonPackage rec {
   pname = "gradio-client";
-  version = "0.14.0";
-  format = "pyproject";
+  version = "0.16.1";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
@@ -37,9 +37,9 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "gradio-app";
     repo = "gradio";
-    rev = "refs/tags/@gradio/client@${version}";
+    rev = "refs/tags/gradio_client@${version}";
     sparseCheckout = [ "client/python" ];
-    hash = "sha256-7oC/Z3YUiOFZdv/60q7PkfluV77broRkHgWiY9Vim9Y=";
+    hash = "sha256-SVUm9LrjYG0r3U1yOd3rctxVMYlnAOW+Opqy9c3osnw=";
   };
   prePatch = ''
     cd client/python
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     "websockets"
   ];
 
-  nativeBuildInputs = [
+  build-system = [
     hatchling
     hatch-requirements-txt
     hatch-fancy-pypi-readme

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -62,7 +62,7 @@
 
 buildPythonPackage rec {
   pname = "gradio";
-  version = "4.27.0";
+  version = "4.29.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -71,7 +71,7 @@ buildPythonPackage rec {
   # and upstream has stopped tagging releases since 3.41.0
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-617zutFhS8NGO4+fcALH8aKbk+reGC65DNWKVVKiWEw=";
+    hash = "sha256-17KT0b9kBO+xLgIgxfpwjETDoRM4aTJPlJv7HjkJXjo=";
   };
 
   # fix packaging.ParserSyntaxError, which can't handle comments


### PR DESCRIPTION
## Description of changes

gradio-client is currently broken on `master`.
Note: this patch is not working yet.

fixes #310761

Changelogs:
- https://github.com/gradio-app/gradio/releases/tag/gradio_client%400.16.1
- https://github.com/gradio-app/gradio/releases/tag/gradio%404.29.0

cc @pbsds @drupol 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
