### PR TITLE
nixos/xone: fixed a typo in the option description

### DIFF
--- a/nixos/modules/hardware/xone.nix
+++ b/nixos/modules/hardware/xone.nix
@@ -6,7 +6,7 @@ let
 in
 {
   options.hardware.xone = {
-    enable = mkEnableOption "the xone driver for Xbox One and Xbobx Series X|S accessories";
+    enable = mkEnableOption "the xone driver for Xbox One and Xbox Series X|S accessories";
   };
 
   config = mkIf cfg.enable {


### PR DESCRIPTION
## Description of changes

Fix a typo in the description of xone

## Things done

Fix a typo in the description of xone