### PR TITLE
openfga: init at 1.5.3

### DIFF
--- a/pkgs/by-name/op/openfga/package.nix
+++ b/pkgs/by-name/op/openfga/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+let
+  pname = "openfga";
+  version = "1.5.3";
+in
+
+buildGoModule {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "openfga";
+    repo = "openfga";
+    rev = "v${version}";
+    hash = "sha256-+ECfBG0Z1XnopMPbq9jngcZ3lcSFOIomWo5iD0T1teQ=";
+  };
+
+  vendorHash = "sha256-MyoqdmNtpsoT08BKA9DPlpldIEXb82qzeXnW4KQXTiE=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  ldflags =
+    let
+      buildInfoPkg = "github.com/openfga/openfga/internal/build";
+    in
+    [
+      "-s"
+      "-w"
+      "-X ${buildInfoPkg}.Version=${version}"
+      "-X ${buildInfoPkg}.Commit=${version}"
+      "-X ${buildInfoPkg}.Date=19700101"
+    ];
+
+  # Tests depend on docker
+  doCheck = false;
+
+  postInstall = ''
+    completions_dir=$TMPDIR/openfga_completions
+    mkdir $completions_dir
+    $out/bin/openfga completion bash > $completions_dir/openfga.bash
+    $out/bin/openfga completion zsh > $completions_dir/_openfga.zsh
+    $out/bin/openfga completion fish > $completions_dir/openfga.fish
+    installShellCompletion $completions_dir/*
+  '';
+
+  meta = {
+    description = "A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar";
+    homepage = "https://openfga.dev/";
+    license = lib.licenses.asl20;
+    mainProgram = "openfga";
+    maintainers = with lib.maintainers; [ jlesquembre ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Add openfga
https://github.com/openfga/openfga
https://openfga.dev/

Related to https://github.com/NixOS/nixpkgs/pull/310184

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
