### PR TITLE
linux: use zstd-based kernel compression for 5.13+

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -30,3 +30,6 @@
 - To facilitate dependency injection, the `imgui` package now builds a static archive using vcpkg' CMake rules.
   The derivation now installs "impl" headers selectively instead of by a wildcard.
   Use `imgui.src` if you just want to access the unpacked sources.
+
+- Kernel modules for Linux kernel 5.13+ are now compressed with `zstd` at the highest
+  compression level instead of with `xz`.

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -954,8 +954,10 @@ let
       THRUSTMASTER_FF    = yes;
       ZEROPLUS_FF        = yes;
 
-      MODULE_COMPRESS      = whenOlder "5.13" yes;
-      MODULE_COMPRESS_XZ   = yes;
+      MODULE_COMPRESS            = whenOlder "5.13" yes;
+      MODULE_COMPRESS_XZ         = whenOlder "5.13" yes;
+      MODULE_COMPRESS_ZSTD       = whenAtLeast "5.13" yes;
+      MODULE_COMPRESS_ZSTD_LEVEL = whenAtLeast "5.13" (freeform "19");
 
       SYSVIPC            = yes;  # System-V IPC
 

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -66,6 +66,19 @@
     patch = ./export-rt-sched-migrate.patch;
   };
 
+  zstd-configurable-level = {
+    name = "allow-setting-zstd-compression-level-for-kernel.patch";
+    patch = fetchurl {
+      url = "https://lore.kernel.org/linux-kbuild/1557177615.69331.1617974903770@office.mailbox.org/raw";
+      hash = "sha256-1hqmQautaOKfdh20C2/FjWGPsIgpAbbNu+LT3YhlE3Y=";
+    };
+  };
+
+  zstd-configurable-level-6_x = {
+    name = "allow-setting-zstd-compression-level-for-kernel-6_x.patch";
+    patch = ./v2-0001-kbuild-allow-setting-zstd-compression-level-for-m.patch;
+  };
+
   rust_1_75 = {
     name = "rust-1.75.patch";
     patch = ./rust-1.75.patch;

--- a/pkgs/os-specific/linux/kernel/v2-0001-kbuild-allow-setting-zstd-compression-level-for-m.patch
+++ b/pkgs/os-specific/linux/kernel/v2-0001-kbuild-allow-setting-zstd-compression-level-for-m.patch
@@ -1,0 +1,54 @@
+From 26b700af5ba3e64bf96186d95949ad4116243b9c Mon Sep 17 00:00:00 2001
+From: "torvic9@mailbox.org" <torvic9@mailbox.org>
+Date: Fri, 9 Apr 2021 15:28:23 +0200
+Subject: [PATCH v2] kbuild: allow setting zstd compression level for modules
+
+Zstd offers a very fine-grained control of compression ratios.
+Add a Kconfig option that allows setting the desired compression
+level for module compression.
+
+Based on Masahiro's linux-kbuild.
+
+Signed-off-by: Tor Vic <torvic9@mailbox.org>
+Tested-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
+Tested-by: Maximilian Bosch <maximilian@mbosch.me>
+---
+ kernel/module/Kconfig    | 8 ++++++++
+ scripts/Makefile.modinst | 2 +-
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/kernel/module/Kconfig b/kernel/module/Kconfig
+index 33a2e991f608..076b18dd3941 100644
+--- a/kernel/module/Kconfig
++++ b/kernel/module/Kconfig
+@@ -317,6 +317,14 @@ config MODULE_COMPRESS_ZSTD
+ 
+ endchoice
+ 
++config MODULE_COMPRESS_ZSTD_LEVEL
++	int "Compression level (1-19)"
++	depends on MODULE_COMPRESS_ZSTD
++	range 1 19
++	default 3
++	help
++	  Compression level used by zstd for compressing modules.
++
+ config MODULE_DECOMPRESS
+ 	bool "Support in-kernel module decompression"
+ 	depends on MODULE_COMPRESS_GZIP || MODULE_COMPRESS_XZ || MODULE_COMPRESS_ZSTD
+diff --git a/scripts/Makefile.modinst b/scripts/Makefile.modinst
+index ab0c5bd1a60f..480d47eca36a 100644
+--- a/scripts/Makefile.modinst
++++ b/scripts/Makefile.modinst
+@@ -101,7 +101,7 @@ quiet_cmd_gzip = GZIP    $@
+ quiet_cmd_xz = XZ      $@
+       cmd_xz = $(XZ) --lzma2=dict=2MiB -f $<
+ quiet_cmd_zstd = ZSTD    $@
+-      cmd_zstd = $(ZSTD) -T0 --rm -f -q $<
++      cmd_zstd = $(ZSTD) -$(CONFIG_MODULE_COMPRESS_ZSTD_LEVEL) -T0 --rm -f -q $<
+ 
+ $(dst)/%.ko.gz: $(dst)/%.ko FORCE
+ 	$(call cmd,gzip)
+-- 
+2.42.0
+

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -142,6 +142,7 @@ in {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
+        kernelPatches.zstd-configurable-level
       ];
     };
 
@@ -150,6 +151,7 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.export-rt-sched-migrate
+        kernelPatches.zstd-configurable-level
       ];
     };
 
@@ -158,6 +160,7 @@ in {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
+        kernelPatches.zstd-configurable-level-6_x
       ];
     };
 
@@ -166,6 +169,7 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.export-rt-sched-migrate
+        kernelPatches.zstd-configurable-level-6_x
       ];
     };
 
@@ -174,6 +178,7 @@ in {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
+        kernelPatches.zstd-configurable-level-6_x
       ];
     };
 
@@ -182,6 +187,7 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.export-rt-sched-migrate
+        kernelPatches.zstd-configurable-level-6_x
       ];
     };
 
@@ -193,6 +199,7 @@ in {
         kernelPatches.rust_1_75
         kernelPatches.rust_1_76
         kernelPatches.rust_1_77-6_8
+        kernelPatches.zstd-configurable-level-6_x
       ];
     };
 
@@ -202,6 +209,7 @@ in {
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.rust_1_77-6_9
+        kernelPatches.zstd-configurable-level-6_x
       ];
     };
 
@@ -213,6 +221,7 @@ in {
         kernelPatches = [
           kernelPatches.bridge_stp_helper
           kernelPatches.request_key_helper
+          kernelPatches.zstd-configurable-level-6_x
         ];
       };
       latest = packageAliases.linux_latest.kernel;


### PR DESCRIPTION
First attempt[1] was reverted because we used the defaults from the kernel's makefile (using the zstd defaults). Using `-19` gives better results:

| Kernel   | Closure Size with XZ | with ZSTD | increase |
| -------- | -------------------- | --------- | -------- |
| 5.15.158 | 111.0M               | 121.5M    | +8,6%    |
| 6.1.90   | 116.3M               | 127.4M    | +8.7%    |
| 6.6.30   | 129.9M               | 142.4M    | +8.7%    |

[1] 2f04c5f8a3063206c66fa69a346d2776b8074115

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
