### PR TITLE
syft: disable update check

### DIFF
--- a/pkgs/by-name/sy/syft/package.nix
+++ b/pkgs/by-name/sy/syft/package.nix
@@ -42,6 +42,12 @@ buildGoModule rec {
     "-X=main.gitTreeState=clean"
   ];
 
+  postPatch = ''
+    # Don't check for updates.
+    substituteInPlace cmd/syft/internal/options/update_check.go \
+      --replace-fail "CheckForAppUpdate: true" "CheckForAppUpdate: false"
+  '';
+
   preBuild = ''
     ldflags+=" -X main.gitCommit=$(cat COMMIT)"
     ldflags+=" -X main.buildDate=$(cat SOURCE_DATE_EPOCH)"
@@ -51,9 +57,6 @@ buildGoModule rec {
   doCheck = false;
 
   postInstall = ''
-    # avoid update checks when generating completions
-    export SYFT_CHECK_FOR_APP_UPDATE=false
-
     installShellCompletion --cmd syft \
       --bash <($out/bin/syft completion bash) \
       --fish <($out/bin/syft completion fish) \
@@ -64,7 +67,6 @@ buildGoModule rec {
   installCheckPhase = ''
     runHook preInstallCheck
 
-    export SYFT_CHECK_FOR_APP_UPDATE=false
     $out/bin/syft --help
     $out/bin/syft version | grep "${version}"
 


### PR DESCRIPTION
## Description of changes

Nixos policy is not to ping home by default, so make the update check
default to false.

It can still be re-enabled by config or env var if required:
- `check-for-app-update: true` in a `.syft.yaml`
- SYFT_CHECK_FOR_APP_UPDATE=true

This can be verified by checking for network connections when
trying to scan a non-existing file (or `toolbox-data.anchore.io` dns
requests):
`strace -f -e connect syft scan a 2>&1 | grep AF_INET`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
