### PR TITLE
python312Packages.tubes: 0.2.1 -> 0.2.1-unstable-2023-11-06

### DIFF
--- a/pkgs/development/python-modules/tubes/default.nix
+++ b/pkgs/development/python-modules/tubes/default.nix
@@ -1,19 +1,30 @@
-{ lib, buildPythonPackage, fetchPypi, python
-, characteristic, six, twisted
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  python,
+  characteristic,
+  six,
+  twisted,
 }:
 
 buildPythonPackage rec {
   pname = "tubes";
-  version = "0.2.1";
+  version = "0.2.1-unstable-2023-11-06";
   format = "setuptools";
 
-  src = fetchPypi {
-    pname = "Tubes";
-    inherit version;
-    hash = "sha256-WbkZfy+m9/xrwygd5VeXrccpu3XJxhO09tbEFZnw14s=";
+  src = fetchFromGitHub {
+    owner = "twisted";
+    repo = "tubes";
+    rev = "b74680b8e7bcfe64362865356bb9461b77bbd5c0";
+    hash = "sha256-E8brnt8CtTEEP1KQTsTsgnl54H4zRGp+1IuoI/Qf5NA=";
   };
 
-  propagatedBuildInputs = [ characteristic six twisted ];
+  propagatedBuildInputs = [
+    characteristic
+    six
+    twisted
+  ];
 
   checkPhase = ''
     ${python.interpreter} -m twisted.trial -j $NIX_BUILD_CORES tubes
@@ -23,8 +34,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "a data-processing and flow-control engine for event-driven programs";
-    homepage    = "https://github.com/twisted/tubes";
-    license     = licenses.mit;
+    homepage = "https://github.com/twisted/tubes";
+    license = licenses.mit;
     maintainers = with maintainers; [ exarkun ];
   };
 }


### PR DESCRIPTION
## Description of changes

no recent releases on PyPi, but latest commit on Github fixes unittest errors on Python 3.12

Part of ZHF: #309482
Fixes Hydra build - https://hydra.nixos.org/build/258920674/nixlog/2

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Bump version to follow latest version on Github
- Format with nixfmt-rfc-style

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
