### PR TITLE
google-cloud-sdk: 467.0.0 -> 475.0.0

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/components.json
+++ b/pkgs/tools/admin/google-cloud-sdk/components.json
@@ -5,7 +5,7 @@
         "checksum": "5a65179c291bc480696ca323d2f8c4874985458303eff8f233e16cdca4e88e6f",
         "contents_checksum": "038c999c7a7d70d5133eab7dc5868c4c3d0358431dad250f9833306af63016c8",
         "size": 800,
-        "source": "components/google-cloud-sdk-alpha-20240229170130.tar.gz",
+        "source": "components/google-cloud-sdk-alpha-20240503145345.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -22,8 +22,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240229170130,
-        "version_string": "2024.02.29"
+        "build_number": 20240503145345,
+        "version_string": "2024.05.03"
       }
     },
     {
@@ -56,15 +56,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "1.5.0"
+        "version_string": "1.5.1"
       }
     },
     {
       "data": {
-        "checksum": "e644f1dfa8a4c25029b33fcf04f4c3c6e01c4c7ed2d572e550890c71d3e8105f",
-        "contents_checksum": "1f789abe50e6cc5423d39c2530995849bda198e866abbd61904ffb964688e3b3",
-        "size": 21674635,
-        "source": "components/google-cloud-sdk-anthos-auth-darwin-arm-20231201141418.tar.gz",
+        "checksum": "37a7174a1716a9f4d84ee904940428ac424b4e20b1c4df7fe2e79704e554a8ce",
+        "contents_checksum": "21f1533ec191871a6677551d0d72687b03f1f2708fa900652875afa948a26df4",
+        "size": 21872436,
+        "source": "components/google-cloud-sdk-anthos-auth-darwin-arm-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -88,16 +88,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231201141418,
-        "version_string": "1.5.0"
+        "build_number": 20240426154730,
+        "version_string": "1.5.1"
       }
     },
     {
       "data": {
-        "checksum": "72a93a9df0d0647ac5587be7dc0f423c9700d191d21e870d7f8218195e8b7c67",
-        "contents_checksum": "80a810795133e6ed5d17b963606a980c85e059011c9eeffc4b23fdecbbc95736",
-        "size": 22732157,
-        "source": "components/google-cloud-sdk-anthos-auth-darwin-x86_64-20231201141418.tar.gz",
+        "checksum": "6f82815ca309a9f5a19bef98aad0a4f70393a66ce57383a4f6e4b0a8d6193a56",
+        "contents_checksum": "81a661e522f5c3b7fe610bad06a49e0a3a20fc9da69e0232150c4aa4fcaf962b",
+        "size": 22957602,
+        "source": "components/google-cloud-sdk-anthos-auth-darwin-x86_64-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -121,16 +121,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231201141418,
-        "version_string": "1.5.0"
+        "build_number": 20240426154730,
+        "version_string": "1.5.1"
       }
     },
     {
       "data": {
-        "checksum": "c6201122eb946238b632d68c944880a172759e7c6e60086d878c8f65017d4614",
-        "contents_checksum": "def3aaea624bd24a35d2cd8321562cb5ef5f4b659415c552e439c47ea80be22b",
-        "size": 21172533,
-        "source": "components/google-cloud-sdk-anthos-auth-linux-arm-20231201141418.tar.gz",
+        "checksum": "d9ad352bdfd50fef92ab1b917bb60be6b2e49bb8a4b49269bd2286570e02681f",
+        "contents_checksum": "c98b7c781c86e14e0dbb2a5f5a6ab9504013d005046fb52956ffb213a7d6f51a",
+        "size": 21399471,
+        "source": "components/google-cloud-sdk-anthos-auth-linux-arm-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -154,16 +154,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231201141418,
-        "version_string": "1.5.0"
+        "build_number": 20240426154730,
+        "version_string": "1.5.1"
       }
     },
     {
       "data": {
-        "checksum": "1a674e3872d702e59c8ef9b275f7e6dfb3a2e428fbaaa177442341f46c62b92d",
-        "contents_checksum": "ce215c3c67f2445ff1e1bd7d3c897ed5e83b169edb6004ce0898da08a3dc5066",
-        "size": 22854830,
-        "source": "components/google-cloud-sdk-anthos-auth-linux-x86_64-20231201141418.tar.gz",
+        "checksum": "c148f4a473afa336390f034d735283d6a4556c06e8e8b5bd0ecfa2f25dcfd184",
+        "contents_checksum": "4dbc4132c3126b53058c12c9113186436ac223018cf6d5e636dc0cf6b38ab1e3",
+        "size": 23109537,
+        "source": "components/google-cloud-sdk-anthos-auth-linux-x86_64-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -187,16 +187,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231201141418,
-        "version_string": "1.5.0"
+        "build_number": 20240426154730,
+        "version_string": "1.5.1"
       }
     },
     {
       "data": {
-        "checksum": "340aff9659764a4b82358dc1face81ca6fccb6cdba0a4b176305d984706f136c",
-        "contents_checksum": "603ea38b094e85e9a4836061bd057c086b37778a8cc2c7134d1d9bbd43b68639",
-        "size": 23111838,
-        "source": "components/google-cloud-sdk-anthos-auth-windows-x86_64-20231201141418.tar.gz",
+        "checksum": "7802808d020056ba132dc1aecda164d4979f057feff4a61071a6da850ef3e6bf",
+        "contents_checksum": "7b8a92cd15dfafa0969273ad9eca138d5f7c69fd5b54079bfd5dadf2141b103b",
+        "size": 23361404,
+        "source": "components/google-cloud-sdk-anthos-auth-windows-x86_64-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -220,8 +220,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231201141418,
-        "version_string": "1.5.0"
+        "build_number": 20240426154730,
+        "version_string": "1.5.1"
       }
     },
     {
@@ -1020,10 +1020,10 @@
     },
     {
       "data": {
-        "checksum": "ae39996160cebbed748ed12a6ef89ff73e93848b4b1a22f153c371c8ec2153ad",
-        "contents_checksum": "66509cd7d0ee0046439e2bc0e70eed9afecb637d578e518d6771925267693055",
-        "size": 132057381,
-        "source": "components/google-cloud-sdk-app-engine-java-20240106004423.tar.gz",
+        "checksum": "8d48814998e693aad877ddac4e1cc9c16b107898eda5e1e8fde6f677968a121c",
+        "contents_checksum": "b6d38276b7131e073deaff71ecdb3b994fd4a4bdfc4a9a2b2e64cff35884ad49",
+        "size": 132375338,
+        "source": "components/google-cloud-sdk-app-engine-java-20240329151455.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1041,8 +1041,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240106004423,
-        "version_string": "2.0.24"
+        "build_number": 20240329151455,
+        "version_string": "2.0.26"
       }
     },
     {
@@ -1142,10 +1142,10 @@
     },
     {
       "data": {
-        "checksum": "893d741c65d65cfc20f3820fdf62cb71f111e814083c942fee4ced13b10944a2",
-        "contents_checksum": "a97004f0aedeff49894c2cce7b5f634762900f64f38f65c1676e7897f3fb2c53",
-        "size": 8780608,
-        "source": "components/google-cloud-sdk-app-engine-python-20240216153112.tar.gz",
+        "checksum": "64171e6c3e1fae05666a7288020b321a0ffad92f8ae6ed7ba93d764c3b0e4369",
+        "contents_checksum": "f7fbbf70cc88e037e8e2d762d8bcd6dc1546a327a259b98f779f734a66be86a5",
+        "size": 5246358,
+        "source": "components/google-cloud-sdk-app-engine-python-20240412130805.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1164,16 +1164,16 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240216153112,
-        "version_string": "1.9.109"
+        "build_number": 20240412130805,
+        "version_string": "1.9.113"
       }
     },
     {
       "data": {
-        "checksum": "44a183b079e30fc932dbd7ca5b497baa6fa7d080ad78c500da99de6ef9e1a132",
-        "contents_checksum": "49a80207105a59c3948dd43fda0e28a6f9621265df127c7a3aa9707862ab7bfe",
-        "size": 33004574,
-        "source": "components/google-cloud-sdk-app-engine-python-extras-20231002150006.tar.gz",
+        "checksum": "e91aacbb794987ea2c24efe524a1204a94e9d46b3ff810740b3a8edd36b320ca",
+        "contents_checksum": "a2243f6ab1398d9caf08f4edcf55de35765698ec756b9f5ed58da87c0f37842e",
+        "size": 2122,
+        "source": "components/google-cloud-sdk-app-engine-python-extras-20240308155052.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1191,8 +1191,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20231002150006,
-        "version_string": "1.9.102"
+        "build_number": 20240308155052,
+        "version_string": "1.9.106"
       }
     },
     {
@@ -1432,7 +1432,7 @@
         "checksum": "707d412854a14450b4fddee199d258e75946fe51b44eb2980c8cd7e274c15760",
         "contents_checksum": "0b4e9d8e6394dc841aece07ca4da91920a460cbd7ec22495be4a2b4f46635b4d",
         "size": 797,
-        "source": "components/google-cloud-sdk-beta-20240229170130.tar.gz",
+        "source": "components/google-cloud-sdk-beta-20240503145345.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1449,8 +1449,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240229170130,
-        "version_string": "2024.02.29"
+        "build_number": 20240503145345,
+        "version_string": "2024.05.03"
       }
     },
     {
@@ -1493,10 +1493,10 @@
     },
     {
       "data": {
-        "checksum": "663eb2bb5e083b366f739b81bc95ce7853187a823890c34e07a8bacdfce35244",
-        "contents_checksum": "20101432339e657f9f272c5898dbdffd89dad2e08dcfccfa26c6609343f39f4c",
-        "size": 7149239,
-        "source": "components/google-cloud-sdk-bigtable-darwin-arm-20240112150613.tar.gz",
+        "checksum": "61389b1bb5534dc7386d30df5ab3a1050cbe3a8c9deda0edb40a1d5985439049",
+        "contents_checksum": "3a7f40f835b1b713a96f5b6c404eae20c7c90d794aae8a92713fd5b59a3c778e",
+        "size": 7344145,
+        "source": "components/google-cloud-sdk-bigtable-darwin-arm-20240329151455.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1521,7 +1521,7 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240112150613,
+        "build_number": 20240329151455,
         "version_string": ""
       }
     },
