### PR TITLE
python312Packages.homematicip: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/development/python-modules/homematicip/default.nix
+++ b/pkgs/development/python-modules/homematicip/default.nix
@@ -31,12 +31,12 @@ buildPythonPackage rec {
     hash = "sha256-VMHInAmNO0Nw0ohZnIJ9c77h35YSSNNnPNYaUpBlKOQ=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
     setuptools-scm
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     aenum
     aiohttp
     async-timeout

--- a/pkgs/development/python-modules/homematicip/default.nix
+++ b/pkgs/development/python-modules/homematicip/default.nix
@@ -1,20 +1,21 @@
-{ lib
-, aenum
-, aiohttp
-, aiohttp-wsgi
-, async-timeout
-, buildPythonPackage
-, fetchFromGitHub
-, pytest7CheckHook
-, pythonAtLeast
-, pythonOlder
-, pytest-aiohttp
-, pytest-asyncio
-, requests
-, setuptools
-, setuptools-scm
-, websocket-client
-, websockets
+{
+  lib,
+  aenum,
+  aiohttp,
+  aiohttp-wsgi,
+  async-timeout,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytest7CheckHook,
+  pythonAtLeast,
+  pythonOlder,
+  pytest-aiohttp,
+  pytest-asyncio,
+  requests,
+  setuptools,
+  setuptools-scm,
+  websocket-client,
+  websockets,
 }:
 
 buildPythonPackage rec {
@@ -52,44 +53,42 @@ buildPythonPackage rec {
     pytest7CheckHook
   ];
 
-  pytestFlagsArray = [
-    "--asyncio-mode=auto"
-  ];
+  pytestFlagsArray = [ "--asyncio-mode=auto" ];
 
-  disabledTests = [
-    # Assert issues with datetime
-    "test_contact_interface_device"
-    "test_dimmer"
-    "test_external_device"
-    "test_heating_failure_alert_group"
-    "test_heating"
-    "test_humidity_warning_rule_group"
-    "test_meta_group"
-    "test_pluggable_switch_measuring"
-    "test_rotary_handle_sensor"
-    "test_security_group"
-    "test_security_zone"
-    "test_shutter_device"
-    "test_smoke_detector"
-    "test_switching_group"
-    "test_temperature_humidity_sensor_outdoor"
-    "test_wall_mounted_thermostat_pro"
-    "test_weather_sensor"
-    # Random failures
-    "test_home_getSecurityJournal"
-    "test_home_unknown_types"
-    # Requires network access
-    "test_websocket"
-  ] ++ lib.optionals (pythonAtLeast "3.10") [
-    "test_connection_lost"
-    "test_user_disconnect_and_reconnect"
-    "test_ws_message"
-    "test_ws_no_pong"
-  ];
+  disabledTests =
+    [
+      # Assert issues with datetime
+      "test_contact_interface_device"
+      "test_dimmer"
+      "test_external_device"
+      "test_heating_failure_alert_group"
+      "test_heating"
+      "test_humidity_warning_rule_group"
+      "test_meta_group"
+      "test_pluggable_switch_measuring"
+      "test_rotary_handle_sensor"
+      "test_security_group"
+      "test_security_zone"
+      "test_shutter_device"
+      "test_smoke_detector"
+      "test_switching_group"
+      "test_temperature_humidity_sensor_outdoor"
+      "test_wall_mounted_thermostat_pro"
+      "test_weather_sensor"
+      # Random failures
+      "test_home_getSecurityJournal"
+      "test_home_unknown_types"
+      # Requires network access
+      "test_websocket"
+    ]
+    ++ lib.optionals (pythonAtLeast "3.10") [
+      "test_connection_lost"
+      "test_user_disconnect_and_reconnect"
+      "test_ws_message"
+      "test_ws_no_pong"
+    ];
 
-  pythonImportsCheck = [
-    "homematicip"
-  ];
+  pythonImportsCheck = [ "homematicip" ];
 
   meta = with lib; {
     description = "Module for the homematicIP REST API";

--- a/pkgs/development/python-modules/homematicip/default.nix
+++ b/pkgs/development/python-modules/homematicip/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "homematicip";
-  version = "1.1.0";
+  version = "1.1.1";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     owner = "hahn-th";
     repo = "homematicip-rest-api";
     rev = "refs/tags/${version}";
-    hash = "sha256-tx7/amXG3rLdUFgRPQcuf57qkBLAPxPWjLGSO7MrcWU=";
+    hash = "sha256-VMHInAmNO0Nw0ohZnIJ9c77h35YSSNNnPNYaUpBlKOQ=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Diff: https://github.com/hahn-th/homematicip-rest-api/compare/refs/tags/1.1.0...1.1.1

Changelog: https://github.com/hahn-th/homematicip-rest-api/releases/tag/1.1.1

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
