### PR TITLE
python3Packages.{gmpy,gmpy2,phe}: bump version, refactor, adopt

### DIFF
--- a/pkgs/development/python-modules/gmpy/default.nix
+++ b/pkgs/development/python-modules/gmpy/default.nix
@@ -1,28 +1,39 @@
-{ buildPythonPackage, fetchurl, isPyPy, gmp, pythonAtLeast } :
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  isPyPy,
+  pythonAtLeast,
+  setuptools,
+  gmp,
+}:
 
-let
+buildPythonPackage rec {
   pname = "gmpy";
   version = "1.17";
-  format = "setuptools";
-in
-
-buildPythonPackage {
-  inherit pname version;
+  pyproject = true;
 
   # Python 3.11 has finally made changes to its C API for which gmpy 1.17,
   # published in 2013, would require patching. It seems unlikely that any
   # patches will be forthcoming.
   disabled = isPyPy || pythonAtLeast "3.11";
 
-  src = fetchurl {
-    url = "mirror://pypi/g/gmpy/${pname}-${version}.zip";
-    sha256 = "1a79118a5332b40aba6aa24b051ead3a31b9b3b9642288934da754515da8fa14";
+  src = fetchFromGitHub {
+    owner = "aleaxit";
+    repo = "gmpy";
+    rev = "refs/tags/gmpy_${lib.replaceStrings [ "." ] [ "_" ] version}";
+    hash = "sha256-kMidOjhKJlDRu2qaiq9c+XcwD1tNAoPhRTvvGcOJe8I=";
   };
 
+  build-system = [ setuptools ];
+
   buildInputs = [ gmp ];
+
+  pythonImportsCheck = [ "gmpy" ];
 
   meta = {
     description = "GMP or MPIR interface to Python 2.4+ and 3.x";
     homepage = "https://github.com/aleaxit/gmpy/";
+    license = lib.licenses.lgpl21Plus;
   };
 }

--- a/pkgs/development/python-modules/gmpy2/default.nix
+++ b/pkgs/development/python-modules/gmpy2/default.nix
@@ -1,42 +1,73 @@
-{ lib
-, buildPythonPackage
-, fetchFromGitHub
-, isPyPy
-, gmp
-, mpfr
-, libmpc
-
-# Reverse dependency
-, sage
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  isPyPy,
+  pythonOlder,
+  setuptools,
+  gmp,
+  mpfr,
+  libmpc,
+  pytestCheckHook,
+  hypothesis,
+  cython,
+  mpmath,
+  # Reverse dependency
+  sage,
 }:
 
-let
+buildPythonPackage rec {
   pname = "gmpy2";
-  version = "2.1.2";
-  format = "setuptools";
-in
+  version = "2.2.0a2";
+  pyproject = true;
 
-buildPythonPackage {
-  inherit pname version;
-
-  disabled = isPyPy;
+  disabled = isPyPy || pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "aleaxit";
     repo = "gmpy";
-    rev = "gmpy2-${version}";
-    hash = "sha256-ARCttNzRA+Ji2j2NYaSCDXgvoEg01T9BnYadyqON2o0=";
+    rev = "refs/tags/gmpy2-${version}";
+    hash = "sha256-luLEDEY1cezhzZo4fXmM/MUg2YyAaz7n0HwSpbNayP8=";
   };
 
-  buildInputs = [ gmp mpfr libmpc ];
+  build-system = [ setuptools ];
+
+  buildInputs = [
+    gmp
+    mpfr
+    libmpc
+  ];
+
+  # make relative imports in tests work properly
+  preCheck = ''
+    rm gmpy2 -r
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    hypothesis
+    cython
+    mpmath
+  ];
+
+  disabledTests = lib.optionals (stdenv.isLinux && stdenv.isAarch64) [
+    # issue with some overflow logic
+    "test_mpz_to_bytes"
+    "test_mpz_from_bytes"
+  ];
 
   pythonImportsCheck = [ "gmpy2" ];
 
-  passthru.tests = { inherit sage; };
+  passthru.tests = {
+    inherit sage;
+  };
 
-  meta = with lib; {
-    description = "GMP/MPIR, MPFR, and MPC interface to Python 2.6+ and 3.x";
+  meta = {
+    changelog = "https://github.com/aleaxit/gmpy/blob/${src.rev}/docs/history.rst";
+    description = "Interface to GMP, MPFR, and MPC for Python 3.7+";
     homepage = "https://github.com/aleaxit/gmpy/";
-    license = licenses.gpl3Plus;
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ tomasajt ];
   };
 }

--- a/pkgs/development/python-modules/phe/default.nix
+++ b/pkgs/development/python-modules/phe/default.nix
@@ -1,31 +1,48 @@
-{ lib, buildPythonPackage, fetchPypi, isPyPy, isPy3k, click, gmpy2, numpy } :
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  isPyPy,
+  isPy3k,
+  setuptools,
+  click,
+  gmpy2,
+  pytestCheckHook,
+  numpy,
+}:
 
-let
+buildPythonPackage rec {
   pname = "phe";
   version = "1.5.0";
-  format = "setuptools";
-in
+  pyproject = true;
 
-buildPythonPackage {
-  inherit pname version;
+  # https://github.com/data61/python-paillier/issues/51
+  disabled = isPyPy || !isPy3k;
 
-  # https://github.com/n1analytics/python-paillier/issues/51
-  disabled = isPyPy || ! isPy3k;
-
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-mS+3CR0kJ/DZczlG+PNQrN1NHQEgV/Kq02S6eflwM5w=";
+  src = fetchFromGitHub {
+    owner = "data61";
+    repo = "python-paillier";
+    rev = "refs/tags/${version}";
+    hash = "sha256-fsZ8x/K+8V4zyVgkci6XNAm89zQFWEbmRVp4jazFfVY=";
   };
 
-  buildInputs = [ click gmpy2 numpy ];
+  build-system = [ setuptools ];
 
-  # 29/233 tests fail
-  doCheck = false;
+  dependencies = [
+    click
+    gmpy2 # optional, but major speed improvement
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    numpy
+  ];
 
   meta = with lib; {
     description = "A library for Partially Homomorphic Encryption in Python";
     mainProgram = "pheutil";
-    homepage = "https://github.com/n1analytics/python-paillier";
+    homepage = "https://github.com/data61/python-paillier";
     license = licenses.gpl3;
+    maintainers = with maintainers; [ tomasajt ];
   };
 }


### PR DESCRIPTION
## Description of changes

ZHF: https://github.com/NixOS/nixpkgs/issues/309482

This PR refactors the `gmpy`, `gmpy2` and `phe` python packages.

The build for `gmpy2` was failing on python >=3.11, because some of the ABI has changed. `gmpy` already disables itself because of the ABI change. `gmpy2` had an alpha build available that supports the new ABI, so I changed over to that version. The `phe` package depended on the `gmpy2` package, so I also reworked that derivation.

- use `pyproject = true`
- adopt `gmpy2` and `phe`
- add some missing licenses
- use `fetchFromGitHub` instead of fetching from pypi
  - one of the github repos moved over to a different owner, the old link redirecting to the new
- enable testing where possible

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
