### PR TITLE
sublime-music: unpin dependencies, fix build

### DIFF
--- a/pkgs/applications/audio/sublime-music/default.nix
+++ b/pkgs/applications/audio/sublime-music/default.nix
@@ -17,20 +17,14 @@
 python3.pkgs.buildPythonApplication rec {
   pname = "sublime-music";
   version = "0.12.0";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sublime-music";
-    repo = pname;
+    repo = "sublime-music";
     rev = "refs/tags/v${version}";
     hash = "sha256-FPzeFqDOcaiariz7qJwz6P3Wd+ZDxNP57uj+ptMtEyM=";
   };
-
-  nativeBuildInputs = [
-    python3.pkgs.flit-core
-    gobject-introspection
-    wrapGAppsHook3
-  ];
 
   postPatch = ''
     sed -i "/--cov/d" setup.cfg
@@ -39,6 +33,15 @@ python3.pkgs.buildPythonApplication rec {
     # https://github.com/sublime-music/sublime-music/commit/f477659d24e372ed6654501deebad91ae4b0b51c
     sed -i "s/python-mpv/mpv/g" pyproject.toml
   '';
+
+  build-system = with python3.pkgs; [
+    flit-core
+  ];
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook3
+  ];
 
   buildInputs = [
     gtk3
@@ -91,10 +94,10 @@ python3.pkgs.buildPythonApplication rec {
 
   meta = with lib; {
     description = "GTK3 Subsonic/Airsonic client";
-    mainProgram = "sublime-music";
     homepage = "https://sublimemusic.app/";
     changelog = "https://github.com/sublime-music/sublime-music/blob/v${version}/CHANGELOG.rst";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ albakham sumnerevans ];
+    mainProgram = "sublime-music";
   };
 }

--- a/pkgs/applications/audio/sublime-music/default.nix
+++ b/pkgs/applications/audio/sublime-music/default.nix
@@ -5,7 +5,6 @@
 , gtk3
 , pango
 , wrapGAppsHook3
-, xvfb-run
 , chromecastSupport ? false
 , serverSupport ? false
 , keyringSupport ? true
@@ -15,34 +14,7 @@
 , networkmanager
 }:
 
-let
-  python = python3.override {
-    packageOverrides = self: super: {
-      semver = super.semver.overridePythonAttrs (oldAttrs: rec {
-        version = "2.13.0";
-        src = fetchFromGitHub {
-          owner = "python-semver";
-          repo = "python-semver";
-          rev = "refs/tags/${version}";
-          hash = "sha256-IWTo/P9JRxBQlhtcH3JMJZZrwAA8EALF4dtHajWUc4w=";
-        };
-        doCheck = false; # no tests
-      });
-
-      dataclasses-json = super.dataclasses-json.overridePythonAttrs (oldAttrs: rec {
-        version = "0.5.7";
-        src = fetchFromGitHub {
-          owner = "lidatong";
-          repo = "dataclasses-json";
-          rev = "refs/tags/v${version}";
-          hash = "sha256-0tw5Lz+c4ymO+AGpG6THbiALWGBrehC84+yWWk1eafc=";
-        };
-        nativeBuildInputs = [ python3.pkgs.setuptools ];
-      });
-    };
-  };
-in
-python.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "sublime-music";
   version = "0.12.0";
   format = "pyproject";
@@ -55,7 +27,7 @@ python.pkgs.buildPythonApplication rec {
   };
 
   nativeBuildInputs = [
-    python.pkgs.flit-core
+    python3.pkgs.flit-core
     gobject-introspection
     wrapGAppsHook3
   ];
@@ -76,7 +48,7 @@ python.pkgs.buildPythonApplication rec {
   ++ lib.optional networkSupport networkmanager
   ;
 
-  propagatedBuildInputs = with python.pkgs; [
+  propagatedBuildInputs = with python3.pkgs; [
     bleach
     bottle
     dataclasses-json
@@ -94,13 +66,14 @@ python.pkgs.buildPythonApplication rec {
   ++ lib.optional keyringSupport keyring
   ;
 
-  nativeCheckInputs = with python.pkgs; [
-    pytest
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
   ];
 
-  checkPhase = ''
-    ${xvfb-run}/bin/xvfb-run pytest
-  '';
+  disabledTests = [
+    # https://github.com/sublime-music/sublime-music/issues/439
+    "test_get_music_directory"
+  ];
 
   pythonImportsCheck = [
     "sublime_music"


### PR DESCRIPTION
I did a few things here:

- Removed the call to `xvfb-run`, it's no longer needed after upstream removed its ui tests: https://github.com/sublime-music/sublime-music/commit/bd573a0ed8faa246a35da6e16195826874e343fe
- Unpin `dataclasses-json`. This fixes https://github.com/NixOS/nixpkgs/issues/311270. It was pinned in https://github.com/nixos/nixpkgs/commit/8780d5eecff5645b763e9e8c5457ac7b05d75b3d with no explanation. When unpinning, I discovered that sublime-music's tests fail when run with the latest version of `dataclasses-music`. There's already an issue filed upstream about this: https://github.com/sublime-music/sublime-music/issues/439
  - To work around this, I switched to using `pytestCheckHook` and added `test_get_music_directory` to `disabledTests`.
- Unpin `semver`. It was pinned in https://github.com/nixos/nixpkgs/commit/ac848b1e6896957ba84177844be0f0b41d06ae5f with no explanation. This isn't necessary to fix the build, but it felt like good hygiene while I was in here (we shouldn't be pinning things without an explanation *why* they're pinned).

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
