### PR TITLE
modules/sysctl: Harden default options

### DIFF
--- a/nixos/modules/config/sysctl.nix
+++ b/nixos/modules/config/sysctl.nix
@@ -13,13 +13,21 @@ let
         checkType val || (val._type or "" == "override" && checkType val.content);
     merge = loc: defs: mergeOneOption loc (filterOverrides defs);
   };
+  boolOrBitmask = numBitsInMask: mkOptionType {
+    name = "sysctl option value";
+    check = val: isBool val || 0 <= val <= ((1 <<< (numBitsInMask + 1)) - 1); # +1 bit for global enable/disable
+    merge = loc: defs: foldl (a: b:
+      if (a == 0 || b == 0 || a == false || b == false) then 0 # Explicitly disabled overrides all
+      else if (a == 1 || a == true || b == 1 || b == true) then 1 # Explicitly enabled overrides a bitmask
+      else builtins.bitwiseOr a b # Bitwise OR
+    ) 0 (filterOverrides defs);
+  };
 
 in
 
 {
 
   options = {
-
     boot.kernel.sysctl = mkOption {
       type = let
         highestValueType = types.ints.unsigned // {
@@ -34,14 +42,373 @@ in
         options = {
           "net.core.rmem_max" = mkOption {
             type = types.nullOr highestValueType;
-            default = null;
             description = "The maximum receive socket buffer size in bytes. In case of conflicting values, the highest will be used.";
+            default = null;
           };
 
           "net.core.wmem_max" = mkOption {
             type = types.nullOr highestValueType;
-            default = null;
             description = "The maximum send socket buffer size in bytes. In case of conflicting values, the highest will be used.";
+            default = null;
+          };
+
+          "dev.tty.ldisc_autoload" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Automatically load line discipline modules for tty devices.";
+            # Prevent unprivileged attackers from loading vulnerable line disciplines with the TIOCSETD ioctl
+            default = false;
+          };
+
+          "fs.protected_hardlinks" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Protect hardlinks created by other users.";
+            # Prevent unprivileged attackers from creating world-writable sticky hardlinks
+            default = true;
+          };
+
+          "fs.protected_symlinks" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Protect symlinks created by other users.";
+            # Prevent unprivileged attackers from creating world-writable sticky symlinks
+            default = true;
+          };
+
+          "fs.protected_fifos" = mkOption {
+            type = types.nullOr highestValueType;
+            description = "Protect pipes and FIFOs from being written to by other users.";
+            # Prevent unprivileged attackers from creating world-writable sticky FIFOs
+            default = 2;
+          };
+
+          "fs.protected_regular" = mkOption {
+            type = types.nullOr highestValueType;
+            description = "Protect files created by other users.";
+            # Prevent unprivileged attackers from creating world-writable sticky files
+            default = 2;
+          };
+
+          "fs.suid_dumpable" = mkOption {
+            type = types.nullOr highestValueType;
+            description = "Controls the core dump mode for setuid processes.";
+            # Prevent setuid processes from dumping core
+            default = 0;
+          };
+
+          "kernel.ctrl-alt-del" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Enable the Ctrl-Alt-Del key combination to trigger a kernel reboot.";
+            # This is a security risk, as it allows users to reboot the system without authentication
+            default = false;
+          };
+
+          "kernel.dmesg_restrict" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Restrict access to kernel log buffer.";
+            # Hide kernel log buffer to make it harder to exploit kernel vulnerabilities (e.g. by leaking kernel pointers)
+            default = true;
+          };
+
+          "kernel.kptr_restrict" = mkOption {
+            type = types.nullOr highestValueType;
+            description = "Restrict access to kernel pointers.";
+            # Hide kernel pointers to make it harder to exploit kernel vulnerabilities
+            default = 2;
+          };
+
+          "kernel.modules_disabled" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Disable kernel module loading.";
+            # Prevent loading kernel modules after boot to reduce attack surface
+            default = true;
+          };
+
+          "kernel.kexec_load_disabled" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Disable kexec loading.";
+            # Prevent loading a new kernel image without rebooting the system
+            default = true;
+          };
+
+          "kernel.randomize_va_space" = mkOption {
+            type = types.nullOr highestValueType;
+            description = "Randomize the address space layout.";
+            # Randomize the address space layout to make it harder to exploit memory corruption vulnerabilities
+            default = 2;
+          };
+
+          "kernel.sysrq" = mkOption {
+            type = types.nullOr (boolOrBitmask 7)
+            description = "Enable SysRq key combinations.";
+            # This is a security risk, as it allows users to perform various low-level operations without authentication
+            # The sysrq key can be triggered remotely!
+            default = false;
+          };
+
+          "kernel.perf_event_paranoid" = mkOption {
+            type = types.nullOr highestValueType;
+            description = "Controls use of the performance events system by unprivileged users.";
+            # Restrict use of the performance events system to processes with CAP_PERFMON capability
+            default = 3;
+          };
+
+          "kernel.unprivileged_bpf_disabled" = mkOption {
+            type = types.nullOr highestValueType;
+            description = "Disable unprivileged BPF access.";
+            # Restricts loading BPF programs to processes with the CAP_BPF capability
+            default = 1;
+          };
+
+          "kernel.yama.ptrace_scope" = mkOption {
+            type = types.nullOr highestValueType;
+            description = "Restrict ptrace access.";
+            # Restrict ptrace access to processes with the CAP_SYS_PTRACE capability
+            default = 2;
+          };
+
+          "kernel.unprivileged_userns_clone" = mkOption {
+            type = types.nullOr highestValueType;
+            description = "Restrict unprivileged user namespaces.";
+            # Restricts creating user namespaces to processes with the CAP_SYS_ADMIN capability
+            default = 0;
+          };
+
+          "net.core.bpf_jit_harden" = mkOption {
+            type = types.nullOr highestValueType;
+            description = "Harden BPF JIT against speculative execution attacks.";
+            # Hardens BPF JIT against speculative execution attacks
+            default = 2;
+          };
+
+          "net.ipv4.conf.all.accept_source_route" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Accept source routed packets.";
+            # Protects against MitM attacks
+            default = false;
+          };
+
+          "net.ipv4.conf.all.bootp_relay" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Enable BOOTP relay.";
+            # Protects against MitM attacks
+            default = false;
+          };
+
+          "net.ipv4.conf.all.forwarding" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Enable IP forwarding.";
+            # Protects against MitM attacks
+            default = false;
+          };
+
+          "net.ipv4.conf.all.log_martians" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Log packets with impossible addresses to the kernel log.";
+            # Protects against IP spoofing attacks
+            default = true;
+          };
+
+          "net.ipv4.conf.all.mc_forwarding" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Enable multicast routing.";
+            # Protects against IP spoofing attacks
+            default = false;
+          };
+
+          "net.ipv4.conf.all.proxy_arp" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Enable proxy ARP.";
+            # Protects against ARP spoofing attacks
+            default = false;
+          };
+
+          "net.ipv4.conf.all.rp_filter" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Enable reverse path filtering.";
+            # Protects against IP spoofing attacks
+            default = false;
+          };
+
+          "net.ipv4.icmp_echo_ignore_all" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Ignore all ICMP echo requests.";
+            # Protects against Smurf attacks
+            default = true;
+          };
+
+          "net.ipv4.conf.all.send_redirects" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Send ICMP redirect messages.";
+            # Protects against MitM attacks
+            default = false;
+          };
+
+          "net.ipv4.conf.all.secure_redirects" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Accept only ICMP redirects from gateways listed in the default gateway list.";
+            # Protects against MitM attacks
+            default = false;
+          };
+
+          "net.ipv4.conf.all.accept_redirects" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Accept ICMP redirect messages.";
+            # Protects against MitM attacks
+            default = false;
+          };
+
+          "net.ipv4.tcp_sack" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Enable TCP selective acknowledgments.";
+            # Unnecessary in most cases, and can be used to exploit vulnerabilities in some TCP/IP stacks
+            default = false;
+          };
+
+          "net.ipv4.tcp_dsack" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Enable TCP duplicate selective acknowledgments.";
+            # Unnecessary in most cases, and can be used to exploit vulnerabilities in some TCP/IP stacks
+            default = false;
+          };
+
+          "net.ipv4.tcp_fack" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Enable TCP Forward Acknowledgment.";
+            # Unnecessary in most cases, and can be used to exploit vulnerabilities in some TCP/IP stacks
+            default = false;
+          };
+
+          "net.ipv4.conf.default.rp_filter" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Enable reverse path filtering.";
+            # Protects against IP spoofing attacks
+            default = true;
+          };
+
+          "net.ipv4.conf.default.accept_source_route" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Accept source routed packets.";
+            # Protects against MitM attacks
+            default = false;
+          };
+
+          "net.ipv4.conf.default.send_redirects" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Send ICMP redirect messages.";
+            # Protects against MitM attacks
+            default = false;
+          };
+
+          "net.ipv4.conf.default.secure_redirects" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Accept only ICMP redirects from gateways listed in the default gateway list.";
+            # Protects against MitM attacks
+            default = false;
+          };
+
+          "net.ipv4.conf.default.accept_redirects" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Accept ICMP redirect messages.";
+            # Protects against MitM attacks
+            default = false;
+          };
+
+          "net.ipv4.conf.default.log_martians" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Log packets with impossible addresses to the kernel log.";
+            # Protects against IP spoofing attacks
+            default = true;
+          };
+
+          "net.ipv4.icmp_echo_ignore_broadcasts" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Ignore ICMP echo broadcasts.";
+            # Protects against Smurf attacks
+            default = true;
+          };
+
+          "net.ipv4.icmp_ignore_bogus_error_responses" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Ignore bogus error responses.";
+            # Protects against ICMP error message attacks
+            default = true;
+          };
+
+          "net.ipv4.tcp_syncookies" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Enable TCP SYN cookies.";
+            # Protects against SYN flood attacks
+            default = true;
+          };
+
+          "net.ipv4.tcp_rfc1337" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Enable RFC 1337 protection.";
+            # Protects against time-wait assassination attacks
+            default = true;
+          };
+
+          "net.ipv4.tcp_timestamps" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Enable TCP timestamps.";
+            # Improves performance and helps protect against sequence number guessing attacks
+            default = true;
+          };
+
+          "net.ipv6.conf.all.accept_redirects" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Accept ICMPv6 redirect messages.";
+            # Protects against MitM attacks
+            default = false;
+          };
+
+          "net.ipv6.conf.all.accept_source_route" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Accept source routed packets.";
+            # Protects against MitM attacks
+            default = false;
+          };
+
+          "net.ipv6.conf.default.accept_redirects" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Accept ICMPv6 redirect messages.";
+            # Protects against MitM attacks
+            default = false;
+          };
+
+          "net.ipv6.conf.default.accept_source_route" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Accept source routed packets.";
+            # Protects against MitM attacks
+            default = false;
+          };
+
+          "net.ipv6.conf.all.accept_ra" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Accept Router Advertisements.";
+            # Protects against MitM attacks
+            default = false;
+          };
+
+          "net.ipv6.conf.default.accept_ra" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Accept Router Advertisements.";
+            # Protects against MitM attacks
+            default = false;
+          };
+
+          "vm.unprivileged_userfaultfd" = mkOption {
+            type = types.nullOr types.bool;
+            description = "Allow unprivileged users to register userfaultfd.";
+            # Restricts userfaultfd to processes with the CAP_SYS_PTRACE capability
+            # This syscall can be abused to exploit use-after-free vulnerabilities
+            default = false;
+          };
+
+          "vm.max_map_count" = mkOption {
+            type = types.nullOr highestValueType;
+            description = "Maximum number of memory map areas a process may have.";
+            # Improve compatibility with applications that allocate a lot of memory, like modern games
+            default = 1048576;
           };
         };
       };
