### PR TITLE
python312Packages.ecdsa: use pyproject=true, enable testing

### DIFF
--- a/pkgs/development/python-modules/ecdsa/default.nix
+++ b/pkgs/development/python-modules/ecdsa/default.nix
@@ -1,28 +1,40 @@
-{ lib
-, buildPythonPackage
-, fetchPypi
-, pkgs
-, six
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  six,
+  pytestCheckHook,
+  hypothesis,
+  pkgs,
 }:
 
 buildPythonPackage rec {
   pname = "ecdsa";
   version = "0.19.0";
-  format = "setuptools";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-YOqtEZllmQDdCvUh7UYreTu9+GdDKzlI6HQWrkyva/g=";
+  src = fetchFromGitHub {
+    owner = "tlsfuzzer";
+    repo = "python-ecdsa";
+    rev = "python-ecdsa-${version}";
+    hash = "sha256-yDhTlc0adNo+RzVpP+L4D73Av+NbcvJ1uNB2hUxXsBA=";
   };
 
-  propagatedBuildInputs = [ six ];
-  # Only needed for tests
-  nativeCheckInputs = [ pkgs.openssl ];
+  build-system = [ setuptools ];
+
+  dependencies = [ six ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    hypothesis
+    pkgs.openssl # Only needed for tests
+  ];
 
   meta = with lib; {
     description = "ECDSA cryptographic signature library";
-    homepage = "https://github.com/warner/python-ecdsa";
+    homepage = "https://github.com/tlsfuzzer/python-ecdsa";
     license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
-
 }


### PR DESCRIPTION
## Description of changes

Seems like at some point `ecdsa` switched over to pytest, so `format = "setuptools"` no longer did any actual testing. This PR updates the check-time dependencies, so that testing is done again.

Other changes:
- fetch from github
  - https://github.com/warner/python-ecdsa redirects to https://github.com/tlsfuzzer/python-ecdsa, so I used that
  - also updated the meta homepage
- use pyproject=true
- use new naming system
- add an empty maintainers list

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
