### PR TITLE
hare: fix makeflags

### DIFF
--- a/pkgs/by-name/ha/hare/package.nix
+++ b/pkgs/by-name/ha/hare/package.nix
@@ -99,6 +99,11 @@ stdenv.mkDerivation (finalAttrs: {
     # Don't build haredoc since it uses the build `hare` bin, which breaks
     # cross-compilation.
     ./002-dont-build-haredoc.patch
+    # Display toolchains when using `hare version -v`.
+    (fetchpatch {
+      url = "https://git.sr.ht/~sircmpwn/hare/commit/e35f2284774436f422e06f0e8d290b173ced1677.patch";
+      hash = "sha256-A59bGO/9tOghV8/MomTxd8xRExkHVdoMom2d+HTfQGg=";
+    })
   ];
 
   nativeBuildInputs = [
@@ -122,7 +127,6 @@ stdenv.mkDerivation (finalAttrs: {
       "ARCH=${arch}"
       "VERSION=${finalAttrs.version}-nixpkgs"
       "QBEFLAGS=-t${qbePlatform}"
-      "CC=${stdenv.cc.targetPrefix}cc"
       "AS=${stdenv.cc.targetPrefix}as"
       "LD=${stdenv.cc.targetPrefix}ld"
       # Strip the variable of an empty $(SRCDIR)/hare/third-party, since nix does
@@ -136,9 +140,9 @@ stdenv.mkDerivation (finalAttrs: {
       "AARCH64_AS=${embeddedOnBinaryTools.aarch64.as}"
       "AARCH64_CC=${embeddedOnBinaryTools.aarch64.cc}"
       "AARCH64_LD=${embeddedOnBinaryTools.aarch64.ld}"
-      "x86_64_AS=${embeddedOnBinaryTools.x86_64.as}"
-      "x86_64_CC=${embeddedOnBinaryTools.x86_64.cc}"
-      "x86_64_LD=${embeddedOnBinaryTools.x86_64.ld}"
+      "X86_64_AS=${embeddedOnBinaryTools.x86_64.as}"
+      "X86_64_CC=${embeddedOnBinaryTools.x86_64.cc}"
+      "X86_64_LD=${embeddedOnBinaryTools.x86_64.ld}"
     ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
## Description of changes

Remove `CC` since it is not used.

Capitalize x86_64 (from `x86_64` to `X86_64`) to embed their values on
the binary.

Patch the `hare` command so that it has the `-v` option for the
`version` subcommand. With it, is much easier to check the paths of the
toolchains, since we do not need to rely on:
`strings <path-to-hare-binary> | grep <toolchain-path>`

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>himitsu-firefox</li>
  </ul>
</details>
<details>
  <summary>16 packages built:</summary>
  <ul>
    <li>bonsai</li>
    <li>hare</li>
    <li>hare.man</li>
    <li>hareThirdParty.hare-compress</li>
    <li>hareThirdParty.hare-ev</li>
    <li>hareThirdParty.hare-json</li>
    <li>hareThirdParty.hare-png</li>
    <li>hareThirdParty.hare-ssh</li>
    <li>hareThirdParty.hare-toml</li>
    <li>haredo</li>
    <li>haredo.man</li>
    <li>haredoc</li>
    <li>haredoc.man</li>
    <li>himitsu</li>
    <li>treecat</li>
    <li>treecat.man</li>
  </ul>
</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
