### PR TITLE
ratchet: init at 0.9.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3199,6 +3199,16 @@
     githubId = 3212452;
     name = "Cameron Nemo";
   };
+  cameronraysmith = {
+    email = "cameronraysmith@gmail.com";
+    matrix = "@cameronraysmith:matrix.org";
+    github = "cameronraysmith";
+    githubId = 420942;
+    name = "Cameron Smith";
+    keys = [{
+      fingerprint = "3F14 C258 856E 88AE E0F9  661E FF04 3B36 8811 DD1C";
+    }];
+  };
   camillemndn = {
     email = "camillemondon@free.fr";
     github = "camillemndn";

--- a/pkgs/by-name/ra/ratchet/package.nix
+++ b/pkgs/by-name/ra/ratchet/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  callPackage,
+}:
+buildGoModule rec {
+  pname = "ratchet";
+  version = "0.9.2";
+
+  # ratchet uses the git sha-1 in the version string, e.g.
+  #
+  # $ ./ratchet --version
+  # ratchet 0.9.2 (d57cc1a53c022d3f87c4820bc6b64384a06c8a07, darwin/arm64)
+  #
+  # so we need to either hard-code the sha-1 corresponding to the version tag
+  # head or retain the git metadata folder and extract it using the git cli.
+  # We currently hard-code it.
+  src = fetchFromGitHub {
+    owner = "sethvargo";
+    repo = "ratchet";
+    rev = "d57cc1a53c022d3f87c4820bc6b64384a06c8a07";
+    hash = "sha256-gQ98uD9oPUsECsduv/lqGdYNmtHetU49ETfWCE8ft8U=";
+  };
+
+  proxyVendor = true;
+  vendorHash = "sha256-J7LijbhpKDIfTcQMgk2x5FVaYG7Kgkba/1aSTmgs5yw=";
+
+  subPackages = [ "." ];
+
+  ldflags =
+    let
+      package_url = "github.com/sethvargo/ratchet";
+    in
+    [
+      "-s"
+      "-w"
+      "-X ${package_url}/internal/version.name=${pname}"
+      "-X ${package_url}/internal/version.version=${version}"
+      "-X ${package_url}/internal/version.commit=${src.rev}"
+    ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/ratchet --version 2>&1 | grep ${version};
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -Dm755 "$GOPATH/bin/ratchet" -T $out/bin/ratchet
+    runHook postInstall
+  '';
+
+  passthru.tests = {
+    execution = callPackage ./tests.nix { };
+  };
+
+  meta = with lib; {
+    description = "A tool for securing CI/CD workflows with version pinning.";
+    mainProgram = "ratchet";
+    downloadPage = "https://github.com/sethvargo/ratchet";
+    homepage = "https://github.com/sethvargo/ratchet";
+    license = licenses.asl20;
+    maintainers = with maintainers; [
+      cameronraysmith
+      ryanccn
+    ];
+  };
+}

--- a/pkgs/by-name/ra/ratchet/tests.nix
+++ b/pkgs/by-name/ra/ratchet/tests.nix
@@ -1,0 +1,17 @@
+{
+  lib,
+  runCommand,
+  ratchet,
+}: let
+  inherit (ratchet) pname version;
+in
+  runCommand "${pname}-tests" {meta.timeout = 60;}
+  ''
+    set -euo pipefail
+
+    # Ensure ratchet is executable
+    ${ratchet}/bin/ratchet --version
+    ${ratchet}/bin/ratchet --help
+
+    touch $out
+  ''


### PR DESCRIPTION
## Description of changes

As [noted below prior to this update](https://github.com/NixOS/nixpkgs/pull/311799#issuecomment-2111465962), https://github.com/sethvargo/ratchet has been previously proposed at 0.7.0 in #282464. This PR proposes to add ratchet at 0.9.2 in a manner that produces equivalent results for `ratchet --version` to those produced by the upstream release in https://github.com/sethvargo/ratchet/releases/tag/v0.9.2 together with package binary execution smoke tests. Nixos module tests were executed locally in nixos on aarch64 and then removed in https://github.com/NixOS/nixpkgs/pull/311799/commits/0dc182611b02e10e01dbe097b48dbc7725495cf8.

This upstream tracking issue https://github.com/sethvargo/ratchet/issues/83 will be closed when some version of ratchet is merged into nixpkgs.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
