### PR TITLE
dbeaver-bin: install to `$out/opt`, wrap program, add `.desktop` file

### DIFF
--- a/pkgs/by-name/db/dbeaver-bin/package.nix
+++ b/pkgs/by-name/db/dbeaver-bin/package.nix
@@ -30,9 +30,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/usr/share/dbeaver $out/bin
-    cp -r * $out/usr/share/dbeaver
-    ln -s $out/usr/share/dbeaver/dbeaver $out/bin/dbeaver
+    mkdir -p $out/opt/dbeaver $out/bin
+    cp -r * $out/opt/dbeaver
+    ln -s $out/opt/dbeaver/dbeaver $out/bin/dbeaver
     runHook postInstall
   '';
 

--- a/pkgs/by-name/db/dbeaver-bin/package.nix
+++ b/pkgs/by-name/db/dbeaver-bin/package.nix
@@ -1,11 +1,15 @@
 { lib
 , stdenvNoCC
 , fetchurl
+, makeWrapper
+, openjdk17
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "dbeaver-bin";
   version = "24.0.4";
+
+  nativeBuildInputs = [ makeWrapper ];
 
   src =
     let
@@ -32,7 +36,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook preInstall
     mkdir -p $out/opt/dbeaver $out/bin
     cp -r * $out/opt/dbeaver
-    ln -s $out/opt/dbeaver/dbeaver $out/bin/dbeaver
+    makeWrapper $out/opt/dbeaver/dbeaver $out/bin/dbeaver \
+      --prefix PATH : "${openjdk17}/bin" \
+      --set JAVA_HOME "${openjdk17.home}"
     runHook postInstall
   '';
 

--- a/pkgs/by-name/db/dbeaver-bin/package.nix
+++ b/pkgs/by-name/db/dbeaver-bin/package.nix
@@ -4,6 +4,7 @@
 , makeWrapper
 , openjdk17
 , gnused
+, autoPatchelfHook
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -13,6 +14,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeWrapper
     gnused
+    autoPatchelfHook
   ];
 
   src =

--- a/pkgs/by-name/db/dbeaver-bin/package.nix
+++ b/pkgs/by-name/db/dbeaver-bin/package.nix
@@ -3,13 +3,17 @@
 , fetchurl
 , makeWrapper
 , openjdk17
+, gnused
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "dbeaver-bin";
   version = "24.0.4";
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    gnused
+  ];
 
   src =
     let
@@ -39,6 +43,19 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     makeWrapper $out/opt/dbeaver/dbeaver $out/bin/dbeaver \
       --prefix PATH : "${openjdk17}/bin" \
       --set JAVA_HOME "${openjdk17.home}"
+
+    mkdir -p $out/share/icons/hicolor/256x256/apps
+    ln -s $out/opt/dbeaver/dbeaver.png $out/share/icons/hicolor/256x256/apps/dbeaver.png
+
+    mkdir -p $out/share/applications
+    ln -s $out/opt/dbeaver/dbeaver-ce.desktop $out/share/applications/dbeaver.desktop
+
+    substituteInPlace $out/opt/dbeaver/dbeaver-ce.desktop \
+      --replace-fail "/usr/share/dbeaver-ce/dbeaver.png" "dbeaver" \
+      --replace-fail "/usr/share/dbeaver-ce/dbeaver" "$out/bin/dbeaver"
+
+    sed -i '/^Path=/d' $out/share/applications/dbeaver.desktop
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR contains commits that do a few things:

- installs DBeaver to `$out/opt` instead of `$out/usr/share`
- wraps the final executable to be able to find `openjdk17`, so as to not require the user to manually pull it into their `PATH`
- patches & propagates DBeaver's original `.desktop` file, so it doesn't have to be run from terminal

Note: Not sure if setting `JAVA_HOME` is needed, I've found it runs fine without, but since `openjdk17` is already part of the closure, I figured why not.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
