### PR TITLE
ffmpegthumbnailer: unstable-2022-02-18 -> unstable-2024-01-04

### DIFF
--- a/pkgs/development/libraries/ffmpegthumbnailer/default.nix
+++ b/pkgs/development/libraries/ffmpegthumbnailer/default.nix
@@ -1,23 +1,23 @@
 {
-  fetchFromGitHub,
   lib,
   stdenv,
-  ffmpeg-headless,
+  fetchFromGitHub,
   cmake,
-  libpng,
   pkg-config,
+  ffmpeg-headless,
+  libpng,
   libjpeg,
 }:
 
 stdenv.mkDerivation rec {
   pname = "ffmpegthumbnailer";
-  version = "unstable-2022-02-18";
+  version = "unstable-2024-01-04";
 
   src = fetchFromGitHub {
     owner = "dirkvdb";
     repo = "ffmpegthumbnailer";
-    rev = "3db9fe895b2fa656bb40ddb7a62e27604a688171";
-    sha256 = "0606pbg391l4s8mpyyalm9zrcnm75fwqdlrxy2gif9n21i2fm3rc";
+    rev = "1b5a77983240bcf00a4ef7702c07bcd8f4e5f97c";
+    hash = "sha256-7SPRQMPgdvP7J3HCf7F1eXxZjUH5vCYZ9UOwTUFMLp0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/ffmpegthumbnailer/default.nix
+++ b/pkgs/development/libraries/ffmpegthumbnailer/default.nix
@@ -1,4 +1,12 @@
-{ fetchFromGitHub, lib, stdenv, ffmpeg-headless, cmake, libpng, pkg-config, libjpeg
+{
+  fetchFromGitHub,
+  lib,
+  stdenv,
+  ffmpeg-headless,
+  cmake,
+  libpng,
+  pkg-config,
+  libjpeg,
 }:
 
 stdenv.mkDerivation rec {
@@ -12,8 +20,17 @@ stdenv.mkDerivation rec {
     sha256 = "0606pbg391l4s8mpyyalm9zrcnm75fwqdlrxy2gif9n21i2fm3rc";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ ffmpeg-headless libpng libjpeg ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    ffmpeg-headless
+    libpng
+    libjpeg
+  ];
+
   cmakeFlags = [ "-DENABLE_THUMBNAILER=ON" ];
 
   # https://github.com/dirkvdb/ffmpegthumbnailer/issues/215
@@ -22,21 +39,20 @@ stdenv.mkDerivation rec {
       --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
   '';
 
-  meta = with lib;  {
-    homepage = "https://github.com/dirkvdb/ffmpegthumbnailer";
+  meta = with lib; {
     description = "A lightweight video thumbnailer";
-    mainProgram = "ffmpegthumbnailer";
     longDescription = "FFmpegthumbnailer is a lightweight video
         thumbnailer that can be used by file managers to create thumbnails
-        for your video files. The thumbnailer uses ffmpeg o decode frames
+        for your video files. The thumbnailer uses ffmpeg to decode frames
         from the video files, so supported videoformats depend on the
         configuration flags of ffmpeg.
         This thumbnailer was designed to be as fast and lightweight as possible.
-        The only dependencies are ffmpeg and libpng.
+        The only dependencies are ffmpeg and libpng/libjpeg.
     ";
-    platforms = platforms.unix;
+    homepage = "https://github.com/dirkvdb/ffmpegthumbnailer";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.jagajaga ];
+    platforms = platforms.unix;
+    mainProgram = "ffmpegthumbnailer";
   };
-
 }


### PR DESCRIPTION
## Description of changes
- ffmpegthumbnailer: refactored code with nixfmt
- ffmpegthumbnailer: unstable-2022-02-18 -> unstable-2024-01-04  = [date of most recent commit](https://github.com/dirkvdb/ffmpegthumbnailer/commits/master/)

Result of `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`

```
11 packages built:
ctpv deepin.dde-file-manager deepin.dde-gsettings-schemas deepin.deepin-movie-reborn deepin.deepin-movie-reborn.dev ffmpegthumbnailer geeqie spaceFM xfce.tumbler xfce.tumbler.dev yazi
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
