### PR TITLE
ark-pixel-font: fix build

### DIFF
--- a/pkgs/by-name/ar/ark-pixel-font/package.nix
+++ b/pkgs/by-name/ar/ark-pixel-font/package.nix
@@ -6,13 +6,13 @@
 
 python312Packages.buildPythonPackage rec {
   pname = "ark-pixel-font";
-  version = "2024.04.05";
+  version = "2024.05.12";
 
   src = fetchFromGitHub {
     owner = "TakWolf";
-    repo = pname;
-    rev = version;
-    hash = "sha256-G34cu/mSt/p8UPJt+Q1T2qy6d9LGgT1Jslt9syRz5eo=";
+    repo = "ark-pixel-font";
+    rev = "refs/tags/${version}";
+    hash = "sha256-PGhhKWHDpvOqa3vaI40wuIsAEdWGb62cN7QJeHQqiss=";
   };
 
   format = "other";

--- a/pkgs/development/python-modules/bdffont/default.nix
+++ b/pkgs/development/python-modules/bdffont/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "bdffont";
-  version = "0.0.20";
+  version = "0.0.24";
 
   disabled = pythonOlder "3.11";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-T0gTtudsZmL0VZ3a3+C/v+dWAwbXUgf0PEdNtkxWROw=";
+    hash = "sha256-3HJwtBV78zsMUlmwJrPj74Vd5cru1zflvies5mNGcy4=";
   };
 
   format = "pyproject";

--- a/pkgs/development/python-modules/pcffont/default.nix
+++ b/pkgs/development/python-modules/pcffont/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, hatchling
+, bdffont
+, pytestCheckHook
+, nix-update-script
+}:
+
+buildPythonPackage rec {
+  pname = "pcffont";
+  version = "0.0.11";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "TakWolf";
+    repo = "pcffont";
+    rev = "refs/tags/${version}";
+    hash = "sha256-gu9niWxYTw3rcA++z8B+MdKp5XaqAGjmvd+PdSDosfg=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    bdffont
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pcffont" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Library for manipulating Portable Compiled Format (PCF) fonts";
+    homepage = "https://github.com/TakWolf/pcffont";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/pixel-font-builder/default.nix
+++ b/pkgs/development/python-modules/pixel-font-builder/default.nix
@@ -10,23 +10,32 @@
 , brotli
 , fonttools
 , pypng
+, pcffont
+, pythonRelaxDepsHook
 }:
 
 buildPythonPackage rec {
   pname = "pixel-font-builder";
-  version = "0.0.19";
+  version = "0.0.24";
+  pyproject = true;
 
   disabled = pythonOlder "3.11";
 
   src = fetchPypi {
     pname = "pixel_font_builder";
     inherit version;
-    hash = "sha256-f38DyM5hojHfv8k/W6kcHxbOjz43hHW6i4Scm6NbHiQ=";
+    hash = "sha256-hBlTTIPx4TRgeXapVnSaKPUwseR3uYT0gcgKLGmmSZI=";
   };
 
-  format = "pyproject";
+  pythonRelaxDeps = [
+    "fonttools"
+  ];
 
   nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
+  build-system = [
     hatch-vcs
     hatchling
   ];
@@ -36,10 +45,11 @@ buildPythonPackage rec {
     pypng
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     bdffont
     brotli
     fonttools
+    pcffont
   ];
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1338,6 +1338,8 @@ self: super: with self; {
 
   paddlepaddle = callPackage ../development/python-modules/paddlepaddle { };
 
+  pcffont = callPackage ../development/python-modules/pcffont { };
+
   pueblo = callPackage ../development/python-modules/pueblo { };
 
   pulumi = callPackage ../development/python-modules/pulumi { inherit (pkgs) pulumi; };


### PR DESCRIPTION
## Description of changes

- **python311Packages.bdffont: 0.0.20 -> 0.0.24**
- **python311Packages.pcffont: init at 0.0.11**
- **python311Packages.pixel-font-builder: 0.0.19 -> 0.0.24**
- **ark-pixel-font: 2024.04.05 -> 2024.05.12**

fixes #310751

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
