### PR TITLE
ecdsatool: fix build

### DIFF
--- a/pkgs/tools/security/ecdsatool/ctype-header-c99-implicit-function-declaration.patch
+++ b/pkgs/tools/security/ecdsatool/ctype-header-c99-implicit-function-declaration.patch
@@ -1,0 +1,12 @@
+diff --git a/libecdsaauth/base64.c b/libecdsaauth/base64.c
+index 0f9b7a3..84df22a 100644
+--- a/libecdsaauth/base64.c
++++ b/libecdsaauth/base64.c
+@@ -45,6 +45,7 @@
+ #include <string.h>
+ #include <unistd.h>
+ #include <assert.h>
++#include <ctype.h>
+ 
+ static const char Base64[] =
+ 	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";

--- a/pkgs/tools/security/ecdsatool/default.nix
+++ b/pkgs/tools/security/ecdsatool/default.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation {
     ./configure --prefix=$out
   '';
 
+  patches = [
+    ./ctype-header-c99-implicit-function-declaration.patch
+    ./openssl-header-c99-implicit-function-declaration.patch
+  ];
+
   nativeBuildInputs = with pkgs; [openssl autoconf automake];
   buildInputs = with pkgs; [libuecc];
 

--- a/pkgs/tools/security/ecdsatool/openssl-header-c99-implicit-function-declaration.patch
+++ b/pkgs/tools/security/ecdsatool/openssl-header-c99-implicit-function-declaration.patch
@@ -1,0 +1,33 @@
+diff --git a/libecdsaauth/keypair.c b/libecdsaauth/keypair.c
+index 5e098c5..b5dd21e 100644
+--- a/libecdsaauth/keypair.c
++++ b/libecdsaauth/keypair.c
+@@ -22,6 +22,7 @@
+ 
+ #include <string.h>
+ #include <stdlib.h>
++#include <openssl/pem.h>
+ 
+ static inline libecdsaauth_key_t *libecdsaauth_key_alloc(void)
+ {
+diff --git a/tool/main.c b/tool/main.c
+index 23d19a3..f88016c 100644
+--- a/tool/main.c
++++ b/tool/main.c
+@@ -21,6 +21,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <openssl/pem.h>
+ 
+ #include "libecdsaauth/keypair.h"
+ #include "libecdsaauth/op.h"
+@@ -41,7 +42,7 @@ static int tool_keygen(int argc, const char *argv[])
+ 	key = libecdsaauth_key_new();
+ 
+ 	pubout = fopen(argv[1], "w");
+-	PEM_write_ECPrivateKey(pubout, key->eckey, NULL, NULL, 0, NULL);
++	PEM_write_ECPrivateKey(pubout, key->eckey, NULL, NULL, 0, NULL, NULL);
+ 	fclose(pubout);
+ 
+ 	pubkey = libecdsaauth_key_public_key_base64(key);


### PR DESCRIPTION
## Description of changes

Part of #309482.

[kaniini/ecdsatool](https://github.com/kaniini/ecdsatool) is a long unmaintained package, that has f[ailed to build](https://hydra.nixos.org/build/258387065) since November 2023.

I have patched some missing headers and old openssl invocations, and the tool seems to work now (at least as far as the README commands from upstream go).

I am not keen to maintain this however, and we should consider removing it outright - it is an ancient piece of openssl-reliant code that deals with cryptography, it is only a matter of time before it breaks again.

If there is no feedback supporting its continued inclusion in nixpkgs, I will update this PR to remove it instead.

<details><summary>Test run</summary>
<pre>
$ ./result/bin/ecdsatool keygen /tmp/test.key                                                                      
AzM0YzHDf9Y1dZaxPfAJHyJ7IWurlADtnyBCbQEvgEiA
$ cat /tmp/test.key                                                                                                
-----BEGIN EC PRIVATE KEY-----
MFcCAQEEIHZlrPOEqHsKWH76rZEVy1UAcfzeJkEUoGdIFx5GNRGjoAoGCCqGSM49
AwEHoSQDIgADMzRjMcN/1jV1lrE98AkfInsha6uUAO2fIEJtAS+ASIA=
-----END EC PRIVATE KEY-----
$ ./result/bin/ecdsatool pubkey /tmp/test.key                                                                      
AzM0YzHDf9Y1dZaxPfAJHyJ7IWurlADtnyBCbQEvgEiA
$ ./result/bin/ecdsatool keyinfo /tmp/test.key                                                                     
Information on /tmp/test.key:
    Private-Key: (256 bit)
    priv:
        76:65:ac:f3:84:a8:7b:0a:58:7e:fa:ad:91:15:cb:
        55:00:71:fc:de:26:41:14:a0:67:48:17:1e:46:35:
        11:a3
    pub:
        03:33:34:63:31:c3:7f:d6:35:75:96:b1:3d:f0:09:
        1f:22:7b:21:6b:ab:94:00:ed:9f:20:42:6d:01:2f:
        80:48:80
    ASN1 OID: prime256v1
    NIST CURVE: P-256                                                                                              
$ ./result/bin/ecdsatool sign /tmp/test.key 'QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE='                   
MEQCIHlB6er4whQ6dS9XmyB0mjLxUnK5JzaAsu0SrSij1qBFAiAyie7QOoDhbiiE3Z25R6aI83cdWnSqSFCTzgj1/SA9xw==
</pre>
</details> 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
