### PR TITLE
cp2k, pythonPackages.gpaw: improve closure size

### DIFF
--- a/pkgs/applications/science/chemistry/cp2k/remove-compiler-options.patch
+++ b/pkgs/applications/science/chemistry/cp2k/remove-compiler-options.patch
@@ -1,0 +1,37 @@
+diff --git a/src/start/cp2k.F b/src/start/cp2k.F
+index f69146ea3..a195f0620 100644
+--- a/src/start/cp2k.F
++++ b/src/start/cp2k.F
+@@ -58,8 +58,7 @@ PROGRAM cp2k
+    USE input_cp2k,                      ONLY: create_cp2k_root_section
+    USE input_section_types,             ONLY: section_release,&
+                                               section_type
+-   USE iso_fortran_env,                 ONLY: compiler_options,&
+-                                              compiler_version
++   USE iso_fortran_env,                 ONLY: compiler_version
+    USE kinds,                           ONLY: default_path_length
+    USE machine,                         ONLY: default_output_unit
+ #include "../base/base_uses.f90"
+@@ -70,7 +69,6 @@ PROGRAM cp2k
+                                            arg_att, command
+    CHARACTER(LEN=default_path_length), &
+       DIMENSION(:, :), ALLOCATABLE      :: initial_variables, initial_variables_tmp
+-   CHARACTER(LEN=:), ALLOCATABLE        :: compiler_options_string
+    INTEGER                              :: output_unit, l, i, var_set_sep, inp_var_idx
+    INTEGER                              :: ierr, i_arg
+    LOGICAL                              :: check, usage, echo_input, command_line_error
+@@ -328,14 +326,6 @@ PROGRAM cp2k
+                WRITE (output_unit, "(T2,A)") cp2k_version, &
+                   "Source code revision "//TRIM(compile_revision), &
+                   TRIM(cp2k_flags())
+-               compiler_options_string = compiler_options()
+-               WRITE (output_unit, "(T2,A,A)") "compiler: ", compiler_version()
+-               WRITE (output_unit, "(T2,A)") "compiler options:"
+-               DO i = 0, (LEN(compiler_options_string) - 1)/68
+-                  WRITE (output_unit, "(T4,A)") &
+-                     compiler_options_string(i*68 + 1:MIN(LEN(compiler_options_string), (i + 1)*68))
+-               END DO
+-               DEALLOCATE (compiler_options_string)
+             END IF
+          END IF
+ 

--- a/pkgs/by-name/si/sirius/package.nix
+++ b/pkgs/by-name/si/sirius/package.nix
@@ -47,6 +47,9 @@ stdenv.mkDerivation rec {
     hash = "sha256-DYie6ufgZNqg7ohlIed3Bo+sqLKHOxWXTwAkea2guLk=";
   };
 
+
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [
     cmake
     gfortran
@@ -60,6 +63,7 @@ stdenv.mkDerivation rec {
     libxc
     hdf5
     umpire
+    mpi
     spglib
     spfft
     spla
@@ -80,7 +84,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional stdenv.isDarwin llvmPackages.openmp
   ;
 
-  propagatedBuildInputs = [ mpi ];
+  propagatedBuildInputs = [ (lib.getBin mpi) ];
 
   CXXFLAGS = [
     # GCC 13: error: 'uintptr_t' in namespace 'std' does not name a type

--- a/pkgs/by-name/sp/spfft/package.nix
+++ b/pkgs/by-name/sp/spfft/package.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     fftw
+    mpi
   ] ++ lib.optionals (gpuBackend == "cuda") [
     cudaPackages.libcufft
     cudaPackages.cuda_cudart
@@ -47,8 +48,6 @@ stdenv.mkDerivation rec {
     rocmPackages.hipfft
   ] ++ lib.optional stdenv.isDarwin llvmPackages.openmp
   ;
-
-  propagatedBuildInputs = [ mpi ];
 
   cmakeFlags = [
     "-DSPFFT_OMP=ON"

--- a/pkgs/by-name/sp/spla/package.nix
+++ b/pkgs/by-name/sp/spla/package.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-71QpwTsRogH+6Bik9DKwezl9SqwoLxQt4SZ7zw5X6DE=";
   };
 
+  outputs = [ "out" "dev" ];
+
   postPatch = ''
     substituteInPlace src/gpu_util/gpu_blas_api.hpp \
       --replace '#include <rocblas.h>' '#include <rocblas/rocblas.h>'
@@ -43,6 +45,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     blas
+    mpi
   ]
   ++ lib.optional (gpuBackend == "cuda") cudaPackages.cudatoolkit
   ++ lib.optionals (gpuBackend == "rocm") [
@@ -50,8 +53,6 @@ stdenv.mkDerivation rec {
     rocmPackages.rocblas
   ] ++ lib.optional stdenv.isDarwin llvmPackages.openmp
   ;
-
-  propagatedBuildInputs = [ mpi ];
 
   cmakeFlags = [
     "-DSPLA_OMP=ON"
@@ -65,10 +66,15 @@ stdenv.mkDerivation rec {
   ++ lib.optional (gpuBackend == "rocm") [ "-DSPLA_GPU_BACKEND=ROCM" ]
   ;
 
+  preFixup = ''
+    substituteInPlace $out/lib/cmake/SPLA/SPLASharedTargets-release.cmake \
+      --replace-fail "\''${_IMPORT_PREFIX}" "$out"
+  '';
+
   meta = with lib; {
     description = "Specialized Parallel Linear Algebra, providing distributed GEMM functionality for specific matrix distributions with optional GPU acceleration";
     homepage = "https://github.com/eth-cscs/spla";
     license = licenses.bsd3;
-    maintainers = [ maintainers.sheepforce ];#
+    maintainers = [ maintainers.sheepforce ];
   };
 }

--- a/pkgs/development/libraries/science/chemistry/libvdwxc/default.nix
+++ b/pkgs/development/libraries/science/chemistry/libvdwxc/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook gfortran ];
 
-  propagatedBuildInputs = [ mpi fftwMpi ];
+  buildInputs = [ mpi fftwMpi ];
 
   preConfigure = ''
     mkdir build && cd build

--- a/pkgs/development/python-modules/gpaw/default.nix
+++ b/pkgs/development/python-modules/gpaw/default.nix
@@ -6,6 +6,7 @@
 , blas
 , lapack
 , mpi
+, fftw
 , scalapack
 , libxc
 , libvdwxc
@@ -89,9 +90,9 @@ in buildPythonPackage rec {
   # execute `rsh` as a side-effect.
   nativeBuildInputs = [ which inetutils ];
 
-  buildInputs = [ blas scalapack libxc libvdwxc ];
+  buildInputs = [ blas scalapack libxc libvdwxc fftw ];
 
-  propagatedBuildInputs = [ ase scipy numpy mpi pyyaml ];
+  propagatedBuildInputs = [ ase scipy numpy (lib.getBin mpi) pyyaml ];
 
   patches = [ ./SetupPath.patch ];
 


### PR DESCRIPTION
## Description of changes

I have done some output splitting for sirius and spla to separate the dev outputs. Moreover, the PR contains some fixes on `propagatedBuildInputs`: after doing some reading it became clear that `propagatedBuildInputs` should be used for run-time dependencies rather than build time dependencies. 
CP2K pulls in the whole the compiler command line via an intrinsic Fortran macro and hard codes it into the binary. Tbis results in many dev inputs to being pulled into the closure. I wrote a patch to remove this functionality.

Reduction of runtime closure sizes:
* cp2k: 3.2 GB -> 2.6 GB
* gpaw: 1.5 GB -> 1.0 GB


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
