### PR TITLE
k3s: fix a blank space making update script not match nixfmt-rfc-styles

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/update-script.sh
+++ b/pkgs/applications/networking/cluster/k3s/update-script.sh
@@ -57,7 +57,7 @@ CHARTS_URL=https://k3s.io/k3s-charts/assets
 rm -f chart-versions.nix.update
 cat > chart-versions.nix.update <<EOF
 {
-  traefik-crd  = {
+  traefik-crd = {
     url = "${CHARTS_URL}/traefik-crd/${CHART_FILES[0]}";
     sha256 = "$(nix-prefetch-url --quiet "${CHARTS_URL}/traefik-crd/${CHART_FILES[0]}")";
   };


### PR DESCRIPTION
k3s: fix a blank space making update script not match nixfmt-rfc-styles

Caught issue after update script execution. Unfortunately, a bit late.

CC @wrmilling @yajo @euank @mic92