### PR TITLE
hedgedoc: Revert "hedgedoc: move files to share/hedeodc in the package" and Fix non-existent node_modules path

### DIFF
--- a/nixos/modules/services/web-apps/hedgedoc.nix
+++ b/nixos/modules/services/web-apps/hedgedoc.nix
@@ -236,9 +236,9 @@ in
     };
 
     services.hedgedoc.settings = {
-      defaultNotePath = lib.mkDefault "${cfg.package}/share/hedgedoc/public/default.md";
-      docsPath = lib.mkDefault "${cfg.package}/share/hedgedoc/public/docs";
-      viewPath = lib.mkDefault "${cfg.package}/share/hedgedoc/public/views";
+      defaultNotePath = lib.mkDefault "${cfg.package}/public/default.md";
+      docsPath = lib.mkDefault "${cfg.package}/public/docs";
+      viewPath = lib.mkDefault "${cfg.package}/public/views";
     };
 
     systemd.services.hedgedoc = {

--- a/pkgs/servers/web-apps/hedgedoc/default.nix
+++ b/pkgs/servers/web-apps/hedgedoc/default.nix
@@ -6,6 +6,7 @@
 , yarn
 , makeBinaryWrapper
 , nodejs
+, bash
 , python3
 , nixosTests
 }:
@@ -90,7 +91,8 @@ in stdenv.mkDerivation {
     for bin in $out/bin/*; do
       wrapProgram $bin \
         --set NODE_ENV production \
-        --set NODE_PATH "$out/node_modules"
+        --set NODE_PATH "$out/node_modules" \
+        --set PATH "$PATH:${nodejs}/bin:${bash}/bin"
     done
     makeWrapper ${nodejs}/bin/node $out/bin/hedgedoc \
       --add-flags $out/app.js \

--- a/pkgs/servers/web-apps/hedgedoc/default.nix
+++ b/pkgs/servers/web-apps/hedgedoc/default.nix
@@ -90,12 +90,12 @@ in stdenv.mkDerivation {
     for bin in $out/bin/*; do
       wrapProgram $bin \
         --set NODE_ENV production \
-        --set NODE_PATH "$out/lib/node_modules"
+        --set NODE_PATH "$out/node_modules"
     done
     makeWrapper ${nodejs}/bin/node $out/bin/hedgedoc \
       --add-flags $out/app.js \
       --set NODE_ENV production \
-      --set NODE_PATH "$out/lib/node_modules"
+      --set NODE_PATH "$out/node_modules"
 
     runHook postInstall
   '';

--- a/pkgs/servers/web-apps/hedgedoc/default.nix
+++ b/pkgs/servers/web-apps/hedgedoc/default.nix
@@ -84,19 +84,18 @@ in stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/share/hedgedoc
-    cp -r bin $out
-    cp -r {app.js,lib,locales,node_modules,package.json,public} $out/share/hedgedoc
+    mkdir -p $out
+    cp -R {app.js,bin,lib,locales,node_modules,package.json,public} $out
 
     for bin in $out/bin/*; do
       wrapProgram $bin \
         --set NODE_ENV production \
-        --set NODE_PATH "$out/share/hedgedoc/lib/node_modules"
+        --set NODE_PATH "$out/lib/node_modules"
     done
     makeWrapper ${nodejs}/bin/node $out/bin/hedgedoc \
-      --add-flags $out/share/hedgedoc/app.js \
+      --add-flags $out/app.js \
       --set NODE_ENV production \
-      --set NODE_PATH "$out/share/hedgedoc/lib/node_modules"
+      --set NODE_PATH "$out/lib/node_modules"
 
     runHook postInstall
   '';


### PR DESCRIPTION
This reverts commit e91a7b7a4e9513f4a2741b1a38c52fb81d4c9415.

## Description of changes

This PR reverts split of `hedgedoc` into `bin` and `share/hedgedoc` parts, which break NodeJS relative path's imports (`require`). Adding these paths to NODE_PATH doesn't resolve relative paths issue as per p.3: https://nodejs.org/docs/v20.12.1/api/esm.html#resolution-algorithm-specification .
Also NODE_PATH exposed `$out/lib/node_modules`, which appeared to be incorrect, as real node_modules location is `$out/node_modules`, so this PR fixes it.

Closes https://github.com/NixOS/nixpkgs/issues/189213 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
