### PR TITLE
nixos/firewall: fix reverse path check failures with IPsec 

### DIFF
--- a/nixos/modules/services/networking/firewall-iptables.nix
+++ b/nixos/modules/services/networking/firewall-iptables.nix
@@ -123,6 +123,9 @@ let
       # Allows this host to act as a DHCP4 client without first having to use APIPA
       iptables -t mangle -A nixos-fw-rpfilter -p udp --sport 67 --dport 68 -j RETURN
 
+      # Allows decrypted packets from an IPsec VPN
+      ip46tables -t mangle -A nixos-fw-rpfilter -m policy --dir in --pol ipsec -j RETURN
+
       # Allows this host to act as a DHCPv4 server
       iptables -t mangle -A nixos-fw-rpfilter -s 0.0.0.0 -d 255.255.255.255 -p udp --sport 68 --dport 67 -j RETURN
 

--- a/nixos/modules/services/networking/firewall-nftables.nix
+++ b/nixos/modules/services/networking/firewall-nftables.nix
@@ -82,6 +82,11 @@ in
       }
     ];
 
+    networking.nftables.preCheckRuleset = ''
+      # can't validate IPsec rules
+      sed '/meta ipsec/d' -i ruleset.conf
+    '';
+
     networking.nftables.tables."nixos-fw".family = "inet";
     networking.nftables.tables."nixos-fw".content = ''
         ${optionalString (cfg.checkReversePath != false) ''
@@ -89,6 +94,7 @@ in
             type filter hook prerouting priority mangle + 10; policy drop;
 
             meta nfproto ipv4 udp sport . udp dport { 67 . 68, 68 . 67 } accept comment "DHCPv4 client/server"
+            meta ipsec exists accept comment "decrypted packets from an IPsec VPN"
             fib saddr . mark ${optionalString (cfg.checkReversePath != "loose") ". iif"} oif exists accept
 
             jump rpfilter-allow

--- a/nixos/tests/firewall.nix
+++ b/nixos/tests/firewall.nix
@@ -36,7 +36,7 @@ import ./make-test-python.nix ( { pkgs, nftables, ... } : {
     };
 
   testScript = { nodes, ... }: let
-    newSystem = nodes.walled2.config.system.build.toplevel;
+    newSystem = nodes.walled2.system.build.toplevel;
     unit = if nftables then "nftables" else "firewall";
   in ''
     start_all()


### PR DESCRIPTION
## Description of changes

The endpoint of an IPsec tunnel receives encrypted IPsec packets that
are first decrypted and then forwarded to the intended destination.
The decrypted traffic appears to originate from the same interface it
came in from, so in most cases these packets will fail the reverse path
check even if legitimate.

This change adds an exception to not reject packets that were previously
IPsec-encrypted, meaning the have been accepted, decrypted and are in
the process of being forwarded to their final destinal.

## Things done

- Tested via 
  - [x] `nixosTests.firewall`
  - [x] `nixosTests.firewall-nftables`
  - [x] `nixosTests.libreswan-nat` see PR #310404
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
