### PR TITLE
home-assistant-custom-components.tuya_local: init at 2024.5.2

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -44,6 +44,8 @@
 
   smartthinq-sensors = callPackage ./smartthinq-sensors {};
 
+  tuya_local = callPackage ./tuya_local {};
+
   waste_collection_schedule = callPackage ./waste_collection_schedule {};
 
   xiaomi_gateway3 = callPackage ./xiaomi_gateway3 {};

--- a/pkgs/servers/home-assistant/custom-components/tuya_local/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/tuya_local/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildHomeAssistantComponent
+, fetchFromGitHub
+
+# dependencies
+, tinytuya
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "make-all";
+  domain = "tuya_local";
+  version = "2024.5.2";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "tuya-local";
+    rev = "refs/tags/${version}";
+    hash = "sha256-If5SLLizagolXF5Y43UQK5IZ9oB1lQJVjTorgmtRXtg=";
+  };
+
+  dependencies = [ tinytuya ];
+
+  meta = with lib; {
+    description = "Local support for Tuya devices in Home Assistant";
+    homepage = "https://github.com/make-all/tuya-local";
+    changelog = "https://github.com/make-all/tuya-local/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pathob ];
+  };
+}


### PR DESCRIPTION
## Description of changes

[Tuya Local](https://github.com/make-all/tuya-local/) is a custom component for Home assistant which offers local support for Tuya-powered IoT devices. It is not to be confused with the similar component [LocalTuya](https://github.com/rospogrigio/localtuya) for which already a Nix package exists. Compared to LocalTuya, Tuya Local offers support for a much larger amount of [devices](https://github.com/make-all/tuya-local/blob/main/DEVICES.md) and is well maintaned. The last release was on 2024-05-04 (LocalTuya's last release was on 2023-06-07), which is why I would like to see Tuya Local added to Nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
