### PR TITLE
lx-music-sync-server: init at 2.1.2, nixos/lx-music-sync-server: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -217,6 +217,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [keto](https://www.ory.sh/keto/), a permission & access control server, the first open source implementation of ["Zanzibar: Google's Consistent, Global Authorization System"](https://research.google/pubs/zanzibar-googles-consistent-global-authorization-system/).
 
+- [lx-music-sync-server](https://github.com/lyswhut/lx-music-sync-server), a data synchronization service of [LX Music](https://github.com/lyswhut/lx-music-desktop) running on Node.js.
+
 ## Backward Incompatibilities {#sec-release-24.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1377,6 +1377,7 @@
   ./services/web-apps/lanraragi.nix
   ./services/web-apps/lemmy.nix
   ./services/web-apps/limesurvey.nix
+  ./services/web-apps/lx-music-sync-server.nix
   ./services/web-apps/mainsail.nix
   ./services/web-apps/mastodon.nix
   ./services/web-apps/matomo.nix

--- a/nixos/modules/services/web-apps/lx-music-sync-server.nix
+++ b/nixos/modules/services/web-apps/lx-music-sync-server.nix
@@ -1,0 +1,305 @@
+{ config
+, lib
+, pkgs
+, ...
+}:
+
+let
+  cfg = config.services.lx-music-sync-server;
+
+  accountOption = { name, ... }: {
+    options = {
+      name = lib.mkOption {
+        type = lib.types.strMatching "[a-zA-Z0-9_]+";
+        default = name;
+        defaultText = ''
+          config.services.lx-music-sync-server.account.<name>
+        '';
+        description = ''
+          Name of a user of the synchronization service. Only alphabets, digits
+          and underscores are allowed.
+        '';
+      };
+
+      password = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          The corresponding user's password. Warning: it will be world-readable
+          in /nix/store.
+        '';
+      };
+
+      passwordFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "/run/secrets/lx-music-sync-server-password";
+        description = ''
+          The file from which a user's password is loaded.
+        '';
+      };
+
+      maxSnapshotNum = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = cfg.maxSnapshotNum;
+        defaultText = ''
+          config.services.lx-music-sync-server.maxSnapshotNum
+        '';
+        description = ''
+          The user-specific maximum number of snapshots.
+        '';
+      };
+
+      listAddMusicLocation = lib.mkOption {
+        type = lib.types.enum [ "top" "bottom" ];
+        default = cfg.listAddMusicLocation;
+        defaultText = ''
+          config.services.lx-music-sync-server.listAddMusicLocation
+        '';
+        description = ''
+          The user-specific location of a newly added music.
+        '';
+      };
+    };
+  };
+
+  logDir = if cfg.logDir == null
+    then "%L/lx-music-sync-server"
+    else cfg.logDir;
+
+  dataDir = if cfg.logDir == null
+    then "%S/lx-music-sync-server"
+    else cfg.dataDir;
+in {
+  ###### interface
+
+  options.services.lx-music-sync-server = {
+    enable = lib.mkEnableOption
+      ("Data synchronization service of LX Music running on Node.js");
+
+    package = lib.mkPackageOption pkgs "lx-music-sync-server" {};
+
+    name = lib.mkOption {
+      type = lib.types.str;
+      default = "LX Music Sync Server";
+      description = ''
+        The name of the synchronization service.
+      '';
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 9527;
+      description = ''
+        Port for theh server to listen on.
+      '';
+    };
+
+    ip = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = ''
+        The IP address for the service to bind. Use 127.0.0.1 by default. Use
+        0.0.0.0 to accept all IPv4 requests. Or use :: to accept all requests
+        including IPv4 and IPv6.
+      '';
+    };
+
+    proxy = {
+      enable = lib.mkEnableOption ("Whether to enable support for reverse proxy");
+
+      header = lib.mkOption {
+        type = lib.types.str;
+        default = "x-real-ip";
+        description = ''
+          The request header's field from which the client's real IP is obtained.
+        '';
+      };
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "lx-music-sync-server";
+      description = ''
+        The user to run lx-music-sync-server as.
+      '';
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "lx-music-sync-server";
+      description = ''
+        The group to run lx-music-sync-server under.
+      '';
+    };
+
+    logDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "/var/lx-music-sync-server/";
+      description = ''
+        The directory to which the service's log writes.
+      '';
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "/var/lib/lx-music-sync-server/";
+      description = ''
+        The directory where the service's data is stored.
+      '';
+    };
+
+    maxSnapshotNum = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 10;
+      description = ''
+        The maximum number of snapshots. This option can be overridden by
+        account-specific configurations.
+      '';
+    };
+
+    listAddMusicLocation = lib.mkOption {
+      type = lib.types.enum [ "top" "bottom" ];
+      default = "top";
+      description = ''
+        The location of a newly added music. This option can be overridden by
+        account-specific configurations.
+      '';
+    };
+
+    accounts = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule accountOption);
+      default = {};
+      example = lib.literalExpression ''
+        {
+          user1 = {
+            passwordFile = "/path/to/password";
+            maxSnapshotNum = 10;
+            listAddMusicLocation = "top";
+          };
+        }
+      '';
+      description = ''
+        Configurations of all accounts. Note that usernames should only contain
+        alphabets, digits and underscores. The password of each user should be
+        unique.
+      '';
+    };
+  };
+
+  ###### implementation
+
+  config = lib.mkIf cfg.enable {
+    warnings = builtins.concatMap
+      (account: lib.optional
+        (account.password != null)
+        "The password of lx-music-sync-server user ${account.name} will be world-readable in /nix/store")
+      (builtins.attrValues cfg.accounts);
+
+    assertions =
+      let
+        buildAssertion = account: [
+          {
+            assertion = lib.or (account.password != null) (account.passwordFile != null);
+            message = "Neither a password nor a password file is set for lx-music-sync-server user ${account.name}";
+          }
+        ];
+      in
+      builtins.concatMap buildAssertion (builtins.attrValues cfg.accounts);
+
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.group;
+      description = "lx-music-sync-server service user";
+    };
+
+    users.groups.${cfg.group} = {};
+
+    systemd.tmpfiles.settings."10-lx-music-sync-server" = {
+      ${dataDir}.d = {
+        inherit (cfg) user;
+        group = config.users.users.${cfg.user}.group;
+      };
+      ${logDir}.d = {
+        inherit (cfg) user;
+        group = config.users.users.${cfg.user}.group;
+      };
+    };
+
+    systemd.services.lx-music-sync-server = {
+      description = "LX Music Sync Server daemon";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        PORT = builtins.toString cfg.port;
+        BIND_IP = cfg.ip;
+        PROXY_HEADER = lib.mkIf cfg.proxy.enable cfg.proxy.header;
+        LOG_PATH = logDir;
+        DATA_PATH = dataDir;
+        MAX_SNAPSHOT_NUM = builtins.toString cfg.maxSnapshotNum;
+        LIST_ADD_MUSIC_LOCATION_TYPE = cfg.listAddMusicLocation;
+      };
+
+      script = let
+        convertAccountConfig = account: {
+          inherit (account) maxSnapshotNum;
+          password = if account.passwordFile != null
+            then ''$(cat ${account.passwordFile})''
+            else account.password;
+          "list.addMusicLocationType" = account.listAddMusicLocation;
+        };
+        buildEnvKeyValue = name: value: {
+          name = "LX_USER_${name}";
+          value = "${(builtins.toJSON (convertAccountConfig value))}";
+        };
+        exportEnvCmd = builtins.concatStringsSep
+          "\n"
+          (builtins.map
+            ({ name, value }: ''export ${name}=${lib.escapeShellArg value}'')
+            (lib.mapAttrsToList buildEnvKeyValue cfg.accounts));
+      in ''
+        ${exportEnvCmd}
+
+        ${cfg.package}/bin/lx-music-sync-server
+      '';
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = config.users.users.${cfg.user}.group;
+        LogsDirectory = logDir;
+        StateDirectory = dataDir;
+        WorkDirectory = cfg.package;
+        ReadWritePaths = "-${dataDir} -${logDir}";
+        CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
+        DeviceAllow = "";
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        UMask = "0007";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ oo-infty ];
+}

