### PR TITLE
cargo-typify: add update script, mark as broken

### DIFF
--- a/pkgs/by-name/ca/cargo-typify/package.nix
+++ b/pkgs/by-name/ca/cargo-typify/package.nix
@@ -30,5 +30,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/oxidecomputer/typify";
     license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ david-r-cox ];
+    broken = true;
   };
 }

--- a/pkgs/by-name/ca/cargo-typify/package.nix
+++ b/pkgs/by-name/ca/cargo-typify/package.nix
@@ -1,4 +1,4 @@
-{ lib, rustfmt, rustPlatform, fetchFromGitHub }:
+{ lib, rustfmt, rustPlatform, fetchFromGitHub, gitUpdater }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-typify";
@@ -21,6 +21,8 @@ rustPlatform.buildRustPackage rec {
     # cargo-typify depends on rustfmt-wrapper, which requires RUSTFMT:
     export RUSTFMT="${lib.getExe rustfmt}"
   '';
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   meta = with lib; {
     description = "JSON Schema to Rust type converter";


### PR DESCRIPTION
## Description of changes
ZHF #309482

Add update script

Didn't update the package because the same test error still happens on both latest commit and latest release

```
cargo-typify> failures:                                                                                                                                
cargo-typify>                                                                                                                                          
cargo-typify> ---- convert::tests::test_int_nonzerou8 stdout ----                                                                                      
cargo-typify> thread 'convert::tests::test_int_nonzerou8' panicked at typify-impl/src/convert.rs:1949:5:                                               
cargo-typify> assertion `left == right` failed                                                                                                         
cargo-typify>   left: "NonZeroU8"                                                                                                                      
cargo-typify>  right: "NonZero<u8>"                                                                                                                    
cargo-typify>                                                                                                                                          
cargo-typify> ---- convert::tests::test_int_nonzerou64 stdout ----                                                                                     
cargo-typify> thread 'convert::tests::test_int_nonzerou64' panicked at typify-impl/src/convert.rs:1952:5:                                              
cargo-typify> assertion `left == right` failed                                                                                                         
cargo-typify>   left: "NonZeroU64"                                                                                                                     
cargo-typify>  right: "NonZero<u64>"                                                                                                                   
cargo-typify>                                                                                                                                          
cargo-typify> ---- convert::tests::test_int_nonzerou16 stdout ----                                                                                     
cargo-typify> thread 'convert::tests::test_int_nonzerou16' panicked at typify-impl/src/convert.rs:1950:5:                                              
cargo-typify> assertion `left == right` failed                                                                                                         
cargo-typify>   left: "NonZeroU16"                                                                                                                     
cargo-typify>  right: "NonZero<u16>"                                                                                                                   
cargo-typify>                                                                                                                                          
cargo-typify> ---- convert::tests::test_int_nonzerou32 stdout ----                                                                                     
cargo-typify> thread 'convert::tests::test_int_nonzerou32' panicked at typify-impl/src/convert.rs:1951:5:                                              
cargo-typify> assertion `left == right` failed                                                                                                         
cargo-typify>   left: "NonZeroU32"                                                                                                                     
cargo-typify>  right: "NonZero<u32>"                                                                                                                   
cargo-typify> note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace                                                            
cargo-typify>                                                                                                                                          
cargo-typify>  
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
