### PR TITLE
nixos/nvidia-container-toolkit: add option for driver path

### DIFF
--- a/nixos/modules/services/hardware/nvidia-container-toolkit/cdi-generate.nix
+++ b/nixos/modules/services/hardware/nvidia-container-toolkit/cdi-generate.nix
@@ -17,10 +17,13 @@
     (mount:
       ["${lib.getExe jq} '${jqAddMountExpression} ${builtins.toJSON (mkMount mount)}'"])
     mounts;
+  ldLibraryPathExport = if builtins.isString nvidia-driver then "export LD_LIBRARY_PATH=${nvidia-driver}/lib" else "";
 in
 writeScriptBin "nvidia-cdi-generator"
 ''
 #! ${runtimeShell}
+
+${ldLibraryPathExport}
 
 function cdiGenerate {
   ${lib.getExe' nvidia-container-toolkit "nvidia-ctk"} cdi generate \


### PR DESCRIPTION
## Description of changes

Add an option `nvidia-driver-path` (in `hardware.nvidia-container-toolkit`) for systems where NVIDIA drivers are not set up by NixOS. This is useful for example in WSL systems where the Windows drivers can be used and are located in `/usr/lib/wsl/lib`.

Tested with Podman

```bash
podman run --rm --device=nvidia.com/gpu=all \
    nvcr.io/nvidia/nvhpc:24.3-devel-cuda_multi-ubuntu22.04 \
    nvidia-smi -L
```

on a WSL NixOS system with 

```nix
hardware.nvidia-container-toolkit = {
  enable = true;
  nvidia-driver-path = "/usr/lib/wsl";
  mount-nvidia-executables = false;
  mount-nvidia-docker-1-directories = false;
};
```

Also tested the compilation and run of [simple CUDA programs](https://github.com/loicreynier/sandbox/tree/main/cuda-demo) on that container.

Not sure yet if this option should always disables the `mount-nvidia-executables` and `mount-nvidia-docker-1-directories
` options.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