@@ -1561,10 +1561,10 @@
     },
     {
       "data": {
-        "checksum": "c00519ab786c673527f79f72770d1f4b5bf599c16f9c5d4b42a3f6658414ac22",
-        "contents_checksum": "55675241aba0458e9e7e272511ed469bc30949464d23cf672b2e8549e16559a5",
-        "size": 7384031,
-        "source": "components/google-cloud-sdk-bigtable-darwin-x86_64-20240112150613.tar.gz",
+        "checksum": "1d719de1aa61fb4837d221502e4113b2f786671e1139852275d69dc77d02e494",
+        "contents_checksum": "747c8a308249abd684ad2bc8bb9c3b34ed5092da0825b2887188c7f65385c81a",
+        "size": 7656241,
+        "source": "components/google-cloud-sdk-bigtable-darwin-x86_64-20240329151455.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1589,16 +1589,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240112150613,
+        "build_number": 20240329151455,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "bb6a7e3068ba643e11505e2cbf2fb7418662045566105c711ccda37bbce2f235",
-        "contents_checksum": "a2613adc36a34833bf1e11c7f725688389a330d89e3719e5f4e00387dfa20fb8",
-        "size": 7032893,
-        "source": "components/google-cloud-sdk-bigtable-linux-arm-20240112150613.tar.gz",
+        "checksum": "573c369501c73a684744007a9fc23ca29d8a81fa6c1dd18bed18c659ed406711",
+        "contents_checksum": "5abcfae3e7a061c532d3b4acbb6659d98cc4a7077e21ae4859e4d83d9c07e84f",
+        "size": 7210539,
+        "source": "components/google-cloud-sdk-bigtable-linux-arm-20240329151455.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1623,16 +1623,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240112150613,
+        "build_number": 20240329151455,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "5e762be2009986b3a9594cefc861d186eb3130c0f1b0dbf08bef6534ce868761",
-        "contents_checksum": "2adb488dd36830e794eb141ec5243b0bc5f24206a6bd0ae5a731a31346f08078",
-        "size": 7287874,
-        "source": "components/google-cloud-sdk-bigtable-linux-x86-20240112150613.tar.gz",
+        "checksum": "987ee97fb43e647db218c80cb9c3381477072aa494292db4d108e23f298e8926",
+        "contents_checksum": "da67b3b932497c895d74221dd3f670374abeda9b18ea32e225b733e69dc87cdc",
+        "size": 7374147,
+        "source": "components/google-cloud-sdk-bigtable-linux-x86-20240329151455.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1657,16 +1657,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240112150613,
+        "build_number": 20240329151455,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "b3c54cb77875fddf48a0ff41a8870cb55891bf49ae81e23adeb72c1280fc1fd0",
-        "contents_checksum": "711fd9de39fbf4583dbb22c52e7b3fa801ad81dee1e2a4d65d98992738f2aa34",
-        "size": 7488736,
-        "source": "components/google-cloud-sdk-bigtable-linux-x86_64-20240112150613.tar.gz",
+        "checksum": "a21817f2aae3ea9580a34f3f169a81baf289cbbd0a3b93455252c326654fe8b2",
+        "contents_checksum": "3ac22e1972afab99190324f7b9363fe9454ae845beba9eb3750d6240f40f5ee4",
+        "size": 7668508,
+        "source": "components/google-cloud-sdk-bigtable-linux-x86_64-20240329151455.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1691,16 +1691,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240112150613,
+        "build_number": 20240329151455,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "7ae926f8aad9bb48247a2468da737b1cd239764aca4ef31b02aebe14437bc5f9",
-        "contents_checksum": "a4409d3c0f7bce7ab0aeaf66adb80ea96a2f8c3854aa0570f3badf21b8b7d430",
-        "size": 7317721,
-        "source": "components/google-cloud-sdk-bigtable-windows-x86-20240112150613.tar.gz",
+        "checksum": "44b0bfe67b3e19db8acf4bb144f465509afe1fc25ad9c8dfee18a70c1202d3a3",
+        "contents_checksum": "2fdcda84a5bdb706895ffc4333597c2dbf48cf4fd52048174ece638e2d63348a",
+        "size": 7568622,
+        "source": "components/google-cloud-sdk-bigtable-windows-x86-20240329151455.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1725,16 +1725,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240112150613,
+        "build_number": 20240329151455,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "96eac561a6b2efe89e840ff2c6fa22e50f368a536a5db6c168ce9072f6142271",
-        "contents_checksum": "7d9e07ff31df84f57a66a4f9b0d3d0d666c70c7a17174cb2c69feea2db8a194e",
-        "size": 7479168,
-        "source": "components/google-cloud-sdk-bigtable-windows-x86_64-20240112150613.tar.gz",
+        "checksum": "36f5c9f98188e968cd53fe4545b3f8cb01dc2dfe2bda5c1f607ac384f358f329",
+        "contents_checksum": "cae59bae355fc9b8ff8fc37296d3885a9944d85b0ba84a4c2e9985380db488e6",
+        "size": 7841324,
+        "source": "components/google-cloud-sdk-bigtable-windows-x86_64-20240329151455.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1759,16 +1759,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240112150613,
+        "build_number": 20240329151455,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "8918c7fd033de8f13f331152e59dc16a33f0f7007a6be615b7b53337197be33f",
-        "contents_checksum": "f516a7a4d24280d59d67bf908d80d0a560b8d680e8c2699efc1071b1c0039c1f",
-        "size": 1679148,
-        "source": "components/google-cloud-sdk-bq-20240112150613.tar.gz",
+        "checksum": "a99ddbb8738b92fb9e899fdcd81b8f6ff10499ae301d4c5660de756d5c689046",
+        "contents_checksum": "c2012e29e4fe8f14dacb252272e0953ea0618df9f9182bb6405eb7bcbab5af96",
+        "size": 1746678,
+        "source": "components/google-cloud-sdk-bq-20240412130805.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1787,8 +1787,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240112150613,
-        "version_string": "2.0.101"
+        "build_number": 20240412130805,
+        "version_string": "2.1.4"
       }
     },
     {
@@ -1827,10 +1827,10 @@
     },
     {
       "data": {
-        "checksum": "5d3fdd2bd23beba4e15e60d8e2befdb3d68ae9faed8a19b14526ffacb247546e",
-        "contents_checksum": "aa61d0c34c3b3d6509e7a529b28446faaa645f15abb56a27be3b425ed6404fac",
-        "size": 2683,
-        "source": "components/google-cloud-sdk-bq-win-20240226203415.tar.gz",
+        "checksum": "3bfb69819bbca110fa33474612db6ec6bfb20d2c2334ff41ac21b6f7179441f7",
+        "contents_checksum": "543b11ef740e32b7013fdecdc0ea02fa076e16972dec18155647fb3f0682d743",
+        "size": 4104,
+        "source": "components/google-cloud-sdk-bq-win-20240503145345.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1852,8 +1852,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240226203415,
-        "version_string": "2.0.101"
+        "build_number": 20240503145345,
+        "version_string": "2.1.4"
       }
     },
     {
@@ -1982,7 +1982,7 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "3.11.6"
+        "version_string": "3.11.8"
       }
     },
     {
@@ -2048,10 +2048,10 @@
     },
     {
       "data": {
-        "checksum": "78b090d3d133b622c8fa591e55d97dec41ebeceda117f1fc4c87a3a3053710fc",
-        "contents_checksum": "b18344f58a872b7fd500946a8ca7c7929608a4bf5257570e7c60c2f5b9208ad4",
-        "size": 20426074,
-        "source": "components/google-cloud-sdk-bundled-python3-windows-x86-20231110155547.tar.gz",
+        "checksum": "6b42a2592dc79efb45b3848f58de62866d9fba0d033a8e91aa919be047ee3cb6",
+        "contents_checksum": "6cce2af1b3947deeff09b5adce78ef1c6b39716ce2ef27c58b48c14408b2e3a0",
+        "size": 20457544,
+        "source": "components/google-cloud-sdk-bundled-python3-windows-x86-20240315155000.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2076,16 +2076,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231110155547,
-        "version_string": "3.11.6"
+        "build_number": 20240315155000,
+        "version_string": "3.11.8"
       }
     },
     {
       "data": {
-        "checksum": "f80970b12053a77afb5888982362396c379392462806837c47c4ed3271c19aaf",
-        "contents_checksum": "3207aea9e98dcf0cf0ee6ad339235fda213dbf8ac997bfa823698c52d68b7f65",
-        "size": 22512051,
-        "source": "components/google-cloud-sdk-bundled-python3-windows-x86_64-20231110155547.tar.gz",
+        "checksum": "22a2f8a7370780239ed00ef8771729318b3301e498afba74ef27f300d3b29ec1",
+        "contents_checksum": "9b781d6ff139270cd317f233e448c88d2b54ef3d05970b2c765540485acf1451",
+        "size": 22664923,
+        "source": "components/google-cloud-sdk-bundled-python3-windows-x86_64-20240315155000.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2110,8 +2110,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231110155547,
-        "version_string": "3.11.6"
+        "build_number": 20240315155000,
+        "version_string": "3.11.8"
       }
     },
     {
@@ -2148,15 +2148,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "1.17.2"
+        "version_string": "1.19.0"
       }
     },
     {
       "data": {
-        "checksum": "538df81550df3242dd9047437ceea867abb38125df24154ffafb5298dee1a2b8",
-        "contents_checksum": "02563cdae195531dc844381cd1cfed92ec8217adc475b9dac73898f1a25c0a45",
-        "size": 16720666,
-        "source": "components/google-cloud-sdk-cbt-darwin-arm-20240112150613.tar.gz",
+        "checksum": "afa1887247d8c5eb0ab71127767c289267f5742702e07827d4c856249efc3753",
+        "contents_checksum": "c2239a7e4967b5c0ab0a3bf09328d269a444b06dfab5617879f29ec94bbde352",
+        "size": 17509814,
+        "source": "components/google-cloud-sdk-cbt-darwin-arm-20240329151455.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2180,8 +2180,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240112150613,
-        "version_string": "1.17.2"
+        "build_number": 20240329151455,
+        "version_string": "1.19.0"
       }
     },
     {
@@ -2219,10 +2219,10 @@
     },
     {
       "data": {
-        "checksum": "b9194d1a8371dea7c63147767a6f9e3f8c6f4b03fa30ca3bc5ea901d97acd011",
-        "contents_checksum": "c359de592aa1b957326c205b8723a59520cac0f142bf278b84eed03399b56b59",
-        "size": 17196541,
-        "source": "components/google-cloud-sdk-cbt-darwin-x86_64-20240112150613.tar.gz",
+        "checksum": "1fc383dfab3e4c99969d05b939620349fadd115124cfcfd7e6d5c8853718f7cf",
+        "contents_checksum": "76b3bc91860334a7263fbad820ac8ac2db54ca773568aafb86e9221e717e24d3",
+        "size": 18273086,
+        "source": "components/google-cloud-sdk-cbt-darwin-x86_64-20240329151455.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2246,16 +2246,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240112150613,
-        "version_string": "1.17.2"
+        "build_number": 20240329151455,
+        "version_string": "1.19.0"
       }
     },
     {
       "data": {
-        "checksum": "eb0c6f7e7f9c3bfecbfd733ea018c09fb8ba61b78b1cf8c1c9263c7109ad8671",
-        "contents_checksum": "5c1a36f98fd4654ee47fccea2a9a50ce8b22cd70e013b83bb051fe357122638d",
-        "size": 16297518,
-        "source": "components/google-cloud-sdk-cbt-linux-arm-20240112150613.tar.gz",
+        "checksum": "2ea8a9dfff13f06b8498622b7b4a13488749dc4ac1560728f3df9fe63537df88",
+        "contents_checksum": "f70c2888bdb2efec1afe421edc65bef9c356fec3b09a5cc0c4650409dca303f2",
+        "size": 17062983,
+        "source": "components/google-cloud-sdk-cbt-linux-arm-20240329151455.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2279,16 +2279,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240112150613,
-        "version_string": "1.17.2"
+        "build_number": 20240329151455,
+        "version_string": "1.19.0"
       }
     },
     {
       "data": {
-        "checksum": "39ca479add8bc11ad11a3b2965e562e62858901c96d79aa1aa2c938a7f40993c",
-        "contents_checksum": "fc6133d7e68b1ad303d87cb9e712bc94fd40511f3818979b4e20d7f5f2074df7",
-        "size": 16492482,
-        "source": "components/google-cloud-sdk-cbt-linux-x86-20240112150613.tar.gz",
+        "checksum": "25ffea5b8d4a13120cbff9cdeee10759f0149f522efa3b090de7e49fcfe44ca4",
+        "contents_checksum": "73be18b59b731a6c2aca12e254c0248039ee0b4d3f460198f84842a9753286c9",
+        "size": 16860591,
+        "source": "components/google-cloud-sdk-cbt-linux-x86-20240329151455.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2312,16 +2312,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240112150613,
-        "version_string": "1.17.2"
+        "build_number": 20240329151455,
+        "version_string": "1.19.0"
       }
     },
     {
       "data": {
-        "checksum": "23df574487ba9ddb32ffc8c387a0d428ef27be297d5769800710974266d4932c",
-        "contents_checksum": "8134edf246fa051787bf993034e8f1800bb1f04620bbd13cc1f40e965bf32599",
-        "size": 17340658,
-        "source": "components/google-cloud-sdk-cbt-linux-x86_64-20240112150613.tar.gz",
+        "checksum": "0e5a55bd053d76d9f22223728241e1a0ca89b36661a7e886250de942da8afd76",
+        "contents_checksum": "fb9e07d468b2d3043632c4b1ace676cc503e5e5efa5b8c3a757f1725cb142dbc",
+        "size": 18166629,
+        "source": "components/google-cloud-sdk-cbt-linux-x86_64-20240329151455.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2345,16 +2345,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240112150613,
-        "version_string": "1.17.2"
+        "build_number": 20240329151455,
+        "version_string": "1.19.0"
       }
     },
     {
       "data": {
-        "checksum": "ae60d8116338562cc98ba1ad852842760d2ab78016377ec827701c80dc7b7b41",
-        "contents_checksum": "61f3390cc8c868a77e378f9d4aa37502d4e04357d8ab33735f1e5418a3a225e7",
-        "size": 16750394,
-        "source": "components/google-cloud-sdk-cbt-windows-x86-20240112150613.tar.gz",
+        "checksum": "b6b9ad0a151bcddc67829349ed03f18b21598b6ced116eb721947acabe4cae10",
+        "contents_checksum": "13b82fdff12b1385cdf3fc71da26f449c2668cf45fff1d0fb76d3c9b9992a64c",
+        "size": 17268775,
+        "source": "components/google-cloud-sdk-cbt-windows-x86-20240329151455.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2378,16 +2378,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240112150613,
-        "version_string": "1.17.2"
+        "build_number": 20240329151455,
+        "version_string": "1.19.0"
       }
     },
     {
       "data": {
-        "checksum": "ce201b8cb3e4e10d4ae1cbec9ff253474dff5931eaff9c1d260b117ac03781e3",
-        "contents_checksum": "d28a7a0d5156bff526e51932172d63a6bc8fc6258138551e81ffc241e20faeb3",
-        "size": 17415844,
-        "source": "components/google-cloud-sdk-cbt-windows-x86_64-20240112150613.tar.gz",
+        "checksum": "ba26da1afb70320e7faeecd5f0378b3d9e16dd7e51091c373c79a53d1fb0fde4",
+        "contents_checksum": "492d56556efb6c662c8702d66dc4b48e837de0112fc1e949ea7e24671eee5840",
+        "size": 18413114,
+        "source": "components/google-cloud-sdk-cbt-windows-x86_64-20240329151455.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2411,8 +2411,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240112150613,
-        "version_string": "1.17.2"
+        "build_number": 20240329151455,
+        "version_string": "1.19.0"
       }
     },
     {
@@ -2572,10 +2572,10 @@
     },
     {
       "data": {
-        "checksum": "412203bd80a2ce63b6893f2fc7af0c9c86a4725bd9cf4aeca6a6905269f267b8",
-        "contents_checksum": "f43be764e885bb2206a1b7fdacabd0fca828cd76d95e5006c9509645dfd27b0e",
-        "size": 46597550,
-        "source": "components/google-cloud-sdk-cloud-firestore-emulator-20240229170130.tar.gz",
+        "checksum": "93285cbe088cafc8d3761476b276be1c19a3718ac4545692ece4e6cc147deed8",
+        "contents_checksum": "fe301599250d79f91f06cfdf570fa5815c82414d322d085b1fa47a364bf7ae12",
+        "size": 47265060,
+        "source": "components/google-cloud-sdk-cloud-firestore-emulator-20240503145345.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2592,8 +2592,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240229170130,
-        "version_string": "1.19.2"
+        "build_number": 20240503145345,
+        "version_string": "1.19.6"
       }
     },
     {
@@ -2818,15 +2818,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "1.5.13"
+        "version_string": "1.5.16"
       }
     },
     {
       "data": {
-        "checksum": "7c8f4db773fae956a385c746203ef7d2784d992fd674cdbacf59720c4d3e0ca6",
-        "contents_checksum": "d3df9908458ec5b1115dd1c439b256fcc7ba00533f0c7363ac09685f5bc95790",
-        "size": 37731211,
-        "source": "components/google-cloud-sdk-cloud-spanner-emulator-linux-x86_64-20240106004423.tar.gz",
+        "checksum": "555c0b4202082b7e94bc9d910460b4f28d2ea6ebf4d51a58825d244331961f84",
+        "contents_checksum": "e0ad5cac6f972f24e4390fd7d9d54420bc7432ecdcb9c21a299a07ecb893d8cd",
+        "size": 38255843,
+        "source": "components/google-cloud-sdk-cloud-spanner-emulator-linux-x86_64-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2851,8 +2851,275 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240106004423,
-        "version_string": "1.5.13"
+        "build_number": 20240426154730,
+        "version_string": "1.5.16"
+      }
+    },
+    {
+      "dependencies": [
+        "cloud-sql-proxy-darwin-arm",
+        "cloud-sql-proxy-darwin-x86_64",
+        "cloud-sql-proxy-linux-arm",
+        "cloud-sql-proxy-linux-x86",
+        "cloud-sql-proxy-linux-x86_64",
+        "cloud-sql-proxy-windows-x86",
+        "cloud-sql-proxy-windows-x86_64"
+      ],
+      "details": {
+        "description": "Provides cloud-sql-proxy executable. See https://github.com/GoogleCloudPlatform/cloud-sql-proxy",
+        "display_name": "Cloud SQL Proxy v2"
+      },
+      "id": "cloud-sql-proxy",
+      "is_configuration": false,
+      "is_hidden": false,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX",
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "2.10.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "12ab4fc64c3c2972e51fd18144b9633e3dcd6a2190dd8484d63f25f4346f46f7",
+        "contents_checksum": "7739e095d51e0ad78c0c801e61ce178700cb5b8490ec65f5fa7bf4322897783e",
+        "size": 13848476,
+        "source": "components/google-cloud-sdk-cloud-sql-proxy-darwin-arm-20240412130805.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud-sql-proxy"
+      ],
+      "details": {
+        "description": "Provides cloud-sql-proxy executable. See https://github.com/GoogleCloudPlatform/cloud-sql-proxy",
+        "display_name": "Cloud SQL Proxy v2"
+      },
+      "id": "cloud-sql-proxy-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20240412130805,
+        "version_string": "2.10.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "fdc1ed4057693e802e480353479a553694423b61a23cbafb3ea1a2237e82bb68",
+        "contents_checksum": "87f96d979d238df85b2c2cde4c40d4a5f7869d36b86a0966c38a7c5df6e34d3a",
+        "size": 14482528,
+        "source": "components/google-cloud-sdk-cloud-sql-proxy-darwin-x86_64-20240412130805.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud-sql-proxy"
+      ],
+      "details": {
+        "description": "Provides cloud-sql-proxy executable. See https://github.com/GoogleCloudPlatform/cloud-sql-proxy",
+        "display_name": "Cloud SQL Proxy v2"
+      },
+      "id": "cloud-sql-proxy-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20240412130805,
+        "version_string": "2.10.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "6ec1b56eae8b797f488e02e01f390a7da2136e812cd78e26b31770f6f4f33005",
+        "contents_checksum": "afc9d080ec70126505ccfc1afd385ba3f3d2c81a9a9f7481cd8865439d384117",
+        "size": 13586220,
+        "source": "components/google-cloud-sdk-cloud-sql-proxy-linux-arm-20240412130805.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud-sql-proxy"
+      ],
+      "details": {
+        "description": "Provides cloud-sql-proxy executable. See https://github.com/GoogleCloudPlatform/cloud-sql-proxy",
+        "display_name": "Cloud SQL Proxy v2"
+      },
+      "id": "cloud-sql-proxy-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20240412130805,
+        "version_string": "2.10.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "c876aa706464616c5a2f612f1860b4a6098079a54fe3f579d93b60d0c7c0ce00",
+        "contents_checksum": "d0b6a430d200d210847762ab7b84160aa5196273112d837d97123a45c6864eae",
+        "size": 13629073,
+        "source": "components/google-cloud-sdk-cloud-sql-proxy-linux-x86-20240412130805.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud-sql-proxy"
+      ],
+      "details": {
+        "description": "Provides cloud-sql-proxy executable. See https://github.com/GoogleCloudPlatform/cloud-sql-proxy",
+        "display_name": "Cloud SQL Proxy v2"
+      },
+      "id": "cloud-sql-proxy-linux-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20240412130805,
+        "version_string": "2.10.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "8738b48da32f96d08859045c0dd75f03c7e455fe5cab22278ccb717de4c99270",
+        "contents_checksum": "351c1514a9c63b9d0e730c465c724a84400d91ad45658213f763a51eae6f04bf",
+        "size": 14521265,
+        "source": "components/google-cloud-sdk-cloud-sql-proxy-linux-x86_64-20240412130805.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud-sql-proxy"
+      ],
+      "details": {
+        "description": "Provides cloud-sql-proxy executable. See https://github.com/GoogleCloudPlatform/cloud-sql-proxy",
+        "display_name": "Cloud SQL Proxy v2"
+      },
+      "id": "cloud-sql-proxy-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20240412130805,
+        "version_string": "2.10.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "83628225ad611dabac12a473c532f876992ea5cdcb822183812a6e21003506af",
+        "contents_checksum": "c58a80989336d672aca1b9ea393998fb5bd01339cf561197f14c497a91b84062",
+        "size": 13662947,
+        "source": "components/google-cloud-sdk-cloud-sql-proxy-windows-x86-20240412130805.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud-sql-proxy"
+      ],
+      "details": {
+        "description": "Provides cloud-sql-proxy executable. See https://github.com/GoogleCloudPlatform/cloud-sql-proxy",
+        "display_name": "Cloud SQL Proxy v2"
+      },
+      "id": "cloud-sql-proxy-windows-x86",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20240412130805,
+        "version_string": "2.10.0"
+      }
+    },
+    {
+      "data": {
+        "checksum": "5f9775a84500409f09cf4dc02d279e306414c4a555356ae7097c785349b9462a",
+        "contents_checksum": "45f653110069a220eec0f70bf65e54470ae1c682ea7a6f5f369fe6a2610192d2",
+        "size": 14417645,
+        "source": "components/google-cloud-sdk-cloud-sql-proxy-windows-x86_64-20240412130805.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "cloud-sql-proxy"
+      ],
+      "details": {
+        "description": "Provides cloud-sql-proxy executable. See https://github.com/GoogleCloudPlatform/cloud-sql-proxy",
+        "display_name": "Cloud SQL Proxy v2"
+      },
+      "id": "cloud-sql-proxy-windows-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "WINDOWS"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20240412130805,
+        "version_string": "2.10.0"
       }
     },
     {
@@ -2871,7 +3138,7 @@
       },
       "id": "cloud_sql_proxy",
       "is_configuration": false,
