### PR TITLE
ferm: Fix import-ferm error importing ferm wrapped script

### DIFF
--- a/pkgs/tools/networking/ferm/default.nix
+++ b/pkgs/tools/networking/ferm/default.nix
@@ -11,6 +11,10 @@ in stdenv.mkDerivation rec {
     sha256 = "sha256-wA2RDVOU5pZ1YI617g9QTVz9pB6ZCi2akbqsbfk+P5I=";
   };
 
+  patches = [
+    ./import-ferm-wrapped.patch
+  ];
+
   # perl is used at build time to gather the ferm version.
   nativeBuildInputs = [ makeWrapper perl ];
   buildInputs = [ perl ];

--- a/pkgs/tools/networking/ferm/import-ferm-wrapped.patch
+++ b/pkgs/tools/networking/ferm/import-ferm-wrapped.patch
@@ -1,0 +1,14 @@
+--- old/src/import-ferm
++++ new/src/import-ferm
+@@ -42,9 +42,9 @@
+     # find the main "ferm" program
+     my $ferm;
+     if ($0 =~ /^(.*)\//) {
+-        $ferm = "$1/ferm";
++        $ferm = "$1/.ferm-wrapped";
+     } else {
+-        $ferm = 'ferm';
++        $ferm = '.ferm-wrapped';
+     }
+ 
+     # Perl 5.24 requires this prefix or else it will only look in @INC


### PR DESCRIPTION
import-ferm binary was importing wrapper script instead of perl code
so perl was "SEGFAULTing"

```
❯ nix-shell -p ferm --run "import-ferm --help"                
Scalar found where operator expected (Missing operator before "$PATH"?) at /nix/store/am3zfgfy95l6xslbw110dwmy7kg3zmw3-ferm-2.7/sbin/ferm line 2, near "':'$PATH"
syntax error at /nix/store/am3zfgfy95l6xslbw110dwmy7kg3zmw3-ferm-2.7/sbin/ferm line 2, near "':'$PATH"
Execution of /nix/store/am3zfgfy95l6xslbw110dwmy7kg3zmw3-ferm-2.7/sbin/ferm aborted due to compilation errors.
Compilation failed in require at /nix/store/am3zfgfy95l6xslbw110dwmy7kg3zmw3-ferm-2.7/sbin/.import-ferm-wrapped line 54.
BEGIN failed--compilation aborted at /nix/store/am3zfgfy95l6xslbw110dwmy7kg3zmw3-ferm-2.7/sbin/.import-ferm-wrapped line 58.
```

in fact ferm perl script is now in .ferm-wrapped

## Description of changes

make import-ferm call the right perl code

## Things done

Did it an ugly way, dunno if there's a better way of doing it

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
