### PR TITLE
Python312Packages.pymilter: fix test failure deprecation for pytest assertEqual(s) function

### DIFF
--- a/pkgs/development/python-modules/pymilter/default.nix
+++ b/pkgs/development/python-modules/pymilter/default.nix
@@ -1,4 +1,15 @@
-{ lib, python, buildPythonPackage, fetchFromGitHub, libmilter, bsddb3, pydns, iana-etc, libredirect }:
+{ lib
+, python
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, libmilter
+, bsddb3
+, pydns
+, iana-etc
+, libredirect
+, pyasyncore
+}:
 
 buildPythonPackage rec {
   pname = "pymilter";
@@ -13,7 +24,14 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ libmilter ];
+  nativeCheckInputs = [ pyasyncore ];
   propagatedBuildInputs = [ bsddb3 pydns ];
+  patches = [ (fetchpatch {
+    name = "Remove-calls-to-the-deprecated-method-assertEquals";
+    url = "https://github.com/sdgathman/pymilter/pull/57.patch";
+    hash = "sha256-/5LlDR15nMR3l7rkVjT3w4FbDTFAAgNdERWlPNL2TVg=";
+    })
+  ];
 
   preBuild = ''
     sed -i 's/import thread/import _thread as thread/' Milter/greylist.py


### PR DESCRIPTION
See upstream commit : https://github.com/sdgathman/pymilter/pull/57

EDIT : 
```nix
Automatic merge went well; stopped before committing as requested
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/kenshin/.cache/nixpkgs-review/pr-308157-7/nixpkgs nixpkgs-overlays=/tmp/tmpq91akokq -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
9 packages updated:
exaile gramps python3.11-bsddb3 python3.11-pymilter python3.11-scrapy-deltafetch python3.12-bsddb3 python3.12-pymilter python3.12-scrapy-deltafetch spf-engine

$ nix build --nix-path nixpkgs=/home/kenshin/.cache/nixpkgs-review/pr-308157-7/nixpkgs nixpkgs-overlays=/tmp/tmpq91akokq --extra-experimental-features nix-command no-url-literals --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed -f /home/kenshin/.cache/nixpkgs-review/pr-308157-7/build.nix
error: builder for '/nix/store/4b0yac479mdwca75ggwa4d276r1xhzwc-python3.12-pymilter-1.0.5.drv' failed with exit code 1;
       last 10 log lines:
       >     self.assertEquals(cache['temp@bar.com'],'testing')
       >     ^^^^^^^^^^^^^^^^^
       > AttributeError: 'AddrCacheTestCase' object has no attribute 'assertEquals'. Did you mean: 'assertEqual'?
       >
       > ----------------------------------------------------------------------
       > Ran 27 tests in 0.357s
       >
       > FAILED (errors=6, expected failures=1)
       > Test failed: <unittest.runner.TextTestResult run=27 errors=6 failures=0>
       > error: Test failed: <unittest.runner.TextTestResult run=27 errors=6 failures=0>
       For full logs, run 'nix log /nix/store/4b0yac479mdwca75ggwa4d276r1xhzwc-python3.12-pymilter-1.0.5.drv'.
error: 1 dependencies of derivation '/nix/store/x91p0xxgylixarbp6vdqdjqavg8fpqd3-review-shell.drv' failed to build

Link to currently reviewing PR:
https://github.com/NixOS/nixpkgs/pull/308157

2 packages failed to build:
python312Packages.pymilter python312Packages.pymilter.dist

15 packages built:
exaile gramps gramps.dist python311Packages.bsddb3 python311Packages.bsddb3.dist python311Packages.pymilter python311Packages.pymilter.dist python311Packages.scrapy-deltafetch python311Packages.scrapy-deltafetch.dist python312Packages.bsddb3 python312Packages.bsddb3.dist python312Packages.scrapy-deltafetch python312Packages.scrapy-deltafetch.dist spf-engine spf-engine.dist
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
