### PR TITLE
maa-assistant-arknights: add dependency EmulatorExtras

### DIFF
--- a/pkgs/by-name/ma/maa-assistant-arknights/package.nix
+++ b/pkgs/by-name/ma/maa-assistant-arknights/package.nix
@@ -5,7 +5,6 @@
 , fetchFromGitHub
 , asio
 , cmake
-, eigen
 , libcpr
 , onnxruntime
 , opencv
@@ -16,6 +15,13 @@
 
 let
   fastdeploy = callPackage ./fastdeploy-ppocr.nix { };
+  emulator-extras = fetchFromGitHub {
+    owner = "MaaXYZ";
+    repo = "EmulatorExtras";
+    # follows https://github.com/MaaAssistantArknights/MaaAssistantArknights/tree/dev/3rdparty
+    rev = "42442b11835844ee1ff01371e6537d0291ca9505";
+    hash = "sha256-gfzEono2v+G6V0PjU8+S7+TSZFBp7jXgJlPFM2KlYl8=";
+  };
   sources = lib.importJSON ./pin.json;
 in
 stdenv.mkDerivation (finalAttr: {
@@ -31,6 +37,8 @@ stdenv.mkDerivation (finalAttr: {
 
   # https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=maa-assistant-arknights
   postPatch = ''
+    cp -r ${emulator-extras}/* ./3rdparty/EmulatorExtras
+
     substituteInPlace CMakeLists.txt \
       --replace-fail 'RUNTIME DESTINATION .' ' ' \
       --replace-fail 'LIBRARY DESTINATION .' ' ' \

--- a/pkgs/by-name/ma/maa-assistant-arknights/pin.json
+++ b/pkgs/by-name/ma/maa-assistant-arknights/pin.json
@@ -4,7 +4,7 @@
     "hash": "sha256-fjlvP5PPmSSNYefYRrEBVdhbN3yZ0pCbvIe763U5y5o="
   },
   "beta": {
-    "version": "5.2.3",
-    "hash": "sha256-fjlvP5PPmSSNYefYRrEBVdhbN3yZ0pCbvIe763U5y5o="
+    "version": "5.3.0-beta.1",
+    "hash": "sha256-eOSMNAH4odKmNpJvYOgGL73di2mXWBf7vIkT/bkoMNg="
   }
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

upstream: https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/8939
fix: https://github.com/Cryolitia/nur-packages/actions/runs/9048315830

update beta to v5.3.0-beta.1 in order to test in advance

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
