### PR TITLE
fits-cloudctl: add verioning ldflags

### DIFF
--- a/pkgs/tools/admin/fits-cloudctl/default.nix
+++ b/pkgs/tools/admin/fits-cloudctl/default.nix
@@ -5,7 +5,10 @@
 
 buildGoModule rec {
   pname = "fits-cloudctl";
-  version = "0.12.19";
+  version = "0.12.19"; # also update these 3 vars:
+  gitversion = "tags/v0.12.19-0-g0a0d89a"; # git describe --long --all
+  gitsha = "0a0d89a8";                     # git rev-parse --short=8 HEAD
+  gittime = "2024-05-15T17:34:46+02:00";   # date --iso-8601=seconds
 
   src = fetchFromGitHub {
     owner = "fi-ts";
@@ -15,6 +18,13 @@ buildGoModule rec {
   };
 
   vendorHash = "sha256-mK10DxDUrEkCdumq6MM6h7B8C8P1hGE466ko3yj1kto=";
+
+  ldflags = [
+    "-X github.com/metal-stack/v.Version=${version}"
+    "-X github.com/metal-stack/v.Revision=${gitversion}"
+    "-X github.com/metal-stack/v.GitSHA1=${gitsha}"
+    "-X github.com/metal-stack/v.BuildDate=${gittime}"
+  ];
 
   meta = with lib; {
     description = "Command-line client for FI-TS Finance Cloud Native services";


### PR DESCRIPTION
## Description of changes

The tool `cloudctl` needs a couple of variables compiled into it. In its current state these are missing, because the Makefile is not being used for building, which would add them otherwise. Output looks like this now:
```shell
cloudctl version
client: version not set, please build your app with appropriate ldflags, see https://github.com/metal-stack/v for reference, go1.22.2
[..]
```

This patch adds the missing variables via `ldflags`. Now the output is:
```shell
result/bin/cloudctl version                                                                                                                                                              
client: 0.12.19 (0a0d89a8), tags/v0.12.19-0-g0a0d89a, 2024-05-15T17:34:46+02:00, go1.22.2
[..]
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
