### PR TITLE
pkgs/formats: add generator for PHP config files

### DIFF
--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -146,6 +146,27 @@ have a predefined type and string generator already declared under
     :   Outputs the given attribute set as an Elixir map, instead of the
         default Elixir keyword list
 
+`pkgs.formats.php { finalVariable }` []{#pkgs-formats-php}
+
+:   A function taking an attribute set with values
+
+    `finalVariable`
+
+    :   The variable that will store generated expression (usually `config`). If set to `null`, generated expression will contain `return`.
+
+    It returns a set with PHP-Config-specific attributes `type`, `lib`, and
+    `generate` as specified [below](#pkgs-formats-result).
+
+    The `lib` attribute contains functions to be used in settings, for
+    generating special PHP values:
+
+    `mkRaw phpCode`
+
+    :   Outputs the given string as raw PHP code
+
+    `mkMixedArray list set`
+
+    :   Creates PHP array that contains both indexed and associative values. For example, `lib.mkMixedArray [ "hello" "world" ] { "nix" = "is-great"; }` returns `['hello', 'world', 'nix' => 'is-great']`
 
 []{#pkgs-formats-result}
 These functions all return an attribute set with these values:

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -43,6 +43,8 @@ rec {
 
   hocon = (import ./formats/hocon/default.nix { inherit lib pkgs; }).format;
 
+  php = (import ./formats/php/default.nix { inherit lib pkgs; }).format;
+
   json = {}: {
 
     type = with lib.types; let

--- a/pkgs/pkgs-lib/formats/php/default.nix
+++ b/pkgs/pkgs-lib/formats/php/default.nix
@@ -1,0 +1,69 @@
+{pkgs, lib}: {
+  # Format for defining configuration of some PHP services, that use "include 'config.php';" approach.
+  format = {finalVariable ? null}: let
+    toPHP = value: {
+        "null" = "null";
+        "bool" = if value then "true" else "false";
+        "int" = toString value;
+        "float" = toString value;
+        "string" = string value;
+        "set" = attrs value;
+        "list" = list value;
+      }
+      .${builtins.typeOf value} or
+        (abort "should never happen: unknown value type ${builtins.typeOf value}");
+
+    # https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.single
+    escapeSingleQuotedString = lib.escape [ "'" "\\" ];
+    string = value: "'${escapeSingleQuotedString value}'";
+
+    listContent = values: lib.concatStringsSep ", " (map toPHP values);
+    list = values: "[" + (listContent values) + "]";
+
+    attrsContent = values: lib.pipe values [
+      (lib.mapAttrsToList (k: v: "${toPHP k} => ${toPHP v}"))
+      (lib.concatStringsSep ", ")
+    ];
+    attrs = set:
+      if set ? _phpType then specialType set
+      else
+          "[" + attrsContent set + "]";
+
+    mixedArray = {list, set}: if list == [] then attrs set else "[${listContent list}, ${attrsContent set}]";
+
+    specialType = {value, _phpType}: {
+      "mixed_array" = mixedArray value;
+      "raw" = value;
+    }.${_phpType};
+
+    type = with lib.types;
+      nullOr (oneOf [
+        bool
+        int
+        float
+        str
+        (attrsOf type)
+        (listOf type)
+      ])
+      // {
+        description = "PHP value";
+      };
+  in {
+
+    inherit type;
+
+    lib = {
+      mkMixedArray = list: set: {_phpType = "mixed_array"; value = { inherit list set;}; };
+      mkRaw = raw: {_phpType = "raw"; value = raw;};
+    };
+
+    generate = name: value: pkgs.writeTextFile {
+      inherit name;
+      text = let
+        # strict_types enabled here to easily debug problems when calling functions of incorrect type using `mkRaw`.
+        phpHeader = "<?php\ndeclare(strict_types=1);\n";
+      in if finalVariable == null then phpHeader + "return ${toPHP value};\n" else phpHeader + "\$${finalVariable} = ${toPHP value};\n";
+    };
+
+  };
+}

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -425,4 +425,48 @@ in runBuildTests {
       \u0627\u0644\u062c\u0628\u0631 = \u0623\u0643\u062b\u0631 \u0645\u0646 \u0645\u062c\u0631\u062f \u0623\u0631\u0642\u0627\u0645
     '';
   };
+
+  phpAtoms = shouldPass rec {
+    format = formats.php { finalVariable = "config"; };
+    input = {
+      null = null;
+      false = false;
+      true = true;
+      int = 10;
+      float = 3.141;
+      str = "foo";
+      str_special = "foo\ntesthello'''";
+      attrs.foo = null;
+      list = [ null null ];
+      mixed = format.lib.mkMixedArray [ 10 3.141 ] {
+        str = "foo";
+        attrs.foo = null;
+      };
+      raw = format.lib.mkRaw "random_function()";
+    };
+    expected = ''
+      <?php
+      declare(strict_types=1);
+      $config = ['attrs' => ['foo' => null], 'false' => false, 'float' => 3.141000, 'int' => 10, 'list' => [null, null], 'mixed' => [10, 3.141000, 'attrs' => ['foo' => null], 'str' => 'foo'], 'null' => null, 'raw' => random_function(), 'str' => 'foo', 'str_special' => 'foo
+      testhello\'\'\'${"'"}, 'true' => true];
+    '';
+  };
+
+  phpReturn = shouldPass {
+    format = formats.php { };
+    input = {
+      int = 10;
+      float = 3.141;
+      str = "foo";
+      str_special = "foo\ntesthello'''";
+      attrs.foo = null;
+    };
+    expected = ''
+      <?php
+      declare(strict_types=1);
+      return ['attrs' => ['foo' => null], 'float' => 3.141000, 'int' => 10, 'str' => 'foo', 'str_special' => 'foo
+      testhello\'\'\'${"'"}];
+    '';
+  };
+
 }


### PR DESCRIPTION
## Description of changes

Some PHP apps are configurable through evaluation of `config.php` file (file should contain php code that should set options on hashmap), for example [Filesender](https://github.com/filesender/filesender) or [Flarum](https://docs.flarum.org/config/).

This PR adds generation of PHP configs through Nix DSL.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
