### PR TITLE
gnome.gnome-keyring: support cross compilation

### DIFF
--- a/pkgs/desktops/gnome/core/gnome-keyring/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-keyring/default.nix
@@ -10,7 +10,6 @@
 , libxslt
 , gettext
 , gcr
-, autoreconfHook
 , libcap_ng
 , libselinux
 , p11-kit
@@ -37,8 +36,6 @@ stdenv.mkDerivation rec {
     pkg-config
     gettext
     libxslt
-    # Upstream uses ancient autotools to pre-generate the scripts.
-    autoreconfHook
     docbook-xsl-nons
     docbook_xml_dtd_43
     wrapGAppsHook3
@@ -63,6 +60,10 @@ stdenv.mkDerivation rec {
     # gnome-keyring doesn't build with ssh-agent by default anymore, we need to
     # switch to using gcr https://github.com/NixOS/nixpkgs/issues/140824
     "--enable-ssh-agent"
+    # cross compilation requires these paths to be explicitly declared:
+    "LIBGCRYPT_CONFIG=${lib.getExe' (lib.getDev libgcrypt) "libgcrypt-config"}"
+    "SSH_ADD=${lib.getExe' openssh "ssh-add"}"
+    "SSH_AGENT=${lib.getExe' openssh "ssh-agent"}"
   ];
 
   # Tends to fail non-deterministically.


### PR DESCRIPTION
## Description of changes

built (and deployed) from an x86_64-linux machine:
- `nix build '.#pkgsCross.aarch64-multiplatform.gnome.gnome-keyring'`
- `nix build '.#gnome.gnome-keyring'`

the `LIBGCRYPT_CONFIG` flag is lifted from the [libgnome-keyring](https://github.com/NixOS/nixpkgs/blob/d1414f543e40172dfd20e5a42ccd8c9108219693/pkgs/development/libraries/libgnome-keyring/default.nix#L25) nix package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
