### PR TITLE
wafHook: don't add cross compilation flags

### DIFF
--- a/doc/hooks/waf.section.md
+++ b/doc/hooks/waf.section.md
@@ -20,10 +20,6 @@ If `wafPath` doesn't exist, then `wafHook` will copy the `waf` provided from Nix
 
 Controls the flags passed to waf tool during build and install phases. For settings specific to build or install phases, use `wafBuildFlags` or `wafInstallFlags` respectively.
 
-#### `dontAddWafCrossFlags` {#dont-add-waf-cross-flags}
-
-When set to `true`, don't add cross compilation flags during configure phase.
-
 #### `dontUseWafConfigure` {#dont-use-waf-configure}
 
 When set to true, don't use the predefined `wafConfigurePhase`.

--- a/pkgs/by-name/wa/waf/hook.nix
+++ b/pkgs/by-name/wa/waf/hook.nix
@@ -13,8 +13,6 @@ makeSetupHook {
     # waf is not inserted into propagatedBuildInputs, rather it is inserted
     # directly
     inherit waf;
-    wafCrossFlags = lib.optionalString (stdenv.hostPlatform.system != stdenv.targetPlatform.system)
-      ''--cross-compile "--cross-execute=${stdenv.targetPlatform.emulator pkgs}"'';
   };
 
   meta = {

--- a/pkgs/by-name/wa/waf/setup-hook.sh
+++ b/pkgs/by-name/wa/waf/setup-hook.sh
@@ -22,10 +22,6 @@ wafConfigurePhase() {
         ${wafConfigureTargets:-configure}
     )
 
-    if [ -z "${dontAddWafCrossFlags:-}" ]; then
-        flagsArray+=(@wafCrossFlags@)
-    fi
-
     echoCmd 'waf configure flags' "${flagsArray[@]}"
     python "$wafPath" "${flagsArray[@]}"
 

--- a/pkgs/development/libraries/aubio/default.nix
+++ b/pkgs/development/libraries/aubio/default.nix
@@ -15,7 +15,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ alsa-lib fftw libjack2 libsamplerate libsndfile ];
 
   strictDeps = true;
-  dontAddWafCrossFlags = true;
   wafFlags = lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "--disable-tests";
 
   postPatch = ''

--- a/pkgs/development/libraries/ldb/default.nix
+++ b/pkgs/development/libraries/ldb/default.nix
@@ -12,6 +12,7 @@
 , docbook_xml_dtd_42
 , cmocka
 , wafHook
+, buildPackages
 , libxcrypt
 , testers
 }:
@@ -62,6 +63,9 @@ stdenv.mkDerivation (finalAttrs: {
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"
     "--without-ldb-lmdb"
+  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "--cross-compile"
+    "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
   ];
 
   # python-config from build Python gives incorrect values when cross-compiling.

--- a/pkgs/development/libraries/talloc/default.nix
+++ b/pkgs/development/libraries/talloc/default.nix
@@ -9,6 +9,7 @@
 , docbook_xml_dtd_42
 , fixDarwinDylibNames
 , wafHook
+, buildPackages
 }:
 
 stdenv.mkDerivation rec {
@@ -50,6 +51,9 @@ stdenv.mkDerivation rec {
     "--enable-talloc-compat1"
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"
+  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "--cross-compile"
+    "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
   ];
 
   # python-config from build Python gives incorrect values when cross-compiling.

--- a/pkgs/development/libraries/tdb/default.nix
+++ b/pkgs/development/libraries/tdb/default.nix
@@ -2,6 +2,7 @@
 , fetchurl
 , pkg-config
 , wafHook
+, buildPackages
 , python3
 , readline
 , libxslt
@@ -46,6 +47,9 @@ stdenv.mkDerivation rec {
   wafConfigureFlags = [
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"
+  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "--cross-compile"
+    "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
   ];
 
   postFixup = if stdenv.isDarwin

--- a/pkgs/development/libraries/tevent/default.nix
+++ b/pkgs/development/libraries/tevent/default.nix
@@ -10,6 +10,7 @@
 , docbook_xml_dtd_42
 , which
 , wafHook
+, buildPackages
 , libxcrypt
 }:
 
@@ -52,6 +53,9 @@ stdenv.mkDerivation rec {
   wafConfigureFlags = [
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"
+  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "--cross-compile"
+    "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
   ];
 
   # python-config from build Python gives incorrect values when cross-compiling.

--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -50,8 +50,6 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs --build svnversion_regenerate.sh
   '';
 
-  dontAddWafCrossFlags = true;
-
   wafConfigureFlags = [
     "--classic"
     "--autostart=${if (optDbus != null) then "dbus" else "classic"}"

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -173,6 +173,8 @@ stdenv.mkDerivation (finalAttrs: {
     ++ optional (!enablePam) "--without-pam"
     ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "--bundled-libraries=!asn1_compile,!compile_et"
+    "--cross-compile"
+    "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
   ] ++ optionals stdenv.buildPlatform.is32bit [
     # By default `waf configure` spawns as many as available CPUs. On
     # 32-bit systems with many CPUs (like `i686` chroot on `x86_64`


### PR DESCRIPTION
## Description of changes

**This should wait until breaking changes are allowed again.**

These flags are not part of waf, they're custom flags that are not widely implemented.  More packages are broken because of these flags being added than actually recognise them.

Of the packages in Nixpkgs that directly depend on wafHook that we can attempt to cross compile (i.e. all their dependencies cross compile), 5 already successfully cross compile and recognise these flags, 2 already successfully cross compile because they have been opted out of these flags, 2 don't cross compile successfully for reasons unrelated to these flags, and for the remaining 8, the only thing stopping them cross compiling successfully is that they are being passed these flags that they don't recognise.

All of the five successfully cross-compiling packages that do recognise these flags are samba projects: ldb, talloc, tdb, tevent, and samba4.  So this isn't a general waf convention, just a samba one. It therefore doesn't make sense to set these flags by default.  They should just be included in the expressions for each samba project, like all the other quirks common to samba build systems.

This change fixes cross compilation of the following packages:

  blockhash fomp ganv ndn-cxx mda_lv2 pflask raul saldl

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
