### PR TITLE
[23.11] python311Packages.aiohttp: add patch for CVE-2024-27306

### DIFF
--- a/pkgs/development/python-modules/aiohttp/3.8.6-CVE-2024-27306.patch
+++ b/pkgs/development/python-modules/aiohttp/3.8.6-CVE-2024-27306.patch
@@ -1,0 +1,230 @@
+Based on upstream 28335525d1eac015a7e7584137678cbb6ff19397 with adjustments
+made only to the test additions, allowing them to apply to 3.8.6
+
+
+diff --git a/CHANGES/8317.bugfix.rst b/CHANGES/8317.bugfix.rst
+new file mode 100644
+index 00000000..b24ef2ae
+--- /dev/null
++++ b/CHANGES/8317.bugfix.rst
+@@ -0,0 +1 @@
++Escaped filenames in static view -- by :user:`bdraco`.
+diff --git a/aiohttp/web_urldispatcher.py b/aiohttp/web_urldispatcher.py
+index 5942e355..a0db2621 100644
+--- a/aiohttp/web_urldispatcher.py
++++ b/aiohttp/web_urldispatcher.py
+@@ -1,7 +1,9 @@
+ import abc
+ import asyncio
+ import base64
++import functools
+ import hashlib
++import html
+ import inspect
+ import keyword
+ import os
+@@ -87,6 +89,8 @@ PATH_SEP: Final[str] = re.escape("/")
+ _ExpectHandler = Callable[[Request], Awaitable[None]]
+ _Resolve = Tuple[Optional["UrlMappingMatchInfo"], Set[str]]
+ 
++html_escape = functools.partial(html.escape, quote=True)
++
+ 
+ class _InfoDict(TypedDict, total=False):
+     path: str
+@@ -696,7 +700,7 @@ class StaticResource(PrefixResource):
+         assert filepath.is_dir()
+ 
+         relative_path_to_dir = filepath.relative_to(self._directory).as_posix()
+-        index_of = f"Index of /{relative_path_to_dir}"
++        index_of = f"Index of /{html_escape(relative_path_to_dir)}"
+         h1 = f"<h1>{index_of}</h1>"
+ 
+         index_list = []
+@@ -704,7 +708,7 @@ class StaticResource(PrefixResource):
+         for _file in sorted(dir_index):
+             # show file url as relative to static path
+             rel_path = _file.relative_to(self._directory).as_posix()
+-            file_url = self._prefix + "/" + rel_path
++            quoted_file_url = _quote_path(f"{self._prefix}/{rel_path}")
+ 
+             # if file is a directory, add '/' to the end of the name
+             if _file.is_dir():
+@@ -713,9 +717,7 @@ class StaticResource(PrefixResource):
+                 file_name = _file.name
+ 
+             index_list.append(
+-                '<li><a href="{url}">{name}</a></li>'.format(
+-                    url=file_url, name=file_name
+-                )
++                f'<li><a href="{quoted_file_url}">{html_escape(file_name)}</a></li>'
+             )
+         ul = "<ul>\n{}\n</ul>".format("\n".join(index_list))
+         body = f"<body>\n{h1}\n{ul}\n</body>"
+diff --git a/tests/test_web_urldispatcher.py b/tests/test_web_urldispatcher.py
+index f24f451e..b800b54e 100644
+--- a/tests/test_web_urldispatcher.py
++++ b/tests/test_web_urldispatcher.py
+@@ -35,35 +35,42 @@ def tmp_dir_path(request):
+ 
+ 
+ @pytest.mark.parametrize(
+-    "show_index,status,prefix,data",
++    "show_index,status,prefix,request_path,data",
+     [
+-        pytest.param(False, 403, "/", None, id="index_forbidden"),
++        pytest.param(False, 403, "/", "/", None, id="index_forbidden"),
+         pytest.param(
+             True,
+             200,
+             "/",
+-            b"<html>\n<head>\n<title>Index of /.</title>\n"
+-            b"</head>\n<body>\n<h1>Index of /.</h1>\n<ul>\n"
+-            b'<li><a href="/my_dir">my_dir/</a></li>\n'
+-            b'<li><a href="/my_file">my_file</a></li>\n'
+-            b"</ul>\n</body>\n</html>",
+-            id="index_root",
++            "/",
++            b"<html>\n<head>\n<title>Index of /.</title>\n</head>\n<body>\n<h1>Index of"
++            b' /.</h1>\n<ul>\n<li><a href="/my_dir">my_dir/</a></li>\n<li><a href="/my_file">'
++            b"my_file</a></li>\n</ul>\n</body>\n</html>",
+         ),
+         pytest.param(
+             True,
+             200,
+             "/static",
+-            b"<html>\n<head>\n<title>Index of /.</title>\n"
+-            b"</head>\n<body>\n<h1>Index of /.</h1>\n<ul>\n"
+-            b'<li><a href="/static/my_dir">my_dir/</a></li>\n'
+-            b'<li><a href="/static/my_file">my_file</a></li>\n'
+-            b"</ul>\n</body>\n</html>",
++            "/static",
++            b"<html>\n<head>\n<title>Index of /.</title>\n</head>\n<body>\n<h1>Index of"
++            b' /.</h1>\n<ul>\n<li><a href="/static/my_dir">my_dir/</a></li>\n<li><a href="'
++            b'/static/my_file">my_file</a></li>\n</ul>\n</body>\n</html>',
+             id="index_static",
+         ),
++        pytest.param(
++            True,
++            200,
++            "/static",
++            "/static/my_dir",
++            b"<html>\n<head>\n<title>Index of /my_dir</title>\n</head>\n<body>\n<h1>"
++            b'Index of /my_dir</h1>\n<ul>\n<li><a href="/static/my_dir/my_file_in_dir">'
++            b"my_file_in_dir</a></li>\n</ul>\n</body>\n</html>",
++            id="index_subdir",
++        ),
+     ],
+ )
+ async def test_access_root_of_static_handler(
+-    tmp_dir_path, aiohttp_client, show_index, status, prefix, data
++    tmp_dir_path, aiohttp_client, show_index, status, prefix, request_path, data
+ ) -> None:
+     # Tests the operation of static file server.
+     # Try to access the root of static file server, and make
+@@ -88,13 +95,99 @@ async def test_access_root_of_static_handler(
+     client = await aiohttp_client(app)
+ 
+     # Request the root of the static directory.
+-    r = await client.get(prefix)
+-    assert r.status == status
++    async with await client.get(request_path) as r:
++        assert r.status == status
++
++        if data:
++            assert r.headers["Content-Type"] == "text/html; charset=utf-8"
++            read_ = await r.read()
++            assert read_ == data
++
++
++@pytest.mark.skipif(
++    not sys.platform.startswith("linux"),
++    reason="Invalid filenames on some filesystems (like Windows)",
++)
++@pytest.mark.parametrize(
++    "show_index,status,prefix,request_path,data",
++    [
++        pytest.param(False, 403, "/", "/", None, id="index_forbidden"),
++        pytest.param(
++            True,
++            200,
++            "/",
++            "/",
++            b"<html>\n<head>\n<title>Index of /.</title>\n</head>\n<body>\n<h1>Index of"
++            b' /.</h1>\n<ul>\n<li><a href="/%3Cimg%20src=0%20onerror=alert(1)%3E.dir">&l'
++            b't;img src=0 onerror=alert(1)&gt;.dir/</a></li>\n<li><a href="/%3Cimg%20sr'
++            b'c=0%20onerror=alert(1)%3E.txt">&lt;img src=0 onerror=alert(1)&gt;.txt</a></l'
++            b"i>\n</ul>\n</body>\n</html>",
++        ),
++        pytest.param(
++            True,
++            200,
++            "/static",
++            "/static",
++            b"<html>\n<head>\n<title>Index of /.</title>\n</head>\n<body>\n<h1>Index of"
++            b' /.</h1>\n<ul>\n<li><a href="/static/%3Cimg%20src=0%20onerror=alert(1)%3E.'
++            b'dir">&lt;img src=0 onerror=alert(1)&gt;.dir/</a></li>\n<li><a href="/stat'
++            b'ic/%3Cimg%20src=0%20onerror=alert(1)%3E.txt">&lt;img src=0 onerror=alert(1)&'
++            b"gt;.txt</a></li>\n</ul>\n</body>\n</html>",
++            id="index_static",
++        ),
++        pytest.param(
++            True,
++            200,
++            "/static",
++            "/static/<img src=0 onerror=alert(1)>.dir",
++            b"<html>\n<head>\n<title>Index of /&lt;img src=0 onerror=alert(1)&gt;.dir</t"
++            b"itle>\n</head>\n<body>\n<h1>Index of /&lt;img src=0 onerror=alert(1)&gt;.di"
++            b'r</h1>\n<ul>\n<li><a href="/static/%3Cimg%20src=0%20onerror=alert(1)%3E.di'
++            b'r/my_file_in_dir">my_file_in_dir</a></li>\n</ul>\n</body>\n</html>',
++            id="index_subdir",
++        ),
++    ],
++)
++async def test_access_root_of_static_handler_xss(
++    tmp_path,
++    aiohttp_client,
++    show_index,
++    status,
++    prefix,
++    request_path,
++    data,
++) -> None:
++    # Tests the operation of static file server.
++    # Try to access the root of static file server, and make
++    # sure that correct HTTP statuses are returned depending if we directory
++    # index should be shown or not.
++    # Ensure that html in file names is escaped.
++    # Ensure that links are url quoted.
++    my_file = tmp_path / "<img src=0 onerror=alert(1)>.txt"
++    my_dir = tmp_path / "<img src=0 onerror=alert(1)>.dir"
++    my_dir.mkdir()
++    my_file_in_dir = my_dir / "my_file_in_dir"
++
++    with my_file.open("w") as fw:
++        fw.write("hello")
++
++    with my_file_in_dir.open("w") as fw:
++        fw.write("world")
++
++    app = web.Application()
++
++    # Register global static route:
++    app.router.add_static(prefix, str(tmp_path), show_index=show_index)
++    client = await aiohttp_client(app)
++
++    # Request the root of the static directory.
++    async with await client.get(request_path) as r:
++        assert r.status == status
+ 
+-    if data:
+-        assert r.headers["Content-Type"] == "text/html; charset=utf-8"
+-        read_ = await r.read()
+-        assert read_ == data
++        if data:
++            assert r.headers["Content-Type"] == "text/html; charset=utf-8"
++            read_ = await r.read()
++            assert read_ == data
+ 
+ 
+ async def test_follow_symlink(tmp_dir_path, aiohttp_client) -> None:

--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -50,6 +50,7 @@ buildPythonPackage rec {
     })
     ./3.8.6-CVE-2024-23334.patch
     ./3.8.6-CVE-2024-30251.patch
+    ./3.8.6-CVE-2024-27306.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2024-27306

Built all `.*aiohttp.*` reverse-dependencies on nixos x86_64 & macos 12 x86_64.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
