### PR TITLE
batman-adv: 2024.0 -> 2024.1

### DIFF
--- a/pkgs/os-specific/linux/batman-adv/version.nix
+++ b/pkgs/os-specific/linux/batman-adv/version.nix
@@ -1,16 +1,16 @@
 {
-  version = "2024.0";
+  version = "2024.1";
 
   # To get these, run:
   #
   # ```
   # for tool in alfred batctl batman-adv; do
-  #   nix-prefetch-url https://downloads.open-mesh.org/batman/releases/batman-adv-2024.0/$tool-2024.0.tar.gz --type sha256 | xargs nix hash to-sri --type sha256
+  #   nix-prefetch-url https://downloads.open-mesh.org/batman/releases/batman-adv-2024.1/$tool-2024.1.tar.gz --type sha256 | xargs nix hash to-sri --type sha256
   # done
   # ```
   sha256 = {
-    alfred = "sha256-0CmkNjirFnceX3HhNLyEPRcT10BBxlvNoYox0Y9VMb0=";
-    batctl = "sha256-doU+hyAa9jxBHbFS/QxiWnKalzMRWJfRMxYE4sWmfH0=";
-    batman-adv = "sha256-YREGl7V5n2RqKoKk3Pl/rtS7EqfMQ79Gg9LE3k9rQOc=";
+    alfred = "sha256-Ji2tOcm+EirH8GFwXIo+O21GJ4K74zcubfyazgw4Tbk=";
+    batctl = "sha256-aD3anWBU6yYKGsACLGQnmP9ASNbFOmcuoLMXjmt1egk=";
+    batman-adv = "sha256-pxQynGJR9IMOnPA/U8v7IoDwZ4RxtUxdRvrmGngtQyU=";
   };
 }


### PR DESCRIPTION
## Description of changes

* support latest kernels (4.19 - 6.9)
* coding style cleanups and refactoring
* bugs squashed:
  - avoid infinite loop while trying to resize local translation table

Changelog: https://www.open-mesh.org/news/116

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
