### PR TITLE
firefox-unwrapped: 125.0.3 -> 126.0

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,1025 +1,1025 @@
 {
-  version = "125.0.3";
+  version = "126.0";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ach/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ach/firefox-126.0.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "1811a9f5618f725b80dbda41568985c051b987dca7c2e207a039668a0d48d42d";
+      sha256 = "dda46876fc45b17419fb3c06d09c3b36d0f7fc3ef8cb9dcdff7870ddc72a57e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/af/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/af/firefox-126.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "5cca7823582d1be336a25278d02bad75d77f37111b43b56e4168b61edab8986a";
+      sha256 = "b1821ce2bb2ce8cde7b688069a174e1fc857e79db03066301d39ee42d6791fe8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/an/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/an/firefox-126.0.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "d38de568b16d3553402dac58f11c494b0e093523d74c20fcaad172fd87d41ad3";
+      sha256 = "7600270871a1d5bcf5a255998a8c785dad2ca62cfcce2e2c808059b687825b4b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ar/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ar/firefox-126.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "9c643e7791c50c99a8e983e972ff721955af638c2d24a6421e82b0a7dd66f68d";
+      sha256 = "b1d3afe019fbe6a29a199a52cbfd727aa6d89a824a050d268d475e7357da65cb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ast/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ast/firefox-126.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "7cb20ed5898279ef7f96aa33ff931438b553f964d12d94ffaee1925b9523c8cc";
+      sha256 = "78495567e03154559d4d92cd655a5214d84cf5f3621c825fe54d83379d3f68b7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/az/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/az/firefox-126.0.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "1ae2d85a6bb4dbcefd0cd518af75614cce6af43c641c49dbfe7c4bacef6691d7";
+      sha256 = "085e8f9cad96ffcad9a2c1e25bbbf7f2388ed4a7e0210f3057ea240b99a4d7bd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/be/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/be/firefox-126.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "84d7aed6ac1f46390b378ce432ecc00723a70caf5b34e33adac9449fb704ebf9";
+      sha256 = "e58272a5f5b0afa919780d32061e593e22d7be9c7cf9e42b7361569d1ed60b3c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/bg/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/bg/firefox-126.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "9071fc64447f3772c88469385eef3fcc1f36188628c18b929ba1320b4bc01d1f";
+      sha256 = "1bec5b56518f07abf5f2b56b50e70bfa210a1a34075d65bfc089e37fd9f0023a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/bn/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/bn/firefox-126.0.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "c8ccaf292b17f5d89b9c7af28b79a5a9d5edc53d3a7cff92be8cfb5166481ba4";
+      sha256 = "09533d6cc055b802c3612b3a1c975e5f968f512b3d64e3dd13fbcf4b0ea2e1da";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/br/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/br/firefox-126.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "4cae7d705d2161603b35dcdfb2cd92c3a80922bba95bdc3f5945a59a1b19a011";
+      sha256 = "bfbd169cf9bd0f5ae7a070f8341beef5a03216a71e1bd75179057f2090ce1124";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/bs/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/bs/firefox-126.0.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "cb74e00873abd0466c97f500ff5de4ab914beb7e0714f8f07ad7f72eeb300013";
+      sha256 = "1bab87a8f437cb4e3aafe1b7c6ed9e18d01bedf6f4004faa6c40689c0280fd9c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ca-valencia/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ca-valencia/firefox-126.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "2995878a5d1b127fa68fdc196f74c4173b14d48e13bfeb28252515ace585ceb4";
+      sha256 = "cfe1a015695e451b423b1d2897a4a31780ae5e8ad9cef8f6f5c1d90fe1094447";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ca/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ca/firefox-126.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "47180f3814da29da56848baf7f050184face647f42f2e0b6dac9d9979979028d";
+      sha256 = "b2aa6766fc820cb43e4c885885c4f246aaa40db5b6b290801f318381e1a82f10";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/cak/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/cak/firefox-126.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "ab400636a09114d9b79a42a375aa2eefeef0e191aa69aa0ee12ee2caaf5e72f1";
+      sha256 = "26ab9b3720ad0f84a19619768a17637e9297731f3824a3f5c2662cdf0c8a62ee";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/cs/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/cs/firefox-126.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "5506a162fbde8afa5e255a657b87c840202d5d02784e6a78ac68c02a1affdbfd";
+      sha256 = "bf7d2029945d76e96aa173e2b3768cb7f744e003299858459f95df2b033f780d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/cy/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/cy/firefox-126.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "5dc8e2177e509c4f5d971b89c6b95b89a2d33d2bfdcc70533bc226d41d2b28cc";
+      sha256 = "b93d29f9bf112d4f9fd5522724aad6b9a2cd30c41da77d4a2eb3a0559f003a34";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/da/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/da/firefox-126.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "d8ca13cba46ddb0ba0f10d99ebac9f75da7e9ee5b3858b50315d0f3212d86ef0";
+      sha256 = "9f17d40911a779f6e5285d7afba95fe7072e5372929430e728aaf2714ff7004a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/de/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/de/firefox-126.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "74aec53ca8eccfa25fa1925a1d26323d481c7b0457fbde0be32eb4210e8daea9";
+      sha256 = "b15f91694b64048ee631d95ee90514cee174fb31cd1d3b3ac769294de933c250";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/dsb/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/dsb/firefox-126.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "f6725093e244d296bcb048998ed9bcb70dd58a9864e45f28bfa5cd833e265c1d";
+      sha256 = "5a1b033bd3166d61433af4026942e435a43c0443abb2b400a0a2f7e1b13063b7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/el/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/el/firefox-126.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "9cadc42340a199d5f5744d55dcd403584cf06e7853be6d6a030767ca5590a872";
+      sha256 = "18b897662c121c14fef38a5922cd8046a07b5755ccd6001d7ebe6c28a4383515";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/en-CA/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/en-CA/firefox-126.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "02e518fb52863d60edeb31e5b21e77eb15a153e7058d23757eb4c8902edc10e1";
+      sha256 = "20194008264b80bb71ccb30e983f3fd128a59f7653540414074e79e14e29d72a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/en-GB/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/en-GB/firefox-126.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "ea6539089c86b53df22c02179a8988a0ca66b854ceca5d2aa8ff6885d9bbc7b7";
+      sha256 = "16abfc46286ec9d376dba40551e48816aad8617fd8fd70a618cfe023b23f50fe";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/en-US/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/en-US/firefox-126.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "2fb91b8dd196a8ee47238d82d6b7afef3dd1bb3212b29122ab1c3897052d8a49";
+      sha256 = "f029b9dd18e1955fa1391cfaac2fdbe338343ddff59eeb1f4b2f509cc01b4584";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/eo/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/eo/firefox-126.0.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "3ffa103c2a31f729d7e38637762a8e8e9885fadd819afbe2448db795519ae239";
+      sha256 = "3f5f0e4af585b255749f991d6189d8b0f9b8a6c96df914966ed5b0ad9cce499e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/es-AR/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/es-AR/firefox-126.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "6f03108c3500c4328f074477bb6dbf303d9ec4c654afa7acc109407fe1682787";
+      sha256 = "37ce7d900ba92d66f0ea78e4cda3e43c577b6d2269eeaaafc91c458554455be2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/es-CL/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/es-CL/firefox-126.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "630476e38a0f9119f794933dea000c591687f13be94693917e457f8dfa8dca52";
+      sha256 = "8308744a0150013cb040a45b1de18199b9cb03eb3e69c81d85578ecd6a2d61fc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/es-ES/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/es-ES/firefox-126.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "87603bce7aac62d12725b922b74d6376365074c110dfaf01706dc0b31c05a9ff";
+      sha256 = "fc7045b3b5ad6a15164b6e9dba56ec89099d41faab870a9d6d40ccbb08ca1be8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/es-MX/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/es-MX/firefox-126.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "ddfa1aa04be68932659439d93bb61de2ab0542f04677808eaa91f12e6e72714a";
+      sha256 = "ddf2c17e4da881c8ed4e128911f0b02ac5bb95e8cc2d43ec02bb3c3a4451432f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/et/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/et/firefox-126.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "817596c186d4f8aaf51434b7abbe63b06256987b9187fc28cada01977574baa3";
+      sha256 = "92d94afe650e4d39c1a02f51b8bb9b2f0c796ab4bc75af7292f2605fd83f638b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/eu/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/eu/firefox-126.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "f49aa967f260c08f8af7da05d57580e4c0e0804cc36bf6f702bca849cf8754c2";
+      sha256 = "e7d6fd2e7eddb60691a3bf51986e9349f55d38aecc4470fefa3c9d98daa63c77";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/fa/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/fa/firefox-126.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "d770af123d38d3dec2d5a35537b0f4bed9d980be810f12e5036cf665e93dac56";
+      sha256 = "75a2a7736c10999ef86d7a42281aececd484291914cc7b1d41bdd1715514cc32";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ff/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ff/firefox-126.0.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "70f1e5026f00ecea44209a88239ba3ea68d5f10cccc8ed20cd4de2bd0194c7f2";
+      sha256 = "dbdf9ee4fd80778751bb8218ffcecc02dc2a38d0286e6f48e2435973f06b1bf2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/fi/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/fi/firefox-126.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "9ecc9c29c701d3b2e298e191cec6f1764168e6831c9fa9472a82d15b2b29a169";
+      sha256 = "538454759802c6ee105235234544b87a6380c846e96069f9d593b9cb8190afed";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/fr/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/fr/firefox-126.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "07d5f4dbba19bc643a995dc6cd06456cab9342ab2563c0274ac742d02c7aa674";
+      sha256 = "64d840787bd70d8bedae1c61a12ea0b577d4ae9f00d2e6e9ae1ee23e23433856";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/fur/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/fur/firefox-126.0.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "707d814ea0ea3a7c5c5455f678e496e4b0b14fcdd6872e81b5fc82241cb2b12f";
+      sha256 = "624cc6275197390b6d8f8ce95b4db83a7ead03c03e41148492adf83079458af3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/fy-NL/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/fy-NL/firefox-126.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "3fea1cf498eb47c4038b6a76a61e37d5d354f2457fc5a9198e5943df227aaa09";
+      sha256 = "22d4598ce65a777243cade386ba9507b34968b115cb308635392b08f6ac88330";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ga-IE/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ga-IE/firefox-126.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "8790df138ec92eb83891a7f5ae575c63e181041cb06a24789ec347411c948c40";
+      sha256 = "4c97fef0b3d97e663d6c55f81152c781616bf8e5842ae894800f8a1a0aab2147";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/gd/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/gd/firefox-126.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "b2de6dfb77b655befa785938da00cb71da490ca88fe01d568e86bd037faeabef";
+      sha256 = "49635b4d34bbb79980a63a47872006be8bc9d1f7e9b96e2bd8423b9b1e70752c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/gl/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/gl/firefox-126.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "15ac0bb2b9d61dcbb81243954123d79a0025d480fd66e1703ad1906c3ca09c28";
+      sha256 = "539323f69d7f5a54948553e532a749e4b1d2802dff8dbbc52dfa51d4a314ba27";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/gn/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/gn/firefox-126.0.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "5c6e43ab908a99692b9702531b8639d8f503d3396c51e4c3f8a12f5e143bed26";
+      sha256 = "123a34d0bc07276b2aabdc5a91dafdd422bfdc3f839a2b5d225e52f484a11193";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/gu-IN/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/gu-IN/firefox-126.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "0a140f0beb0112b88c058bd8d4d4fc8990c6146c60def24f4c15bb85daadd164";
+      sha256 = "50b578df5cc60410f2bda81ac95f67b4f507e03336a4c324e84d63ab68034326";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/he/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/he/firefox-126.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "ce9251aee641a5a4c1cd2a55ac8c7f8d33ea444a746ec5eb783b6d7a5ab4735a";
+      sha256 = "5d6e95ba7c93d723c8db7590ee14f8e0f6a97af151ee60264a9358bac980857d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/hi-IN/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/hi-IN/firefox-126.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "35a9d216fed5fddd71f1801b0a2a1178c8c646a4d879502d0f56daa2675deea4";
+      sha256 = "b8a6c4fe3e2b853cceabaae133194b807a55feb5c8dcb01b54d82691ae4af18e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/hr/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/hr/firefox-126.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "b7d62b7ba3261f76e1f6a8c9df79dbbb7a2e2c9efb56a4d30f6be1b37a6f1f1f";
+      sha256 = "e98d20183bbd3a361f7b182fdf823b4cd7b87a43ad0c4781aad4dd7bd47dc021";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/hsb/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/hsb/firefox-126.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "b6e5031ea996de5449c362d476afacbd7a7310f22cfc108dbab0e745897459c8";
+      sha256 = "e0f62a403877da98f6731f19024810285bcd11066f52b38db0d7150b8bd127e5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/hu/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/hu/firefox-126.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "fbc3cdadb14dd5755ad6e64dda7350df60f43c576dcba09ed082fabda2a5a130";
+      sha256 = "3d3adecc44d456dfee04a5bad74c84493267c91ae7526f8852c80b8db541b249";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/hy-AM/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/hy-AM/firefox-126.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "d37f52f64d3a56cf043ce1f198485228877419c4231a8b1816af7d2efb7c9156";
+      sha256 = "47aace044667c4c5341a871f2729192a0ebc1af50d84395e3363d235c53f0cf0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ia/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ia/firefox-126.0.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "1abb3b691d218da98df54b08228181d201ebcdd397b23bd438761c26e91d70b0";
+      sha256 = "dfe76f863d8d73eccefb29159796652314a1ede465b56e52f0da2cc5079effe4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/id/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/id/firefox-126.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "e003f96e908abb817efaa518ad4d4da3724077b0e478eec311b065f5a1ef6a26";
+      sha256 = "6b875b88e075db1f354365ff3523db837b0f25bc079bbae6aff4831dd694fd1a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/is/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/is/firefox-126.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "09ea5c1828d9bb6d9eb89cce854892ff5300641e3eec69bec251937d442caea6";
+      sha256 = "05ac5378b326dad5a2e37c52835a08061b83f204e0030e9ed00149d0fbf6b52f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/it/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/it/firefox-126.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "ab3e1df035e7198a70a6ad5dbcbf13915a5a98a554497438980a56adb550b45c";
+      sha256 = "c840cedbbfb49b54aae0e446a723e69a886adc36f6c6c251dc4039ace345af2a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ja/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ja/firefox-126.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "1d9cac5e97b86c76b908fef1c8f981476a054cfd6d365cf7d9d3a7cd2800d56f";
+      sha256 = "b8672862d851e4dac374a89d98a6e259786e4c6e00a292401b94e8d44891f6d1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ka/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ka/firefox-126.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "518b72d8e5188f01e0ea0eb90d4760b98b0dd7f1e74a0cde8e9809e25117d9f9";
+      sha256 = "1898dc72d9361c7d93cc86919d4b3c882853539535523f226d906b4a9268470d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/kab/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/kab/firefox-126.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "eac92cceaae9348cfae57ad891fae6827f25ec03df649e2d7a3c7186fcbab01d";
+      sha256 = "07a1f0630c4c1ecae65133523157cf1e38f5ea7db2cee73e11c846c21ac907d6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/kk/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/kk/firefox-126.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "c2dfc1d48cc5386c9925de7a33cf368b2040accea7dfcc67038d2394d828b3e4";
+      sha256 = "94f2b8c0ed553b85625dafd01b65b08eb0f306b7da07951ec008dea623ed55b3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/km/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/km/firefox-126.0.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "f032f51e6c6b655ac6ab7ed1605f701c99f71bc316d76f06c2fa6fb111c61276";
+      sha256 = "300b63d65dfadb49e4b4e5323a60156ea0da30fd09ad868ed8bab76b7ec66e9a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/kn/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/kn/firefox-126.0.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "8d47dd21f7968cd1151d25609fa2276cf3e9b8bc7cbfab307a2efa84f541e5ba";
+      sha256 = "663669b5480878205fbd7770734a25bc8370776238be318043731ee925c55da3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ko/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ko/firefox-126.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "de7b527a436ba0f27175ee7f8e6ed9238bbcb716ebb26f9b0c9cc5b30a3240eb";
+      sha256 = "2d3c1fb5925e719db9879c97017ba950c9d81f3131e2cbed468b092de51d23ba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/lij/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/lij/firefox-126.0.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "809675ae60d9885fe20e4053d0d0686cc6d22cb6fc6fbcbb76c76579e47d97f2";
+      sha256 = "0f63a277d9eb4a29113944e63cd666504b03f798b6bf9c41dc93e0a9d7450ec9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/lt/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/lt/firefox-126.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "cb512ed0fef4a1d544c4a74d81e6872091ccee8a2356c5c5f18d6edd1a601c06";
+      sha256 = "582d209cbc97a77c913dffe48ab927f5a1f743505ca68d0821db70ab64178ac2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/lv/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/lv/firefox-126.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "5d693ca8c453c37baa6a1c284041a380815e48f6e728b4ead06f6afcb27f0558";
+      sha256 = "94d7da74b9f2c8e236e312e97edc34a86ae77d83aa1f9eae311aba17c7af5156";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/mk/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/mk/firefox-126.0.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "352daa1a8995c40803bf34f1e00afa6ed95a2b98582992d1a34b0d6331e1c893";
+      sha256 = "ff7ace9f394694e83a76cb722fb75e210249ecdafc2ee237d86ccc7a99331c03";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/mr/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/mr/firefox-126.0.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "a5bb5ea7fc2a3f5f0f71f14cba8b594bff15da10a3a879fb14311ea25b12ccb3";
+      sha256 = "ff9d005ae4ac745b0affe51cadd040213579a1561970605e14b7e97c713b7a1e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ms/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ms/firefox-126.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "c544e324549f84337d9a7e0e863c1b0be6f3435d9cf890a6a73fff62ce9ab8ae";
+      sha256 = "a64e318bffab978f41d99320184edc406214a64d0ce3e43ab5ca79a9a803b8e2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/my/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/my/firefox-126.0.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "9de9d7f95e75f733666599de2b57b487ac3ca545487101ab3d097e85dd9f2daf";
+      sha256 = "3be1543f24f4a23a163524ff30b757741a6387bb807955f943d1b8cccddeb6ef";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/nb-NO/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/nb-NO/firefox-126.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "c1a5ce764dbb1f090c01330991af161745d4df945d51346a571f24dae6dc0353";
+      sha256 = "d1af51acaf3c8f0b7328ff3e62c31bbbd0951d1a3a82f74f2f81da4c30cb173f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ne-NP/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ne-NP/firefox-126.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "7c04f1b49e4d301533e1e15c08a88a768c536677a55f1d2cc9f4fa7d3bd1f26a";
+      sha256 = "1f1c957660b705293fbbfa824156710c8f90347ea042885053ec9a2060834f7a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/nl/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/nl/firefox-126.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "a81916a67375d43a2883111474858ca8aed787a12cee1d503fae5ec2413cc778";
+      sha256 = "2b6f54aeca9a689b7f405f66e267f21bbe195f7ed13185201020d529aae97fcc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/nn-NO/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/nn-NO/firefox-126.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "282e7e2dcd7d01c1bb8c3861511aaa989a1e23e79c7ad5958956a3725c595650";
+      sha256 = "1a3535a184ddadc86863848f9f603216c0401fafb939921acb865eb00631af19";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/oc/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/oc/firefox-126.0.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "aad97d4a4bb4229017ef8e84ce79597e5ffe0108c1898c4188ffc1baf2368bf6";
+      sha256 = "5845b3b682a780aeca38b03cad6c02a353de6b032baba5af3da7e514c41cefef";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/pa-IN/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/pa-IN/firefox-126.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "1ae4b77596984e0daf341ee562d78aa653914b8e20627dc568d86ec2bc87a7bb";
+      sha256 = "2568a37dc1cfe1e42d5c9dfae2dbe74cae1185abd35f9ee3977390eb80661bb9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/pl/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/pl/firefox-126.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "979b3892b3f7056ea173946e5950f71e0ea8a740f4016ae9aeb4a58edb0fb679";
+      sha256 = "c69112cdedc150908a0cac8a7f003bfc44dab14a8d32a31ace22748c391b7a84";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/pt-BR/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/pt-BR/firefox-126.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "7aa3b0e46f6c0c36443c61b43b15db420e509d6793f6ff63759ee0e9eed3d6c2";
+      sha256 = "b7369e99da8a96aed5018f5f4bd1acaa252d50629179b79a2b61929d71c1750d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/pt-PT/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/pt-PT/firefox-126.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "ecbeb1dc3292eeecdad0cd302b70445e9fa4fa6a6f9c83a698e5193f2f4c543e";
+      sha256 = "a2ddd2dc66e8dd6e8d7a628e090ec987a2060ccfe14015c91be2988244990b6e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/rm/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/rm/firefox-126.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "17dfd6e52f056481d4c5ef45ffae76a8005034fdcfdca046d12966b316852b91";
+      sha256 = "1edab3ce5b47dc44e2c83a7a2b0b0cee771e36018c98be540e20bd7cd5123b1d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ro/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ro/firefox-126.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "03e3bb8b8d6f6752aee13b445f79cbcb5999224359165deb565c00e79505aee7";
+      sha256 = "36abb93c19c2e629e37b73e807d1b6858a42877a035bb526eb2329bc6784fb39";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ru/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ru/firefox-126.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "b3f3bc5db58106f7ce085aa13422974ec2a77fc1289e6ccecce66731194b1885";
+      sha256 = "3aa49a597b80fff5fa963ac16f881aab2290ae938f721412dd42202947ad77f9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/sat/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/sat/firefox-126.0.tar.bz2";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "de73c27a3eddba12687edcc6cb18cd1e7d055eb0f19e13b019901a8e21ade74c";
+      sha256 = "828efcc83d23bcf9c31225155eaa65a6248448c21e57c9b2a71f54d75fd4a037";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/sc/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/sc/firefox-126.0.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "a5444d59372a88fc3fa7eef03d8ed5840b07b3cb5845ac96b2cbcab404cff35b";
+      sha256 = "255c7b998f797605daf9fb4bd4f6d29ac64ef40f270c7d615c695452d0d5f20b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/sco/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/sco/firefox-126.0.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "a4cab5bb51709ae5f3a6ac1b4c113dd9adcc973aee3bc480b763d89677b4b75c";
+      sha256 = "4892e68434fb5494d8f4e7eaa95f10ffd39f75e05bf4015ffb7c0ed0e895c8b7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/si/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/si/firefox-126.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "8d4b2d9d5de196db515c4852fe6bc0b866c7bdaae7f734053fd6f0fabaab8054";
+      sha256 = "28440c8658377ab98cb93de1db073d264fba046e390c433148abe11459a91652";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/sk/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/sk/firefox-126.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "58b4b780317ad6e88b824fc31fd1777425abc673ce76a578dbfbae3db1247599";
+      sha256 = "9029db81a8258fb7e352a29de9bd20ed793b579a569e8ed5fd06d0f25b122297";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/sl/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/sl/firefox-126.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "c6663467611b7b9bed4d3bb0bf70465ed7812038067a6d034f70ec59af3c937f";
+      sha256 = "9f6f60a27ea5c478ce0c1af7de426d0d55178c506c4abf9301b50534396e453d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/son/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/son/firefox-126.0.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "066b5c9ffd986a56460bba1021272a42b66e1c93f601664f8f6a0e939314f22f";
+      sha256 = "1e255b7fc86c5ef4d5b7b9871cc70cea6f93fe4ad74575e48786c57256f6dde8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/sq/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/sq/firefox-126.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "d9d696c0748b1cc3238c39cc3f7b69e6ef2970402d68494084e6897f947d1493";
+      sha256 = "dd918a5d4c1404b159698c8c0128ba6155a26addf52ab72372a523ec05d55354";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/sr/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/sr/firefox-126.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "73411b25f8abebd15a4e716c2ee3a861670df257d7b1497ccfbc92aa055b8af2";
+      sha256 = "fc58ba9e476b69db4a7500e599b4933379f0ae7ef2b494e4b2df8327a6fb39d7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/sv-SE/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/sv-SE/firefox-126.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "a877cf095668f7492a762d4fcebfe9ce154d0594e3a4a105d5c9046e1f9ee26c";
+      sha256 = "3c6d7d83a3d45eff199221157e0f91c2ad483ea281ce51e738603bea4d050713";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/szl/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/szl/firefox-126.0.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "45477dba947128e7e4902715ee1ac7898422c34551c308f6f2388df8bc3f8982";
+      sha256 = "42d650ee5043556620c34a4aafabd1075e4ccedcf044e059d382fa4e21708718";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ta/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ta/firefox-126.0.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "acb5eefe0aafcd146946ce390a9df077c477c029f0cfda6da3da00a3a6e844cd";
+      sha256 = "b095636c31b9d760713e04969abc45223ef79b255bbd1a27cdfdd20b5d2fd9ca";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/te/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/te/firefox-126.0.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "98e43739bbe0117a5b875d5e66863e76a45d45f8a9b7b7afdfcd9d858402c075";
+      sha256 = "55b14dcb7db3f3604d197de83cb87895c8a58d12db0f23e2023bae7a9f596a74";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/tg/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/tg/firefox-126.0.tar.bz2";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "8c6f9dce430b7207665cdfd442cbd1bdaa1978651e745eec3b77c8eb52963aa1";
+      sha256 = "b35e457267437963018eae1ed56f4c20af928c0a24053cd7c66e6e155c8f5e2b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/th/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/th/firefox-126.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "2a18d85e28fb7d415ab71f9a966b6799dd6c2fdeeff5f4b0e65dbea449a77fa2";
+      sha256 = "02d72cae8815ea2f9f0a01358ec131e28fb1cfb6568370f2151e64e8d919b4b7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/tl/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/tl/firefox-126.0.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "4517393fdbcba061dd7a667b92ba7b44e69ee73036ab36624e5681195a372a6b";
+      sha256 = "2004e3a1b985f73151e00f81d3d2700d7d8f6c6a8a25ef47f842a386309b9c20";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/tr/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/tr/firefox-126.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "5bff1a8d3044d5ce9195d5cd9aba3e02b21d4e23bf84870ac3b288777c5001c4";
+      sha256 = "d2fe1ea72bb321dc3e0bd3d5b6f2a44592f5286cb420d1707293f1210a3bb7c2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/trs/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/trs/firefox-126.0.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "8c75284765e4e4778a8dcba326369f7f8d62627bcf95f4384ab68b2339f245b9";
+      sha256 = "37cb52d3abaab1c1e6d285553c4a7dbd0c99c08713f88b6b693c5d0ddd63205a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/uk/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/uk/firefox-126.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "6ad348a509db7651e96ad6a4015dad3b7e4073d02a6936eac0b15aab9216feef";
+      sha256 = "9ba4b7ca7c3f545abde9ae835def611aaaf644257f7036d97c7945e6d1294bf3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/ur/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/ur/firefox-126.0.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "71714780ef8d0d7bd072744dc450f4d3db43e8eaca8df76ebf0471debe8fdbb6";
+      sha256 = "963abf5bc134585d9df57085da5d0b32b5e7e3437ddd31581d5ba86c9ae5d077";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/uz/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/uz/firefox-126.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "c8e095e7259f14c6b98a32fba83154c6f83b2dbe8e19f7876434b22d3529fe4e";
+      sha256 = "b52aac7d993ef57c055a48fb7658e86a120cd2f4edbc734f4c3d89e24a5beb4b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/vi/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/vi/firefox-126.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "82b8321d1e5d321f65ca1977a24d67b5663866c883fecae1553dc2d6a2b70304";
+      sha256 = "337cecc697dc0fdadede5a41a0c3c0fd259281ffdda6bd1903f1061f96e58a93";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/xh/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/xh/firefox-126.0.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "06a67bbcedf238921f3211b2d36ebe02ee123cac3cb90820fd06eba7316fdaab";
+      sha256 = "a41f854be36ef9d9cf0d8a229e1b088bf855b3d5ef417cb20cd9801631505403";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/zh-CN/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/zh-CN/firefox-126.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "074fadec864960fafa5aafb41f05e638a97b37c00a26e8f9e838357f484c523b";
+      sha256 = "0e1e754315f0919d78b0ad29e4374287ea3d397dc3ccee6bf835a027776fcdca";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-x86_64/zh-TW/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-x86_64/zh-TW/firefox-126.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "01cf02595225f172ab77ad12c3c7d61456703f3e80d88e38e4fbd5d047f2c0f3";
+      sha256 = "90d723ea118e1dbcf2dc6345131843df48059e90ca7e99061b91095a2e21b727";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ach/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ach/firefox-126.0.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "051c3f7ed00fd372275aea30306469f732aa7ec59fc08f98e04606d2cca1ae6d";
+      sha256 = "24da13a3aed6ffc2dc8c75e4e3d349cb419a2dadd6c689349a136d9ebda37a04";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/af/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/af/firefox-126.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "6d1ee2379de68187991326d0d89e13edd733424adab5a7d6cf5e9aaf3368feb1";
+      sha256 = "348bf05b0613ee0741318a27b2810c666a6525757846755f5296e1f69dc06131";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/an/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/an/firefox-126.0.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "0ecfa115508f05a7066be1927159faf3e02fe338df61d9c823a1936a56aabe95";
+      sha256 = "64d8665b8b2c2e9d9f475e546520c3a735fd647cdbf69fe605284f77e2e93b9c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ar/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ar/firefox-126.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "af4cb6ee6c7215be5e199d9ca64867484de7e693a013d9a33eb410e8d9feaa0a";
+      sha256 = "0e94cd589ae11ccfd2e575d420bbef5e451959beeee2118c2a205920d74b890a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ast/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ast/firefox-126.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "04647b722d70f11d32f6a49dc4fda2f57560c96c3a098680b8e1964324cd9a18";
+      sha256 = "d325eebe6c40cf958e5a4f40ae55b429536e4ecf4e00e7df2c16674b125067a6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/az/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/az/firefox-126.0.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "499cd8960c5e21956372fcdcdbba8ce59929fdf3c199c94b604be235834fec9d";
+      sha256 = "b8645cadd3b2b8dd790634ec8f16cc1ac478081dac234fa96eb83a7030ece589";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/be/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/be/firefox-126.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "215c1fda1f502d87c8685a8dfeb23d2b34b51c569de96cf52ba6a8179cdca4d5";
+      sha256 = "e36e2243c833441b614ce90fff63762572e98aeedb10b8bfad1dc5268c7c0448";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/bg/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/bg/firefox-126.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "d24acc50c74d070c9c3fcea8030914e08ec98f77a373f0c640f5c5644b52868e";
+      sha256 = "66c0ce40beb176ae4b167411708ed3a381408e04cf34b88010b7bd0b13950e95";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/bn/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/bn/firefox-126.0.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "c0f5570e5f05996e105485fa73580da3c4d3b7a0eb5db8cd1c6dd316b770d4f7";
+      sha256 = "1f6702ca2d492708a89450404a162a5b8131087552b539ee19e275336a556510";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/br/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/br/firefox-126.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "7adc8a1c0397bc7e3390a598bb064d6abb318a2689be7e99a90f31c3346f557e";
+      sha256 = "b0599dae8e8b9fcffea5afc113c954d46a78a81b2f6f9076256922a57b840df1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/bs/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/bs/firefox-126.0.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "43d74f20af450faa633216821af7c1d37bb1a1c6a6ceeb75a0474adbf9b015ce";
+      sha256 = "b893fd06193a43799959037b257d0079a58c7d823384d6f73668571655e7c5a5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ca-valencia/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ca-valencia/firefox-126.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "1416a98df2841c0e9d3a783fd236f8e8c7f3dc4e17fe027e4cf04b8b0bde187b";
+      sha256 = "3f8d3a6566b616ef7766bfe7a342b0a138bb4b5cffedaa65e0da03ae113c1bc7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ca/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ca/firefox-126.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "1c09a6d5ed0dfcae1d25fb9876c08663218f8a83bdc9f15ad52e39cd22428c5b";
+      sha256 = "4e4ab9b73d5f939f8bd824453e197e2e668518c99f41309970c5c7e4f582cb9e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/cak/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/cak/firefox-126.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "6fbec6115cccaca619389d68cb917c331faeb19ca165f5b9e5425b78ffabf0d9";
+      sha256 = "ef1b8a1f318fe3a49ec99f050d4417c5ecb2018788309d2bafe0582e9f0f67b2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/cs/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/cs/firefox-126.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "d1da5d44dd511d94341837c578eaa9d5aed5e2d63afc502b2b76b049d6110ece";
+      sha256 = "a87b9f9b3b028c15c1e1b37a15e6909f01e52f53f880c874d98ff762d8ff6dcf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/cy/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/cy/firefox-126.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "eddafcccca339deee2cd0e67885692217f7c49141ffc64ca1a998bb935d45636";
+      sha256 = "ff30ceff65bbca5abbbba22d7ec9723a368b3db62f7dac08f4ac9dd2c6505ce2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/da/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/da/firefox-126.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "d5a3a9ee1927f26b18ccf696aee7ebde30dd3ba439c9a376b4a6072d04756ca2";
+      sha256 = "426a00ba520924c5ed011b0f046f5e21a9abeb8db1f1015d5efecc47708c39d7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/de/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/de/firefox-126.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "2d61def83c8a52b94828b14c2c8697c1b77106a4c16a7df1e9e258212d23b583";
+      sha256 = "c7db7cad161da5c28ed40f4aeb37f786712516cc2697dd8cb505cb2be14ebbcf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/dsb/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/dsb/firefox-126.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "09f25336d1a46ec5cae5301d35e0573b205ccb3e1482c79b2f76db02045a9d18";
+      sha256 = "ab530f570d5cb46ea1cd451365fa60b4a1872e14754363bd22f95daf85a479c2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/el/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/el/firefox-126.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "4e055eda0cbc2d8c71ce472982b26ef0c0ebc20f72dbd0a1d6b4f0d50a4966df";
+      sha256 = "89f0429e7a8985e65ba320094e1b2e9b1ed5cb38df609aa23cca7c900a0b671c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/en-CA/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/en-CA/firefox-126.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "5ab7b3ac4d84e949c47da2d3a77708847fe73214bd641562017359f71e254dc3";
+      sha256 = "d0c8d0cfe91f897bba6502bc7fbe385880db6e0af6fc93db8702aeb0eb09660a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/en-GB/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/en-GB/firefox-126.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "dc793c9a3161974ed1120572d6b65d3ca5a5d8947e53cf1d31da33d4bba6ca82";
+      sha256 = "7a560bc7591e436bac570a287c4a18b8e8978eb48b022c2e21e74957e85ecc6a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/en-US/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/en-US/firefox-126.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "1a7a16c2e75bfbd0e318095c259ab63fa0c097005b872d93885539c9f186ef80";
+      sha256 = "3d49a8a3655d8502f7538f67973a6d7099bf4f2579f4519a48177ced50795ccc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/eo/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/eo/firefox-126.0.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "bc78e75ccaa66dea4f2b8585dd2ec8217ac065058defcb991dc6628acb16c3cb";
+      sha256 = "67c107f8a0d98a932e25de900f934c2e377dd3edbf1b8cc5554f13271d89a8aa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/es-AR/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/es-AR/firefox-126.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "da954c777d0441c30c6b292ebf8fe316e7b52d75a76602bf6502ba4677c1cb64";
+      sha256 = "6c8e6be51abf98ea214983232077947a7ae80dce47c92aa651664c43fc2b6e71";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/es-CL/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/es-CL/firefox-126.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "c4282cba4b588da12708921ed5c3998f24d4d81790a677090c38529c297867bb";
+      sha256 = "2296eb97d6990dbb9ac1a4a2a66e8398ad2f36d54cc7bcb5b686f72cf7ebcf83";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/es-ES/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/es-ES/firefox-126.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "15a1fed207e2c14e962c4e2eb8abe3cbc62d0621656b254675befe3d974d3cb5";
+      sha256 = "7122c71207f430b0a4a4f802220ce569f820f0461e2f92dd14b9b868cfa4bf56";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/es-MX/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/es-MX/firefox-126.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "a962e53d6902ec7017ca3a8521c6b5730e7a7ae5244356c4d6d9117e50b37ebd";
+      sha256 = "ee3bf12d3230c287f934db6e5368d90651c976a4c8177dc1e8dd134f587e42a4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/et/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/et/firefox-126.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "9e58939f49650dcf0f0267d586919a3144eeec53ae58ef548613311bde905eb5";
+      sha256 = "4297a9954af8145e8f938dd236dd8ebec126edda142a6dd73e94f70a0375de3b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/eu/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/eu/firefox-126.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "b5427601b225370def60f93e2f8cefe9600898183f0c184487bd95f8f86d2894";
+      sha256 = "41a02f5f530e9e625524a1f370856621c9cc0e04324ef301f889454c251824c2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/fa/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/fa/firefox-126.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "38fb2703b0e7fa9788aaa42dd1a89eadf616924c116f1b67b07f3d5df0963962";
+      sha256 = "36d5a5d3d616e184b29227403e333d0f3dcf6ff226bdc1c022ccdcb432fcac2a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ff/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ff/firefox-126.0.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "a7b764758d16c901511062065eaa6e16414d777d8eea315424f19eecf54ef5e0";
+      sha256 = "4dc033065adaa117a44366f9ea31c657d2f236e553fa925e0b4fb9622e092b0a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/fi/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/fi/firefox-126.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "153ce3d7f4ced7a280bbb5bd539913a55f6c0790fe756e8b5335539ac651f7e0";
+      sha256 = "03adea0ca2fe7e8408d81fa9105226d113bd66bb75be5b18c3eb640f71807c82";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/fr/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/fr/firefox-126.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "b5aa0cff2a5493bbb816ae12f43ff79354a4946c1649173de767b1cf543a427e";
+      sha256 = "bea2e88d69f51ade377594ae02ad9751db7d1d886bce28b218715299e210dc5c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/fur/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/fur/firefox-126.0.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "d4884765fa3c28e7236a6624aaff5f874c4a155b26d0b70d481109fea5159c84";
+      sha256 = "7eaff23205978990eea395299d1fc9609b8bd6ac15c87a13df83abd14d76f88a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/fy-NL/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/fy-NL/firefox-126.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "49ebbe560e1960d34a2ab3258c05913ccc1d5bb60b3644dce6f4370733d7a59b";
+      sha256 = "baf7d3fe44f6d0b3e334365b44327b2c8225d94010f2238477ce2db66a31dceb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ga-IE/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ga-IE/firefox-126.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "13d06ed7c8c73ecdeeb071a02d7aab98796927812127527be5f3b5fbcd9ea487";
+      sha256 = "bdf605c386888ea39e244501e885ac5f51513093e33c3038c5d87ec2f742c49d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/gd/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/gd/firefox-126.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "2435d0910e347581e1ff60217fd517b78e0464adc0d2b35b803bf8f83bf6d993";
+      sha256 = "662eae8fb0d725472d3de3b00a95b26210a0b66de584184bbf2475f85d54332c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/gl/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/gl/firefox-126.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "cac5e02326f5ccdfb88e9cc1bdecc1060585b3274028f9050422834ea5559ede";
+      sha256 = "2e33e5f0e6d6e7224b85dfa1d55cb648ee35d85b5a12bb06a8a442a4e71fac8b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/gn/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/gn/firefox-126.0.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "addcb8beed0a341c6eafc4894d11a6b3e8ff9c69c60442d674cac5dfa4552eb4";
+      sha256 = "e306c867a303068a203df7f157426f376db22e40bdef19913e460c5ddfb6016a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/gu-IN/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/gu-IN/firefox-126.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "2342dc7b3996019edf66375533e5dd46e94db1cb7e37635002f3f7826c7b35cf";
+      sha256 = "22fac69fc82f18b5927460c8fd438c9d964329a39538cce9c3cc944022873808";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/he/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/he/firefox-126.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "a6026c597c8f917006893da69998586b704b5ea89687a5a4f57f4fd1c6060c22";
+      sha256 = "d448d9d47536b765193aa9e0132a0a2dd6cda3a5812cce11a7538abd4fdfdd07";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/hi-IN/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/hi-IN/firefox-126.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "12d8bc4072ce6118f50aea48f1d0cf19ac2cde7a43b169dce92088058ee135c8";
+      sha256 = "c668f9bf4e3901d7d6eafbb29d6971d8f28dca0b327d7ae6d31eb337446edb15";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/hr/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/hr/firefox-126.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "fa93237908e0a30fd911a2208cb1734d0480e9514877625fc7bb8a0a4f5eda89";
+      sha256 = "d7834cb0075cef6545dc8e4894e734e83e4c258ae34ecdec570959a11d121b95";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/hsb/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/hsb/firefox-126.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "4936df4e7258830565e0718fe89375c8876d5318d65e92995a104498a0353846";
+      sha256 = "edc6ab5329bf6242ed178d4a8cf908f83c34036b7a44d223a2389ce1b94f75b9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/hu/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/hu/firefox-126.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "2e87fc4c2965f25a0826348b1bb8296bb037c9213cfa4a7d86e65421b36c4527";
+      sha256 = "3552897a8e67dbca66ad8fab1da93111b74e97d2e073b901f89e040458b6a1e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/hy-AM/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/hy-AM/firefox-126.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "8a7660e5a5f5755daab77fe4bea805bef9124b3d7e1ede72f3f2b3ca0094b5db";
+      sha256 = "e9280a2dbafea3ffd999d06640800c8be1d4d49bb417c4c22c98df62efaaaa27";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ia/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ia/firefox-126.0.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "883a6bae7c4e2f72cb4bb1bee676058e9093d7069bccad29fab329d873d68075";
+      sha256 = "ae4f4754f9a839359cd9ddd1103e5f6c13b836b8d605f87c7c9ec50195397958";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/id/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/id/firefox-126.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "0a2de5d0a841481f351d2f4e26fb4cf56592d580075b5ff08054b661e17bbacf";
+      sha256 = "6b620340c38277530507c3c163bcd194d3984fc42bce73a20118acf9e1d24104";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/is/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/is/firefox-126.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "33376b28936467ff5c3fff5898ae1eeee882dd15d34d8d42b9010981cd27d53b";
+      sha256 = "72e4a73a842f03d8487907a8af71e4f40c6655dd78c38600e80b90857aa1c01c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/it/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/it/firefox-126.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "37cc5b95d46d637633d7c368350683ab2e63871e7b8f574bb50cadec80adc558";
+      sha256 = "316f3475bec0daee2646af4bbc73b7bb1122644a3165b7f0a332af16369b6c6d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ja/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ja/firefox-126.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "4feb22e07f2a536bf18c5cd9dd82a1b60e9d846f81d08326b119b19212088ba9";
+      sha256 = "ce4db4762e09619353bcb80f1281fe75faa216a6995f8d0ecc369c2e988340ec";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ka/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ka/firefox-126.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "e786417de882825c05b8385855eee0580cad0f64a14eec53966d90108c42d524";
+      sha256 = "47e20bd8415b81a47788aa224e2eaf7086a96d6d586eef9b21c0c1a8e59dc172";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/kab/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/kab/firefox-126.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "b58f6d29cb6ebac1407cf46bce238f80f56c60e4b400fc6beb9fefdaff19aede";
+      sha256 = "81036648ee991ddc851a70a9242b567159324b13809d04735f11c81e1dc8f3ae";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/kk/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/kk/firefox-126.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "8d868c1553a1c8708f166d6b99cf0fede333366994c46d490014cf15330046e4";
+      sha256 = "86d928d9e42569fbc2862d6e14150da4ef35243016753b3d982fbba5bb6baa2b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/km/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/km/firefox-126.0.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "deafa1829c27ed270718effd342cd9bc26453e5e6f64cdd7c83f0a86dec3533a";
+      sha256 = "16b24d02899cd2bd1a7958b8b0f56bdd231ceb4c3c0c987e19d219d93af29435";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/kn/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/kn/firefox-126.0.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "9a19b06844c60e9d4d6348c6b207273378228a59f1a831c9eb99e1073eba2a16";
+      sha256 = "4cc091be288f7704f4c270bf982ac9f2f309979c92c435afe36fac6af1951d03";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ko/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ko/firefox-126.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "bf79f74b659344291a745fa62aa726401f8c84369a96c0a13eb66be9bff2368d";
+      sha256 = "bc81fbde00f8f47e58bd1ca871ec9dee8bc6763df67f5f32b70af31007369a79";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/lij/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/lij/firefox-126.0.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "41c8b57d4426251b33c7d528cb23e635b22d3b81c4188c6844a39e87800fb9bf";
+      sha256 = "9d3aa0c4fc3e14b0fe5180d372b374a83fb375d859ffd55d1be369ed0b5bffdb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/lt/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/lt/firefox-126.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "34c57fa25ef83b9f6747e61eaeb4a98b312ffda9bcfdfb761392c94565e41348";
+      sha256 = "07318635215f2c399e5cc9178f181b36a0884e6e96e2059e4a5b88bf0b6c2051";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/lv/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/lv/firefox-126.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "173afd7c09962de9af491917b7c14d245e02e6c109f69b9b7330466515dd1549";
+      sha256 = "a2467dce574e6bb646d0531c59fe22f49178994b3b204f11c607c6ce709c6cf4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/mk/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/mk/firefox-126.0.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "b2ace494099bffc7d70d074197d1e4b0a9a387e553e4fffb31efce7d5f89053d";
+      sha256 = "3f13386ac308a6f2572931501cf6322592ead6705ee8a420249f0030e284404d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/mr/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/mr/firefox-126.0.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "1d4075ee01d742d9d846a9cce63847baf5ad749d260e7d2018391719e3478200";
+      sha256 = "b57bd92eabd3820d5be7d660eb774c210781a89f20d9e48a5739ad16af723cca";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ms/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ms/firefox-126.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "aa9012aa1dab8a1da2b4d21743fb01e2cae1322873cd67113f0d3298cc7b62e6";
+      sha256 = "704232123025b3ad2cedb0eadb8edaace22c01d3c62fbd3b27e5c9d2495c9530";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/my/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/my/firefox-126.0.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "a52f0bddf09a9381616ee91246a2bbf02112bbe7d8e651a75bf71bb4ff0a55ff";
+      sha256 = "c07bbe85128366dd95ecae97ab00821b5be4c39442428e483c3cb434e536e790";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/nb-NO/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/nb-NO/firefox-126.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "9c221603c7cbe51e53e03bceb2bfa64b51bda3935f8d59f995270297dfe435b5";
+      sha256 = "c079d995c6bc2e5be20ebb4ed1ca76179bce17c4eaa4e47c39ba67ec50db0268";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ne-NP/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ne-NP/firefox-126.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "026fa9b87a1fb8cfc347aee7edd09cf07433d2febb6bc7284c90942aeea886cb";
+      sha256 = "a8f3ae15f481e2a2faa41330571a30464e38e070ef27ee18bffd27628f5c05a3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/nl/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/nl/firefox-126.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "5454546bf2eea2e8785ec994302e9d8d9f3468a89cc5be1eaf491132f8449deb";
+      sha256 = "d0a70bd54c185f6edc93a6dd1c93b28fceb6c9a1af3e91cb78b131fb69d05023";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/nn-NO/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/nn-NO/firefox-126.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "a71e340f55985cf76a5e768ee63c5d9fe5f5a68334642f34062324211cc48b2d";
+      sha256 = "05eeb23cc7154dc3dfbf99493bab95739f36eb52e2129b70a0cc32b4c2d67f7b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/oc/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/oc/firefox-126.0.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "441a44314d02b9e54e86b0fa1b8049ceaad7bab7b66e54c0a841f8d624ce76aa";
+      sha256 = "80e59358349d1aea78f12b67674faf8f5fb6d23bba27cf9eb49ed55bf57e331b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/pa-IN/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/pa-IN/firefox-126.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "b72d31b37d4f6d7798e96c6685512814c991a987253767aad79cf515012b057f";
+      sha256 = "f3e2b5c2c044f74910b14e2a6594c5c0a91b1b0e19b8d18e557ba9b1643c906b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/pl/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/pl/firefox-126.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "1ae017de12a7faf49b06c9c4bab7e20e776e5fad1430fb0e7f9af519739659cc";
+      sha256 = "8730e394f6362c9f2118f90c8f32a490e4c2b7fc4da55db0c5901e4e31a17a9c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/pt-BR/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/pt-BR/firefox-126.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "6a5f5afb1b3e4f71dffa20ed5ebd3037b63bf127cf9daf09291bf62d9e8a093d";
+      sha256 = "82aae4a9eecba2ac0c2860019f80b44a70b53290476113ce66a595f4d58f767c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/pt-PT/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/pt-PT/firefox-126.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "64763768287dd897705be573e01a61c06c916bd413f8d6a1fd47a64f0d918c09";
+      sha256 = "92eefc83ed6c748bdec86441423bd33061278a98b764d5ef28c4eaf7a9256efb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/rm/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/rm/firefox-126.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "4ef4a5c3180e3432f7b9380deb84df9f816eaf4ca333c93cfce8e0a52a1cd39b";
+      sha256 = "71cda80240bd2ba45b7d66ac7a31a06e5a2132285cd3148aeaed39953feb2721";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ro/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ro/firefox-126.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "a89a97ae37721ea57f0e087c430dea88ffdb43b1a4b823cd9fff6e40faa46d81";
+      sha256 = "8e9268fa43b051519eab3212d90feabe74f50b4f3536fba436f4fc0824df6be5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ru/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ru/firefox-126.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "93dfb081232b4af62d9cd4826501832dcd90f1a91dbafa9efa5be2a094eb2df7";
+      sha256 = "10e846b452a32a9e14568dbd9f0d00471a09045eee5b0fc265752ac52ee52681";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/sat/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/sat/firefox-126.0.tar.bz2";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "33292fec9a1ac64f7e0b18758de38af19a19d9dbc437e8fce7f8fa20bf58da98";
+      sha256 = "fa83bd09a708f8a2aee2e22260fb79606a1d045d8330af3eecc69cb33475f17d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/sc/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/sc/firefox-126.0.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "368600cf67e645dc9eed1835ead1eeebda974b1fc2ff5ca8ce3a65047da402f5";
+      sha256 = "59d1738d837c612f9738dae172197052817890d9640dddbcacb732cff837f88c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/sco/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/sco/firefox-126.0.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "20db2d38c151893b43727af5016b7f48684aeac4e66386a99cdb7f640678970f";
+      sha256 = "615cb45683769a02a78cc5158b423e5449977aa325ae0553ae3c1b91097643b4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/si/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/si/firefox-126.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "56f3baecb795a6f99f52ac4749d9b7e69222f43a847fa5e26363a656fdfad8e0";
+      sha256 = "978b8a33535d159848db81e8d67ea96bcc804917be437c123cd7d72eef644436";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/sk/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/sk/firefox-126.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "7c7c25a7426b1f3b98d5aa86433237bb4e7d9f4d4c74d3302966783985a6a067";
+      sha256 = "09c76c363fed0b85c603cb6a038863aecc6ec8bd9b6536c5fe46178e94148c82";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/sl/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/sl/firefox-126.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "43d59e1d98e772336eafd0a2d9eeb5ddb17ffe2e21b41ec8501d5f92d01e33bf";
+      sha256 = "9c7e786634ae4de0d1745f302dc8b1bb7f02d25cbdbe0aefd07cd4e387042b03";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/son/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/son/firefox-126.0.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "561fb6ac615a92d24229f33be1bec0c40c593eb46bdd8c5b0f916ce72c7ae0c7";
+      sha256 = "9049588a9910c85767e4c501d0361be434f678b7390395dd7ed89b3d6127da04";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/sq/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/sq/firefox-126.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "b58d25f1a89ffda900b77bda85b8a0b4013009d07756f1e80c2f464b4f00e9dc";
+      sha256 = "73637bf2473d33658fb2650129cfd321e07912ab4396e4fe3b2b96f1c5a2f7d3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/sr/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/sr/firefox-126.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "6efb25e0762457b7738ce878830a236543d8ac3e27eb26fd92038f83031980ad";
+      sha256 = "6ef94639d56fe3542c0df18b0fcd54284b102aaf769949f252f09471c7c5b9cb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/sv-SE/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/sv-SE/firefox-126.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "01e408103e812278d0c81b3acef7045636d64999237dfeb74024e63f640084aa";
+      sha256 = "cb6e649a40b53ecaf7460ab1527f37ea69250c7cbae4441aa839b857a858608d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/szl/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/szl/firefox-126.0.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "940138fe1ec2f707f153147db6b6e5eca9dce191ae8765a52662cc89d9e18fe1";
+      sha256 = "2fccc546c7fdaa965902618eed57a2a18cea2091130950c483f1b982f972d438";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ta/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ta/firefox-126.0.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "d90039aef7fc7e56e948d4af079f3edef5b65588ad5fd650cb70f59188c758fd";
+      sha256 = "52bc70dd238c6b099549b5e704ef12e7655cee23ac577671d27685c479c4045f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/te/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/te/firefox-126.0.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "1ad8d8e42c691566cf1d082464f5c32e8ecef628182ff4dbebb4482e2eb33465";
+      sha256 = "f819512f4f0428f732115c1587aa876a7374564b606e9581c3d405c9273a8d16";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/tg/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/tg/firefox-126.0.tar.bz2";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "4c6974fcdc6d55662073b259b4891472eae22f79aa718ba6f13e73e54f97ca42";
+      sha256 = "278142e32bd078092e69dac8ce8b1d5d88d1d7adc13abf681d6d53c5d97a8784";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/th/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/th/firefox-126.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "6725c41f5465bf1a1731154654bd6e0a8aa9b5175e1e7f64ae719e8b1fed0057";
+      sha256 = "8443f0793f817568b002aeb436423793108594e2cc43da929ec48079e0fcfd5f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/tl/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/tl/firefox-126.0.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "6e7dee9256a30aec0c7fa67cff5d3b295bd45f417a0d02f34cdafd2fabffa6b1";
+      sha256 = "d03a4714b86f5f0dfffb1b4780b09862653266eb3736a7b0630784bd3a6c739f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/tr/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/tr/firefox-126.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "fc1f91da8f5b30301a0f3238b6dde5e0accd314f6fe43d18715b786a2917d8e6";
+      sha256 = "1f87ae9443c4fa9a8d4616e2de1fb799c0fa1b95b37070e669db475f5de9be28";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/trs/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/trs/firefox-126.0.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "ab8cf88696df73b802f6dd6f42c33172c35685af462e92e2fd161ed3307c5fae";
+      sha256 = "b9f8c5a2ecd83b4bdd6f5e26037f8aff0d9b2ba7abcae08b7868c15ddcc38def";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/uk/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/uk/firefox-126.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "40fd34bcbef5937190065db1769227ae05fe29d7df65cab96b4b47b68acfd0f2";
+      sha256 = "566d6daca65e49cb8280dd64716e7ba3b9f00baa995ddfe31f847166ef70eb2f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/ur/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/ur/firefox-126.0.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "360c8abcfc50fa78f1115973f152785ee52f1ab9a8e512183df7e7f6f9099ae9";
+      sha256 = "530b7cd6338c09f1c92cf7eb8f0e5fa150d4477913f14257a18567e325d8c64e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/uz/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/uz/firefox-126.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "ac301677aa02e5e8f4ebbf382b511b9a7ee07036e7f74726ec23dfae2b82614f";
+      sha256 = "b525c6a6ec58ded4b637299832b3f1542d1f17958bc2f9074e05d1e96303d4cd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/vi/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/vi/firefox-126.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "78964ade29f3d8c3d664be9a634ab6f2e7c33100d08936de4b813b7718946d39";
+      sha256 = "dbeebc029258ffc4678ae05aeca5cf43e634413862deb2b10d21fcd96039ca7a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/xh/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/xh/firefox-126.0.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "3692b2d980105d1d1640c0dfaec52df29cc5c5b3868250aee6c011d9e3a95963";
+      sha256 = "05029e34aa21b1b1ee1a02ca13afdc2764cb0757fdaa533a8fdbc633d6bd11ba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/zh-CN/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/zh-CN/firefox-126.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "b9c137726f279abef9f86e8f2889465d1f9f2bfd34cb7008471a5c7e5222fd78";
+      sha256 = "c528f20f5ff5ac5353997f474ff88fb17834e6c913b1e2bf2af9fdaf837bc031";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/125.0.3/linux-i686/zh-TW/firefox-125.0.3.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/126.0/linux-i686/zh-TW/firefox-126.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "a7cd7f510e92be7608a405ee7048becf1e2866dc0153434e465fa3f381921ad1";
+      sha256 = "03edbb562a60417320469ae06a632ec6c302d420a6565f2a25acb3e3b4e7e61d";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -3,10 +3,10 @@
 {
   firefox = buildMozillaMach rec {
     pname = "firefox";
-    version = "125.0.3";
+    version = "126.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "18e705a3093290311ccb5f27f01e43fe243ece94c1769a9ccc4fa53d370e32a1ec6a107cdeb531e9468b9aca1a1fe668161adb7acc1ec65fd383837882c7d484";
+      sha512 = "56025b051d544ca294911a1d6a66f09945f71012131881b64313dafb579730810a4b091950c90a21d4fd3f393ba23670d8409086e1677d80d0bbbe347c303527";
     };
 
     extraPatches = [

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -94,11 +94,11 @@
 
   firefox-esr-115 = buildMozillaMach rec {
     pname = "firefox-esr-115";
-    version = "115.10.0esr";
+    version = "115.11.0esr";
     applicationName = "Mozilla Firefox ESR";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "0626e2c68ce43f24dfc2b9216e2565537ad8781daf4195d53420e1b78d57d0f6360fbe56b0ddbedae3818546c72472c85c1ff2b208c123d32a0543e666f42b65";
+      sha512 = "0f3a87c99fb008088afd509d9259f893fdd44ea6bf6a5e69806fefb8d355415e81b9e8832a392acb9d0c1c50e4add7f1362a4aaadc35e1d9c2e55baf7136aed8";
     };
 
     meta = {


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/126.0/releasenotes/
https://www.mozilla.org/en-US/firefox/115.11.0/releasenotes/

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
