### PR TITLE
zig.hook: fix broken cache dir in impure devshells

### DIFF
--- a/pkgs/development/compilers/zig/setup-hook.sh
+++ b/pkgs/development/compilers/zig/setup-hook.sh
@@ -3,6 +3,8 @@
 readonly zigDefaultFlagsArray=(@zig_default_flags@)
 
 function zigSetGlobalCacheDir {
+    if [ "${IN_NIX_SHELL-}" = impure ]; then return 0; fi
+
     ZIG_GLOBAL_CACHE_DIR=$(mktemp -d)
     export ZIG_GLOBAL_CACHE_DIR
 }


### PR DESCRIPTION
## Description of changes

This is a fix for https://github.com/NixOS/nixpkgs/issues/270415#issuecomment-2098916635.

To fix, we simply do not set `ZIG_GLOBAL_CACHE_DIR` if we are inside an impure devshell.

This approach is also followed by stdenv: https://github.com/NixOS/nixpkgs/blob/5c0c6e14926c39d5c90073f01ca7fa6d24e3671b/pkgs/stdenv/generic/setup.sh#L806

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- ~~For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~~
- ~~Tested, as applicable: …~~
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- ~~[24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).