### PR TITLE
nixos/networkd: get rid of *Config attributes in lists

### DIFF
--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -182,6 +182,30 @@ in rec {
   in if errors == [] then true
      else trace (concatStringsSep "\n" errors) false;
 
+  checkUnitConfigWithLegacyKey = legacyKey: group: checks: attrs:
+    let
+      dump = lib.generators.toPretty { }
+        (lib.generators.withRecursion { depthLimit = 2; throwOnDepthLimit = false; } attrs);
+      attrs' =
+        if legacyKey == null
+          then attrs
+        else if ! attrs?${legacyKey}
+          then attrs
+        else if removeAttrs attrs [ legacyKey ] == {}
+          then attrs.${legacyKey}
+        else throw ''
+          The declaration
+
+          ${dump}
+
+          must not mix unit options with the legacy key '${legacyKey}'.
+
+          This can be fixed by moving all settings from within ${legacyKey}
+          one level up.
+        '';
+    in
+    checkUnitConfig group checks attrs';
+
   toOption = x:
     if x == true then "true"
     else if x == false then "false"

--- a/nixos/lib/systemd-network-units.nix
+++ b/nixos/lib/systemd-network-units.nix
@@ -63,13 +63,13 @@ in {
       ${attrsToSection def.l2tpConfig}
     '' + flip concatMapStrings def.l2tpSessions (x: ''
       [L2TPSession]
-      ${attrsToSection x.l2tpSessionConfig}
+      ${attrsToSection x}
     '') + optionalString (def.wireguardConfig != { }) ''
       [WireGuard]
       ${attrsToSection def.wireguardConfig}
     '' + flip concatMapStrings def.wireguardPeers (x: ''
       [WireGuardPeer]
-      ${attrsToSection x.wireguardPeerConfig}
+      ${attrsToSection x}
     '') + optionalString (def.bondConfig != { }) ''
       [Bond]
       ${attrsToSection def.bondConfig}
@@ -122,13 +122,13 @@ in {
       ${concatStringsSep "\n" (map (s: "Xfrm=${s}") def.xfrm)}
     '' + "\n" + flip concatMapStrings def.addresses (x: ''
       [Address]
-      ${attrsToSection x.addressConfig}
+      ${attrsToSection x}
     '') + flip concatMapStrings def.routingPolicyRules (x: ''
       [RoutingPolicyRule]
-      ${attrsToSection x.routingPolicyRuleConfig}
+      ${attrsToSection x}
     '') + flip concatMapStrings def.routes (x: ''
       [Route]
-      ${attrsToSection x.routeConfig}
+      ${attrsToSection x}
     '') + optionalString (def.dhcpV4Config != { }) ''
       [DHCPv4]
       ${attrsToSection def.dhcpV4Config}
@@ -149,22 +149,22 @@ in {
       ${attrsToSection def.ipv6SendRAConfig}
     '' + flip concatMapStrings def.ipv6Prefixes (x: ''
       [IPv6Prefix]
-      ${attrsToSection x.ipv6PrefixConfig}
+      ${attrsToSection x}
     '') + flip concatMapStrings def.ipv6RoutePrefixes (x: ''
       [IPv6RoutePrefix]
-      ${attrsToSection x.ipv6RoutePrefixConfig}
+      ${attrsToSection x}
     '') + flip concatMapStrings def.dhcpServerStaticLeases (x: ''
       [DHCPServerStaticLease]
-      ${attrsToSection x.dhcpServerStaticLeaseConfig}
+      ${attrsToSection x}
     '') + optionalString (def.bridgeConfig != { }) ''
       [Bridge]
       ${attrsToSection def.bridgeConfig}
     '' + flip concatMapStrings def.bridgeFDBs (x: ''
       [BridgeFDB]
-      ${attrsToSection x.bridgeFDBConfig}
+      ${attrsToSection x}
     '') + flip concatMapStrings def.bridgeMDBs (x: ''
       [BridgeMDB]
-      ${attrsToSection x.bridgeMDBConfig}
+      ${attrsToSection x}
     '') + optionalString (def.lldpConfig != { }) ''
       [LLDP]
       ${attrsToSection def.lldpConfig}
@@ -251,7 +251,7 @@ in {
       ${attrsToSection def.quickFairQueueingConfigClass}
     '' + flip concatMapStrings def.bridgeVLANs (x: ''
       [BridgeVLAN]
-      ${attrsToSection x.bridgeVLANConfig}
+      ${attrsToSection x}
     '') + def.extraConfig;
 
 }

--- a/nixos/modules/services/networking/rosenpass.nix
+++ b/nixos/modules/services/networking/rosenpass.nix
@@ -130,8 +130,8 @@ in
             relevant = config.systemd.network.enable;
             root = config.systemd.network.netdevs;
             peer = (x: x.wireguardPeers);
-            key = (x: if x.wireguardPeerConfig ? PublicKey then x.wireguardPeerConfig.PublicKey else null);
-            description = "${options.systemd.network.netdevs}.\"<name>\".wireguardPeers.*.wireguardPeerConfig.PublicKey";
+            key = x: x.PublicKey or null;
+            description = "${options.systemd.network.netdevs}.\"<name>\".wireguardPeers.*.PublicKey";
           }
           {
             relevant = config.networking.wireguard.enable;

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -32,13 +32,13 @@ let
     optionalAttrs (gateway != null && gateway.interface != null) {
       networks."40-${gateway.interface}" = {
         matchConfig.Name = gateway.interface;
-        routes = [{
-          routeConfig = {
+        routes = [
+          ({
             Gateway = gateway.address;
           } // optionalAttrs (gateway.metric != null) {
             Metric = gateway.metric;
-          };
-        }];
+          })
+        ];
       };
     }
   ));
@@ -95,65 +95,63 @@ let
       address = forEach (interfaceIps i)
         (ip: "${ip.address}/${toString ip.prefixLength}");
       routes = forEach (interfaceRoutes i)
-        (route: {
+        (route:
           # Most of these route options have not been tested.
           # Please fix or report any mistakes you may find.
-          routeConfig =
-            optionalAttrs (route.address != null && route.prefixLength != null) {
-              Destination = "${route.address}/${toString route.prefixLength}";
-            } //
-            optionalAttrs (route.options ? fastopen_no_cookie) {
-              FastOpenNoCookie = route.options.fastopen_no_cookie;
-            } //
-            optionalAttrs (route.via != null) {
-              Gateway = route.via;
-            } //
-            optionalAttrs (route.type != null) {
-              Type = route.type;
-            } //
-            optionalAttrs (route.options ? onlink) {
-              GatewayOnLink = true;
-            } //
-            optionalAttrs (route.options ? initrwnd) {
-              InitialAdvertisedReceiveWindow = route.options.initrwnd;
-            } //
-            optionalAttrs (route.options ? initcwnd) {
-              InitialCongestionWindow = route.options.initcwnd;
-            } //
-            optionalAttrs (route.options ? pref) {
-              IPv6Preference = route.options.pref;
-            } //
-            optionalAttrs (route.options ? mtu) {
-              MTUBytes = route.options.mtu;
-            } //
-            optionalAttrs (route.options ? metric) {
-              Metric = route.options.metric;
-            } //
-            optionalAttrs (route.options ? src) {
-              PreferredSource = route.options.src;
-            } //
-            optionalAttrs (route.options ? protocol) {
-              Protocol = route.options.protocol;
-            } //
-            optionalAttrs (route.options ? quickack) {
-              QuickAck = route.options.quickack;
-            } //
-            optionalAttrs (route.options ? scope) {
-              Scope = route.options.scope;
-            } //
-            optionalAttrs (route.options ? from) {
-              Source = route.options.from;
-            } //
-            optionalAttrs (route.options ? table) {
-              Table = route.options.table;
-            } //
-            optionalAttrs (route.options ? advmss) {
-              TCPAdvertisedMaximumSegmentSize = route.options.advmss;
-            } //
-            optionalAttrs (route.options ? ttl-propagate) {
-              TTLPropagate = route.options.ttl-propagate == "enabled";
-            };
-        });
+          optionalAttrs (route.address != null && route.prefixLength != null) {
+            Destination = "${route.address}/${toString route.prefixLength}";
+          } //
+          optionalAttrs (route.options ? fastopen_no_cookie) {
+            FastOpenNoCookie = route.options.fastopen_no_cookie;
+          } //
+          optionalAttrs (route.via != null) {
+            Gateway = route.via;
+          } //
+          optionalAttrs (route.type != null) {
+            Type = route.type;
+          } //
+          optionalAttrs (route.options ? onlink) {
+            GatewayOnLink = true;
+          } //
+          optionalAttrs (route.options ? initrwnd) {
+            InitialAdvertisedReceiveWindow = route.options.initrwnd;
+          } //
+          optionalAttrs (route.options ? initcwnd) {
+            InitialCongestionWindow = route.options.initcwnd;
+          } //
+          optionalAttrs (route.options ? pref) {
+            IPv6Preference = route.options.pref;
+          } //
+          optionalAttrs (route.options ? mtu) {
+            MTUBytes = route.options.mtu;
+          } //
+          optionalAttrs (route.options ? metric) {
+            Metric = route.options.metric;
+          } //
+          optionalAttrs (route.options ? src) {
+            PreferredSource = route.options.src;
+          } //
+          optionalAttrs (route.options ? protocol) {
+            Protocol = route.options.protocol;
+          } //
+          optionalAttrs (route.options ? quickack) {
+            QuickAck = route.options.quickack;
+          } //
+          optionalAttrs (route.options ? scope) {
+            Scope = route.options.scope;
+          } //
+          optionalAttrs (route.options ? from) {
+            Source = route.options.from;
+          } //
+          optionalAttrs (route.options ? table) {
+            Table = route.options.table;
+          } //
+          optionalAttrs (route.options ? advmss) {
+            TCPAdvertisedMaximumSegmentSize = route.options.advmss;
+          } //
+          optionalAttrs (route.options ? ttl-propagate) {
+            TTLPropagate = route.options.ttl-propagate == "enabled";
+          });
       networkConfig.IPv6PrivacyExtensions = "kernel";
       linkConfig = optionalAttrs (i.macAddress != null) {
         MACAddress = i.macAddress;

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -95,63 +95,64 @@ let
       address = forEach (interfaceIps i)
         (ip: "${ip.address}/${toString ip.prefixLength}");
       routes = forEach (interfaceRoutes i)
-        (route:
+        (route: mkMerge [
           # Most of these route options have not been tested.
           # Please fix or report any mistakes you may find.
-          optionalAttrs (route.address != null && route.prefixLength != null) {
+          (mkIf (route.address != null && route.prefixLength != null) {
             Destination = "${route.address}/${toString route.prefixLength}";
-          } //
-          optionalAttrs (route.options ? fastopen_no_cookie) {
+          })
+          (mkIf (route.options ? fastopen_no_cookie) {
             FastOpenNoCookie = route.options.fastopen_no_cookie;
-          } //
-          optionalAttrs (route.via != null) {
+          })
+          (mkIf (route.via != null) {
             Gateway = route.via;
-          } //
-          optionalAttrs (route.type != null) {
+          })
+          (mkIf (route.type != null) {
             Type = route.type;
-          } //
-          optionalAttrs (route.options ? onlink) {
+          })
+          (mkIf (route.options ? onlink) {
             GatewayOnLink = true;
-          } //
-          optionalAttrs (route.options ? initrwnd) {
+          })
+          (mkIf (route.options ? initrwnd) {
             InitialAdvertisedReceiveWindow = route.options.initrwnd;
-          } //
-          optionalAttrs (route.options ? initcwnd) {
+          })
+          (mkIf (route.options ? initcwnd) {
             InitialCongestionWindow = route.options.initcwnd;
-          } //
-          optionalAttrs (route.options ? pref) {
+          })
+          (mkIf (route.options ? pref) {
             IPv6Preference = route.options.pref;
-          } //
-          optionalAttrs (route.options ? mtu) {
+          })
+          (mkIf (route.options ? mtu) {
             MTUBytes = route.options.mtu;
-          } //
-          optionalAttrs (route.options ? metric) {
+          })
+          (mkIf (route.options ? metric) {
             Metric = route.options.metric;
-          } //
-          optionalAttrs (route.options ? src) {
+          })
+          (mkIf (route.options ? src) {
             PreferredSource = route.options.src;
-          } //
-          optionalAttrs (route.options ? protocol) {
+          })
+          (mkIf (route.options ? protocol) {
             Protocol = route.options.protocol;
-          } //
-          optionalAttrs (route.options ? quickack) {
+          })
+          (mkIf (route.options ? quickack) {
             QuickAck = route.options.quickack;
-          } //
-          optionalAttrs (route.options ? scope) {
+          })
+          (mkIf (route.options ? scope) {
             Scope = route.options.scope;
-          } //
-          optionalAttrs (route.options ? from) {
+          })
+          (mkIf (route.options ? from) {
             Source = route.options.from;
-          } //
-          optionalAttrs (route.options ? table) {
+          })
+          (mkIf (route.options ? table) {
             Table = route.options.table;
-          } //
-          optionalAttrs (route.options ? advmss) {
+          })
+          (mkIf (route.options ? advmss) {
             TCPAdvertisedMaximumSegmentSize = route.options.advmss;
-          } //
-          optionalAttrs (route.options ? ttl-propagate) {
+          })
+          (mkIf (route.options ? ttl-propagate) {
             TTLPropagate = route.options.ttl-propagate == "enabled";
-          });
+          })
+        ]);
       networkConfig.IPv6PrivacyExtensions = "kernel";
       linkConfig = optionalAttrs (i.macAddress != null) {
         MACAddress = i.macAddress;

--- a/nixos/tests/clatd.nix
+++ b/nixos/tests/clatd.nix
@@ -59,7 +59,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
             "100.64.0.2/24"
           ];
           routes = [
-            { routeConfig = { Destination = "192.0.2.0/24"; Gateway = "100.64.0.1"; }; }
+            { Destination = "192.0.2.0/24"; Gateway = "100.64.0.1"; }
           ];
         };
       };
