### PR TITLE
bash-kernel: fix and add smoke test

### DIFF
--- a/pkgs/development/python-modules/bash-kernel/test.ipynb
+++ b/pkgs/development/python-modules/bash-kernel/test.ipynb
@@ -1,0 +1,26 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "echo hi"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernel_info": {
+      "display_name": "Unknown",
+      "name": "bash"
+    },
+    "language_info": {
+      "file_extension": ".ipynb",
+      "name": "bash",
+      "version": "5.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}


### PR DESCRIPTION
## Description of changes

The `bash-kernel` in Nixpkgs is currently broken due to https://github.com/takluyver/bash_kernel/issues/142.

The underlying issue is that `bash-kernel` uses invisible characters in its prompt, which are currently not being output.

This PR fixes it by using `bashInteractive` instead of `bash`.  I don't totally understand why this fix works--AFAICT, the main difference between the two is that `bashInteractive` has the `readline` library included. In any case, using `bashInteractive` is probably closer to how most people use `bash-kernel`, as it just runs whatever `bash` is on the PATH.

This PR also adds a smoke test, in the form of a test notebook that gets evaluated by Papermill. If this succeeds, we know basic kernel evaluation works.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

CC @zimbatm @teto 