### PR TITLE
mpack: patch CVE-2011-4919

### DIFF
--- a/pkgs/tools/networking/mpack/CVE-2011-4919.patch
+++ b/pkgs/tools/networking/mpack/CVE-2011-4919.patch
@@ -1,0 +1,23 @@
+commit 0c87201f64491575350b18d04c62ec142e119d1f
+Author: Sebastian Pipping <sebastian@pipping.org>
+Date:   Sat, 31 Dec 2011 19:17:20 +0000 (20:17 +0100)
+Source: https://web.archive.org/web/20120128080247/http://git.goodpoint.de/?p=mpack.git;a=commitdiff;h=0c87201f64491575350b18d04c62ec142e119d1f
+
+    Fix permissions
+
+diff --git a/unixos.c b/unixos.c
+index fa6d0a7..0e2f469 100644 (file)
+--- a/unixos.c
++++ b/unixos.c
+@@ -134,9 +134,9 @@ FILE *os_createnewfile(char *fname)
+     FILE *ret;
+      
+ #ifdef O_EXCL
+-    fd=open(fname, O_RDWR|O_CREAT|O_EXCL, 0644);
++    fd=open(fname, O_RDWR|O_CREAT|O_EXCL, 0600);
+ #else
+-    fd=open(fname, O_RDWR|O_CREAT|O_TRUNC, 0644);
++    fd=open(fname, O_RDWR|O_CREAT|O_TRUNC, 0600);
+ #endif
+ 
+     if (fd == -1)

--- a/pkgs/tools/networking/mpack/default.nix
+++ b/pkgs/tools/networking/mpack/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0k590z96509k96zxmhv72gkwhrlf55jkmyqlzi72m61r7axhhh97";
   };
 
-  patches = [ ./build-fix.patch ./sendmail-via-execvp.diff ];
+  patches = [ ./build-fix.patch ./sendmail-via-execvp.diff ./CVE-2011-4919.patch ];
 
   postPatch = ''
     for f in *.{c,man,pl,unix} ; do


### PR DESCRIPTION
## Description of changes

More information available here: https://www.openwall.com/lists/oss-security/2011/12/31/1

The original patch is by Sebastian Pipping and is available here: https://web.archive.org/web/20120128080247/http://git.goodpoint.de/?p=mpack.git;a=commitdiff;h=0c87201f64491575350b18d04c62ec142e119d1f

We copy the patch in-tree, as the original source of the patch did not have the "raw" diff made available.

Closes #90905

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
