### PR TITLE
cmake: replace propagated ps input with abspath patch

### DIFF
--- a/pkgs/by-name/cm/cmake/007-darwin-bsd-ps-abspath.diff
+++ b/pkgs/by-name/cm/cmake/007-darwin-bsd-ps-abspath.diff
@@ -1,0 +1,41 @@
+diff -ur a/Source/kwsys/ProcessUNIX.c b/Source/kwsys/ProcessUNIX.c
+--- a/Source/kwsys/ProcessUNIX.c	2024-04-11 07:12:19.000000000 -0700
++++ b/Source/kwsys/ProcessUNIX.c	2024-05-15 10:41:00.286160616 -0700
+@@ -2501,20 +2501,20 @@
+    have two integers to store: the pid and then the ppid.  */
+ #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) ||       \
+   defined(__OpenBSD__) || defined(__GLIBC__) || defined(__GNU__)
+-#  define KWSYSPE_PS_COMMAND "ps axo pid,ppid"
++#  define KWSYSPE_PS_COMMAND "@ps@ axo pid,ppid"
+ #  define KWSYSPE_PS_FORMAT "%d %d\n"
+ #elif defined(__sun) && (defined(__SVR4) || defined(__svr4__)) /* Solaris */
+-#  define KWSYSPE_PS_COMMAND "ps -e -o pid,ppid"
++#  define KWSYSPE_PS_COMMAND "@ps@ -e -o pid,ppid"
+ #  define KWSYSPE_PS_FORMAT "%d %d\n"
+ #elif defined(__hpux) || defined(__sun__) || defined(__sgi) ||                \
+   defined(_AIX) || defined(__sparc)
+-#  define KWSYSPE_PS_COMMAND "ps -ef"
++#  define KWSYSPE_PS_COMMAND "@ps@ -ef"
+ #  define KWSYSPE_PS_FORMAT "%*s %d %d %*[^\n]\n"
+ #elif defined(__QNX__)
+-#  define KWSYSPE_PS_COMMAND "ps -Af"
++#  define KWSYSPE_PS_COMMAND "@ps@ -Af"
+ #  define KWSYSPE_PS_FORMAT "%*d %d %d %*[^\n]\n"
+ #elif defined(__CYGWIN__)
+-#  define KWSYSPE_PS_COMMAND "ps aux"
++#  define KWSYSPE_PS_COMMAND "@ps@ aux"
+ #  define KWSYSPE_PS_FORMAT "%d %d %*[^\n]\n"
+ #endif
+ 
+diff -ur a/Source/kwsys/SystemInformation.cxx b/Source/kwsys/SystemInformation.cxx
+--- a/Source/kwsys/SystemInformation.cxx	2024-04-11 07:12:19.000000000 -0700
++++ b/Source/kwsys/SystemInformation.cxx	2024-05-15 10:40:00.901059278 -0700
+@@ -3884,7 +3884,7 @@
+   long long memUsed = 0;
+   pid_t pid = getpid();
+   std::ostringstream oss;
+-  oss << "ps -o rss= -p " << pid;
++  oss << "@ps@ -o rss= -p " << pid;
+   FILE* file = popen(oss.str().c_str(), "r");
+   if (file == nullptr) {
+     return -1;

--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -101,7 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional stdenv.isDarwin CoreServices
   ++ lib.optional (stdenv.isDarwin && !isMinimalBuild) SystemConfiguration;
 
-  propagatedBuildInputs = lib.optional stdenv.isDarwin ps;
+  propagatedBuildInputs = lib.optional (stdenv.isDarwin || stdenv.isFreeBSD) ps;
 
   preConfigure = ''
     fixCmakeFiles .

--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, substituteAll
 , buildPackages
 , bzip2
 , curlMinimal
@@ -66,7 +67,13 @@ stdenv.mkDerivation (finalAttrs: {
   # Derived from https://github.com/curl/curl/commit/31f631a142d855f069242f3e0c643beec25d1b51
   ++ lib.optional (stdenv.isDarwin && isMinimalBuild) ./005-remove-systemconfiguration-dep.diff
   # On Darwin, always set CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG.
-  ++ lib.optional stdenv.isDarwin ./006-darwin-always-set-runtime-c-flag.diff;
+  ++ lib.optional stdenv.isDarwin ./006-darwin-always-set-runtime-c-flag.diff
+  # On platforms where ps is not part of stdenv, patch the invocation of ps to use an absolute path.
+  ++ lib.optional (stdenv.isDarwin || stdenv.isFreeBSD) (
+    substituteAll {
+      src = ./007-darwin-bsd-ps-abspath.diff;
+      ps = lib.getExe ps;
+    });
 
   outputs = [ "out" ] ++ lib.optionals buildDocs [ "man" "info" ];
   separateDebugInfo = true;
@@ -100,8 +107,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional qt5UI qtbase
   ++ lib.optional stdenv.isDarwin CoreServices
   ++ lib.optional (stdenv.isDarwin && !isMinimalBuild) SystemConfiguration;
-
-  propagatedBuildInputs = lib.optional (stdenv.isDarwin || stdenv.isFreeBSD) ps;
 
   preConfigure = ''
     fixCmakeFiles .


### PR DESCRIPTION
## Description of changes

part of https://github.com/NixOS/nixpkgs/pull/296581

Similar to the Darwin case. Should be self-explanatory.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
