### PR TITLE
modules/obs-studio: optionally enable v4l2loopback

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -155,6 +155,8 @@
 
 - [Immich](https://github.com/immich-app/immich), a self-hosted photo and video backup solution. Available as [services.immich](#opt-services.immich.enable).
 
+- [obs-studio](https://obsproject.com/), Free and open source software for video recording and live streaming. Available as [programs.obs-studio.enable](#opt-programs.obs-studio.enable).
+
 ## Backward Incompatibilities {#sec-release-24.11-incompatibilities}
 
 - The `sound` options have been removed or renamed, as they had a lot of unintended side effects. See [below](#sec-release-24.11-migration-sound) for details.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -259,6 +259,7 @@
   ./programs/oblogout.nix
   ./programs/oddjobd.nix
   ./programs/openvpn3.nix
+  ./programs/obs-studio.nix
   ./programs/partition-manager.nix
   ./programs/plotinus.nix
   ./programs/pqos-wrapper.nix

--- a/nixos/modules/programs/obs-studio.nix
+++ b/nixos/modules/programs/obs-studio.nix
@@ -1,0 +1,64 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+
+let
+  cfg = config.programs.obs-studio;
+in
+{
+  options.programs.obs-studio = {
+    enable = lib.mkEnableOption "Free and open source software for video recording and live streaming";
+
+    package = lib.mkPackageOption pkgs "obs-studio" { example = "obs-studio"; };
+
+    finalPackage = lib.mkOption {
+      type = lib.types.package;
+      visible = false;
+      readOnly = true;
+      description = "Resulting customized OBS Studio package.";
+    };
+
+    plugins = lib.mkOption {
+      default = [ ];
+      example = lib.literalExpression "[ pkgs.obs-studio-plugins.wlrobs ]";
+      description = "Optional OBS plugins.";
+      type = lib.types.listOf lib.types.package;
+    };
+
+    enableVirtualCamera = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Installs and sets up the v4l2loopback kernel module, necessary for OBS
+        to start a virtual camera.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.obs-studio.finalPackage = pkgs.wrapOBS.override { obs-studio = cfg.package; } {
+      plugins = cfg.plugins;
+    };
+
+    environment.systemPackages = [ cfg.finalPackage ];
+
+    boot = lib.mkIf cfg.enableVirtualCamera {
+      kernelModules = [ "v4l2loopback" ];
+      extraModulePackages = [ config.boot.kernelPackages.v4l2loopback ];
+
+      extraModprobeConfig = ''
+        options v4l2loopback devices=1 video_nr=1 card_label="OBS Cam" exclusive_caps=1
+      '';
+    };
+
+    security.polkit.enable = lib.mkIf cfg.enableVirtualCamera true;
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    CaptainJawZ
+    GaetanLepage
+  ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -717,6 +717,7 @@ in {
   nzbhydra2 = handleTest ./nzbhydra2.nix {};
   ocis = handleTest ./ocis.nix {};
   oddjobd = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./oddjobd.nix {};
+  obs-studio = handleTest ./obs-studio.nix {};
   oh-my-zsh = handleTest ./oh-my-zsh.nix {};
   ollama = runTest ./ollama.nix;
   ollama-cuda = runTestOn ["x86_64-linux" "aarch64-linux"] ./ollama-cuda.nix;

--- a/nixos/tests/obs-studio.nix
+++ b/nixos/tests/obs-studio.nix
@@ -1,0 +1,40 @@
+import ./make-test-python.nix (
+  { ... }:
+
+  {
+    name = "obs-studio";
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        imports = [
+          ./common/x11.nix
+          ./common/user-account.nix
+        ];
+
+        programs.obs-studio = {
+          enable = true;
+          plugins = with pkgs.obs-studio-plugins; [
+            wlrobs
+            obs-vkcapture
+          ];
+          enableVirtualCamera = true;
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_x()
+      machine.succeed("obs --version")
+
+      # virtual camera tests
+      machine.succeed("lsmod | grep v4l2loopback")
+      machine.succeed("ls /dev/video1")
+      machine.succeed("obs --startvirtualcam >&2 &")
+      machine.wait_for_window("OBS")
+      machine.sleep(5)
+
+      # test plugins
+      machine.succeed("which obs-vkcapture")
+    '';
+  }
+)


### PR DESCRIPTION
## Description of changes
created a module for obs-studio so using programs.obs-studio.enable it installs obs studio, and using the enableVirtiaulCamera setups the kernel module configurations as well as the security policy necessary for the Virtual Camera support to be enabled 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