-      "is_hidden": false,
+      "is_hidden": true,
       "is_required": false,
       "platform": {
         "architectures": [
@@ -3322,10 +3589,10 @@
     },
     {
       "data": {
-        "checksum": "394b9a3441b3a88962ee3fe01e2b816671466ca55c244826adc1093395a08117",
-        "contents_checksum": "b22a86659b93e65751c75128448d23b9d935b9a85c46301498bc4054256aff86",
-        "size": 23893614,
-        "source": "components/google-cloud-sdk-core-20240229170130.tar.gz",
+        "checksum": "e8e87ff80c3f46ff4bce660c584ebe7bae8679366c9d2bf5ec5f98c06e450aa5",
+        "contents_checksum": "56ce80562703967dc39b2b05e6dd814e07cfe07a078706d9f0ad6ce0716495c8",
+        "size": 19446060,
+        "source": "components/google-cloud-sdk-core-20240503145345.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3346,8 +3613,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240229170130,
-        "version_string": "2024.02.29"
+        "build_number": 20240503145345,
+        "version_string": "2024.05.03"
       }
     },
     {
@@ -4138,10 +4405,10 @@
     },
     {
       "data": {
-        "checksum": "199a922d9427440154dbd427650aac513dde9dcf5fb904f696011e208af16436",
-        "contents_checksum": "bd1cee79ccb1075e6174ce72da21507e22c9309c7d453ec4c0365c38184dbf72",
-        "size": 17398946,
-        "source": "components/google-cloud-sdk-gcloud-deps-20240229170130.tar.gz",
+        "checksum": "2678d4b85b8247cb896f38bb6741e6e30c9e5f2c65e495e85795131493ef5acc",
+        "contents_checksum": "91de55f1ec585b9e8326f529655b1c550739f8f864059b47e2d7554c4fc170a6",
+        "size": 17408040,
+        "source": "components/google-cloud-sdk-gcloud-deps-20240503145345.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4164,8 +4431,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240229170130,
-        "version_string": "2024.02.29"
+        "build_number": 20240503145345,
+        "version_string": "2024.05.03"
       }
     },
     {
@@ -4401,10 +4668,10 @@
     },
     {
       "data": {
-        "checksum": "5002cd1d0b639317a879d8c6eaf1c8b65ae30d908be20168b3d1126a7a9931fb",
-        "contents_checksum": "be1175193dbcc96732f074ee8916e2d01bae057865ca4cc9af4fce96669a2e82",
-        "size": 6729281,
-        "source": "components/google-cloud-sdk-gcloud-man-pages-nix-20240229170130.tar.gz",
+        "checksum": "19aaaf05ce45d6a62dac77e167d4315563dcadddfa9838da2ac9bc9df4ccac62",
+        "contents_checksum": "b2c128b9a1602e364e4801df1f6ec76004cd84fa2ab25c9df1b309eec73377b3",
+        "size": 6857693,
+        "source": "components/google-cloud-sdk-gcloud-man-pages-nix-20240503145345.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4429,7 +4696,7 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240229170130,
+        "build_number": 20240503145345,
         "version_string": ""
       }
     },
@@ -4865,7 +5132,7 @@
       },
       "id": "istioctl",
       "is_configuration": false,
