### PR TITLE
starpls-bin: init at 0.1.14

### DIFF
--- a/pkgs/by-name/st/starpls-bin/package.nix
+++ b/pkgs/by-name/st/starpls-bin/package.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "starpls-bin";
+  version = "0.1.14";
+
+  src = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/withered-magic/starpls/releases/download/v${finalAttrs.version}/starpls-linux-amd64";
+      hash = "sha256-PYU+Jv3uaJqJKw6zSNOPl+NlIQgfm38cOrRqTdNXY+8=";
+    };
+    aarch64-darwin = fetchurl {
+      url = "https://github.com/withered-magic/starpls/releases/download/v${finalAttrs.version}/starpls-darwin-arm64";
+      hash = "sha256-9d1ybebguEUJu2PvMcToQEd8M4ajRrQUvBZqS6o0sbw=";
+    };
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    install -D $src $out/bin/starpls
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/withered-magic/starpls";
+    description = "A language server for Starlark";
+    license = licenses.asl20;
+    platforms = [ "aarch64-darwin" "x86_64-linux" ];
+    maintainers = with maintainers; [ aaronjheng ];
+    mainProgram = "starpls";
+  };
+})


### PR DESCRIPTION
## Description of changes

https://github.com/withered-magic/starpls

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
