### PR TITLE
prometheus-jmx-javaagent: init at 0.20.0

### DIFF
--- a/pkgs/by-name/pr/prometheus-jmx-javaagent/package.nix
+++ b/pkgs/by-name/pr/prometheus-jmx-javaagent/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    jarName = "jmx_prometheus_javaagent-${finalAttrs.version}.jar";
+  in
+  {
+    pname = "jmx-prometheus-javaagent";
+    version = "0.20.0";
+    src = fetchurl {
+      url = "mirror://maven/io/prometheus/jmx/jmx_prometheus_javaagent/${finalAttrs.version}/${jarName}";
+      sha256 = "sha256-i2ftQEhdR1ZIw20R0hRktIRAb4X6+RKzNj9xpqeGEyA=";
+    };
+
+    dontUnpack = true;
+
+    installPhase = ''
+      env
+      mkdir -p $out/lib
+      cp $src $out/lib/${jarName}
+    '';
+
+    meta = {
+      homepage = "https://github.com/prometheus/jmx_exporter";
+      description = "A process for exposing JMX Beans via HTTP for Prometheus consumption";
+      sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+      license = lib.licenses.asl20;
+      maintainers = [ lib.maintainers.srhb ];
+      platforms = lib.platforms.unix;
+    };
+  }
+)


### PR DESCRIPTION
## Description of changes

This adds the javaagent analogous to the already-packaged prometheus-jmx-httpserver. This is the recommended mode of deployment for the Prometheux JMX exporter, however, unlike the httpserver, it is not a standalone application but needs to be run as a javaagent with the primary application, so there's not much to do but simply ship the jar.

See https://github.com/prometheus/jmx_exporter/tree/release-0.20.0?tab=readme-ov-file#running-the-java-agent for details

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
