### PR TITLE
dosbox-staging: 0.80.1 -> 0.81.1

### DIFF
--- a/pkgs/by-name/do/dosbox-staging/package.nix
+++ b/pkgs/by-name/do/dosbox-staging/package.nix
@@ -1,33 +1,34 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, SDL2
-, SDL2_image
-, SDL2_net
-, alsa-lib
-, copyDesktopItems
-, darwin
-, fluidsynth
-, glib
-, gtest
-, iir1
-, libGL
-, libGLU
-, libjack2
-, libmt32emu
-, libogg
-, libpng
-, libpulseaudio
-, libslirp
-, libsndfile
-, makeDesktopItem
-, makeWrapper
-, meson
-, ninja
-, opusfile
-, pkg-config
-, speexdsp
-, nix-update-script
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  SDL2,
+  SDL2_image,
+  SDL2_net,
+  alsa-lib,
+  copyDesktopItems,
+  darwin,
+  fluidsynth,
+  glib,
+  gtest,
+  iir1,
+  libGL,
+  libGLU,
+  libjack2,
+  libmt32emu,
+  libogg,
+  libpng,
+  libpulseaudio,
+  libslirp,
+  libsndfile,
+  makeDesktopItem,
+  makeWrapper,
+  meson,
+  ninja,
+  opusfile,
+  pkg-config,
+  speexdsp,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -50,31 +51,35 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
-  buildInputs = [
-    fluidsynth
-    glib
-    iir1
-    libGL
-    libGLU
-    libjack2
-    libmt32emu
-    libogg
-    libpng
-    libpulseaudio
-    libslirp
-    libsndfile
-    opusfile
-    SDL2
-    SDL2_image
-    SDL2_net
-    speexdsp
-  ] ++ lib.optionals stdenv.isLinux [
-    alsa-lib
-  ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-    AudioUnit
-    Carbon
-    Cocoa
-  ]);
+  buildInputs =
+    [
+      fluidsynth
+      glib
+      iir1
+      libGL
+      libGLU
+      libjack2
+      libmt32emu
+      libogg
+      libpng
+      libpulseaudio
+      libslirp
+      libsndfile
+      opusfile
+      SDL2
+      SDL2_image
+      SDL2_net
+      speexdsp
+    ]
+    ++ lib.optionals stdenv.isLinux [ alsa-lib ]
+    ++ lib.optionals stdenv.isDarwin (
+      with darwin.apple_sdk.frameworks;
+      [
+        AudioUnit
+        Carbon
+        Cocoa
+      ]
+    );
 
   desktopItems = [
     (makeDesktopItem {
@@ -84,7 +89,10 @@ stdenv.mkDerivation (finalAttrs: {
       comment = "x86 dos emulator enhanced";
       desktopName = "DosBox-Staging";
       genericName = "DOS emulator";
-      categories = [ "Emulator" "Game" ];
+      categories = [
+        "Emulator"
+        "Game"
+      ];
     })
   ];
 
@@ -102,7 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
     popd
   '';
 
-  passthru.updateScript = nix-update-script {};
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://dosbox-staging.github.io/";
@@ -114,7 +122,10 @@ stdenv.mkDerivation (finalAttrs: {
       practices.
     '';
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ joshuafern AndersonTorres ];
+    maintainers = with lib.maintainers; [
+      joshuafern
+      AndersonTorres
+    ];
     platforms = lib.platforms.unix;
     priority = 101;
   };

--- a/pkgs/by-name/do/dosbox-staging/package.nix
+++ b/pkgs/by-name/do/dosbox-staging/package.nix
@@ -6,7 +6,6 @@
   SDL2_image,
   SDL2_net,
   alsa-lib,
-  copyDesktopItems,
   darwin,
   fluidsynth,
   glib,
@@ -18,10 +17,10 @@
   libmt32emu,
   libogg,
   libpng,
+  zlib-ng,
   libpulseaudio,
   libslirp,
   libsndfile,
-  makeDesktopItem,
   makeWrapper,
   meson,
   ninja,
@@ -43,7 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    copyDesktopItems
     gtest
     makeWrapper
     meson
@@ -62,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
       libmt32emu
       libogg
       libpng
+      zlib-ng
       libpulseaudio
       libslirp
       libsndfile
@@ -81,20 +80,9 @@ stdenv.mkDerivation (finalAttrs: {
       ]
     );
 
-  desktopItems = [
-    (makeDesktopItem {
-      name = "dosbox-staging";
-      exec = "dosbox-staging";
-      icon = "dosbox-staging";
-      comment = "x86 dos emulator enhanced";
-      desktopName = "DosBox-Staging";
-      genericName = "DOS emulator";
-      categories = [
-        "Emulator"
-        "Game"
-      ];
-    })
-  ];
+  postInstall = ''
+    install -Dm644 $src/contrib/linux/dosbox-staging.desktop $out/share/applications/
+  '';
 
   postFixup = ''
     # Rename binary, add a wrapper, and copy manual to avoid conflict with

--- a/pkgs/by-name/do/dosbox-staging/package.nix
+++ b/pkgs/by-name/do/dosbox-staging/package.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , SDL2
 , SDL2_image
 , SDL2_net
@@ -28,70 +27,19 @@
 , opusfile
 , pkg-config
 , speexdsp
+, nix-update-script
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dosbox-staging";
-  version = "0.80.1";
+  version = "0.81.1";
 
   src = fetchFromGitHub {
     owner = "dosbox-staging";
     repo = "dosbox-staging";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-I90poBeLSq1c8PXyjrx7/UcbfqFNnnNiXfJdWhLPGMc=";
+    hash = "sha256-XGssEyX+AVv7/ixgGTRtPFjsUSX0FT0fhP+TXsFl2fY=";
   };
-
-  patches = [
-    # Pull missind SDL2_net dependency:
-    #   https://github.com/dosbox-staging/dosbox-staging/pull/2358
-    (fetchpatch {
-      name = "sdl2-net.patch";
-      url = "https://github.com/dosbox-staging/dosbox-staging/commit/1b02f187a39263f4b0285323dcfe184bccd749c2.patch";
-      hash = "sha256-Ev97xApInu6r5wvI9Q7FhkSXqtMW/rwJj48fExvqnT0=";
-    })
-
-    # Pull missing SDL2_image dependency:
-    #   https://github.com/dosbox-staging/dosbox-staging/pull/2239
-    (fetchpatch {
-      name = "sdl2-image.patch";
-      url = "https://github.com/dosbox-staging/dosbox-staging/commit/ca8b7a906d29a3f8ce956c4af7dc829a6ac3e229.patch";
-      hash = "sha256-WtTVSWWSlfXrdPVsnlDe4P5K/Fnj4QsOzx3Wo/Kusmg=";
-      includes = [ "src/gui/meson.build" ];
-    })
-  ]
-  # Pagesize detection via syscall; remove when next stable version arrives
-  ++ [
-    (fetchpatch {
-      # Added as a parent commit of 7e20f6e
-      # Fix ppc64le backend and 64K page size support (#2828)
-      name = "meson-add-ppc64.patch";
-      url = "https://github.com/dosbox-staging/dosbox-staging/commit/765bcc2b1d87050a4ea366bf22e1db075ad5660b.patch";
-      hash = "sha256-RtkidyF7w6RrPmCKK4Bd+3FtAn/+/38xk2cl32+yzxw=";
-      includes = [ "meson.build" ];
-    })
-    (fetchpatch {
-      # Added as a parent commit of 7e20f6e
-      # Account for debian powerpc prefix (instead of ppc)
-      name = "meson-powerpc64le.patch";
-      url = "https://github.com/dosbox-staging/dosbox-staging/commit/d44aa7441cd871ffac08974f22af7a735a839288.patch";
-      hash = "sha256-oMZtfmB1CRlDWyXwEWc3XzC+XxKazXDgo+jUiNBoJDw=";
-      includes = [ "meson.build" ];
-    })
-    (fetchpatch {
-      # Added as a parent commit of 7e20f6e
-      # Restore the PowerPC dynrec core to working order
-      name = "meson-option-write-or-execute.patch";
-      url = "https://github.com/dosbox-staging/dosbox-staging/commit/ef86642de390839afc77b2b591a6ea9ac43909b3.patch";
-      hash = "sha256-htOKEaXRRy28XNMX/t6uFTBLCkTr7YPtfmI9UyIBiz4=";
-      includes = [ "meson_options.txt" ];
-    })
-    (fetchpatch {
-      # Use a system call to detect the page size
-      name = "meson-detect-pagesize-by-syscall.patch";
-      url = "https://github.com/dosbox-staging/dosbox-staging/commit/7e20f6e401956a7a308f1b3462294d7ac9fa5db8.patch";
-      hash = "sha256-QW9lpHWCYSlQFgTqX/UxHAAWisz4wfPrdjLqROn/wR0=";
-    })
-  ];
 
   nativeBuildInputs = [
     copyDesktopItems
@@ -154,6 +102,8 @@ stdenv.mkDerivation (finalAttrs: {
     popd
   '';
 
+  passthru.updateScript = nix-update-script {};
+
   meta = {
     homepage = "https://dosbox-staging.github.io/";
     description = "A modernized DOS emulator";
@@ -169,4 +119,3 @@ stdenv.mkDerivation (finalAttrs: {
     priority = 101;
   };
 })
-# TODO: report upstream about not finding SDL2_net


### PR DESCRIPTION
## Description of changes
- Closes https://github.com/NixOS/nixpkgs/issues/293911
- remove patches that are now upstream

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
