### PR TITLE
go_1_22: 1.22.2 -> 1.22.3

### DIFF
--- a/pkgs/development/compilers/go/1.22.nix
+++ b/pkgs/development/compilers/go/1.22.nix
@@ -47,11 +47,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";
-  version = "1.22.2";
+  version = "1.22.3";
 
   src = fetchurl {
     url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-N06oKyiexzjpaCZ8rFnH1f8YD5SSJQJUeEsgROkN9ak=";
+    hash = "sha256-gGSO80+QMZPXKlnA3/AZ9fmK4MmqE63gsOy/+ZGnb2g=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
## Description of changes

Changelog: https://go.dev/doc/devel/release#go1.22.minor

**Warning:** This is my first contribution to a package. I tried to run `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` as described in https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#tested-compilation-of-all-pkgs-that-depend-on-this-change-using-nixpkgs-review but got an error. I attached it below.

Go 1.22.3 is required to update `symfony-cli` package. I was able to build it after using this updated Go toolchain.

CC @zowoq 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) [by building symfony-cli]
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Edit:

<details>
<summary>Output of nixpkgs-review</summary>

```
~ $ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 148, done.
remote: Counting objects: 100% (126/126), done.
remote: Compressing objects: 100% (76/76), done.
remote: Total 148 (delta 71), reused 70 (delta 46), pack-reused 22
Receiving objects: 100% (148/148), 1.02 MiB | 10.52 MiB/s, done.
Resolving deltas: 100% (77/77), completed with 23 local objects.
From https://github.com/NixOS/nixpkgs
   bc8257ce445c..1df0fb8ad1ff  master     -> refs/nixpkgs-review/0
$ git worktree add /home/rafael/.cache/nixpkgs-review/rev-3c49a795709c48a8711748b077669b3f70174734-1/nixpkgs 1df0fb8ad1ff83a990e2027161afae73408b3a8e
Preparing worktree (detached HEAD 1df0fb8ad1ff)
Updating files: 100% (41074/41074), done.
HEAD is now at 1df0fb8ad1ff Merge pull request #312131 from r-ryantm/auto-update/netbird-ui
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/rafael/.cache/nixpkgs-review/rev-3c49a795709c48a8711748b077669b3f70174734-1/nixpkgs nixpkgs-overlays=/run/user/1000/tmpvt5df5vz -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
$ git worktree remove -f /home/rafael/.cache/nixpkgs-review/rev-3c49a795709c48a8711748b077669b3f70174734-1/nixpkgs
Traceback (most recent call last):
  File "/nix/store/0bn72s5vkywg4816wqmc0ghm4prfw0dp-nixpkgs-review-2.10.3/bin/.nixpkgs-review-wrapped", line 9, in <module>
    sys.exit(main())
             ^^^^^^
  File "/nix/store/0bn72s5vkywg4816wqmc0ghm4prfw0dp-nixpkgs-review-2.10.3/lib/python3.11/site-packages/nixpkgs_review/__init__.py", line 10, in main
    cli.main(command, args)
  File "/nix/store/0bn72s5vkywg4816wqmc0ghm4prfw0dp-nixpkgs-review-2.10.3/lib/python3.11/site-packages/nixpkgs_review/cli/__init__.py", line 334, in main
    return cast(str, args.func(args))
                     ^^^^^^^^^^^^^^^
  File "/nix/store/0bn72s5vkywg4816wqmc0ghm4prfw0dp-nixpkgs-review-2.10.3/lib/python3.11/site-packages/nixpkgs_review/cli/rev.py", line 14, in rev_command
    return review_local_revision(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/0bn72s5vkywg4816wqmc0ghm4prfw0dp-nixpkgs-review-2.10.3/lib/python3.11/site-packages/nixpkgs_review/review.py", line 582, in review_local_revision
    review.review_commit(builddir.path, args.branch, commit, staged, print_result)
  File "/nix/store/0bn72s5vkywg4816wqmc0ghm4prfw0dp-nixpkgs-review-2.10.3/lib/python3.11/site-packages/nixpkgs_review/review.py", line 310, in review_commit
    self.build_commit(branch_rev, reviewed_commit, staged),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/0bn72s5vkywg4816wqmc0ghm4prfw0dp-nixpkgs-review-2.10.3/lib/python3.11/site-packages/nixpkgs_review/review.py", line 161, in build_commit
    base_packages = list_packages(
                    ^^^^^^^^^^^^^^
  File "/nix/store/0bn72s5vkywg4816wqmc0ghm4prfw0dp-nixpkgs-review-2.10.3/lib/python3.11/site-packages/nixpkgs_review/review.py", line 398, in list_packages
    raise NixpkgsReviewError(
nixpkgs_review.errors.NixpkgsReviewError: Failed to list packages: nix-env failed with exit code -9
```
</details

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
