### PR TITLE
hare: remove shell wrapping overhead

### DIFF
--- a/pkgs/by-name/ha/hare/003-hardcode-qbe-and-harec.patch
+++ b/pkgs/by-name/ha/hare/003-hardcode-qbe-and-harec.patch
@@ -1,0 +1,24 @@
+diff --git a/cmd/hare/build.ha b/cmd/hare/build.ha
+index b2ac6518..417b46c6 100644
+--- a/cmd/hare/build.ha
++++ b/cmd/hare/build.ha
+@@ -37,7 +37,7 @@ fn build(name: str, cmd: *getopt::command) (void | error) = {
+ 		case let ncpu: size =>
+ 			yield ncpu;
+ 		},
+-		version = build::get_version(os::tryenv("HAREC", "harec"))?,
++		version = build::get_version(os::tryenv("HAREC", "@harec@"))?,
+ 		arch = arch.qbe_name,
+ 		platform = build::get_platform(os::sysname())?,
+ 		...
+@@ -145,8 +145,8 @@ fn build(name: str, cmd: *getopt::command) (void | error) = {
+ 	set_arch_tags(&ctx.ctx.tags, arch);
+ 
+ 	ctx.cmds = ["",
+-		os::tryenv("HAREC", "harec"),
+-		os::tryenv("QBE", "qbe"),
++		os::tryenv("HAREC", "@harec@"),
++		os::tryenv("QBE", "@qbe@"),
+ 		os::tryenv("AS", arch.as_cmd),
+ 		os::tryenv("LD", arch.ld_cmd),
+ 	];


### PR DESCRIPTION
## Description of changes

Hardcode qbe and harec to avoid the overhead of wrapping hare with a
bash script.

By doing that, we also had to change how `makeFlags` were defined: Now
only part of the `<ARCH>_<TOOL>` make variables are conditioned to the
enableCrossCompilation. The ones belonging to the build platform are
passed unconditionally.

Add qbe and harec to propagatedBuildInputs.

Some build frameworks may rely on having harec and qbe available on
PATH by setting `HAREC` and `QBE` to relative paths --- e. g., `haredo`.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>himitsu-firefox</li>
  </ul>
</details>
<details>
  <summary>16 packages built:</summary>
  <ul>
    <li>bonsai</li>
    <li>hare</li>
    <li>hare.man</li>
    <li>hareThirdParty.hare-compress</li>
    <li>hareThirdParty.hare-ev</li>
    <li>hareThirdParty.hare-json</li>
    <li>hareThirdParty.hare-png</li>
    <li>hareThirdParty.hare-ssh</li>
    <li>hareThirdParty.hare-toml</li>
    <li>haredo</li>
    <li>haredo.man</li>
    <li>haredoc</li>
    <li>haredoc.man</li>
    <li>himitsu</li>
    <li>treecat</li>
    <li>treecat.man</li>
  </ul>
</details>

### Note for reviewers

The following code may be used to confirm the non breaking nature of this PR.
It:

1. Natively compiles qbe, harec, hare, bonsai, haredoc, haredo and treecat
   (tested on x86_64);
1. Cross compiles qbe, harec, hare, bonsai and haredoc for aarch64; and
1. Cross compiles qbe, harec, hare, bonsai and haredoc for riscv64.

These packages were chosen, since:

1. qbe, harec and hare are the packages needed for compilation;
1. bonsai and haredoc support being cross compiled; and
1. treecat has haredo as its build framework.

```bash
nix-build -E '
    let
        pkgs = import ./. {};
    in
        builtins.attrValues {
            inherit (pkgs) qbe harec hare bonsai haredoc haredo treecat;
        } ++ builtins.attrValues {
            inherit (pkgs.pkgsCross.aarch64-multiplatform)
                qbe
                harec
                hare
                bonsai
                haredoc
                ;
        } ++ builtins.attrValues {
            inherit (pkgs.pkgsCross.riscv64)
                qbe
                harec
                hare
                bonsai
                haredoc
                ;
        }
'
```



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
