### PR TITLE
binlore: migrate override lore to package passthru

### DIFF
--- a/pkgs/by-name/pd/pdf2odt/package.nix
+++ b/pkgs/by-name/pd/pdf2odt/package.nix
@@ -49,6 +49,10 @@ resholve.mkDerivation rec {
       imagemagick
       zip
     ];
+    execer = [
+      # zip can exec; confirmed 2 invocations in pdf2odt don't
+      "cannot:${zip}/bin/zip"
+    ];
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -23,6 +23,9 @@
 , cmake
 , nix
 , samba
+
+# for passthru.lore
+, binlore
 }:
 
 assert xarSupport -> libxml2 != null;
@@ -125,4 +128,11 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.tests = {
     inherit cmake nix samba;
   };
+
+  # bsdtar is detected as "cannot" because its exec is internal to
+  # calls it makes into libarchive itself. If binlore gains support
+  # for detecting another layer down into libraries, this can be cut.
+  passthru.binlore.out = binlore.synthesize finalAttrs.finalPackage ''
+    execer can bin/bsdtar
+  '';
 })

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -11,6 +11,7 @@
 , mouseSupport ? false, gpm
 , unicodeSupport ? true
 , testers
+, binlore
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -178,6 +179,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   preFixup = lib.optionalString (!stdenv.hostPlatform.isCygwin && !enableStatic) ''
     rm "$out"/lib/*.a
+  '';
+
+  # I'm not very familiar with ncurses, but it looks like most of the
+  # exec here will run hard-coded executables. There's one that is
+  # dynamic, but it looks like it only comes from executing a terminfo
+  # file, so I think it isn't going to be under user control via CLI?
+  # Happy to have someone help nail this down in either direction!
+  # The "capability" is 'iprog', and I could only find 1 real example:
+  # https://invisible-island.net/ncurses/terminfo.ti.html#tic-linux-s
+  passthru.binlore.out = binlore.synthesize ncurses ''
+    execer cannot bin/{reset,tput,tset}
   '';
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/nixos-rebuild/default.nix
+++ b/pkgs/os-specific/linux/nixos-rebuild/default.nix
@@ -10,6 +10,8 @@
 , lib
 , nixosTests
 , installShellFiles
+, binlore
+, nixos-rebuild
 }:
 let
   fallback = import ./../../../../nixos/modules/installer/tools/nix-fallback-paths.nix;
@@ -48,6 +50,13 @@ substitute {
     specialisations = nixosTests.nixos-rebuild-specialisations;
     target-host = nixosTests.nixos-rebuild-target-host;
   };
+
+  # nixos-rebuild can’t execute its arguments
+  # (but it can run ssh with the with the options stored in $NIX_SSHOPTS,
+  # and ssh can execute its arguments...)
+  passthru.binlore.out = binlore.synthesize nixos-rebuild ''
+    execer cannot bin/nixos-rebuild
+  '';
 
   meta = {
     description = "Rebuild your NixOS configuration and switch to it, on local hosts and remote";

--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -15,6 +15,9 @@
   # exception is ‘watch’ which is portable enough to run on pretty much
   # any UNIX-compatible system.
 , watchOnly ? !(stdenv.isLinux || stdenv.isCygwin)
+
+, binlore
+, procps
 }:
 
 stdenv.mkDerivation rec {
@@ -59,6 +62,12 @@ stdenv.mkDerivation rec {
   installPhase = lib.optionalString watchOnly ''
     install -m 0755 -D watch $out/bin/watch
     install -m 0644 -D watch.1 $out/share/man/man1/watch.1
+  '';
+
+  # no obvious exec in documented arguments; haven't trawled source
+  # to figure out what exec binlore hits on
+  passthru.binlore.out = binlore.synthesize procps ''
+    execer cannot bin/{ps,top,free}
   '';
 
   meta = with lib; {

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -7,6 +7,8 @@
 , perl
 , texinfo
 , xz
+, binlore
+, coreutils
 , gmpSupport ? true, gmp
 , aclSupport ? stdenv.isLinux, acl
 , attrSupport ? stdenv.isLinux, attr
@@ -27,7 +29,7 @@ assert aclSupport -> acl != null;
 assert selinuxSupport -> libselinux != null && libsepol != null;
 
 let
-  inherit (lib) concatStringsSep isString optional optionals optionalString;
+  inherit (lib) concatStringsSep isString optional optionalAttrs optionals optionalString;
   isCross = (stdenv.hostPlatform != stdenv.buildPlatform);
 in
 stdenv.mkDerivation rec {
@@ -180,6 +182,26 @@ stdenv.mkDerivation rec {
   + optionalString minimal ''
     rm -r "$out/share"
   '';
+
+  passthru = {} // optionalAttrs (singleBinary != false) {
+    # everything in the single binary gets the same verdict, so we
+    # override _that case_ with verdicts from separate binaries.
+    #
+    # binlore only spots exec in runcon on some platforms (i.e., not
+    # darwin; see comment on inverse case below)
+    binlore.out = binlore.synthesize coreutils ''
+      execer can bin/{chroot,env,install,nice,nohup,runcon,sort,split,stdbuf,timeout}
+      execer cannot bin/{[,b2sum,base32,base64,basename,basenc,cat,chcon,chgrp,chmod,chown,cksum,comm,cp,csplit,cut,date,dd,df,dir,dircolors,dirname,du,echo,expand,expr,factor,false,fmt,fold,groups,head,hostid,id,join,kill,link,ln,logname,ls,md5sum,mkdir,mkfifo,mknod,mktemp,mv,nl,nproc,numfmt,od,paste,pathchk,pinky,pr,printenv,printf,ptx,pwd,readlink,realpath,rm,rmdir,seq,sha1sum,sha224sum,sha256sum,sha384sum,sha512sum,shred,shuf,sleep,stat,stty,sum,sync,tac,tail,tee,test,touch,tr,true,truncate,tsort,tty,uname,unexpand,uniq,unlink,uptime,users,vdir,wc,who,whoami,yes}
+    '';
+  } // optionalAttrs (singleBinary == false) {
+    # binlore only spots exec in runcon on some platforms (i.e., not
+    # darwin; I have a note that the behavior may need selinux?).
+    # hard-set it so people working on macOS don't miss cases of
+    # runcon until ofBorg fails.
+    binlore.out = binlore.synthesize coreutils ''
+      execer can bin/runcon
+    '';
+  };
 
   meta = with lib; {
     homepage = "https://www.gnu.org/software/coreutils/";

--- a/pkgs/tools/misc/linuxquota/default.nix
+++ b/pkgs/tools/misc/linuxquota/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, e2fsprogs, openldap, pkg-config }:
+{ lib, stdenv, fetchurl, e2fsprogs, openldap, pkg-config, binlore, linuxquota }:
 
 stdenv.mkDerivation rec {
   version = "4.09";
@@ -13,6 +13,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ e2fsprogs openldap ];
+
+  passthru.binlore.out = binlore.synthesize linuxquota ''
+    execer cannot bin/quota
+  '';
 
   meta = with lib; {
     description = "Tools to manage kernel-level quotas in Linux";

--- a/pkgs/tools/nix/nixos-install-tools/default.nix
+++ b/pkgs/tools/nix/nixos-install-tools/default.nix
@@ -8,6 +8,7 @@
   nixos-install-tools,
   runCommand,
   nixosTests,
+  binlore,
 }:
 let
   inherit (nixos {}) config;
@@ -62,6 +63,12 @@ in
       touch $out
     '';
   };
+
+  # no documented flags show signs of exec; skim of source suggests
+  # it's just --help execing man
+  passthru.binlore.out = binlore.synthesize nixos-install-tools ''
+    execer cannot bin/nixos-generate-config
+  '';
 }).overrideAttrs {
   inherit version;
   pname = "nixos-install-tools";

--- a/pkgs/tools/text/esh/default.nix
+++ b/pkgs/tools/text/esh/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, asciidoctor, gawk, gnused, runtimeShell }:
+{ lib, stdenv, fetchFromGitHub, asciidoctor, gawk, gnused, runtimeShell, binlore, esh }:
 
 stdenv.mkDerivation rec {
   pname = "esh";
@@ -29,6 +29,14 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
   checkTarget = "test";
+
+  # working around a bug in file. Was fixed in
+  # file 5.41-5.43 but regressed in 5.44+
+  # see https://bugs.astron.com/view.php?id=276
+  # "can" verdict because of `-s SHELL` arg
+  passthru.binlore.out = binlore.synthesize esh ''
+    execer can bin/esh
+  '';
 
   meta = with lib; {
     description = "Simple templating engine based on shell";


### PR DESCRIPTION
Move lore overrides from binlore's source repo to the passthru of the target packages.

> Note: to keep this from sprawling, see issue/previous PR below for more background/explanation:
> - #295029
> - #304956

## Description of changes

- Change how lore is merged/gathered:
	- Don't apply overrides from binlore's source. 
	- Merge lore from `$out/nix-support/<loretype>` if it exists. Prepares binlore to collect lore generated by `makeWrapper` and friends. 

	    (Saving that for a follow-up, since it's a huge rebuild that makes this harder to test.)

	- Merge lore from `<package>.binlore` if it exists.

	    (Happy to debate this name. Avoiding `overrideLore` since `override` is roughly a contract in nixpkgs.)
	    
	    > *Note*: this has been changed from `<package>.lore` to `<package>.binlore` during review in order to mitigate confusion about what this is for. We might need to revisit this later if there are more lore providers (or we come up with better terms all around).

- Add a utility function (`binlore.synthesize`) for ~synthesizing lore overrides. It rolls in a small Shell DSL for efficiently expressing overrides.

    (Happy to debate this name. Avoiding `override` since it's roughly a contract in nixpkgs.) 

- Reimplement most overrides using `passthru.binlore = binlore.synthesize ...;`. (I'm skipping some to pare them back to the set needed for nixpkgs and other public repos found via search.)

- Expand resholve's passthru tests to better exercise the machinery.

I also have a [branch with these changes](https://github.com/abathur/nixpkgs/tree/move_lore_overrides_to_passthru_unstable) based on a recent nixpkgs-unstable commit for easier testing. I generally test with `nix-build -A resholve.tests`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc