### PR TITLE
libtiff: Add ZSTD support

### DIFF
--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -12,6 +12,7 @@
 , libjpeg
 , xz
 , zlib
+, zstd
 
   # for passthru.tests
 , libgeotiff
@@ -62,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     lerc
+    zstd
   ];
 
   # TODO: opengl support (bogus configure detection)


### PR DESCRIPTION
## Description of changes

Compile libtiff against zstd (https://gitlab.com/libtiff/libtiff/-/blob/master/ChangeLog?ref_type=heads#L7566).

(previously opened as https://github.com/NixOS/nixpkgs/pull/311922)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

(tested when the commit was on top of master, now that it is on top of staging it requires too many rebuilds for me)

```
nix-build -A gdalMinimal

./result/bin/gdal_create -outsize 10 10 -co COMPRESS=ZSTD test.tif
./result/bin/gdalinfo test.tif
Driver: GTiff/GeoTIFF
Files: test.tif
Size is 10, 10
Image Structure Metadata:
  COMPRESSION=ZSTD
  INTERLEAVE=BAND
Corner Coordinates:
Upper Left  (    0.0,    0.0)
Lower Left  (    0.0,   10.0)
Upper Right (   10.0,    0.0)
Lower Right (   10.0,   10.0)
Center      (    5.0,    5.0)
Band 1 Block=10x10 Type=Byte, ColorInterp=Gray

./result/bin/gdal_create -outsize 10 10 -co COMPRESS=LERC_ZSTD test.tif
./result/bin/gdalinfo test.tif
Driver: GTiff/GeoTIFF
Files: test.tif
Size is 10, 10
Image Structure Metadata:
  COMPRESSION=LERC_ZSTD
  INTERLEAVE=BAND
  LERC_VERSION=2.4
Corner Coordinates:
Upper Left  (    0.0,    0.0)
Lower Left  (    0.0,   10.0)
Upper Right (   10.0,    0.0)
Lower Right (   10.0,   10.0)
Center      (    5.0,    5.0)
Band 1 Block=10x10 Type=Byte, ColorInterp=Gray
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
