### PR TITLE
xwayland: 23.2.6 -> 24.1.0, add a few things, add myself as maintainer

### DIFF
--- a/pkgs/servers/x11/xorg/xwayland.nix
+++ b/pkgs/servers/x11/xorg/xwayland.nix
@@ -4,6 +4,7 @@
 , fetchpatch
 , fontutil
 , lib
+, libdecor
 , libei
 , libGL
 , libGLU
@@ -33,6 +34,7 @@
 , pkg-config
 , pixman
 , stdenv
+, systemd
 , wayland
 , wayland-protocols
 , wayland-scanner
@@ -47,21 +49,20 @@
 
 stdenv.mkDerivation rec {
   pname = "xwayland";
-  version = "23.2.6";
+  version = "24.1.0";
 
   src = fetchurl {
     url = "mirror://xorg/individual/xserver/${pname}-${version}.tar.xz";
-    hash = "sha256-HJo2a058ytug+b0xPFnq4S0jvXJUOyKibq+LIINc/G0=";
+    hash = "sha256-vvIcTxiAek7VccTi32CrY7VGa71QLszrJIW4kqt23MI=";
   };
 
   patches = [
-    # Backport fix for libei scrolling
-    # Notably affects Steam Input, but also anything else using xtest
+    # Backport fix for pkg-config generation to make CMake happy
     # FIXME: remove when merged
-    # Upstream PR: https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1531
+    # Upstream PR: https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1543
     (fetchpatch {
-      url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/317712eb5a1aa4a1c3d737a8fcaee57add9981c9.patch";
-      hash = "sha256-TZo38Pyr9IJUF+3bqlmF4M84XGgo9G6WFTvbaP9r0XU=";
+      url = "https://gitlab.freedesktop.org/xorg/xserver/-/commit/8cb1c21a4240a5b6bf4aeeef51819639b4e0ad24.patch";
+      hash = "sha256-MZPP9QgYO4RFJ/vcjkpu7SVSo5Dh09ZdZjOwTopjdYQ=";
     })
   ];
 
@@ -76,6 +77,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     egl-wayland
+    libdecor
     libepoxy
     libei
     fontutil
@@ -102,6 +104,7 @@ stdenv.mkDerivation rec {
     mesa
     openssl
     pixman
+    systemd
     wayland
     wayland-protocols
     xkbcomp
@@ -112,7 +115,6 @@ stdenv.mkDerivation rec {
     libunwind
   ];
   mesonFlags = [
-    (lib.mesonBool "xwayland_eglstream" true)
     (lib.mesonBool "xcsecurity" true)
     (lib.mesonOption "default_font_path" defaultFontPath)
     (lib.mesonOption "xkb_bin_dir" "${xkbcomp}/bin")
@@ -132,7 +134,7 @@ stdenv.mkDerivation rec {
     homepage = "https://wayland.freedesktop.org/xserver.html";
     license = licenses.mit;
     mainProgram = "Xwayland";
-    maintainers = with maintainers; [ emantor ];
+    maintainers = with maintainers; [ emantor k900 ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
- libsystemd used for starting via sd-notify, is already in the closure via libei
- libdecor used for window decorations on rootful
- eglstream backend is gone

Includes patch from #311886.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
