### PR TITLE
libbpf_0: 0.8.1 -> 0.8.3

### DIFF
--- a/pkgs/os-specific/linux/libbpf/0.x.nix
+++ b/pkgs/os-specific/linux/libbpf/0.x.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libbpf";
-  version = "0.8.1";
+  version = "0.8.3";
 
   src = fetchFromGitHub {
     owner = "libbpf";
     repo = "libbpf";
     rev = "v${version}";
-    sha256 = "sha256-daVS+TErmDU8ksThOvcepg1A61iD8N8GIkC40cmc9/8=";
+    sha256 = "sha256-J5cUvfUYc+uLdkFa2jx/2bqBoZg/eSzc6SWlgKqcfIc=";
   };
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
## Description of changes

update libbpf_0: https://github.com/libbpf/libbpf/releases/tag/v0.8.3 (note there is no 0.8.2)
> Single fix (https://github.com/libbpf/libbpf/pull/795) on top of v0.8.1, fixing the name of bpf_program__pin_instance() API call, previously erroneously specified as bpf_object__pin_instance() in the code.

Since there is no auto-update this was half forgotten; it's just a symbol fix for 1.0-compat API but might as well take it before 24.05

(note I moved the file in #310571, but git should be smart enough to merge the two and there should be no problem going forward with both PRs. If a conflict does pop up because github merge isn't as good as native git I'll rebase.)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
