### PR TITLE
nixos/input-method: deprecate .enabled option; add .type and .enable options

### DIFF
--- a/doc/packages/ibus.section.md
+++ b/doc/packages/ibus.section.md
@@ -11,7 +11,8 @@ On NixOS, you need to explicitly enable `ibus` with given engines before customi
 ```nix
 { pkgs, ... }: {
   i18n.inputMethod = {
-    enabled = "ibus";
+    enable = true;
+    type = "ibus";
     ibus.engines = with pkgs.ibus-engines; [ typing-booster ];
   };
 }

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -215,6 +215,9 @@
   The derivation now installs "impl" headers selectively instead of by a wildcard.
   Use `imgui.src` if you just want to access the unpacked sources.
 
+- The `i18n.inputMethod` module introduces two new properties:
+  `enable` and `type`, for declaring whether to enable an alternative input method and defining which input method respectfully. The options available in `type` are the same as the existing `enabled` option. `enabled` is now deprecated, and will be removed in a future release.
+
 - `security.pam.u2f` now follows RFC42.
   All module options are now settable through the freeform `.settings`.
 

--- a/nixos/modules/i18n/input-method/default.md
+++ b/nixos/modules/i18n/input-method/default.md
@@ -25,7 +25,8 @@ The following snippet can be used to configure IBus:
 ```nix
 {
   i18n.inputMethod = {
-    enabled = "ibus";
+    enable = true;
+    type = "ibus";
     ibus.engines = with pkgs.ibus-engines; [ anthy hangul mozc ];
   };
 }
