### PR TITLE
doc: migrate lib.derivations to doc-comment format

### DIFF
--- a/lib/derivations.nix
+++ b/lib/derivations.nix
@@ -61,31 +61,31 @@ in
         (lazyDerivation { inherit derivation }).passthru
 
         (lazyDerivation { inherit derivation }).pythonPath
+
     # Inputs
 
-    structured function argument
+    Takes an attribute set with the following attributes
 
-    : derivation
-      : The derivation to be wrapped.
+    `derivation`
+    : The derivation to be wrapped.
 
-    : meta
-      : Optional meta attribute.
+    `meta`
+    : Optional meta attribute.
 
-        While this function is primarily about derivations, it can improve
-        the `meta` package attribute, which is usually specified through
-        `mkDerivation`.
+      While this function is primarily about derivations, it can improve
+      the `meta` package attribute, which is usually specified through
+      `mkDerivation`.
 
-    : passthru
-      : Optional list of assumed outputs. Default: ["out"]
+    `passthru`
+    : Optional extra values to add to the returned attrset.
 
-        This must match the set of outputs that the returned derivation has.
-        You must use this when the derivation has multiple outputs.
+      This can be used for adding package attributes, such as `tests`.
 
-    : outputs
-      : Optional list of assumed outputs. Default: ["out"]
+    `outputs`
+    : Optional list of assumed outputs. Default: ["out"]
 
-        This must match the set of outputs that the returned derivation has.
-        You must use this when the derivation has multiple outputs.
+      This must match the set of outputs that the returned derivation has.
+      You must use this when the derivation has multiple outputs.
   */
   lazyDerivation =
     args@{

--- a/lib/derivations.nix
+++ b/lib/derivations.nix
@@ -17,7 +17,7 @@ let
     else "";
 in
 {
-  /*
+  /**
     Restrict a derivation to a predictable set of attribute names, so
     that the returned attrset is not strict in the actual derivation,
     saving a lot of computation when the derivation is non-trivial.
@@ -61,26 +61,37 @@ in
         (lazyDerivation { inherit derivation }).passthru
 
         (lazyDerivation { inherit derivation }).pythonPath
+    # Inputs
 
+    structured function argument
+
+    : derivation
+      : The derivation to be wrapped.
+
+    : meta
+      : Optional meta attribute.
+
+        While this function is primarily about derivations, it can improve
+        the `meta` package attribute, which is usually specified through
+        `mkDerivation`.
+
+    : passthru
+      : Optional list of assumed outputs. Default: ["out"]
+
+        This must match the set of outputs that the returned derivation has.
+        You must use this when the derivation has multiple outputs.
+
+    : outputs
+      : Optional list of assumed outputs. Default: ["out"]
+
+        This must match the set of outputs that the returned derivation has.
+        You must use this when the derivation has multiple outputs.
   */
   lazyDerivation =
     args@{
-      # The derivation to be wrapped.
-      derivation
-    , # Optional meta attribute.
-      #
-      # While this function is primarily about derivations, it can improve
-      # the `meta` package attribute, which is usually specified through
-      # `mkDerivation`.
-      meta ? null
-    , # Optional extra values to add to the returned attrset.
-      #
-      # This can be used for adding package attributes, such as `tests`.
-      passthru ? { }
-    , # Optional list of assumed outputs. Default: ["out"]
-      #
-      # This must match the set of outputs that the returned derivation has.
-      # You must use this when the derivation has multiple outputs.
+      derivation,
+      meta ? null,
+      passthru ? { },
       outputs ? [ "out" ]
     }:
     let
@@ -149,29 +160,50 @@ in
     // genAttrs outputs (outputName: checked.${outputName})
     // passthru;
 
-  /* Conditionally set a derivation attribute.
+  /**
+    Conditionally set a derivation attribute.
 
-     Because `mkDerivation` sets `__ignoreNulls = true`, a derivation
-     attribute set to `null` will not impact the derivation output hash.
-     Thus, this function passes through its `value` argument if the `cond`
-     is `true`, but returns `null` if not.
+    Because `mkDerivation` sets `__ignoreNulls = true`, a derivation
+    attribute set to `null` will not impact the derivation output hash.
+    Thus, this function passes through its `value` argument if the `cond`
+    is `true`, but returns `null` if not.
 
-     Type: optionalDrvAttr :: Bool -> a -> a | Null
 
-     Example:
-       (stdenv.mkDerivation {
-         name = "foo";
-         x = optionalDrvAttr true 1;
-         y = optionalDrvAttr false 1;
-       }).drvPath == (stdenv.mkDerivation {
-         name = "foo";
-         x = 1;
-       }).drvPath
-       => true
+    # Inputs
+
+    `cond`
+
+    : Condition
+
+    `value`
+
+    : Attribute value
+
+    # Type
+
+    ```
+    optionalDrvAttr :: Bool -> a -> a | Null
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.derivations.optionalDrvAttr` usage example
+
+    ```nix
+    (stdenv.mkDerivation {
+      name = "foo";
+      x = optionalDrvAttr true 1;
+      y = optionalDrvAttr false 1;
+    }).drvPath == (stdenv.mkDerivation {
+      name = "foo";
+      x = 1;
+    }).drvPath
+    => true
+    ```
+
+    :::
   */
   optionalDrvAttr =
-    # Condition
     cond:
-    # Attribute value
     value: if cond then value else null;
 }


### PR DESCRIPTION
## Description of changes

- Migrate `lib.derivations` to use doc-comments (/** */) with explicit markdown.
- migrated argument documentation.

Ping @DanielSidhion for review.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
