### PR TITLE
agrep: fix build failure

### DIFF
--- a/pkgs/tools/text/agrep/default.nix
+++ b/pkgs/tools/text/agrep/default.nix
@@ -1,33 +1,43 @@
-{ lib, stdenv, fetchFromGitHub }:
-
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+let
+  # This repository has numbered versions, but not Git tags.
+  rev = "b7d180fe73636740f694ec60c1ffab52b06e7150";
+in
 stdenv.mkDerivation {
   pname = "agrep";
-  version = "3.41.5";
+  version = "3.41.5-unstable-2022-03-23";
 
   src = fetchFromGitHub {
+    inherit rev;
     owner = "Wikinaut";
     repo = "agrep";
-    # This repository has numbered versions, but not Git tags.
-    rev = "eef20411d605d9d17ead07a0ade75046f2728e21";
-    sha256 = "14addnwspdf2mxpqyrw8b84bb2257y43g5ccy4ipgrr91fmxq2sk";
+    hash = "sha256-2J4bw5BVZgTEcIn9IuD5Q8/L+8tldDbToDefuxDf85g=";
   };
-
-  # Related: https://github.com/Wikinaut/agrep/pull/11
-  prePatch = lib.optionalString (stdenv.hostPlatform.isMusl || stdenv.isDarwin) ''
-    sed -i '1i#include <sys/stat.h>' checkfil.c newmgrep.c recursiv.c
-  '';
-  installPhase = ''
-    install -Dm 555 agrep -t "$out/bin"
-    install -Dm 444 docs/* -t "$out/doc"
-  '';
 
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
-  meta = with lib; {
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-std=c89";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm 555 agrep -t "$out/bin"
+    install -Dm 444 docs/* -t "$out/doc"
+
+    runHook postInstall
+  '';
+
+  meta = {
     description = "Approximate grep for fast fuzzy string searching";
     mainProgram = "agrep";
     homepage = "https://www.tgries.de/agrep/";
-    license = licenses.isc;
-    platforms = with platforms; linux ++ darwin;
+    maintainers = with lib.maintainers; [ momeemt ];
+    changelog = "https://github.com/Wikinaut/agrep/blob/${rev}/CHANGES";
+    license = lib.licenses.isc;
+    platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
changed to compile option '-ansi' and patched Makefile

## Description of changes

agrep failed to build on the [all platforms](https://hydra.nixos.org/build/258221963). It needs to be built with C89 and Unix target, so I added a patch file to the Makefile and changed the compiler cc to gcc ansi.
I also added myself to its maintainers, as it is no longer maintained by anyone.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
