### PR TITLE
nixos/public-inbox: enable and test confinement

### DIFF
--- a/nixos/modules/services/mail/public-inbox.nix
+++ b/nixos/modules/services/mail/public-inbox.nix
@@ -84,14 +84,7 @@ let
           ++ filter (x: x != null) [
             cfg.${proto}.cert or null
             cfg.${proto}.key or null
-          ]
-          ++
-            # Without confinement the whole Nix store
-            # is made available to the service
-            optionals (!config.systemd.services."public-inbox-${srv}".confinement.enable) [
-              "${pkgs.dash}/bin/dash:/bin/sh"
-              builtins.storeDir
-            ];
+          ];
         # The following options are only for optimizing:
         # systemd-analyze security public-inbox-'*'
         AmbientCapabilities = "";
@@ -108,7 +101,7 @@ let
         ProtectHostname = true;
         ProtectKernelLogs = true;
         ProtectProc = "invisible";
-        #ProtectSystem = "strict";
+        ProtectSystem = "strict";
         RemoveIPC = true;
         RestrictAddressFamilies =
           [ "AF_UNIX" ]
@@ -130,28 +123,9 @@ let
           # Not removing @timer because git upload-pack needs it.
         ];
         SystemCallArchitectures = "native";
-
-        # The following options are redundant when confinement is enabled
-        RootDirectory = "/var/empty";
-        TemporaryFileSystem = "/";
-        PrivateMounts = true;
-        MountAPIVFS = true;
-        PrivateDevices = true;
-        PrivateTmp = true;
-        PrivateUsers = true;
-        ProtectControlGroups = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
       };
       confinement = {
-        # Until we agree upon doing it directly here in NixOS
-        # https://github.com/NixOS/nixpkgs/pull/104457#issuecomment-1115768447
-        # let the user choose to enable the confinement with:
-        # systemd.services.public-inbox-httpd.confinement.enable = true;
-        # systemd.services.public-inbox-imapd.confinement.enable = true;
-        # systemd.services.public-inbox-init.confinement.enable = true;
-        # systemd.services.public-inbox-nntpd.confinement.enable = true;
-        #enable = true;
+        enable = true;
         mode = "full-apivfs";
         # Inline::C needs a /bin/sh, and dash is enough
         binSh = "${pkgs.dash}/bin/dash";

--- a/nixos/tests/public-inbox.nix
+++ b/nixos/tests/public-inbox.nix
@@ -10,11 +10,9 @@ import ./make-test-python.nix (
       install -D -t $out key.pem cert.pem
     '';
 
-    # Git repositories paths in Gitolite.
-    # Here only their baseNameOf is used for configuring public-inbox inboxes.
     gitRepositories = [
-      "user/repo1"
-      "user/repo2"
+      "repo1"
+      "repo2"
     ];
   in
   {
@@ -81,7 +79,7 @@ import ./make-test-python.nix (
           };
           inboxes =
             lib.recursiveUpdate
-              (lib.genAttrs (map baseNameOf gitRepositories) (repo: {
+              (lib.genAttrs gitRepositories (repo: {
                 address = [
                   # Routed to the "public-inbox:" transport in services.postfix.transport
                   "${repo}@${domain}"
@@ -106,7 +104,7 @@ import ./make-test-python.nix (
           settings.coderepo = lib.listToAttrs (
             map (
               repositoryName:
-              lib.nameValuePair (baseNameOf repositoryName) {
+              lib.nameValuePair repositoryName {
                 dir = "/var/lib/public-inbox/repositories/${repositoryName}.git";
                 cgitUrl = "https://git.${domain}/${repositoryName}.git";
               }

--- a/nixos/tests/public-inbox.nix
+++ b/nixos/tests/public-inbox.nix
@@ -183,6 +183,12 @@ import ./make-test-python.nix (
     testScript = ''
       start_all()
 
+      # The threshold and/or hardening may have to be changed with new features/checks
+      with subtest("systemd hardening thresholds"):
+        print(machine.succeed("systemd-analyze security public-inbox-httpd.service --threshold=5 --no-pager"))
+        print(machine.succeed("systemd-analyze security public-inbox-imapd.service --threshold=5 --no-pager"))
+        print(machine.succeed("systemd-analyze security public-inbox-nntpd.service --threshold=4 --no-pager"))
+
       machine.wait_for_unit("multi-user.target")
       machine.wait_for_unit("public-inbox-init.service")
 


### PR DESCRIPTION
## Description of changes
- [X] ~Fix typo `BindPathsReadOnly` => `BindReadOnlyPaths`~ (was fixed in 14c57ce7f7c207072ed895c2fad06ef2b2ca1ca3) and actually test the binding with `gitolite` repositories.
- [X] Enable `ProtectSystem = "strict"`.
- [X] Enable `confinement`.
- [X] Test `confinement`.
- [X] Test `systemd-analyze security` thresholds.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