@@ -81,7 +82,8 @@ The following snippet can be used to configure Fcitx:
 ```nix
 {
   i18n.inputMethod = {
-    enabled = "fcitx5";
+    enable = true;
+    type = "fcitx5";
     fcitx5.addons = with pkgs; [ fcitx5-mozc fcitx5-hangul fcitx5-m17n ];
   };
 }
@@ -119,7 +121,8 @@ The following snippet can be used to configure Nabi:
 ```nix
 {
   i18n.inputMethod = {
-    enabled = "nabi";
+    enable = true;
+    type = "nabi";
   };
 }
 ```
@@ -134,7 +137,8 @@ The following snippet can be used to configure uim:
 ```nix
 {
   i18n.inputMethod = {
-    enabled = "uim";
+    enable = true;
+    type = "uim";
   };
 }
 ```
@@ -154,7 +158,8 @@ The following snippet can be used to configure Hime:
 ```nix
 {
   i18n.inputMethod = {
-    enabled = "hime";
+    enable = true;
+    type = "hime";
   };
 }
 ```
@@ -168,7 +173,8 @@ The following snippet can be used to configure Kime:
 ```nix
 {
   i18n.inputMethod = {
-    enabled = "kime";
+    enable = true;
+    type = "kime";
   };
 }
 ```

--- a/nixos/modules/i18n/input-method/default.nix
+++ b/nixos/modules/i18n/input-method/default.nix
@@ -4,6 +4,8 @@ with lib;
 let
   cfg = config.i18n.inputMethod;
 
+  allowedTypes = types.enum [ "ibus" "fcitx5" "nabi" "uim" "hime" "kime" ];
+
   gtk2_cache = pkgs.runCommand "gtk2-immodule.cache"
     { preferLocalBuild = true;
       allowSubstitutes = false;
@@ -28,9 +30,22 @@ in
 {
   options.i18n = {
     inputMethod = {
+      enable = mkEnableOption "an additional input method type" // {
+        default = cfg.enabled != null;
+        defaultText = literalMD "`true` if the deprecated option `enabled` is set, false otherwise";
+      };
+
       enabled = mkOption {
-        type    = types.nullOr (types.enum [ "ibus" "fcitx5" "nabi" "uim" "hime" "kime" ]);
+        type    = types.nullOr allowedTypes;
         default = null;
+        example = "fcitx5";
+        description = "Deprecated - use `type` and `enable = true` instead";
+      };
+
+      type = mkOption {
+        type    = types.nullOr allowedTypes;
+        default = cfg.enabled;
+        defaultText = literalMD "The value of the deprecated option `enabled`, defaulting to null";
         example = "fcitx5";
         description = ''
           Select the enabled input method. Input methods is a software to input symbols that are not available on standard input devices.
@@ -59,7 +74,8 @@ in
     };
   };
 
-  config = mkIf (cfg.enabled != null) {
+  config = mkIf cfg.enable {
+    warnings = optional (cfg.enabled != null) "i18n.inputMethod.enabled will be removed in a future release. Please use .type, and .enable = true instead";
     environment.systemPackages = [ cfg.package gtk2_cache gtk3_cache ];
   };
 

--- a/nixos/modules/i18n/input-method/fcitx5.nix
+++ b/nixos/modules/i18n/input-method/fcitx5.nix
@@ -3,8 +3,8 @@
 with lib;
 
 let
-  im = config.i18n.inputMethod;
-  cfg = im.fcitx5;
+  imcfg = config.i18n.inputMethod;
+  cfg = imcfg.fcitx5;
   fcitx5Package =
     if cfg.plasma6Support
     then pkgs.qt6Packages.fcitx5-with-addons.override { inherit (cfg) addons; }
@@ -108,7 +108,7 @@ in
     '')
   ];
 
-  config = mkIf (im.enabled == "fcitx5") {
+  config = mkIf (imcfg.enable && imcfg.type == "fcitx5") {
     i18n.inputMethod.package = fcitx5Package;
 
     i18n.inputMethod.fcitx5.addons = lib.optionals (cfg.quickPhrase != { }) [

--- a/nixos/modules/i18n/input-method/hime.nix
+++ b/nixos/modules/i18n/input-method/hime.nix
@@ -1,8 +1,12 @@
 { config, pkgs, lib, ... }:
 
 with lib;
+
+let
+  imcfg = config.i18n.inputMethod;
+in
 {
-  config = mkIf (config.i18n.inputMethod.enabled == "hime") {
+  config = mkIf (imcfg.enable && imcfg.type == "hime") {
     i18n.inputMethod.package = pkgs.hime;
     environment.variables = {
       GTK_IM_MODULE = "hime";

--- a/nixos/modules/i18n/input-method/ibus.nix
+++ b/nixos/modules/i18n/input-method/ibus.nix
@@ -3,7 +3,8 @@
 with lib;
 
 let
-  cfg = config.i18n.inputMethod.ibus;
+  imcfg = config.i18n.inputMethod;
+  cfg = imcfg.ibus;
   ibusPackage = pkgs.ibus-with-plugins.override { plugins = cfg.engines; };
   ibusEngine = types.package // {
     name  = "ibus-engine";
@@ -52,7 +53,7 @@ in
     };
   };
 
-  config = mkIf (config.i18n.inputMethod.enabled == "ibus") {
+  config = mkIf (imcfg.enable && imcfg.type == "ibus") {
     i18n.inputMethod.package = ibusPackage;
 
     environment.systemPackages = [

--- a/nixos/modules/i18n/input-method/kime.nix
+++ b/nixos/modules/i18n/input-method/kime.nix
@@ -1,5 +1,6 @@
 { config, pkgs, lib, generators, ... }:
-let imcfg = config.i18n.inputMethod;
+let
+  imcfg = config.i18n.inputMethod;
 in {
   imports = [
     (lib.mkRemovedOptionModule [ "i18n" "inputMethod" "kime" "config" ] "Use i18n.inputMethod.kime.* instead")
@@ -31,7 +32,7 @@ in {
     };
   };
 
-  config = lib.mkIf (imcfg.enabled == "kime") {
+  config = lib.mkIf (imcfg.enable && imcfg.type == "kime") {
     i18n.inputMethod.package = pkgs.kime;
 
     environment.variables = {

--- a/nixos/modules/i18n/input-method/nabi.nix
+++ b/nixos/modules/i18n/input-method/nabi.nix
@@ -1,8 +1,11 @@
 { config, pkgs, lib, ... }:
 
 with lib;
+let
+  imcfg = config.i18n.inputMethod;
+in
 {
-  config = mkIf (config.i18n.inputMethod.enabled == "nabi") {
+  config = mkIf (imcfg.enable && imcfg.type == "nabi") {
     i18n.inputMethod.package = pkgs.nabi;
 
     environment.variables = {

--- a/nixos/modules/i18n/input-method/uim.nix
+++ b/nixos/modules/i18n/input-method/uim.nix
@@ -3,7 +3,8 @@
 with lib;
 
 let
-  cfg = config.i18n.inputMethod.uim;
+  imcfg = config.i18n.inputMethod;
+  cfg = imcfg.uim;
 in
 {
   options = {
@@ -21,7 +22,7 @@ in
 
   };
 
-  config = mkIf (config.i18n.inputMethod.enabled == "uim") {
+  config = mkIf (imcfg.enable && imcfg.type == "uim") {
     i18n.inputMethod.package = pkgs.uim;
 
     environment.variables = {

--- a/nixos/tests/installed-tests/ibus.nix
+++ b/nixos/tests/installed-tests/ibus.nix
@@ -5,7 +5,10 @@ makeInstalledTest {
 
   testConfig = {
     i18n.supportedLocales = [ "all" ];
-    i18n.inputMethod.enabled = "ibus";
+    i18n.inputMethod = {
+      enable = true;
+      type = "ibus";
+    };
     systemd.user.services.ibus-daemon = {
       serviceConfig.ExecStart = "${pkgs.ibus}/bin/ibus-daemon --xim --verbose";
       wantedBy = [ "graphical-session.target" ];


### PR DESCRIPTION
## Description of changes
This commit introduces two new properties:
`enable` and `type`, to replace the `enabled` property.
`enable` has the same meaning as is common across nixpkgs.
`type` has the same meaning as the existing `enabled` property.
`enabled` property is now deprecated and will be removed in a future release.

Fixes #180654

I updated and ran the existing inputMethod tests:
`nix-build -A nixosTests.fcitx5 -A nixosTests.installed-tests.ibus`

Maintainers:
@ericsagnes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