--- a/pkgs/by-name/lx/lx-music-sync-server/package.nix
+++ b/pkgs/by-name/lx/lx-music-sync-server/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+, nodejs
+, bash
+, nix-update-script
+}:
+
+buildNpmPackage rec {
+  pname = "lx-music-sync-server";
+  version = "2.1.2";
+
+  src = fetchFromGitHub {
+    owner = "lyswhut";
+    repo = "lx-music-sync-server";
+    rev = "v${version}";
+    hash = "sha256-FRk7bY2ijlCgzbtN6yRHP2pFQYQsAYj7RxpHVU0IYQo=";
+  };
+
+  npmDepsHash = "sha256-04OYD/H/vnlQBgG9o6FZfPc0xHE1MLURlGeqtbvLTZc=";
+  makeCacheWritable = true;
+
+  buildInputs = [
+    nodejs
+    bash
+  ];
+
+  postInstall = ''
+    cp -r server $out/lib/node_modules/lx-music-sync-server
+    install -Dm0555 ${./wrapper.sh} $out/bin/lx-music-sync-server
+
+    substituteInPlace $out/bin/lx-music-sync-server \
+        --replace-fail "@@node@@" "${nodejs}/bin/node" \
+        --replace-fail "@@out@@" "$out"
+  '';
+
+  passthru.updateScript = nix-update-script {};
+
+  meta = {
+    description = "Data synchronization service of LX Music running on Node.js";
+    homepage = "https://github.com/lyswhut/lx-music-sync-server";
+    changelog = "https://github.com/lyswhut/lx-music-sync-server/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    mainProgram = "lx-music-sync-server";
+    maintainers = with lib.maintainers; [ oo-infty ];
+  };
+}

--- a/pkgs/by-name/lx/lx-music-sync-server/wrapper.sh
+++ b/pkgs/by-name/lx/lx-music-sync-server/wrapper.sh
@@ -1,0 +1,11 @@
+#! /usr/bin/env bash
+
+if [[ -z "$LOG_PATH" ]]; then
+    export LOG_PATH="/var/log/lx-music-sync-server"
+fi
+
+if [[ -z "$DATA_PATH" ]]; then
+    export DATA_PATH="/var/lib/lx-music-sync-server"
+fi
+
+@@node@@ @@out@@/lib/node_modules/lx-music-sync-server/index.js


### PR DESCRIPTION
## Description of changes

Closes #294378.

`lx-music-sync-server` is a data synchronization service of `lx-music-desktop`. Homepage: <https://github.com/lyswhut/lx-music-sync-server>.

This program by default writes data and logs to `/nix/store`. Is it necessary to specifying a writable path for it? In addition, I have completed a NixOS module for it. Shall I add the corresponding module to this PR?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
