### PR TITLE
chromium: remove internal widevine drv in favor of `widevine-cdm`

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -5,6 +5,7 @@
 , libva, pipewire, wayland
 , gcc, nspr, nss, runCommand
 , lib, libkrb5
+, widevine-cdm
 , electron-source # for warnObsoleteVersionConditional
 
 # package customization
@@ -74,78 +75,6 @@ let
     ungoogled-chromium = pkgsBuildBuild.callPackage ./ungoogled.nix {};
   };
 
-  pkgSuffix = if channel == "dev" then "unstable" else
-    (if channel == "ungoogled-chromium" then "stable" else channel);
-  pkgName = "google-chrome-${pkgSuffix}";
-  chromeSrc =
-    let
-      # Use the latest stable Chrome version if necessary:
-      version = if chromium.upstream-info.hash_deb_amd64 != null
-        then chromium.upstream-info.version
-        else (import ./upstream-info.nix).stable.version;
-      hash = if chromium.upstream-info.hash_deb_amd64 != null
-        then chromium.upstream-info.hash_deb_amd64
-        else (import ./upstream-info.nix).stable.hash_deb_amd64;
-    in fetchurl {
-      urls = map (repo: "${repo}/${pkgName}/${pkgName}_${version}-1_amd64.deb") [
-        "https://dl.google.com/linux/chrome/deb/pool/main/g"
-        "http://95.31.35.30/chrome/pool/main/g"
-        "http://mirror.pcbeta.com/google/chrome/deb/pool/main/g"
-        "http://repo.fdzh.org/chrome/deb/pool/main/g"
-      ];
-      inherit hash;
-  };
-
-  mkrpath = p: "${lib.makeSearchPathOutput "lib" "lib64" p}:${lib.makeLibraryPath p}";
-  widevineCdm = stdenv.mkDerivation {
-    name = "chrome-widevine-cdm";
-
-    src = chromeSrc;
-
-    unpackCmd = let
-      widevineCdmPath =
-        if (channel == "stable" || channel == "ungoogled-chromium") then
-          "./opt/google/chrome/WidevineCdm"
-        else if channel == "beta" then
-          "./opt/google/chrome-beta/WidevineCdm"
-        else if channel == "dev" then
-          "./opt/google/chrome-unstable/WidevineCdm"
-        else
-          throw "Unknown chromium channel.";
-    in ''
-      # Extract just WidevineCdm from upstream's .deb file
-      ar p "$src" data.tar.xz | tar xJ "${widevineCdmPath}"
-
-      # Move things around so that we don't have to reference a particular
-      # chrome-* directory later.
-      mv "${widevineCdmPath}" ./
-
-      # unpackCmd wants a single output directory; let it take WidevineCdm/
-      rm -rf opt
-    '';
-
-    doCheck = true;
-    checkPhase = ''
-      ! find -iname '*.so' -exec ldd {} + | grep 'not found'
-    '';
-
-    PATCH_RPATH = mkrpath [ gcc.cc glib nspr nss ];
-
-    patchPhase = ''
-      patchelf --set-rpath "$PATCH_RPATH" _platform_specific/linux_x64/libwidevinecdm.so
-    '';
-
-    installPhase = ''
-      mkdir -p $out/WidevineCdm
-      cp -a * $out/WidevineCdm/
-    '';
-
-    meta = {
-      platforms = [ "x86_64-linux" ];
-      license = lib.licenses.unfree;
-    };
-  };
-
   suffix = lib.optionalString (channel != "stable" && channel != "ungoogled-chromium") ("-" + channel);
 
   sandboxExecutableName = chromium.browser.passthru.sandboxExecutableName;
@@ -159,7 +88,7 @@ let
         mkdir -p $out
         cp -a ${browser}/* $out/
         chmod u+w $out/libexec/chromium
-        cp -a ${widevineCdm}/WidevineCdm $out/libexec/chromium/
+        cp -a ${widevine-cdm}/share/google/chrome/WidevineCdm $out/libexec/chromium/
       ''
     else browser;
 
@@ -244,7 +173,7 @@ in stdenv.mkDerivation {
   passthru = {
     inherit (chromium) upstream-info browser;
     mkDerivation = chromium.mkChromiumDerivation;
-    inherit chromeSrc sandboxExecutableName;
+    inherit sandboxExecutableName;
   };
 }
 # the following is a complicated and long-winded variant of

--- a/pkgs/applications/networking/browsers/chromium/update.py
+++ b/pkgs/applications/networking/browsers/chromium/update.py
@@ -20,7 +20,6 @@ from os.path import abspath, dirname
 from urllib.request import urlopen
 
 RELEASES_URL = 'https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/all/versions/all/releases'
-DEB_URL = 'https://dl.google.com/linux/chrome/deb/pool/main/g'
 
 PIN_PATH = dirname(abspath(__file__)) + '/upstream-info.nix'
 UNGOOGLED_FLAGS_PATH = dirname(abspath(__file__)) + '/ungoogled-flags.toml'
@@ -259,10 +258,6 @@ with urlopen(RELEASES_URL) as resp:
                     version
                 )
                 src_hash_cache[version] = channel["hash"]
-
-            channel['hash_deb_amd64'] = nix_prefetch_url(
-                f'{DEB_URL}/google-chrome-{google_chrome_suffix}/' +
-                f'google-chrome-{google_chrome_suffix}_{version}-1_amd64.deb')
         except subprocess.CalledProcessError:
             # This release isn't actually available yet.  Continue to
             # the next one.

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -16,7 +16,6 @@
       };
     };
     hash = "sha256-nSI+tkJxOedMtYgtiqW37v0ZjgxxU5o/0sH9bPAchBg=";
-    hash_deb_amd64 = "sha256-RvQdpDmWRcsASh1b8M0Zg+AvZprE5qhi14shfo0WlfE=";
     version = "124.0.6367.201";
   };
   ungoogled-chromium = {
@@ -33,7 +32,6 @@
       };
     };
     hash = "sha256-nSI+tkJxOedMtYgtiqW37v0ZjgxxU5o/0sH9bPAchBg=";
-    hash_deb_amd64 = "sha256-RvQdpDmWRcsASh1b8M0Zg+AvZprE5qhi14shfo0WlfE=";
     version = "124.0.6367.201";
   };
 }


### PR DESCRIPTION
## Description of changes

This gets rid of a lot of redundant logic that is already present in the `widevine-cdm` package :)

The resulting directory structure is the same and works just as well.

Needs backport, because otherwise we wouldn't be able to backport future chromium bumps due to the removal of `hash_deb_amd64` in `upstream-info.nix`.

Not considered a breaking change.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