@@ -149,7 +149,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
             "2001:db8::2/64"
           ];
           routes = [
-            { routeConfig = { Destination = "::/0"; Gateway = "2001:db8::1"; }; }
+            { Destination = "::/0"; Gateway = "2001:db8::1"; }
           ];
         };
       };

--- a/nixos/tests/rosenpass.nix
+++ b/nixos/tests/rosenpass.nix
@@ -74,10 +74,8 @@ in
           wireguardConfig.ListenPort = server.wg.listen;
           wireguardPeers = [
             {
-              wireguardPeerConfig = {
-                AllowedIPs = [ "::/0" ];
-                PublicKey = client.wg.public;
-              };
+              AllowedIPs = [ "::/0" ];
+              PublicKey = client.wg.public;
             }
           ];
         };
@@ -97,11 +95,9 @@ in
 
         systemd.network.netdevs."10-${deviceName}".wireguardPeers = [
           {
-            wireguardPeerConfig = {
-              AllowedIPs = [ "::/0" ];
-              PublicKey = server.wg.public;
-              Endpoint = "server:${builtins.toString server.wg.listen}";
-            };
+            AllowedIPs = [ "::/0" ];
+            PublicKey = server.wg.public;
+            Endpoint = "server:${builtins.toString server.wg.listen}";
           }
         ];
 

