### PR TITLE
python312Packages.{hawkauthlib,pybrowserid}: fix tests, refactor; python312Packages.pyfxa: use pyproject = true

### DIFF
--- a/pkgs/development/python-modules/hawkauthlib/default.nix
+++ b/pkgs/development/python-modules/hawkauthlib/default.nix
@@ -1,28 +1,45 @@
-{ lib
-, buildPythonPackage
-, fetchFromGitHub
-, requests
-, webob
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  requests,
+  webob,
+  unittestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "hawkauthlib";
   version = "0.1.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mozilla-services";
-    repo = pname;
+    repo = "hawkauthlib";
     rev = "refs/tags/v${version}";
-    sha256 = "0mr1mpx4j9q7sch9arwfvpysnpf2p7ijy7072wilxm8pnj0bwvsi";
+    hash = "sha256-UW++gLQX1U4jFwccL+O5wl2r/d2OZ5Ug0wcnSfqtIVc=";
   };
 
-  propagatedBuildInputs = [ requests webob ];
+  postPatch = ''
+    substituteInPlace hawkauthlib/tests/* \
+        --replace-warn 'assertEquals' 'assertEqual'
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    requests
+    webob
+  ];
+
+  pythonImportsCheck = [ "hawkauthlib" ];
+
+  nativeCheckInputs = [ unittestCheckHook ];
 
   meta = with lib; {
     homepage = "https://github.com/mozilla-services/hawkauthlib";
     description = "Hawk Access Authentication protocol";
     license = licenses.mpl20;
+    maintainers = with maintainers; [ ];
   };
-
 }

--- a/pkgs/development/python-modules/pybrowserid/default.nix
+++ b/pkgs/development/python-modules/pybrowserid/default.nix
@@ -1,24 +1,44 @@
-{ lib, buildPythonPackage, fetchPypi
-, requests, mock }:
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  requests,
+  unittestCheckHook,
+  mock,
+}:
 
 buildPythonPackage rec {
   pname = "pybrowserid";
   version = "0.14.0";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "PyBrowserID";
     inherit version;
-    sha256 = "1qvi79kfb8x9kxkm5lw2mp42hm82cpps1xknmsb5ghkwx1lpc8kc";
+    hash = "sha256-bCJ2aeh8wleWrnb2oO9lAlUoyK2C01Jnn6mj5WY6ceM=";
   };
 
-  propagatedBuildInputs = [ requests ];
+  postPatch = ''
+    substituteInPlace browserid/tests/* \
+        --replace-warn 'assertEquals' 'assertEqual'
+  '';
 
-  nativeCheckInputs = [ mock ];
+  build-system = [ setuptools ];
+
+  dependencies = [ requests ];
+
+  pythonImportsCheck = [ "browserid" ];
+
+  nativeCheckInputs = [
+    unittestCheckHook
+    mock
+  ];
 
   meta = with lib; {
     description = "Python library for the BrowserID Protocol";
-    homepage    = "https://github.com/mozilla/PyBrowserID";
-    license     = licenses.mpl20;
+    homepage = "https://github.com/mozilla/PyBrowserID";
+    license = licenses.mpl20;
     maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pyfxa/default.nix
+++ b/pkgs/development/python-modules/pyfxa/default.nix
@@ -18,7 +18,7 @@
 buildPythonPackage rec {
   pname = "pyfxa";
   version = "0.7.8";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -28,7 +28,11 @@ buildPythonPackage rec {
     hash = "sha256-DMFZl1hbYNaScOTWkAbK2nKti6wD5SS5A30q7TW5vO4=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     cryptography
     hawkauthlib
     pybrowserid


### PR DESCRIPTION
## Description of changes

ZHF: https://github.com/NixOS/nixpkgs/issues/309482

2 dependencies of `pyfxa` were failing, this PR fixes that.
Interestingly, both packages had the same issue with the tests: `assertEquals` no longer exists, so they fail because of it.

Other than fixing the tests, I replaced `sha256` with `hash`, added the missed `pythonImportsCheck` values where it was missing, and set `pyproject = true` adding the corresponding `build-system` with it.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
