### PR TITLE
emilua: 0.7.2 -> 0.7.3, reformat

### DIFF
--- a/pkgs/development/interpreters/emilua/default.nix
+++ b/pkgs/development/interpreters/emilua/default.nix
@@ -1,46 +1,47 @@
-{ lib
-, stdenv
-, meson
-, ninja
-, fetchFromGitHub
-, fetchFromGitLab
-, re2c
-, gperf
-, gawk
-, pkg-config
-, boost182
-, fmt
-, luajit_openresty
-, ncurses
-, serd
-, sord
-, libcap
-, liburing
-, openssl
-, cereal
-, cmake
-, asciidoctor
-, makeWrapper
+{
+  lib,
+  stdenv,
+  meson,
+  ninja,
+  fetchFromGitHub,
+  fetchFromGitLab,
+  re2c,
+  gperf,
+  gawk,
+  pkg-config,
+  boost182,
+  fmt,
+  luajit_openresty,
+  ncurses,
+  serd,
+  sord,
+  libcap,
+  liburing,
+  openssl,
+  cereal,
+  cmake,
+  asciidoctor,
+  makeWrapper,
 }:
 
 let
   trial-protocol-wrap = fetchFromGitHub {
-      owner = "breese";
-      repo = "trial.protocol";
-      rev = "79149f604a49b8dfec57857ca28aaf508069b669";
-      name = "trial-protocol";
-      hash = "sha256-Xd8bX3z9PZWU17N9R95HXdj6qo9at5FBL/+PTVaJgkw=";
+    owner = "breese";
+    repo = "trial.protocol";
+    rev = "79149f604a49b8dfec57857ca28aaf508069b669";
+    name = "trial-protocol";
+    hash = "sha256-Xd8bX3z9PZWU17N9R95HXdj6qo9at5FBL/+PTVaJgkw=";
   };
 in
 stdenv.mkDerivation rec {
   pname = "emilua";
-  version = "0.7.2";
+  version = "0.7.3";
 
   src = fetchFromGitLab {
-      owner = "emilua";
-      repo = "emilua";
-      rev = "v${version}";
-      hash = "sha256-gt+THEr3nilweDEDmEMwIsU4i9own4ICJlZD+z8XWRQ=";
+    owner = "emilua";
+    repo = "emilua";
+    rev = "v${version}";
+    hash = "sha256-j8ohhqHjSBgc4Xk9PcQNrbADmsz4VH2zCv+UNqiCv4I=";
   };
 
   buildInputs = [
@@ -83,7 +84,6 @@ stdenv.mkDerivation rec {
     (lib.mesonBool "enable_tests" true)
     (lib.mesonBool "enable_manpages" true)
     (lib.mesonOption "version_suffix" "-nixpkgs1")
-    (lib.mesonOption "ipc_actor_msg_max_members_number" "40")
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

emilua build [is failing on Hydra](https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.emilua.x86_64-linux). This PR updates it to the latest version, released three days ago. Besides reformatting with nixfmt-rfc-style and the version update, nothing else was touched. Let's see if it now builds fine.

All tests pass:

```
emilua> Ok:                 291
emilua> Expected Fail:      0
emilua> Fail:               0
emilua> Unexpected Pass:    0
emilua> Skipped:            0
emilua> Timeout:            0
```

## Things done

- Update versions
- Reformat with nixfmt-rfc-style

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
