### PR TITLE
deepin.dtk6: init

### DIFF
--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -27,6 +27,7 @@ let
     dtk6gui = callPackage ./library/dtk6gui { };
     dtk6widget = callPackage ./library/dtk6widget { };
     dtk6declarative = callPackage ./library/dtk6declarative { };
+    dtk6systemsettings = callPackage ./library/dtk6systemsettings { };
 
     #### CORE
     deepin-kwin = callPackage ./core/deepin-kwin { };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -7,7 +7,6 @@ let
     #### LIBRARIES
     dtkcommon = callPackage ./library/dtkcommon { };
     dtkcore = callPackage ./library/dtkcore { };
-    dtk6core = callPackage ./library/dtk6core { };
     dtkgui = callPackage ./library/dtkgui { };
     dtkwidget = callPackage ./library/dtkwidget { };
     dtkdeclarative = callPackage ./library/dtkdeclarative { };
@@ -24,6 +23,8 @@ let
     image-editor = callPackage ./library/image-editor { };
     udisks2-qt5 = callPackage ./library/udisks2-qt5 { };
     util-dfm = callPackage ./library/util-dfm { };
+    dtk6core = callPackage ./library/dtk6core { };
+    dtk6gui = callPackage ./library/dtk6gui { };
 
     #### CORE
     deepin-kwin = callPackage ./core/deepin-kwin { };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -26,6 +26,7 @@ let
     dtk6core = callPackage ./library/dtk6core { };
     dtk6gui = callPackage ./library/dtk6gui { };
     dtk6widget = callPackage ./library/dtk6widget { };
+    dtk6declarative = callPackage ./library/dtk6declarative { };
 
     #### CORE
     deepin-kwin = callPackage ./core/deepin-kwin { };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -7,6 +7,7 @@ let
     #### LIBRARIES
     dtkcommon = callPackage ./library/dtkcommon { };
     dtkcore = callPackage ./library/dtkcore { };
+    dtk6core = callPackage ./library/dtk6core { };
     dtkgui = callPackage ./library/dtkgui { };
     dtkwidget = callPackage ./library/dtkwidget { };
     dtkdeclarative = callPackage ./library/dtkdeclarative { };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -25,6 +25,7 @@ let
     util-dfm = callPackage ./library/util-dfm { };
     dtk6core = callPackage ./library/dtk6core { };
     dtk6gui = callPackage ./library/dtk6gui { };
+    dtk6widget = callPackage ./library/dtk6widget { };
 
     #### CORE
     deepin-kwin = callPackage ./core/deepin-kwin { };

