### PR TITLE
neovim: Update bundled tree-sitter parsers

### DIFF
--- a/pkgs/by-name/ne/neovim-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/package.nix
@@ -86,7 +86,11 @@ in {
 
     dontFixCmake = true;
 
-    inherit lua treesitter-parsers;
+    inherit lua;
+    treesitter-parsers = treesitter-parsers //
+      { markdown = treesitter-parsers.markdown // { location = "tree-sitter-markdown"; }; } //
+      { markdown-inline = treesitter-parsers.markdown // { language = "markdown_inline"; location = "tree-sitter-markdown-inline"; }; }
+      ;
 
     buildInputs = [
       gperf
@@ -169,11 +173,13 @@ in {
     '' + ''
       mkdir -p $out/lib/nvim/parser
     '' + lib.concatStrings (lib.mapAttrsToList
-      (language: src: ''
+      (language: grammar: ''
         ln -s \
           ${tree-sitter.buildGrammar {
-            inherit language src;
+            inherit (grammar) src;
             version = "neovim-${finalAttrs.version}";
+            language = grammar.language or language;
+            location = grammar.location or null;
           }}/parser \
           $out/lib/nvim/parser/${language}.so
       '')

--- a/pkgs/by-name/ne/neovim-unwrapped/treesitter-parsers.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/treesitter-parsers.nix
@@ -1,24 +1,36 @@
 { fetchurl }:
 
 {
-  c = fetchurl {
-    url = "https://github.com/tree-sitter/tree-sitter-c/archive/v0.20.2.tar.gz";
-    hash = "sha256:af66fde03feb0df4faf03750102a0d265b007e5d957057b6b293c13116a70af2";
+  c.src = fetchurl {
+    url = "https://github.com/tree-sitter/tree-sitter-c/archive/v0.21.0.tar.gz";
+    hash = "sha256:6f0f5d1b71cf8ffd8a37fb638c6022fa1245bd630150b538547d52128ce0ea7e";
   };
-  lua = fetchurl {
-    url = "https://github.com/MunifTanjim/tree-sitter-lua/archive/v0.0.14.tar.gz";
-    hash = "sha256:930d0370dc15b66389869355c8e14305b9ba7aafd36edbfdb468c8023395016d";
+  lua.src = fetchurl {
+    url = "https://github.com/tree-sitter-grammars/tree-sitter-lua/archive/v0.1.0.tar.gz";
+    hash = "sha256:230cfcbfa74ed1f7b8149e9a1f34c2efc4c589a71fe0f5dc8560622f8020d722";
   };
-  vim = fetchurl {
-    url = "https://github.com/neovim/tree-sitter-vim/archive/v0.3.0.tar.gz";
-    hash = "sha256:403acec3efb7cdb18ff3d68640fc823502a4ffcdfbb71cec3f98aa786c21cbe2";
+  vim.src = fetchurl {
+    url = "https://github.com/neovim/tree-sitter-vim/archive/v0.4.0.tar.gz";
+    hash = "sha256:9f856f8b4a10ab43348550fa2d3cb2846ae3d8e60f45887200549c051c66f9d5";
   };
-  vimdoc = fetchurl {
-    url = "https://github.com/neovim/tree-sitter-vimdoc/archive/v2.0.0.tar.gz";
-    hash = "sha256:1ff8f4afd3a9599dd4c3ce87c155660b078c1229704d1a254433e33794b8f274";
+  vimdoc.src = fetchurl {
+    url = "https://github.com/neovim/tree-sitter-vimdoc/archive/v2.5.1.tar.gz";
+    hash = "sha256:063645096504b21603585507c41c6d8718ff3c11b2150c5bfc31e8f3ee9afea3";
   };
-  query = fetchurl {
-    url = "https://github.com/nvim-treesitter/tree-sitter-query/archive/v0.1.0.tar.gz";
-    hash = "sha256:e2b806f80e8bf1c4f4e5a96248393fe6622fc1fc6189d6896d269658f67f914c";
+  query.src = fetchurl {
+    url = "https://github.com/tree-sitter-grammars/tree-sitter-query/archive/v0.3.0.tar.gz";
+    hash = "sha256:f878ff37abcb83250e31a6569e997546f3dbab74dcb26683cb2d613f7568cfc0";
+  };
+  python.src = fetchurl {
+    url = "https://github.com/tree-sitter/tree-sitter-python/archive/v0.21.0.tar.gz";
+    hash = "sha256:720304a603271fa89e4430a14d6a81a023d6d7d1171b1533e49c0ab44f1e1c13";
+  };
+  bash.src = fetchurl {
+    url = "https://github.com/tree-sitter/tree-sitter-bash/archive/v0.21.0.tar.gz";
+    hash = "sha256:f0515efda839cfede851adb24ac154227fbc0dfb60c6c11595ecfa9087d43ceb";
+  };
+  markdown.src = fetchurl {
+    url = "https://github.com/MDeiml/tree-sitter-markdown/archive/v0.2.3.tar.gz";
+    hash = "sha256:4909d6023643f1afc3ab219585d4035b7403f3a17849782ab803c5f73c8a31d5";
   };
 }

--- a/pkgs/by-name/ne/neovim-unwrapped/update-treesitter-parsers.py
+++ b/pkgs/by-name/ne/neovim-unwrapped/update-treesitter-parsers.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 parsers = {}
 dir = Path(__file__).parent
-regex = re.compile(r"^set\(TREESITTER_([A-Z_]+)_(URL|SHA256)\s+([^ \)]+)\s*\)\s*$")
+regex = re.compile(r"^TREESITTER_([A-Z_]+)_(URL|SHA256)\s+(.+)$")
 
 src = subprocess.check_output(
     [
@@ -20,8 +20,8 @@ src = subprocess.check_output(
     text=True,
 ).strip()
 
-for line in open(f"{src}/cmake.deps/CMakeLists.txt"):
-    m = regex.fullmatch(line)
+for line in open(f"{src}/cmake.deps/deps.txt"):
+    m = regex.fullmatch(line.strip())
     if m is None:
         continue
 
@@ -37,7 +37,7 @@ with open(dir / "treesitter-parsers.nix", "w") as f:
     f.write("{ fetchurl }:\n\n{\n")
     for lang, src in parsers.items():
         f.write(
-            f"""  {lang} = fetchurl {{
+            f"""  {lang}.src = fetchurl {{
     url = "{src["URL"]}";
     hash = "sha256:{src["SHA256"]}";
   }};


### PR DESCRIPTION
## Description of changes

Update bundled parsers (+ updater)
New deps are in: https://github.com/neovim/neovim/blob/06135cc21571b2707121e31176f544a0e0901e1d/cmake.deps/deps.txt

To avoid issues like https://github.com/NixOS/nixpkgs/pull/311047#issuecomment-2116272660

~I'm currently having issues to build the `neovim` package as the [tree-sitter-markdown](https://github.com/tree-sitter-grammars/tree-sitter-markdown) repo actually has 2 parsers 🤔
Will check how it's packaged in nixpkgs, to see how to update neovim's env build..~

I copied the parser overrides for the markdown parsers as is done here:
https://github.com/NixOS/nixpkgs/blob/ea77cefecb0ab07e61d6bde3e24c7ae6820b96d5/pkgs/development/tools/parsing/tree-sitter/default.nix#L72-L73

I quickly tested things by opening a few files and checked with `:InspectTree` that the parser is correctly working.
:warning:  I'm not 100% sure how to check that the `markdown_inline` parser works though, every line of a markdown document are marked as `inline` but it doesn't go down into the `markdown_inline` parser. Do I need the `nvim-treesitter` plugin for that to work?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
