### PR TITLE
alacarte: init at 3.52.0

### DIFF
--- a/pkgs/by-name/al/alacarte/package.nix
+++ b/pkgs/by-name/al/alacarte/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  fetchFromGitLab,
+  python3,
+  autoconf,
+  automake,
+  gettext,
+  pkg-config,
+  libxslt,
+  gobject-introspection,
+  wrapGAppsHook3,
+  gnome-menus,
+  glib,
+  gtk3,
+  docbook_xsl,
+  nix-update-script,
+}:
+python3.pkgs.buildPythonApplication rec {
+  pname = "alacarte";
+  version = "3.52.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "alacarte";
+    rev = version;
+    hash = "sha256-SkolSk6RireH3aKkRTUCib/nflqD02PR9uVtXePRHQY=";
+  };
+
+  format = "other";
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    gettext
+    pkg-config
+    python3
+    libxslt
+    gobject-introspection
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    gnome-menus
+    glib
+    gtk3
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [ pygobject3 ];
+
+  configureScript = "./autogen.sh";
+
+  # Builder couldn't fetch the docbook.xsl from the internet directly,
+  # so we substitute it with the docbook.xsl in already in nixpkgs
+  preConfigure = ''
+    substituteInPlace man/Makefile.am \
+      --replace-fail "http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl" "${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://gitlab.gnome.org/GNOME/alacarte";
+    description = "A menu editor for GNOME using the freedesktop.org menu specification";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    mainProgram = "alacarte";
+    maintainers = with lib.maintainers; [ pluiedev ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds Alacarte, a menu editor for GNOME using the freedesktop.org menu specification.

Closes #310382

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
