### PR TITLE
povray: 3.8.0-x.10064738 -> 3.8.0-beta.2, cleanup, adopt

### DIFF
--- a/pkgs/tools/graphics/povray/default.nix
+++ b/pkgs/tools/graphics/povray/default.nix
@@ -14,14 +14,14 @@
 , SDL
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "povray";
   version = "3.8.0-beta.2";
 
   src = fetchFromGitHub {
     owner = "POV-Ray";
     repo = "povray";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-BsWalXzEnymiRbBfE/gsNyWgAqzbxEzO/EQiJpbwoKs=";
   };
 
@@ -59,4 +59,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     mainProgram = "povray";
   };
-}
+})

--- a/pkgs/tools/graphics/povray/default.nix
+++ b/pkgs/tools/graphics/povray/default.nix
@@ -11,7 +11,8 @@
 , libpng
 , libjpeg
 , libtiff
-, SDL
+, pkg-config
+, SDL2
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -25,8 +26,23 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-BsWalXzEnymiRbBfE/gsNyWgAqzbxEzO/EQiJpbwoKs=";
   };
 
-  nativeBuildInputs = [ automake autoconf ];
-  buildInputs = [ boost zlib libX11 libICE libSM libpng libjpeg libtiff SDL ];
+  nativeBuildInputs = [
+    automake
+    autoconf
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    libX11
+    libICE
+    libSM
+    libpng
+    libjpeg
+    libtiff
+    SDL2
+    zlib
+  ];
 
   # the installPhase wants to put files into $HOME. I let it put the files
   # to $TMPDIR, so they don't get into the $out

--- a/pkgs/tools/graphics/povray/default.nix
+++ b/pkgs/tools/graphics/povray/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "povray";
-  version = "3.8.0-x.10064738";
+  version = "3.8.0-beta.2";
 
   src = fetchFromGitHub {
     owner = "POV-Ray";
     repo = "povray";
     rev = "v${version}";
-    sha256 = "0hy5a3q5092szk2x3s9lpn1zkszgq9bp15rxzdncxlvnanyzsasf";
+    sha256 = "sha256-BsWalXzEnymiRbBfE/gsNyWgAqzbxEzO/EQiJpbwoKs=";
   };
 
   nativeBuildInputs = [ automake autoconf ];

--- a/pkgs/tools/graphics/povray/default.nix
+++ b/pkgs/tools/graphics/povray/default.nix
@@ -55,7 +55,11 @@ stdenv.mkDerivation (finalAttrs: {
                  sed -i -e 's/^povgroup.*/povgroup=nogroup/' Makefile.{am,in}
                '';
 
-  configureFlags = [ "COMPILED_BY='nix'" "--with-boost-thread=boost_thread" "--with-x" ];
+  configureFlags = [
+    "COMPILED_BY=NixOS"
+    "--with-boost-thread=boost_thread"
+    "--with-x"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/graphics/povray/default.nix
+++ b/pkgs/tools/graphics/povray/default.nix
@@ -72,11 +72,12 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "http://www.povray.org/";
     description = "Persistence of Vision Raytracer";
-    license = licenses.free;
-    platforms = platforms.linux;
+    license = lib.licenses.free;
+    platforms = lib.platforms.linux;
     mainProgram = "povray";
+    maintainers = with lib.maintainers; [ fgaz ];
   };
 })


### PR DESCRIPTION
## Description of changes

* update: acfef2ea91da653452776c2b35efbdd01d625dc5 updated it to a pre-release, so let's continue following 3.8.0 prereleases until a stable release.
* use finalAttrs pattern
* update SDL and use pkg-config
* use NixOS as vendor id: it's less ambiguous than "nix"
* add @fgaz to maintainers

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
