### PR TITLE
python312Packages.pytest-{fixture-config,shutil,server-fixtures,virtualenv}: * -> 1.7.1-unstable-2022-10-03

### DIFF
--- a/pkgs/development/python-modules/pytest-fixture-config/default.nix
+++ b/pkgs/development/python-modules/pytest-fixture-config/default.nix
@@ -1,17 +1,30 @@
-{ lib, buildPythonPackage, fetchPypi
-, setuptools-git, pytest }:
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-git,
+  pytest,
+}:
 
 buildPythonPackage rec {
   pname = "pytest-fixture-config";
-  version = "1.7.0";
-  format = "setuptools";
+  version = "1.7.1-unstable-2022-10-03";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "13i1qpz22w3x4dmw8vih5jdnbqfqvl7jiqs0dg764s0zf8bp98a1";
+  src = fetchFromGitHub {
+    owner = "man-group";
+    repo = "pytest-plugins";
+    rev = "5f9b88a65a8c1e506885352bbd9b2a47900f5014";
+    hash = "sha256-huN3RzwtfVf4iMJ96VRP/ldOxTUlUMF1wJIdbcGXHn4=";
   };
 
-  nativeBuildInputs = [ setuptools-git ];
+  sourceRoot = "${src.name}/pytest-fixture-config";
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-git
+  ];
 
   buildInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/pytest-server-fixtures/default.nix
+++ b/pkgs/development/python-modules/pytest-server-fixtures/default.nix
@@ -1,26 +1,45 @@
-{ lib, buildPythonPackage, fetchPypi
-, pytest, pytest-shutil, pytest-fixture-config, psutil
-, requests, future, retry }:
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  future,
+  psutil,
+  pytest,
+  pytest-shutil,
+  pytest-fixture-config,
+  requests,
+  retry,
+  six,
+  setuptools,
+}:
 
 buildPythonPackage rec {
   pname = "pytest-server-fixtures";
-  version = "1.7.1";
-  format = "setuptools";
+  inherit (pytest-fixture-config) version src;
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-xecz0gqNDnc8pRPjYOS6JkeVLqlCj6K9BVFsYoHqPOc=";
-  };
+  sourceRoot = "${src.name}/pytest-server-fixtures";
+
+  build-system = [ setuptools ];
 
   buildInputs = [ pytest ];
-  propagatedBuildInputs = [ pytest-shutil pytest-fixture-config psutil requests future retry ];
 
-  # RuntimeError: Unable to find a free server number to start Xvfb
+  dependencies = [
+    future
+    psutil
+    pytest-shutil
+    pytest-fixture-config
+    requests
+    retry
+    six
+  ];
+
+  # Don't run intergration tests
   doCheck = false;
 
   meta = with lib; {
     description = "Extensible server fixures for py.test";
-    homepage  = "https://github.com/manahl/pytest-plugins";
+    homepage = "https://github.com/manahl/pytest-plugins";
     license = licenses.mit;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/development/python-modules/pytest-shutil/default.nix
+++ b/pkgs/development/python-modules/pytest-shutil/default.nix
@@ -1,13 +1,15 @@
 { lib
 , isPyPy
 , buildPythonPackage
-, fetchPypi
+, pytest-fixture-config
+, fetchpatch
 
-# build
-, pytest
+# build-time
+, setuptools
+, setuptools-git
 
 # runtime
-, setuptools-git
+, pytest
 , mock
 , path
 , execnet
@@ -15,32 +17,34 @@
 , six
 
 # tests
-, cmdline
 , pytestCheckHook
  }:
 
 buildPythonPackage rec {
   pname = "pytest-shutil";
-  version = "1.7.0";
-  format = "setuptools";
+  inherit (pytest-fixture-config) version src;
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-2BZSYd5251CFBcNB2UwCsRPclj8nRUOrynTb+r0CEmE=";
-  };
+  sourceRoot = "${src.name}/pytest-shutil";
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "contextlib2" 'contextlib2;python_version<"3"' \
-      --replace "path.py" "path"
-  '';
-
-  buildInputs = [
-    pytest
+  # imp was removed in Python 3.12
+  patches = [
+    (fetchpatch {
+      name = "stop-using-imp.patch";
+      url = "https://build.opensuse.org/public/source/openSUSE:Factory/python-pytest-shutil/stop-using-imp.patch?rev=10";
+      hash = "sha256-L8tXoQ9q8o6aP3TpJY/sUVVbUd/ebw0h6de6dBj1WNY=";
+      stripLen = 1;
+    })
   ];
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
     setuptools-git
+  ];
+
+  buildInputs = [ pytest ];
+
+  dependencies = [
     mock
     path
     execnet
@@ -49,7 +53,6 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    cmdline
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/pytest-virtualenv/default.nix
+++ b/pkgs/development/python-modules/pytest-virtualenv/default.nix
@@ -1,21 +1,43 @@
-{ lib, buildPythonPackage, fetchPypi
-, pytest, pytest-cov, mock, cmdline, pytest-fixture-config, pytest-shutil, virtualenv }:
+{
+  lib,
+  buildPythonPackage,
+  cmdline,
+  importlib-metadata,
+  mock,
+  pytestCheckHook,
+  pytest,
+  pytest-fixture-config,
+  pytest-shutil,
+  setuptools,
+  virtualenv,
+}:
 
 buildPythonPackage rec {
   pname = "pytest-virtualenv";
-  version = "1.7.0";
-  format = "setuptools";
+  inherit (pytest-fixture-config) version src;
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "03w2zz3crblj1p6i8nq17946hbn3zqp9z7cfnifw47hi4a4fww12";
-  };
+  sourceRoot = "${src.name}/pytest-virtualenv";
 
-  nativeCheckInputs = [ pytest pytest-cov mock cmdline ];
-  propagatedBuildInputs = [ pytest-fixture-config pytest-shutil virtualenv ];
-  checkPhase = "py.test tests/unit ";
+  build-system = [ setuptools ];
 
-  nativeBuildInputs = [ pytest ];
+  buildInputs = [ pytest ];
+
+  dependencies = [
+    importlib-metadata
+    pytest-fixture-config
+    pytest-shutil
+    virtualenv
+  ];
+
+  nativeCheckInputs = [
+    cmdline
+    mock
+    pytestCheckHook
+  ];
+
+  # Don't run integration tests
+  disabledTestPaths = [ "tests/integration/*" ];
 
   meta = with lib; {
     description = "Create a Python virtual environment in your test that cleans up on teardown. The fixture has utility methods to install packages and list what’s installed.";


### PR DESCRIPTION
## Description of changes

ZHF: https://github.com/NixOS/nixpkgs/issues/309482

Some packages were failing, because they tried to import `common_setup` from a directory that doesn't exist. I could solve this by fetching from the GitHub repo instead.
I used the latest commit, because that has the most fixes applied to it.
To not repeat myself, I only used fetchFromGitHub in `pytest-fixture-config` and in all other packages I just inherited the version and src values.

Changes done to all packages:
- use `pyproject = true`
- move dependencies around

Changes done to `pytest-shutil`
- remove unused check-time dep
- add patch fixing the build on newer python versions

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
