### PR TITLE
undocker: 1.0.4 -> 1.2.2

### DIFF
--- a/pkgs/tools/misc/undocker/default.nix
+++ b/pkgs/tools/misc/undocker/default.nix
@@ -1,25 +1,36 @@
 { lib
 , buildGoModule
-, fetchFromSourcehut
+, fetchFromGitea
+, gnumake
 }:
-buildGoModule rec {
-  pname = "undocker";
-  version = "1.0.4";
-
-  src = fetchFromSourcehut {
-    owner = "~motiejus";
-    repo = pname;
+let
+  version = "1.2.2";
+  hash = "sha256-kBqNopcHpldU5oD6zoVjPjP84t12QFcbWBSNNgwImKg=";
+  src = fetchFromGitea {
+    domain = "git.jakstys.lt";
+    owner = "motiejus";
+    repo = "undocker";
     rev = "v${version}";
-    hash = "sha256-I+pTbr1lKELyYlyHrx2gB+aeZ3/PmcePQfXu1ckhKAk=";
+    hash = hash;
   };
+in
+buildGoModule {
+  pname = "undocker";
+  inherit version src;
+
+  nativeBuildInputs = [ gnumake ];
+
+  buildPhase = "make VSN=v${version} VSNHASH=${hash} undocker";
+
+  installPhase = "install -D undocker $out/bin/undocker";
 
   vendorHash = null;
 
   meta = with lib; {
-    homepage = "https://git.sr.ht/~motiejus/undocker";
+    homepage = "https://git.jakstys.lt/motiejus/undocker";
     description = "A CLI tool to convert a Docker image to a flattened rootfs tarball";
     license = licenses.asl20;
-    maintainers = with maintainers; [ jordanisaacs ];
+    maintainers = with maintainers; [ jordanisaacs motiejus ];
     mainProgram = "undocker";
   };
 }


### PR DESCRIPTION
## Description of changes

* bump v1.0.4 -> v1.2.2
* change the origin website
* add myself to the maintainers (I am the upstream author).

Co-Authored-By: John Chadwick <johnwchadwick@gmail.com>


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
