### PR TITLE
python3Packages.pygsl: 2.3.3 -> 2.3.4

### DIFF
--- a/pkgs/development/python-modules/pygsl/default.nix
+++ b/pkgs/development/python-modules/pygsl/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , gsl
 , swig
 , numpy
@@ -9,12 +9,14 @@
 
 buildPythonPackage rec {
   pname = "pygsl";
-  version = "2.3.3";
+  version = "2.3.4";
   format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-F3m85Bs8sONw0Rv0EAOFK6R1DFHfW4dxuzQmXo4PHfM=";
+  src = fetchFromGitHub {
+    owner = "pygsl";
+    repo = "pygsl";
+    rev = "refs/tags/v.${version}";
+    hash = "sha256-2TalLKDDoJdKGZHr7eNNvVW8fL7wQJjnZv34LJokfow=";
   };
 
   nativeBuildInputs = [
@@ -24,9 +26,13 @@ buildPythonPackage rec {
   buildInputs = [
     gsl
   ];
-  propagatedBuildInputs = [
+  dependencies = [
     numpy
   ];
+
+  preBuild = ''
+    python setup.py build_ext --inplace
+  '';
 
   preCheck = ''
     cd tests


### PR DESCRIPTION
## Description of changes

https://github.com/pygsl/pygsl/releases/tag/v.2.3.4

It isn't on pypi for some reason; we need some extra command to get it to build from GitHub (seems to be due to cython, also see #255262).

The new version fixes the build with Python 3.12

ZHF: #309482

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
