### PR TITLE
sync: init at 0.10.1

### DIFF
--- a/pkgs/by-name/sy/sync/package.nix
+++ b/pkgs/by-name/sy/sync/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  autoreconfHook,
+  libgcrypt,
+  pkg-config,
+  curlWithGnuTls,
+  gnunet,
+  jansson,
+  libmicrohttpd,
+  libsodium,
+  libtool,
+  postgresql,
+  taler-exchange,
+  taler-merchant,
+  runtimeShell,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sync";
+  version = "0.10.1";
+
+  src = fetchgit {
+    url = "https://git.taler.net/sync.git";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-7EBm4Zp1sjZw7pXxQySY+1It3C/KLG2SHhqUPhDATbg=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    libgcrypt
+    pkg-config
+  ];
+
+  buildInputs = [
+    curlWithGnuTls
+    gnunet
+    jansson
+    libgcrypt
+    libmicrohttpd
+    libsodium
+    libtool
+    postgresql
+    taler-exchange
+    taler-merchant
+  ];
+
+  preFixup = ''
+    substituteInPlace "$out/bin/sync-dbconfig" \
+      --replace-fail "/bin/bash" "${runtimeShell}"
+  '';
+
+  meta = {
+    description = "Backup and synchronization service";
+    homepage = "https://git.taler.net/sync.git";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ wegank ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

https://git.taler.net/sync.git
https://taler.net/en/news/2024-06.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
