### PR TITLE
cli11: pkgs/development -> pkgs/by-name, refactor

### DIFF
--- a/pkgs/by-name/cl/cli11/package.nix
+++ b/pkgs/by-name/cl/cli11/package.nix
@@ -1,29 +1,34 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, boost
-, catch2
-, cmake
-, gtest
-, python3
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  boost,
+  catch2,
+  cmake,
+  python3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cli11";
   version = "2.3.2";
 
   src = fetchFromGitHub {
     owner = "CLIUtils";
     repo = "CLI11";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-x3/kBlf5LdzkTO4NYOKanZBfcU4oK+fJw9L7cf88LsY=";
   };
 
+  buildInputs = [ catch2 ];
   nativeBuildInputs = [ cmake ];
 
-  nativeCheckInputs = [ boost python3 catch2 ];
+  nativeCheckInputs = [
+    boost
+    python3
+  ];
 
   doCheck = true;
+  strictDeps = true;
 
   meta = with lib; {
     description = "Command line parser for C++11";
@@ -32,5 +37,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ];
     license = licenses.bsd3;
   };
-
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18555,8 +18555,6 @@ with pkgs;
 
   sigrok-firmware-fx2lafw = callPackage ../development/tools/sigrok-firmware-fx2lafw { };
 
-  cli11 = callPackage ../development/tools/misc/cli11 { };
-
   datree = callPackage ../development/tools/datree { };
 
   detekt = callPackage ../development/tools/detekt { };


### PR DESCRIPTION
## Description of changes

* Fix and enable strictDeps.
* Apply RFC linter.
* Move to pkgs by-name.
* Use finalAttrs.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).