### PR TITLE
python39Packages.bsddb3,python312Packages.berkeleydb, gramps, exaile: mark broken from Pyt…

### DIFF
--- a/pkgs/applications/audio/exaile/default.nix
+++ b/pkgs/applications/audio/exaile/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     gst-plugins-ugly
     gst-libav
   ]) ++ (with python3.pkgs; [
-    bsddb3
+    berkeleydb
     dbus-python
     mutagen
     pygobject3

--- a/pkgs/applications/misc/gramps/default.nix
+++ b/pkgs/applications/misc/gramps/default.nix
@@ -69,7 +69,7 @@ buildPythonApplication rec {
   ;
 
   propagatedBuildInputs = with pythonPackages; [
-    bsddb3
+    berkeleydb
     pyicu
     pygobject3
     pycairo

--- a/pkgs/development/python-modules/berkeleydb/default.nix
+++ b/pkgs/development/python-modules/berkeleydb/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  pkgs,
+  python,
+}:
+
+buildPythonPackage rec {
+  pname = "berkeleydb";
+  version = "18.1.8";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-4YMaeQv9hVdA5cEvlS8Z9kbCaYBs/DYnda/Zh4zzJVc=";
+  };
+
+  build-system = [ setuptools ];
+
+  checkPhase = ''
+    ${python.interpreter} test.py
+  '';
+
+  # See: https://github.com/NixOS/nixpkgs/pull/311198/files#r1597746759
+  env = {
+    BERKELEYDB_INCDIR = "${lib.getDev pkgs.db}/include";
+    BERKELEYDB_LIBDIR = "${lib.getLib pkgs.db}/lib";
+  };
+
+  meta = with lib; {
+    description = "Python bindings for Oracle Berkeley DB";
+    homepage = "https://www.jcea.es/programacion/pybsddb.htm";
+    license = with licenses; [ bsd3 ];
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1503,6 +1503,8 @@ self: super: with self; {
 
   bentoml = callPackage ../development/python-modules/bentoml { };
 
+  berkeleydb = callPackage ../development/python-modules/berkeleydb { };
+
   bespon = callPackage ../development/python-modules/bespon { };
 
   betacode = callPackage ../development/python-modules/betacode { };


### PR DESCRIPTION
…hon36, init 18.1.8, add berkeleydb dependency, add berkeleydb dependency

## Description of changes

Deprecate the use of bsddb3 from Python 3.6 and newer, it was replaced upstream by `berkeleydb`, see : https://www.jcea.es/programacion/pybsddb.htm

Berkeleydb was thus packaged and all occurences of `bsddb3` were replaced by `berkeleydb`.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
