### PR TITLE
linkchecker: fix tests, separate dependencies

### DIFF
--- a/pkgs/tools/networking/linkchecker/default.nix
+++ b/pkgs/tools/networking/linkchecker/default.nix
@@ -1,5 +1,4 @@
 { lib
-, stdenv
 , fetchFromGitHub
 , python3
 , gettext
@@ -8,49 +7,48 @@
 python3.pkgs.buildPythonApplication rec {
   pname = "linkchecker";
   version = "10.2.1";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "linkchecker";
+    repo = "linkchecker";
     rev = "refs/tags/v${version}";
     hash = "sha256-z7Qp74cai8GfsxB4n9dSCWQepp0/4PimFiRJQBaVSoo=";
   };
 
-  nativeBuildInputs = [
-    gettext
+  nativeBuildInputs = [ gettext ];
+
+  build-system = with python3.pkgs; [
+    hatchling
+    hatch-vcs
+    polib # translations
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3.pkgs; [
     argcomplete
     beautifulsoup4
-    configargparse
     dnspython
-    hatch-vcs
-    hatchling
-    pyopenssl
     requests
   ];
 
   nativeCheckInputs = with python3.pkgs; [
+    pyopenssl
     parameterized
     pytestCheckHook
   ];
 
   disabledTests = [
-    # test_timeit2 is flakey, and depends sleep being precise to the milisecond
     "TestLoginUrl"
-    "test_timeit2"
+    "test_timeit2" # flakey, and depends sleep being precise to the milisecond
+    "test_internet" # uses network, fails on Darwin (not sure why it doesn't fail on linux)
   ];
 
   disabledTestPaths = [
     "tests/checker/telnetserver.py"
     "tests/checker/test_telnet.py"
-  ] ++ lib.optionals stdenv.isDarwin [
-    "tests/checker/test_content_allows_robots.py"
-    "tests/checker/test_http*.py"
-    "tests/test_network.py"
   ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
     description = "Check websites for broken links";


### PR DESCRIPTION
## Description of changes

ZHF: https://github.com/NixOS/nixpkgs/issues/309482

This PR disables a test that has been failing on darwin, while enabling some disabled tests by setting the `__darwinAllowLocalNetworking` flag.

Other changes:
- use new dependency list naming scheme
- separate the dependencies properly
- add a compile-time dependency that generates translation files
- remove the `configargparse` dependency (not sure why it was there)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
