### PR TITLE
moneydance: restrict supported platforms to linux

### DIFF
--- a/pkgs/by-name/mo/moneydance/package.nix
+++ b/pkgs/by-name/mo/moneydance/package.nix
@@ -53,7 +53,11 @@ stdenv.mkDerivation (finalAttrs: {
     description = "An easy to use and full-featured personal finance app that doesn't compromise your privacy";
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
     license = lib.licenses.unfree;
-    platforms = jdk.meta.platforms;
+    # Darwin refers to Zulu Java, which breaks the evaluation of this derivation
+    # for some reason
+    #
+    # https://github.com/NixOS/nixpkgs/pull/306372#issuecomment-2111688236
+    platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.lucasbergman ];
   };
 })


### PR DESCRIPTION
## Description of changes

This removes Darwin from the supported platforms for `moneydance`.

#306372 unintentionally breaks the package set evaluation (in some cases, I'm not quite sure what triggers it) for aarch64-darwin (see [logs](https://github.com/NixOS/nixpkgs/pull/306372#issuecomment-2111688236))

<details><summary>Before</summary>
<pre>
raghavsood@r-mbp-a15> nix-build -A moneydance                                                                                                                                ~/r/local/dev/github.com/RaghavSood/nixpkgs
error:
       … in the condition of the assert statement

         at /Users/raghavsood/r/local/dev/github.com/RaghavSood/nixpkgs/lib/customisation.nix:365:17:

          364|     in commonAttrs // {
          365|       drvPath = assert condition; drv.drvPath;
             |                 ^
          366|       outPath = assert condition; drv.outPath;

       … while evaluating the attribute 'handled'

         at /Users/raghavsood/r/local/dev/github.com/RaghavSood/nixpkgs/pkgs/stdenv/generic/check-meta.nix:507:7:

          506|       # or, alternatively, just output a warning message.
          507|       handled =
             |       ^
          508|         (

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: Package ‘moneydance-2024.1_5118’ in /Users/raghavsood/r/local/dev/github.com/RaghavSood/nixpkgs/pkgs/by-name/mo/moneydance/package.nix:53 has an unfree license (‘unfree’), refusing to evaluate.

       a) To temporarily allow unfree packages, you can use an environment variable
          for a single invocation of the nix tools.

            $ export NIXPKGS_ALLOW_UNFREE=1

          Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
                then pass `--impure` in order to allow use of environment variables.

       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allowUnfree = true; }
       in configuration.nix to override this.

       Alternatively you can configure a predicate to allow specific packages:
         { nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
             "moneydance"
           ];
         }

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allowUnfree = true; }
       to ~/.config/nixpkgs/config.nix.
</pre>
</details> 

<details><summary>After</summary>
<pre>
raghavsood@r-mbp-a15> NIXPKGS_ALLOW_UNFREE=1 nix-build -A moneydance                                                                                                     ~/r/local/dev/github.com/RaghavSood/nixpkgs
error:
       … in the condition of the assert statement

         at /Users/raghavsood/r/local/dev/github.com/RaghavSood/nixpkgs/lib/customisation.nix:365:17:

          364|     in commonAttrs // {
          365|       drvPath = assert condition; drv.drvPath;
             |                 ^
          366|       outPath = assert condition; drv.outPath;

       … while evaluating the attribute 'handled'

         at /Users/raghavsood/r/local/dev/github.com/RaghavSood/nixpkgs/pkgs/stdenv/generic/check-meta.nix:507:7:

          506|       # or, alternatively, just output a warning message.
          507|       handled =
             |       ^
          508|         (

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: Package ‘moneydance-2024.1_5118’ in /Users/raghavsood/r/local/dev/github.com/RaghavSood/nixpkgs/pkgs/by-name/mo/moneydance/package.nix:53 is not available on the requested hostPlatform:
         hostPlatform.config = "aarch64-apple-darwin"
         package.meta.platforms = [
           "aarch64-linux"
           "armv5tel-linux"
           "armv6l-linux"
           "armv7a-linux"
           "armv7l-linux"
           "i686-linux"
           "loongarch64-linux"
           "m68k-linux"
           "microblaze-linux"
           "microblazeel-linux"
           "mips-linux"
           "mips64-linux"
           "mips64el-linux"
           "mipsel-linux"
           "powerpc64-linux"
           "powerpc64le-linux"
           "riscv32-linux"
           "riscv64-linux"
           "s390-linux"
           "s390x-linux"
           "x86_64-linux"
         ]
         package.meta.badPlatforms = [ ]
       , refusing to evaluate.

       a) To temporarily allow packages that are unsupported for this system, you can use an environment variable
          for a single invocation of the nix tools.

            $ export NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1

          Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
                then pass `--impure` in order to allow use of environment variables.

       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allowUnsupportedSystem = true; }
       in configuration.nix to override this.

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allowUnsupportedSystem = true; }
       to ~/.config/nixpkgs/config.nix.
</pre>
</details> 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
