### PR TITLE
python3Packages.miasm: init at 0.1.5-unstable-2024-04-28

### DIFF
--- a/pkgs/development/python-modules/miasm/0001-setup.py-use-valid-semver.patch
+++ b/pkgs/development/python-modules/miasm/0001-setup.py-use-valid-semver.patch
@@ -1,0 +1,26 @@
+From c85780ce97798f332d627bd44cbbfa19c9ea565e Mon Sep 17 00:00:00 2001
+From: Moritz Sanft <58110325+msanft@users.noreply.github.com>
+Date: Sat, 11 May 2024 11:03:34 +0200
+Subject: [PATCH] setup.py: use valid semver
+
+Signed-off-by: Moritz Sanft <58110325+msanft@users.noreply.github.com>
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index e1e54434..98e29fee 100644
+--- a/setup.py
++++ b/setup.py
+@@ -314,7 +314,7 @@ def build_all():
+         try:
+             s = setup(
+                 name = "miasm",
+-                version = __import__("miasm").VERSION,
++                version = "v0.0.0",
+                 packages = packages,
+                 data_files=[("", ["README.md"])],
+                 package_data = {
+-- 
+2.44.0
+

--- a/pkgs/development/python-modules/miasm/0002-core-remove-IDAPython-dependency.patch
+++ b/pkgs/development/python-modules/miasm/0002-core-remove-IDAPython-dependency.patch
@@ -1,0 +1,65 @@
+From fd2a6b2899c8b836a086b43ec9ebccf726f71ec4 Mon Sep 17 00:00:00 2001
+From: Moritz Sanft <58110325+msanft@users.noreply.github.com>
+Date: Sat, 11 May 2024 11:04:19 +0200
+Subject: [PATCH] core: remove IDAPython dependency
+
+Signed-off-by: Moritz Sanft <58110325+msanft@users.noreply.github.com>
+---
+ miasm/core/bin_stream_ida.py | 45 ------------------------------------
+ 1 file changed, 45 deletions(-)
+ delete mode 100644 miasm/core/bin_stream_ida.py
+
+diff --git a/miasm/core/bin_stream_ida.py b/miasm/core/bin_stream_ida.py
+deleted file mode 100644
+index 15bd9d8b..00000000
+--- a/miasm/core/bin_stream_ida.py
++++ /dev/null
+@@ -1,45 +0,0 @@
+-from builtins import range
+-from idc import get_wide_byte, get_segm_end
+-from idautils import Segments
+-from idaapi import is_mapped
+-
+-from miasm.core.utils import int_to_byte
+-from miasm.core.bin_stream import bin_stream_str
+-
+-
+-class bin_stream_ida(bin_stream_str):
+-    """
+-    bin_stream implementation for IDA
+-
+-    Don't generate xrange using address computation:
+-    It can raise error on overflow 7FFFFFFF with 32 bit python
+-    """
+-    def _getbytes(self, start, l=1):
+-        out = []
+-        for ad in range(l):
+-            offset = ad + start + self.base_address
+-            if not is_mapped(offset):
+-                raise IOError(f"not enough bytes @ offset {offset:x}")
+-            out.append(int_to_byte(get_wide_byte(offset)))
+-        return b''.join(out)
+-
+-    def readbs(self, l=1):
+-        if self.offset + l > self.l:
+-            raise IOError("not enough bytes")
+-        content = self.getbytes(self.offset)
+-        self.offset += l
+-        return content
+-
+-    def __str__(self):
+-        raise NotImplementedError('Not fully functional')
+-
+-    def setoffset(self, val):
+-        self.offset = val
+-
+-    def getlen(self):
+-        # Lazy version
+-        if hasattr(self, "_getlen"):
+-            return self._getlen
+-        max_addr = get_segm_end(list(Segments())[-1]  - (self.offset - self.base_address))
+-        self._getlen = max_addr
+-        return max_addr
+-- 
+2.44.0
+

--- a/pkgs/development/python-modules/miasm/default.nix
+++ b/pkgs/development/python-modules/miasm/default.nix
@@ -1,0 +1,58 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, future
+, gcc
+, llvmlite
+, parameterized
+, pycparser
+, pyparsing
+, z3-solver
+, setuptools
+}:
+let
+  commit = "90dc1671b59077ee27c3d44d9d536d6659eb3bbe";
+in
+buildPythonPackage rec {
+  pname = "miasm";
+  version = "0.1.5-unstable-2024-04-28";
+
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  src = fetchFromGitHub {
+    owner = "cea-sec";
+    repo = "miasm";
+    rev = commit;
+    hash = "sha256-nkRcirJLmTwSL7lwd+Yk6mteU3YPnm5ekJ4eFF5FmYo=";
+  };
+
+  patches = [
+    #  Use a valid semver as now required by setuptools
+    ./0001-setup.py-use-valid-semver.patch
+
+    # Removes the (unfree) IDAPython dependency
+    ./0002-core-remove-IDAPython-dependency.patch
+  ];
+
+  dependencies = [
+    future
+    llvmlite
+    parameterized
+    pycparser
+    pyparsing
+    z3-solver
+  ];
+
+  buildInputs = [ gcc ];
+
+  pythonImportsCheck = [ "miasm" ];
+
+  meta = {
+    description = "Reverse engineering framework in Python";
+    homepage = "https://github.com/cea-sec/miasm";
+    changelog = "https://github.com/cea-sec/miasm/blob/${commit}/CHANGELOG.md";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ msanft ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7389,6 +7389,8 @@ self: super: with self; {
 
   mhcgnomes = callPackage ../development/python-modules/mhcgnomes { };
 
+  miasm = callPackage ../development/python-modules/miasm { };
+
   miauth = callPackage ../development/python-modules/miauth { };
 
   micawber = callPackage ../development/python-modules/micawber { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This adds the [miasm](https://github.com/cea-sec/miasm?tab=readme-ov-file) Python reverse engineering framework.

Related to #81418 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
