### PR TITLE
jailer: init at 16.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7777,6 +7777,12 @@
     githubId = 10654650;
     name = "Guillaume Koenig";
   };
+  guillaumematheron = {
+    email = "guillaume_nix@matheron.eu";
+    github = "guillaumematheron";
+    githubId = 1949438;
+    name = "Guillaume Matheron";
+  };
   guitargeek = {
     email = "jonas.rembser@cern.ch";
     github = "guitargeek";

--- a/pkgs/by-name/ja/jailer/package.nix
+++ b/pkgs/by-name/ja/jailer/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  ant,
+  copyDesktopItems,
+  fetchFromGitHub,
+  jdk,
+  jre,
+  makeDesktopItem,
+  makeWrapper,
+  stdenv,
+  stripJavaArchivesHook,
+  wrapGAppsHook4,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  name = "jailer";
+  version = "16.1.4";
+
+  src = fetchFromGitHub {
+    owner = "Wisser";
+    repo = "Jailer";
+    rev = "dcde48b2e0c7b68cc1b6f73c80fde06fdf31fdc6";
+    sha256 = "sha256-cPOWW2z44vCc/Fw1zYZUsYafgKr82e0g+K0Db5A9F5M=";
+  };
+
+
+  buildPhase = ''
+    runHook preBuild
+    rm jailer.jar
+    ant
+    runHook postBuild
+  '';
+
+  nativeBuildInputs = [ ant jdk stripJavaArchivesHook makeWrapper wrapGAppsHook4 copyDesktopItems ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 jailer.jar $out/share/java/jailer.jar
+    install -Dm644 jailer-engine-${finalAttrs.version}.jar $out/share/java/
+    mkdir -p $out/share/java/lib
+    for f in lib/*.jar; do
+      install -Dm644 $f $out/share/java/lib
+    done
+
+    mkdir -p $out/bin
+    mkdir -p $out/share
+    mkdir -p $out/share/pixmaps
+    cp driverlist.csv $out/share
+    cp admin/jailer.png $out/share/pixmaps
+
+    # On first run, create a local configuration folder and copy driverlist.csv there.
+    cat << EOF > $out/bin/jailer
+    #!/usr/bin/env bash
+    CFG="''${XDG_CONFIG_HOME:-\$HOME/.config}/jailer"
+    mkdir -p \$CFG
+    cp -n $out/share/driverlist.csv \$CFG
+    cd \$CFG
+    _JAVA_AWT_WM_NONREPARENTING=1 ${jre}/bin/java -jar $out/share/java/jailer.jar
+    EOF
+    chmod +x $out/bin/jailer
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Jailer";
+      desktopName = "Jailer";
+      exec = "jailer";
+      icon = "jailer";
+      categories = [ "Development" ];
+    })
+  ];
+
+  meta = {
+    description = "A tool for database subsetting and relational data browsing";
+    license = lib.licenses.asl20;
+    homepage = "https://github.com/Wisser/Jailer";
+    changelog = "https://github.com/Wisser/Jailer/releases/tag/${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ guillaumematheron ];
+    mainProgram = "jailer";
+  };
+})


### PR DESCRIPTION
## Description of changes

Jailer is a tool for database subsetting and relational data browsing

This is my first contribution to nixpkgs, I appreciate any feedback.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
  - [ ] 
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
