### PR TITLE
python311Packages.ldappool: fix build, use pyproject = true, clean up

### DIFF
--- a/pkgs/development/python-modules/ldappool/default.nix
+++ b/pkgs/development/python-modules/ldappool/default.nix
@@ -1,42 +1,56 @@
-{ lib
-, buildPythonPackage
-, fetchPypi
-, pbr
-, python-ldap
-, prettytable
-, six
-, fixtures
-, testresources
-, testtools
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  pbr,
+  python-ldap,
+  prettytable,
+  six,
+  unittestCheckHook,
+  fixtures,
+  testresources,
+  testtools,
 }:
 
 buildPythonPackage rec {
   pname = "ldappool";
   version = "3.0.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "ldappool";
     inherit version;
-    sha256 = "4bb59b7d6b11407f48ee01a781267e3c8ba98d91f426806ac7208612ae087b86";
+    hash = "sha256-S7WbfWsRQH9I7gGngSZ+PIupjZH0JoBqxyCGEq4Ie4Y=";
   };
 
-  postPatch = ''
-    # Tests run without most of the dependencies
-    echo "" > test-requirements.txt
-    # PrettyTable is now maintained again
-    substituteInPlace requirements.txt --replace "PrettyTable<0.8,>=0.7.2" "PrettyTable"
-  '';
+  build-system = [
+    setuptools
+    pbr
+  ];
 
-  nativeBuildInputs = [ pbr ];
+  dependencies = [
+    python-ldap
+    prettytable
+    six
+  ];
 
-  propagatedBuildInputs = [ python-ldap prettytable six ];
+  nativeCheckInputs = [
+    unittestCheckHook
+    fixtures
+    testresources
+    testtools
+  ];
 
-  nativeCheckInputs = [ fixtures testresources testtools ];
+  pythonImportsCheck = [ "ldappool" ];
 
   meta = with lib; {
     description = "A simple connector pool for python-ldap";
     homepage = "https://opendev.org/openstack/ldappool/";
-    license = with licenses; [ mpl11 lgpl21Plus gpl2Plus ];
+    license = with licenses; [
+      mpl11
+      lgpl21Plus
+      gpl2Plus
+    ];
   };
 }


### PR DESCRIPTION
## Description of changes

ZHF: #309482


The `ldappool` python package had some issues with `format = "setuptools"` build process, so I migrated it over to `pyproject = true`.

Other changes:
- use `build-system` and `dependencies`
- remove unused patches
- add `pythonImportsCheck`
- use `hash` instead of `sha256`
- format code

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
