### PR TITLE
Always use "nodev" for Grub to not fail on NVMe-powered AWS EC2 instances

### DIFF
--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -59,7 +59,7 @@ in
     # boot.
     boot.blacklistedKernelModules = [ "nouveau" "xen_fbfront" ];
 
-    boot.loader.grub.device = if cfg.efi then "nodev" else "/dev/xvda";
+    boot.loader.grub.device = "nodev";
     boot.loader.grub.efiSupport = cfg.efi;
     boot.loader.grub.efiInstallAsRemovable = cfg.efi;
     boot.loader.timeout = 1;


### PR DESCRIPTION
[#62824](https://github.com/NixOS/nixpkgs/issues/62824)

It should be carefully considered if the `efi` condition was really needed, so far seemingly it's not optimal.
