### PR TITLE
doc: migrate lib.filesystem to doc-comment format

### DIFF
--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -310,20 +310,20 @@ in
 
     Structured function argument
 
-    : callPackage
+    : Attribute set containing the following attributes.
+      Additional attributes are ignored.
+
+      `callPackage`
 
       : `pkgs.callPackage`
 
         Type: `Path -> AttrSet -> a`
 
-    : directory
+      `directory`
 
       : The directory to read package files from
 
         Type: `Path`
-
-    : `...`
-      : Additional attributes are ignored
 
 
     # Type

--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -1,4 +1,4 @@
-/*
+/**
   Functions for querying information about the filesystem
   without copying any files to the Nix store.
 */
@@ -29,19 +29,35 @@ in
 
 {
 
-  /*
+  /**
     The type of a path. The path needs to exist and be accessible.
     The result is either "directory" for a directory, "regular" for a regular file, "symlink" for a symlink, or "unknown" for anything else.
 
-    Type:
-      pathType :: Path -> String
+    # Inputs
 
-    Example:
-      pathType /.
-      => "directory"
+    path
 
-      pathType /some/file.nix
-      => "regular"
+    : The path to query
+
+    # Type
+
+    ```
+    pathType :: Path -> String
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.filesystem.pathType` usage example
+
+    ```nix
+    pathType /.
+    => "directory"
+
+    pathType /some/file.nix
+    => "regular"
+    ```
+
+    :::
   */
   pathType =
     builtins.readFileType or
@@ -59,53 +75,97 @@ in
       else (readDir (dirOf path)).${baseNameOf path}
     );
 
-  /*
+  /**
     Whether a path exists and is a directory.
 
-    Type:
-      pathIsDirectory :: Path -> Bool
 
-    Example:
-      pathIsDirectory /.
-      => true
+    # Inputs
 
-      pathIsDirectory /this/does/not/exist
-      => false
+    `path`
 
-      pathIsDirectory /some/file.nix
-      => false
+    : 1\. Function argument
+
+    # Type
+
+    ```
+    pathIsDirectory :: Path -> Bool
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.filesystem.pathIsDirectory` usage example
+
+    ```nix
+    pathIsDirectory /.
+    => true
+
+    pathIsDirectory /this/does/not/exist
+    => false
+
+    pathIsDirectory /some/file.nix
+    => false
+    ```
+
+    :::
   */
   pathIsDirectory = path:
     pathExists path && pathType path == "directory";
 
-  /*
+  /**
     Whether a path exists and is a regular file, meaning not a symlink or any other special file type.
 
-    Type:
-      pathIsRegularFile :: Path -> Bool
 
-    Example:
-      pathIsRegularFile /.
-      => false
+    # Inputs
 
-      pathIsRegularFile /this/does/not/exist
-      => false
+    `path`
 
-      pathIsRegularFile /some/file.nix
-      => true
+    : 1\. Function argument
+
+    # Type
+
+    ```
+    pathIsRegularFile :: Path -> Bool
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.filesystem.pathIsRegularFile` usage example
+
+    ```nix
+    pathIsRegularFile /.
+    => false
+
+    pathIsRegularFile /this/does/not/exist
+    => false
+
+    pathIsRegularFile /some/file.nix
+    => true
+    ```
+
+    :::
   */
   pathIsRegularFile = path:
     pathExists path && pathType path == "regular";
 
-  /*
+  /**
     A map of all haskell packages defined in the given path,
     identified by having a cabal file with the same name as the
     directory itself.
 
-    Type: Path -> Map String Path
+
+    # Inputs
+
+    `root`
+
+    : The directory within to search
+
+    # Type
+
+    ```
+    Path -> Map String Path
+    ```
   */
   haskellPathsInDir =
-    # The directory within to search
     root:
     let # Files in the root
         root-files = builtins.attrNames (builtins.readDir root);
@@ -120,17 +180,30 @@ in
             builtins.pathExists (value + "/${name}.cabal")
           ) root-files-with-paths;
     in builtins.listToAttrs cabal-subdirs;
-  /*
+  /**
     Find the first directory containing a file matching 'pattern'
     upward from a given 'file'.
     Returns 'null' if no directories contain a file matching 'pattern'.
 
-    Type: RegExp -> Path -> Nullable { path : Path; matches : [ MatchResults ]; }
+
+    # Inputs
+
+    `pattern`
+
+    : The pattern to search for
+
+    `file`
+
+    : The file to start searching upward from
+
+    # Type
+
+    ```
+    RegExp -> Path -> Nullable { path : Path; matches : [ MatchResults ]; }
+    ```
   */
   locateDominatingFile =
-    # The pattern to search for
     pattern:
-    # The file to start searching upward from
     file:
     let go = path:
           let files = builtins.attrNames (builtins.readDir path);
@@ -150,13 +223,23 @@ in
     in go (if isDir then file else parent);
 
 
-  /*
+  /**
     Given a directory, return a flattened list of all files within it recursively.
 
-    Type: Path -> [ Path ]
+
+    # Inputs
+
+    `dir`
+
+    : The path to recursively list
+
+    # Type
+
+    ```
+    Path -> [ Path ]
+    ```
   */
   listFilesRecursive =
-    # The path to recursively list
     dir:
     lib.flatten (lib.mapAttrsToList (name: type:
     if type == "directory" then
@@ -165,7 +248,7 @@ in
       dir + "/${name}"
   ) (builtins.readDir dir));
 
-  /*
+  /**
     Transform a directory tree containing package files suitable for
     `callPackage` into a matching nested attribute set of derivations.
 
@@ -223,40 +306,57 @@ in
         As a result, directories with no `.nix` files (including empty
         directories) will be transformed into empty attribute sets.
 
-    Example:
-      packagesFromDirectoryRecursive {
-        inherit (pkgs) callPackage;
+    # Inputs
+
+    Structured function argument
+
+    : callPackage
+
+      : `pkgs.callPackage`
+
+        Type: `Path -> AttrSet -> a`
+
+    : directory
+
+      : The directory to read package files from
+
+        Type: `Path`
+
+    : `...`
+      : Additional attributes are ignored
+
+
+    # Type
+
+    ```
+    packagesFromDirectoryRecursive :: AttrSet -> AttrSet
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.filesystem.packagesFromDirectoryRecursive` usage example
+
+    ```nix
+    packagesFromDirectoryRecursive {
+      inherit (pkgs) callPackage;
+      directory = ./my-packages;
+    }
+    => { ... }
+
+    lib.makeScope pkgs.newScope (
+      self: packagesFromDirectoryRecursive {
+        callPackage = self.callPackage;
         directory = ./my-packages;
       }
-      => { ... }
+    )
+    => { ... }
+    ```
 
-      lib.makeScope pkgs.newScope (
-        self: packagesFromDirectoryRecursive {
-          callPackage = self.callPackage;
-          directory = ./my-packages;
-        }
-      )
-      => { ... }
-
-    Type:
-      packagesFromDirectoryRecursive :: AttrSet -> AttrSet
+    :::
   */
   packagesFromDirectoryRecursive =
-    # Options.
     {
-      /*
-        `pkgs.callPackage`
-
-        Type:
-          Path -> AttrSet -> a
-      */
       callPackage,
-      /*
-        The directory to read package files from
-
-        Type:
-          Path
-      */
       directory,
       ...
     }:


### PR DESCRIPTION
## Description of changes

- Migrate `lib.derivations` to use doc-comments (/** */) with explicit markdown.
- migrated argument documentation.

Ping @DanielSidhion for review.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
