### PR TITLE
testers.hasPkgConfigModules: fix bug in `versionCheck` handling

### DIFF
--- a/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
+++ b/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
@@ -55,7 +55,7 @@ runCommand testName {
       fi
     done
 
-    if [[ $notFound -eq 0 ]] && ([[ $versionMismatch -eq 0 ]] || [[ "$versionCheck" == false ]]); then
+    if [[ $notFound -eq 0 ]] && ([[ $versionMismatch -eq 0 ]] || [[ -z "$versionCheck" ]]); then
       exit 0
     fi
     if [[ $notFound -ne 0 ]]; then

--- a/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
+++ b/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
@@ -45,7 +45,7 @@ runCommand testName {
         if [[ "$moduleVersion" == "$version" ]]; then
           echo "✅ pkg-config module $moduleName exists and has version $moduleVersion"
         else
-          echo "${if versionCheck then "❌" else "⚠"} pkg-config module $moduleName exists and has version $moduleVersion when $version was expected"
+          echo "${if versionCheck then "❌" else "ℹ️"} pkg-config module $moduleName exists at version $moduleVersion != $version (drv version)"
           ((versionMismatch+=1))
         fi
         printf '%s\t%s\n' "$moduleName" "$version" >> "$out"

--- a/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
+++ b/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
@@ -45,7 +45,7 @@ runCommand testName {
         if [[ "$moduleVersion" == "$version" ]]; then
           echo "✅ pkg-config module $moduleName exists and has version $moduleVersion"
         else
-          echo "❌ pkg-config module $moduleName exists and has version $moduleVersion when $version was expected"
+          echo "${if versionCheck then "❌" else "⚠"} pkg-config module $moduleName exists and has version $moduleVersion when $version was expected"
           ((versionMismatch+=1))
         fi
         printf '%s\t%s\n' "$moduleName" "$version" >> "$out"

--- a/pkgs/build-support/testers/hasPkgConfigModules/tests.nix
+++ b/pkgs/build-support/testers/hasPkgConfigModules/tests.nix
@@ -11,9 +11,14 @@ lib.recurseIntoAttrs {
 
   miniz-versions-mismatch = testers.testBuildFailure (testers.hasPkgConfigModules {
     package = miniz;
-    version = "1.2.3";
+    version = "1.2.3";  # Deliberately-incorrect version number
     versionCheck = true;
   });
+
+  miniz-no-versionCheck = testers.hasPkgConfigModules {
+    package = miniz;
+    version = "1.2.3";  # Deliberately-incorrect version number
+  };
 
   zlib-has-zlib = testers.hasPkgConfigModules {
     package = zlib;


### PR DESCRIPTION
## Description of changes

- add testcase for the bug reported in https://github.com/NixOS/nixpkgs/pull/307770#issuecomment-2102586718
- fix bug

Alternative to #310535


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
