### PR TITLE
nzportable: init at 2.0.0-indev+20241012190425

### DIFF
--- a/pkgs/by-name/nz/nzportable/assets.nix
+++ b/pkgs/by-name/nz/nzportable/assets.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "nzp-assets";
+  version = "0-unstable-2024-09-28-13-34-48";
+
+  src = fetchFromGitHub {
+    owner = "nzp-team";
+    repo = "assets";
+    rev = "4a7b1b787061c1c7c17ab3b59a8e0e0f44c9546f";
+    hash = "sha256-gCTC/76r0ITIDLIph9uivq0ZJGaPUmlBGizdCUxJrng=";
+  };
+
+  outputs = [
+    "out"
+    "pc"
+  ];
+
+  # TODO: add more outputs for other ports
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r common/* $out
+
+    mkdir -p $pc
+    cp -r pc/* $pc
+    chmod -R +w $pc/nzp
+    cp -r $out/* $pc/nzp
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Game asset repository for Nazi Zombies: Portable";
+    homepage = "https://github.com/nzp-team/assets";
+    license = with lib.licenses; [ cc-by-sa-40 ];
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ pluiedev ];
+  };
+}

--- a/pkgs/by-name/nz/nzportable/fteqw.nix
+++ b/pkgs/by-name/nz/nzportable/fteqw.nix
@@ -1,0 +1,176 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  cmake,
+  ninja,
+  pkg-config,
+  makeWrapper,
+  zip,
+  gettext,
+
+  libpng,
+  zlib,
+  gnutls,
+  libGL,
+  xorg,
+  alsa-lib,
+  libjpeg,
+  libogg,
+  libvorbis,
+  libopus,
+  dbus,
+  fontconfig,
+  SDL2,
+  bullet,
+  openexr,
+  sqlite,
+  addDriverRunpath,
+
+  enableEGL ? true,
+  libglvnd,
+
+  enableVulkan ? true,
+  vulkan-headers,
+  vulkan-loader,
+
+  enableWayland ? true,
+  wayland,
+  libxkbcommon,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nzp-fteqw";
+  version = "0-unstable-2024-09-11-20-07-31";
+
+  src = fetchFromGitHub {
+    owner = "nzp-team";
+    repo = "fteqw";
+    rev = "593345a7f03245fc45580ac252857e5db5105033";
+    hash = "sha256-ANDHh4PKh8fAvbBiiW47l1XeGOCes0Sg595+65NFG6w=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    makeWrapper
+    pkg-config
+    zip
+    gettext
+  ];
+
+  buildInputs =
+    [
+      libGL
+      xorg.libX11
+      xorg.libXrandr
+      xorg.libXcursor
+      xorg.libXScrnSaver
+      dbus
+      fontconfig
+      libjpeg
+      libpng
+      alsa-lib
+      libogg
+      libvorbis
+      libopus
+      SDL2
+      gnutls
+      zlib
+      bullet
+    ]
+    ++ lib.optional enableEGL libglvnd
+    ++ lib.optionals enableWayland [
+      wayland
+      libxkbcommon
+    ]
+    ++ lib.optional enableVulkan vulkan-headers;
+
+  cmakeFlags = [
+    (lib.cmakeFeature "FTE_BUILD_CONFIG" "${finalAttrs.src}/engine/common/config_nzportable.h")
+    # Disable optional tools - only keep FTEQCC
+    (lib.cmakeBool "FTE_TOOL_IQM" false)
+    (lib.cmakeBool "FTE_TOOL_IMAGE" false)
+    (lib.cmakeBool "FTE_TOOL_QTV" false)
+    (lib.cmakeBool "FTE_TOOL_MASTER" false)
+  ];
+
+  postInstall = ''
+    mv $out/games $out/bin
+  '';
+
+  postFixup =
+    let
+      # grep for `Sys_LoadLibrary` for more.
+      # Some of the deps listed in the source code are actually not active
+      # due to being either disabled by the nzportable profile (e.g. lua, bz2),
+      # available in /run/opengl-driver,
+      # or statically linked (e.g. libpng, libjpeg, zlib, freetype)
+      # Some of them are also just deprecated by better backend options
+      # (SDL audio is preferred over ALSA, OpenAL and PulseAudio, for example)
+
+      libs = [
+        addDriverRunpath.driverLink
+
+        # gl/gl_vidlinuxglx.c
+        xorg.libX11
+        xorg.libXrandr
+        xorg.libXxf86vm
+        xorg.libXxf86dga
+        xorg.libXi
+        xorg.libXcursor
+        libGL
+
+        libvorbis
+
+        sqlite # server/sv_sql.c
+
+        SDL2 # a lot of different files
+        gnutls # common/net_ssl_gnutls.c
+        openexr # client/image.c
+
+        (placeholder "out")
+      ] ++ lib.optional enableWayland wayland ++ lib.optional enableVulkan vulkan-loader;
+    in
+    ''
+      wrapProgram $out/bin/fteqw \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath libs}"
+    '';
+
+  meta = {
+    description = "Nazi Zombies: Portable's fork of Spike's FTEQW engine/client";
+    longDescription = ''
+      This package contains only the FTEQW engine, and none of the assets used in NZ:P.
+      Please use the `nzportable` package for an out-of-the-box NZ:P experience.
+
+      FTEQW supports several graphics options.
+      You can specify those graphics option by overriding the FTEQW package, like this:
+      ```nix
+        nzp-fteqw.override {
+          enableVulkan = true;
+        }
+      ```
+      And in the game, you need to run `setrenderer <renderer>` to change the current renderer.
+
+      Supported graphics options are as follows:
+      - `enableEGL`: Enable the OpenGL ES renderer (`egl`). Enabled by default.
+      - `enableVulkan`: Enable the Vulkan renderer (`xvk`). Enabled by default.
+      - `enableWayland`: Enable native Wayland support, instead of using X11.
+        Adds up to two renderers, based on whether EGL and Vulkan are installed: `wlgl` and `wlvk`.
+        Seems to be currently broken and currently not enabled by default.
+    '';
+    homepage = "https://github.com/nzp-team/fteqw";
+    license = lib.licenses.gpl2Plus;
+    # See README
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+      "armv7l-linux"
+      "aarch64-linux"
+      "x86_64-windows"
+      "i686-windows"
+    ];
+    maintainers = with lib.maintainers; [ pluiedev ];
+    mainProgram = "fteqw";
+  };
+})

--- a/pkgs/by-name/nz/nzportable/package.nix
+++ b/pkgs/by-name/nz/nzportable/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  callPackage,
+  writeShellApplication,
+}:
+let
+  assets = callPackage ./assets.nix { };
+  quakec = callPackage ./quakec.nix { };
+  fteqw = callPackage ./fteqw.nix { };
+
+  # We use the youngest version of all of the dependencies as the version number.
+  # This is similar to what upstream uses, except ours is a bit more accurate
+  # since we don't rely on a CI to run at an arbitrary time.
+  dateString =
+    lib.pipe
+      [
+        assets
+        fteqw
+        quakec
+      ]
+      [
+        # Find the youngest (most recently updated) version
+        (lib.foldl' (acc: p: if lib.versionOlder acc p.version then p.version else acc) "")
+        (lib.splitString "-")
+        (lib.sublist 2 6) # drop the first two segments (0 and unstable) and only keep the date
+        lib.concatStrings
+      ];
+
+  version = "2.0.0-indev+${dateString}";
+in
+writeShellApplication {
+  name = "nzportable";
+
+  text = ''
+    runDir=''${XDG_DATA_HOME:-$HOME/.local/share}/nzportable
+    data=${assets.pc}
+
+    relinkGameFiles() {
+      mkdir -p "$runDir"/nzp
+
+      # Remove existing links
+      find "$runDir" -type l -exec rm {} +
+
+      # Link game files
+      ln -s $data/default.fmf "$runDir"
+      ln -st "$runDir"/nzp $data/nzp/* ${quakec.fte}/*
+
+      # Write current version
+      echo "${version}" > "$runDir"/nzp/version.txt
+    }
+
+    if [[ ! -d $runDir ]]; then
+      echo "Game directory $runDir not found. Assuming first launch"
+      echo "Linking game files"
+      relinkGameFiles
+    else
+      currentVersion=$(<"$runDir"/nzp/version.txt)
+      if [[ "${version}" != "$currentVersion" ]]; then
+        echo "Version mismatch! (saved version $currentVersion != current version ${version})"
+        echo "Relinking game files"
+        relinkGameFiles
+      fi
+    fi
+
+    exec ${lib.getExe fteqw} -basedir "$runDir" "$@"
+  '';
+
+  derivationArgs = {
+    inherit version;
+    passthru = {
+      updateScript = callPackage ./update.nix { };
+      inherit assets quakec fteqw;
+    };
+  };
+
+  meta = {
+    inherit (fteqw.meta) platforms;
+    description = "Call of Duty: Zombies demake, powered by various Quake sourceports (PC version)";
+    homepage = "https://docs.nzp.gay";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ pluiedev ];
+    mainProgram = "nzportable";
+  };
+}

--- a/pkgs/by-name/nz/nzportable/quakec.nix
+++ b/pkgs/by-name/nz/nzportable/quakec.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  python3,
+  nzportable,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "nzp-quakec";
+  version = "0-unstable-2024-10-12-12-03-59";
+
+  src = fetchFromGitHub {
+    owner = "nzp-team";
+    repo = "quakec";
+    rev = "01e95c4dab91ce0e8b7387d2726d9ee307792ae7";
+    hash = "sha256-h4llx3tzeoI1aHLokM7NqkZJWuo6rcrmWfb0pDQL+zM=";
+  };
+
+  outputs = [
+    "out"
+    "fte"
+  ];
+
+  nativeBuildInputs = [ python3 ];
+
+  buildInputs = with python3.pkgs; [
+    colorama
+    fastcrc
+    pandas
+    nzportable.fteqw
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    python3 bin/qc_hash_generator.py -i tools/asset_conversion_table.csv -o source/server/hash_table.qc
+
+    mkdir -p build/{fte,standard}
+
+    fteqcc -srcfile progs/csqc.src
+    fteqcc -O3 -DFTE -srcfile progs/ssqc.src
+    fteqcc -O3 -srcfile progs/ssqc.src
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out $fte
+    cp -r build/standard/* $out
+    cp -r build/fte/* $fte
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "QuakeC repository for Nazi Zombies: Portable";
+    homepage = "https://github.com/nzp-team/quakec";
+    license = lib.licenses.gpl2Plus;
+    platforms = with lib.platforms; linux ++ darwin;
+    maintainers = with lib.maintainers; [ pluiedev ];
+  };
+}

--- a/pkgs/by-name/nz/nzportable/update.nix
+++ b/pkgs/by-name/nz/nzportable/update.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  writeShellApplication,
+  jq,
+  curl,
+  nix-prefetch-git,
+  common-updater-scripts,
+}:
+
+lib.getExe (writeShellApplication {
+  name = "nzp-updater";
+  runtimeInputs = [
+    jq
+    curl
+    nix-prefetch-git
+    common-updater-scripts
+  ];
+  text = ''
+    youngest=0
+    update() {
+      repo=$1
+      tag=$2
+
+      prefetch=$(nix-prefetch-git "https://github.com/nzp-team/$repo" --rev "$tag")
+
+      timestamp=$(echo "$prefetch" | jq -r '.date | strptime("%Y-%m-%dT%H:%M:%S%z") | mktime | strftime("%Y-%m-%d-%H-%M-%S")')
+      rev=$(echo "$prefetch" | jq -r ".rev")
+      hash=$(echo "$prefetch" | jq -r ".hash")
+
+      if [[ $youngest -lt $timestamp ]]; then
+        youngest=$timestamp
+      fi
+
+      update-source-version "$UPDATE_NIX_ATTR_PATH.$repo" "0-unstable-$timestamp" "$hash" --rev="$rev"
+    }
+
+    update fteqw bleeding-edge
+    update assets newest
+    update quakec bleeding-edge
+  '';
+})

--- a/pkgs/development/python-modules/fastcrc/default.nix
+++ b/pkgs/development/python-modules/fastcrc/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  rustPlatform,
+  pytestCheckHook,
+  pytest-benchmark,
+  nix-update-script,
+}:
+let
+  pname = "fastcrc";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "overcat";
+    repo = "fastcrc";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-yLrv/zqsjgygJAIJtztwxlm4s9o9EBVsCyx1jUXd7hA=";
+  };
+in
+buildPythonPackage {
+  inherit pname version src;
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-wSE7548L+ymNjN9TfygAGY1BrssXOPGXlmE83wV7zb4=";
+  };
+
+  pythonImportsCheck = [ "fastcrc" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-benchmark
+  ];
+
+  # Python source files interfere with testing
+  preCheck = ''
+    rm -r fastcrc
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Hyper-fast Python module for computing CRC(8, 16, 32, 64) checksum";
+    homepage = "https://fastcrc.readthedocs.io/en/latest/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pluiedev ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4323,6 +4323,8 @@ self: super: with self; {
 
   fastapi-sso = callPackage ../development/python-modules/fastapi-sso { };
 
+  fastcrc = callPackage ../development/python-modules/fastcrc { };
+
   fast-histogram = callPackage ../development/python-modules/fast-histogram { };
 
   fastavro = callPackage ../development/python-modules/fastavro { };


### PR DESCRIPTION
## Description of changes

Adds [Nazi Zombies: Portable](https://docs.nzp.gay), a Call of Duty: Zombies "demake" built on Quake engine source ports, and all of its dependencies. 

The game is currently entirely built from source and does not rely on upstream artifacts, which causes some problems with the version scheme. Each build has a timestamp, which is entirely dependent on whenever upstream's CI decides to run the build and not on anything else. I've *sort of* solved this by just using the version of the most recently updated component and formatting the version string to match upstream, but they'll likely never quite match up. It would be easier if upstream just used Git hashes in the version name, but...

Extensively playtested on OpenGL, EGL and Vulkan all the way to Round 9 :D　

Unresolved questions:
- [ ] Should we keep the current version scheme or try to adhere to upstream as much as possible?
- [ ] Should we name the PC port `nzportable` or `nzportable-pc` to accommodate for other ports?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
