### PR TITLE
[WIP] qt6.qtwebengine: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine.nix
@@ -122,6 +122,11 @@ qtModule {
   hardeningDisable = [ "format" ];
 
   patches = [
+    # removes macOS 12+ dependencies
+    ../patches/qtwebengine-darwin-no-low-latency-flag.patch
+    ../patches/qtwebengine-darwin-no-copy-certificate-chain.patch
+    ../patches/qtwebengine-darwin-no-safe-area-insets.patch
+    ../patches/qtwebengine-darwin-no-stage-manager.patch
     # Don't assume /usr/share/X11, and also respect the XKB_CONFIG_ROOT
     # environment variable, since NixOS relies on it working.
     # See https://github.com/NixOS/nixpkgs/issues/226484 for more context.

--- a/pkgs/development/libraries/qt-6/patches/qtwebengine-darwin-no-copy-certificate-chain.patch
+++ b/pkgs/development/libraries/qt-6/patches/qtwebengine-darwin-no-copy-certificate-chain.patch
@@ -1,0 +1,17 @@
+diff --git a/src/3rdparty/chromium/net/cert/x509_util_apple.cc b/src/3rdparty/chromium/net/cert/x509_util_apple.cc
+index 415acbd5a..f59737180 100644
+--- a/src/3rdparty/chromium/net/cert/x509_util_apple.cc
++++ b/src/3rdparty/chromium/net/cert/x509_util_apple.cc
+@@ -147,10 +147,12 @@ SHA256HashValue CalculateFingerprint256(SecCertificateRef cert) {
+ 
+ base::apple::ScopedCFTypeRef<CFArrayRef> CertificateChainFromSecTrust(
+     SecTrustRef trust) {
++#if 0
+   if (__builtin_available(macOS 12.0, iOS 15.0, *)) {
+     return base::apple::ScopedCFTypeRef<CFArrayRef>(
+         SecTrustCopyCertificateChain(trust));
+   }
++#endif
+ 
+ // TODO(crbug.com/1426476): Remove code when it is no longer needed.
+ #if (BUILDFLAG(IS_MAC) &&                                    \

--- a/pkgs/development/libraries/qt-6/patches/qtwebengine-darwin-no-low-latency-flag.patch
+++ b/pkgs/development/libraries/qt-6/patches/qtwebengine-darwin-no-low-latency-flag.patch
@@ -1,0 +1,67 @@
+diff --git a/src/3rdparty/chromium/media/gpu/mac/vt_video_encode_accelerator_mac.cc b/src/3rdparty/chromium/media/gpu/mac/vt_video_encode_accelerator_mac.cc
+index 06e1d311a..fb4bf1881 100644
+--- a/src/3rdparty/chromium/media/gpu/mac/vt_video_encode_accelerator_mac.cc
++++ b/src/3rdparty/chromium/media/gpu/mac/vt_video_encode_accelerator_mac.cc
+@@ -34,7 +34,9 @@
+ // EnableLowLatencyRateControl flag. The flag is actually supported since 11.3,
+ // but there we see frame drops even with ample bitrate budget. Excessive frame
+ // drops were fixed in 12.0.1.
++#if 0
+ #define LOW_LATENCY_AND_SVC_AVAILABLE_VER 12.0.1
++#endif
+ 
+ namespace media {
+ 
+@@ -69,16 +71,20 @@ bool IsSVCSupported(const VideoCodec& codec) {
+ #if BUILDFLAG(ENABLE_HEVC_PARSER_AND_HW_DECODER) && defined(ARCH_CPU_ARM_FAMILY)
+   // macOS 14.0+ support SVC HEVC encoding for Apple Silicon chips only.
+   if (codec == VideoCodec::kHEVC) {
++#if 0
+     if (__builtin_available(macOS 14.0, iOS 17.0, *)) {
+       return true;
+     }
++#endif
+     return false;
+   }
+ #endif  // BUILDFLAG(ENABLE_HEVC_PARSER_AND_HW_DECODER) &&
+         // defined(ARCH_CPU_ARM_FAMILY)
++#if 0
+   if (__builtin_available(macOS LOW_LATENCY_AND_SVC_AVAILABLE_VER, *)) {
+     return codec == VideoCodec::kH264;
+   }
++#endif
+   return false;
+ }
+ 
+@@ -751,6 +757,7 @@ bool VTVideoEncodeAccelerator::CreateCompressionSession(
+   }
+ #endif
+ 
++#if 0
+   if (__builtin_available(macOS LOW_LATENCY_AND_SVC_AVAILABLE_VER, *)) {
+     if (require_low_delay_ && IsSVCSupported(codec)) {
+       encoder_keys.push_back(
+@@ -758,6 +765,7 @@ bool VTVideoEncodeAccelerator::CreateCompressionSession(
+       encoder_values.push_back(kCFBooleanTrue);
+     }
+   }
++#endif
+   base::apple::ScopedCFTypeRef<CFDictionaryRef> encoder_spec =
+       video_toolbox::DictionaryWithKeysAndValues(
+           encoder_keys.data(), encoder_values.data(), encoder_keys.size());
+@@ -870,6 +878,7 @@ bool VTVideoEncodeAccelerator::ConfigureCompressionSession(VideoCodec codec) {
+     return false;
+   }
+ 
++#if 0
+   if (__builtin_available(macOS LOW_LATENCY_AND_SVC_AVAILABLE_VER, *)) {
+     if (!session_property_setter.IsSupported(
+             kVTCompressionPropertyKey_BaseLayerFrameRateFraction)) {
+@@ -884,6 +893,7 @@ bool VTVideoEncodeAccelerator::ConfigureCompressionSession(VideoCodec codec) {
+       return false;
+     }
+   }
++#endif
+ 
+   return true;
+ }

--- a/pkgs/development/libraries/qt-6/patches/qtwebengine-darwin-no-safe-area-insets.patch
+++ b/pkgs/development/libraries/qt-6/patches/qtwebengine-darwin-no-safe-area-insets.patch
@@ -1,0 +1,38 @@
+diff --git a/src/3rdparty/chromium/components/remote_cocoa/app_shim/immersive_mode_controller.mm b/src/3rdparty/chromium/components/remote_cocoa/app_shim/immersive_mode_controller.mm
+index 3cff2cbcfab..7be0078c856 100644
+--- a/src/3rdparty/chromium/components/remote_cocoa/app_shim/immersive_mode_controller.mm
++++ b/src/3rdparty/chromium/components/remote_cocoa/app_shim/immersive_mode_controller.mm
+@@ -485,9 +485,11 @@ double ImmersiveModeController::GetOffscreenYOrigin() {
+ 
+   // Make sure to make it past the safe area insets, otherwise some portion
+   // of the window may still be displayed.
++#if 0
+   if (@available(macOS 12.0, *)) {
+     y += browser_window_.screen.safeAreaInsets.top;
+   }
++#endif
+ 
+   return y;
+ }
+diff --git a/src/3rdparty/chromium/ui/views/cocoa/immersive_mode_controller_unittest.mm b/src/3rdparty/chromium/ui/views/cocoa/immersive_mode_controller_unittest.mm
+index d822965b9ba..294dd2d3f7e 100644
+--- a/src/3rdparty/chromium/ui/views/cocoa/immersive_mode_controller_unittest.mm
++++ b/src/3rdparty/chromium/ui/views/cocoa/immersive_mode_controller_unittest.mm
+@@ -226,13 +226,17 @@ TEST_F(CocoaImmersiveModeControllerTest, TitlebarObserver) {
+     [titlebar_container_view
+         setFrame:NSMakeRect(0, kOverlayViewHeight + 1, kOverlayViewWidth,
+                             kOverlayViewHeight)];
++#if 0
+     if (@available(macOS 12.0, *)) {
+       EXPECT_EQ(overlay().frame.origin.y,
+                 browser().screen.frame.size.height +
+                     browser().screen.safeAreaInsets.top);
+     } else {
++#endif
+       EXPECT_EQ(overlay().frame.origin.y, browser().screen.frame.size.height);
++#if 0
+     }
++#endif
+ 
+     // Remove the clip and make sure the overlay window moves back.
+     [titlebar_container_view

--- a/pkgs/development/libraries/qt-6/patches/qtwebengine-darwin-no-stage-manager.patch
+++ b/pkgs/development/libraries/qt-6/patches/qtwebengine-darwin-no-stage-manager.patch
@@ -1,0 +1,24 @@
+diff --git a/src/3rdparty/chromium/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm b/src/3rdparty/chromium/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
+index 7c702f14028..443ba2d4107 100644
+--- a/src/3rdparty/chromium/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
++++ b/src/3rdparty/chromium/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
+@@ -1480,15 +1480,19 @@ void NativeWidgetNSWindowBridge::SetCanAppearInExistingFullscreenSpaces(
+     bool can_appear_in_existing_fullscreen_spaces) {
+   NSWindowCollectionBehavior collectionBehavior = window_.collectionBehavior;
+   if (can_appear_in_existing_fullscreen_spaces) {
++#if 0
+     if (@available(macOS 13.0, *)) {
+       collectionBehavior &= ~NSWindowCollectionBehaviorPrimary;
+     }
++#endif
+     collectionBehavior |= NSWindowCollectionBehaviorFullScreenAuxiliary;
+     collectionBehavior &= ~NSWindowCollectionBehaviorFullScreenPrimary;
+   } else {
++#if 0
+     if (@available(macOS 13.0, *)) {
+       collectionBehavior |= NSWindowCollectionBehaviorPrimary;
+     }
++#endif
+     collectionBehavior |= NSWindowCollectionBehaviorFullScreenPrimary;
+     collectionBehavior &= ~NSWindowCollectionBehaviorFullScreenAuxiliary;
+   }


### PR DESCRIPTION
## Description of changes

Work in progress.

```
[24852/29077] OBJCXX obj/content/browser/browser/tts_mac.o
FAILED: obj/content/browser/browser/tts_mac.o 
In file included from ../../../../../src/3rdparty/chromium/content/browser/speech/tts_mac.mm:5:
../../../../../src/3rdparty/chromium/content/browser/speech/tts_mac.h:8:9: fatal error: 'AVFAudio/AVFAudio.h' file not found
#import <AVFAudio/AVFAudio.h>
        ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

https://github.com/chromium/chromium/commit/1299120f15b90db3d3870dc18a0ccf3f2e5ac4db

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
