### PR TITLE
python311Packages.pypng,python312Packages.pypng: fix test scripts

### DIFF
--- a/pkgs/development/python-modules/pypng/default.nix
+++ b/pkgs/development/python-modules/pypng/default.nix
@@ -21,7 +21,18 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  pythonImportsCheck = [ "png" ];
+  patches = [
+    # pngsuite is imported by code/test_png.py but is not defined in
+    # setup.cfg, so it isn't built - this adds it to py_modules
+    ./setup-cfg-pngsuite.patch
+  ];
+
+  # allow tests to use the binaries produced by this package
+  preCheck = ''
+    export PATH="$out/bin:$PATH"
+  '';
+
+  pythonImportsCheck = [ "png" "pngsuite" ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/pypng/setup-cfg-pngsuite.patch
+++ b/pkgs/development/python-modules/pypng/setup-cfg-pngsuite.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.cfg b/setup.cfg
+index 04bba8a..db159d2 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -28,6 +28,7 @@ package_dir =
+        = code
+ py_modules =
+     png
++    pngsuite
+ scripts =
+     code/prichunkpng
+     code/pricolpng


### PR DESCRIPTION
## Description of changes

ZHF: https://github.com/NixOS/nixpkgs/issues/309482

pypng is one of the last remaining dependencies in on https://zh.fail with 10+ packages waiting for it to be fixed.

It seems fine on linux, but tests on macos fail due to:

1. A missing pngsuite import (available in the same package, but missing from setup.cfg)
2. Unpatched paths referencing the executable outputs of this module in the test scripts

This PR resolves both.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
