### PR TITLE
k0sctl: 0.17.5 -> 0.17.8

### DIFF
--- a/pkgs/applications/networking/cluster/k0sctl/default.nix
+++ b/pkgs/applications/networking/cluster/k0sctl/default.nix
@@ -6,16 +6,16 @@
 
 buildGoModule rec {
   pname = "k0sctl";
-  version = "0.17.5";
+  version = "0.17.8";
 
   src = fetchFromGitHub {
     owner = "k0sproject";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-NHfS1iJtpt0t2iIqXBETiD4rpA2XzA8eOg5mP4N8El4=";
+    hash = "sha256-QHTVNrPglNDT9CUQWwc6oD7ttwEUBq8WIX49DiAXf8s=";
   };
 
-  vendorHash = "sha256-MPTdOcNoveBnHMJ2YHqHuvOHHe6IdisZLc05qViA1YQ=";
+  vendorHash = "sha256-6Kj1kHKXbbPMr9thkDTmGYbZvCSW7CvSzASpk6agEpI=";
 
   ldflags = [
     "-s"

--- a/pkgs/applications/networking/cluster/k0sctl/default.nix
+++ b/pkgs/applications/networking/cluster/k0sctl/default.nix
@@ -2,6 +2,8 @@
 , buildGoModule
 , fetchFromGitHub
 , installShellFiles
+, testers
+, k0sctl
 }:
 
 buildGoModule rec {
@@ -33,6 +35,13 @@ buildGoModule rec {
         --$shell <($out/bin/${pname} completion --shell $shell)
     done
   '';
+
+  passthru.tests.version = testers.testVersion {
+    package = k0sctl;
+    command = "k0sctl version";
+    # See https://github.com/carlmjohnson/versioninfo/discussions/12
+    version = "version: (devel)\ncommit: v${version}\n";
+  };
 
   meta = with lib; {
     description = "A bootstrapping and management tool for k0s clusters.";


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/k0sproject/k0sctl/compare/v0.17.5...v0.17.8

Also add a version test.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```console
$ nix-build -A k0sctl
/nix/store/fgi01qfzvjg9p5cb11w2p8wzmhvw4ljn-k0sctl-0.17.8

$ find /nix/store/fgi01qfzvjg9p5cb11w2p8wzmhvw4ljn-k0sctl-0.17.8 -type f
/nix/store/fgi01qfzvjg9p5cb11w2p8wzmhvw4ljn-k0sctl-0.17.8/bin/k0sctl
/nix/store/fgi01qfzvjg9p5cb11w2p8wzmhvw4ljn-k0sctl-0.17.8/share/bash-completion/completions/k0sctl.bash
/nix/store/fgi01qfzvjg9p5cb11w2p8wzmhvw4ljn-k0sctl-0.17.8/share/zsh/site-functions/_k0sctl
/nix/store/fgi01qfzvjg9p5cb11w2p8wzmhvw4ljn-k0sctl-0.17.8/share/fish/vendor_completions.d/k0sctl.fish

$ nix-build --attr pkgs.k0sctl.passthru.tests
/nix/store/f79wjcp1ww833dv44bv72gk5czrnxd1k-k0sctl-0.17.8-test-version
```
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
