### PR TITLE
chatzone-desktop: init at 5.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16233,6 +16233,13 @@
     githubId = 74465;
     name = "James Fargher";
   };
+  progrm_jarvis = {
+    email = "mrjarviscraft+nix@gmail.com";
+    github = "JarvisCraft";
+    githubId = 7693005;
+    name = "Petr Portnov";
+    keys = [ { fingerprint = "884B 08D2 8DFF 6209 1857  C1C7 7E8F C8F7 D1BB 84A3"; } ];
+  };
   progval = {
     email = "progval+nix@progval.net";
     github = "progval";

--- a/pkgs/by-name/ch/chatzone-desktop/package.nix
+++ b/pkgs/by-name/ch/chatzone-desktop/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  stdenvNoCC,
+  makeDesktopItem,
+  copyDesktopItems,
+  makeWrapper,
+}:
+
+let
+  pname = "chatzone-desktop";
+  version = "5.2.1";
+  src = fetchurl {
+    url = "https://cdn1.ozone.ru/s3/chatzone-clients/ci/31072024-1/407/chatzone-desktop-linux-5.2.1.AppImage";
+    hash = "sha256-IXn7mAY3+2q+/PKcNQbRVW+wbAPMWLUh/DGAic6M898=";
+  };
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+stdenvNoCC.mkDerivation {
+  inherit pname version;
+
+  src = appimageTools.wrapType2 { inherit pname version src; };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "chatzone";
+      exec = "chatzone-desktop";
+      icon = "chatzone-desktop";
+      terminal = false;
+      desktopName = "Chatzone";
+      genericName = "Ozon corporate messenger";
+      comment = "Mattermost Desktop application for Linux";
+      categories = [
+        "Network"
+        "InstantMessaging"
+        "Chat"
+      ];
+      mimeTypes = [ "x-scheme-handler/mattermost" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/
+    cp -r bin $out/bin
+
+    mkdir -p $out/share/chatzone-desktop/
+    cp ${appimageContents}/app_icon.png $out/share/chatzone-desktop/
+    cp -r ${appimageContents}/usr/share/icons $out/share
+
+    wrapProgram $out/bin/chatzone-desktop \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Ozon corporate messenger";
+    mainProgram = "chatzone-desktop";
+    homepage = "https://apps.o3team.ru/";
+    downloadPage = "https://apps.o3team.ru/";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = [ lib.maintainers.progrm_jarvis ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes

[Chatzone(-desktop)](https://apps.o3team.ru/?mainNav=Chatzone) is a corporate fork of Mattermost(-desktop) with some performance improvements. It is maintained by [Ozon Tech](https://ozon.tech/) and is available as an `x86_64` AppImage.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - *not applicable*
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - *none required*
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
