### PR TITLE
edk2: cross-compilation fix

### DIFF
--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -41,6 +41,11 @@ edk2 = stdenv.mkDerivation rec {
       url = "https://src.fedoraproject.org/rpms/edk2/raw/08f2354cd280b4ce5a7888aa85cf520e042955c3/f/0021-Tweak-the-tools_def-to-support-cross-compiling.patch";
       hash = "sha256-E1/fiFNVx0aB1kOej2DJ2DlBIs9tAAcxoedym2Zhjxw=";
     })
+    # https://github.com/tianocore/edk2/pull/5658
+    (fetchpatch {
+      url = "https://github.com/tianocore/edk2/commit/a34ff4a8f69a7b8a52b9b299153a8fac702c7df1.patch";
+      hash = "sha256-u+niqwjuLV5tNPykW4xhb7PW2XvUmXhx5uvftG1UIbU=";
+    })
   ];
 
   srcWithVendoring = fetchFromGitHub {
@@ -81,12 +86,6 @@ edk2 = stdenv.mkDerivation rec {
     + lib.optionalString (stdenv.isDarwin) " -Wno-error=macro-redefined";
 
   hardeningDisable = [ "format" "fortify" ];
-
-  # For cross-compilation we need to build antlr and dlg for the build arch
-  preBuild = ''
-    BIN_DIR='.' make -C BaseTools/Source/C/VfrCompile/Pccts/antlr CC=$CC_FOR_BUILD CXX=$CXX_FOR_BUILD -j$NIX_BUILD_CORES
-    BIN_DIR='.' make -C BaseTools/Source/C/VfrCompile/Pccts/dlg CC=$CC_FOR_BUILD CXX=$CXX_FOR_BUILD -j$NIX_BUILD_CORES
-  '';
 
   installPhase = ''
     mkdir -vp $out

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -94,8 +94,8 @@ edk2 = stdenv.mkDerivation rec {
     mv -v edksetup.sh $out
     # patchShebangs fails to see these when cross compiling
     for i in $out/BaseTools/BinWrappers/PosixLike/*; do
-      substituteInPlace $i --replace '/usr/bin/env bash' ${buildPackages.bash}/bin/bash
       chmod +x "$i"
+      patchShebangs --build "$i"
     done
   '';
 

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -82,6 +82,13 @@ edk2 = stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" "fortify" ];
 
+  # Fix cross-compilation issue, use build cc/c++ for building antlr and dlg
+  postPatch = ''
+    substituteInPlace BaseTools/Source/C/VfrCompile/GNUmakefile \
+      --replace '$(MAKE) -C Pccts/antlr' '$(MAKE) -C Pccts/antlr CC=cc CXX=c++' \
+      --replace '$(MAKE) -C Pccts/dlg' '$(MAKE) -C Pccts/dlg CC=cc CXX=c++'
+  '';
+
   installPhase = ''
     mkdir -vp $out
     mv -v BaseTools $out


### PR DESCRIPTION
## Description of changes

Force of using build gcc for compiling build-time tools like antlr.
Also use `buildPackages.edk2` when build OVMF variants.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
