### PR TITLE
treewide: add update script to packages maintained by johnrtitor

### DIFF
--- a/pkgs/by-name/an/ananicy-rules-cachyos/package.nix
+++ b/pkgs/by-name/an/ananicy-rules-cachyos/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  unstableGitUpdater,
 }:
 
 stdenvNoCC.mkDerivation {
@@ -25,6 +26,10 @@ stdenvNoCC.mkDerivation {
     cp -r * $out/etc/ananicy.d
     runHook postInstall
   '';
+
+  passthru.updateScript = unstableGitUpdater {
+    hardcodeZeroVersion = true;
+  };
 
   meta = {
     homepage = "https://github.com/CachyOS/ananicy-rules";

--- a/pkgs/by-name/go/google-chrome/package.nix
+++ b/pkgs/by-name/go/google-chrome/package.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, patchelf, makeWrapper, fetchurl
+{ lib, stdenv, patchelf, makeWrapper, fetchurl, writeScript
 
 # Linked dynamic libraries.
 , glib, fontconfig, freetype, pango, cairo, libX11, libXi, atk, nss, nspr
@@ -141,6 +141,17 @@ in stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru = {
+    updateScript = writeScript "update-google-chrome.sh" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl jq common-updater-scripts
+      url="https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/stable/versions/all/releases"
+      response=$(curl --silent $url)
+      version=$(jq ".releases[0].version" --raw-output <<< "$response")
+      update-source-version ${finalAttrs.pname} "$version" --ignore-same-hash
+    '';
+  };
 
   meta = {
     description = "A freeware web browser developed by Google";

--- a/pkgs/by-name/li/lightningcss/package.nix
+++ b/pkgs/by-name/li/lightningcss/package.nix
@@ -2,6 +2,7 @@
 , stdenv
 , rustPlatform
 , fetchFromGitHub
+, nix-update-script
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -36,6 +37,8 @@ rustPlatform.buildRustPackage rec {
   cargoTestFlags = [
     "--lib"
   ];
+
+  passthru.updateScript = nix-update-script {};
 
   meta = with lib; {
     description = "Extremely fast CSS parser, transformer, and minifier written in Rust";

--- a/pkgs/by-name/py/pyprland/package.nix
+++ b/pkgs/by-name/py/pyprland/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   python3Packages,
+  nix-update-script,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -56,6 +57,8 @@ python3Packages.buildPythonApplication rec {
     "pyprland.plugins.toggle_special"
     "pyprland.plugins.workspaces_follow_focus"
   ];
+
+  passthru.updateScript = nix-update-script {};
 
   meta = {
     mainProgram = "pypr";

--- a/pkgs/common-updater/unstable-updater.nix
+++ b/pkgs/common-updater/unstable-updater.nix
@@ -8,6 +8,10 @@
 
 # This is an updater for unstable packages that should always use the latest
 # commit.
+# To use this updater, add the following to your package set:
+# passthru.updateScript = unstableGitUpdater { };
+# relevant attributes can be passed as below:
+
 { url ? null # The git url, if empty it will be set to src.gitRepoUrl
 , branch ? null
 , hardcodeZeroVersion ? false # Use a made-up version "0" instead of latest tag. Use when there is no previous release, or the project's tagging system is incompatible with what we expect from versions

--- a/pkgs/tools/filesystems/bcachefs-tools/default.nix
+++ b/pkgs/tools/filesystems/bcachefs-tools/default.nix
@@ -20,7 +20,7 @@
   rustc,
   rustPlatform,
   makeWrapper,
-  writeScript,
+  nix-update-script,
   python3,
   fuseSupport ? false,
 }:
@@ -104,15 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
       inherit (nixosTests.installer) bcachefsSimple bcachefsEncrypted bcachefsMulti;
     };
 
-    updateScript = writeScript "update-bcachefs-tools-and-cargo-lock.sh" ''
-      #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl jq common-updater-scripts
-      res="$(curl ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
-        -sL "https://api.github.com/repos/${finalAttrs.src.owner}/${finalAttrs.src.repo}/tags?per_page=1")"
-
-      version="$(echo $res | jq '.[0].name | split("v") | .[1]' --raw-output)"
-      update-source-version ${finalAttrs.pname} "$version" --ignore-same-hash
-    '';
+    updateScript = nix-update-script {};
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
## Description of changes
Added update script for:
- `google-chrome`
- `ananicy-rules-cachyos`
- `lightningcss`
- `pyprland`

Use `nix-update-script` for: `bcachefs-tools`

This should ease burden on us maintainers, and will let @r-ryantm automatically bump these.

Also added a comment in `unstableGitUpdater` script for its usage, since it does not seem to be documented anywhere.

Should cause ZERO rebuilds.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
