### PR TITLE
zulu22: fix javafx hashes

### DIFF
--- a/pkgs/development/compilers/zulu/22.nix
+++ b/pkgs/development/compilers/zulu/22.nix
@@ -11,7 +11,7 @@ callPackage ./common.nix ({
       zuluVersion = "22.28.91";
       jdkVersion = "22.0.0";
       hash =
-        if enableJavaFX then "sha256-HvMiODsz+puu1xtxG2RRXH/PWCk91PGNZ7UcOd9orqQ="
+        if enableJavaFX then "sha256-+qUrZ+GlspSP3RLTAbgEtFm0B0fzX/VD1WUl6mk2c/0="
         else "sha256-HvMiODsz+puu1xtxG2RRXH/PWCk91PGNZ7UcOd9orqQ=";
     };
 
@@ -27,7 +27,7 @@ callPackage ./common.nix ({
       zuluVersion = "22.28.91";
       jdkVersion = "22.0.0";
       hash =
-        if enableJavaFX then "sha256-Y6PSNQjHRXukwux2sVbvpTIqT+Cg+KeG1C0iSEwyKZw="
+        if enableJavaFX then "sha256-QkFwbc2YFEWb5rddhH4a+zmtsrXxUBSuS8yg9qUb728="
         else "sha256-Y6PSNQjHRXukwux2sVbvpTIqT+Cg+KeG1C0iSEwyKZw=";
     };
 
@@ -35,7 +35,7 @@ callPackage ./common.nix ({
       zuluVersion = "22.28.91";
       jdkVersion = "22.0.0";
       hash =
-        if enableJavaFX then "sha256-o0VkWB4+PzBmNNWy+FZlyjTgukBTe6owfydb3YNfEE0="
+        if enableJavaFX then "sha256-256UP6MtUReQYqCKVt0ThN9BVDyKLAMXQTdpcDB9t24="
         else "sha256-o0VkWB4+PzBmNNWy+FZlyjTgukBTe6owfydb3YNfEE0=";
     };
   };


### PR DESCRIPTION
## Description of changes

Fixes hashes for various builds of JDK (using prebuilt builds from Azul Zulu) - previously, hashes were identical between non-JavaFx and JavaFx versions of the JDK, which produced hash errors when trying to use the JavaFx versions (which incorrectly had non-JavaFx hashes)

Note: hashes can be verified with `nix hash convert --hash-algo sha256 $(nix-prefetch-url https://cdn.azul.com/zulu/bin/zulu22.28.91-ca-fx-jdk22.0.0-linux_x64.tar.gz)`, substituting the filename for the various options available from https://www.azul.com/downloads/?version=java-22&package=jdk&show-old-builds=true#zulu

Closes #311796 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
