### PR TITLE
nixos/fcitx5: add config for tables, minor cleanup

### DIFF
--- a/nixos/modules/i18n/input-method/fcitx5.nix
+++ b/nixos/modules/i18n/input-method/fcitx5.nix
@@ -10,6 +10,7 @@ let
     then pkgs.qt6Packages.fcitx5-with-addons.override { inherit (cfg) addons; }
     else pkgs.libsForQt5.fcitx5-with-addons.override { inherit (cfg) addons; };
   settingsFormat = pkgs.formats.ini { };
+  settingsFormatWithGlobalSection = pkgs.formats.iniWithGlobalSection { };
 in
 {
   options = {
@@ -68,7 +69,7 @@ in
           };
           default = { };
           description = ''
-            The global options in `config` file in ini format.
+            The global options in `config` file in INI format.
           '';
         };
         inputMethod = lib.mkOption {
@@ -77,17 +78,27 @@ in
           };
           default = { };
           description = ''
-            The input method configure in `profile` file in ini format.
+            The input method configure in `profile` file in INI format.
           '';
         };
         addons = lib.mkOption {
-          type = with lib.types; (attrsOf anything);
+          type = with lib.types; (attrsOf settingsFormatWithGlobalSection.type);
           default = { };
           description = ''
-            The addon configures in `conf` folder in ini format with global sections.
+            The addon configures in `conf` folder in INI format with global sections.
             Each item is written to the corresponding file.
           '';
           example = literalExpression "{ pinyin.globalSection.EmojiEnabled = \"True\"; }";
+        };
+        tables = lib.mkOption {
+          type = with lib.types; (attrsOf settingsFormat.type);
+          default = { };
+          description = ''
+            The configuration for tables, used for input methods that map sequences of key presses
+            into characters, in INI format.
+            Each item is written to the corresponding file.
+          '';
+          example = literalExpression ''{ cangjie5.MatchingKey = "z"; }'';
         };
       };
       ignoreUserConfig = lib.mkOption {
@@ -123,18 +134,18 @@ in
     environment.etc =
       let
         optionalFile = p: f: v: lib.optionalAttrs (v != { }) {
-          "xdg/fcitx5/${p}".text = f v;
+          "xdg/fcitx5/${p}".source = f.generate p v;
         };
       in
       lib.attrsets.mergeAttrsList [
-        (optionalFile "config" (lib.generators.toINI { }) cfg.settings.globalOptions)
-        (optionalFile "profile" (lib.generators.toINI { }) cfg.settings.inputMethod)
+        (optionalFile "config" settingsFormat cfg.settings.globalOptions)
+        (optionalFile "profile" settingsFormat cfg.settings.inputMethod)
         (lib.concatMapAttrs
-          (name: value: optionalFile
-            "conf/${name}.conf"
-            (lib.generators.toINIWithGlobalSection { })
-            value)
+          (name: optionalFile "conf/${name}.conf" settingsFormatWithGlobalSection)
           cfg.settings.addons)
+        (lib.concatMapAttrs
+          (name: optionalFile "table/${name}.conf" settingsFormat)
+          cfg.settings.tables)
       ];
 
     environment.variables = {


### PR DESCRIPTION
## Description of changes

Fixes #279349, also unifies everything to use `pkgs.format.{ini,iniWithGlobalSection}`.

Not yet tested because I don't use an IME that makes use of it (in fact I'm pretty sure I don't even _have_ a `table/` directory in my Fcitx 5 configs) — can anyone who uses Cangjie give this a shot?

cc @leana8959

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