-      "is_hidden": true,
+      "is_hidden": false,
       "is_required": false,
       "platform": {
         "architectures": [
@@ -4880,15 +5147,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "1.20.311"
+        "version_string": "1.20.47"
       }
     },
     {
       "data": {
-        "checksum": "e21e0b1b1a143e74b1b0ba7392ed4fdd1cf28323bd74ef59f116e218f49824fb",
-        "contents_checksum": "ea25e0ffad0fcd5877d24e86ef5b96be2e86446f432926385ebfc08590a9be36",
-        "size": 26043155,
-        "source": "components/google-cloud-sdk-istioctl-darwin-arm-20240229170130.tar.gz",
+        "checksum": "c5b61b4e3b0d5434e4610d706270b5701ef085fd35e1e53541876bb4e03d678a",
+        "contents_checksum": "a2bd9195d75037b1c96b9378109e6a2313d52476c19f5ca3e3d17767c70310ed",
+        "size": 26052154,
+        "source": "components/google-cloud-sdk-istioctl-darwin-arm-20240412130805.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4912,16 +5179,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240229170130,
-        "version_string": "1.20.311"
+        "build_number": 20240412130805,
+        "version_string": "1.20.47"
       }
     },
     {
       "data": {
-        "checksum": "e26416a75034738c5decb4e88b69f060849db045eb1a416dbe5def38ca036051",
-        "contents_checksum": "9ed26dc784a70ed4f98d845dac4ba8b298a90dcdfb169e665e1756cbbfadbfc7",
-        "size": 26886694,
-        "source": "components/google-cloud-sdk-istioctl-darwin-x86_64-20240229170130.tar.gz",
+        "checksum": "2f1b4a1df42ae31d4cd0b301c47d30f998497a701e301ff1a4f81902318b93a7",
+        "contents_checksum": "a41f542d1cb16bf4118643ded861c94ba3cd9dc378d601fd572042360f38e3dc",
+        "size": 26898803,
+        "source": "components/google-cloud-sdk-istioctl-darwin-x86_64-20240412130805.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4945,16 +5212,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240229170130,
-        "version_string": "1.20.311"
+        "build_number": 20240412130805,
+        "version_string": "1.20.47"
       }
     },
     {
       "data": {
-        "checksum": "5fbeafb59962e1f5e42b874caf897a151ce05f2082063e04edddd054be1b9b78",
-        "contents_checksum": "62e413e41af9e75ae3523f45e5e60063ce9363d9b73e7b5b427e6e451bbc6816",
-        "size": 22993370,
-        "source": "components/google-cloud-sdk-istioctl-linux-arm-20240229170130.tar.gz",
+        "checksum": "311368b6b4812b945dbe77c3921d89477bbc7a8dbbd90bc871a927621f4f564c",
+        "contents_checksum": "4fbd1efcce42b8e2ab3edff729239cb27ccdc0f4b005fe18f65062abd9ec9e70",
+        "size": 23005079,
+        "source": "components/google-cloud-sdk-istioctl-linux-arm-20240412130805.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4978,16 +5245,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240229170130,
-        "version_string": "1.20.311"
+        "build_number": 20240412130805,
+        "version_string": "1.20.47"
       }
     },
     {
       "data": {
-        "checksum": "167b9dc19cb7b64b5eca9e0efecf609a621eb18ce7ece2288a36038e1124658e",
-        "contents_checksum": "1d3a6f9870ab2b0b693927d32154cd44b4686079a9c117590cdc2b385b040869",
-        "size": 25190186,
-        "source": "components/google-cloud-sdk-istioctl-linux-x86_64-20240229170130.tar.gz",
+        "checksum": "5f9f4d0aee5adc83960591c9413e523e914c86538a08895958fba3d6610e2e92",
+        "contents_checksum": "4523dd63d1fd52a26170cb366da1bb492a631d36765bdb9b6037af42b70ef3b2",
+        "size": 25206798,
+        "source": "components/google-cloud-sdk-istioctl-linux-x86_64-20240412130805.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5011,8 +5278,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240229170130,
-        "version_string": "1.20.311"
+        "build_number": 20240412130805,
+        "version_string": "1.20.47"
       }
     },
     {
@@ -5180,10 +5447,10 @@
     },
     {
       "data": {
-        "checksum": "e06b2f2bd331421fa8f8c5776b7370b793101232a8316c61420ebad9622e2709",
-        "contents_checksum": "d7c1385f3b9bedea994733230851e6d3548ea4be8f5014b1feadbf4ca2c6ca46",
+        "checksum": "8ce711be6e55790700edd6d6f7c03a2fa5a1c5b8cea7571aab75300e976b924c",
+        "contents_checksum": "90557d61aa4010c4cf40966c482a9560a6ebab9f66fe3858db13134d1a3766fc",
         "size": 35936,
-        "source": "components/google-cloud-sdk-kubectl-20240209195330.tar.gz",
+        "source": "components/google-cloud-sdk-kubectl-20240322135349.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5207,16 +5474,16 @@
       "platform": {},
       "platform_required": true,
       "version": {
-        "build_number": 20240209195330,
-        "version_string": "1.26.13"
+        "build_number": 20240322135349,
+        "version_string": "1.26.15"
       }
     },
     {
       "data": {
-        "checksum": "ad4230981ddba174dc301d5ed31704c86819b99de90fc0a391d379197b221ff0",
-        "contents_checksum": "8208474ff6408f57a030648f9e0409eb66f854f95eb1cc8fc28897e3dae882b7",
-        "size": 76487537,
-        "source": "components/google-cloud-sdk-kubectl-darwin-arm-20240209195330.tar.gz",
+        "checksum": "893498f06440eac7fe42bd0c42e83ab1e2fd30a0bd1d53ddd8ebfebc27d8ca8a",
+        "contents_checksum": "71c9869732c57c7c66cec80e59ab20bcc2e94b1cc79dce1c8093b2f0862b1383",
+        "size": 91161627,
+        "source": "components/google-cloud-sdk-kubectl-darwin-arm-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5241,16 +5508,16 @@
       },
       "platform_required": true,
       "version": {
-        "build_number": 20240209195330,
-        "version_string": "1.26.13"
+        "build_number": 20240426154730,
+        "version_string": "1.26.15"
       }
     },
     {
       "data": {
-        "checksum": "7154fc7e724a41ba9109fc4d3211fdfb24bb9c706f82175a0543158a74ea64f4",
-        "contents_checksum": "1db2fb77158d4aeb37b895ca7beb34d2380b6d7bda97e18189c03a235473a26f",
-        "size": 80131408,
-        "source": "components/google-cloud-sdk-kubectl-darwin-x86_64-20240209195330.tar.gz",
+        "checksum": "ddf25a006aeedb5e717d474dc695882caf35a4befaace22f28d9a4d0fee28bae",
+        "contents_checksum": "ac249c8eca65960152719c9440c197a0be335fa1d2e724a32e77418dacd6dd12",
+        "size": 96033579,
+        "source": "components/google-cloud-sdk-kubectl-darwin-x86_64-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5275,16 +5542,16 @@
       },
       "platform_required": true,
       "version": {
-        "build_number": 20240209195330,
-        "version_string": "1.26.13"
+        "build_number": 20240426154730,
+        "version_string": "1.26.15"
       }
     },
     {
       "data": {
-        "checksum": "655be0e96cc23f6e04c4ec176ef19d6ac4164f0093de7e6a5ab882128bacf3cc",
-        "contents_checksum": "69a8d347c6cc78a42b8ec340794632e449b2ceac8f7a8cf3e677f97743fa6e66",
-        "size": 72277260,
-        "source": "components/google-cloud-sdk-kubectl-linux-arm-20240209195330.tar.gz",
+        "checksum": "25279f7ff336d39f312dd6f363100b8329ad19e402c378230bfb2a8c4181325e",
+        "contents_checksum": "255cb5b298d9ddb4f81aa7571d452e3adab7c464e1c2b4686d1bfd5eec7e5abd",
+        "size": 86862918,
+        "source": "components/google-cloud-sdk-kubectl-linux-arm-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5309,16 +5576,16 @@
       },
       "platform_required": true,
       "version": {
-        "build_number": 20240209195330,
-        "version_string": "1.26.13"
+        "build_number": 20240426154730,
+        "version_string": "1.26.15"
       }
     },
     {
       "data": {
-        "checksum": "37931d1405a46bac8833f106c35734512445fc218cc9f1e007604bb48cdee55b",
-        "contents_checksum": "8222dd939577e50f8ffc0f667d6a2ccbd88c8a0813925f4889a58d27b180ff98",
-        "size": 71637401,
-        "source": "components/google-cloud-sdk-kubectl-linux-x86-20240209195330.tar.gz",
+        "checksum": "6e8d0ea5ba1b88b82c902d869e54cb42d69cab4544e9b87190e8a9751b8e7510",
+        "contents_checksum": "5ef6f72d98198ce6ec9a380fab8925259fca9aef9e5afc22bef4f1d8d01c3cf4",
+        "size": 85033644,
+        "source": "components/google-cloud-sdk-kubectl-linux-x86-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5343,16 +5610,16 @@
       },
       "platform_required": true,
       "version": {
-        "build_number": 20240209195330,
-        "version_string": "1.26.13"
+        "build_number": 20240426154730,
+        "version_string": "1.26.15"
       }
     },
     {
       "data": {
-        "checksum": "479be7e5c55b77eacb26a86afb8063ee0c22664eca0af154c6725c6d413f4631",
-        "contents_checksum": "0d9e46f2a36f34ac1d485901b2243bbedc5f66e54cb3d8e42172cbc6484075ea",
-        "size": 76232083,
-        "source": "components/google-cloud-sdk-kubectl-linux-x86_64-20240209195330.tar.gz",
+        "checksum": "2463ae5fa3cdb8952183845b4b1d5a335edfb22716f38525441121a8233177f0",
+        "contents_checksum": "41dc3fa15a64ab76478e164cb48bfaf6e93bceaec8edc32772a20deec1a592ea",
+        "size": 91798182,
+        "source": "components/google-cloud-sdk-kubectl-linux-x86_64-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5377,8 +5644,8 @@
       },
       "platform_required": true,
       "version": {
-        "build_number": 20240209195330,
-        "version_string": "1.26.13"
+        "build_number": 20240426154730,
+        "version_string": "1.26.15"
       }
     },
     {
@@ -5411,15 +5678,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "1.5.0"
+        "version_string": "1.5.1"
       }
     },
     {
       "data": {
-        "checksum": "ca1e67289f1d377b6fc300777cdd8853a4ebc7eb11c00db85a3e7394c8daea30",
-        "contents_checksum": "3d35d8343042427849f27fe09652e94dbb563ebb6026ded792641beb1c536ebd",
-        "size": 21674622,
-        "source": "components/google-cloud-sdk-kubectl-oidc-darwin-arm-20231201141418.tar.gz",
+        "checksum": "668657665d86db6d1c2ca53116f022799e9b6202d7e6e0080acd9a89f2e69667",
+        "contents_checksum": "55b5c287ac965c8cb331fcfa27cf8a7a346ceb103eef9e7ff603067a3b8d2217",
+        "size": 21872424,
+        "source": "components/google-cloud-sdk-kubectl-oidc-darwin-arm-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5443,16 +5710,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231201141418,
-        "version_string": "1.5.0"
+        "build_number": 20240426154730,
+        "version_string": "1.5.1"
       }
     },
     {
       "data": {
-        "checksum": "d8b175936d29c11412e099627cbc9d4bc4574e7201a48bd045714aa4d5039d97",
-        "contents_checksum": "b4c5609dd10b63e9946c1afaf9a6e242fe3b09cb0d5c0c453e4ead4fb173c4e2",
-        "size": 22732154,
-        "source": "components/google-cloud-sdk-kubectl-oidc-darwin-x86_64-20231201141418.tar.gz",
+        "checksum": "efee37ae3fd4c68bd04b7d851a3a737d4730d1d2c1ea1d1ae0ff1c4b9b415e2e",
+        "contents_checksum": "d5caa4ebe32784b39af30c044d1526cd2c9cfc468912f151c50591818f86981f",
+        "size": 22957587,
+        "source": "components/google-cloud-sdk-kubectl-oidc-darwin-x86_64-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5476,16 +5743,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231201141418,
-        "version_string": "1.5.0"
+        "build_number": 20240426154730,
+        "version_string": "1.5.1"
       }
     },
     {
       "data": {
-        "checksum": "da25e182095d25746563ded62b84c614f6ba87514e751e1f445b8ef9ddbcf239",
-        "contents_checksum": "f1bd3477dd4ad77ed8c02631cfd0b7e102000e6bac495dcd3fb69daf6b21ba93",
-        "size": 21172499,
-        "source": "components/google-cloud-sdk-kubectl-oidc-linux-arm-20231201141418.tar.gz",
+        "checksum": "c1bffc495c0f18b7a8b7231815d03ad050d8f7da54e3ae8fb252f30bd9774553",
+        "contents_checksum": "ac25a44fb809f2b4c158abccb88b1a2e66433be79bf46092522f07b02d72ab68",
+        "size": 21399468,
+        "source": "components/google-cloud-sdk-kubectl-oidc-linux-arm-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5509,16 +5776,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231201141418,
-        "version_string": "1.5.0"
+        "build_number": 20240426154730,
+        "version_string": "1.5.1"
       }
     },
     {
       "data": {
-        "checksum": "94eb2344e8f1a5cff5b2f1db0c35e3cfc378336f148a701ac94e4111f17069f1",
-        "contents_checksum": "9ddfa977b16e32f97c5d5ad574ff09ae06f67b87f218f45a178cfae5f88d4355",
-        "size": 22854824,
-        "source": "components/google-cloud-sdk-kubectl-oidc-linux-x86_64-20231201141418.tar.gz",
+        "checksum": "314b8b36331fc2b67fee555fcfb7c0aa1c4c742dcb995164f9822fc513f269de",
+        "contents_checksum": "a7e6a84feb050b265084ae1ea6d8bd0898258b76e7f6226c01d9d8e65fceeb5d",
+        "size": 23109484,
+        "source": "components/google-cloud-sdk-kubectl-oidc-linux-x86_64-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5542,16 +5809,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231201141418,
-        "version_string": "1.5.0"
+        "build_number": 20240426154730,
+        "version_string": "1.5.1"
       }
     },
     {
       "data": {
-        "checksum": "386b201a127ea6723ba4f4ac943c596310d03aa0568d947f23980577fc0c5685",
-        "contents_checksum": "72ccfee0b039eaf5d4bd5445044806c84a1af5d55318de032a372af0fdf779c4",
-        "size": 23111830,
-        "source": "components/google-cloud-sdk-kubectl-oidc-windows-x86_64-20231201141418.tar.gz",
+        "checksum": "b72cb005890e61307350e45fed931c783f9954a18249210059f780b42ae0c6fc",
+        "contents_checksum": "cabcb7396bd79cf1e80baeb1a53da5e56497ce49a97fbd9e33127da81999e0d7",
+        "size": 23361379,
+        "source": "components/google-cloud-sdk-kubectl-oidc-windows-x86_64-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5575,16 +5842,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231201141418,
-        "version_string": "1.5.0"
+        "build_number": 20240426154730,
+        "version_string": "1.5.1"
       }
     },
     {
       "data": {
-        "checksum": "80b067c1eed2401d32b2078e9296322ceecad8de4903105c8627a182bc626f89",
-        "contents_checksum": "008b98a6902a2d260427a6067f7b26278c947c3da0f65a135bea6806906de7cc",
-        "size": 75077053,
-        "source": "components/google-cloud-sdk-kubectl-windows-x86-20240209195330.tar.gz",
+        "checksum": "ea209e06d08eed40e21b67d72464b125a44c0bff85e846d44aef998ddfe5fc1f",
+        "contents_checksum": "b4a4f3ff7f7b3c687cf47a38813226385f7e893fdcd9a7a5d60b1dbdf99ae2a3",
+        "size": 89369395,
+        "source": "components/google-cloud-sdk-kubectl-windows-x86-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5611,16 +5878,16 @@
       },
       "platform_required": true,
       "version": {
-        "build_number": 20240209195330,
-        "version_string": "1.26.13"
+        "build_number": 20240426154730,
+        "version_string": "1.26.15"
       }
     },
     {
       "data": {
-        "checksum": "a632645797fb65db3f112548543ce4f7b1e048963f264bf5bc9e318f9f85cda2",
-        "contents_checksum": "bcdf97a387126e7b831c903b905bc96af608ff2fc5d2013482280535f077c21c",
-        "size": 77301897,
-        "source": "components/google-cloud-sdk-kubectl-windows-x86_64-20240209195330.tar.gz",
+        "checksum": "0841109ca38d58e3dde3b54854b52ca1a0ac3405cbd7c76ea23cad5c31bdad2b",
+        "contents_checksum": "d024e22580bf9c9e3e35a5952241cae4681411e9b33c76f19b1b4b623b7269b1",
+        "size": 94204602,
+        "source": "components/google-cloud-sdk-kubectl-windows-x86_64-20240426154730.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5647,8 +5914,8 @@
       },
       "platform_required": true,
       "version": {
-        "build_number": 20240209195330,
-        "version_string": "1.26.13"
+        "build_number": 20240426154730,
+        "version_string": "1.26.15"
       }
     },
     {
@@ -6398,15 +6665,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "1.17.2-rc.1"
+        "version_string": "1.17.3-rc.2"
       }
     },
     {
       "data": {
-        "checksum": "3fd0c679ed6a308edc3460a04e939ef67152e9717ebac4c18b38e98edac51cea",
-        "contents_checksum": "bc7d9a0ef3f3a61d1d4d59a500ec650acae2425ab17b723bc4c2ad5d05a0837a",
-        "size": 29981784,
-        "source": "components/google-cloud-sdk-nomos-darwin-x86_64-20240229170130.tar.gz",
+        "checksum": "d419aaa0a419d8a01b025d5b79372e92d0b08def255e7a8bfb0361c8332267f6",
+        "contents_checksum": "d3f8f98cdba8da0aadf0a19d8503955023f70a2d8045838b893eb3e0b0e345ce",
+        "size": 29981660,
+        "source": "components/google-cloud-sdk-nomos-darwin-x86_64-20240322135349.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6430,16 +6697,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240229170130,
-        "version_string": "1.17.2-rc.1"
+        "build_number": 20240322135349,
+        "version_string": "1.17.3-rc.2"
       }
     },
     {
       "data": {
-        "checksum": "93d532890f146415a74734c921ded0e8bdd408d3d9424beb6bbb7113530ec5fe",
-        "contents_checksum": "b429ab3ef37405bc06cbd594edc0730dd162f37a933fa854597a1bd5e59c761d",
-        "size": 30144691,
-        "source": "components/google-cloud-sdk-nomos-linux-x86_64-20240229170130.tar.gz",
+        "checksum": "d744e544fc05b996439c39e36454ec902f2998bcc9bf9d32337aaeb34bbb604e",
+        "contents_checksum": "d0458512f4a0047c7ba2504246d8428fc0f8de3fec56b37b69b43e62ceb2af75",
+        "size": 30144536,
+        "source": "components/google-cloud-sdk-nomos-linux-x86_64-20240322135349.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6463,8 +6730,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240229170130,
-        "version_string": "1.17.2-rc.1"
+        "build_number": 20240322135349,
+        "version_string": "1.17.3-rc.2"
       }
     },
     {
@@ -6744,10 +7011,10 @@
     },
     {
       "data": {
-        "checksum": "a080b9775844f83bcce039e5c9dff7f4c87d69ae7cf6f0cc85a3c9212b8361ed",
-        "contents_checksum": "bcc50b05f18aabe3fd90857ec8933e7580ee9212d764d3efb9ac6ef26b01a9fa",
-        "size": 66384213,
-        "source": "components/google-cloud-sdk-pubsub-emulator-20240229170130.tar.gz",
+        "checksum": "3bafcd5a4ec4e65c540640a97737e4a5e596795e73ead6f4fd75591879c9e529",
+        "contents_checksum": "956782b7d4b6b2057f339a7978728426fef50f7a99c888e1b1342eaf2f9ee8d9",
+        "size": 66777134,
+        "source": "components/google-cloud-sdk-pubsub-emulator-20240419141706.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6764,8 +7031,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240229170130,
-        "version_string": "0.8.12"
+        "build_number": 20240419141706,
+        "version_string": "0.8.14"
       }
     },
     {
@@ -6799,15 +7066,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "2.9.0"
+        "version_string": "2.11.1"
       }
     },
     {
       "data": {
-        "checksum": "badd2854a9b5a3b4d3b8b55c163656776778c572eba854262bfd637c803ca3b7",
-        "contents_checksum": "45e2f3eb2703f29f735cbc820e9d4004f1e95bea1ab96e698ded74f2a5de857d",
-        "size": 24426195,
-        "source": "components/google-cloud-sdk-skaffold-darwin-arm-20231110155547.tar.gz",
+        "checksum": "53c4ab91c11e5cbd68568f8599906e6e5192f3b4019e9761fddfdc45f9af7845",
+        "contents_checksum": "d24345e52dde87a54de371fe79441dd90afe4fe3079bebce79c4f7043f8ac506",
+        "size": 23881902,
+        "source": "components/google-cloud-sdk-skaffold-darwin-arm-20240412130805.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6832,16 +7099,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231110155547,
-        "version_string": "2.9.0"
+        "build_number": 20240412130805,
+        "version_string": "2.11.1"
       }
     },
     {
       "data": {
-        "checksum": "cba0d4046df4764747f9a15ebe061fec60f9f768d1079041feea2321c5cd5e76",
-        "contents_checksum": "941bc43d4633be69ed64eadf7ad3ba477929bd6dcb519dc668b77f29b5115a57",
-        "size": 26530698,
-        "source": "components/google-cloud-sdk-skaffold-darwin-x86_64-20231110155547.tar.gz",
+        "checksum": "b7dcae5f81e8a66ecf964d9a7e6c009be0be26770daa64470c344a0824a70d6c",
+        "contents_checksum": "a1845e050a4fc99ce6bd24c4c8e30e9c7fe0baa7ca6d89ade4a9ac945a1335fd",
+        "size": 26019391,
+        "source": "components/google-cloud-sdk-skaffold-darwin-x86_64-20240412130805.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6866,16 +7133,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231110155547,
-        "version_string": "2.9.0"
+        "build_number": 20240412130805,
+        "version_string": "2.11.1"
       }
     },
     {
       "data": {
-        "checksum": "45cb0e94d47b3b28db5d8dda5fbd1dd7fbfad96936ce3bbbdce3f2f8be63a093",
-        "contents_checksum": "2f36d4b1b0eab170b21fe0df2964aa31d79694a8860070c32b7eb7bc471a74aa",
-        "size": 22439050,
-        "source": "components/google-cloud-sdk-skaffold-linux-arm-20231110155547.tar.gz",
+        "checksum": "0f285235cc2840a8e62d5e8591015c709287ebf01bd8f95b204a5b4d4b019b2a",
+        "contents_checksum": "061859c0ad969a5cb9a3bcd0b34760963c8c842b9902f9b22e97df4e94ff7a65",
+        "size": 23133354,
+        "source": "components/google-cloud-sdk-skaffold-linux-arm-20240412130805.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6900,16 +7167,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231110155547,
-        "version_string": "2.9.0"
+        "build_number": 20240412130805,
+        "version_string": "2.11.1"
       }
     },
     {
       "data": {
-        "checksum": "6add62f50ef3b9d77259177118ee30251c2f07074fc4555d516a3ae5dfbbb3b6",
-        "contents_checksum": "065a00f4d25312efad8a854d21809862d9f0e41588511a1c1930ed5c34e7e57b",
-        "size": 24544699,
-        "source": "components/google-cloud-sdk-skaffold-linux-x86_64-20231110155547.tar.gz",
+        "checksum": "3e7164c21840917c2f565998cdbd20be3972ba5cc09ddad31f01cbd0233c34f6",
+        "contents_checksum": "99c37298757f59403dc8b7b080419ccb62bdb23fb88f559bd31b603cb9a2b4d6",
+        "size": 25252692,
+        "source": "components/google-cloud-sdk-skaffold-linux-x86_64-20240412130805.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6934,16 +7201,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231110155547,
-        "version_string": "2.9.0"
+        "build_number": 20240412130805,
+        "version_string": "2.11.1"
       }
     },
     {
       "data": {
-        "checksum": "577504b2686302f74a7e00bebe9a561b0caa15d3294dc0c9e15dba2d9d745f32",
-        "contents_checksum": "940d470dd53773d3e907de4d80ef70df247824167fcb95a05494e66e6bb28c9a",
-        "size": 25035980,
-        "source": "components/google-cloud-sdk-skaffold-windows-x86_64-20231110155547.tar.gz",
+        "checksum": "8f864d4189e19ce50bcb52ba61802d70e4e83bb18b13ff32ded5086a7c867fe5",
+        "contents_checksum": "c340681db503b83f07f4ac5ea4f00c4c8db288eaaf6e19ddf6e4b52c29d13e48",
+        "size": 25741614,
+        "source": "components/google-cloud-sdk-skaffold-windows-x86_64-20240412130805.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6968,8 +7235,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231110155547,
-        "version_string": "2.9.0"
+        "build_number": 20240412130805,
+        "version_string": "2.11.1"
       }
     },
     {
@@ -6995,15 +7262,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "3.2.2"
+        "version_string": "3.2.4"
       }
     },
     {
       "data": {
-        "checksum": "6f55289b6cdb9206c110e5e1f3e040e4c9a69aa129c5c0caae71bc668b17bca9",
-        "contents_checksum": "2284e73fc19acea54651526b45fd808530a9272fd56b0c553386bbfaac02f729",
-        "size": 24615874,
-        "source": "components/google-cloud-sdk-spanner-migration-tool-linux-x86_64-20240112150613.tar.gz",
+        "checksum": "3772182f6246ce7ee4a24d4af5f07a0b0ce718d563c80439baabd8cf13318505",
+        "contents_checksum": "49868f973b97b24f2f042d5a3b05105ef0c4ba8974c9268ecaa1a232a735d902",
+        "size": 24679221,
+        "source": "components/google-cloud-sdk-spanner-migration-tool-linux-x86_64-20240412130805.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -7027,8 +7294,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20240112150613,
-        "version_string": "3.2.2"
+        "build_number": 20240412130805,
+        "version_string": "3.2.4"
       }
     },
     {
@@ -7056,10 +7323,10 @@
     },
     {
       "data": {
-        "checksum": "d1e1fda36ce35e058bf23f8cf114acd776c2891227f23cf3b9d78fb35f89b523",
-        "contents_checksum": "8a106316d2efe6baaa483a8677c9f0f807b43189ad3cbe1cefa8055e7500a318",
-        "size": 3485676,
-        "source": "components/google-cloud-sdk-ssh-tools-windows-20211112160846.tar.gz",
+        "checksum": "120bd981566b18fae7041191f60980d99bb654e8fc846cc0eabf5de1719981e9",
+        "contents_checksum": "1fa1d0fcc0a4fa9fc465722a33fd5f89a0ad09e014840594557461409535ca81",
+        "size": 3783443,
+        "source": "components/google-cloud-sdk-ssh-tools-windows-20240419141706.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -7080,7 +7347,7 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20211112160846,
+        "build_number": 20240419141706,
         "version_string": ""
       }
     },
