### PR TITLE
llvmPackages: add support for native FreeBSD

### DIFF
--- a/pkgs/development/compilers/llvm/16/compiler-rt/asan-offset.patch
+++ b/pkgs/development/compilers/llvm/16/compiler-rt/asan-offset.patch
@@ -1,0 +1,11 @@
+--- a/lib/asan/CMakeLists.txt        2022-06-22 16:46:24.000000000 +0000
++++ b/lib/asan/CMakeLists.txt
+@@ -46,7 +46,7 @@ set(ASAN_STATIC_SOURCES
+   asan_rtl_static.cpp
+   )
+ 
+-if (NOT WIN32 AND NOT APPLE)
++if (LINUX)
+   list(APPEND ASAN_STATIC_SOURCES
+     asan_rtl_x86_64.S
+   )

--- a/pkgs/development/compilers/llvm/16/compiler-rt/freebsd-i386.patch
+++ b/pkgs/development/compilers/llvm/16/compiler-rt/freebsd-i386.patch
@@ -1,0 +1,21 @@
+--- a/lib/builtins/fp_lib.h	1969-12-31 16:00:01.000000000 -0800
++++ b/lib/builtins/fp_lib.h	2023-12-21 23:39:36.066927293 -0800
+@@ -26,18 +26,6 @@
+ #include <stdbool.h>
+ #include <stdint.h>
+ 
+-// x86_64 FreeBSD prior v9.3 define fixed-width types incorrectly in
+-// 32-bit mode.
+-#if defined(__FreeBSD__) && defined(__i386__)
+-#include <sys/param.h>
+-#if __FreeBSD_version < 903000 // v9.3
+-#define uint64_t unsigned long long
+-#define int64_t long long
+-#undef UINT64_C
+-#define UINT64_C(c) (c##ULL)
+-#endif
+-#endif
+-
+ #if defined SINGLE_PRECISION
+ 
+ typedef uint16_t half_rep_t;

--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -128,11 +128,17 @@ stdenv.mkDerivation ({
   '') + ''
     substituteInPlace lib/builtins/int_util.c \
       --replace "#include <stdlib.h>" ""
+  '' + (if stdenv.hostPlatform.isFreeBSD then
+    # As per above, but in FreeBSD assert is a macro and simply allowing it to be implicitly declared causes Issues!!!!!
+    ''
+    substituteInPlace lib/builtins/clear_cache.c lib/builtins/cpu_model.c \
+      --replace "#include <assert.h>" "#define assert(e) ((e)?(void)0:__assert(__FUNCTION__,__FILE__,__LINE__,#e))"
+    '' else ''
     substituteInPlace lib/builtins/clear_cache.c \
       --replace "#include <assert.h>" ""
     substituteInPlace lib/builtins/cpu_model${lib.optionalString (lib.versionAtLeast version "18") "/x86"}.c \
       --replace "#include <assert.h>" ""
-  '');
+  ''));
 
   # Hack around weird upsream RPATH bug
   postInstall = lib.optionalString (stdenv.hostPlatform.isDarwin) ''

--- a/pkgs/development/compilers/llvm/common/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/common/libcxx/default.nix
@@ -13,11 +13,15 @@
 , python3
 , fixDarwinDylibNames
 , version
-, cxxabi ? if stdenv.hostPlatform.isFreeBSD then libcxxrt else null
+, cxxabi ? null
 , libcxxrt
 , libunwind
 , enableShared ? !stdenv.hostPlatform.isStatic
 }:
