### PR TITLE
mullvad-vpn: 2024.1 -> 2024.2

### DIFF
--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -64,7 +64,11 @@ let
     systemd
   ];
 
+<<<<<<< HEAD
   version = "2024.1";
+=======
+  version = "2024.3";
+>>>>>>> 5c584ea4b0ee (mullvad-vpn: 2024.1 -> 2024.3)
 
   selectSystem = attrs: attrs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
@@ -74,8 +78,13 @@ let
   };
 
   hash = selectSystem {
+<<<<<<< HEAD
     x86_64-linux = "sha256-io6ROUHoSBij1ah6yi1Gbni6yWVVoYZKUd7BR+GXKLg=";
     aarch64-linux = "sha256-bzKTASfqjmjyKZecr8MGaChd6g48aQhfpuc+gUqwoPI=";
+=======
+    x86_64-linux = "sha256-LfuLBYGHlVEcVpHSdRSAEf9D7QChRd/fhx8EoCBZbSc=";
+    aarch64-linux = "sha256-7uUgewZ9KVLyMUax6u0R6ZN1YS3L4c43meVqJQD77lA=";
+>>>>>>> 5c584ea4b0ee (mullvad-vpn: 2024.1 -> 2024.3)
   };
 in
 


### PR DESCRIPTION
https://github.com/mullvad/mullvadvpn-app/releases/tag/2024.2

## Description of changes
Updated Mullvad VPN from 2024.1 to 2024.2

