### PR TITLE
mkvtoolnix: patch to build on Darwin & FreeBSD

### DIFF
--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -8,6 +8,7 @@
 , cmark
 , docbook_xsl
 , expat
+, fetchpatch2
 , file
 , flac
 , fmt
@@ -93,6 +94,11 @@ stdenv.mkDerivation rec {
   ++ optionals withGUI [ cmark ]
   ++ optionals stdenv.isLinux [ qtwayland ]
   ++ optionals stdenv.isDarwin [ libiconv ];
+
+  patches = [ (fetchpatch2 {
+    url = "https://gitlab.com/mbunkus/mkvtoolnix/-/commit/7e1bea9527616ab6ab38425e7290579f05dd9bb1.patch";
+    hash = "sha256-9UZrfwrzfKwF8XDzqYnuaDgZws7l1YAb5O1O1+nxo0g=";
+  }) ];
 
   # autoupdate is not needed but it silences a ton of pointless warnings
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Applied [upstream commit] which fixes a C++20 compatibility issue.
This should fix the [Hydra failure] on Darwin.

[upstream commit]: https://gitlab.com/mbunkus/mkvtoolnix/-/commit/7e1bea9527616ab6ab38425e7290579f05dd9bb1
[Hydra failure]: https://hydra.nixos.org/build/258096907

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
