### PR TITLE
hmm: replace rustc-serialize version to unbreak build

### DIFF
--- a/pkgs/applications/misc/hmm/default.nix
+++ b/pkgs/applications/misc/hmm/default.nix
@@ -14,11 +14,14 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-WPePzqZ2iGeJ7kzTj8eg7q1JEjw91WY7gViJJ46SLRY=";
   };
 
-  cargoHash = "sha256-9Z49aPfcIdMfYCFAXsxFxcfhaLjtPod+nMFHDmvgDY0=";
+  cargoHash = "sha256-CQnM7pFnk4LcstKllhbeohbrggKV6MBQy03oq7DEkP4=";
 
   nativeCheckInputs = [
     perl
   ];
+  # FIXME: remove patch when upstream version of rustc-serialize is updated
+  # https://github.com/NixOS/nixpkgs/pull/310673
+  cargoPatches = [ ./rustc-serialize-fix.patch ];
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/applications/misc/hmm/rustc-serialize-fix.patch
+++ b/pkgs/applications/misc/hmm/rustc-serialize-fix.patch
@@ -1,0 +1,16 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index b1cc23695b30..ffdeb1c90618 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -996,9 +996,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustc-serialize"
+-version = "0.3.24"
++version = "0.3.25"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
++checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
+ 
+ [[package]]
+ name = "rustix"


### PR DESCRIPTION
## Description of changes

This PR adopts the same patch offered in #310125 to [unbreak the build with versions of Rust > 1.76](https://hydra.nixos.org/build/258403567#tabs-summary). Part of ZHF: #309482

## Things done

- Add patch

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
