### PR TITLE
bun: 1.1.7 -> 1.1.8

### DIFF
--- a/pkgs/development/web/bun/default.nix
+++ b/pkgs/development/web/bun/default.nix
@@ -12,7 +12,7 @@
 }:
 
 stdenvNoCC.mkDerivation rec {
-  version = "1.1.7";
+  version = "1.1.8";
   pname = "bun";
 
   src = passthru.sources.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
@@ -51,19 +51,19 @@ stdenvNoCC.mkDerivation rec {
     sources = {
       "aarch64-darwin" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-darwin-aarch64.zip";
-        hash = "sha256-VDS01LVpTMl033tyUDk+efi0ShUyAXnZGrt33Nx2Qfg=";
+        hash = "sha256-n5ElTDuD0fap+llzrXN7de937jYaAG8dpJlKUB0npT4=";
       };
       "aarch64-linux" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-aarch64.zip";
-        hash = "sha256-lvm3jmlY6QkLJVFtWea3h7hARU1DEkunBQniPw563H4=";
+        hash = "sha256-4/kEyaF2kmu8MAjlrPgBqKFDId8bBibu3Zll3b0w8Ro=";
       };
       "x86_64-darwin" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-darwin-x64.zip";
-        hash = "sha256-3Kn4U0iX0RfNY/j919QjzRasmvF6A3elkmvrg9mMe7A=";
+        hash = "sha256-btyslaKqdk86whAnQV0on7NWTBTRTegFvMsOl0YyloY=";
       };
       "x86_64-linux" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
-        hash = "sha256-J6eVZ6SVOj/9ZU3e2kEKZAnU63RKTLf7ef3V7nJqopA=";
+        hash = "sha256-JuDT+8FHbamdMVCDeSTGPYOvhPY2EZ9XeD2zjHEj36Y=";
       };
     };
     updateScript = writeShellScript "update-bun" ''


### PR DESCRIPTION
meta.description for bun is: Incredibly fast JavaScript runtime, bundler, transpiler and package manager – all in one

meta.homepage for bun is: https://bun.sh

meta.changelog for bun is: https://bun.sh/blog/bun-v1.1.8


###### Updates performed
- Ran passthru.UpdateScript

###### To inspect upstream changes



- [Compare changes on GitHub](https://github.com/oven-sh/bun/compare/bun-v1.1.7...bun-v1.1.8)

###### Impact

<b>Checks done</b>

---

- built on NixOS
- The tests defined in `passthru.tests`, if any, passed
- found 1.1.8 with grep in /nix/store/ckwisxpv8d8mxpnyga9653wssjk5j8ss-bun-1.1.8
- found 1.1.8 in filename of file in /nix/store/ckwisxpv8d8mxpnyga9653wssjk5j8ss-bun-1.1.8

---

<details>
<summary>
<b>Rebuild report</b> (if merged into master) (click to expand)
</summary>

```
1 total rebuild path(s)

1 package rebuild(s)

First fifty rebuilds by attrpath
bun
```

</details>

<details>
<summary>
<b>Instructions to test this update</b> (click to expand)
</summary>

---

Build yourself:
```
nix-build -A bun https://github.com/r-ryantm/nixpkgs/archive/cb854ab475b28005ac59bbd6fe415f8253ac0b08.tar.gz
```
Or:
```
nix build github:r-ryantm/nixpkgs/cb854ab475b28005ac59bbd6fe415f8253ac0b08#bun
```

After you've downloaded or built it, look at the files and if there are any, run the binaries:
```
ls -la /nix/store/ckwisxpv8d8mxpnyga9653wssjk5j8ss-bun-1.1.8
ls -la /nix/store/ckwisxpv8d8mxpnyga9653wssjk5j8ss-bun-1.1.8/bin
```

---

</details>
<br/>



### Pre-merge build results

We have automatically built all packages that will get rebuilt due to
this change.

This gives evidence on whether the upgrade will break dependent packages.
Note sometimes packages show up as _failed to build_ independent of the
change, simply because they are already broken on the target branch.

Result of `nixpkgs-review --extra-nixpkgs-config '{ allowInsecurePredicate = x: true; }'` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>bun</li>
    <li>helix-gpt</li>
  </ul>
</details>

---

###### Maintainer pings

cc @DAlperin @06kellyjac @thilobillerbeck @cdmistman @coffee-is-power for [testing](https://github.com/ryantm/nixpkgs-update/blob/main/doc/nixpkgs-maintainer-faq.md#r-ryantm-opened-a-pr-for-my-package-what-do-i-do).