@@ -7284,10 +7551,10 @@
     },
     {
       "data": {
-        "checksum": "274f5f8fa50423d400d3df880f06bab3a10fadf9ce9a4b65bbb00d5ef84afe3a",
-        "contents_checksum": "d3d35039158b47815d55b4cf508dccc25076c4250104e4277e3555782fc81317",
-        "size": 51453272,
-        "source": "components/google-cloud-sdk-tests-20240229170130.tar.gz",
+        "checksum": "f90e47ac6bbf129c724555e5f7ad3dc105de5059d1cc9ab77c99f52a92fae0cb",
+        "contents_checksum": "b515c8b801cde8a8696832a5dbf16d8f1e9adcc4f4651db36fda76e41b008809",
+        "size": 56934482,
+        "source": "components/google-cloud-sdk-tests-20240503145345.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -7304,8 +7571,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20240229170130,
-        "version_string": "2024.02.29"
+        "build_number": 20240503145345,
+        "version_string": "2024.05.03"
       }
     }
   ],
@@ -7324,11 +7591,11 @@
   ],
   "post_processing_command": "components post-process",
   "release_notes_url": "RELEASE_NOTES",
-  "revision": 20240229170130,
+  "revision": 20240503145345,
   "schema_version": {
     "no_update": false,
     "url": "https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz",
     "version": 3
   },
