### PR TITLE
apache-jena-fuseki: fix running with nix run

### DIFF
--- a/pkgs/servers/nosql/apache-jena/fuseki-binary.nix
+++ b/pkgs/servers/nosql/apache-jena/fuseki-binary.nix
@@ -24,9 +24,12 @@ stdenv.mkDerivation rec {
     chmod +x $out/fuseki
     ln -s "$out"/{fuseki-backup,fuseki-server,fuseki} "$out/bin"
     for i in "$out"/bin/*; do
+      # It is necessary to set the default $FUSEKI_BASE directory to a writable location
+      # By default it points to $FUSEKI_HOME/run which is in the nix store
       wrapProgram "$i" \
         --prefix "PATH" : "${java}/bin/:${coreutils}/bin:${which}/bin" \
         --set-default "FUSEKI_HOME" "$out" \
+        --run "if [ -z \"\$FUSEKI_BASE\" ]; then export FUSEKI_BASE=\"\$HOME/.local/fuseki\" ; mkdir -p \"\$HOME/.local/fuseki\" ; fi" \
         ;
     done
   '';
@@ -40,7 +43,9 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.all;
+    sourceProvenance = with sourceTypes; [ binaryBytecode binaryNativeCode ];
     homepage = "https://jena.apache.org";
     downloadPage = "https://archive.apache.org/dist/jena/binaries/";
+    mainProgram = "fuseki";
   };
 }


### PR DESCRIPTION
## Description of changes

This PR fixes using fuseki with `nix run`.

Previously `mainProgram` was unset so the correct binary was not found. fuseki also sets the FUSEKI_BASE path to `$FUSEKI_HOME/run`. However, as our FUSEKI_HOME points to the nix store and is not writeable fuseki fails to start. This PR adjustes the wrapper to set the default FUSEKI_BASE path to `$HOME/.local/fuseki`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
