### PR TITLE
weechatScripts.autosort: init at 3.10

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/autosort/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/autosort/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchurl, weechat }:
+
+stdenv.mkDerivation {
+  pname = "weechat-autosort";
+  version = "3.10";
+
+  src = fetchurl {
+    url = "https://github.com/weechat/scripts/raw/13aef991ca879fc0ff116874a45b09bc2db10607/python/autosort.py";
+    hash = "sha256-xuZUssjGd0l7lCx96d0V8LL+0O3zIxYlWMoDsdzwMf4=";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir -p $out/share
+    cp $src $out/share/autosort.py
+  '';
+
+  passthru = {
+    scripts = [ "autosort.py" ];
+  };
+
+  meta = with lib; {
+    inherit (weechat.meta) platforms;
+    description = "autosort automatically keeps your buffers sorted and grouped by server.";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ flokli ];
+  };
+}

--- a/pkgs/applications/networking/irc/weechat/scripts/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/default.nix
@@ -1,6 +1,8 @@
 { callPackage, luaPackages, perlPackages, python3Packages }:
 
 {
+  autosort = callPackage ./autosort { };
+
   colorize_nicks = callPackage ./colorize_nicks { };
 
   edit = callPackage ./edit { };


### PR DESCRIPTION
This provides autosort, which automatically keeps buffers sorted and grouped by server.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
