### PR TITLE
terminator: don't bleed PATH into session via wrapper

### DIFF
--- a/pkgs/applications/terminal-emulators/terminator/default.nix
+++ b/pkgs/applications/terminal-emulators/terminator/default.nix
@@ -7,6 +7,7 @@
 , gtk3
 , gobject-introspection
 , libnotify
+, makeBinaryWrapper
 , wrapGAppsHook3
 , vte
 , nixosTests
@@ -27,6 +28,7 @@ python3.pkgs.buildPythonApplication rec {
     file
     intltool
     gobject-introspection
+    makeBinaryWrapper
     wrapGAppsHook3
     python3.pkgs.pytest-runner
   ];
@@ -55,8 +57,15 @@ python3.pkgs.buildPythonApplication rec {
 
   dontWrapGApps = true;
 
+  # HACK: 'wrapPythonPrograms' will add things to the $PATH in the wrapper. This bleeds into the
+  # terminal session produced by terminator. To avoid this, we force wrapPythonPrograms to only
+  # use gappsWrapperArgs by redefining wrapProgram to ignore its arguments and only apply the
+  # wrapper arguments we want it to use.
+  # TODO: Adjust wrapPythonPrograms to respect an argument that tells it to leave $PATH alone.
   preFixup = ''
-    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    wrapProgram() {
+      wrapProgramBinary "$1" "''${gappsWrapperArgs[@]}"
+    }
   '';
 
   passthru.tests.test = nixosTests.terminal-emulators.terminator;


### PR DESCRIPTION
Fixes: #47290

## Description of changes

`terminator` creates new terminal sessions, but the Python wrapper bleeds changes to `$PATH` into the new session. This fixes that as the changes to `$PATH` are not necessary to make `terminator` work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
