### PR TITLE
miniscript: unstable-2022-07-19 -> unstable-2023-03-16

### DIFF
--- a/pkgs/applications/blockchains/miniscript/default.nix
+++ b/pkgs/applications/blockchains/miniscript/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, lib, fetchFromGitHub }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+}:
 
 stdenv.mkDerivation rec {
   pname = "miniscript";
@@ -19,12 +23,15 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description     = "Compiler and inspector for the miniscript Bitcoin policy language";
+    description = "Compiler and inspector for the miniscript Bitcoin policy language";
     longDescription = "Miniscript is a language for writing (a subset of) Bitcoin Scripts in a structured way, enabling analysis, composition, generic signing and more.";
-    homepage        = "https://bitcoin.sipa.be/miniscript/";
-    license         = licenses.mit;
-    platforms       = platforms.linux;
-    maintainers     = with maintainers; [ RaghavSood jb55 ];
+    homepage = "https://bitcoin.sipa.be/miniscript/";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [
+      RaghavSood
+      jb55
+    ];
     mainProgram = "miniscript";
   };
 }

--- a/pkgs/applications/blockchains/miniscript/default.nix
+++ b/pkgs/applications/blockchains/miniscript/default.nix
@@ -6,14 +6,25 @@
 
 stdenv.mkDerivation rec {
   pname = "miniscript";
-  version = "unstable-2022-07-19";
+  version = "unstable-2023-03-16";
 
   src = fetchFromGitHub {
     owner = "sipa";
     repo = pname;
-    rev = "ca675488c4aa9605f6ae70c0e68a148a6fb277b4";
-    sha256 = "sha256-kzLIJ0os6UnC0RPEybfw6wGrZpgmRCgj3zifmZjieoU=";
+    rev = "6806dfb15a1fafabf7dd28aae3c9d2bc49db01f1";
+    sha256 = "sha256-qkYDzsl2Y4WEDDXs9cE/jIXm01jclkYUQbDGe1S0wYs=";
   };
+
+    postPatch = lib.optionalString stdenv.isDarwin ''
+    # Replace hardcoded g++ with c++ so clang can be used
+    # on darwin
+    #
+    # lto must be disabled on darwin as well due to
+    # https://github.com/NixOS/nixpkgs/issues/19098
+    substituteInPlace Makefile \
+        --replace-fail 'g++' 'c++' \
+        --replace-fail '-flto' ""
+  '';
 
   installPhase = ''
     runHook preInstall
@@ -27,7 +38,6 @@ stdenv.mkDerivation rec {
     longDescription = "Miniscript is a language for writing (a subset of) Bitcoin Scripts in a structured way, enabling analysis, composition, generic signing and more.";
     homepage = "https://bitcoin.sipa.be/miniscript/";
     license = licenses.mit;
-    platforms = platforms.linux;
     maintainers = with maintainers; [
       RaghavSood
       jb55


### PR DESCRIPTION
## Description of changes

Bumps miniscript to the latest master: https://github.com/sipa/miniscript/compare/ca675488c4aa9605f6ae70c0e68a148a6fb277b4..6806dfb15a1fafabf7dd28aae3c9d2bc49db01f1

This also fixes the build for macos by disabling LTO and replacing out the hardcoded `g++` before building it on darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
