### PR TITLE
maintainers-list: create a field `inactivityReason`

### DIFF
--- a/lib/tests/maintainer-module.nix
+++ b/lib/tests/maintainer-module.nix
@@ -28,5 +28,9 @@ in {
       });
       default = [];
     };
+    inactivityReason = lib.mkOption {
+      type = types.nullOr types.str;
+      default = null;
+    };
   };
 }

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14,6 +14,36 @@
      keys = [{
        fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333";
      }];
+
+     # Default null; should be a free-form string explaining why the maintainer
+     # became inactive.
+     #
+     # The most immediate use of this attribute is to mark maintainers that are
+     # not contributing to Nixpkgs from a long amount of time.
+     # Nonetheless it can be used to mark any *long term inactivity*, including
+     # but not limited to:
+     #
+     # - Sabbatical leave
+     # - Retirement
+     # - Personal or force majeure isues
+     #
+     # In principle, a third person can set this attribute. For the sake of a
+     # good etiquette, in such case at least one contact attempt should be
+     # issued and carried out before effectively committing it to the codebase.
+     #
+     # This attribute can be employed to many useful activities, including but
+     # not limited to:
+     #
+     # - Treewide automation
+     #   - Removal of inactive maintainers from packages
+     #   - Orphaning alerts
+     # - Filter automatic notifications
+     #
+     inactivityReason = ''
+       Real life issues: I want to take the Hunter Exam this year.
+
+       Registered at 2024-06-19 by Theresia.
+     '';
    };
    ```
 
@@ -26,6 +56,7 @@
    - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`),
    - `githubId` is your GitHub user ID, which can be found at `https://api.github.com/users/<userhandle>`,
    - `keys` is a list of your PGP/GPG key fingerprints.
+   - `inactivityReason` is an optional string attribute, explained above.
 
    Specifying a GitHub account ensures that you automatically:
    - get invited to the @NixOS/nixpkgs-maintainers team ;


### PR DESCRIPTION
Default null; should be a free-form string explaining why the maintainer
became inactive.

The most immediate use of this attribute is to mark maintainers that are
not contributing to Nixpkgs from a long amount of time. Nonetheless it can
be used to mark any *long term inactivity*, including but not limited to:

- Sabbatical leave
- Retirement
- Personal issues
- Force majeure

In principle, a third person can set this attribute. For the sake of a good
etiquette, in such case at least one contact attempt should be issued and
carried out before effectively committing it to the codebase.

This attribute can be employed to many useful activities, including but not
limited to:

- Treewide automation
  - Removal of inactive maintainers from packages
  - Orphaning alerts
- Filter automatic notifications

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