+
+# note: our setup using libcxxabi instead of libcxxrt on FreeBSD diverges from
+# normal FreeBSD. This may cause issues with binary patching down the line.
+# If this becomes an issue, try adding as symlink libcxxrt.so -> libc++abi.so
 
 # external cxxabi is not supported on Darwin as the build will not link libcxx
 # properly and not re-export the cxxabi symbols into libcxx

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -125,22 +125,22 @@ stdenv.mkDerivation (rec {
     substituteInPlace cmake/modules/AddLLVM.cmake \
       --replace 'set(_install_name_dir INSTALL_NAME_DIR "@rpath")' "set(_install_name_dir)" \
       --replace 'set(_install_rpath "@loader_path/../''${CMAKE_INSTALL_LIBDIR}''${LLVM_LIBDIR_SUFFIX}" ''${extra_libdir})' ""
-  '' + (optionalString (lib.versionAtLeast release_version "15") (''
-
+  '' +
     # As of LLVM 15, marked as XFAIL on arm64 macOS but lit doesn't seem to pick
     # this up: https://github.com/llvm/llvm-project/blob/c344d97a125b18f8fed0a64aace73c49a870e079/llvm/test/MC/ELF/cfi-version.ll#L7
+    (optionalString (lib.versionAtLeast release_version "15") (''
     rm test/MC/ELF/cfi-version.ll
 
+  '' +
     # This test tries to call `sw_vers` by absolute path (`/usr/bin/sw_vers`)
     # and thus fails under the sandbox:
-  '' + (if lib.versionAtLeast release_version "16" then ''
+    (if lib.versionAtLeast release_version "16" then ''
     substituteInPlace unittests/TargetParser/Host.cpp \
       --replace '/usr/bin/sw_vers' "${(builtins.toString darwin.DarwinTools) + "/bin/sw_vers" }"
   '' else ''
     substituteInPlace unittests/Support/Host.cpp \
       --replace '/usr/bin/sw_vers' "${(builtins.toString darwin.DarwinTools) + "/bin/sw_vers" }"
-  '') + optionalString (lib.versionAtLeast release_version "16") ''
-
+  '') +
     # This test tries to call the intrinsics `@llvm.roundeven.f32` and
     # `@llvm.roundeven.f64` which seem to (incorrectly?) lower to `roundevenf`
     # and `roundeven` on macOS and FreeBSD.
@@ -149,35 +149,30 @@ stdenv.mkDerivation (rec {
     #   - https://www.gnu.org/software/gnulib/manual/html_node/roundevenf.html
     #   - https://www.gnu.org/software/gnulib/manual/html_node/roundeven.html
     #
-    substituteInPlace test/ExecutionEngine/Interpreter/intrinsics.ll \
-      --replace "%roundeven32 = call float @llvm.roundeven.f32(float 0.000000e+00)" "" \
-      --replace "%roundeven64 = call double @llvm.roundeven.f64(double 0.000000e+00)" ""
-  '' + optionalString (!stdenv.hostPlatform.isx86 && lib.versionAtLeast release_version "18") ''
-
-    # fails when run in sandbox
-    substituteInPlace unittests/Support/VirtualFileSystemTest.cpp \
-      --replace "PhysicalFileSystemWorkingDirFailure" "DISABLED_PhysicalFileSystemWorkingDirFailure"
-  ''))) + optionalString (stdenv.isDarwin && stdenv.hostPlatform.isx86 && lib.versionAtLeast release_version "15") (optionalString (lib.versionOlder release_version "16") ''
-    # This test tries to call the intrinsics `@llvm.roundeven.f32` and
-    # `@llvm.roundeven.f64` which seem to (incorrectly?) lower to `roundevenf`
-    # and `roundeven` on x86_64 macOS.
-    #
-    # However these functions are glibc specific so the test fails:
-    #   - https://www.gnu.org/software/gnulib/manual/html_node/roundevenf.html
-    #   - https://www.gnu.org/software/gnulib/manual/html_node/roundeven.html
-    #
     # TODO(@rrbutani): this seems to run fine on `aarch64-darwin`, why does it
     # pass there?
+    optionalString (lib.versionAtLeast release_version "16") ''
+    substituteInPlace test/ExecutionEngine/Interpreter/intrinsics.ll \
+      --replace "%roundeven32 = call float @llvm.roundeven.f32(float 0.000000e+00)" "" \
+      --replace "%roundeven64 = call double @llvm.roundeven.f64(double 0.000000e+00)" ""
+  '' +
+    # fails when run in sandbox
+    optionalString (!stdenv.hostPlatform.isx86 && lib.versionAtLeast release_version "18") ''
+    substituteInPlace unittests/Support/VirtualFileSystemTest.cpp \
+      --replace "PhysicalFileSystemWorkingDirFailure" "DISABLED_PhysicalFileSystemWorkingDirFailure"
+  ''))) +
+    # dup of above patch with different conditions
+    optionalString (stdenv.isDarwin && stdenv.hostPlatform.isx86 && lib.versionAtLeast release_version "15") (optionalString (lib.versionOlder release_version "16") ''
     substituteInPlace test/ExecutionEngine/Interpreter/intrinsics.ll \
       --replace "%roundeven32 = call float @llvm.roundeven.f32(float 0.000000e+00)" "" \
       --replace "%roundeven64 = call double @llvm.roundeven.f64(double 0.000000e+00)" ""
 
-  '' + ((optionalString (lib.versionAtLeast release_version "18") ''
-
+  '' +
     # fails when run in sandbox
+    ((optionalString (lib.versionAtLeast release_version "18") ''
     substituteInPlace unittests/Support/VirtualFileSystemTest.cpp \
       --replace "PhysicalFileSystemWorkingDirFailure" "DISABLED_PhysicalFileSystemWorkingDirFailure"
-  '') + ''
+  '') +
     # This test fails on darwin x86_64 because `sw_vers` reports a different
     # macOS version than what LLVM finds by reading
     # `/System/Library/CoreServices/SystemVersion.plist` (which is passed into
@@ -206,19 +201,20 @@ stdenv.mkDerivation (rec {
     # not clear to me when/where/for what this even gets used in LLVM.
     #
     # TODO(@rrbutani): fix/follow-up
-  '' + (if lib.versionAtLeast release_version "16" then ''
+    (if lib.versionAtLeast release_version "16" then ''
     substituteInPlace unittests/TargetParser/Host.cpp \
       --replace "getMacOSHostVersion" "DISABLED_getMacOSHostVersion"
   '' else ''
     substituteInPlace unittests/Support/Host.cpp \
       --replace "getMacOSHostVersion" "DISABLED_getMacOSHostVersion"
-  '') + ''
-
+  '') +
     # This test fails with a `dysmutil` crash; have not yet dug into what's
     # going on here (TODO(@rrbutani)).
+  ''
     rm test/tools/dsymutil/ARM/obfuscated.test
-  '')) + ''
+  '')) +
     # FileSystem permissions tests fail with various special bits
+  ''
     substituteInPlace unittests/Support/CMakeLists.txt \
       --replace "Path.cpp" ""
     rm unittests/Support/Path.cpp
@@ -230,22 +226,24 @@ stdenv.mkDerivation (rec {
   '' + lib.optionalString (lib.versionOlder release_version "13") ''
     # TODO: Fix failing tests:
     rm test/DebugInfo/X86/vla-multi.ll
-  '' + lib.optionalString (lib.versionAtLeast release_version "16") (''
-
+  '' +
     # Fails in the presence of anti-virus software or other intrusion-detection software that
     # modifies the atime when run. See #284056.
+    lib.optionalString (lib.versionAtLeast release_version "16") (''
     rm test/tools/llvm-objcopy/ELF/strip-preserve-atime.test
   '' + lib.optionalString (lib.versionOlder release_version "17") ''
 
-  '') + lib.optionalString (lib.versionAtLeast release_version "15" && lib.versionOlder release_version "17") ''
+  '') +
     # timing-based tests are trouble
+    lib.optionalString (lib.versionAtLeast release_version "15" && lib.versionOlder release_version "17") ''
     rm utils/lit/tests/googletest-timeout.py
-  '' + optionalString stdenv.hostPlatform.isMusl ''
+  '' +
+    # valgrind unhappy with musl or glibc, but fails w/musl only
+    optionalString stdenv.hostPlatform.isMusl ''
     patch -p1 -i ${./TLI-musl.patch}
     substituteInPlace unittests/Support/CMakeLists.txt \
       --replace "add_subdirectory(DynamicLibrary)" ""
     rm unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp
-    # valgrind unhappy with musl or glibc, but fails w/musl only
     rm test/CodeGen/AArch64/wineh4.mir
   '' + optionalString stdenv.hostPlatform.isAarch32 ''
     # skip failing X86 test cases on 32-bit ARM
@@ -255,26 +253,28 @@ stdenv.mkDerivation (rec {
     rm test/tools/dsymutil/X86/op-convert.test
     rm test/tools/gold/X86/split-dwarf.ll
     rm test/tools/llvm-objcopy/MachO/universal-object.test
-  '' + optionalString (stdenv.hostPlatform.system == "armv6l-linux") ''
+  '' +
     # Seems to require certain floating point hardware (NEON?)
+    optionalString (stdenv.hostPlatform.system == "armv6l-linux") ''
     rm test/ExecutionEngine/frem.ll
-  '' + optionalString stdenv.isFreeBSD ''
-    # TODO: Why does this test fail on FreeBSD?
+  '' +
+    # 1. TODO: Why does this test fail on FreeBSD?
     # It seems to reference /usr/local/lib/libfile.a, which is clearly a problem.
-    rm test/tools/llvm-libtool-darwin/L-and-l.test
-
-    # This test fails for the same reason it fails on MacOS, but the fix is
+    # 2. This test fails for the same reason it fails on MacOS, but the fix is
     # not trivial to apply.
+    optionalString stdenv.isFreeBSD ''
+    rm test/tools/llvm-libtool-darwin/L-and-l.test
     rm test/ExecutionEngine/Interpreter/intrinsics.ll
   '' + ''
     patchShebangs test/BugPoint/compile-custom.ll.py
-  '' + (lib.optionalString (lib.versionOlder release_version "13") ''
+  '' +
     # Tweak tests to ignore namespace part of type to support
     # gcc-12: https://gcc.gnu.org/PR103598.
     # The change below mangles strings like:
     #    CHECK-NEXT: Starting llvm::Function pass manager run.
     # to:
     #    CHECK-NEXT: Starting {{.*}}Function pass manager run.
+    (lib.optionalString (lib.versionOlder release_version "13") (''
     for f in \
       test/Other/new-pass-manager.ll \
       test/Other/new-pm-O0-defaults.ll \
@@ -295,18 +295,19 @@ stdenv.mkDerivation (rec {
         --replace 'Starting llvm::' 'Starting {{.*}}' \
         --replace 'Finished llvm::' 'Finished {{.*}}'
     done
+  '' +
     # gcc-13 fix
+  ''
     sed -i '/#include <string>/i#include <cstdint>' \
       include/llvm/DebugInfo/Symbolize/DIPrinter.h
-  '');
+  ''));
 
+  # Workaround for configure flags that need to have spaces
   preConfigure = if lib.versionAtLeast release_version "15" then ''
-    # Workaround for configure flags that need to have spaces
     cmakeFlagsArray+=(
       -DLLVM_LIT_ARGS="-svj''${NIX_BUILD_CORES} --no-progress-bar"
     )
   '' else ''
-    # Workaround for configure flags that need to have spaces
     cmakeFlagsArray+=(
       -DLLVM_LIT_ARGS='-svj''${NIX_BUILD_CORES} --no-progress-bar'
     )


### PR DESCRIPTION
## Description of changes

part of https://github.com/NixOS/nixpkgs/pull/296581

Tests were done with llvmPackages_16

* asan doesn't work quite right, disable it
* support for 32-bit FreeBSD uses by default logic tuned for a very old FreeBSD; fix that
* Some llvm tests fail for the same reason as MacOS; disable them
* libcxx no longer needs a FreeBSD special case
* add a flag for the inclusion of terminfo, which helps compile static bootstrap files

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).]

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
