### PR TITLE
Update to 0.2024.05.07.08.02.stable_02

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -4,7 +4,7 @@
     "version": "0.2024.05.07.08.02.stable_02"
   },
   "linux": {
-    "hash": "sha256-R9//eoelQkH8OAhoU0ux+o1EpQozWhRJwCTTSY9LBGU=",
+    "hash": "sha256-zUbWNgiupBoFWoN3I726FejGtGne9dctaiGlPBbj5KU=",
     "version": "0.2024.05.07.08.02.stable_02"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,6 +1,6 @@
 {
   "darwin": {
-    "hash": "sha256-oIRZtj1BZWioO1ucEXnJQoz/FfDNHWLdYLExuLk+aJk=",
+    "hash": "sha256-Ky5JyocpI9JKvhmmhk0Cg/Eo7icmo6FQAT639cGIGrA=",
     "version": "0.2024.05.07.08.02.stable_02"
   },
   "linux": {

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "darwin": {
     "hash": "sha256-oIRZtj1BZWioO1ucEXnJQoz/FfDNHWLdYLExuLk+aJk=",
-    "version": "0.2024.04.23.08.01.stable_03"
+    "version": "0.2024.05.07.08.02.stable_02"
   },
   "linux": {
     "hash": "sha256-R9//eoelQkH8OAhoU0ux+o1EpQozWhRJwCTTSY9LBGU=",
-    "version": "0.2024.04.23.08.01.stable_03"
+    "version": "0.2024.05.07.08.02.stable_02"
   }
 }


### PR DESCRIPTION
## Description of changes

2024.05.09 (v0.2024.05.07.08.02)

Bug fixes

   - Vim-related settings no longer appear in the Command Palette when editing with Vim keybindings is disabled

   - Warp's Input Editor now immediately reflects any changes to the Vim status bar settings

   - Fixed a bug when handling URLs with parentheses in notebooks and Warp AI

## Things done

changed the version.json for the linux version, I havent tested on the darwin version for MacOS.

I build it with ```nix-build -A warp-terminal``` and it worked on my machine. NixOS btw

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
