### PR TITLE
sword: 1.8.1 -> 1.9.0

### DIFF
--- a/pkgs/by-name/sw/sword/package.nix
+++ b/pkgs/by-name/sw/sword/package.nix
@@ -1,32 +1,53 @@
-{ lib, stdenv, fetchurl, pkg-config, icu, clucene_core, curl }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  icu,
+  clucene_core,
+  curl,
+}:
 
-stdenv.mkDerivation rec {
-
+stdenv.mkDerivation (finalAttrs: {
   pname = "sword";
-  version = "1.8.1";
+  version = "1.9.0";
 
   src = fetchurl {
-    url = "https://www.crosswire.org/ftpmirror/pub/sword/source/v1.8/${pname}-${version}.tar.gz";
-    sha256 = "14syphc47g6svkbg018nrsgq4z6hid1zydax243g8dx747vsi6nf";
+    url = "https://www.crosswire.org/ftpmirror/pub/sword/source/v${lib.versions.majorMinor finalAttrs.version}/sword-${finalAttrs.version}.tar.gz";
+    hash = "sha256-QkCc894vrxEIUj4sWsB0XSH57SpceO2HjuncwwNCa4o=";
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ icu clucene_core curl ];
+  buildInputs = [
+    icu
+    clucene_core
+    curl
+  ];
+
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   prePatch = ''
     patchShebangs .;
   '';
 
-  configureFlags = [ "--without-conf" "--enable-tests=no" ];
+  configureFlags = [
+    "--without-conf"
+    "--enable-tests=no"
+  ];
+
   CXXFLAGS = [
     "-Wno-unused-but-set-variable"
+    "-Wno-unknown-warning-option"
     # compat with icu61+ https://github.com/unicode-org/icu/blob/release-64-2/icu4c/readme.html#L554
     "-DU_USING_ICU_NAMESPACE=1"
   ];
 
-  meta = with lib; {
-    description = "A software framework that allows research manipulation of Biblical texts";
-    homepage = "http://www.crosswire.org/sword/";
+  meta = {
+    description = "Software framework that allows research manipulation of Biblical texts";
+    homepage = "https://www.crosswire.org/sword/";
     longDescription = ''
       The SWORD Project is the CrossWire Bible Society's free Bible software
       project. Its purpose is to create cross-platform open-source tools --
@@ -36,9 +57,8 @@ stdenv.mkDerivation rec {
       translators of the Bible, and have a growing collection of many hundred
       texts in around 100 languages.
     '';
-    license = licenses.gpl2;
-    maintainers = with maintainers; [ AndersonTorres ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ AndersonTorres ];
+    platforms = lib.platforms.unix;
   };
-
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24565,8 +24565,6 @@ with pkgs;
 
   swiftclient = with python3Packages; toPythonApplication python-swiftclient;
 
-  sword = callPackage ../development/libraries/sword { };
-
   biblesync = callPackage ../development/libraries/biblesync { };
 
   szip = callPackage ../development/libraries/szip { };


### PR DESCRIPTION
## Description of changes

* Update to 1.9.0
* Migrate to `pkgs/by-name`
* Remove superfluous use of `pname`
* Improve `src.url` path by using `lib.version.majorMinor`
* Migrate to `finalAttrs` and `hash` from `rec` and `sha256`
* Add `dev` output for include files
* Remove `with lib` from `meta`
* Change `homepage` url scheme to `https`
* Ran nixfmt

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
