### PR TITLE
nixos/xserver: remove duplicate display-manager.script declaration

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -728,9 +728,6 @@ in
             rm -f /tmp/.X0-lock
           '';
 
-        # TODO: move declaring the systemd service to its own mkIf
-        script = mkIf (config.systemd.services.display-manager.enable == true) "${config.services.displayManager.execCmd}";
-
         # Stop restarting if the display manager stops (crashes) 2 times
         # in one minute. Starting X typically takes 3-4s.
         startLimitIntervalSec = 30;


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/commit/6be2bfcc32d5ee203acf3b85354f5028c8bb50eb 
introduced a duplication of:
```nix
systemd.services.display-manager.script = lib.mkIf (config.systemd.services.display-manager.enable == true) cfg.execCmd;
``` 
```bash
$ rg -F 'mkIf (config.systemd.services.display-manager.enable == true)'
nixos/modules/services/display-managers/default.nix
220:      script = lib.mkIf (config.systemd.services.display-manager.enable == true) cfg.execCmd;

nixos/modules/services/x11/xserver.nix
732:        script = mkIf (config.systemd.services.display-manager.enable == true) "${config.services.displayManager.execCmd}";
```

This duplicates the `systemd.services.systemctl.display-manager.script` contents
```bash
$ cat /nix/store/f7zxggsi49mj0hkqfk8sz0hav3j73va7-unit-script-display-manager-start/bin/display-manager-start
#!/nix/store/h3bhzvz9ipglcybbcvkxvm4vg9lwvqg4-bash-5.2p26/bin/bash
set -e
export PATH=/nix/store/if4msrv8s77qadm4rjkxxjhap0bxrr9v-lightdm-1.32.0/sbin:$PATH
exec /nix/store/if4msrv8s77qadm4rjkxxjhap0bxrr9v-lightdm-1.32.0/sbin/lightdm

export PATH=/nix/store/if4msrv8s77qadm4rjkxxjhap0bxrr9v-lightdm-1.32.0/sbin:$PATH
exec /nix/store/if4msrv8s77qadm4rjkxxjhap0bxrr9v-lightdm-1.32.0/sbin/lightdm
```

CC: @SuperSandro2000 

