### PR TITLE
build-support/rust: rewrite workspace dependency inheritance

### DIFF
--- a/pkgs/build-support/rust/replace-workspace-values.py
+++ b/pkgs/build-support/rust/replace-workspace-values.py
@@ -15,6 +15,9 @@ def load_file(path: str) -> dict[str, Any]:
         return tomli.load(f)
 
 
+# This replicates the dependency merging logic from Cargo.
+# See `inner_dependency_inherit_with`:
+# https://github.com/rust-lang/cargo/blob/4de0094ac78743d2c8ff682489e35c8a7cafe8e4/src/cargo/util/toml/mod.rs#L982
 def replace_key(
     workspace_manifest: dict[str, Any], table: dict[str, Any], section: str, key: str
 ) -> bool:
@@ -25,28 +28,37 @@ def replace_key(
     ):
         print("replacing " + key)
 
-        replaced = table[key]
-        del replaced["workspace"]
+        local_dep = table[key]
+        del local_dep["workspace"]
 
-        workspace_copy = workspace_manifest[section][key]
+        workspace_dep = workspace_manifest[section][key]
 
         if section == "dependencies":
-            crate_features = replaced.get("features")
+            if isinstance(workspace_dep, str):
+                workspace_dep = {"version": workspace_dep}
 
-            if type(workspace_copy) is str:
-                replaced["version"] = workspace_copy
-            else:
-                replaced.update(workspace_copy)
+            final: dict[str, Any] = workspace_dep.copy()
 
-                merged_features = (crate_features or []) + (
-                    workspace_copy.get("features") or []
-                )
+            merged_features = local_dep.pop("features", []) + workspace_dep.get("features", [])
+            if merged_features:
+                final["features"] = merged_features
 
-                if len(merged_features) > 0:
-                    # Dictionaries are guaranteed to be ordered (https://stackoverflow.com/a/7961425)
-                    replaced["features"] = list(dict.fromkeys(merged_features))
+            local_default_features = local_dep.pop("default-features", None)
+            workspace_default_features = workspace_dep.get("default-features")
+
+            if not workspace_default_features and local_default_features:
+                final["default-features"] = True
+
+            optional = local_dep.pop("optional", False)
+            if optional:
+                final["optional"] = True
+
+            if local_dep:
+                raise Exception(f"Unhandled keys in inherited dependency {key}: {local_dep}")
+
+            table[key] = final
         elif section == "package":
-            table[key] = replaced = workspace_copy
+            table[key] = workspace_dep
 
         return True
 


### PR DESCRIPTION
This fixes at least one bug with default-features, and also just aligns us more with what Cargo actually does.

Also some Python style fixes and a bit less mutating state.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
