### PR TITLE
k3s_1_30: init 1.30.0+k3s1

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_30/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_30/chart-versions.nix
@@ -1,0 +1,10 @@
+{
+  traefik-crd = {
+    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.3+up25.0.0.tgz";
+    sha256 = "1z693i4kd3jyf26ccnb0sxjyxadipl6k13n7jyg5v4y93fv1rpdw";
+  };
+  traefik = {
+    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.3+up25.0.0.tgz";
+    sha256 = "1a24qlp7c6iri72ka1i37l1lzn13xibrd26dy295z2wzr55gg7if";
+  };
+}

--- a/pkgs/applications/networking/cluster/k3s/1_30/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_30/versions.nix
@@ -1,0 +1,14 @@
+{
+  k3sVersion = "1.30.0+k3s1";
+  k3sCommit = "14549535f13c63fc239ba055d36d590e68b01503";
+  k3sRepoSha256 = "1dph6clzzanlx7dbdzpamnw7gpw98j850my28lcb3zdzhvhsc74b";
+  k3sVendorHash = "sha256-YBWiIf8F71ibR7sCiYtmsAcY1MsvkhTD/K45tOHQC5w=";
+  chartVersions = import ./chart-versions.nix;
+  k3sRootVersion = "0.13.0";
+  k3sRootSha256 = "1jq5f0lm08abx5ikarf92z56fvx4kjpy2nmzaazblb34lajw87vj";
+  k3sCNIVersion = "1.4.0-k3s2";
+  k3sCNISha256 = "17dg6jgjx18nrlyfmkv14dhzxsljz4774zgwz5dchxcf38bvarqa";
+  containerdVersion = "1.7.15-k3s1";
+  containerdSha256 = "18hlj4ixjk7wvamfd66xyc0cax2hs9s7yjvlx52afxdc73194y0f";
+  criCtlVersion = "1.29.0-k3s1";
+}

--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -54,4 +54,15 @@ in
       ];
     }
   ) extraArgs;
+
+  # 1_30 can be built with the same builder as 1_26
+  k3s_1_30 = common (
+    (import ./1_30/versions.nix)
+    // {
+      updateScript = [
+        ./update-script.sh
+        "30"
+      ];
+    }
+  ) extraArgs;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32079,6 +32079,10 @@ with pkgs;
     buildGoModule = buildGo121Module;
     go = go_1_21;
   }) k3s_1_26 k3s_1_27 k3s_1_28 k3s_1_29;
+  inherit (callPackage ../applications/networking/cluster/k3s {
+    buildGoModule = buildGo122Module;
+    go = go_1_22;
+  }) k3s_1_30;
   k3s = k3s_1_29;
 
   k3sup = callPackage ../applications/networking/cluster/k3sup { };


### PR DESCRIPTION
Release: https://github.com/k3s-io/k3s/releases/tag/v1.30.0%2Bk3s1

Notes:
* I won't be bumping default `k3s` to `k3s_1_30` until it has been properly tested or at least 1-2 weeks have passed by.

CC @euank @Mic92 @wrmilling @yajo

Note: I will get back to this when I have the time. If someone wants to solve this earlier feel free. Sorry about the delay.