### PR TITLE
python312Packages.psycopg2cffi: 2.8.1 -> 2.9.0

### DIFF
--- a/pkgs/development/python-modules/psycopg2cffi/default.nix
+++ b/pkgs/development/python-modules/psycopg2cffi/default.nix
@@ -5,35 +5,46 @@
 , postgresql
 , postgresqlTestHook
 , pytestCheckHook
+, setuptools
 , six
+, stdenv
 }:
 
 buildPythonPackage rec {
   pname = "psycopg2cffi";
-  version = "2.8.1";
-  format = "setuptools";
+  version = "2.9.0";
+  pyproject = true;
 
-  # NB: This is a fork.
-  # The original repo exists at https://github.com/chtd/psycopg2cffi, however
-  # this is mostly unmaintained and does not build for PyPy. Given that the
-  # whole point of this cffi alternative to psycopg2 is to use it with PyPy, I
-  # chose to use a working fork instead, which was linked in the relevant issue:
-  # https://github.com/chtd/psycopg2cffi/issues/113#issuecomment-730548574
-  #
-  # If/when these changes get merged back upstream we should revert to using the
-  # original source as opposed to the fork.
   src = fetchFromGitHub {
-    owner = "Omegapol";
-    repo = pname;
-    rev = "c202b25cd861d5e8f0f55c329764ff1da9f020c0";
-    sha256 = "09hsnjkix1c0vlhmfvrp8pchpnz2ya4xrchyq15czj527nx2dmy2";
+    owner = "chtd";
+    repo = "psycopg2cffi";
+    rev = "refs/tags/${version}";
+    hash = "sha256-9r5MYxw9cvdbLVj8StmMmn0AKQepOpCc7TIBGXZGWe4=";
   };
 
-  nativeBuildInputs = [ postgresql ];
+  postPatch = ''
+    substituteInPlace psycopg2cffi/_impl/_build_libpq.py \
+      --replace-fail "from distutils import sysconfig" "import sysconfig" \
+      --replace-fail "sysconfig.get_python_inc()" "sysconfig.get_path('include')"
+  '';
 
-  propagatedBuildInputs = [ six cffi ];
+  build-system = [
+    postgresql
+    setuptools
+  ];
 
-  nativeCheckInputs = [ postgresqlTestHook pytestCheckHook ];
+  dependencies = [
+    cffi
+    six
+  ];
+
+  # FATAL: could not create shared memory segment: Operation not permitted
+  doCheck = !stdenv.isDarwin;
+
+  nativeCheckInputs = [
+    postgresqlTestHook
+    pytestCheckHook
+  ];
 
   disabledTests = [
     # AssertionError: '{}' != []


### PR DESCRIPTION
https://github.com/chtd/psycopg2cffi/compare/2.8.1...2.9.0

- Return from fork to upstream
- Migrate to PEP517 builder
- Patch out distutils for Python 3.12 compat
- Stop running tests on Darwin, since PostgreSQL is not allowed to allocate the required shared memory segment

#309297

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s) for 3.11/3.12
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
