### PR TITLE
meson: fix build for native FreeBSD

### DIFF
--- a/pkgs/by-name/me/meson/007-freebsd-pkgconfig-path.patch
+++ b/pkgs/by-name/me/meson/007-freebsd-pkgconfig-path.patch
@@ -1,0 +1,15 @@
+diff -ur a/mesonbuild/modules/pkgconfig.py b/mesonbuild/modules/pkgconfig.py
+--- a/mesonbuild/modules/pkgconfig.py	2024-05-17 17:52:30.880877000 -0700
++++ b/mesonbuild/modules/pkgconfig.py	2024-05-17 17:53:10.901068000 -0700
+@@ -693,10 +693,7 @@
+         pcfile = filebase + '.pc'
+         pkgroot = pkgroot_name = kwargs['install_dir'] or default_install_dir
+         if pkgroot is None:
+-            if mesonlib.is_freebsd():
+-                pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(mesonlib.OptionKey('prefix'))), 'libdata', 'pkgconfig')
+-                pkgroot_name = os.path.join('{prefix}', 'libdata', 'pkgconfig')
+-            elif mesonlib.is_haiku():
++            if mesonlib.is_haiku():
+                 pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(mesonlib.OptionKey('prefix'))), 'develop', 'lib', 'pkgconfig')
+                 pkgroot_name = os.path.join('{prefix}', 'develop', 'lib', 'pkgconfig')
+             else:

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -66,6 +66,9 @@ python3.pkgs.buildPythonApplication rec {
     # Nixpkgs cctools does not have bitcode support.
     ./006-disable-bitcode.patch
 
+    # This edge case is explicitly part of meson but is wrong for nix
+    ./007-freebsd-pkgconfig-path.patch
+
     # Fix cross-compilation of proc-macro (and mesa)
     # https://github.com/mesonbuild/meson/issues/12973
     ./0001-Revert-rust-recursively-pull-proc-macro-dependencies.patch
@@ -106,7 +109,7 @@ python3.pkgs.buildPythonApplication rec {
     ''
   ]
   # Remove problematic tests
-  ++ (builtins.map (f: ''rm -vr "${f}";'') [
+  ++ (builtins.map (f: ''rm -vr "${f}";'') ([
     # requires git, creating cyclic dependency
     ''test cases/common/66 vcstag''
     # requires glib, creating cyclic dependency
@@ -116,7 +119,10 @@ python3.pkgs.buildPythonApplication rec {
     ''test cases/linuxlike/14 static dynamic linkage''
     # Nixpkgs cctools does not have bitcode support.
     ''test cases/osx/7 bitcode''
-  ])
+  ] ++ lib.optionals stdenv.isFreeBSD [
+    # pch doesn't work quite right on FreeBSD, I think
+    ''test cases/common/13 pch''
+  ]))
   ++ [
     ''HOME="$TMPDIR" python ./run_project_tests.py''
     "runHook postCheck"


### PR DESCRIPTION
## Description of changes

part of https://github.com/NixOS/nixpkgs/pull/296581

~~The only part of this which is not documented inline is that ldd is not part of the freebsd stdenv, so it must be added as a propagated build input since meson will invoke ldd by PATH during future builds.~~

(@Ericson2314 notes: Everything is documented inline.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
