### PR TITLE
libcamera: disable tracing if unavailable

### DIFF
--- a/pkgs/by-name/li/libcamera/package.nix
+++ b/pkgs/by-name/li/libcamera/package.nix
@@ -9,7 +9,6 @@
 , libdrm
 , libevent
 , libyaml
-, lttng-ust
 , gst_all_1
 , gtest
 , graphviz
@@ -17,6 +16,8 @@
 , python3
 , python3Packages
 , systemd # for libudev
+, withTracing ? lib.meta.availableOn stdenv.hostPlatform lttng-ust
+, lttng-ust # withTracing
 , withQcam ? false
 , qt5 # withQcam
 , libtiff # withQcam
@@ -67,14 +68,12 @@ stdenv.mkDerivation rec {
     # hotplugging
     systemd
 
-    # lttng tracing
-    lttng-ust
-
     # yamlparser
     libyaml
 
     gtest
-  ] ++ lib.optionals withQcam [ libtiff qt5.qtbase qt5.qttools ];
+  ] ++ lib.optionals withTracing [ lttng-ust ]
+    ++ lib.optionals withQcam [ libtiff qt5.qtbase qt5.qttools ];
 
   nativeBuildInputs = [
     meson
@@ -92,7 +91,8 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dv4l2=true"
-    "-Dqcam=${if withQcam then "enabled" else "disabled"}"
+    (lib.mesonEnable "tracing" withTracing)
+    (lib.mesonEnable "qcam" withQcam)
     "-Dlc-compliance=disabled" # tries unconditionally to download gtest when enabled
     # Avoid blanket -Werror to evade build failures on less
     # tested compilers.

--- a/pkgs/development/tools/misc/lttng-ust/generic.nix
+++ b/pkgs/development/tools/misc/lttng-ust/generic.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     mainProgram = "lttng-gen-tp";
     homepage = "https://lttng.org/";
     license = with licenses; [ lgpl21Only gpl2Only mit ];
-    platforms = platforms.linux;
+    platforms = lib.intersectLists platforms.linux liburcu.meta.platforms;
     maintainers = [ maintainers.bjornfor ];
   };
 


### PR DESCRIPTION
## Description of changes

lttng-ust has a mandatory dependency on liburcu, which requires architecture-specific code that isn't available for all platforms.  To enable building libcamera for those platforms, disable tracing support if lttng-ust is unavailable.  This fixes building libcamera for, for example, loongarch64-linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
