### PR TITLE
hare: fix mime module

### DIFF
--- a/pkgs/by-name/ha/hare/003-use-mailcap-for-mimetypes.patch
+++ b/pkgs/by-name/ha/hare/003-use-mailcap-for-mimetypes.patch
@@ -1,0 +1,13 @@
+diff --git a/mime/system.ha b/mime/system.ha
+index 73ff3496..42e7b640 100644
+--- a/mime/system.ha
++++ b/mime/system.ha
+@@ -11,7 +11,7 @@ use strings;
+ use types;
+ 
+ // Path to the system MIME database.
+-export def SYSTEM_DB: str = "/etc/mime.types";
++export def SYSTEM_DB: str = "@mailcap@/etc/mime.types";
+ 
+ @init fn init() void = {
+ 	// Done in a separate function so we can discard errors here

--- a/pkgs/by-name/ha/hare/mime-module-test.nix
+++ b/pkgs/by-name/ha/hare/mime-module-test.nix
@@ -1,0 +1,28 @@
+{
+  hare,
+  runCommandNoCC,
+  writeText,
+}:
+let
+  mainDotHare = writeText "main.ha" ''
+    use fmt;
+    use mime;
+    export fn main() void = {
+        const ext = "json";
+        match(mime::lookup_ext(ext)) {
+        case let mime: const *mime::mimetype =>
+          fmt::printfln("Found mimetype for extension `{}`: {}", ext, mime.mime)!;
+        case null =>
+          fmt::fatalf("Could not find mimetype for `{}`", ext);
+        };
+      };
+  '';
+in
+runCommandNoCC "mime-module-test" { nativeBuildInputs = [ hare ]; } ''
+  HARECACHE="$(mktemp -d)"
+  export HARECACHE
+  readonly binout="test-bin"
+  hare build -qRo "$binout" ${mainDotHare}
+  ./$binout
+  : 1>$out
+''


### PR DESCRIPTION
## Description of changes

The mime module relies on the `/etc/mime.types` file. We may hardcode it
like the Golang recipe[0].
                                                                                                            
Also add a `passthru.tests.mimeModule` so that we can be certain that
the module is working.
                                                                                                            
[0]: https://github.com/NixOS/nixpkgs/blob/f1010e0469db743d14519a1efd37e23f8513d714/pkgs/development/compilers/go/1.22.nix#L79

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>himitsu-firefox</li>
  </ul>
</details>
<details>
  <summary>16 packages built:</summary>
  <ul>
    <li>bonsai</li>
    <li>hare</li>
    <li>hare.man</li>
    <li>hareThirdParty.hare-compress</li>
    <li>hareThirdParty.hare-ev</li>
    <li>hareThirdParty.hare-json</li>
    <li>hareThirdParty.hare-png</li>
    <li>hareThirdParty.hare-ssh</li>
    <li>hareThirdParty.hare-toml</li>
    <li>haredo</li>
    <li>haredo.man</li>
    <li>haredoc</li>
    <li>haredoc.man</li>
    <li>himitsu</li>
    <li>treecat</li>
    <li>treecat.man</li>
  </ul>
</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
