### PR TITLE
Enchant: AppleSpell & configurable spelling provider support

### DIFF
--- a/pkgs/development/libraries/enchant/2.x.nix
+++ b/pkgs/development/libraries/enchant/2.x.nix
@@ -9,6 +9,11 @@
 , hspell
 , nuspell
 , unittest-cpp
+
+, withHspell ? true
+, withAspell ? true
+, withHunspell ? true
+, withNuspell ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -31,7 +36,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glib
+  ] ++ lib.optionals withHunspell [
     hunspell
+  ] ++ lib.optionals withNuspell [
     nuspell
   ];
 
@@ -40,8 +47,9 @@ stdenv.mkDerivation rec {
   ];
 
   # libtool puts these to .la files
-  propagatedBuildInputs = [
+  propagatedBuildInputs = lib.optionals withHspell [
     hspell
+  ] ++ lib.optionals withAspell [
     aspell
   ];
 
@@ -51,10 +59,10 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--enable-relocatable" # needed for tests
-    "--with-aspell"
-    "--with-hspell"
-    "--with-hunspell"
-    "--with-nuspell"
+    (lib.withFeature withAspell "aspell")
+    (lib.withFeature withHspell "hspell")
+    (lib.withFeature withHunspell "hunspell")
+    (lib.withFeature withNuspell "nuspell")
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/enchant/2.x.nix
+++ b/pkgs/development/libraries/enchant/2.x.nix
@@ -14,7 +14,12 @@
 , withAspell ? true
 , withHunspell ? true
 , withNuspell ? true
+, withAppleSpell ? stdenv.isDarwin
+
+, Cocoa
 }:
+
+assert withAppleSpell -> stdenv.isDarwin;
 
 stdenv.mkDerivation rec {
   pname = "enchant";
@@ -40,6 +45,8 @@ stdenv.mkDerivation rec {
     hunspell
   ] ++ lib.optionals withNuspell [
     nuspell
+  ] ++ lib.optionals withAppleSpell [
+    Cocoa
   ];
 
   checkInputs = [
@@ -63,6 +70,7 @@ stdenv.mkDerivation rec {
     (lib.withFeature withHspell "hspell")
     (lib.withFeature withHunspell "hunspell")
     (lib.withFeature withNuspell "nuspell")
+    (lib.withFeature withAppleSpell "applespell")
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20671,7 +20671,9 @@ with pkgs;
 
   emanote = haskell.lib.compose.justStaticExecutables haskellPackages.emanote;
 
-  enchant2 = callPackage ../development/libraries/enchant/2.x.nix { };
+  enchant2 = callPackage ../development/libraries/enchant/2.x.nix {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
   enchant = enchant2;
 
   enet = callPackage ../development/libraries/enet { };


### PR DESCRIPTION
## Description of changes

https://abiword.github.io/enchant/ includes support for AppleSpell, the built-in spelling provider on macOS. I updated the derivation to make this support optional and default on darwin, whilst making the other providers easily-configurable as well.

The casing for AppleSpell is different because that's how Enchant refers to it. See the output of `enchant-lsmod-2`:

```
aspell (Aspell Provider)
hunspell (Hunspell Provider)
nuspell (Nuspell Provider)
AppleSpell (AppleSpell Provider)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
