### PR TITLE
python3Packages.dropbox: 11.36.2 -> 12.0.0

### DIFF
--- a/pkgs/development/python-modules/dropbox/default.nix
+++ b/pkgs/development/python-modules/dropbox/default.nix
@@ -6,15 +6,18 @@
 , requests
 , six
 , stone
+, urllib3
 , mock
 , pytest-mock
 , pytestCheckHook
 , sphinxHook
+, sphinx-rtd-theme
+, pythonRelaxDepsHook
 }:
 
 buildPythonPackage rec {
   pname = "dropbox";
-  version = "11.36.2";
+  version = "12.0.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -25,7 +28,7 @@ buildPythonPackage rec {
     owner = "dropbox";
     repo = "dropbox-sdk-python";
     rev = "refs/tags/v${version}";
-    hash = "sha256-d++lxsbwPxnz1JPguWkImHXB+GQpMa9Uo3JNIxIe2ok=";
+    hash = "sha256-0MDm6NB+0vkN8QRSHvuDYEyYhYQWQD4jsctyd5fLdwE=";
   };
 
   build-system = [
@@ -36,6 +39,7 @@ buildPythonPackage rec {
     requests
     six
     stone
+    urllib3
   ];
 
   nativeCheckInputs = [
@@ -46,7 +50,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner == 5.2.0'," ""
+      --replace "'pytest-runner==5.2.0'," ""
   '';
 
   doCheck = true;
@@ -55,7 +59,20 @@ buildPythonPackage rec {
     "dropbox"
   ];
 
-  nativeBuildInputs = [ sphinxHook ];
+  nativeBuildInputs = [
+    sphinxHook
+    sphinx-rtd-theme
+    pythonRelaxDepsHook
+  ];
+
+  # Version 12.0.0 re-introduced Python 2 support and set some very restrictive version bounds
+  # https://github.com/dropbox/dropbox-sdk-python/commit/75596daf316b4a806f18057e2797a15bdf83cf6d
+  # This will be the last major version to support Python 2, so version bounds might be more reasonable again in the future.
+  pythonRelaxDeps = [
+    "requests"
+    "stone"
+    "urllib3"
+  ];
 
   # Set SCOPED_USER_DROPBOX_TOKEN environment variable to a valid value.
   disabledTests = [
@@ -77,6 +94,8 @@ buildPythonPackage rec {
     "test_as_user"
     "test_as_admin"
     "test_clone_when_team_linked"
+    "test_bad_pins"
+    "test_bad_pins_session"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/maestral/default.nix
+++ b/pkgs/development/python-modules/maestral/default.nix
@@ -24,6 +24,7 @@
 , typing-extensions
 , watchdog
 , xattr
+, fetchpatch
 , pytestCheckHook
 , nixosTests
 }:
@@ -67,6 +68,14 @@ buildPythonPackage rec {
     xattr
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     rubicon-objc
+  ];
+
+  patches = [
+    (fetchpatch {
+      name = "upgrade-dropbox-version-bounds";
+      url = "https://github.com/samschott/maestral/commit/8fd581fa503391534913afbc33a61132ff2e21ce.patch";
+      hash = "sha256-2Dke9iF/5Ptsf3CSRHUkjdFRrmdKY+L3sILRMyYrUH0=";
+    })
   ];
 
   makeWrapperArgs = [


### PR DESCRIPTION
## Description of changes

https://github.com/dropbox/dropbox-sdk-python/releases/tag/v12.0.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
