### PR TITLE
plymouth-matrix-theme: init at 0.1.0-unstable-19-02-2017

### DIFF
--- a/pkgs/by-name/pl/plymouth-matrix-theme/package.nix
+++ b/pkgs/by-name/pl/plymouth-matrix-theme/package.nix
@@ -4,9 +4,11 @@
   lib,
   unstableGitUpdater,
 }:
+
 stdenvNoCC.mkDerivation {
   pname = "plymouth-matrix-theme";
   version = "0.1.0-unstable-19-02-2017";
+
   src = fetchFromGitHub {
     owner = "storax";
     repo = "plymouth-matrix-theme";
@@ -14,17 +16,19 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-JmMmpw1By5U6OTaSPnJOZZxrieSnXivMmdt/JPazjpI=";
   };
 
-  dontBuild = true;
-
   postPatch = ''
     # Remove not needed files
     rm README.rst LICENSE Makefile
   '';
 
+  dontBuild = true;
+
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/share/plymouth/themes/matrix
     cp * $out/share/plymouth/themes/matrix
     find $out/share/plymouth/themes/ -name \*.plymouth -exec sed -i "s@\/usr\/@$out\/@" {} \;
+    runHook postInstall
   '';
 
   passthru.updateScript = unstableGitUpdater;

--- a/pkgs/by-name/pl/plymouth-matrix-theme/package.nix
+++ b/pkgs/by-name/pl/plymouth-matrix-theme/package.nix
@@ -1,0 +1,44 @@
+{
+  stdenvNoCC,
+  fetchFromGitHub,
+  lib,
+  unstableGitUpdater,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "plymouth-matrix-theme";
+  version = "0.1.0-unstable-19-02-2017";
+  src = fetchFromGitHub {
+    owner = "storax";
+    repo = "plymouth-matrix-theme";
+    rev = "b2268f25dea7537ed5709b00d5a83b3600265c54";
+    hash = "sha256-JmMmpw1By5U6OTaSPnJOZZxrieSnXivMmdt/JPazjpI=";
+  };
+
+  dontBuild = true;
+
+  postPatch = ''
+    # Remove not needed files
+    rm README.rst LICENSE Makefile
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/plymouth/themes/matrix
+    cp * $out/share/plymouth/themes/matrix
+    find $out/share/plymouth/themes/ -name \*.plymouth -exec sed -i "s@\/usr\/@$out\/@" {} \;
+  '';
+
+  passthru.updateScript = unstableGitUpdater;
+
+  meta = {
+    description = "Plymouth boot theme inspired by Matrix";
+    longDescription = ''
+      A very simple boot animation that emulates
+      Trinity hacking Neo's computer at the
+      beginning of The Matrix (1999).
+    '';
+    homepage = "https://github.com/storax/plymouth-matrix-theme";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ johnrtitor ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This is a plymouth theme inspired by the 1999 movie The Matrix.
Homepage: https://github.com/storax/plymouth-matrix-theme

Although there has not been any update in the past 7 years, this still works, as I have tested.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
