### PR TITLE
ryzen-monitor-ng: excise (obsolete) binaries from upstream source

### DIFF
--- a/pkgs/by-name/ry/ryzen-monitor-ng/package.nix
+++ b/pkgs/by-name/ry/ryzen-monitor-ng/package.nix
@@ -14,12 +14,13 @@ stdenv.mkDerivation {
     hash = "sha256-fcW2fEsCFliRnMFnboR0jchzVIlCYbr2AE6AS06cb6o=";
   };
 
-  ## Remove binaries committed into upstream repo
+  # Upstream repo contains pre-compiled binaries and object files
+  # that are out of date.
+  # These need to be removed before build stage.
   preBuild = ''
     rm src/ryzen_monitor
+    make clean
   '';
-
-  makeTargets = [ "clean" "install" ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ry/ryzen-monitor-ng/package.nix
+++ b/pkgs/by-name/ry/ryzen-monitor-ng/package.nix
@@ -16,16 +16,15 @@ stdenv.mkDerivation {
     owner = "plasmin";
     repo = "ryzen_monitor_ng";
     rev = "8b7854791d78de731a45ce7d30dd17983228b7b1";
-    hash = "sha256-fcW2fEsCFliRnMFnboR0jchzVIlCYbr2AE6AS06cb6o=";
+    hash = "sha256-xdYNtXCbNy3/y5OAHZEi9KgPtwr1LTtLWAZC5DDCfmE=";
+    # Upstream repo contains pre-compiled binaries and object files
+    # that are out of date.
+    # These need to be removed before build stage.
+    postFetch = ''
+      rm "$out/src/ryzen_monitor"
+      make -C "$out" clean
+    '';
   };
-
-  # Upstream repo contains pre-compiled binaries and object files
-  # that are out of date.
-  # These need to be removed before build stage.
-  preBuild = ''
-    rm src/ryzen_monitor
-    make clean
-  '';
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 

--- a/pkgs/by-name/ry/ryzen-monitor-ng/package.nix
+++ b/pkgs/by-name/ry/ryzen-monitor-ng/package.nix
@@ -1,4 +1,9 @@
-{ lib, stdenv, fetchFromGitHub }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  unstableGitUpdater,
+}:
 
 stdenv.mkDerivation {
   pname = "ryzen-monitor-ng";
@@ -22,14 +27,14 @@ stdenv.mkDerivation {
     make clean
   '';
 
-  makeFlags = [
-    "PREFIX=${placeholder "out"}"
-  ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = with lib; {
     description = "Access Ryzen SMU information exposed by the ryzen_smu driver";
-    homepage = "https://github.com/mann1x/ryzen_monitor_ng";
-    changelog = "https://github.com/mann1x/ryzen_monitor_ng/blob/master/CHANGELOG.md";
+    homepage = "https://github.com/plasmin/ryzen_monitor_ng";
+    changelog = "https://github.com/plasmin/ryzen_monitor_ng/blob/master/CHANGELOG.md";
     license = licenses.agpl3Only;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ phdyellow ];

--- a/pkgs/by-name/ry/ryzen-monitor-ng/package.nix
+++ b/pkgs/by-name/ry/ryzen-monitor-ng/package.nix
@@ -22,14 +22,9 @@ stdenv.mkDerivation {
     make clean
   '';
 
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/bin
-    mv ./src/ryzen_monitor $out/bin
-
-    runHook postInstall
-  '';
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
 
   meta = with lib; {
     description = "Access Ryzen SMU information exposed by the ryzen_smu driver";


### PR DESCRIPTION
## Description of changes
Fix for ryzen_monitor_ng, binaries and .o files were committed to repo. `makeTargets` is not used by the default builder, so `make` was not building the binary. The installed binary was the one committed to the upstream repo, which is out of date.

The best solution seems to be `lib.cleanSource`, since the problem is .o files committed to the repo that should not be used by NixOS.

@Cryolitia 

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
