### PR TITLE
bb: fix bulid by setting C std to c89

### DIFF
--- a/pkgs/applications/misc/bb/default.nix
+++ b/pkgs/applications/misc/bb/default.nix
@@ -1,17 +1,30 @@
-{ stdenv, lib, fetchurl, darwin, aalib, ncurses, xorg, libmikmod }:
+{
+  stdenv,
+  lib,
+  fetchurl,
+  darwin,
+  aalib,
+  ncurses,
+  xorg,
+  libmikmod,
+}:
 
 stdenv.mkDerivation rec {
   pname = "bb";
   version = "1.3rc1";
 
   src = fetchurl {
-    url    = "mirror://sourceforge/aa-project/bb/${version}/${pname}-${version}.tar.gz";
+    url = "mirror://sourceforge/aa-project/bb/${version}/${pname}-${version}.tar.gz";
     sha256 = "1i411glxh7g4pfg4gw826lpwngi89yrbmxac8jmnsfvrfb48hgbr";
   };
 
   buildInputs = [
-    aalib ncurses libmikmod
-    xorg.libXau xorg.libXdmcp xorg.libX11
+    aalib
+    ncurses
+    libmikmod
+    xorg.libXau
+    xorg.libXdmcp
+    xorg.libX11
   ] ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.CoreAudio;
 
   postPatch = lib.optionalString stdenv.isDarwin ''
@@ -19,15 +32,16 @@ stdenv.mkDerivation rec {
   '';
 
   # error: 'regparm' is not valid on this platform
-  env.NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64)
-    "-D__STRICT_ANSI__";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString (
+    stdenv.isDarwin && stdenv.isAarch64
+  ) "-D__STRICT_ANSI__";
 
   meta = with lib; {
-    homepage    = "http://aa-project.sourceforge.net/bb";
+    homepage = "http://aa-project.sourceforge.net/bb";
     description = "AA-lib demo";
-    license     = licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
     maintainers = [ maintainers.rnhmjoj ];
-    platforms   = platforms.unix;
+    platforms = platforms.unix;
     mainProgram = "bb";
   };
 }

--- a/pkgs/applications/misc/bb/default.nix
+++ b/pkgs/applications/misc/bb/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
     sed -i -e '/^#include <malloc.h>$/d' *.c
   '';
 
+  env.CFLAGS = "-std=gnu89";
   # error: 'regparm' is not valid on this platform
   env.NIX_CFLAGS_COMPILE = lib.optionalString (
     stdenv.isDarwin && stdenv.isAarch64


### PR DESCRIPTION
## Description of changes

ZHF: https://github.com/NixOS/nixpkgs/issues/309482

`bb` has seen no updates since 2001, and cannot be compiled with modern C tooling

This fixes the build by setting `-std=gnu89` explicitly.

It also runs `nixfmt-rfc-style`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
