### PR TITLE
bicpl: unstable-2020-10-15 -> unstable-2023-01-19

### DIFF
--- a/pkgs/development/libraries/science/biology/bicpl/default.nix
+++ b/pkgs/development/libraries/science/biology/bicpl/default.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, cmake, libminc, netpbm }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  libminc,
+  netpbm,
+}:
 
 stdenv.mkDerivation rec {
   pname = "bicpl";
@@ -6,14 +13,17 @@ stdenv.mkDerivation rec {
 
   # current master is significantly ahead of most recent release, so use Git version:
   src = fetchFromGitHub {
-    owner  = "BIC-MNI";
-    repo   = pname;
-    rev    = "a58af912a71a4c62014975b89ef37a8e72de3c9d";
+    owner = "BIC-MNI";
+    repo = pname;
+    rev = "a58af912a71a4c62014975b89ef37a8e72de3c9d";
     sha256 = "0iw0pmr8xrifbx5l8a0xidfqbm1v8hwzqrw0lcmimxlzdihyri0g";
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ libminc netpbm ];
+  buildInputs = [
+    libminc
+    netpbm
+  ];
 
   cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/cmake" ];
 
@@ -25,6 +35,9 @@ stdenv.mkDerivation rec {
     description = "Brain Imaging Centre programming library";
     maintainers = with maintainers; [ bcdarwin ];
     platforms = platforms.unix;
-    license   = with licenses; [ hpndUc gpl3Plus ];
+    license = with licenses; [
+      hpndUc
+      gpl3Plus
+    ];
   };
 }

--- a/pkgs/development/libraries/science/biology/bicpl/default.nix
+++ b/pkgs/development/libraries/science/biology/bicpl/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   libminc,
   netpbm,
@@ -9,15 +10,23 @@
 
 stdenv.mkDerivation rec {
   pname = "bicpl";
-  version = "unstable-2020-10-15";
+  version = "unstable-2023-01-19";
 
-  # current master is significantly ahead of most recent release, so use Git version:
+  # master is not actively maintained, using develop and develop-apple branches
   src = fetchFromGitHub {
     owner = "BIC-MNI";
     repo = pname;
-    rev = "a58af912a71a4c62014975b89ef37a8e72de3c9d";
-    sha256 = "0iw0pmr8xrifbx5l8a0xidfqbm1v8hwzqrw0lcmimxlzdihyri0g";
+    rev = "884b3ac8db945a17df51a325d29f49b825a61c3e";
+    hash = "sha256-zAA+hPwjMawQ1rJuv8W30EqKO+AI0aq9ybquBnKlzC0=";
   };
+
+  patches = [
+    # fixes build by including missing time.h header
+    (fetchpatch {
+      url = "https://github.com/RaghavSood/bicpl/commit/3def4acd6bae61ff7a930ef8422ad920690382a6.patch";
+      hash = "sha256-VdAKuLWTZY7JriK1rexIiuj8y5ToaSEJ5Y+BbnfdYnI=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [


### PR DESCRIPTION
## Description of changes

ZHF: https://github.com/NixOS/nixpkgs/issues/309482

Build was broken for darwin platforms - upstream has fixed some of the issues: https://github.com/BIC-MNI/bicpl/compare/a58af912a71a4c62014975b89ef37a8e72de3c9d..develop-apple

One issue remained, which I have fixed and submitted as a PR upstream: https://github.com/BIC-MNI/bicpl/pull/9

This also runs `nixfmt-rfc-style` to modernize the derivation a bit.

This PR fixes `oobicpl` and `bicgl` - they depend on `bicpl` and were broken by extension.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
