### PR TITLE
webcord: Implement ${commandLineArgs}

### DIFF
--- a/pkgs/by-name/we/webcord/package.nix
+++ b/pkgs/by-name/we/webcord/package.nix
@@ -1,12 +1,15 @@
 {
-  lib,
-  buildNpmPackage,
-  fetchFromGitHub,
-  copyDesktopItems,
-  python3,
-  xdg-utils,
-  electron,
-  makeDesktopItem,
+  lib
+  , buildNpmPackage
+  , fetchFromGitHub
+  , copyDesktopItems
+  , python3
+  , xdg-utils
+  , electron
+  , makeDesktopItem
+
+  # command line arguments which are always set e.g "--no-proxy-server"
+  , commandLineArgs ? ""
 }:
 
 buildNpmPackage rec {
@@ -56,7 +59,8 @@ buildNpmPackage rec {
       makeWrapper '${lib.getExe electron}' $out/bin/webcord \
         --suffix PATH : "${binPath}" \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
-        --add-flags $out/lib/node_modules/webcord/
+        --add-flags $out/lib/node_modules/webcord/ \
+        --add-flags ${lib.escapeShellArg commandLineArgs}
 
       runHook postInstall
     '';


### PR DESCRIPTION
## Description of changes

Taking inspiration from the packaging of `brave`:

https://github.com/NixOS/nixpkgs/blob/6308cb8b066539d2fbc7637d2de02349e985e177/pkgs/applications/networking/browsers/brave/make-brave.nix#L49

To enable configuration alike:

https://github.com/Kreyren/nixos-config/tree/e16b1776ffca750cd7ed872efa0becf279780ab3/src/nixos/users/kreyren/home/machines/pelagus/home-configuration.nix#L54-L57

To manage a scenario where the system is using a system-proxy which is causing issues for the user while avoiding doing impure declaration through using `environment.localBinInPath` and making script:

```sh
#!/usr/bin/env sh

# Instruct webcord's electron to not use system proxy
/home/USER/.nix-profile/bin/webcord --no-proxy-server $*
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [-] aarch64-linux
  - [-] x86_64-darwin
  - [-] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [-] `sandbox = relaxed`
  - [-] `sandbox = true`
- [-] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [-] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [-] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [-] (Module updates) Added a release notes entry if the change is significant
  - [-] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
