### PR TITLE
qemu: enable canokey by default

### DIFF
--- a/nixos/tests/systemd-initrd-luks-fido2.nix
+++ b/nixos/tests/systemd-initrd-luks-fido2.nix
@@ -9,7 +9,6 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
       # Booting off the encrypted disk requires having a Nix store available for the init script
       mountHostNixStore = true;
       useEFIBoot = true;
-      qemu.package = lib.mkForce (pkgs.qemu_test.override { canokeySupport = true; });
       qemu.options = [ "-device canokey,file=/tmp/canokey-file" ];
     };
     boot.loader.systemd-boot.enable = true;

--- a/pkgs/applications/virtualization/qemu/canokey-qemu-memcpy.patch
+++ b/pkgs/applications/virtualization/qemu/canokey-qemu-memcpy.patch
@@ -1,0 +1,41 @@
+From 9e59480d941c40b868ebafa5138bbc71ca87f08e Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Sat, 18 May 2024 09:55:17 +0200
+Subject: [PATCH] Fix build where memcpy is a macro
+
+I got the following compiler error with Clang 16 building for
+x86_64-apple-darwin:
+
+	/tmp/nix-build-canokey-qemu-0-unstable-2023-06-06.drv-0/source/canokey-core/applets/oath/oath.c:44:50: error: too many arguments provided to function-like macro invocation
+	  memcpy(RDATA, (uint8_t[]){OATH_TAG_VERSION, 3, 0x05, 0x05, 0x05, OATH_TAG_NAME, HANDLE_LEN}, 7);
+	                                                 ^
+	/nix/store/vw8y07yai2pjv02s1piw3r5cyhmjbddf-Libsystem-1238.60.2/include/secure/_string.h:64:9: note: macro 'memcpy' defined here
+	#define memcpy(dest, src, len)                                  \
+	        ^
+	/tmp/nix-build-canokey-qemu-0-unstable-2023-06-06.drv-0/source/canokey-core/applets/oath/oath.c:44:3: note: parentheses are required around macro argument containing braced initializer list
+	  memcpy(RDATA, (uint8_t[]){OATH_TAG_VERSION, 3, 0x05, 0x05, 0x05, OATH_TAG_NAME, HANDLE_LEN}, 7);
+	  ^
+	                (                                                                            )
+	1 error generated.
+
+Link: https://github.com/canokeys/canokey-core/pull/85
+---
+ canokey-core/applets/oath/oath.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/canokey-core/applets/oath/oath.c b/canokey-core/applets/oath/oath.c
+index bd8361a..2d2c0ef 100644
+--- a/canokey-core/applets/oath/oath.c
++++ b/canokey-core/applets/oath/oath.c
+@@ -41,7 +41,7 @@ int oath_install(uint8_t reset) {
+ static int oath_select(const CAPDU *capdu, RAPDU *rapdu) {
+   if (P2 != 0x00) EXCEPT(SW_WRONG_P1P2);
+ 
+-  memcpy(RDATA, (uint8_t[]){OATH_TAG_VERSION, 3, 0x05, 0x05, 0x05, OATH_TAG_NAME, HANDLE_LEN}, 7);
++  memcpy(RDATA, ((uint8_t[]){OATH_TAG_VERSION, 3, 0x05, 0x05, 0x05, OATH_TAG_NAME, HANDLE_LEN}), 7);
+   if (read_attr(OATH_FILE, ATTR_HANDLE, RDATA + 7, HANDLE_LEN) < 0) return -1;
+   LL = 7 + HANDLE_LEN;
+ 
+-- 
+2.44.0
+

--- a/pkgs/applications/virtualization/qemu/canokey-qemu.nix
+++ b/pkgs/applications/virtualization/qemu/canokey-qemu.nix
@@ -23,6 +23,17 @@ stdenv.mkDerivation rec {
       --replace "COMMAND git describe --always --tags --long --abbrev=8 --dirty >>" "COMMAND echo '$rev' >>"
   '';
 
+  preConfigure = ''
+    cmakeFlagsArray+=(
+      -DCMAKE_C_FLAGS=${lib.escapeShellArg ([
+        "-Wno-error=unused-but-set-parameter"
+        "-Wno-error=unused-but-set-variable"
+      ] ++ lib.optionals stdenv.cc.isClang [
+        "-Wno-error=documentation"
+      ])}
+    )
+  '';
+
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/applications/virtualization/qemu/canokey-qemu.nix
+++ b/pkgs/applications/virtualization/qemu/canokey-qemu.nix
@@ -3,18 +3,19 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  unstableGitUpdater,
 }:
 stdenv.mkDerivation rec {
   pname = "canokey-qemu";
-  version = "unstable-2022-06-23";
-  rev = "b70af31229f1858089c3366f71b8d771de4a1e84";
+  version = "0-unstable-2023-06-06";
+  rev = "151568c34f5e92b086b7a3a62a11c43dd39f628b";
 
   src = fetchFromGitHub {
     owner = "canokeys";
     repo = "canokey-qemu";
     inherit rev;
     fetchSubmodules = true;
-    hash = "sha256-VJb59K/skx+DhoJs5qGUu070hAjQZC2Z6hAMXuX0bMw=";
+    hash = "sha256-4V/2UOgGWgL+tFJO/k90bCDjWSVyIpxw3nYi9NU/OxA=";
   };
 
   postPatch = ''
@@ -25,6 +26,8 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ cmake ];
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = with lib; {
     homepage = "https://github.com/canokeys/canokey-qemu";

--- a/pkgs/applications/virtualization/qemu/canokey-qemu.nix
+++ b/pkgs/applications/virtualization/qemu/canokey-qemu.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-4V/2UOgGWgL+tFJO/k90bCDjWSVyIpxw3nYi9NU/OxA=";
   };
 
+  patches = [
+    ./canokey-qemu-memcpy.patch
+  ];
+
   postPatch = ''
     substituteInPlace canokey-core/CMakeLists.txt \
       --replace "COMMAND git describe --always --tags --long --abbrev=8 --dirty >>" "COMMAND echo '$rev' >>"

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -29,7 +29,7 @@
 , smbdSupport ? false, samba
 , tpmSupport ? !toolsOnly
 , uringSupport ? stdenv.isLinux, liburing
-, canokeySupport ? false, canokey-qemu
+, canokeySupport ? !toolsOnly, canokey-qemu
 , capstoneSupport ? !toolsOnly, capstone
 , enableDocs ? true
 , hostCpuOnly ? false


### PR DESCRIPTION
## Description of changes

Given that we were overriding qemu_test to enable this anyway, enabling this by default saves Hydra a QEMU build.

There's also [clear demand from users][1] for this feature, so our alternatives are:

 - Offer a qemu-canokey attribute.  I don't want to do this, because I don't think there's any reason to make Hydra build an extra QEMU.

 - Enable it only for qemu_test.  I don't want to do this, because it will lead to users using qemu_test without understanding its subtleties.

 - Force users to build from source.  I don't think there's any reason to do this when it's unlikely to hurt anybody having it enabled by default.  There's no reason to single out canokey to be disabled by default in spite of users' needs given that we enable so many other optional QEMU features.

[1]: https://github.com/canokeys/canokey-qemu/issues/6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
