### PR TITLE
Fix `testers.hasPkgConfigModules` version check

### DIFF
--- a/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
+++ b/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
@@ -12,7 +12,8 @@
 runCommand testName {
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ package ];
-    inherit moduleNames version versionCheck;
+    inherit moduleNames versionCheck;
+    version = if versionCheck then version else null;
     meta = {
       description = "Test whether ${package.name} exposes pkg-config modules ${lib.concatStringsSep ", " moduleNames}.";
     }
@@ -42,7 +43,7 @@ runCommand testName {
       r=$?
       set -e
       if [[ $r = 0 ]]; then
-        if [[ "$moduleVersion" == "$version" ]]; then
+        if [[ -z "$versionCheck" || "$moduleVersion" == "$version" ]]; then
           echo "✅ pkg-config module $moduleName exists and has version $moduleVersion"
         else
           echo "❌ pkg-config module $moduleName exists and has version $moduleVersion when $version was expected"

--- a/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
+++ b/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
@@ -56,7 +56,7 @@ runCommand testName {
       fi
     done
 
-    if [[ $notFound -eq 0 ]] && ([[ $versionMismatch -eq 0 ]] || [[ "$versionCheck" == false ]]); then
+    if [[ $notFound -eq 0 ]] && [[ $versionMismatch -eq 0 ]]; then
       exit 0
     fi
     if [[ $notFound -ne 0 ]]; then

--- a/pkgs/build-support/testers/hasPkgConfigModules/tests.nix
+++ b/pkgs/build-support/testers/hasPkgConfigModules/tests.nix
@@ -11,7 +11,7 @@ lib.recurseIntoAttrs {
 
   miniz-versions-mismatch = testers.testBuildFailure (testers.hasPkgConfigModules {
     package = miniz;
-    version = "1.2.3";
+    version = "1.2.3"; # intentionally wrong version to trigger failure
     versionCheck = true;
   });
 

--- a/pkgs/build-support/testers/hasPkgConfigModules/tests.nix
+++ b/pkgs/build-support/testers/hasPkgConfigModules/tests.nix
@@ -15,6 +15,12 @@ lib.recurseIntoAttrs {
     versionCheck = true;
   });
 
+  miniz-version-check-disabled = testers.hasPkgConfigModules {
+    package = miniz.overrideAttrs (o: { passthru = o.passthru // { version = throw "do not use package.version"; }; });
+    version = throw "do not use version when versionCheck == false";
+    # default: versionCheck = false;
+  };
+
   zlib-has-zlib = testers.hasPkgConfigModules {
     package = zlib;
     moduleNames = [ "zlib" ];


### PR DESCRIPTION
## Description of changes

Fix a mistake I reviewed.

- https://github.com/NixOS/nixpkgs/pull/307770#issuecomment-2102586718

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
