### PR TITLE
Python package fixes

### DIFF
--- a/pkgs/development/python-modules/binwalk/default.nix
+++ b/pkgs/development/python-modules/binwalk/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  propagatedBuildInputs =
+  dependencies =
     [
       zlib
       xz
@@ -75,11 +75,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "binwalk" ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/OSPG/binwalk";
     description = "Tool for searching a given binary image for embedded files";
     mainProgram = "binwalk";
-    maintainers = [ maintainers.koral ];
-    license = licenses.mit;
+    maintainers = with lib.maintainers; [ koral ];
+    license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/blessings/default.nix
+++ b/pkgs/development/python-modules/blessings/default.nix
@@ -3,33 +3,33 @@
   buildPythonPackage,
   fetchPypi,
   six,
-  nose,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "blessings";
   version = "1.7";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "98e5854d805f50a5b58ac2333411b0482516a8210f23f43308baeb58d77c157d";
+    hash = "sha256-mOWFTYBfUKW1isIzNBGwSCUWqCEPI/QzCLrrWNd8FX0=";
   };
 
-  # 4 failing tests, 2to3
+  build-system = [ setuptools ];
+
+  dependencies = [ six ];
+
+  # Running tests produces a failure that's not able to be patched easily.
+  # See PR #165 in the repo for the package for more information.
   doCheck = false;
 
-  propagatedBuildInputs = [ six ];
-  nativeCheckInputs = [ nose ];
+  pythonImportsCheck = [ "blessings" ];
 
-  checkPhase = ''
-    nosetests
-  '';
-
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/erikrose/blessings";
     description = "Thin, practical wrapper around terminal coloring, styling, and positioning";
-    license = licenses.mit;
-    maintainers = with maintainers; [ domenkozar ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ domenkozar ];
   };
 }

--- a/pkgs/development/python-modules/cgroup-utils/default.nix
+++ b/pkgs/development/python-modules/cgroup-utils/default.nix
@@ -2,38 +2,41 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pep8,
-  nose,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   version = "0.8";
-  format = "setuptools";
   pname = "cgroup-utils";
-
-  buildInputs = [
-    pep8
-    nose
-  ];
-  # Pep8 tests fail...
-  doCheck = false;
-
-  postPatch = ''
-    sed -i -e "/argparse/d" setup.py
-  '';
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "peo3";
     repo = "cgroup-utils";
     rev = "v${version}";
-    sha256 = "0qnbn8cnq8m14s8s1hcv25xjd55dyb6yy54l5vc7sby5xzzp11fq";
+    hash = "sha256-2IVw/+/FL33YLpQU783yrZQmexGbwaCRJqEibBmyy2I=";
   };
 
-  meta = with lib; {
+  postPatch = ''
+    sed -i -e "/argparse/d" setup.py
+    substituteInPlace test_pep8.py --replace-fail \
+    'print message' 'print(message)'
+    rm test_pep8.py
+  '';
+
+  build-system = [ setuptools ];
+
+  # Importing causes it to check the /sys directory, which isn't allowed, and so
+  # tests fail. Therefore, tests can't be run.
+  doCheck = false;
+
+  pythonImportsCheck = [ "cgutils" ];
+
+  meta = {
     description = "Utility tools for control groups of Linux";
     mainProgram = "cgutil";
-    maintainers = with maintainers; [ layus ];
-    platforms = platforms.linux;
-    license = licenses.gpl2;
+    maintainers = with lib.maintainers; [ layus ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/development/python-modules/chart-studio/default.nix
+++ b/pkgs/development/python-modules/chart-studio/default.nix
@@ -3,9 +3,8 @@
   buildPythonPackage,
   fetchFromGitHub,
   mock,
-  nose,
   plotly,
-  pytest,
+  pytestCheckHook,
   requests,
   retrying,
   setuptools,
@@ -38,18 +37,23 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     mock
-    nose
-    pytest
+    pytestCheckHook
   ];
-  # most tests talk to a service
-  checkPhase = ''
-    HOME=$TMPDIR pytest chart_studio/tests/test_core chart_studio/tests/test_plot_ly/test_api
+
+  preCheck = ''
+    export HOME=$TMPDIR
   '';
 
-  meta = with lib; {
+  # most tests talk to a service
+  pytestFlagsArray = [
+    "chart_studio/tests/test_core"
+    "chart_studio/tests/test_plot_ly/test_api"
+  ];
+
+  meta = {
     description = "Utilities for interfacing with Plotly's Chart Studio service";
     homepage = "https://github.com/plotly/plotly.py/tree/master/packages/python/chart-studio";
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [ ];
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/citeproc-py/default.nix
+++ b/pkgs/development/python-modules/citeproc-py/default.nix
@@ -2,39 +2,41 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  nose,
+  pytestCheckHook,
   git,
   lxml,
   rnc2rng,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "citeproc-py";
   version = "0.6.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d9e3a224f936fe2e5033b5d9ffdacab769cedb61d96c4e0cf2f0b488f1d24b4e";
+    hash = "sha256-2eOiJPk2/i5QM7XZ/9rKt2nO22HZbE4M8vC0iPHSS04=";
   };
 
   buildInputs = [ rnc2rng ];
 
-  propagatedBuildInputs = [ lxml ];
+  build-system = [ setuptools ];
+
+  dependencies = [ lxml ];
 
   nativeCheckInputs = [
-    nose
+    pytestCheckHook
     git
   ];
-  checkPhase = "nosetests tests";
-  doCheck = false; # seems to want a Git repository, but fetchgit with leaveDotGit also fails
+  # doCheck = false;  # seems to want a Git repository, but fetchgit with leaveDotGit also fails
   pythonImportsCheck = [ "citeproc" ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/brechtm/citeproc-py";
     description = "Citation Style Language (CSL) parser for Python";
     mainProgram = "csl_unsorted";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ bcdarwin ];
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ bcdarwin ];
   };
 }


### PR DESCRIPTION
Fixes a few packages that are broken on python 3.12, mainly related to their usage of `nose`, by disabling tests or otherwise migrating them to `pytestCheckHook`.
This also migrates binwalk to the supported fork at OSPG/binwalk, which also fixes a `nose` issue by it migrating to `pytest`.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
