### PR TITLE
backgroundremover: fix build, add update script, update to 0.2.8

### DIFF
--- a/pkgs/by-name/ba/backgroundremover/package.nix
+++ b/pkgs/by-name/ba/backgroundremover/package.nix
@@ -10,14 +10,14 @@ let
   p = python3.pkgs;
   self = p.buildPythonApplication rec {
     pname = "backgroundremover";
-    version = "0.2.6";
+    version = "0.2.8";
     pyproject = true;
 
     src = fetchFromGitHub {
       owner = "nadermx";
       repo = "backgroundremover";
       rev = "v${version}";
-      hash = "sha256-dDOo7NPwvdfV+ae2oMUytCGC+2HF6xUI7dyKk2we23w=";
+      hash = "sha256-LjVT4j0OzfbVSQgU0z/gzRTLm7N0RQRrfxtTugWwOxs=";
     };
 
     models = runCommand "background-remover-models" {} ''
@@ -34,7 +34,7 @@ let
 
     nativeBuildInputs = [ p.setuptools p.wheel p.pythonRelaxDepsHook ];
 
-    pythonRelaxDeps = [ "torchvision" ];
+    pythonRelaxDeps = [ "pillow" "torchvision" ];
 
     propagatedBuildInputs = [
       p.certifi

--- a/pkgs/by-name/ba/backgroundremover/package.nix
+++ b/pkgs/by-name/ba/backgroundremover/package.nix
@@ -31,7 +31,9 @@ let
         --replace 'os.path.expanduser(os.path.join("~", ".u2net", model_name + ".pth"))' "os.path.join(\"$models\", model_name + \".pth\")"
     '';
 
-    nativeBuildInputs = [ p.setuptools p.wheel ];
+    nativeBuildInputs = [ p.setuptools p.wheel p.pythonRelaxDepsHook ];
+
+    pythonRelaxDeps = [ "torchvision" ];
 
     propagatedBuildInputs = [
       p.certifi

--- a/pkgs/by-name/ba/backgroundremover/package.nix
+++ b/pkgs/by-name/ba/backgroundremover/package.nix
@@ -3,6 +3,7 @@
 , runCommand
 , fetchFromGitHub
 , fetchurl
+, gitUpdater
 }:
 
 let
@@ -78,6 +79,7 @@ let
           backgroundremover -i ${demoImage} -o $out
         '';
       };
+      updateScript = gitUpdater { rev-prefix = "v"; };
     };
 
     doCheck = false; # no tests


### PR DESCRIPTION
## Description of changes
- The build was failing because of a weird version quirk related to torchvision. I used `pythonRelaxDepsHook` to fix.
- I also realized that it doesn't have a update script so I added one, and with that did the third commit.

ZHF #309482 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