-  "version": "467.0.0"
+  "version": "475.0.0"
 }

--- a/pkgs/tools/admin/google-cloud-sdk/data.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/data.nix
@@ -1,32 +1,32 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "467.0.0";
+  version = "475.0.0";
   googleCloudSdkPkgs = {
     x86_64-linux =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-467.0.0-linux-x86_64.tar.gz";
-        sha256 = "09qkz9zw23rza5siz77m52nzfyikdzszrqsl200z2zs2cm69g50w";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-475.0.0-linux-x86_64.tar.gz";
+        sha256 = "0yqa2c91n948yj8gxjm91ccdb99dzppimf1npckplzhc2bp7shiw";
       };
     x86_64-darwin =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-467.0.0-darwin-x86_64.tar.gz";
-        sha256 = "0il26ivqym4n94kjb22pcizgmy6j1p70l2yxjfrsj8i6vhwi3qbq";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-475.0.0-darwin-x86_64.tar.gz";
+        sha256 = "078wwvjhpc9a56v03y6433zpwaj3cg3y9xrbg9ww5fdqvcc82q1z";
       };
     aarch64-linux =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-467.0.0-linux-arm.tar.gz";
-        sha256 = "1d72l35jcxg7r2r8ajhyigadj8ydp2k1g25kw6rkwvlg4whv8d7b";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-475.0.0-linux-arm.tar.gz";
+        sha256 = "1wfr6lz62y232wzp7nn3mr18qd4wmw47b3p3sjff0f39jfmcyq30";
       };
     aarch64-darwin =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-467.0.0-darwin-arm.tar.gz";
