### PR TITLE
ncurses: include release number in version

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -13,11 +13,11 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "6.4";
+  version = "6.4.20221231";
   pname = "ncurses" + lib.optionalString (abiVersion == "5") "-abi5-compat";
 
   src = fetchurl {
-    url = "https://invisible-island.net/archives/ncurses/ncurses-${finalAttrs.version}.tar.gz";
+    url = "https://invisible-island.net/archives/ncurses/ncurses-${lib.versions.majorMinor finalAttrs.version}.tar.gz";
     hash = "sha256-aTEoPZrIfFBz8wtikMTHXyFjK7T8NgOsgQCBK+0kgVk=";
   };
 


### PR DESCRIPTION
## Description of changes

Included the release number in the version.
I'm putting it into `staging` because it might rebuild 500+ packages.

- ZHF: #309482

Fix the following Hydra failures (nixpkgs.tests.**pkg-config**.defaultPkgConfigPackages.**[name]**): 

- **check-pkg-form**: [258531998](https://hydra.nixos.org/build/), [258583946](https://hydra.nixos.org/build/258583946), [258533184](https://hydra.nixos.org/build/258533184), [258579848](https://hydra.nixos.org/build/258579848)
- **check-pkg-formw**: [258532352](https://hydra.nixos.org/build/258532352), [258586816](https://hydra.nixos.org/build/258586816), [258532178](https://hydra.nixos.org/build/258532178), [258583614](https://hydra.nixos.org/build/258583614)
- **check-pkg-menu**: [258532451](https://hydra.nixos.org/build/258532451), [258577307](https://hydra.nixos.org/build/258577307), [258532460](https://hydra.nixos.org/build/258532460), [258580353](https://hydra.nixos.org/build/258580353)
- **check-pkg-menuw**: [258533067](https://hydra.nixos.org/build/258533067), [258577737](https://hydra.nixos.org/build/258577737), [258533385](https://hydra.nixos.org/build/258533385), [258586402](https://hydra.nixos.org/build/258586402)
- **check-pkg-ncurses++**: [258532586](https://hydra.nixos.org/build/258532586), [258578414](https://hydra.nixos.org/build/258578414), [258533428](https://hydra.nixos.org/build/258533428), [258577901](https://hydra.nixos.org/build/258577901)
- **check-pkg-ncurses++w**: [258532475](https://hydra.nixos.org/build/258532475), [258581669](https://hydra.nixos.org/build/258581669), [258533149](https://hydra.nixos.org/build/258533149), [258586927](https://hydra.nixos.org/build/258586927)
- **check-pkg-ncurses**: [258532386](https://hydra.nixos.org/build/258532386), [258582876](https://hydra.nixos.org/build/258582876), [258533151](https://hydra.nixos.org/build/258533151), [258576435](https://hydra.nixos.org/build/258576435)
- **check-pkg-ncursesw**: [258532416](https://hydra.nixos.org/build/258532416), [258586091](https://hydra.nixos.org/build/258586091), [258532121](https://hydra.nixos.org/build/258532121), [258583304](https://hydra.nixos.org/build/258583304)
- **check-pkg-config-panel**: [258532669](https://hydra.nixos.org/build/258532669), [258578618](https://hydra.nixos.org/build/258578618), [258532963](https://hydra.nixos.org/build/258532963), [258576839](https://hydra.nixos.org/build/258576839)
- **check-pkg-config-panelw**: [258532410](https://hydra.nixos.org/build/258532410), [258582510](https://hydra.nixos.org/build/258582510), [258532663](https://hydra.nixos.org/build/258532663), [258582194](https://hydra.nixos.org/build/258582194)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
