### PR TITLE
python312Packages.m2crypto: fix build, clean up, format

### DIFF
--- a/pkgs/development/python-modules/m2crypto/default.nix
+++ b/pkgs/development/python-modules/m2crypto/default.nix
@@ -1,12 +1,13 @@
-{ lib
-, stdenv
-, buildPythonPackage
-, fetchPypi
-, openssl
-, parameterized
-, pytestCheckHook
-, pythonOlder
-, swig2
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchPypi,
+  openssl,
+  parameterized,
+  pytestCheckHook,
+  pythonOlder,
+  swig2,
 }:
 
 buildPythonPackage rec {
@@ -32,22 +33,20 @@ buildPythonPackage rec {
     parameterized
   ];
 
-  env = {
-    NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin (toString [
-      "-Wno-error=implicit-function-declaration"
-      "-Wno-error=incompatible-pointer-types"
-    ]);
-  } // lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) {
-    CPP = "${stdenv.cc.targetPrefix}cpp";
-  };
+  env =
+    {
+      NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin (toString [
+        "-Wno-error=implicit-function-declaration"
+        "-Wno-error=incompatible-pointer-types"
+      ]);
+    }
+    // lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) {
+      CPP = "${stdenv.cc.targetPrefix}cpp";
+    };
 
-  nativeCheckInputs = [
-    pytestCheckHook
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [
-    "M2Crypto"
-  ];
+  pythonImportsCheck = [ "M2Crypto" ];
 
   meta = with lib; {
     description = "A Python crypto and SSL toolkit";

--- a/pkgs/development/python-modules/m2crypto/default.nix
+++ b/pkgs/development/python-modules/m2crypto/default.nix
@@ -4,16 +4,16 @@
   buildPythonPackage,
   fetchPypi,
   openssl,
-  parameterized,
   pytestCheckHook,
   pythonOlder,
-  swig2,
+  setuptools,
+  swig,
 }:
 
 buildPythonPackage rec {
   pname = "m2crypto";
   version = "0.41.0";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -23,15 +23,11 @@ buildPythonPackage rec {
     hash = "sha256-OhNYx+6EkEbZF4Knd/F4a/AnocHVG1+vjxlDW/w/FJU=";
   };
 
-  nativeBuildInputs = [
-    swig2
-    openssl
-  ];
+  build-system = [ setuptools ];
 
-  buildInputs = [
-    openssl
-    parameterized
-  ];
+  nativeBuildInputs = [ swig ];
+
+  buildInputs = [ openssl ];
 
   env =
     {
@@ -44,7 +40,10 @@ buildPythonPackage rec {
       CPP = "${stdenv.cc.targetPrefix}cpp";
     };
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    openssl
+  ];
 
   pythonImportsCheck = [ "M2Crypto" ];
 


### PR DESCRIPTION
## Description of changes

ZHF: #309482

The build of the `m2crypto` python package was failing on `python312` because it was using `swig2`, which still generated code that tried to import `imp`, which has been removed.
This PR fixes the build by using `swig` instead of `swig2`.

Other changes done:
- use `pyproject = true`
- move dependencies around
  - remove unused `parameterized` dep
  - move `openssl` to `nativeCheckInputs`, as the `openssl` command is only ever invoked there
- format code

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
