### PR TITLE
buildsupport/php: add passthru.updateScript

### DIFF
--- a/pkgs/build-support/php/builders/v1/build-composer-project.nix
+++ b/pkgs/build-support/php/builders/v1/build-composer-project.nix
@@ -1,5 +1,6 @@
 {
   callPackage,
+  nix-update-script,
   stdenvNoCC,
   lib,
   php,
@@ -88,6 +89,16 @@ let
           composerNoScripts = previousAttrs.composerNoScripts or true;
           composerStrictValidation = previousAttrs.composerStrictValidation or true;
         });
+
+      # Projects providing a lockfile from upstream can be automatically updated.
+      passthru = previousAttrs.passthru or { } // {
+        updateScript =
+          previousAttrs.passthru.updateScript or (if finalAttrs.composerRepository.composerLock
+          == null then
+            nix-update-script { }
+          else
+            null);
+      };
 
       env = {
         COMPOSER_CACHE_DIR = "/dev/null";

--- a/pkgs/build-support/php/builders/v1/build-composer-project.nix
+++ b/pkgs/build-support/php/builders/v1/build-composer-project.nix
@@ -1,21 +1,14 @@
-{
-  callPackage,
-  nix-update-script,
-  stdenvNoCC,
-  lib,
-  php,
-}:
+{ callPackage, nix-update-script, stdenvNoCC, lib, php, }:
 
 let
-  buildComposerProjectOverride =
-    finalAttrs: previousAttrs:
+  buildComposerProjectOverride = finalAttrs: previousAttrs:
 
     let
       phpDrv = finalAttrs.php or php;
       composer = finalAttrs.composer or phpDrv.packages.composer;
-      composer-local-repo-plugin = callPackage ../../pkgs/composer-local-repo-plugin.nix { };
-    in
-    {
+      composer-local-repo-plugin =
+        callPackage ../../pkgs/composer-local-repo-plugin.nix { };
+    in {
       composerLock = previousAttrs.composerLock or null;
       composerNoDev = previousAttrs.composerNoDev or true;
       composerNoPlugins = previousAttrs.composerNoPlugins or true;
@@ -35,59 +28,49 @@ let
       strictDeps = previousAttrs.strictDeps or true;
 
       # Should we keep these empty phases?
-      configurePhase =
-        previousAttrs.configurePhase or ''
-          runHook preConfigure
+      configurePhase = previousAttrs.configurePhase or ''
+        runHook preConfigure
 
-          runHook postConfigure
-        '';
+        runHook postConfigure
+      '';
 
-      buildPhase =
-        previousAttrs.buildPhase or ''
-          runHook preBuild
+      buildPhase = previousAttrs.buildPhase or ''
+        runHook preBuild
 
-          runHook postBuild
-        '';
+        runHook postBuild
+      '';
 
       doCheck = previousAttrs.doCheck or true;
-      checkPhase =
-        previousAttrs.checkPhase or ''
-          runHook preCheck
+      checkPhase = previousAttrs.checkPhase or ''
+        runHook preCheck
 
-          runHook postCheck
-        '';
+        runHook postCheck
+      '';
 
-      installPhase =
-        previousAttrs.installPhase or ''
-          runHook preInstall
+      installPhase = previousAttrs.installPhase or ''
+        runHook preInstall
 
-          runHook postInstall
-        '';
+        runHook postInstall
+      '';
 
       doInstallCheck = previousAttrs.doInstallCheck or false;
-      installCheckPhase =
-        previousAttrs.installCheckPhase or ''
-          runHook preInstallCheck
+      installCheckPhase = previousAttrs.installCheckPhase or ''
+        runHook preInstallCheck
 
-          runHook postInstallCheck
-        '';
+        runHook postInstallCheck
+      '';
 
       composerRepository =
         previousAttrs.composerRepository or (phpDrv.mkComposerRepository {
           inherit composer composer-local-repo-plugin;
-          inherit (finalAttrs)
-            patches
-            pname
-            src
-            vendorHash
-            version
-            ;
+          inherit (finalAttrs) patches pname src vendorHash version;
 
           composerLock = previousAttrs.composerLock or null;
           composerNoDev = previousAttrs.composerNoDev or true;
           composerNoPlugins = previousAttrs.composerNoPlugins or true;
           composerNoScripts = previousAttrs.composerNoScripts or true;
-          composerStrictValidation = previousAttrs.composerStrictValidation or true;
+          composerStrictValidation =
+            previousAttrs.composerStrictValidation or true;
         });
 
       # Projects providing a lockfile from upstream can be automatically updated.
@@ -106,9 +89,7 @@ let
         COMPOSER_MIRROR_PATH_REPOS = "1";
       };
 
-      meta = previousAttrs.meta or { } // {
-        platforms = lib.platforms.all;
-      };
+      meta = previousAttrs.meta or { } // { platforms = lib.platforms.all; };
     };
-in
-args: (stdenvNoCC.mkDerivation args).overrideAttrs buildComposerProjectOverride
+in args:
+(stdenvNoCC.mkDerivation args).overrideAttrs buildComposerProjectOverride


### PR DESCRIPTION
## Description of changes

Lets make sure that (almost) all PHP packages can be updated by the r-ryantm bot!

PHP packages where upstream provides a lock file can be automatically updated with the standard nix-update-script. The next step (in a following PR) will be to create a script that optionally regenerates and replaces the local lock file if upstream doesn't provide it.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
