### PR TITLE
python312Packages.phik: fix dependencies, clean up

### DIFF
--- a/pkgs/development/python-modules/phik/default.nix
+++ b/pkgs/development/python-modules/phik/default.nix
@@ -3,20 +3,17 @@
 , cmake
 , fetchFromGitHub
 , joblib
-, jupyter
-, jupyter-client
 , matplotlib
-, nbconvert
 , ninja
-, numba
 , numpy
 , pandas
+, pathspec
+, pyproject-metadata
 , pybind11
 , pytestCheckHook
 , pythonOlder
-, scikit-build
+, scikit-build-core
 , scipy
-, setuptools
 }:
 
 buildPythonPackage rec {
@@ -24,7 +21,7 @@ buildPythonPackage rec {
   version = "0.12.4";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "KaveIO";
@@ -33,57 +30,38 @@ buildPythonPackage rec {
     hash = "sha256-YsH7vVn6gzejunUjUY/RIcvWtaQ/W1gbciJWKi5LDTk=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     cmake
     ninja
-    scikit-build
-    setuptools
+    pathspec
+    pybind11
+    pyproject-metadata
+    scikit-build-core
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     joblib
-    numpy
-    scipy
-    pandas
     matplotlib
-    numba
-    pybind11
+    numpy
+    pandas
+    scipy
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
-    nbconvert
-    jupyter
-    jupyter-client
   ];
 
-  # Uses setuptools to drive build process
+  # Uses scikit-build-core to drive build process
   dontUseCmakeConfigure = true;
 
   pythonImportsCheck = [
     "phik"
   ];
 
-  postInstall = ''
-    rm -r $out/bin
-  '';
-
   preCheck = ''
     # import from $out
     rm -r phik
   '';
-
-  disabledTests = [
-    # TypeError: 'numpy.float64' object cannot be interpreted as an integer
-    # https://github.com/KaveIO/PhiK/issues/73
-    "test_significance_matrix_hybrid"
-    "test_significance_matrix_mc"
-  ];
-
-  disabledTestPaths = [
-    # Don't test integrations
-    "tests/phik_python/integration/"
-  ];
 
   meta = with lib; {
     description = "Phi_K correlation analyzer library";


### PR DESCRIPTION
## Description of changes

ZHF: #309482

Looks like the build system used changed in one of the recent version bumps, making the `phik` package fail to build. This PR addresses this by updating the list of build-time an run-time dependencies.

The disabled test lists could be removed, because the tests have been removed/fixed.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
