### PR TITLE
nut: 2.8.0 -> 2.8.2

### DIFF
--- a/pkgs/applications/misc/nut/default.nix
+++ b/pkgs/applications/misc/nut/default.nix
@@ -3,7 +3,8 @@
 , autoreconfHook
 , avahi
 , coreutils
-, fetchurl
+, fetchFromGitHub
+, nix-update-script
 , freeipmi
 , gd
 , i2c-tools
@@ -21,13 +22,15 @@
 , gnused
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "nut";
-  version = "2.8.0";
+  version = "2.8.2";
 
-  src = fetchurl {
-    url = "https://networkupstools.org/source/${lib.versions.majorMinor version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-w+WnCNp5e3xwtlPTexIGoAD8tQO4VRn+TN9jU/eSv+U=";
+  src = fetchFromGitHub {
+    owner = "networkupstools";
+    repo = "nut";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-o8X9z/LVGIb5nU5+VVSGmj3vW6UTaaBFd7FHXsiy0W8=";
   };
 
   patches = [
@@ -90,6 +93,8 @@ stdenv.mkDerivation rec {
     rm $out/etc/udev/rules.d/52-nut-ipmipsu.rules
   '';
 
+  passthru.updateScript = nix-update-script {};
+
   meta = with lib; {
     description = "Network UPS Tools";
     longDescription = ''
@@ -103,4 +108,4 @@ stdenv.mkDerivation rec {
     license = with licenses; [ gpl1Plus gpl2Plus gpl3Plus ];
     priority = 10;
   };
-}
+})

--- a/pkgs/applications/misc/nut/hardcode-paths.patch
+++ b/pkgs/applications/misc/nut/hardcode-paths.patch
@@ -3,7 +3,7 @@
 @@ -991,6 +991,12 @@ ssize_t select_write(const int fd, const void *buf, const size_t buflen, const t
   * communications media and/or vendor protocol.
   */
- static const char * search_paths[] = {
+ static const char * search_paths_builtin[] = {
 +	"@avahi@",
 +	"@freeipmi@",
 +	"@libusb@",


### PR DESCRIPTION
## Description of changes

Currently failing build.
```log
       > Makefile.am: installing './INSTALL'
       > Makefile.am: error: required file './NEWS' not found
       > Makefile.am: error: required file './README' not found
       > clients/Makefile.am: installing './depcomp'
       > configure.ac:4981: error: required file 'scripts/augeas/nutupsconf.aug.in' not found
       > configure.ac:4981: error: required file 'scripts/devd/nut-usb.conf.in' not found
       > configure.ac:4873: error: required file 'scripts/systemd/nut-common-tmpfiles.conf.in' not found
       > configure.ac:4981: error: required file 'scripts/udev/nut-usbups.rules.in' not found
       > parallel-tests: installing './test-driver'
       > autoreconf: error: automake failed with exit status: 1
```

Closes #310868

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