--- a/pkgs/desktops/deepin/library/dtk6core/default.nix
+++ b/pkgs/desktops/deepin/library/dtk6core/default.nix
@@ -1,0 +1,84 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, doxygen
+, qt6Packages
+, lshw
+, libuchardet
+, spdlog
+, dtkcommon
+, systemd
+, withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dtk6core";
+  version = "6.0.15";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = "dtk6core";
+    rev = finalAttrs.version;
+    hash = "sha256-zUJFilafR0hNH/Owmuyh6BLBFPbBuFKcHv40fena0GM=";
+  };
+
+  patches = [
+    ./fix-pkgconfig-path.patch
+    ./fix-pri-path.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    doxygen
+    qt6Packages.qttools
+    qt6Packages.wrapQtAppsHook
+  ];
+
+  dontWrapQtApps = true;
+
+  buildInputs = [
+    qt6Packages.qtbase
+    lshw
+    libuchardet
+    spdlog
+  ]
+  ++ lib.optional withSystemd systemd;
+
+  propagatedBuildInputs = [ dtkcommon ];
+
+  cmakeFlags = [
+    "-DDTK_VERSION=${finalAttrs.version}"
+    "-DBUILD_DOCS=ON"
+    "-DBUILD_EXAMPLES=OFF"
+    "-DQCH_INSTALL_DESTINATION=${placeholder "doc"}/share/doc"
+    "-DDSG_PREFIX_PATH='/run/current-system/sw'"
+    "-DMKSPECS_INSTALL_DIR=${placeholder "out"}/mkspecs/modules"
+    "-DD_DSG_APP_DATA_FALLBACK=/var/dsg/appdata"
+    "-DBUILD_WITH_SYSTEMD=${if withSystemd then "ON" else "OFF"}"
+  ];
+
+  preConfigure = ''
+    # qt.qpa.plugin: Could not find the Qt platform plugin "minimal"
+    # A workaround is to set QT_PLUGIN_PATH explicitly
+    export QT_PLUGIN_PATH=${lib.getBin qt6Packages.qtbase}/${qt6Packages.qtbase.qtPluginPrefix}
+  '';
+
+  outputs = [ "out" "dev" "doc" ];
+
+  postFixup = ''
+    for binary in $out/libexec/dtk6/DCore/bin/*; do
+      wrapQtApp $binary
+    done
+  '';
+
+  meta = {
+    description = "Deepin tool kit core library";
+    homepage = "https://github.com/linuxdeepin/dtk6core";
+    license = lib.licenses.lgpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = lib.teams.deepin.members;
+  };
+})

--- a/pkgs/desktops/deepin/library/dtk6core/fix-pkgconfig-path.patch
+++ b/pkgs/desktops/deepin/library/dtk6core/fix-pkgconfig-path.patch
@@ -1,0 +1,14 @@
+diff --git a/misc/dtkcore.pc.in b/misc/dtkcore.pc.in
+index 83eecb7..da24ce8 100644
+--- a/misc/dtkcore.pc.in
++++ b/misc/dtkcore.pc.in
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${prefix}/@LIBRARY_INSTALL_DIR@
+-includedir=${prefix}/@INCLUDE_INSTALL_DIR@
++libdir=@LIBRARY_INSTALL_DIR@
++includedir=@INCLUDE_INSTALL_DIR@
+ 
+ Name: dtk@DTK_VERSION_MAJOR@core
+ Description: Deepin Tool Kit dtkcore header files

--- a/pkgs/desktops/deepin/library/dtk6core/fix-pri-path.patch
+++ b/pkgs/desktops/deepin/library/dtk6core/fix-pri-path.patch
@@ -1,0 +1,17 @@
+diff --git a/misc/qt_lib_dtkcore.pri.in b/misc/qt_lib_dtkcore.pri.in
+index a331f52..ce01dc0 100644
+--- a/misc/qt_lib_dtkcore.pri.in
++++ b/misc/qt_lib_dtkcore.pri.in
+@@ -4,9 +4,9 @@ QT.dtkcore.MINOR_VERSION = @PROJECT_VERSION_MINOR@
+ QT.dtkcore.PATCH_VERSION = @PROJECT_VERSION_PATCH@
+ QT.dtkcore.name = dtkcore
+ QT.dtkcore.module = dtk@DTK_VERSION_MAJOR@core
+-QT.dtkcore.tools = @CMAKE_INSTALL_PREFIX@/@TOOL_INSTALL_DIR@
+-QT.dtkcore.libs = @CMAKE_INSTALL_PREFIX@/@LIBRARY_INSTALL_DIR@
+-QT.dtkcore.includes = @CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_DIR@
++QT.dtkcore.tools = @TOOL_INSTALL_DIR@
++QT.dtkcore.libs = @LIBRARY_INSTALL_DIR@
++QT.dtkcore.includes = @INCLUDE_INSTALL_DIR@
+ QT.dtkcore.frameworks =
+ QT.dtkcore.depends = core dbus xml
+ QT.dtkcore.module_config = v2 ltcg

--- a/pkgs/desktops/deepin/library/dtk6declarative/default.nix
+++ b/pkgs/desktops/deepin/library/dtk6declarative/default.nix
@@ -1,0 +1,70 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, doxygen
+, qt6Packages
+, dtk6gui
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dtk6declarative";
+  version = "6.0.15";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = "dtk6declarative";
+    rev = finalAttrs.version;
+    hash = "sha256-euHEfK2N2jtWMzeajgvTnHSl39zXwp7I0cQIqZRVGZ0=";
+  };
+
+  patches = [
+    ./fix-pkgconfig-path.patch
+    ./fix-pri-path.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    doxygen
+    qt6Packages.qttools
+    qt6Packages.wrapQtAppsHook
+  ];
+
+  propagatedBuildInputs = [
+    dtk6gui
+  ] ++ (with qt6Packages ; [
+    qtbase
+    qtdeclarative
+    qtshadertools
+    qt5compat
+  ]);
+
+  cmakeFlags = [
+    "-DDTK_VERSION=${finalAttrs.version}"
+    "-DBUILD_DOCS=ON"
+    "-DBUILD_EXAMPLES=ON"
+    "-DMKSPECS_INSTALL_DIR=${placeholder "dev"}/mkspecs/modules"
+    "-DQCH_INSTALL_DESTINATION=${placeholder "doc"}/share/doc"
+    "-DQML_INSTALL_DIR=${placeholder "out"}/${qt6Packages.qtbase.qtQmlPrefix}"
+  ];
+
+  preConfigure = ''
+    # qt.qpa.plugin: Could not find the Qt platform plugin "minimal"
+    # A workaround is to set QT_PLUGIN_PATH explicitly
+    export QT_PLUGIN_PATH=${lib.getBin qt6Packages.qtbase}/${qt6Packages.qtbase.qtPluginPrefix}
+    export QML2_IMPORT_PATH=${lib.getBin qt6Packages.qtdeclarative}/${qt6Packages.qtbase.qtQmlPrefix}
+  '';
+
+  outputs = [ "out" "dev" "doc" ];
+
+  meta = {
+    description = "A widget development toolkit based on QtQuick/QtQml";
+    mainProgram = "dtk-exhibition";
+    homepage = "https://github.com/linuxdeepin/dtk6declarative";
+    license = lib.licenses.lgpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = lib.teams.deepin.members;
+  };
+})

--- a/pkgs/desktops/deepin/library/dtk6declarative/fix-pkgconfig-path.patch
+++ b/pkgs/desktops/deepin/library/dtk6declarative/fix-pkgconfig-path.patch
@@ -1,0 +1,14 @@
+diff --git a/misc/dtkdeclarative.pc.in b/misc/dtkdeclarative.pc.in
+index dc3827f..fd0949e 100644
+--- a/misc/dtkdeclarative.pc.in
++++ b/misc/dtkdeclarative.pc.in
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${prefix}/@LIB_INSTALL_DIR@
+-includedir=${prefix}/@INCLUDE_INSTALL_DIR@
++libdir=@LIB_INSTALL_DIR@
++includedir=@INCLUDE_INSTALL_DIR@
+ 
+ Name: DtkDeclarative
+ Description: Deepin Tool Kit DtkDeclarative header files

--- a/pkgs/desktops/deepin/library/dtk6declarative/fix-pri-path.patch
+++ b/pkgs/desktops/deepin/library/dtk6declarative/fix-pri-path.patch
@@ -1,0 +1,15 @@
+diff --git a/misc/qt_lib_dtkdeclarative.pri.in b/misc/qt_lib_dtkdeclarative.pri.in
+index 8797802..44e32a3 100644
+--- a/misc/qt_lib_dtkdeclarative.pri.in
++++ b/misc/qt_lib_dtkdeclarative.pri.in
+@@ -4,8 +4,8 @@ QT.dtkdeclarative.MINOR_VERSION = @PROJECT_VERSION_MINOR@
+ QT.dtkdeclarative.PATCH_VERSION = @PROJECT_VERSION_PATCH@
+ QT.dtkdeclarative.name = dtkdeclarative
+ QT.dtkdeclarative.module = dtk@DTK_VERSION_MAJOR@declarative
+-QT.dtkdeclarative.libs = @CMAKE_INSTALL_PREFIX@/@LIB_INSTALL_DIR@
+-QT.dtkdeclarative.includes = @CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_DIR@
++QT.dtkdeclarative.libs = @LIB_INSTALL_DIR@
++QT.dtkdeclarative.includes = @INCLUDE_INSTALL_DIR@
+ QT.dtkdeclarative.frameworks =
+ QT.dtkdeclarative.depends = core dbus xml gui dtkcore dtkgui quick quick_private
+ QT.dtkdeclarative.module_config = v2 ltcg

--- a/pkgs/desktops/deepin/library/dtk6gui/default.nix
+++ b/pkgs/desktops/deepin/library/dtk6gui/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, doxygen
+, qt6Packages
+, dtk6core
+, librsvg
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dtk6gui";
+  version = "6.0.15";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = "dtk6gui";
+    rev = finalAttrs.version;
+    hash = "sha256-B/A3VXPCon+NIUhO+IVGoojACVjut2h0nH5pLdJYufw=";
+  };
+
+  patches = [
+    ./fix-pkgconfig-path.patch
+    ./fix-pri-path.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    doxygen
+    qt6Packages.qttools
+    qt6Packages.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6Packages.qtbase
+    librsvg
+  ];
+
+  propagatedBuildInputs = [
+    dtk6core
+    qt6Packages.qtimageformats
+  ];
+
+  cmakeFlags = [
+    "-DDTK_VERSION=${finalAttrs.version}"
+    "-DBUILD_DOCS=ON"
+    "-DMKSPECS_INSTALL_DIR=${placeholder "out"}/mkspecs/modules"
+    "-DQCH_INSTALL_DESTINATION=${placeholder "doc"}/share/doc"
+  ];
+
+  preConfigure = ''
+    # qt.qpa.plugin: Could not find the Qt platform plugin "minimal"
+    # A workaround is to set QT_PLUGIN_PATH explicitly
+    export QT_PLUGIN_PATH=${lib.getBin qt6Packages.qtbase}/${qt6Packages.qtbase.qtPluginPrefix}
+  '';
+
+  outputs = [ "out" "dev" "doc" ];
+
+  postFixup = ''
+    for binary in $out/libexec/dtk6/DGui/bin/*; do
+      wrapQtApp $binary
+    done
+  '';
+
+  meta = {
+    description = "Deepin Toolkit, gui module for DDE look and feel";
+    homepage = "https://github.com/linuxdeepin/dtk6gui";
+    license = lib.licenses.lgpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = lib.teams.deepin.members;
+  };
+})

--- a/pkgs/desktops/deepin/library/dtk6gui/fix-pkgconfig-path.patch
+++ b/pkgs/desktops/deepin/library/dtk6gui/fix-pkgconfig-path.patch
@@ -1,0 +1,16 @@
+diff --git a/misc/dtkgui.pc.in b/misc/dtkgui.pc.in
+index 89fdbbf..ad817c4 100644
+--- a/misc/dtkgui.pc.in
++++ b/misc/dtkgui.pc.in
+@@ -1,8 +1,8 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${prefix}/@LIBRARY_INSTALL_DIR@
+-includedir=${prefix}/@INCLUDE_INSTALL_DIR@
+-tooldir=${prefix}/@PACKAGE_TOOL_INSTALL_DIR@
++libdir=@LIBRARY_INSTALL_DIR@
++includedir=@INCLUDE_INSTALL_DIR@
++tooldir=@PACKAGE_TOOL_INSTALL_DIR@
+ 
+ Name: dtk@DTK_VERSION_MAJOR@gui
+ Description: Deepin Tool Kit dtkgui header files

--- a/pkgs/desktops/deepin/library/dtk6gui/fix-pri-path.patch
+++ b/pkgs/desktops/deepin/library/dtk6gui/fix-pri-path.patch
@@ -1,0 +1,17 @@
+diff --git a/misc/qt_lib_dtkgui.pri.in b/misc/qt_lib_dtkgui.pri.in
+index 28308ee..9fb25e6 100644
+--- a/misc/qt_lib_dtkgui.pri.in
++++ b/misc/qt_lib_dtkgui.pri.in
+@@ -4,9 +4,9 @@ QT.dtkgui.MINOR_VERSION = @PROJECT_VERSION_MINOR@
+ QT.dtkgui.PATCH_VERSION = @PROJECT_VERSION_PATCH@
+ QT.dtkgui.name = dtkgui
+ QT.dtkgui.module = dtk@DTK_VERSION_MAJOR@gui
+-QT.dtkgui.tools = @CMAKE_INSTALL_PREFIX@/@TOOL_INSTALL_DIR@
+-QT.dtkgui.libs = @CMAKE_INSTALL_PREFIX@/@LIBRARY_INSTALL_DIR@
+-QT.dtkgui.includes = @CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_DIR@
++QT.dtkgui.tools = @TOOL_INSTALL_DIR@
++QT.dtkgui.libs = @LIBRARY_INSTALL_DIR@
++QT.dtkgui.includes = @INCLUDE_INSTALL_DIR@
+ QT.dtkgui.frameworks =
+ QT.dtkgui.depends = core gui dtkcore gui_private dbus network
+ QT.dtkgui.module_config = v2 internal_module ltcg

--- a/pkgs/desktops/deepin/library/dtk6systemsettings/default.nix
+++ b/pkgs/desktops/deepin/library/dtk6systemsettings/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, pkg-config
+, doxygen
+, qt6Packages
+, dtk6core
+, libxcrypt
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dtk6systemsettings";
+  version = "6.0.2";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    hash = "sha256-b/iI2OKQQoFj3vWatfGdDP9z+SEsK5XBra9KqjlGzqs=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    doxygen
+    qt6Packages.qttools
+  ];
+
+  dontWrapQtApps = true;
+
+  buildInputs = [
+    qt6Packages.qtbase
+    dtk6core
+    libxcrypt
+  ];
+
+  cmakeFlags = [
+    "-DDTK_VERSION=${version}"
+    "-DBUILD_DOCS=ON"
+    "-DBUILD_EXAMPLES=OFF"
+    "-DQCH_INSTALL_DESTINATION=${placeholder "doc"}/share/doc"
+    "-DMKSPECS_INSTALL_DIR=${placeholder "out"}/mkspecs/modules"
+    "-DDTK_INCLUDE_INSTALL_DIR=${placeholder "dev"}/include/dtk/DSystemSettings"
+  ];
+
+  preConfigure = ''
+    # qt.qpa.plugin: Could not find the Qt platform plugin "minimal"
+    # A workaround is to set QT_PLUGIN_PATH explicitly
+    export QT_PLUGIN_PATH=${lib.getBin qt6Packages.qtbase}/${qt6Packages.qtbase.qtPluginPrefix}
+  '';
+
+  outputs = [ "out" "dev" "doc" ];
+
+  meta = {
+    description = "Qt-based development library for system settings";
+    homepage = "https://github.com/linuxdeepin/dtk6systemsettings";
+    license = lib.licenses.lgpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = lib.teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/library/dtk6widget/default.nix
+++ b/pkgs/desktops/deepin/library/dtk6widget/default.nix
@@ -1,0 +1,83 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, doxygen
+, qt6Packages
+, dtk6gui
+, cups
+, libstartup_notification
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dtk6widget";
+  version = "6.0.15";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = "dtk6widget";
+    rev = finalAttrs.version;
+    hash = "sha256-QCdRjkD4JTPecLeZK+Y5U/H9pBgKI4DHRuchz/GymWQ=";
+  };
+
+  patches = [
+    ./fix-pkgconfig-path.patch
+    ./fix-pri-path.patch
+    ./fix-build-on-qt-6_7.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace src/widgets/dapplication.cpp \
+      --replace-fail "auto dataDirs = DStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);" \
+                "auto dataDirs = DStandardPaths::standardLocations(QStandardPaths::GenericDataLocation) << \"$out/share\";"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    pkg-config
+    qt6Packages.qttools
+    qt6Packages.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    cups
+    libstartup_notification
+  ] ++ (with qt6Packages; [
+    qtbase
+    qtmultimedia
+    qtsvg
+  ]);
+
+  propagatedBuildInputs = [ dtk6gui ];
+
+  cmakeFlags = [
+    "-DDTK_VERSION=${finalAttrs.version}"
+    "-DBUILD_DOCS=ON"
+    "-DMKSPECS_INSTALL_DIR=${placeholder "dev"}/mkspecs/modules"
+    "-DQCH_INSTALL_DESTINATION=${placeholder "doc"}/share/doc"
+  ];
+
+  preConfigure = ''
+    # qt.qpa.plugin: Could not find the Qt platform plugin "minimal"
+    # A workaround is to set QT_PLUGIN_PATH explicitly
+    export QT_PLUGIN_PATH=${lib.getBin qt6Packages.qtbase}/${qt6Packages.qtbase.qtPluginPrefix}
+  '';
+
+  outputs = [ "out" "dev" "doc" ];
+
+  postFixup = ''
+    for binary in $out/lib/dtk6/DWidget/bin/*; do
+      wrapQtApp $binary
+    done
+  '';
+
+  meta = {
+    description = "Deepin graphical user interface library";
+    homepage = "https://github.com/linuxdeepin/dtk6widget";
+    license = lib.licenses.lgpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = lib.teams.deepin.members;
+  };
+})

--- a/pkgs/desktops/deepin/library/dtk6widget/fix-build-on-qt-6_7.patch
+++ b/pkgs/desktops/deepin/library/dtk6widget/fix-build-on-qt-6_7.patch
@@ -1,0 +1,20 @@
+diff --git a/src/widgets/dkeysequenceedit.cpp b/src/widgets/dkeysequenceedit.cpp
+index a99e17ae..0e1c57f6 100644
+--- a/src/widgets/dkeysequenceedit.cpp
++++ b/src/widgets/dkeysequenceedit.cpp
+@@ -276,13 +276,13 @@ void DKeySequenceEdit::keyPressEvent(QKeyEvent *e)
+     }
+ 
+     if (e->modifiers() & Qt::ShiftModifier) {
+-        QList<int> possibleKeys = QKeyMapper::possibleKeys(e);
++        auto possibleKeys = QKeyMapper::possibleKeys(e);
+         int pkTotal = possibleKeys.count();
+         if (!pkTotal)
+             return;
+         bool found = false;
+         for (int i = 0; i < possibleKeys.size(); ++i) {
+-            if (possibleKeys.at(i) - nextKey == int(e->modifiers())
++            if (static_cast<int>(possibleKeys.at(i)) - nextKey == static_cast<int>(e->modifiers())
+                 || (possibleKeys.at(i) == nextKey && e->modifiers() == Qt::ShiftModifier)) {
+                 nextKey = possibleKeys.at(i);
+                 found = true;

--- a/pkgs/desktops/deepin/library/dtk6widget/fix-pkgconfig-path.patch
+++ b/pkgs/desktops/deepin/library/dtk6widget/fix-pkgconfig-path.patch
@@ -1,0 +1,14 @@
+diff --git a/misc/DtkWidget.pc.in b/misc/DtkWidget.pc.in
+index 3c610669..b6ed04ca 100644
+--- a/misc/DtkWidget.pc.in
++++ b/misc/DtkWidget.pc.in
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${prefix}/@LIBRARY_INSTALL_DIR@
+-includedir=${prefix}/@INCLUDE_INSTALL_DIR@
++libdir=@LIBRARY_INSTALL_DIR@
++includedir=@INCLUDE_INSTALL_DIR@
+ 
+ Name: dtk@DTK_VERSION_MAJOR@widget
+ Description: Deepin Tool Kit dtkwidget header files

--- a/pkgs/desktops/deepin/library/dtk6widget/fix-pri-path.patch
+++ b/pkgs/desktops/deepin/library/dtk6widget/fix-pri-path.patch
@@ -1,0 +1,17 @@
+diff --git a/misc/qt_lib_DtkWidget.pri.in b/misc/qt_lib_DtkWidget.pri.in
+index 623878d3..561f5186 100644
+--- a/misc/qt_lib_DtkWidget.pri.in
++++ b/misc/qt_lib_DtkWidget.pri.in
+@@ -4,9 +4,9 @@ QT.dtkwidget.MINOR_VERSION = @PROJECT_VERSION_MINOR@
+ QT.dtkwidget.PATCH_VERSION = @PROJECT_VERSION_PATCH@
+ QT.dtkwidget.name = dtkwidget
+ QT.dtkwidget.module = dtk@DTK_VERSION_MAJOR@widget
+-QT.dtkwidget.tools = @CMAKE_INSTALL_PREFIX@/@TOOL_INSTALL_DIR@
+-QT.dtkwidget.libs = @CMAKE_INSTALL_PREFIX@/@LIBRARY_INSTALL_DIR@
+-QT.dtkwidget.includes = @CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_DIR@
++QT.dtkwidget.tools = @TOOL_INSTALL_DIR@
++QT.dtkwidget.libs = @LIBRARY_INSTALL_DIR@
++QT.dtkwidget.includes = @INCLUDE_INSTALL_DIR@
+ QT.dtkwidget.frameworks =
+ QT.dtkwidget.depends = core gui dtkcore network concurrent dtkgui printsupport printsupport_private widgets widgets_private gui_private x11extras dbus
+ QT.dtkwidget.module_config = v2 internal_module ltcg


### PR DESCRIPTION
## Description of changes

close: https://github.com/NixOS/nixpkgs/pull/296102

The basic development library of deepin desktop environment build on qt 6


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
