### PR TITLE
nixos/btrfs: refactor & improve device selection for autoScrub

### DIFF
--- a/nixos/modules/tasks/filesystems/btrfs.nix
+++ b/nixos/modules/tasks/filesystems/btrfs.nix
@@ -9,10 +9,11 @@ let
     mkIf
     optionals
     mkDefault
-    mapAttrsToList
     nameValuePair
     listToAttrs
-    filterAttrs;
+    filterAttrs
+    mapAttrsToList
+    foldl';
 
   inInitrd = config.boot.initrd.supportedFilesystems.btrfs or false;
   inSystem = config.boot.supportedFilesystems.btrfs or false;
@@ -37,8 +38,9 @@ in
         description = ''
           List of paths to btrfs filesystems to regularly call {command}`btrfs scrub` on.
           Defaults to all mount points with btrfs filesystems.
-          If you mount a filesystem multiple times or additionally mount subvolumes,
-          you need to manually specify this list to avoid scrubbing multiple times.
+          Note that if you have filesystems that span multiple devices (e.g. RAID), you should
+          take care to use the same device for any given mount point and let btrfs take care
+          of automatically mounting the rest, in order to avoid scrubbing the same data multiple times.
         '';
       };
 
@@ -107,12 +109,18 @@ in
         }
       ];
 
-      # This will yield duplicated units if the user mounts a filesystem multiple times
-      # or additionally mounts subvolumes, but going the other way around via devices would
-      # yield duplicated units when a filesystem spans multiple devices.
-      # This way around seems like the more sensible default.
-      services.btrfs.autoScrub.fileSystems = mkDefault (mapAttrsToList (name: fs: fs.mountPoint)
-      (filterAttrs (name: fs: fs.fsType == "btrfs") config.fileSystems));
+      # This will remove duplicated units from either having a filesystem mounted multiple
+      # time, or additionally mounted subvolumes, as well as having a filesystem span
+      # multiple devices (provided the same device is used to mount said filesystem).
+      services.btrfs.autoScrub.fileSystems =
+      let
+        isDeviceInList = list: device: builtins.filter (e: e.device == device) list != [ ];
+
+        uniqueDeviceList = foldl' (acc: e: if isDeviceInList acc e.device then acc else acc ++ [ e ]) [ ];
+      in
+      mkDefault (map (e: e.mountPoint)
+        (uniqueDeviceList (mapAttrsToList (name: fs: { mountPoint = fs.mountPoint; device = fs.device; })
+          (filterAttrs (name: fs: fs.fsType == "btrfs") config.fileSystems))));
 
       # TODO: Did not manage to do it via the usual btrfs-scrub@.timer/.service
       # template units due to problems enabling the parameterized units,

--- a/nixos/modules/tasks/filesystems/btrfs.nix
+++ b/nixos/modules/tasks/filesystems/btrfs.nix
@@ -1,8 +1,18 @@
 { config, lib, pkgs, utils, ... }:
 
-with lib;
-
 let
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    types
+    mkMerge
+    mkIf
+    optionals
+    mkDefault
+    mapAttrsToList
+    nameValuePair
+    listToAttrs
+    filterAttrs;
 
   inInitrd = config.boot.initrd.supportedFilesystems.btrfs or false;
   inSystem = config.boot.supportedFilesystems.btrfs or false;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Refactor to no longer use a global `with` import
- Improve the default selection of btrfs filesystems by checking for both filesystems that are mounted multiple times (or mounted with additional subvolumes), as well as filesystems that span multiple devices.

Tested with the following filesystem config:
```nix
fileSystems."/" =
    {
      device = "/dev/disk/by-uuid/[redacted0]";
      fsType = "btrfs";
      options = [ "subvol=@" "compress=zstd:1" "noatime" ];
    };

  fileSystems."/nix" =
    {
      device = "/dev/disk/by-uuid/[redacted0]";
      fsType = "btrfs";
      options = [ "subvol=@nix" "compress=zstd:1" "noatime" ];
    };

  fileSystems."/var" =
    {
      device = "/dev/disk/by-uuid/[redacted0]";
      fsType = "btrfs";
      options = [ "subvol=@var" "compress=zstd:1" "noatime" ];
    };

  fileSystems."/boot" =
    {
      device = "/dev/disk/by-uuid/24F9-3F6A";
      fsType = "vfat";
      options = [ "fmask=0077" "dmask=0077" "defaults" ];
    };

  fileSystems."/home" =
    {
      device = "/dev/disk/by-uuid/[redacted0]";
      fsType = "btrfs";
      options = [ "subvol=@home" "compress=zstd:1" "noatime" ];
    };

  fileSystems."/mnt/ext1" =
    {
      device = "/dev/disk/by-uuid/[redacted1]";
      fsType = "btrfs";
      options = [ "subvol=@" "compress=zstd:1" "noatime" ];
    };
```

Note: `/dev/disk/by-uuid/[redacted0]` is a RAID1 volume together with `/dev/disk/by-uuid/[redacted2]`, but the latter does not need to be explicitly listed in `fileSystems`, since btrfs automatically detects it upon mount and includes it in the RAID configuration.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
