### PR TITLE
unixtools: Add entries for FreeBSD

### DIFF
--- a/pkgs/top-level/unixtools.nix
+++ b/pkgs/top-level/unixtools.nix
@@ -1,4 +1,4 @@
-{ pkgs, buildEnv, runCommand, lib, stdenv }:
+{ pkgs, buildEnv, runCommand, lib, stdenv, freebsd }:
 
 # These are some unix tools that are commonly included in the /usr/bin
 # and /usr/sbin directory under more normal distributions. Along with
@@ -59,6 +59,7 @@ let
     arp = {
       linux = pkgs.nettools;
       darwin = pkgs.darwin.network_cmds;
+      freebsd = pkgs.freebsd.arp;
     };
     col = {
       linux = pkgs.util-linux;
@@ -80,6 +81,7 @@ let
       linux = if stdenv.hostPlatform.libc == "glibc" then pkgs.stdenv.cc.libc.getent
               else pkgs.netbsd.getent;
       darwin = pkgs.netbsd.getent;
+      freebsd = pkgs.freebsd.getent;
     };
     getopt = {
       linux = pkgs.util-linux;
@@ -88,6 +90,7 @@ let
     fdisk = {
       linux = pkgs.util-linux;
       darwin = pkgs.darwin.diskdev_cmds;
+      freebsd = pkgs.freebsd.fdisk;
     };
     fsck = {
       linux = pkgs.util-linux;
@@ -100,10 +103,12 @@ let
     hostname = {
       linux = pkgs.nettools;
       darwin = pkgs.darwin.shell_cmds;
+      freebsd = pkgs.freebsd.bin;
     };
     ifconfig = {
       linux = pkgs.nettools;
       darwin = pkgs.darwin.network_cmds;
+      freebsd = pkgs.freebsd.ifconfig;
     };
     killall = {
       linux = pkgs.psmisc;
@@ -112,6 +117,7 @@ let
     locale = {
       linux = pkgs.glibc;
       darwin = pkgs.darwin.adv_cmds;
+      freebsd = pkgs.freebsd.locale;
     };
     logger = {
       linux = pkgs.util-linux;
@@ -123,18 +129,22 @@ let
     mount = {
       linux = pkgs.util-linux;
       darwin = pkgs.darwin.diskdev_cmds;
+      freebsd = freebsd.mount;
     };
     netstat = {
       linux = pkgs.nettools;
       darwin = pkgs.darwin.network_cmds;
+      freebsd = pkgs.freebsd.netstat;
     };
     ping = {
       linux = pkgs.iputils;
       darwin = pkgs.darwin.network_cmds;
+      freebsd = freebsd.ping;
     };
     ps = {
       linux = pkgs.procps;
       darwin = pkgs.darwin.ps;
+      freebsd = pkgs.freebsd.bin;
     };
     quota = {
       linux = pkgs.linuxquota;
@@ -143,6 +153,7 @@ let
     route = {
       linux = pkgs.nettools;
       darwin = pkgs.darwin.network_cmds;
+      freebsd = pkgs.freebsd.route;
     };
     script = {
       linux = pkgs.util-linux;
@@ -151,10 +162,12 @@ let
     sysctl = {
       linux = pkgs.procps;
       darwin = pkgs.darwin.system_cmds;
+      freebsd = pkgs.freebsd.sysctl;
     };
     top = {
       linux = pkgs.procps;
       darwin = pkgs.darwin.top;
+      freebsd = pkgs.freebsd.top;
     };
     umount = {
       linux = pkgs.util-linux;
@@ -171,8 +184,9 @@ let
       linux = pkgs.procps;
 
       # watch is the only command from procps that builds currently on
-      # Darwin. Unfortunately no other implementations exist currently!
+      # Darwin/FreeBSD. Unfortunately no other implementations exist currently!
       darwin = pkgs.callPackage ../os-specific/linux/procps-ng {};
+      freebsd = pkgs.callPackage ../os-specific/linux/procps-ng {};
     };
     write = {
       linux = pkgs.util-linux;
@@ -181,6 +195,7 @@ let
     xxd = {
       linux = pkgs.vim.xxd;
       darwin = pkgs.vim.xxd;
+      freebsd = pkgs.vim.xxd;
     };
   };
 


### PR DESCRIPTION
## Description of changes

part of https://github.com/NixOS/nixpkgs/pull/311762

Most of these binaries are provided by a forthcoming PR, but this won't hurt anything until it's merged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
