### PR TITLE
wagyu: 0.6.1 -> 0.6.3

### DIFF
--- a/pkgs/tools/misc/wagyu/default.nix
+++ b/pkgs/tools/misc/wagyu/default.nix
@@ -2,16 +2,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "wagyu";
-  version = "0.6.1";
+  version = "0.6.3";
 
   src = fetchFromGitHub {
     owner = "AleoHQ";
     repo = pname;
-    rev = "refs/tags/v${version}";
-    hash = "sha256-ltWNKB3DHtwVVzJyvRWj2I8rjsl7ru2i/RCO9yiQhpg=";
+    rev = "v${version}";
+    hash = "sha256-5n8BmETv5jUvgu0rskAPYaBgYyNL2QU2t/iUb3hNMMw=";
   };
 
-  cargoHash = "sha256-8dbeSHN6+1jLdVA9QxNAy7Y6EX7wflpQI72kqZAEVIE=";
+  cargoPatches = [ ./fix-rustc-serialize-version.patch ];
+
+  cargoHash = "sha256-vseTtok0E0ddg9ALQ1ql3NPPxirfyMPHOSWsM2qu2jU=";
 
   buildInputs = lib.optional stdenv.isDarwin Security;
 

--- a/pkgs/tools/misc/wagyu/fix-rustc-serialize-version.patch
+++ b/pkgs/tools/misc/wagyu/fix-rustc-serialize-version.patch
@@ -1,0 +1,15 @@
+diff --git a/Cargo.lock b/Cargo.lock
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1286,9 +1286,9 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+ 
+ [[package]]
+ name = "rustc-serialize"
+-version = "0.3.24"
++version = "0.3.25"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
++checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
+ 
+ [[package]]
+ name = "rustc_version"


### PR DESCRIPTION
This also includes a fix for the rustc-serialize build issue.

## Description of changes
ZHF: #309482

Currently the package can not be built. However, this PR fixes that.
- failed build: https://hydra.nixos.org/build/259447531
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
