### PR TITLE
python3Package.duckduckgo-search: fix build failure

### DIFF
--- a/pkgs/development/python-modules/duckduckgo-search/default.nix
+++ b/pkgs/development/python-modules/duckduckgo-search/default.nix
@@ -1,20 +1,43 @@
-{ lib
-, aiofiles
-, buildPythonPackage
-, click
-, fetchFromGitHub
-, h2
-, httpx
-, lxml
-, pythonOlder
-, requests
-, setuptools
-, socksio
+{
+  lib,
+  buildPythonPackage,
+  click,
+  fetchFromGitHub,
+  pythonOlder,
+  setuptools,
+  orjson,
+  curl-cffi,
+  rustPlatform,
 }:
+let
+  curl-cffi_0_7_0 = curl-cffi.overrideAttrs (oldAttrs: rec {
+    version = "0.7.0b4";
+    src = fetchFromGitHub {
+      owner = "yifeikong";
+      repo = "curl_cffi";
+      rev = "v${version}";
+      hash = "sha256-txrJNUzswAPeH4Iazn0iKJI0Rqk0HHRoDrtTfDHKMoo=";
+    };
+  });
 
+  orjson_3_10_3 = orjson.overrideAttrs (oldAttrs: rec {
+    version = "3.10.3";
+    src = fetchFromGitHub {
+      owner = "ijl";
+      repo = "orjson";
+      rev = "refs/tags/${version}";
+      hash = "sha256-bK6wA8P/IXEbiuJAx7psd0nUUKjR1jX4scFfJr1MBAk=";
+    };
+    cargoDeps = rustPlatform.fetchCargoTarball {
+      inherit src;
+      name = "${oldAttrs.pname}-${version}";
+      hash = "sha256-ilGq+/gPSuNwURUWy2ZxInzmUv+PxYMxd8esxrMpr2o=";
+    };
+  });
+in
 buildPythonPackage rec {
   pname = "duckduckgo-search";
-  version = "5.0";
+  version = "v5.3.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -22,36 +45,28 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "deedy5";
     repo = "duckduckgo_search";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-OZFkSFyXC2MFP2MbKwF/qR8zvCFzPKgLmX+nuIztOpw=";
+    rev = version;
+    hash = "sha256-T7rlB3dU7y+HbHr1Ss9KkejlXFORhnv9Va7cFTRtfQU=";
   };
 
-  nativeBuildInputs = [
-    setuptools
-  ];
+  nativeBuildInputs = [ setuptools ];
 
   propagatedBuildInputs = [
-    aiofiles
     click
-    h2
-    httpx
-    lxml
-    requests
-    socksio
-  ] ++ httpx.optional-dependencies.brotli
-    ++ httpx.optional-dependencies.http2
-    ++ httpx.optional-dependencies.socks;
-
-  pythonImportsCheck = [
-    "duckduckgo_search"
+    orjson_3_10_3
+    curl-cffi_0_7_0
   ];
 
-  meta = with lib; {
+  doCheck = false; # tests require network access
+
+  pythonImportsCheck = [ "duckduckgo_search" ];
+
+  meta = {
     description = "Python CLI and library for searching for words, documents, images, videos, news, maps and text translation using the DuckDuckGo.com search engine";
     mainProgram = "ddgs";
     homepage = "https://github.com/deedy5/duckduckgo_search";
-    changelog = "https://github.com/deedy5/duckduckgo_search/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    changelog = "https://github.com/deedy5/duckduckgo_search/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/duckduckgo-search/default.nix
+++ b/pkgs/development/python-modules/duckduckgo-search/default.nix
@@ -10,30 +10,34 @@
   rustPlatform,
 }:
 let
-  curl-cffi_0_7_0 = curl-cffi.overrideAttrs (final: old: {
-    version = "0.7.0b4";
-    src = fetchFromGitHub {
-      owner = "yifeikong";
-      repo = "curl_cffi";
-      rev = "v${final.version}";
-      hash = "sha256-txrJNUzswAPeH4Iazn0iKJI0Rqk0HHRoDrtTfDHKMoo=";
-    };
-  });
+  curl-cffi_0_7_0 = curl-cffi.overrideAttrs (
+    final: old: {
+      version = "0.7.0b4";
+      src = fetchFromGitHub {
+        owner = "yifeikong";
+        repo = "curl_cffi";
+        rev = "v${final.version}";
+        hash = "sha256-txrJNUzswAPeH4Iazn0iKJI0Rqk0HHRoDrtTfDHKMoo=";
+      };
+    }
+  );
 
-  orjson_3_10_3 = orjson.overrideAttrs (final: old: {
-    version = "3.10.3";
-    src = fetchFromGitHub {
-      owner = "ijl";
-      repo = old.pname;
-      rev = "refs/tags/${final.version}";
-      hash = "sha256-bK6wA8P/IXEbiuJAx7psd0nUUKjR1jX4scFfJr1MBAk=";
-    };
-    cargoDeps = rustPlatform.fetchCargoTarball {
-      inherit (final) src;
-      name = "${old.pname}-${final.version}";
-      hash = "sha256-ilGq+/gPSuNwURUWy2ZxInzmUv+PxYMxd8esxrMpr2o=";
-    };
-  });
+  orjson_3_10_3 = orjson.overrideAttrs (
+    final: old: {
+      version = "3.10.3";
+      src = fetchFromGitHub {
+        owner = "ijl";
+        repo = "orjson";
+        rev = "refs/tags/${final.version}";
+        hash = "sha256-bK6wA8P/IXEbiuJAx7psd0nUUKjR1jX4scFfJr1MBAk=";
+      };
+      cargoDeps = rustPlatform.fetchCargoTarball {
+        inherit (final) src;
+        name = "${old.pname}-${final.version}";
+        hash = "sha256-ilGq+/gPSuNwURUWy2ZxInzmUv+PxYMxd8esxrMpr2o=";
+      };
+    }
+  );
 in
 buildPythonPackage rec {
   pname = "duckduckgo-search";

--- a/pkgs/development/python-modules/duckduckgo-search/default.nix
+++ b/pkgs/development/python-modules/duckduckgo-search/default.nix
@@ -7,7 +7,12 @@
   setuptools,
   orjson,
   curl-cffi,
+
+  # To build orjson
   rustPlatform,
+
+  # Optional dependencies
+  lxml,
 }:
 let
   curl-cffi_0_7_0 = curl-cffi.overrideAttrs (
@@ -60,6 +65,10 @@ buildPythonPackage rec {
     orjson_3_10_3
     curl-cffi_0_7_0
   ];
+
+  passthru.optional-dependencies = {
+    lxml = [ lxml ];
+  };
 
   doCheck = false; # tests require network access
 

--- a/pkgs/development/python-modules/duckduckgo-search/default.nix
+++ b/pkgs/development/python-modules/duckduckgo-search/default.nix
@@ -10,27 +10,27 @@
   rustPlatform,
 }:
 let
-  curl-cffi_0_7_0 = curl-cffi.overrideAttrs (oldAttrs: rec {
+  curl-cffi_0_7_0 = curl-cffi.overrideAttrs (final: old: {
     version = "0.7.0b4";
     src = fetchFromGitHub {
       owner = "yifeikong";
       repo = "curl_cffi";
-      rev = "v${version}";
+      rev = "v${final.version}";
       hash = "sha256-txrJNUzswAPeH4Iazn0iKJI0Rqk0HHRoDrtTfDHKMoo=";
     };
   });
 
-  orjson_3_10_3 = orjson.overrideAttrs (oldAttrs: rec {
+  orjson_3_10_3 = orjson.overrideAttrs (final: old: {
     version = "3.10.3";
     src = fetchFromGitHub {
       owner = "ijl";
-      repo = "orjson";
-      rev = "refs/tags/${version}";
+      repo = old.pname;
+      rev = "refs/tags/${final.version}";
       hash = "sha256-bK6wA8P/IXEbiuJAx7psd0nUUKjR1jX4scFfJr1MBAk=";
     };
     cargoDeps = rustPlatform.fetchCargoTarball {
-      inherit src;
-      name = "${oldAttrs.pname}-${version}";
+      inherit (final) src;
+      name = "${old.pname}-${final.version}";
       hash = "sha256-ilGq+/gPSuNwURUWy2ZxInzmUv+PxYMxd8esxrMpr2o=";
     };
   });

--- a/pkgs/development/python-modules/duckduckgo-search/default.nix
+++ b/pkgs/development/python-modules/duckduckgo-search/default.nix
@@ -67,6 +67,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/deedy5/duckduckgo_search";
     changelog = "https://github.com/deedy5/duckduckgo_search/releases/tag/${version}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ drawbu ];
   };
 }


### PR DESCRIPTION
ZHF: #309482

## Description of changes

duckduckgo-search was broken due to missing dependencies. I took the opportunity to update it.

Updated duckduckgo-search: v5.0 -> v5.3.1
Updated local dependencies:
- curl-cffi: 0.6.3 -> 0.7.0b4
- orjson: 3.10.1 -> 3.10.3

I did not update curl-cffi as this is not a stable release.

I tried to update orjson, but a LOT of stuff depends on it.
 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
