### PR TITLE
hare: refactor derivation

### DIFF
--- a/pkgs/by-name/ha/hare/003-hardcode-qbe-and-harec.patch
+++ b/pkgs/by-name/ha/hare/003-hardcode-qbe-and-harec.patch
@@ -1,0 +1,24 @@
+diff --git a/cmd/hare/build.ha b/cmd/hare/build.ha
+index b2ac6518..417b46c6 100644
+--- a/cmd/hare/build.ha
++++ b/cmd/hare/build.ha
+@@ -37,7 +37,7 @@ fn build(name: str, cmd: *getopt::command) (void | error) = {
+ 		case let ncpu: size =>
+ 			yield ncpu;
+ 		},
+-		version = build::get_version(os::tryenv("HAREC", "harec"))?,
++		version = build::get_version(os::tryenv("HAREC", "@harec@"))?,
+ 		arch = arch.qbe_name,
+ 		platform = build::get_platform(os::sysname())?,
+ 		...
+@@ -145,8 +145,8 @@ fn build(name: str, cmd: *getopt::command) (void | error) = {
+ 	set_arch_tags(&ctx.ctx.tags, arch);
+ 
+ 	ctx.cmds = ["",
+-		os::tryenv("HAREC", "harec"),
+-		os::tryenv("QBE", "qbe"),
++		os::tryenv("HAREC", "@harec@"),
++		os::tryenv("QBE", "@qbe@"),
+ 		os::tryenv("AS", arch.as_cmd),
+ 		os::tryenv("LD", arch.ld_cmd),
+ 	];

--- a/pkgs/by-name/ha/hare/004-use-mailcap-for-mimetypes.patch
+++ b/pkgs/by-name/ha/hare/004-use-mailcap-for-mimetypes.patch
@@ -1,0 +1,13 @@
+diff --git a/mime/system.ha b/mime/system.ha
+index 73ff3496..42e7b640 100644
+--- a/mime/system.ha
++++ b/mime/system.ha
+@@ -11,7 +11,7 @@ use strings;
+ use types;
+ 
+ // Path to the system MIME database.
+-export def SYSTEM_DB: str = "/etc/mime.types";
++export def SYSTEM_DB: str = "@mailcap@/etc/mime.types";
+ 
+ @init fn init() void = {
+ 	// Done in a separate function so we can discard errors here

--- a/pkgs/by-name/ha/hare/cross-compilation-tests.nix
+++ b/pkgs/by-name/ha/hare/cross-compilation-tests.nix
@@ -1,31 +1,32 @@
-{ lib
-, buildPackages
-, hare
-, runCommandNoCC
-, stdenv
-, writeText
+{
+  lib,
+  hare,
+  runCommandNoCC,
+  writeText,
 }:
 let
-  inherit (stdenv.hostPlatform.uname) processor;
-  inherit (stdenv.hostPlatform) emulator;
+  archs = lib.concatStringsSep " " (
+    builtins.map (lib.removeSuffix "-linux") (
+      builtins.filter (lib.hasSuffix "-linux") hare.meta.platforms
+    )
+  );
   mainDotHare = writeText "main.ha" ''
-    use fmt;
-    use os;
-    export fn main() void = {
-        const machine = os::machine();
-        if (machine == "${processor}") {
-            fmt::println("os::machine() matches ${processor}")!;
-        } else {
-            fmt::fatalf("os::machine() does not match ${processor}: {}", machine);
-        };
-    };
+    export fn main() void = void;
   '';
 in
-runCommandNoCC "${hare.pname}-cross-compilation-test" { meta.timeout = 60; } ''
-  HARECACHE="$(mktemp -d --tmpdir harecache.XXXXXXXX)"
+runCommandNoCC "${hare.pname}-cross-compilation-test" { nativeBuildInputs = [ hare ]; } ''
+  HARECACHE="$(mktemp -d)"
   export HARECACHE
-  outbin="test-${processor}"
-  ${lib.getExe hare} build -q -a "${processor}" -o "$outbin" ${mainDotHare}
-  ${emulator buildPackages} "./$outbin"
+  readonly binprefix="bin"
+  for a in ${archs}; do
+    outbin="$binprefix-$a"
+    set -x
+    hare build -o "$outbin" -q -R -a "$a" ${mainDotHare}
+    set +x
+    printf -- 'Built "%s" target\n' "$a"
+  done
+
+  printf -- 'Generated binary file: %s\n' "$binprefix-"*
+
   : 1>$out
 ''

--- a/pkgs/by-name/ha/hare/package.nix
+++ b/pkgs/by-name/ha/hare/package.nix
@@ -99,6 +99,11 @@ stdenv.mkDerivation (finalAttrs: {
     # Don't build haredoc since it uses the build `hare` bin, which breaks
     # cross-compilation.
     ./002-dont-build-haredoc.patch
+    # Display toolchains when using `hare version -v`.
+    (fetchpatch {
+      url = "https://git.sr.ht/~sircmpwn/hare/commit/e35f2284774436f422e06f0e8d290b173ced1677.patch";
+      hash = "sha256-A59bGO/9tOghV8/MomTxd8xRExkHVdoMom2d+HTfQGg=";
+    })
   ];
 
   nativeBuildInputs = [
@@ -122,7 +127,6 @@ stdenv.mkDerivation (finalAttrs: {
       "ARCH=${arch}"
       "VERSION=${finalAttrs.version}-nixpkgs"
       "QBEFLAGS=-t${qbePlatform}"
-      "CC=${stdenv.cc.targetPrefix}cc"
       "AS=${stdenv.cc.targetPrefix}as"
       "LD=${stdenv.cc.targetPrefix}ld"
       # Strip the variable of an empty $(SRCDIR)/hare/third-party, since nix does
@@ -136,9 +140,9 @@ stdenv.mkDerivation (finalAttrs: {
       "AARCH64_AS=${embeddedOnBinaryTools.aarch64.as}"
       "AARCH64_CC=${embeddedOnBinaryTools.aarch64.cc}"
       "AARCH64_LD=${embeddedOnBinaryTools.aarch64.ld}"
-      "x86_64_AS=${embeddedOnBinaryTools.x86_64.as}"
-      "x86_64_CC=${embeddedOnBinaryTools.x86_64.cc}"
-      "x86_64_LD=${embeddedOnBinaryTools.x86_64.ld}"
+      "X86_64_AS=${embeddedOnBinaryTools.x86_64.as}"
+      "X86_64_CC=${embeddedOnBinaryTools.x86_64.cc}"
+      "X86_64_LD=${embeddedOnBinaryTools.x86_64.ld}"
     ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/ha/hare/package.nix
+++ b/pkgs/by-name/ha/hare/package.nix
@@ -147,7 +147,10 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   # Append the distribution name to the version
-  env.LOCALVER = "nixpkgs";
+  # It doesn't work right, now, hence, setting `VERSION` in `makeFlags`, but it seems it will be
+  # fixed on 0.24.1. See here:
+  # https://lists.sr.ht/~sircmpwn/hare-users/%3Cb7cd9c94d2132c62940818089ae5afa2@onemoresuza.mailer.me%3E
+  # env.LOCALVER = "nixpkgs";
 
   strictDeps = true;
 

--- a/pkgs/by-name/ha/hare/package.nix
+++ b/pkgs/by-name/ha/hare/package.nix
@@ -7,6 +7,7 @@
   gitUpdater,
   scdoc,
   tzdata,
+  mailcap,
   substituteAll,
   fetchpatch,
   callPackage,
@@ -113,6 +114,11 @@ stdenv.mkDerivation (finalAttrs: {
     (fetchpatch {
       url = "https://git.sr.ht/~sircmpwn/hare/commit/e35f2284774436f422e06f0e8d290b173ced1677.patch";
       hash = "sha256-A59bGO/9tOghV8/MomTxd8xRExkHVdoMom2d+HTfQGg=";
+    })
+    # Use mailcap `/etc/mime.types` for Hare's mime module
+    (substituteAll {
+      src = ./004-use-mailcap-for-mimetypes.patch;
+      inherit mailcap;
     })
   ];
 


### PR DESCRIPTION
## Description of changes

Each commit describes in more detail what's being done, but, in broad strokes, this PR:

1. Formats the `package.nix` file with `nixfmt-rfc-style`;
2. Fixes the `X86_64_<TOOL>` make variables not being embedded on the binary;
3. Simplify the generation of the embedded values;
4. Removes the wrapping of the binary;
5. Refactor the cross-compilation test so that there is cross-compilation; and
6. Fixes the mime module.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>himitsu-firefox</li>
  </ul>
</details>
<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>treecat</li>
    <li>treecat.man</li>
  </ul>
</details>
<details>
  <summary>14 packages built:</summary>
                                                                                                          
  <ul>                                                                                                          
    <li>bonsai</li>                                                                                                          
    <li>hare</li>                                                                                                          
    <li>hare.man</li>                                                                                                          
    <li>hareThirdParty.hare-compress</li>                                                                                                          
    <li>hareThirdParty.hare-ev</li>                                                                                                          
    <li>hareThirdParty.hare-json</li>                                                                                                          
    <li>hareThirdParty.hare-png</li>                                                                                                          
    <li>hareThirdParty.hare-ssh</li>                                                                                                          
    <li>hareThirdParty.hare-toml</li>                                                                                                          
    <li>haredo</li>                                                                                                          
    <li>haredo.man</li>                                                                                                          
    <li>haredoc</li>                                                                                                          
    <li>haredoc.man</li>                                                                                                          
    <li>himitsu</li>                                                                                                          
  </ul>                                                                                                          
</details>                                                                                                          


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
