### PR TITLE
haredo: remove shell wrapper

### DIFF
--- a/pkgs/by-name/ha/haredo/001-use-nix-store-sh.patch
+++ b/pkgs/by-name/ha/haredo/001-use-nix-store-sh.patch
@@ -1,0 +1,20 @@
+diff --git a/src/haredo.ha b/src/haredo.ha
+index c2e56e6..304c9ad 100644
+--- a/src/haredo.ha
++++ b/src/haredo.ha
+@@ -280,12 +280,12 @@ fn try_do(
+ 	const tmpfilepath = strings::concat(ctx.tmpdir, "/", tmpfilename);
+ 
+ 	const cmd = if (ctx.verbose) {
+-		fmt::errorln("* sh -ev", dopaths.do, dopaths.target,
++		fmt::errorln("* @bash@/bin/sh -ev", dopaths.do, dopaths.target,
+ 			dopaths.basename, tmpfilepath)?;
+-		yield exec::cmd("sh", "-ev", dopaths.do, dopaths.target,
++		yield exec::cmd("@bash@/bin/sh", "-ev", dopaths.do, dopaths.target,
+ 			dopaths.basename, tmpfilepath)?;
+ 	} else {
+-		yield exec::cmd("sh", "-e", dopaths.do, dopaths.target,
++		yield exec::cmd("@bash@/bin/sh", "-e", dopaths.do, dopaths.target,
+ 			dopaths.basename, tmpfilepath)?;
+ 	};
+ 

--- a/pkgs/by-name/ha/haredo/package.nix
+++ b/pkgs/by-name/ha/haredo/package.nix
@@ -1,17 +1,21 @@
-{ stdenv
-, lib
-, fetchFromSourcehut
-, hare
-, scdoc
-, nix-update-script
-, makeWrapper
-, bash
+{
+  stdenv,
+  lib,
+  fetchFromSourcehut,
+  hare,
+  scdoc,
+  nix-update-script,
+  makeWrapper,
+  bash,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "haredo";
   version = "1.0.5";
 
-  outputs = [ "out" "man" ];
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchFromSourcehut {
     owner = "~autumnull";
@@ -64,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postFixup = ''
     wrapProgram $out/bin/haredo \
-      --prefix PATH : "${lib.makeBinPath [bash]}"
+      --prefix PATH : "${lib.makeBinPath [ bash ]}"
   '';
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/by-name/ha/haredo/package.nix
+++ b/pkgs/by-name/ha/haredo/package.nix
@@ -7,6 +7,7 @@
   nix-update-script,
   makeWrapper,
   bash,
+  substituteAll,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "haredo";
@@ -23,6 +24,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = finalAttrs.version;
     hash = "sha256-gpui5FVRw3NKyx0AB/4kqdolrl5vkDudPOgjHc/IE4U=";
   };
+
+  patches = [
+    # Use nix store's bash instead of sh. `@bash@/bin/sh` is used, since haredo expects a posix shell.
+    (substituteAll {
+      src = ./001-use-nix-store-sh.patch;
+      inherit bash;
+    })
+  ];
 
   nativeBuildInputs = [
     hare
@@ -64,11 +73,6 @@ stdenv.mkDerivation (finalAttrs: {
     ./bootstrap.sh install
 
     runHook postInstall
-  '';
-
-  postFixup = ''
-    wrapProgram $out/bin/haredo \
-      --prefix PATH : "${lib.makeBinPath [ bash ]}"
   '';
 
   setupHook = ./setup-hook.sh;


### PR DESCRIPTION
## Description of changes

There's only three mentions of `sh` in the source code, being only two
of them command calls; thus, is very trivial to patch them directly.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>haredo</li>
    <li>haredo.man</li>
    <li>treecat</li>
    <li>treecat.man</li>
  </ul>
</details>


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
