### PR TITLE
highlight-pointer: init at 1.1.3

### DIFF
--- a/pkgs/by-name/hi/highlight-pointer/package.nix
+++ b/pkgs/by-name/hi/highlight-pointer/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libX11,
+  xorg,
+  libXext,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "highlight-pointer";
+  version = "1.1.3";
+
+  src = fetchFromGitHub {
+    owner = "swillner";
+    repo = "highlight-pointer";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-mz9gXAtrtSV0Lapx8xBOPljuF+HRgDaF2DKCDrHXQa8=";
+  };
+
+  buildInputs = [
+    libX11
+    libXext
+    xorg.libXi
+    xorg.libXfixes
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -m 555 -D highlight-pointer $out/bin/highlight-pointer
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Highlight mouse pointer/cursor using a dot";
+    homepage = "https://github.com/swillner/highlight-pointer";
+    changelog = "https://github.com/swillner/highlight-pointer/releases/tag/v${finalAttrs.version}";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ DCsunset ];
+    mainProgram = "highlight-pointer";
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`highlight-pointer` is a tool to highlight mouse pointer/cursor using a dot, which is useful for presentations, screen sharing, and etc.

See more on its [home page](https://github.com/swillner/highlight-pointer).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
