### PR TITLE
telegram-bot-api: 5.7 -> 7.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6839,6 +6839,12 @@
       fingerprint = "B722 6464 838F 8BDB 2BEA  C8C8 5B0E FDDF BA81 6105";
     }];
   };
+  Forden = {
+    email = "forden@zuku.tech";
+    github = "Forden";
+    githubId = 24463229;
+    name = "Forden";
+  };
   forkk = {
     email = "forkk@forkk.net";
     github = "Forkk";

--- a/pkgs/servers/telegram-bot-api/default.nix
+++ b/pkgs/servers/telegram-bot-api/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "telegram-bot-api";
-  version = "5.7";
+  version = "7.3";
 
   src = fetchFromGitHub {
     repo = "telegram-bot-api";
     owner = "tdlib";
-    rev = "c57b04c4c8c4e8d8bb6fdd0bd3bfb5b93b9d8f05";
-    sha256 = "sha256-WetzX8GBdwQAnnZjek+W4v+QN1aUFdlvs+Jv6n1B+eY=";
+    rev = "5951bfbab8b1274437c613c1c48d91be2a050371";
+    hash = "sha256-5aNZqP4K+zP7q1+yllr6fysEcewhh/V9Vl6GXQolanI=";
     fetchSubmodules = true;
   };
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
     description = "Telegram Bot API server";
     homepage = "https://github.com/tdlib/telegram-bot-api";
     license = licenses.boost;
-    maintainers = with maintainers; [ Anillc ];
+    maintainers = with maintainers; [ Anillc Forden ];
     platforms = platforms.all;
     mainProgram = "telegram-bot-api";
   };


### PR DESCRIPTION
## Description of changes

https://core.telegram.org/bots/api-changelog

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
