### PR TITLE
lektor: 3.4.0b8 -> 3.4.0b12

### DIFF
--- a/pkgs/tools/misc/lektor/default.nix
+++ b/pkgs/tools/misc/lektor/default.nix
@@ -30,7 +30,11 @@ python.pkgs.buildPythonApplication rec {
     owner = "lektor";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-USwHSUXpk4XM5ySTXnYc5FqqkTaf8PoxQTeRnWOvbxk=";
+    # fix for case-insensitive filesystems
+    postFetch = ''
+      rm -f $out/tests/demo-project/content/icc-profile-test/{LICENSE,license}.txt
+    '';
+    hash = "sha256-y0/fYuiIB/O5tsYKjzOPnCafOIZCn4Z5OITPMcnHd/M=";
   };
 
   npmDeps = fetchNpmDeps {

--- a/pkgs/tools/misc/lektor/default.nix
+++ b/pkgs/tools/misc/lektor/default.nix
@@ -23,19 +23,19 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "lektor";
-  version = "3.4.0b8";
+  version = "3.4.0b12";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "lektor";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-FtmRW4AS11zAX2jvGY8XTsPrN3mhHkIWoFY7sXmqG/U=";
+    hash = "sha256-USwHSUXpk4XM5ySTXnYc5FqqkTaf8PoxQTeRnWOvbxk=";
   };
 
   npmDeps = fetchNpmDeps {
-    src = "${src}/frontend";
-    hash = "sha256-Z7LP9rrVSzKoLITUarsnRbrhIw7W7TZSZUgV/OT+m0M=";
+    src = "${src}/${npmRoot}";
+    hash = "sha256-LXe5/u4nAGig8RSu6r8Qsr3p3Od8eoMxukW8Z4HkJ44=";
   };
 
   npmRoot = "frontend";
@@ -50,8 +50,6 @@ python.pkgs.buildPythonApplication rec {
   propagatedBuildInputs = with python.pkgs; [
     babel
     click
-    exifread
-    filetype
     flask
     inifile
     jinja2
@@ -71,11 +69,6 @@ python.pkgs.buildPythonApplication rec {
     pytest-click
     pytest-mock
     pytestCheckHook
-    pythonRelaxDepsHook
-  ];
-
-  pythonRelaxDeps = [
-    "werkzeug"
   ];
 
   postInstall = ''
@@ -90,16 +83,18 @@ python.pkgs.buildPythonApplication rec {
     # Tests require network access
     "test_path_installed_plugin_is_none"
     "test_VirtualEnv_run_pip_install"
-    # expects FHS paths
-    "test_VirtualEnv_executable"
   ];
 
-  meta = with lib; {
+  postCheck = ''
+    make test-js
+  '';
+
+  meta = {
     description = "A static content management system";
     homepage = "https://www.getlektor.com/";
     changelog = "https://github.com/lektor/lektor/blob/v${version}/CHANGES.md";
-    license = licenses.bsd0;
+    license = lib.licenses.bsd3;
     mainProgram = "lektor";
-    maintainers = with maintainers; [ ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
## Description of changes

https://github.com/lektor/lektor/blob/v3.4.0b12/CHANGES.md
https://github.com/lektor/lektor/compare/v3.4.0b8...v3.4.0b12

ZHF: #309482

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>lektor</li>
    <li>lektor.dist</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc