### PR TITLE
wordpressPackages.plugins.surge: init at 1.1.0

### DIFF
--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -30,10 +30,10 @@
     "version": "2.1.7"
   },
   "co-authors-plus": {
-    "path": "co-authors-plus/tags/3.5.15",
-    "rev": "2959167",
-    "sha256": "1n01sk2vgiym25wvxi4igpx773ph59y5f5lvwaasilamdpw0lzh4",
-    "version": "3.5.15"
+    "path": "co-authors-plus/tags/3.6.1",
+    "rev": "3077160",
+    "sha256": "10733qibrcrshm3c9zjxhwqar2fg60na70npam1z2lz6gnwmwdqn",
+    "version": "3.6.1"
   },
   "code-syntax-block": {
     "path": "code-syntax-block/tags/3.2.1",
@@ -60,10 +60,10 @@
     "version": "1.4.0"
   },
   "gutenberg": {
-    "path": "gutenberg/tags/18.2.0",
-    "rev": "3077097",
-    "sha256": "126zbp5ix94qrkrw4lwsiwk3mri7xd28f7zz4cqbv03wq7pzla6x",
-    "version": "18.2.0"
+    "path": "gutenberg/tags/18.3.0",
+    "rev": "3083588",
+    "sha256": "0dl6hdi38988zpcl69avy1p8s93djlzk6f56ra490lvzlmf4g73z",
+    "version": "18.3.0"
   },
   "hcaptcha-for-forms-and-more": {
     "path": "hcaptcha-for-forms-and-more/tags/4.1.1",
@@ -84,10 +84,10 @@
     "version": "3.0.2"
   },
   "jetpack": {
-    "path": "jetpack/tags/13.3.1",
-    "rev": "3068650",
-    "sha256": "0fwigf6xg5y5nqfkk2nv08qyqp97v96rnccx2a72p19a6dq6b97x",
-    "version": "13.3.1"
+    "path": "jetpack/tags/13.4.1",
+    "rev": "3084434",
+    "sha256": "17fg162f5nqf87xi0bii9xsgc19vfd9hrf86b82c4m6sgb80rf2p",
+    "version": "13.4.1"
   },
   "jetpack-lite": {
     "path": "jetpack-lite/tags/3.0.3",
@@ -108,10 +108,10 @@
     "version": "2.09"
   },
   "mailpoet": {
-    "path": "mailpoet/tags/4.48.2",
-    "rev": "3067726",
-    "sha256": "13brfys3xmpmw5yd1wn826mrzxvb6312177l7hmr6mhk0adp5lhz",
-    "version": "4.48.2"
+    "path": "mailpoet/tags/4.50.0",
+    "rev": "3083197",
+    "sha256": "01z2r87jw94ap9ha8kz1l999pczpa6985j4z0nq44b20672p62gv",
+    "version": "4.50.0"
   },
   "merge-minify-refresh": {
     "path": "merge-minify-refresh/trunk",
@@ -142,6 +142,12 @@
     "rev": "2941521",
     "sha256": "1mrwgqp1ril54xqr8k2gwgjcsbf4xv3671v15xawapwz730h2c4r",
     "version": "0.10.0"
+  },
+  "surge": {
+    "path": "surge/tags/1.1.0",
+    "rev": "3030901",
+    "sha256": "1bg99gsxv32l62pv0n2pq0384ggk2p154pg79yxiwnab2mrrs8j2",
+    "version": "1.1.0"
   },
   "tc-custom-javascript": {
     "path": "tc-custom-javascript/tags/1.2.3",

--- a/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
@@ -23,6 +23,7 @@
 , "simple-login-captcha": "gpl2Plus"
 , "simple-mastodon-verification": "gpl2Plus"
 , "static-mail-sender-configurator": "mit"
+, "surge": "gpl3Only"
 , "tc-custom-javascript": "gpl2Plus"
 , "webp-converter-for-media": "gpl2Plus"
 , "webp-express": "gpl3Only"


### PR DESCRIPTION
## Description of changes
Adding the plugin [surge](https://wordpress.org/plugins/surge/)

## Things done
* Built on platform(s)
  
  * [x]  x86_64-linux
  * [ ]  aarch64-linux
  * [ ]  x86_64-darwin
  * [ ]  aarch64-darwin
* For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  
  * [ ]  `sandbox = relaxed`
  * [ ]  `sandbox = true`
* [ ]  Tested, as applicable:
  
  * [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  * and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  * or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  * made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
* [ ]  Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
* [ ]  Tested basic functionality of all binary files (usually in `./result/bin/`)
* [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  
  * [ ]  (Package updates) Added a release notes entry if the change is major or breaking
  * [ ]  (Module updates) Added a release notes entry if the change is significant
  * [ ]  (Module addition) Added a release notes entry if adding a new NixOS module
* [x]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Add a 👍 [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to [pull requests you find important](https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
