### PR TITLE
monocraft: 2.4 -> 3.0

### DIFF
--- a/pkgs/data/fonts/monocraft/default.nix
+++ b/pkgs/data/fonts/monocraft/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, lib, fetchurl }:
+{ stdenvNoCC, lib, fetchurl }:
 
 let
-  version = "2.4";
+  version = "3.0";
   relArtifact = name: hash: fetchurl {
     inherit name hash;
     url = "https://github.com/IdreesInc/Monocraft/releases/download/v${version}/${name}";
   };
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "monocraft";
   inherit version;
 
@@ -18,16 +18,14 @@ stdenv.mkDerivation {
     (relArtifact "Monocraft-nerd-fonts-patched.ttf" "sha256-QxMp8UwcRjWySNHWoNeX2sX9teZ4+tCFj+DG41azsXw=")
   ];
 
-  sourceRoot = ".";
-  unpackCmd = ''cp "$curSrc" $(basename $curSrc)'';
-
+  dontUnpack = true;
   dontConfigure = true;
   dontBuild = true;
 
   installPhase = ''
     runHook preInstall
-    install -Dm644 -t $out/share/fonts/opentype *.otf
-    install -Dm644 -t $out/share/fonts/truetype *.ttf
+    find $srcs -name '*.otf' -exec install -Dm644 --target $out/share/fonts/opentype {} +
+    find $srcs -name '*.ttf' -exec install -Dm644 --target $out/share/fonts/truetype {} +
     runHook postInstall
   '';
 


### PR DESCRIPTION
## Description of changes

3.0 release notes of monocraft: https://github.com/IdreesInc/Monocraft/releases/tag/v3.0
and 2.5 release notes: https://github.com/IdreesInc/Monocraft/releases/tag/v2.5

Not much changes in the way they are released, but I changed it to use `stdenvNoCC` and also remove the unpack phase

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
