### PR TITLE
flutter: keep `$ORIGIN` in `RUNPATH`

### DIFF
--- a/pkgs/development/compilers/flutter/artifacts/overrides/linux.nix
+++ b/pkgs/development/compilers/flutter/artifacts/overrides/linux.nix
@@ -6,5 +6,8 @@
 }:
 
 {
+  # https://github.com/flutter/engine/pull/28525
+  appendRunpaths = "$ORIGIN";
+
   buildInputs = buildInputs ++ [ gtk3 ];
 }


### PR DESCRIPTION
## Description of changes

[autoPatchelfHook](https://github.com/NixOS/nixpkgs/blob/be9b31b774960b0e98821621c95dd7ee9341aa32/pkgs/development/compilers/flutter/artifacts/prepare-artifacts.nix#L12) drop `$ORIGIN` from elf, which will allow problems solved in https://github.com/flutter/engine/pull/28525 to reoccur, e.g. https://github.com/fzyzcjy/flutter_rust_bridge/issues/1898

#### original
```
File: result/bin/cache/artifacts/engine/linux-x64/libflutter_linux_gtk.so
...
  0x000000000000001d (RUNPATH)      Library runpath: [$ORIGIN]
...
```

https://github.com/flutter/engine/pull/28525 only configures `$ORIGIN` for `libflutter_linux_gtk.so`, but `autoPatchelfHook` don't seem to support single-file setup, but so far `autoPatchelfHook` has only patched `libflutter_linux_gtk.so`, so that should be fine!

I guess this PR is not the best solution and should actually be implemented in #212328?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
