### PR TITLE
npins: 0.2.2 -> 0.2.4

### DIFF
--- a/pkgs/tools/nix/npins/default.nix
+++ b/pkgs/tools/nix/npins/default.nix
@@ -19,7 +19,7 @@ in rustPlatform.buildRustPackage rec {
   version = src.version;
   src = passthru.mkSource sources.npins;
 
-  cargoSha256 = "sha256-eySVpmCVWBJfyAkTQv+LqojWMO/3r6kBYP1a4z+FYHY=";
+  cargoSha256 = "sha256-YwMypBl+P1ygf4zUbkZlq4zPrOzf+lPOz2FLg2/xI3k=";
 
   buildInputs = lib.optional stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Security ]);
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/nix/npins/sources.json
+++ b/pkgs/tools/nix/npins/sources.json
@@ -9,10 +9,10 @@
       },
       "pre_releases": false,
       "version_upper_bound": null,
-      "version": "0.2.2",
-      "revision": "a443c58d9c7b818aaea3c47821d7c561faef66ec",
-      "url": "https://api.github.com/repos/andir/npins/tarball/0.2.2",
-      "hash": "0rv6m8c9lmzkb76b682w7ax6jy8ls4l4y17wjx98jk64b74qspca"
+      "version": "0.2.4",
+      "revision": "181da464f7edb5e675dd96cc25d611760796a739",
+      "url": "https://api.github.com/repos/andir/npins/tarball/0.2.4",
+      "hash": "04155dr6i1gy2zgy49v8zm75sn1akm83l4x8h6cxvxyk1l2abn4q"
     }
   },
   "version": 3


### PR DESCRIPTION
## Description of changes

Updates `npins` to version `0.2.4`.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---
