### PR TITLE
abaddon: fix null audio backend

### DIFF
--- a/pkgs/applications/networking/instant-messengers/abaddon/default.nix
+++ b/pkgs/applications/networking/instant-messengers/abaddon/default.nix
@@ -6,10 +6,12 @@
 , makeDesktopItem
 , makeWrapper
 , pkg-config
+, alsa-lib
 , curl
 , gtkmm3
 , libhandy
 , libopus
+, libpulseaudio
 , libsecret
 , libsodium
 , nlohmann_json
@@ -58,6 +60,7 @@ stdenv.mkDerivation rec {
     mkdir $out/bin
     cp abaddon $out/bin
     wrapProgram $out/bin/abaddon \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ alsa-lib libpulseaudio ]}" \
       --chdir $out/share/abaddon
 
     runHook postInstall


### PR DESCRIPTION
## Description of changes
This PR fixes abaddon not finding alsa/pulse shared libraries, which leads to a null audio backend for the miniaudio lib.
<details>

<summary>Errors without this change</summary>

```
[2024-05-15 12:51:40.634] [miniaudio] [info] Failed to load library: libpulse.so
[2024-05-15 12:51:40.634] [miniaudio] [info] Failed to load library: libpulse.so.0
[2024-05-15 12:51:40.635] [miniaudio] [info] Failed to load library: libasound.so.2
[2024-05-15 12:51:40.635] [miniaudio] [info] Failed to load library: libasound.so
[2024-05-15 12:51:40.635] [miniaudio] [info] Failed to load library: libjack.so
[2024-05-15 12:51:40.635] [miniaudio] [info] Failed to load library: libjack.so.0
[2024-05-15 12:51:40.635] [audio] [info] Audio backend: Null
[2024-05-15 12:51:40.635] [miniaudio] [info] [Null]
```

</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
