### PR TITLE
python312Packages.bayespy: add missing dependency, clean up; python312Packages.truncnorm: init at 0.0.2

### DIFF
--- a/pkgs/development/python-modules/bayespy/default.nix
+++ b/pkgs/development/python-modules/bayespy/default.nix
@@ -1,29 +1,48 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, pythonOlder
-, pytestCheckHook, nose, glibcLocales, fetchpatch
-, numpy, scipy, matplotlib, h5py }:
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  setuptools,
+  numpy,
+  scipy,
+  h5py,
+  truncnorm,
+  pytestCheckHook,
+}:
 
 buildPythonPackage rec {
   pname = "bayespy";
   version = "0.6.1";
-  format = "setuptools";
+  pyproject = true;
 
   # Python 2 not supported and not some old Python 3 because MPL doesn't support
   # them properly.
   disabled = pythonOlder "3.4";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-3N8w/LiTLsDZbHp3z26FvDg3vStB2l3XkIWx+Mma1G0=";
+  src = fetchFromGitHub {
+    owner = "bayespy";
+    repo = "bayespy";
+    rev = "refs/tags/${version}";
+    hash = "sha256-X7CwJBrKHlU1jqMkt/7XEzaiwul1Yzkb/V64lXG4Aqo=";
   };
 
-  nativeCheckInputs = [ pytestCheckHook nose glibcLocales ];
+  postPatch = ''
+    substituteInPlace versioneer.py \
+      --replace-fail SafeConfigParser ConfigParser \
+      --replace-fail readfp read_file
+  '';
 
-  propagatedBuildInputs = [ numpy scipy matplotlib h5py ];
+  build-system = [ setuptools ];
 
-  disabledTests = [
-    # Assertion error
-    "test_message_to_parents"
+  dependencies = [
+    numpy
+    scipy
+    h5py
+    truncnorm
   ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "bayespy" ];
 

--- a/pkgs/development/python-modules/truncnorm/default.nix
+++ b/pkgs/development/python-modules/truncnorm/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  numpy,
+  scipy,
+}:
+
+buildPythonPackage rec {
+  pname = "truncnorm";
+  version = "0.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jluttine";
+    repo = "truncnorm";
+    rev = "refs/tags/${version}";
+    hash = "sha256-F+RBXN/pjxmHf26/Vxptz1NbF58eqU018l3zmepSoJk=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    numpy
+    scipy
+  ];
+
+  # No checks
+  doCheck = false;
+
+  pythonImportsCheck = [ "truncnorm" ];
+
+  meta = with lib; {
+    homepage = "https://pypi.org/project/truncnorm";
+    description = "Moments for doubly truncated multivariate normal distributions";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15426,6 +15426,8 @@ self: super: with self; {
 
   trueskill = callPackage ../development/python-modules/trueskill { };
 
+  truncnorm = callPackage ../development/python-modules/truncnorm { };
+
   trustme = callPackage ../development/python-modules/trustme { };
 
   truststore = callPackage ../development/python-modules/truststore { };


### PR DESCRIPTION
## Description of changes

ZHF: #309482

This package fixes the build of the `bayespy` package by adding the missing `truncnorm` dependency, which hasn't been packaged yet.

I used `pyproject = true` for both  packages.
I also opted to use the GitHub sources instead of the PyPi sources.

@jluttine, I added you as a maintainer for `truncnorm`, because you maintain the `bayespy` package both upstream and in nixpkgs. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