-        sha256 = "0yd9hjn8pgaih7hj3hhbl70apcmg5b3gkx758r8m9823vhqkk5wm";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-475.0.0-darwin-arm.tar.gz";
+        sha256 = "1cjhbq0qsy35nwl5h1f8xp4d67a6hwmfjzdk349g1npf5dhhdd94";
       };
     i686-linux =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-467.0.0-linux-x86.tar.gz";
-        sha256 = "0wag0qjzh0m6kmpzvmzvr7sy74w20xzgysljwjfravqr1xmw9m48";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-475.0.0-linux-x86.tar.gz";
+        sha256 = "1cj5321lj3dbb48h35qlxllrzzg90lwq92n71c2y4s2mqk33543h";
       };
   };
 }


### PR DESCRIPTION
## Description of changes

Update to the latest Google Cloud SDK

See: https://cloud.google.com/sdk/docs/release-notes#47500_2024-05-07

This is a replacement of #306237 as 3 new versions has been released since.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Verified all plugins install properly:
```
$ nix build --print-build-logs --impure --expr 'let pkgs = import ./. {}; in pkgs.google-cloud-sdk.withExtraComponents (with pkgs.google-cloud-sdk.components; [anthos-auth anthoscli app-engine-go app-engine-grpc app-engine-java app-engine-python app-engine-python-extras 
appctl bigtable cbt cloud-build-local cloud-datastore-emulator cloud-firestore-emulator cloud-run-proxy cloud-sql-proxy cloud-spanner-emulator cloud_sql_proxy config-connector docker-credential-gcr enterprise-certificate-proxy gcloud-crc32c gcloud-man-pages gke-gcloud-au
th-plugin harbourbridge istioctl kpt kubectl kubectl-oidc kustomize local-extract log-streaming minikube nomos package-go-module pkg pubsub-emulator skaffold spanner-migration-tool terraform-tools])'
```