--- a/nixos/tests/systemd-networkd-dhcpserver-static-leases.nix
+++ b/nixos/tests/systemd-networkd-dhcpserver-static-leases.nix
@@ -28,10 +28,8 @@ import ./make-test-python.nix ({ lib, ... }: {
               Address = "10.0.0.1/24";
             };
             dhcpServerStaticLeases = [{
-              dhcpServerStaticLeaseConfig = {
-                MACAddress = "02:de:ad:be:ef:01";
-                Address = "10.0.0.10";
-              };
+              MACAddress = "02:de:ad:be:ef:01";
+              Address = "10.0.0.10";
             }];
           };
         };

--- a/nixos/tests/systemd-networkd-dhcpserver.nix
+++ b/nixos/tests/systemd-networkd-dhcpserver.nix
@@ -54,7 +54,7 @@ import ./make-test-python.nix ({pkgs, ...}: {
             name = "eth1";
             networkConfig.Bridge = "br0";
             bridgeVLANs = [
-              { bridgeVLANConfig = { PVID = 2; EgressUntagged = 2; }; }
+              { PVID = 2; EgressUntagged = 2; }
             ];
           };
           "02-br0" = {
@@ -69,8 +69,8 @@ import ./make-test-python.nix ({pkgs, ...}: {
               PoolSize = 1;
             };
             bridgeVLANs = [
-              { bridgeVLANConfig = { PVID = 1; EgressUntagged = 1; }; }
-              { bridgeVLANConfig = { VLAN = 2; }; }
+              { PVID = 1; EgressUntagged = 1; }
+              { VLAN = 2; }
             ];
           };
           "02-vlan2" = {

--- a/nixos/tests/systemd-networkd-ipv6-prefix-delegation.nix
+++ b/nixos/tests/systemd-networkd-ipv6-prefix-delegation.nix
@@ -258,7 +258,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
           "01-lo" = {
             name = "lo";
             addresses = [
-              { addressConfig.Address = "FD42::1/128"; }
+              { Address = "FD42::1/128"; }
             ];
           };
         };

--- a/nixos/tests/systemd-networkd-vrf.nix
+++ b/nixos/tests/systemd-networkd-vrf.nix
@@ -59,14 +59,14 @@ in {
           matchConfig.Name = "vrf1";
           networkConfig.IPForward = "yes";
           routes = [
-            { routeConfig = { Destination = "192.168.1.2"; Metric = 100; }; }
+            { Destination = "192.168.1.2"; Metric = 100; }
           ];
         };
         networks."10-vrf2" = {
           matchConfig.Name = "vrf2";
           networkConfig.IPForward = "yes";
           routes = [
-            { routeConfig = { Destination = "192.168.2.3"; Metric = 100; }; }
+            { Destination = "192.168.2.3"; Metric = 100; }
           ];
         };
 

--- a/nixos/tests/systemd-networkd.nix
+++ b/nixos/tests/systemd-networkd.nix
@@ -23,13 +23,13 @@ let generateNodeConf = { lib, pkgs, config, privk, pubk, peerId, nodeId, ...}: {
               ListenPort = 51820;
               FirewallMark = 42;
             };
-            wireguardPeers = [ {wireguardPeerConfig={
+            wireguardPeers = [ {
               Endpoint = "192.168.1.${peerId}:51820";
               PublicKey = pubk;
               PresharedKeyFile = pkgs.writeText "psk.key" "yTL3sCOL33Wzi6yCnf9uZQl/Z8laSE+zwpqOHC4HhFU=";
               AllowedIPs = [ "10.0.0.${peerId}/32" ];
               PersistentKeepalive = 15;
-            };}];
+            } ];
           };
         };
         networks = {
@@ -41,8 +41,8 @@ let generateNodeConf = { lib, pkgs, config, privk, pubk, peerId, nodeId, ...}: {
             matchConfig = { Name = "wg0"; };
             address = [ "10.0.0.${nodeId}/32" ];
             routes = [
-              { routeConfig = { Gateway = "10.0.0.${nodeId}"; Destination = "10.0.0.0/24"; }; }
-              { routeConfig = { Gateway = "10.0.0.${nodeId}"; Destination = "10.0.0.0/24"; Table = "custom"; }; }
+              { Gateway = "10.0.0.${nodeId}"; Destination = "10.0.0.0/24"; }
+              { Gateway = "10.0.0.${nodeId}"; Destination = "10.0.0.0/24"; Table = "custom"; }
             ];
           };
           "30-eth1" = {
@@ -52,11 +52,11 @@ let generateNodeConf = { lib, pkgs, config, privk, pubk, peerId, nodeId, ...}: {
               "fe80::${nodeId}/64"
             ];
             routingPolicyRules = [
-              { routingPolicyRuleConfig = { Table = 10; IncomingInterface = "eth1"; Family = "both"; };}
-              { routingPolicyRuleConfig = { Table = 20; OutgoingInterface = "eth1"; };}
-              { routingPolicyRuleConfig = { Table = 30; From = "192.168.1.1"; To = "192.168.1.2"; SourcePort = 666 ; DestinationPort = 667; };}
-              { routingPolicyRuleConfig = { Table = 40; IPProtocol = "tcp"; InvertRule = true; };}
-              { routingPolicyRuleConfig = { Table = 50; IncomingInterface = "eth1"; Family = "ipv4"; };}
+              { Table = 10; IncomingInterface = "eth1"; Family = "both"; }
+              { Table = 20; OutgoingInterface = "eth1"; }
+              { Table = 30; From = "192.168.1.1"; To = "192.168.1.2"; SourcePort = 666 ; DestinationPort = 667; }
+              { Table = 40; IPProtocol = "tcp"; InvertRule = true; }
+              { Table = 50; IncomingInterface = "eth1"; Family = "ipv4"; }
             ];
           };
         };

