### PR TITLE
ares-cli: init at 3.1.1

### DIFF
--- a/pkgs/by-name/ar/ares-cli/package.nix
+++ b/pkgs/by-name/ar/ares-cli/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+buildNpmPackage rec {
+  pname = "ares-cli";
+  version = "3.1.1";
+  src = fetchFromGitHub {
+    owner = "webos-tools";
+    repo = "cli";
+    rev = "v${version}";
+    hash = "sha256-gMAGMg/hobV8WhqutDmYBjqjZqfAdw+EoJX7j8pux18=";
+  };
+
+  postPatch = ''
+    ln -s npm-shrinkwrap.json package-lock.json
+  '';
+
+  dontNpmBuild = true;
+  npmDepsHash = "sha256-3ZUlGJY0aEf7wBig75txlkA6a6JcdkphJILFfIGIN04=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://webostv.developer.lge.com/develop/tools/cli-introduction";
+    description = "A collection of commands used for creating, packaging, installing, and launching web apps for LG webOS TV.";
+    longDescription = ''
+      webOS CLI (Command Line Interface) provides a collection of commands used for creating, packaging, installing,
+      and launching web apps in the command line environment. The CLI allows you to develop and test your app without using
+      a specific IDE.
+    '';
+    mainProgram = "ares";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ rucadi ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Ares is the main cli tool used by developers for interacting with LG WebOs Tv, documentation of this tool can be found here:  https://webostv.developer.lge.com/develop/tools/cli-introduction

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
