### PR TITLE
sirikali: 1.5.1 -> 1.6.0

### DIFF
--- a/pkgs/by-name/si/sirikali/package.nix
+++ b/pkgs/by-name/si/sirikali/package.nix
@@ -1,54 +1,47 @@
 { lib
 , stdenv
-, qtbase
 , libpwquality
 , hicolor-icon-theme
 , fetchFromGitHub
-, wrapQtAppsHook
 , cmake
 , pkg-config
-, libgcrypt
+, qt6
+, kdePackages
 , cryfs
 , encfs
 , fscrypt-experimental
 , gocryptfs
 , securefs
 , sshfs
+, libgcrypt
 , libsecret
-, kwallet
 , withKWallet ? true
 , withLibsecret ? true
 }:
 
 stdenv.mkDerivation rec {
   pname = "sirikali";
-  version = "1.5.1";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "mhogomchungu";
     repo = "sirikali";
     rev = version;
-    hash = "sha256-1bY8cCMMK4Jie4+9c7eUEBrPEYDaOqFHZ5252TPSotA=";
+    hash = "sha256-org8mYKwZDdOvkQyd3eD+GaI0aHshMbe2f9i1bM+lBk=";
   };
 
   buildInputs = [
-    qtbase
+    qt6.qtbase
     libpwquality
     hicolor-icon-theme
     libgcrypt
-    cryfs
-    encfs
-    fscrypt-experimental
-    gocryptfs
-    securefs
-    sshfs
   ]
-  ++ lib.optionals withKWallet [ libsecret ]
-  ++ lib.optionals withLibsecret [ kwallet ]
+  ++ lib.optionals withKWallet [ kdePackages.kwallet ]
+  ++ lib.optionals withLibsecret [ libsecret ]
   ;
 
   nativeBuildInputs = [
-    wrapQtAppsHook
+    qt6.wrapQtAppsHook
     cmake
     pkg-config
   ];
@@ -64,17 +57,13 @@ stdenv.mkDerivation rec {
     ]}''
   ];
 
-  postPatch = ''
-    substituteInPlace "src/engines.cpp" --replace "/sbin/" "/run/wrappers/bin/"
-  '';
-
   doCheck = true;
 
   cmakeFlags = [
     "-DINTERNAL_LXQT_WALLET=false"
     "-DNOKDESUPPORT=${if withKWallet then "false" else "true"}"
     "-DNOSECRETSUPPORT=${if withLibsecret then "false" else "true"}"
-    "-DQT5=true"
+    "-DBUILD_WITH_QT6=true"
   ];
 
   meta = with lib; {
@@ -83,5 +72,7 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/mhogomchungu/sirikali/blob/${src.rev}/changelog";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ linuxissuper ];
+    mainProgram = "sirikali";
+    platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41110,8 +41110,6 @@ with pkgs;
 
   dict-cc-py = callPackage ../applications/misc/dict-cc-py { };
 
-  sirikali = libsForQt5.callPackage ../tools/security/sirikali { };
-
   wpm = callPackage ../applications/misc/wpm { };
 
   weggli = callPackage ../tools/security/weggli { };


### PR DESCRIPTION
## Description of changes

    sirikali: 1.5.1 -> 1.6.0

    move to by-name folder
    build with qt6 instead of qt5

    remove postPatch because sirikali can now find the binaries in PATH variable
    also fix broken lib.optionals logic


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
