### PR TITLE
nixos/gnome-keyring: add SSH support by exporting SSH_AUTH_SOCK

### DIFF
--- a/nixos/modules/security/ssh-agent.nix
+++ b/nixos/modules/security/ssh-agent.nix
@@ -1,0 +1,26 @@
+{ config, pkgs, lib, ... }:
+let
+  cfg = config.security.SSHAgent;
+in {
+
+  options = {
+    security.SSHAgent = {
+      socket = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "The path to the SSH agent socket";
+      };
+    };
+  };
+
+
+  config = lib.mkIf cfg.SSHAgent.socket != null {
+    environment.extraInit =   ''
+      if [ -z "$SSH_AUTH_SOCK" -a -n "$XDG_RUNTIME_DIR" ]; then
+        export SSH_AUTH_SOCK=${cfg.SSHAgent.socket}
+      fi
+    '';
+  };
+
+
+}

--- a/nixos/modules/security/ssh-agent.nix
+++ b/nixos/modules/security/ssh-agent.nix
@@ -17,7 +17,7 @@ in {
   config = lib.mkIf cfg.socket != null {
     environment.extraInit =   ''
       if [ -z "$SSH_AUTH_SOCK" -a -n "$XDG_RUNTIME_DIR" ]; then
-        export SSH_AUTH_SOCK=${cfg.SSHAgent.socket}
+        export SSH_AUTH_SOCK=${cfg.socket}
       fi
     '';
   };

--- a/nixos/modules/security/ssh-agent.nix
+++ b/nixos/modules/security/ssh-agent.nix
@@ -14,7 +14,7 @@ in {
   };
 
 
-  config = lib.mkIf cfg.SSHAgent.socket != null {
+  config = lib.mkIf cfg.socket != null {
     environment.extraInit =   ''
       if [ -z "$SSH_AUTH_SOCK" -a -n "$XDG_RUNTIME_DIR" ]; then
         export SSH_AUTH_SOCK=${cfg.SSHAgent.socket}

--- a/nixos/modules/services/desktops/gnome/gnome-keyring.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-keyring.nix
@@ -26,14 +26,7 @@ in
         '';
       };
 
-      enableSSHSupport = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Enable SSH agent support in Gnome Keyring by setting SSH_AUTH_SOCK
-          environment variable correctly.
-        '';
-      };
+      enableSSHSupport = lib.mkEnableOption "SSH agent support for GNOME Keyring by setting the SSH_AUTH_SOCK environment variable";
 
     };
 

--- a/nixos/modules/services/desktops/gnome/gnome-keyring.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-keyring.nix
@@ -26,7 +26,7 @@ in
         '';
       };
 
-      enableSSHSupport = lib.mkEnableOption "SSH agent support for GNOME Keyring by setting the SSH_AUTH_SOCK environment variable";
+      SSHSupport.enable = lib.mkEnableOption "SSH agent support for GNOME Keyring by setting the SSH_AUTH_SOCK environment variable";
 
     };
 

--- a/nixos/modules/services/desktops/gnome/gnome-keyring.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-keyring.nix
@@ -52,11 +52,7 @@ in
       source = "${pkgs.gnome.gnome-keyring}/bin/gnome-keyring-daemon";
     };
 
-    environment.extraInit = lib.mkIf cfg.enableSSHSupport ''
-      if [ -z "$SSH_AUTH_SOCK" -a -n "$XDG_RUNTIME_DIR" ]; then
-        export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/keyring/ssh"
-      fi
-    '';
+    security.SSHAgent.socket = lib.mkIf cfg.SSHSupport.enable "$XDG_RUNTIME_DIR/keyring/ssh";  
 
   };
 


### PR DESCRIPTION
## Description of changes
Added SSH support inside the gnome-keyring module, similar to [ssh.nix](https://github.com/NixOS/nixpkgs/blob/27c13997bf450a01219899f5a83bd6ffbfc70d3c/nixos/modules/programs/ssh.nix#L347) and [gnupg.nix](https://github.com/NixOS/nixpkgs/blob/71bae31b7dbc335528ca7e96f479ec93462323ff/nixos/modules/programs/gnupg.nix#L232) by exporting `SSH_AUTH_SOCK`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
