### PR TITLE
python312Packages.pybrowserid: Fix on Darwin

### DIFF
--- a/pkgs/development/python-modules/pybrowserid/default.nix
+++ b/pkgs/development/python-modules/pybrowserid/default.nix
@@ -19,6 +19,11 @@ buildPythonPackage rec {
     hash = "sha256-bCJ2aeh8wleWrnb2oO9lAlUoyK2C01Jnn6mj5WY6ceM=";
   };
 
+  patches = [
+    ./fix_pickle_error.patch
+    ./fix_tests_when_spawning.patch
+  ];
+
   postPatch = ''
     substituteInPlace browserid/tests/* \
         --replace-warn 'assertEquals' 'assertEqual'

--- a/pkgs/development/python-modules/pybrowserid/fix_pickle_error.patch
+++ b/pkgs/development/python-modules/pybrowserid/fix_pickle_error.patch
@@ -1,0 +1,147 @@
+commit 56b959a5e17de7e6c236373167b44e7043a2167f
+Author: Palmer Cox <p@lmercox.com>
+Date:   Tue May 14 23:07:48 2024 -0400
+
+    python312Packages.pybrowserid: Fix WorkerPool verifier when not forking
+    
+    The WorkerPoolVerifier works by spawning one or more child processes in
+    order to run the verification process. This is fine on Linux when using
+    the default "fork" method of the multiprocessing module. However, this
+    breaks when using the "spawn" or "forkserver" method since those methods
+    require that the arguments passed into the Process object be pickleable.
+    Significantly, we're passing threading.Lock objects to the child process
+    which are not pickleable.
+    
+    Passing a Lock to a child process spawned via fork mostly does nothing -
+    the child process ends up with its own copy of the Lock which its free
+    to lock or unlock as it pleases and it has no effect on the parent
+    process. So, we don't actually need to pass the Lock to the child
+    process since it has never done anything. All we need to do is _not_
+    pass it since it causes errors when its passed because its not
+    pickleable. We don't need to re-create its functionality.
+    
+    Anyway, there are two places where we are passing locks to the child
+    process. The first is the WorkerPoolVerifier class. This lock isn't
+    actually being used - its just passed because we're passing the "self"
+    object to the worker thread. So, we can fix this by making the target
+    method to run in the worker thread a free-function and only passing the
+    object we need - thus avoiding passing the unused Lock that triggers the
+    pickle error.
+    
+    The other place that a Lock is passed ia via the FIFOCache. We can work
+    around this by making the Lock a global variable instead of an instance
+    variable. This shouldn't cause any significant performance issues
+    because the FIFOCache only holds this lock for brief periods when its
+    updating itself - its not doing any network call or long running
+    operations. Anyway, because its a global variable now, its not passed to
+    the process and we avoid the pickle error.
+
+diff --git a/browserid/supportdoc.py b/browserid/supportdoc.py
+index d995fed..249b37e 100644
+--- a/browserid/supportdoc.py
++++ b/browserid/supportdoc.py
+@@ -26,6 +26,9 @@ DEFAULT_TRUSTED_SECONDARIES = ("browserid.org", "diresworb.org",
+                                "login.persona.org")
+ 
+ 
++FIFO_CACHE_LOCK = threading.Lock()
++
++
+ class SupportDocumentManager(object):
+     """Manager for mapping hostnames to their BrowserID support documents.
+ 
+@@ -131,7 +134,6 @@ class FIFOCache(object):
+         self.max_size = max_size
+         self.items_map = {}
+         self.items_queue = collections.deque()
+-        self._lock = threading.Lock()
+ 
+     def __getitem__(self, key):
+         """Lookup the given key in the cache.
+@@ -147,7 +149,7 @@ class FIFOCache(object):
+                 # it hasn't been updated by another thread in the meantime.
+                 # This is a little more work during eviction, but it means we
+                 # can avoid locking in the common case of non-expired items.
+-                self._lock.acquire()
++                FIFO_CACHE_LOCK.acquire()
+                 try:
+                     if self.items_map[key][0] == timestamp:
+                         # Just delete it from items_map.  Trying to find
+@@ -157,7 +159,7 @@ class FIFOCache(object):
+                 except KeyError:
+                     pass
+                 finally:
+-                    self._lock.release()
++                    FIFO_CACHE_LOCK.release()
+                     raise KeyError
+         return value
+ 
+@@ -168,7 +170,7 @@ class FIFOCache(object):
+         there's enough room in the cache and evicting items if necessary.
+         """
+         now = time.time()
+-        with self._lock:
++        with FIFO_CACHE_LOCK:
+             # First we need to make sure there's enough room.
+             # This is a great opportunity to evict any expired items,
+             # helping to keep memory small for sparse caches.
+diff --git a/browserid/verifiers/workerpool.py b/browserid/verifiers/workerpool.py
+index c669107..d250222 100644
+--- a/browserid/verifiers/workerpool.py
++++ b/browserid/verifiers/workerpool.py
+@@ -32,7 +32,6 @@ class WorkerPoolVerifier(object):
+         if verifier is None:
+             verifier = LocalVerifier()
+         self.num_procs = num_procs
+-        self.verifier = verifier
+         # Create the various communication channels.
+         # Yes, this duplicates a lot of the logic from multprocessing.Pool.
+         # I don't want to have to constantly pickle the verifier object
+@@ -53,7 +52,7 @@ class WorkerPoolVerifier(object):
+         self._result_thread.start()
+         self._processes = []
+         for n in range(num_procs):
+-            proc = multiprocessing.Process(target=self._run_worker)
++            proc = multiprocessing.Process(target=_run_worker, args=(self._work_queue, verifier, self._result_queue))
+             self._processes.append(proc)
+             proc.start()
+ 
+@@ -128,21 +127,21 @@ class WorkerPoolVerifier(object):
+                 self._waiting_conds[job_id] = (ok, result)
+                 cond.notify()
+ 
+-    def _run_worker(self):
+-        """Method to run for the background worker processes.
++def _run_worker(work_queue, verifier, result_queue):
++    """Method to run for the background worker processes.
+ 
+-        This method loops through jobs from the work queue, executing them
+-        with the verifier object and pushing the result back via the result
+-        queue.
+-        """
+-        while True:
+-            job_id, args, kwds = self._work_queue.get()
+-            if job_id is None:
+-                break
+-            try:
+-                result = self.verifier.verify(*args, **kwds)
+-                ok = True
+-            except Exception as e:
+-                result = e
+-                ok = False
+-            self._result_queue.put((job_id, ok, result))
++    This method loops through jobs from the work queue, executing them
++    with the verifier object and pushing the result back via the result
++    queue.
++    """
++    while True:
++        job_id, args, kwds = work_queue.get()
++        if job_id is None:
++            break
++        try:
++            result = verifier.verify(*args, **kwds)
++            ok = True
++        except Exception as e:
++            result = e
++            ok = False
++        result_queue.put((job_id, ok, result))

--- a/pkgs/development/python-modules/pybrowserid/fix_tests_when_spawning.patch
+++ b/pkgs/development/python-modules/pybrowserid/fix_tests_when_spawning.patch
@@ -1,0 +1,99 @@
+commit c7938d0c7b34ece8a379e75f148d8cba375158ba
+Author: Palmer Cox <p@lmercox.com>
+Date:   Tue May 14 23:16:01 2024 -0400
+
+    python312Packages.pybrowserid: Fix tests when not forking
+    
+    When running the tests on Linux, everything passes. This is because the
+    tests patch out the network calls and then run the tests against the
+    WorkerPoolVerifier which spawns child processes via fork() - ie, they
+    inherit the patched functions that skip the network calls.
+    
+    When running the tests on Darwin (or Windows), where the default
+    multiprocessing method is "spawn", however, this doesn't work. The
+    Spawned process does not inherit the patches since it starts up as a
+    completely fresh process.
+    
+    There is a second problem as well: the spawned process runs the setup()
+    function in setup.py again! This causes it to start the tests a second
+    time. Which causes a new process to spawn and to try to run the tests as
+    well. And so on.
+    
+    Anyway, we fix this issues by:
+    
+    1. Checking if we're in a child process. If so, we run the patching code
+       that the tests would normally run.
+    2. Check that __name__ == "__main__" before running setup.py - this
+       prevents us from attempting to recursively run the tests.
+
+diff --git a/setup.py b/setup.py
+index 49ff7fb..943de11 100644
+--- a/setup.py
++++ b/setup.py
+@@ -2,6 +2,7 @@
+ import os
+ import sys
+ from setuptools import setup, find_packages
++import multiprocessing
+ 
+ here = os.path.abspath(os.path.dirname(__file__))
+ 
+@@ -17,25 +18,36 @@ tests_require = requires + ['mock']
+ if sys.version_info < (2, 7):
+     tests_require.append("unittest2")
+ 
+-setup(name='PyBrowserID',
+-      version='0.14.0',
+-      description='Python library for the BrowserID Protocol',
+-      long_description=README + '\n\n' + CHANGES,
+-      license='MPLv2.0',
+-      classifiers=[
+-        "Programming Language :: Python",
+-        "Programming Language :: Python :: 2",
+-        "Programming Language :: Python :: 3",
+-        "Development Status :: 4 - Beta",
+-        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+-        ],
+-      author='Mozilla Identity Team',
+-      author_email='dev-identity@lists.mozilla.org',
+-      url='https://github.com/mozilla/PyBrowserID',
+-      keywords='authentication browserid login email',
+-      packages=find_packages(),
+-      include_package_data=True,
+-      zip_safe=False,
+-      install_requires=requires,
+-      tests_require=tests_require,
+-      test_suite="browserid.tests")
++# The problem here is that when tests are run on Mac OS, the worker
++# processes are spawned not forked like on Linux. That means that the
++# patches to the supportdoc fetching functions are lost. So, as a bit
++# of a hack, if the current process isn't the main process, we assume
++# that we must be a worker process inside of a test case and apply
++# the patches manually.
++if multiprocessing.current_process().name != "MainProcess":
++    from browserid.tests.support import patched_supportdoc_fetching
++    patched_supportdoc_fetching().__enter__()
++
++if __name__ == '__main__':
++    setup(name='PyBrowserID',
++          version='0.14.0',
++          description='Python library for the BrowserID Protocol',
++          long_description=README + '\n\n' + CHANGES,
++          license='MPLv2.0',
++          classifiers=[
++            "Programming Language :: Python",
++            "Programming Language :: Python :: 2",
++            "Programming Language :: Python :: 3",
++            "Development Status :: 4 - Beta",
++            "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
++            ],
++          author='Mozilla Identity Team',
++          author_email='dev-identity@lists.mozilla.org',
++          url='https://github.com/mozilla/PyBrowserID',
++          keywords='authentication browserid login email',
++          packages=find_packages(),
++          include_package_data=True,
++          zip_safe=False,
++          install_requires=requires,
++          tests_require=tests_require,
++          test_suite="browserid.tests")


### PR DESCRIPTION
There are 2 patches needed to fix building the package on Darwin:

* The first fixes an issue where WorkerPoolVerifier was being passed non-pickleable arguments which doesn't work when the multiprocessing start mode is not "fork" - such as on Darwin where the default is "spawn".
* The second fixes an issue where tests would fail when the start mode is not "fork" because the child processes would attempt to re-run the tests all over again and without any patched functions that would inhibit network access attempts.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tried running `nixpkgs-review` but it was failing on an unrelated package. I tried to run it on the previous commit, and it failed there as well. So, my assumption was that there is something else that was causing failures outside of this change.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
