### PR TITLE
rocm{5,6}: use elfutils instead of abandoned libelf

### DIFF
--- a/pkgs/development/rocm-modules/5/rocm-runtime/default.nix
+++ b/pkgs/development/rocm-modules/5/rocm-runtime/default.nix
@@ -7,7 +7,7 @@
 , xxd
 , rocm-device-libs
 , rocm-thunk
-, libelf
+, elfutils
 , libdrm
 , numactl
 , valgrind
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     rocm-thunk
-    libelf
+    elfutils
     libdrm
     numactl
     valgrind

--- a/pkgs/development/rocm-modules/6/rocm-runtime/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-runtime/default.nix
@@ -8,7 +8,7 @@
 , xxd
 , rocm-device-libs
 , rocm-thunk
-, libelf
+, elfutils
 , libdrm
 , numactl
 , valgrind
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     rocm-thunk
-    libelf
+    elfutils
     libdrm
     numactl
     valgrind


### PR DESCRIPTION
## Description of changes

Switch from using unmaintained libelf to elfutils for the `rocmPackages_5.rocm-runtime` and `rocmPackages_6.rocm-runtime` packages.

- https://github.com/NixOS/nixpkgs/issues/271473

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).