### PR TITLE
cloudsmith-cli: Fix compatibility with urllib3 2.0

### DIFF
--- a/pkgs/development/tools/cloudsmith-cli/default.nix
+++ b/pkgs/development/tools/cloudsmith-cli/default.nix
@@ -1,18 +1,36 @@
 { lib
 , python3
-, fetchPypi
+, fetchFromGitHub
+, fetchpatch
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "cloudsmith-cli";
   version = "1.2.3";
-  format = "wheel";
+  format = "setuptools";
 
-  src = fetchPypi {
-    pname = "cloudsmith_cli";
-    inherit format version;
-    hash = "sha256-MIoRLWk6G8uchQlGOYOsg3XliZ1wMrYSOhAEQrus+fQ=";
+  src = fetchFromGitHub {
+    owner = "cloudsmith-io";
+    repo = "cloudsmith-cli";
+    rev = "v${version}";
+    hash = "sha256-a4hLx+INdFq6Ux3XkI5GWgAiGLHCoDA+MP2FNY3E6WA=";
   };
+
+  patches = [
+    # Fix compatibility with urllib3 2.0
+    (fetchpatch {
+      url = "https://github.com/cloudsmith-io/cloudsmith-cli/commit/1a8d2d91c01320537b26778003735d6b694141c2.patch";
+      revert = true;
+      includes = [
+        "cloudsmith_cli/core/rest.py"
+      ];
+      hash = "sha256-Rf3MMJuLr8fzkRqSftIJ1eUbgNdfrng2V609jYvpogc=";
+    })
+  ];
+
+  nativeBuildInputs = with python3.pkgs; [
+    pip
+  ];
 
   propagatedBuildInputs = with python3.pkgs; [
     click
@@ -30,12 +48,37 @@ python3.pkgs.buildPythonApplication rec {
     setuptools # needs pkg_resources
   ];
 
-  # Wheels have no tests
-  doCheck = false;
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+    pytest-cov
+  ];
+
+  checkInputs = with python3.pkgs; [
+    httpretty
+  ];
 
   pythonImportsCheck = [
     "cloudsmith_cli"
   ];
+
+  postPatch = ''
+    # Permit urllib3 2.0
+    substituteInPlace setup.py \
+      --replace-fail 'urllib3<2.0' 'urllib3'
+  '';
+
+  preCheck = ''
+    # E   _pytest.pathlib.ImportPathMismatchError: ('cloudsmith_cli.cli.tests.conftest', '/build/source/build/lib/cloudsmith_cli/cli/tests/conftest.py', PosixPath('/build/source/cloudsmith_cli/cli/tests/conftest.py'))
+    # ___________ ERROR collecting cloudsmith_cli/core/tests/test_init.py ____________
+    # import file mismatch:
+    # imported module 'cloudsmith_cli.core.tests.test_init' has this __file__ attribute:
+    #   /build/source/build/lib/cloudsmith_cli/core/tests/test_init.py
+    # which is not the same as the test file we want to collect:
+    #   /build/source/cloudsmith_cli/core/tests/test_init.py
+    # HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
+    # https://github.com/NixOS/nixpkgs/issues/255262
+    cd "$out"
+  '';
 
   meta = with lib; {
     homepage = "https://help.cloudsmith.io/docs/cli/";


### PR DESCRIPTION
## Description of changes

This requires a patch but we cannot really apply those to a wheel, so I had to switch to fetching the source from GitHub.
As a side benefit, we can now run tests.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  Used it to remove stray tags:

  ```fish
  for perm in (nix shell -f ~/Projects/nixpkgs cloudsmith-cli -c cloudsmith list packages fossar/selfoss-git -F pretty_json -q 'version:latest' | jq -r ".data[].slug_perm")
      nix shell -f ~/Projects/nixpkgs cloudsmith-cli -c cloudsmith tags remove fossar/selfoss-git/$perm version:latest
  end
  ```
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