@@ -64,23 +431,13 @@ in
   };
 
   config = {
+    environment.etc."sysctl.d/60-nixos.conf".text = concatStrings (mapAttrsToList (n: v:
+      optionalString (v != null) "${n}=${if v == false then "0" else toString v}\n"
+    ) config.boot.kernel.sysctl);
 
-    environment.etc."sysctl.d/60-nixos.conf".text =
-      concatStrings (mapAttrsToList (n: v:
-        optionalString (v != null) "${n}=${if v == false then "0" else toString v}\n"
-      ) config.boot.kernel.sysctl);
-
-    systemd.services.systemd-sysctl =
-      { wantedBy = [ "multi-user.target" ];
-        restartTriggers = [ config.environment.etc."sysctl.d/60-nixos.conf".source ];
-      };
-
-    # Hide kernel pointers (e.g. in /proc/modules) for unprivileged
-    # users as these make it easier to exploit kernel vulnerabilities.
-    boot.kernel.sysctl."kernel.kptr_restrict" = mkDefault 1;
-
-    # Improve compatibility with applications that allocate
-    # a lot of memory, like modern games
-    boot.kernel.sysctl."vm.max_map_count" = mkDefault 1048576;
+    systemd.services.systemd-sysctl = {
+      wantedBy = [ "multi-user.target" ];
+      restartTriggers = [ config.environment.etc."sysctl.d/60-nixos.conf".source ];
+    };
   };
 }


### PR DESCRIPTION
## Description of changes

Adds a lot of sysctl options and assigns secure defaults.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
