### PR TITLE
glib: disable introspection for cross-endian

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -23,7 +23,10 @@
 , testers
 , gobject-introspection
 , mesonEmulatorHook
-, withIntrospection ? stdenv.hostPlatform.emulatorAvailable buildPackages && lib.meta.availableOn stdenv.hostPlatform gobject-introspection
+, withIntrospection ?
+  stdenv.hostPlatform.emulatorAvailable buildPackages &&
+  lib.meta.availableOn stdenv.hostPlatform gobject-introspection &&
+  stdenv.hostPlatform.isLittleEndian == stdenv.buildPlatform.isLittleEndian
 }:
 
 assert stdenv.isLinux -> util-linuxMinimal != null;


### PR DESCRIPTION
## Description of changes

https://github.com/NixOS/nixpkgs/pull/309309#issuecomment-2100785761

```
/nix/store/xxgjhia4jhnx9910vb7iw1cm9l6qwfd4-qemu-8.2.3/bin/qemu-ppc64: error while loading shared libraries: /build/glib-2.80.0/build/glib/libglib-2.0.so.0: ELF file data encoding not little-endian
Command '['/nix/store/054wr9piy48ww123yn2pcbkcsnvlx3fg-gobject-introspection-wrapped-1.80.1-dev/bin/g-ir-scanner-qemuwrapper', '/build/glib-2.80.0/build/tmp-introspectiyhf5flt/GLib-2.0', '--introspect-dump=/build/glib-2.80.0/build/tmp-introspectiyhf5flt/functions.txt,/build/glib-2.80.0/build/tmp-introspectiyhf5flt/dump.xml']' returned non-zero exit status 127.
```

I don't have a suitable environment for testing whether it's broken big→little, but it seems likely.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
