### PR TITLE
makejinja: init at 2.6.0

### DIFF
--- a/pkgs/by-name/ma/makejinja/package.nix
+++ b/pkgs/by-name/ma/makejinja/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "makejinja";
+  version = "2.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mirkolenz";
+    repo = "makejinja";
+    rev = "v${version}";
+    hash = "sha256-sH4m+rcHA6nW21xEJon10lS7e5QiFwUyvV49NZ3UY+s=";
+  };
+
+  build-system = with python3Packages; [ poetry-core ];
+
+  dependencies =
+    with python3Packages;
+    [
+      jinja2
+      pyyaml
+      rich-click
+      typed-settings
+      immutables
+    ]
+    ++ typed-settings.optional-dependencies.attrs
+    ++ typed-settings.optional-dependencies.cattrs
+    ++ typed-settings.optional-dependencies.click;
+
+  preCheck = ''
+    substituteInPlace pyproject.toml \
+        --replace-fail "--cov makejinja --cov-report term-missing" ""
+  '';
+
+  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
+
+  meta = {
+    description = "Generate entire directory structures using Jinja templates with support for external data and custom plugins";
+    homepage = "https://github.com/mirkolenz/makejinja";
+    license = lib.licenses.mit;
+    mainProgram = "makejinja";
+    maintainers = with lib.maintainers; [
+      tomasajt
+      mirkolenz
+    ];
+    platforms = lib.platforms.darwin ++ lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/310653

This PR adds 1 new package: `makejinja`


@mirkolenz as the upstream maintainer, would you like to also be listed as a maintainer inside nixpkgs?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