--- a/nixos/tests/tayga.nix
+++ b/nixos/tests/tayga.nix
@@ -55,7 +55,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
             "100.64.0.2/24"
           ];
           routes = [
-            { routeConfig = { Destination = "192.0.2.0/24"; Gateway = "100.64.0.1"; }; }
+            { Destination = "192.0.2.0/24"; Gateway = "100.64.0.1"; }
           ];
         };
       };
@@ -202,7 +202,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
             "2001:db8::2/64"
           ];
           routes = [
-            { routeConfig = { Destination = "64:ff9b::/96"; Gateway = "2001:db8::1"; }; }
+            { Destination = "64:ff9b::/96"; Gateway = "2001:db8::1"; }
           ];
         };
       };


### PR DESCRIPTION

## Description of changes
This patch is about removing `wireguardPeerConfig`, `dhcpServerStaticLeaseConfig` - a.k.a. the
AbstractSingletonProxyFactoryBean of nixpkgs - and friends.

As a former colleague said

> worst abstraction ever

I second that. I've written enough networkd config for NixOS systems so far to have a strong dislike. In fact, these don't even make sense: `netdevs.wireguardPeers._.wireguardPeerConfig` will be rendered into the key `[WireGuardPeer]` and every key from `wireguardPeerConfig` is in there. Since it's INI, there's no place where sections on the same level as wireguardPeerConfig fit into. Hence, get rid of it all.

For the transition, using the old way is still allowed, but gives a warning. I think we could drop this after one release.

The tests of rosenpass and systemd-networkd-dhcpserver-static-leases were broken on the rev before, hence they were updated, but are still not building.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
