### PR TITLE
luaPackages.toml: unbreak 

### DIFF
--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -709,9 +709,11 @@ in
     propagatedBuildInputs = oa.propagatedBuildInputs ++ [ sol2 ];
 
     postPatch = ''
-      substituteInPlace CMakeLists.txt --replace-fail \
-        "TOML_PLUS_PLUS_SRC" \
-        "${tomlplusplus.src}"
+      substituteInPlace CMakeLists.txt \
+        --replace-fail "TOML_PLUS_PLUS_SRC" "${tomlplusplus.src}/include/toml++" \
+        --replace-fail "MAGIC_ENUM_SRC" "${magic-enum.src}/include/magic_enum"
+
+      cat CMakeLists.txt
     '';
   });
 

--- a/pkgs/development/lua-modules/toml.patch
+++ b/pkgs/development/lua-modules/toml.patch
@@ -1,16 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index faae37a..6990d4a 100644
+index ab3884c..c0fd356 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -38,26 +38,17 @@ include(FetchContent)
+@@ -38,32 +38,23 @@ include(FetchContent)
  
  FetchContent_Declare(
  	${TOML++}
 -	GIT_REPOSITORY "https://github.com/marzer/tomlplusplus.git"
 -	GIT_SHALLOW ON
 -    GIT_SUBMODULES ""
--	GIT_TAG "v3.4.0"
-+      DOWNLOAD_COMMAND true
+-	GIT_TAG "v3.3.0"
++  DOWNLOAD_COMMAND true
  )
  
  FetchContent_Declare(
@@ -19,7 +19,7 @@ index faae37a..6990d4a 100644
 -	GIT_SHALLOW ON
 -    GIT_SUBMODULES ""
 -	GIT_TAG "v3.3.0"
-+      DOWNLOAD_COMMAND true
++  DOWNLOAD_COMMAND true
  )
  
  FetchContent_Declare(
@@ -27,26 +27,35 @@ index faae37a..6990d4a 100644
 -	GIT_REPOSITORY "https://github.com/Neargye/magic_enum.git"
 -	GIT_SHALLOW ON
 -    GIT_SUBMODULES ""
--	GIT_TAG "v0.9.5"
-+      DOWNLOAD_COMMAND true
+-	GIT_TAG "v0.8.2"
++  DOWNLOAD_COMMAND true
  )
  
  FetchContent_GetProperties(${TOML++})
-@@ -112,7 +103,7 @@ if(NOT LUA_INCLUDE_DIR OR (WIN32 AND NOT LUA_LIBRARIES))
+ if(NOT ${TOML++}_POPULATED)
+     message(STATUS "Cloning ${TOML++}")
+-	FetchContent_Populate(${TOML++}) 
++	FetchContent_Populate(${TOML++})
+     FetchContent_MakeAvailable(${TOML++})
+ endif()
+ 
+@@ -113,7 +104,7 @@ if(NOT LUA_INCLUDE_DIR OR (WIN32 AND NOT LUA_LIBRARIES))
      find_package(Lua)
  endif()
  
 -include_directories(${LUA_INCLUDE_DIR} src src/include ${${TOML++}_SOURCE_DIR} ${${SOL2}_SOURCE_DIR}/include ${${MAGIC_ENUM}_SOURCE_DIR}/include)
-+include_directories(${LUA_INCLUDE_DIR} src src/include TOML_PLUS_PLUS_SRC ${${SOL2}_SOURCE_DIR}/include MAGIC_ENUM_SRC/include)
++include_directories(${LUA_INCLUDE_DIR} src src/include TOML_PLUS_PLUS_SRC ${${SOL2}_SOURCE_DIR}/include MAGIC_ENUM_SRC)
  
  set(SOURCES
      src/toml.cpp
-@@ -129,7 +120,7 @@ source_group(src FILES ${SOURCES})
- if(WIN32 AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR MSVC)
+@@ -129,8 +120,8 @@ source_group(src FILES ${SOURCES})
+ 
+ if(WIN32 AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
  	target_link_options(toml.lua PUBLIC ${PROJECT_SOURCE_DIR}\\libs\\lua51.lib)
- else() 
--    target_link_libraries(toml.lua ${LUA_LIBRARIES} tomlplusplus::tomlplusplus)    
-+    target_link_libraries(toml.lua ${LUA_LIBRARIES} tomlplusplus)
+-else() 
+-    target_link_libraries(toml.lua ${LUA_LIBRARIES})    
++else()
++    target_link_libraries(toml.lua ${LUA_LIBRARIES})
  endif()
  
  if (LINK_FLAGS)


### PR DESCRIPTION
## Description of changes

Regression introduced by commit 199efdb1dead77efa41fbed267cdb1285f907000 in PR #305799

ZHF #309482

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
