### PR TITLE
deterministic-uname: overridable platform

### DIFF
--- a/pkgs/build-support/deterministic-uname/default.nix
+++ b/pkgs/build-support/deterministic-uname/default.nix
@@ -5,6 +5,7 @@
 , coreutils
 , getopt
 , modDirVersion ? ""
+, forPlatform ? stdenv.buildPlatform
 }:
 
 substituteAll {
@@ -17,8 +18,8 @@ substituteAll {
 
   inherit coreutils getopt;
 
-  uSystem = if stdenv.buildPlatform.uname.system != null then stdenv.buildPlatform.uname.system else "unknown";
-  inherit (stdenv.buildPlatform.uname) processor;
+  uSystem = if forPlatform.uname.system != null then forPlatform.uname.system else "unknown";
+  inherit (forPlatform.uname) processor;
 
   # uname -o
   # maybe add to lib/systems/default.nix uname attrset
@@ -26,9 +27,9 @@ substituteAll {
   # https://stackoverflow.com/questions/61711186/where-does-host-operating-system-in-uname-c-comes-from
   # https://github.com/coreutils/gnulib/blob/master/m4/host-os.m4
   operatingSystem =
-    if stdenv.buildPlatform.isLinux
+    if forPlatform.isLinux
     then "GNU/Linux"
-    else if stdenv.buildPlatform.isDarwin
+    else if forPlatform.isDarwin
     then "Darwin" # darwin isn't in host-os.m4 so where does this come from?
     else "unknown";
 
@@ -42,11 +43,12 @@ substituteAll {
     mainProgram = "uname";
     longDescription = ''
       This package provides a replacement for `uname` whose output depends only
-      on `stdenv.buildPlatform`.  It is meant to be used from within derivations.
-      Many packages' build processes run `uname` at compile time and embed its
-      output into the result of the build.  Since `uname` calls into the kernel,
-      and the Nix sandbox currently does not intercept these calls, builds made
-      on different kernels will produce different results.
+      on `stdenv.buildPlatform`, or a configurable `forPlatform`.  It is meant
+      to be used from within derivations. Many packages' build processes run
+      `uname` at compile time and embed its output into the result of the build.
+      Since `uname` calls into the kernel, and the Nix sandbox currently does
+      not intercept these calls, builds made on different kernels will produce
+      different results.
     '';
     license = [ licenses.mit ];
     maintainers = with maintainers; [ artturin ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3692,6 +3692,8 @@ with pkgs;
 
   deterministic-uname = callPackage ../build-support/deterministic-uname { };
 
+  deterministic-host-uname = deterministic-uname.override { forPlatform = stdenv.hostPlatform; };
+
   dfmt = callPackage ../tools/text/dfmt { };
 
   diopser = callPackage ../applications/audio/diopser { };


### PR DESCRIPTION
## Description of changes

Some packages rely on `uname` to configure the host target which breaks cross-compilation. We can have more control over the evaluation of `uname` by placing `deterministic-uname` into the package's `nativeBuildInputs`. However the current `deterministic-uname` is hardcoded to `buildPlatform`.

This PR introduces a build argument `forPlatform` to `deterministic-uname` which allows you to override the platform it reports.

Example:
```nix
deterministic-uname.override { forPlatform = stdenv.hostPlatform; }
```

### Some other ideas:

`deterministic-uname` could be based on `stdenv.hostPlatform`. Say we have:
- `system = "aarch64-darwin"`
- `crossSystem = "aarch64-linux"`
 
We could use it like so:
- `$(${pkgsBuildHost.deterministic-uname}/bin/uname) == "Linux"`
- `$(${pkgsBuildBuild.deterministic-uname}/bin/uname) == "Darwin"`.

And placing `deterministic-uname` in `nativeBuildInputs` would therefore solve cross-compilation ootb.

However this would be a backwards incompatible change. If we want to avoid that we could introduce a new variant like so:
```
host-deterministic-uname = deterministic-uname.override { forPlatform = stdenv.hostPlatform; }
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
