### PR TITLE
python312Packages.aiocoap: 0.4.7 -> 0.4.8

### DIFF
--- a/pkgs/development/python-modules/aiocoap/default.nix
+++ b/pkgs/development/python-modules/aiocoap/default.nix
@@ -1,25 +1,19 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
-, pythonAtLeast
-, pythonOlder
-
-# build-system
-, setuptools
-
-# optionals
-, cbor2
 , cbor-diag
+, cbor2
 , cryptography
+, dtlssocket
+, fetchFromGitHub
 , filelock
 , ge25519
-, dtlssocket
-, websockets
-, termcolor
 , pygments
-
-# tests
 , pytestCheckHook
+, pythonAtLeast
+, pythonOlder
+, setuptools
+, termcolor
+, websockets
 }:
 
 buildPythonPackage rec {
@@ -31,12 +25,12 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "chrysn";
-    repo = pname;
+    repo = "aiocoap";
     rev = "refs/tags/${version}";
     hash = "sha256-jBRxorHr5/CgAR6WVXBUycZpJ6n1DYVFQk6kqVv8D1Q=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
   ];
 
@@ -65,23 +59,6 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = lib.optionals (pythonAtLeast "3.12") [
-    # https://github.com/chrysn/aiocoap/issues/339
-    "--deselect=tests/test_server.py::TestServerTCP::test_big_resource"
-    "--deselect=tests/test_server.py::TestServerTCP::test_empty_accept"
-    "--deselect=tests/test_server.py::TestServerTCP::test_error_resources"
-    "--deselect=tests/test_server.py::TestServerTCP::test_fast_resource"
-    "--deselect=tests/test_server.py::TestServerTCP::test_js_accept"
-    "--deselect=tests/test_server.py::TestServerTCP::test_manualbig_resource"
-    "--deselect=tests/test_server.py::TestServerTCP::test_nonexisting_resource"
-    "--deselect=tests/test_server.py::TestServerTCP::test_replacing_resource"
-    "--deselect=tests/test_server.py::TestServerTCP::test_root_resource"
-    "--deselect=tests/test_server.py::TestServerTCP::test_slow_resource"
-    "--deselect=tests/test_server.py::TestServerTCP::test_slowbig_resource"
-    "--deselect=tests/test_server.py::TestServerTCP::test_spurious_resource"
-    "--deselect=tests/test_server.py::TestServerTCP::test_unacceptable_accept"
-  ];
-
   disabledTestPaths = [
     # Don't test the plugins
     "tests/test_tls.py"
@@ -92,6 +69,21 @@ buildPythonPackage rec {
   disabledTests = [
     # Communication is not properly mocked
     "test_uri_parser"
+  ] ++ lib.optionals (pythonAtLeast "3.12") [
+    # https://github.com/chrysn/aiocoap/issues/339
+    "TestServerTCP::test_big_resource"
+    "TestServerTCP::test_empty_accept"
+    "TestServerTCP::test_error_resources"
+    "TestServerTCP::test_fast_resource"
+    "TestServerTCP::test_js_accept"
+    "TestServerTCP::test_manualbig_resource"
+    "TestServerTCP::test_nonexisting_resource"
+    "TestServerTCP::test_replacing_resource"
+    "TestServerTCP::test_root_resource"
+    "TestServerTCP::test_slow_resource"
+    "TestServerTCP::test_slowbig_resource"
+    "TestServerTCP::test_spurious_resource"
+    "TestServerTCP::test_unacceptable_accept"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/aiocoap/default.nix
+++ b/pkgs/development/python-modules/aiocoap/default.nix
@@ -24,7 +24,7 @@
 
 buildPythonPackage rec {
   pname = "aiocoap";
-  version = "0.4.7";
+  version = "0.4.8";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     owner = "chrysn";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-4iwoPfmIwk+PlWUp60aqA5qZgzyj34pnZHf9uH5UhnY=";
+    hash = "sha256-jBRxorHr5/CgAR6WVXBUycZpJ6n1DYVFQk6kqVv8D1Q=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/aiocoap/default.nix
+++ b/pkgs/development/python-modules/aiocoap/default.nix
@@ -1,19 +1,20 @@
-{ lib
-, buildPythonPackage
-, cbor-diag
-, cbor2
-, cryptography
-, dtlssocket
-, fetchFromGitHub
-, filelock
-, ge25519
-, pygments
-, pytestCheckHook
-, pythonAtLeast
-, pythonOlder
-, setuptools
-, termcolor
-, websockets
+{
+  lib,
+  buildPythonPackage,
+  cbor-diag,
+  cbor2,
+  cryptography,
+  dtlssocket,
+  fetchFromGitHub,
+  filelock,
+  ge25519,
+  pygments,
+  pytestCheckHook,
+  pythonAtLeast,
+  pythonOlder,
+  setuptools,
+  termcolor,
+  websockets,
 }:
 
 buildPythonPackage rec {
@@ -30,9 +31,7 @@ buildPythonPackage rec {
     hash = "sha256-jBRxorHr5/CgAR6WVXBUycZpJ6n1DYVFQk6kqVv8D1Q=";
   };
 
-  build-system = [
-    setuptools
-  ];
+  build-system = [ setuptools ];
 
   passthru.optional-dependencies = {
     oscore = [
@@ -41,12 +40,8 @@ buildPythonPackage rec {
       filelock
       ge25519
     ];
-    tinydtls = [
-      dtlssocket
-    ];
-    ws = [
-      websockets
-    ];
+    tinydtls = [ dtlssocket ];
+    ws = [ websockets ];
     prettyprint = [
       termcolor
       cbor2
@@ -55,9 +50,7 @@ buildPythonPackage rec {
     ];
   };
 
-  nativeCheckInputs = [
-    pytestCheckHook
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   disabledTestPaths = [
     # Don't test the plugins
@@ -66,29 +59,29 @@ buildPythonPackage rec {
     "tests/test_oscore_plugtest.py"
   ];
 
-  disabledTests = [
-    # Communication is not properly mocked
-    "test_uri_parser"
-  ] ++ lib.optionals (pythonAtLeast "3.12") [
-    # https://github.com/chrysn/aiocoap/issues/339
-    "TestServerTCP::test_big_resource"
-    "TestServerTCP::test_empty_accept"
-    "TestServerTCP::test_error_resources"
-    "TestServerTCP::test_fast_resource"
-    "TestServerTCP::test_js_accept"
-    "TestServerTCP::test_manualbig_resource"
-    "TestServerTCP::test_nonexisting_resource"
-    "TestServerTCP::test_replacing_resource"
-    "TestServerTCP::test_root_resource"
-    "TestServerTCP::test_slow_resource"
-    "TestServerTCP::test_slowbig_resource"
-    "TestServerTCP::test_spurious_resource"
-    "TestServerTCP::test_unacceptable_accept"
-  ];
+  disabledTests =
+    [
+      # Communication is not properly mocked
+      "test_uri_parser"
+    ]
+    ++ lib.optionals (pythonAtLeast "3.12") [
+      # https://github.com/chrysn/aiocoap/issues/339
+      "TestServerTCP::test_big_resource"
+      "TestServerTCP::test_empty_accept"
+      "TestServerTCP::test_error_resources"
+      "TestServerTCP::test_fast_resource"
+      "TestServerTCP::test_js_accept"
+      "TestServerTCP::test_manualbig_resource"
+      "TestServerTCP::test_nonexisting_resource"
+      "TestServerTCP::test_replacing_resource"
+      "TestServerTCP::test_root_resource"
+      "TestServerTCP::test_slow_resource"
+      "TestServerTCP::test_slowbig_resource"
+      "TestServerTCP::test_spurious_resource"
+      "TestServerTCP::test_unacceptable_accept"
+    ];
 
-  pythonImportsCheck = [
-    "aiocoap"
-  ];
+  pythonImportsCheck = [ "aiocoap" ];
 
   meta = with lib; {
     description = "Python CoAP library";


### PR DESCRIPTION
Diff: https://github.com/chrysn/aiocoap/compare/refs/tags/0.4.7...0.4.8

Changelog: https://github.com/chrysn/aiocoap/blob/0.4.8/NEWS

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
