### PR TITLE
uxplay: migrate to pkgs/by-name and other enhancements

### DIFF
--- a/pkgs/by-name/ux/uxplay/package.nix
+++ b/pkgs/by-name/ux/uxplay/package.nix
@@ -1,14 +1,16 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, cmake
-, openssl
-, libplist
-, pkg-config
-, wrapGAppsHook3
-, avahi
-, avahi-compat
-, gst_all_1
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  openssl,
+  libplist,
+  pkg-config,
+  wrapGAppsHook3,
+  avahi,
+  avahi-compat,
+  gst_all_1,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -47,12 +49,15 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gst-libav
   ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
+    changelog = "https://github.com/FDH2/UxPlay/releases/tag/v${finalAttrs.version}";
     description = "AirPlay Unix mirroring server";
     homepage = "https://github.com/FDH2/UxPlay";
     license = lib.licenses.gpl3Plus;
+    mainProgram = "uxplay";
     maintainers = [ lib.maintainers.azuwis ];
     platforms = lib.platforms.unix;
-    mainProgram = "uxplay";
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26691,8 +26691,6 @@ with pkgs;
 
   urserver = callPackage ../servers/urserver { };
 
-  uxplay = callPackage ../servers/uxplay { };
-
   vouch-proxy = callPackage ../servers/vouch-proxy { };
 
   virtiofsd = callPackage ../servers/misc/virtiofsd { };


### PR DESCRIPTION
## Description of changes

- Format using nixfmt-rfc-style
- Add passthru.updateScript
- Add meta.changelog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
