### PR TITLE
bcc/bpftrace: use default llvmPackages

### DIFF
--- a/pkgs/by-name/bc/bcc/package.nix
+++ b/pkgs/by-name/bc/bcc/package.nix
@@ -118,5 +118,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage    = "https://iovisor.github.io/bcc/";
     license     = licenses.asl20;
     maintainers = with maintainers; [ ragge mic92 thoughtpolice martinetd ];
+    platforms   = platforms.linux;
   };
 }

--- a/pkgs/by-name/bp/bpftrace/package.nix
+++ b/pkgs/by-name/bp/bpftrace/package.nix
@@ -67,5 +67,6 @@ stdenv.mkDerivation rec {
     mainProgram = "bpftrace";
     license     = licenses.asl20;
     maintainers = with maintainers; [ rvl thoughtpolice martinetd mfrw ];
+    platforms   = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18318,14 +18318,6 @@ with pkgs;
 
   bpftools = callPackage ../os-specific/linux/bpftools { };
 
-  bcc = callPackage ../by-name/bc/bcc/package.nix {
-    llvmPackages = llvmPackages_16;
-  };
-
-  bpftrace = callPackage ../by-name/bp/bpftrace/package.nix {
-    llvmPackages = llvmPackages_16;
-  };
-
   bpm-tools = callPackage ../tools/audio/bpm-tools { };
 
   byacc = callPackage ../development/tools/parsing/byacc { };


### PR DESCRIPTION
## Description of changes

Switch bcc and bpftrace to the current default llvm version for linux.

This doesn't seem to bring anything useful, but we shouldn't pull in an older llvm version for no reason as that'll increase system closure size

Back when we set a specific version the default linux version was very old and having a more modern version brought in some candies, but it doesn't seem to be as true now clang supports bpf well.

Conversely the latest llvm 18 isn't supported yet by the latest release of bpftrace, but it works with bcc's, and bpftrace master also has support so it won't be far behind: the nixos default version shouldn't break, so let's use it.


While here, also add the missing platforms.linux attribute so builder doesn't try to build it on darwin (pretty sure it stops fast anyway as dependency isn't available, but might as well make it clear)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


co-maintainers:
@Mic92 (bcc)
@thoughtpolice (bcc, bpftrace)
@rvl (bpftrace)
@mfrw (bpftrace)
@ragnard (bcc)