### PR TITLE
python312Packages.albumentations: fix dependencies, fix tests

### DIFF
--- a/pkgs/development/python-modules/albumentations/default.nix
+++ b/pkgs/development/python-modules/albumentations/default.nix
@@ -1,19 +1,21 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , setuptools
+, deepdiff
 , numpy
 , opencv4
 , pyyaml
-, qudida
 , scikit-image
+, scikit-learn
 , scipy
-, deepdiff
+, pydantic
 , pytestCheckHook
 , pythonOlder
 , pythonRelaxDepsHook
 , torch
 , torchvision
+, typing-extensions
 }:
 
 buildPythonPackage rec {
@@ -23,9 +25,11 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.8";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-VNpClOBdoaQOqU92Mm/Z5Q7P+fZzR+m43SFA9pSi1M0=";
+  src = fetchFromGitHub {
+    owner = "albumentations-team";
+    repo = "albumentations";
+    rev = "refs/tags/${version}";
+    hash = "sha256-7t1+22zzFtkZaAyOo6xjk+MXT9N44PmQ/NRRfvLeRVk=";
   };
 
   nativeBuildInputs = [
@@ -34,6 +38,7 @@ buildPythonPackage rec {
 
   pythonRemoveDeps = [
     "opencv-python"
+    "pydantic"
   ];
 
   build-system = [
@@ -43,10 +48,12 @@ buildPythonPackage rec {
   dependencies = [
     numpy
     opencv4
+    pydantic
     pyyaml
-    qudida
     scikit-image
+    scikit-learn
     scipy
+    typing-extensions
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
## Description of changes

ZHF: #309482

This PR fixes the `albumentations` python package by adding a missed dependency (`pydantic`). It also declares some extra dependencies that are propagated by another dependency, but are still listed inside `setup.py`.

The tests were also broken because the tarball from `fetchPypi` didn't contain an important file used by pytest. This PR addresses this by fetching from GitHub instead.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
