### PR TITLE
canon-capt: init at 0.1.4.2-GxB

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4239,6 +4239,11 @@
     githubId = 111202;
     name = "Henry Bubert";
   };
+  cryptoluks = {
+    github = "cryptoluks";
+    githubId = 9020527;
+    name = "cryptoluks";
+  };
   CrystalGamma = {
     email = "nixos@crystalgamma.de";
     github = "CrystalGamma";

--- a/pkgs/by-name/ca/canon-capt/package.nix
+++ b/pkgs/by-name/ca/canon-capt/package.nix
@@ -1,0 +1,71 @@
+{
+  autoconf,
+  automake,
+  cups,
+  fetchFromGitHub,
+  lib,
+  stdenv,
+}:
+
+let
+  version = "0.1.4.2-GxB";
+in
+stdenv.mkDerivation {
+  pname = "canon-capt";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "mounaiban";
+    repo = "captdriver";
+    rev = "8ecc3cde1ae9a20dcb015994bb0fea0dbefa2b83";
+    hash = "sha256-FslofWZNmF7G9+lmw1JehRBYZIAXcg6Dmv9xJ/c4Evo=";
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+  ];
+
+  buildInputs = [ cups ];
+
+  # Fix for 'ppdc: Unable to find include file "<font.defs>"', which blocks '*.ppd' generation.
+  # Issue occurs in hermetic sandbox; this workaround is the current solution.
+  # Source: https://github.com/NixOS/nixpkgs/blob/9997402000a82eda4327fde36291234118c7515e/pkgs/misc/drivers/hplip/default.nix#L160
+  CUPS_DATADIR = "${cups}/share/cups";
+
+  configurePhase = ''
+    runHook preConfigure
+    aclocal
+    autoconf
+    automake --add-missing
+    ./configure --prefix=$out/usr
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    make
+    make ppd
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/cups/filter
+    install -D -m 755 ./src/rastertocapt $out/lib/cups/filter/rastertocapt
+
+    mkdir -p $out/share/cups/model/canon
+    install -D -m 644 ./ppd/CanonLBP-2900-3000.ppd $out/share/cups/model/canon/CanonLBP-2900-3000.ppd
+    install -D -m 644 ./ppd/CanonLBP-3010-3018-3050.ppd $out/share/cups/model/canon/CanonLBP-3010-3018-3050.ppd
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Community-driven driver for Canon CAPT-based printers";
+    homepage = "https://github.com/mounaiban/captdriver";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ cryptoluks ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
Add canon-capt driver package. This is a community-driven driver for Canon CAPT-based printers, based on reverse engineering attempts. Note that this is not the official Canon driver.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
