### PR TITLE
linuxPackages.ena: 2.8.9 -> 2.12.0

### DIFF
--- a/pkgs/os-specific/linux/ena/default.nix
+++ b/pkgs/os-specific/linux/ena/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchFromGitHub, kernel }:
 
 stdenv.mkDerivation rec {
-  version = "2.8.9";
+  version = "2.12.0";
   name = "ena-${version}-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "amzn";
     repo = "amzn-drivers";
     rev = "ena_linux_${version}";
-    hash = "sha256-9Csrq9wM7Q99qPj7+NlnQgP6KcciNHMbAAb+Wg7eYAU=";
+    hash = "sha256-Z/eeIUY7Yl2l/IqK3Z2nxPhn+JLvP976IZ9ZXPBqoSo=";
   };
 
   hardeningDisable = [ "pic" ];

--- a/pkgs/os-specific/linux/ena/default.nix
+++ b/pkgs/os-specific/linux/ena/default.nix
@@ -19,6 +19,12 @@ stdenv.mkDerivation rec {
   # linux 3.12
   env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
 
+  patches = [
+    # Use kernel version checks instead of API feature detection
+    # See https://github.com/NixOS/nixpkgs/pull/310680
+    ./override-features-api-detection.patch
+  ];
+
   configurePhase = ''
     runHook preConfigure
     cd kernel/linux/ena

--- a/pkgs/os-specific/linux/ena/override-features-api-detection.patch
+++ b/pkgs/os-specific/linux/ena/override-features-api-detection.patch
@@ -1,0 +1,55 @@
+diff --git a/kernel/linux/ena/kcompat.h b/kernel/linux/ena/kcompat.h
+index 32a9cc5..8d39362 100644
+--- a/kernel/linux/ena/kcompat.h
++++ b/kernel/linux/ena/kcompat.h
+@@ -888,21 +888,6 @@ xdp_prepare_buff(struct xdp_buff *xdp, unsigned char *hard_start,
+ #define ENA_XDP_XMIT_FREES_FAILED_DESCS_INTERNALLY
+ #endif
+ 
+-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0) && \
+-	!(LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 188) && \
+-	 LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)) && \
+-	!(LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 251) && \
+-	 LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 0))) && \
+-	!(defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 6)) && \
+-	!(defined(SUSE_VERSION) && (SUSE_VERSION == 15 && SUSE_PATCHLEVEL >= 4)) && \
+-	!(defined(SUSE_VERSION) && (SUSE_VERSION == 15 && SUSE_PATCHLEVEL == 3) && \
+-	  ENA_KERNEL_VERSION_GTE(5, 3, 18, 150300, 59, 43))
+-static inline void eth_hw_addr_set(struct net_device *dev, const u8 *addr)
+-{
+-	memcpy(dev->dev_addr, addr, ETH_ALEN);
+-}
+-#endif
+-
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0) || \
+ 	(defined(RHEL_RELEASE_CODE) && \
+ 	RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 6) && \
+@@ -1112,7 +1097,7 @@ static inline void ena_dma_unmap_page_attrs(struct device *dev,
+ #define pci_dev_id(pdev) ((((u16)(pdev->bus->number)) << 8) | (pdev->devfn))
+ #endif /* ENA_HAVE_PCI_DEV_ID */
+ 
+-#ifndef ENA_HAVE_XDP_DO_FLUSH
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 0)
+ #define xdp_do_flush xdp_do_flush_map
+ #endif /* ENA_HAVE_XDP_DO_FLUSH */
+ 
+@@ -1147,15 +1132,15 @@ static inline unsigned int cpumask_local_spread(unsigned int i, int node)
+ }
+ #endif /* ENA_HAVE_CPUMASK_LOCAL_SPREAD */
+ 
+-#ifndef ENA_HAVE_UPDATE_AFFINITY_HINT
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
+ static inline int irq_update_affinity_hint(unsigned int irq, const struct cpumask *m)
+ {
+ 	return 0;
+ }
+-#endif /* ENA_HAVE_UPDATE_AFFINITY_HINT */
++#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(5.17.0) */
+ 
+-#ifndef ENA_HAVE_ETHTOOL_PUTS
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
+ #define ethtool_puts ethtool_sprintf
+-#endif /* ENA_HAVE_ETHTOOL_PUTS */
++#endif
+ 
+ #endif /* _KCOMPAT_H_ */


### PR DESCRIPTION
## Description of changes

This PR upgrades the Amazon Elastic Network Adapter driver to the latest version, also resolving the [broken build](https://hydra.nixos.org/build/259097959/nixlog/1).

ZHF: #309482

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
