### PR TITLE
curl-impersonate: fix darwin build and make cross-compilation work

### DIFF
--- a/pkgs/tools/networking/curl-impersonate/curl-impersonate-0.6.1-fix-command-paths.patch
+++ b/pkgs/tools/networking/curl-impersonate/curl-impersonate-0.6.1-fix-command-paths.patch
@@ -7,7 +7,7 @@ index 877c54f..3e39ed1 100644
  $(nss_static_libs): $(NSS_VERSION).tar.gz
  	tar xf $(NSS_VERSION).tar.gz
 +	sed -i -e "1s@#!/usr/bin/env bash@#!$$(type -p bash)@" $(NSS_VERSION)/nss/build.sh
-+	sed -i -e "s@/usr/bin/env grep@$$(type -p grep)@" $(NSS_VERSION)/nss/coreconf/config.gypi
++	sed -i -e "s@/usr/bin/\(env \)\?grep@$$(type -p grep)@" $(NSS_VERSION)/nss/coreconf/config.gypi
  
  ifeq ($(host),$(build))
  	# Native build, use NSS' build script.

--- a/pkgs/tools/networking/curl-impersonate/default.nix
+++ b/pkgs/tools/networking/curl-impersonate/default.nix
@@ -6,16 +6,14 @@
 , buildGoModule
 , installShellFiles
 , symlinkJoin
+, buildPackages
 , zlib
 , sqlite
 , cmake
 , python3
 , ninja
 , perl
-# autoconf-2.71 fails on problematic configure:
-#   checking curl version... 7.84.0
-#   ./configure: line 6713: syntax error near unexpected token `;;'
-, autoconf269
+, autoconf
 , automake
 , libtool
 , darwin
@@ -41,13 +39,14 @@ let
     };
 
     patches = [
-      # Fix shebangs in the NSS build script
-      # (can't just patchShebangs since makefile unpacks it)
-      ./curl-impersonate-0.5.2-fix-shebangs.patch
+      # Fix shebangs and commands in the NSS build scripts
+      # (can't just patchShebangs or substituteInPlace since makefile unpacks it)
+      ./curl-impersonate-0.6.1-fix-command-paths.patch
 
       # SOCKS5 heap buffer overflow - https://curl.se/docs/CVE-2023-38545.html
       (fetchpatch {
-        url = "https://github.com/lwthiker/curl-impersonate/commit/e7b90a0d9c61b6954aca27d346750240e8b6644e.patch";
+        name = "curl-impersonate-patch-cve-2023-38545.patch";
+        url = "https://github.com/lwthiker/curl-impersonate/commit/e7b90a0d9c61b6954aca27d346750240e8b6644e.diff";
         hash = "sha256-jFrz4Q+MJGfNmwwzHhThado4c9hTd/+b/bfRsr3FW5k=";
       })
     ];
@@ -58,6 +57,10 @@ let
 
     strictDeps = true;
 
+    depsBuildBuild = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+      buildPackages.stdenv.cc
+    ];
+
     nativeBuildInputs = lib.optionals stdenv.isDarwin [
       # Must come first so that it shadows the 'libtool' command but leaves 'libtoolize'
       darwin.cctools
@@ -65,10 +68,10 @@ let
       installShellFiles
       cmake
       python3
-      python3.pkgs.gyp
+      python3.pythonOnBuildForHost.pkgs.gyp
       ninja
       perl
-      autoconf269
+      autoconf
       automake
       libtool
       unzip
@@ -115,26 +118,26 @@ let
       # Patch all shebangs of installed scripts
       patchShebangs $out/bin
 
+      # Install headers
+      make -C curl-*/include install
+    '' + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
       # Build and install completions for each curl binary
 
       # Patch in correct binary name and alias it to all scripts
       perl curl-*/scripts/completion.pl --curl $out/bin/curl-impersonate-${name} --shell zsh >$TMPDIR/curl-impersonate-${name}.zsh
       substituteInPlace $TMPDIR/curl-impersonate-${name}.zsh \
-        --replace \
+        --replace-fail \
           '#compdef curl' \
           "#compdef curl-impersonate-${name}$(find $out/bin -name 'curl_*' -printf ' %f=curl-impersonate-${name}')"
 
       perl curl-*/scripts/completion.pl --curl $out/bin/curl-impersonate-${name} --shell fish >$TMPDIR/curl-impersonate-${name}.fish
       substituteInPlace $TMPDIR/curl-impersonate-${name}.fish \
-        --replace \
+        --replace-fail \
           '--command curl' \
           "--command curl-impersonate-${name}$(find $out/bin -name 'curl_*' -printf ' --command %f')"
 
       # Install zsh and fish completions
       installShellCompletion $TMPDIR/curl-impersonate-${name}.{zsh,fish}
-
-      # Install headers
-      make -C curl-*/include install
     '';
 
     preFixup = let
@@ -142,9 +145,10 @@ let
     in ''
       # If libnssckbi.so is needed, link libnssckbi.so without needing nss in closure
       if grep -F nssckbi $out/lib/libcurl-impersonate-*${libext} &>/dev/null; then
-        # NOTE: "p11-kit-trust" always ends in ".so" even when on darwin
-        ln -s ${p11-kit}/lib/pkcs11/p11-kit-trust.so $out/lib/libnssckbi${libext}
-        ${lib.optionalString stdenv.isLinux "patchelf --add-needed libnssckbi${libext} $out/lib/libcurl-impersonate-*${libext}"}
+        ln -s ${p11-kit}/lib/pkcs11/p11-kit-trust${libext} $out/lib/libnssckbi${libext}
+        ${lib.optionalString stdenv.hostPlatform.isElf ''
+          patchelf --add-needed libnssckbi${libext} $out/lib/libcurl-impersonate-*${libext}
+        ''}
       fi
     '';
 

--- a/pkgs/tools/networking/curl-impersonate/default.nix
+++ b/pkgs/tools/networking/curl-impersonate/default.nix
@@ -175,13 +175,14 @@ let
       license = with licenses; [ curl mit ];
       maintainers = with maintainers; [ deliciouslytyped lilyinstarlight ];
       platforms = platforms.unix;
+      mainProgram = "curl-impersonate-${name}";
     };
   };
 in
 
 symlinkJoin rec {
   pname = "curl-impersonate";
-  inherit (passthru.curl-impersonate-ff) version meta;
+  inherit (passthru.curl-impersonate-chrome) version meta;
 
   name = "${pname}-${version}";
 
@@ -196,7 +197,7 @@ symlinkJoin rec {
 
     updateScript = ./update.sh;
 
-    inherit (passthru.curl-impersonate-ff) src;
+    inherit (passthru.curl-impersonate-chrome) src;
 
     tests = { inherit (nixosTests) curl-impersonate; };
   };


### PR DESCRIPTION
## Description of changes

Darwin build has been broken since the last version bump, and it broke because upstream added a `/usr/bin/grep` call that needs to be patched. Additioanlly it looks like p11-kit changed `p11-kit-trust.so` to `p11-kit-trust.dylib` on darwin too at some point

I don't actually remember if cross was ever tested before, but it works now (at least x86_64-linux build for aarch64-linux host)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
  - [x] x86_64-linux -> aarch64-linux (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc