### PR TITLE
spade: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/by-name/sp/spade/Cargo.lock
+++ b/pkgs/by-name/sp/spade/Cargo.lock
@@ -980,7 +980,7 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "spade"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "atty",
  "clap",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "spade-ast"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "num",
  "spade-common",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "spade-ast-lowering"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "itertools",
  "local-impl",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "spade-common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "codespan",
  "codespan-reporting 0.12.0",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "spade-diagnostics"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "codespan",
  "codespan-reporting 0.12.0",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "spade-hir"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "codespan-reporting 0.12.0",
  "colored",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "spade-hir-lowering"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "codespan",
  "codespan-reporting 0.12.0",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "spade-macros"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "spade-mir"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "codespan",
  "codespan-reporting 0.12.0",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "spade-parser"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "codespan",
  "colored",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "spade-python"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "codespan-reporting 0.12.0",
  "color-eyre",
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "spade-simulation-ext"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "codespan-reporting 0.12.0",
  "color-eyre",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "spade-tests"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "codespan-reporting 0.12.0",
  "colored",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "spade-typeinference"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "assert_matches",
  "codespan",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "spade-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "num",
  "serde",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "spade-wordlength-inference"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "codespan",
  "codespan-reporting 0.12.0",

--- a/pkgs/by-name/sp/spade/package.nix
+++ b/pkgs/by-name/sp/spade/package.nix
@@ -9,13 +9,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "spade";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitLab {
     owner = "spade-lang";
     repo = "spade";
     rev = "v${version}";
-    hash = "sha256-oJfOgWobjt+DAVdP465E8iLMJCdqhs0vzJJFgRqVAP8=";
+    hash = "sha256-J3AdXuN1WLKFED9YeBly68umPlx05Wl+mhT2YbBsJVk=";
     # only needed for vatch, which contains test data
     fetchSubmodules = true;
   };


### PR DESCRIPTION
## Description of changes

https://blog.spade-lang.org/v0-8-0/
    
Changelog: https://gitlab.com/spade-lang/spade/-/blob/v0.8.0/CHANGELOG.md


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
