### PR TITLE
libwacom-surface: 2.7.0 -> 2.10.0

### DIFF
--- a/pkgs/development/libraries/libwacom/surface.nix
+++ b/pkgs/development/libraries/libwacom/surface.nix
@@ -7,8 +7,8 @@ let
   libwacom-surface = fetchFromGitHub {
     owner = "linux-surface";
     repo = "libwacom-surface";
-    rev = "v2.7.0-1";
-    hash = "sha256-LgJ8YFQQN05kyd6kxBakIIiGgZ9icW27xKK3Dz6TwLs=";
+    rev = "v2.10.0-1";
+    hash = "sha256-5/9X20veXazXEdSDGY5aMGQixulqMlC5Av0NGOF9m98=";
   };
 in libwacom.overrideAttrs (old: {
   pname = "libwacom-surface";
@@ -23,11 +23,15 @@ in libwacom.overrideAttrs (old: {
     "0005-data-Add-Microsoft-Surface-Pro-5.patch"
     "0006-data-Add-Microsoft-Surface-Pro-6.patch"
     "0007-data-Add-Microsoft-Surface-Pro-7.patch"
-    "0008-data-Add-Microsoft-Surface-Book.patch"
-    "0009-data-Add-Microsoft-Surface-Book-2-13.5.patch"
-    "0010-data-Add-Microsoft-Surface-Book-2-15.patch"
-    "0011-data-Add-Microsoft-Surface-Book-3-13.5.patch"
-    "0012-data-Add-Microsoft-Surface-Book-3-15.patch"
+    "0008-data-Add-Microsoft-Surface-Pro-7.patch"
+    "0009-data-Add-Microsoft-Surface-Pro-8.patch"
+    "0010-data-Add-Microsoft-Surface-Pro-9.patch"
+    "0011-data-Add-Microsoft-Surface-Book.patch"
+    "0012-data-Add-Microsoft-Surface-Book-2-13.5.patch"
+    "0013-data-Add-Microsoft-Surface-Book-2-15.patch"
+    "0014-data-Add-Microsoft-Surface-Book-3-13.5.patch"
+    "0015-data-Add-Microsoft-Surface-Book-3-15.patch"
+    "0016-data-Add-Microsoft-Surface-Laptop-Studio.patch"
   ];
 
   meta = old.meta // {


### PR DESCRIPTION
## Description of changes

https://github.com/linux-surface/libwacom-surface/releases/tag/v2.10.0-1

Adds patches for:
Surface Pro 7 (additional for some reason)
Surface Pro 8
Surface Pro 9
Surface Laptop Studio 1

As shown here:
https://github.com/linux-surface/libwacom-surface/tree/master/patches/v2

And per this issue:
https://github.com/linux-surface/linux-surface/issues/1440