```
$ ./result/bin/gcloud components list                                                                                                                                                                                                                                 (17.96s) 

Your current Google Cloud CLI version is: 475.0.0
The latest available version is: 475.0.0

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                  Components                                                 │
├───────────┬──────────────────────────────────────────────────────┬──────────────────────────────┬───────────┤
│   Status  │                         Name                         │              ID              │    Size   │
├───────────┼──────────────────────────────────────────────────────┼──────────────────────────────┼───────────┤
│ Installed │ App Engine Go Extensions                             │ app-engine-go                │   4.7 MiB │
│ Installed │ Appctl                                               │ appctl                       │  21.0 MiB │
│ Installed │ Artifact Registry Go Module Package Helper           │ package-go-module            │   < 1 MiB │
│ Installed │ BigQuery Command Line Tool                           │ bq                           │   1.7 MiB │
│ Installed │ Bundled Python 3.11                                  │ bundled-python3-unix         │  74.9 MiB │
│ Installed │ Cloud Bigtable Command Line Tool                     │ cbt                          │  17.3 MiB │
│ Installed │ Cloud Bigtable Emulator                              │ bigtable                     │   7.3 MiB │
│ Installed │ Cloud Datastore Emulator                             │ cloud-datastore-emulator     │  36.2 MiB │
│ Installed │ Cloud Firestore Emulator                             │ cloud-firestore-emulator     │  45.1 MiB │
│ Installed │ Cloud Pub/Sub Emulator                               │ pubsub-emulator              │  63.7 MiB │
│ Installed │ Cloud Run Proxy                                      │ cloud-run-proxy              │  13.3 MiB │
│ Installed │ Cloud SQL Proxy v2                                   │ cloud-sql-proxy              │  13.8 MiB │
│ Installed │ Cloud Spanner Emulator                               │ cloud-spanner-emulator       │  36.5 MiB │
│ Installed │ Cloud Spanner Migration Tool                         │ harbourbridge                │  20.9 MiB │
│ Installed │ Cloud Storage Command Line Tool                      │ gsutil                       │  11.3 MiB │
│ Installed │ Google Cloud CLI Core Libraries                      │ core                         │  18.5 MiB │
│ Installed │ Google Cloud CRC32C Hash Tool                        │ gcloud-crc32c                │   1.2 MiB │
│ Installed │ Google Container Registry's Docker credential helper │ docker-credential-gcr        │   1.8 MiB │
│ Installed │ Kustomize                                            │ kustomize                    │   4.3 MiB │
│ Installed │ Log Streaming                                        │ log-streaming                │  13.9 MiB │
│ Installed │ Minikube                                             │ minikube                     │  35.4 MiB │
│ Installed │ Nomos CLI                                            │ nomos                        │  28.7 MiB │
│ Installed │ On-Demand Scanning API extraction helper             │ local-extract                │  14.4 MiB │
│ Installed │ Skaffold                                             │ skaffold                     │  24.1 MiB │
│ Installed │ Spanner migration tool                               │ spanner-migration-tool       │  23.5 MiB │
│ Installed │ Terraform Tools                                      │ terraform-tools              │  66.1 MiB │
│ Installed │ anthos-auth                                          │ anthos-auth                  │  22.0 MiB │
│ Installed │ config-connector                                     │ config-connector             │  56.7 MiB │
│ Installed │ enterprise-certificate-proxy                         │ enterprise-certificate-proxy │   8.6 MiB │
│ Installed │ gcloud Alpha Commands                                │ alpha                        │   < 1 MiB │
│ Installed │ gcloud Beta Commands                                 │ beta                         │   < 1 MiB │
│ Installed │ gcloud app Java Extensions                           │ app-engine-java              │ 126.2 MiB │
│ Installed │ gcloud app Python Extensions                         │ app-engine-python            │   5.0 MiB │
│ Installed │ gcloud app Python Extensions (Extra Libraries)       │ app-engine-python-extras     │   < 1 MiB │
│ Installed │ gke-gcloud-auth-plugin                               │ gke-gcloud-auth-plugin       │   7.9 MiB │
│ Installed │ istioctl                                             │ istioctl                     │  24.0 MiB │
│ Installed │ kpt                                                  │ kpt                          │  14.4 MiB │
│ Installed │ kubectl                                              │ kubectl                      │   < 1 MiB │
│ Installed │ kubectl-oidc                                         │ kubectl-oidc                 │  22.0 MiB │
│ Installed │ pkg                                                  │ pkg                          │           │
└───────────┴──────────────────────────────────────────────────────┴──────────────────────────────┴───────────┘
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
