### PR TITLE
python312Packages.courlan: 1.0.0 -> 1.1.0, python311Packages.trafilatura: 1.8.1 -> 1.9.0

### DIFF
--- a/pkgs/development/python-modules/courlan/default.nix
+++ b/pkgs/development/python-modules/courlan/default.nix
@@ -1,4 +1,5 @@
 { lib
+, babel
 , buildPythonPackage
 , fetchPypi
 , langcodes
@@ -10,17 +11,18 @@
 
 buildPythonPackage rec {
   pname = "courlan";
-  version = "1.0.0";
+  version = "1.1.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-PDVRHDZSXLL5Qc1nCbejp0LtlfC55WyX7sDBb9wDUYM=";
+    hash = "sha256-1wZoQzTxi+StofvVfyaArfADZkj22ECFL3pIItOt/Y0=";
   };
 
   propagatedBuildInputs = [
+    babel
     langcodes
     tld
     urllib3

--- a/pkgs/development/python-modules/courlan/default.nix
+++ b/pkgs/development/python-modules/courlan/default.nix
@@ -1,13 +1,14 @@
-{ lib
-, babel
-, buildPythonPackage
-, fetchPypi
-, langcodes
-, pytestCheckHook
-, pythonOlder
-, setuptools
-, tld
-, urllib3
+{
+  lib,
+  babel,
+  buildPythonPackage,
+  fetchPypi,
+  langcodes,
+  pytestCheckHook,
+  pythonOlder,
+  setuptools,
+  tld,
+  urllib3,
 }:
 
 buildPythonPackage rec {
@@ -30,9 +31,7 @@ buildPythonPackage rec {
       --replace-fail "/tmp" "$TMPDIR"
   '';
 
-  build-system = [
-    setuptools
-  ];
+  build-system = [ setuptools ];
 
   dependencies = [
     babel
@@ -41,14 +40,10 @@ buildPythonPackage rec {
     urllib3
   ];
 
-  nativeCheckInputs = [
-    pytestCheckHook
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   # disable tests that require an internet connection
-  disabledTests = [
-    "test_urlcheck"
-  ];
+  disabledTests = [ "test_urlcheck" ];
 
   pythonImportsCheck = [ "courlan" ];
 

--- a/pkgs/development/python-modules/trafilatura/default.nix
+++ b/pkgs/development/python-modules/trafilatura/default.nix
@@ -1,16 +1,17 @@
-{ lib
-, buildPythonPackage
-, certifi
-, charset-normalizer
-, courlan
-, fetchPypi
-, htmldate
-, justext
-, lxml
-, pytestCheckHook
-, pythonOlder
-, setuptools
-, urllib3
+{
+  lib,
+  buildPythonPackage,
+  certifi,
+  charset-normalizer,
+  courlan,
+  fetchPypi,
+  htmldate,
+  justext,
+  lxml,
+  pytestCheckHook,
+  pythonOlder,
+  setuptools,
+  urllib3,
 }:
 
 buildPythonPackage rec {
@@ -34,9 +35,7 @@ buildPythonPackage rec {
       --replace-fail "trafilatura_bin = 'trafilatura'" "trafilatura_bin = '$out/bin/trafilatura'"
   '';
 
-  build-system = [
-    setuptools
-  ];
+  build-system = [ setuptools ];
 
   dependencies = [
     certifi
@@ -48,9 +47,7 @@ buildPythonPackage rec {
     urllib3
   ];
 
-  nativeCheckInputs = [
-    pytestCheckHook
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   disabledTests = [
     # Disable tests that require an internet connection
@@ -65,9 +62,7 @@ buildPythonPackage rec {
     "test_whole"
   ];
 
-  pythonImportsCheck = [
-    "trafilatura"
-  ];
+  pythonImportsCheck = [ "trafilatura" ];
 
   meta = with lib; {
     description = "Python package and command-line tool designed to gather text on the Web";

--- a/pkgs/development/python-modules/trafilatura/default.nix
+++ b/pkgs/development/python-modules/trafilatura/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "trafilatura";
-  version = "1.8.1";
+  version = "1.9.0";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-a4eN/b1cXftV0Pgwfyt9wVrDRYBU90hh/5ihcvXjhyA=";
+    hash = "sha256-5oM9KauKE+2FOTfXyR5oaLxi774QIUrCsQZDbdI9FBI=";
   };
 
   nativeBuildInputs = [
@@ -45,14 +45,15 @@ buildPythonPackage rec {
 
   disabledTests = [
     # Disable tests that require an internet connection
+    "test_cli_pipeline"
+    "test_crawl_page"
     "test_download"
     "test_fetch"
-    "test_redirection"
     "test_meta_redirections"
-    "test_crawl_page"
-    "test_whole"
     "test_probing"
-    "test_cli_pipeline"
+    "test_queue"
+    "test_redirection"
+    "test_whole"
   ];
 
   # patch out gui cli because it is not supported in this packaging

--- a/pkgs/development/python-modules/trafilatura/default.nix
+++ b/pkgs/development/python-modules/trafilatura/default.nix
@@ -1,16 +1,16 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, pytestCheckHook
-, pythonOlder
 , certifi
 , charset-normalizer
 , courlan
+, fetchPypi
 , htmldate
 , justext
 , lxml
-, urllib3
+, pytestCheckHook
+, pythonOlder
 , setuptools
+, urllib3
 }:
 
 buildPythonPackage rec {
@@ -25,11 +25,20 @@ buildPythonPackage rec {
     hash = "sha256-5oM9KauKE+2FOTfXyR5oaLxi774QIUrCsQZDbdI9FBI=";
   };
 
-  nativeBuildInputs = [
+  # Patch out gui cli because it is not supported in this packaging and
+  # nixify path to the trafilatura binary in the test suite
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail '"trafilatura_gui=trafilatura.gui:main",' ""
+    substituteInPlace tests/cli_tests.py \
+      --replace-fail "trafilatura_bin = 'trafilatura'" "trafilatura_bin = '$out/bin/trafilatura'"
+  '';
+
+  build-system = [
     setuptools
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     certifi
     charset-normalizer
     courlan
@@ -55,15 +64,6 @@ buildPythonPackage rec {
     "test_redirection"
     "test_whole"
   ];
-
-  # patch out gui cli because it is not supported in this packaging
-  # nixify path to the trafilatura binary in the test suite
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail '"trafilatura_gui=trafilatura.gui:main",' ""
-    substituteInPlace tests/cli_tests.py \
-      --replace-fail "trafilatura_bin = 'trafilatura'" "trafilatura_bin = '$out/bin/trafilatura'"
-  '';
 
   pythonImportsCheck = [
     "trafilatura"


### PR DESCRIPTION
Changelog: https://github.com/adbar/courlan/blob/v1.1.0/HISTORY.md

Changelog: https://github.com/adbar/trafilatura/blob/v1.9.0/HISTORY.md

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
