### PR TITLE
rust/cargo-check-hook: set RUST_TEST_THREADS

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -380,8 +380,9 @@ rustPlatform.buildRustPackage {
 
 #### Setting `test-threads` {#setting-test-threads}
 
-`buildRustPackage` will use parallel test threads by default,
-sometimes it may be necessary to disable this so the tests run consecutively.
+`buildRustPackage` will use parallel test threads by default (by setting
+`RUST_TEST_THREADS`), sometimes it may be necessary to disable this so the
+tests run consecutively.
 
 ```nix
 rustPlatform.buildRustPackage {

--- a/pkgs/applications/misc/navi/default.nix
+++ b/pkgs/applications/misc/navi/default.nix
@@ -23,11 +23,6 @@ rustPlatform.buildRustPackage rec {
       --prefix PATH : ${lib.makeBinPath([ wget ] ++ lib.optionals withFzf [ fzf ])}
   '';
 
-  checkFlags = [
-    # error: Found argument '--test-threads' which wasn't expected, or isn't valid in this context
-    "--skip=test_parse_variable_line"
-   ];
-
   meta = with lib; {
     description = "An interactive cheatsheet tool for the command-line and application launchers";
     homepage = "https://github.com/denisidoro/navi";

--- a/pkgs/applications/version-management/glitter/default.nix
+++ b/pkgs/applications/version-management/glitter/default.nix
@@ -22,9 +22,6 @@ rustPlatform.buildRustPackage rec {
     git init
   '';
 
-  # error: Found argument '--test-threads' which wasn't expected, or isn't valid in this context
-  checkFlags = [ "--skip" "runs_correctly" ];
-
   meta = with lib; {
     description = "A git wrapper that allows you to compress multiple commands into one";
     homepage = "https://github.com/milo123459/glitter";

--- a/pkgs/build-support/rust/hooks/cargo-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-check-hook.sh
@@ -11,9 +11,9 @@ cargoCheckHook() {
     fi
 
     if [[ -z ${dontUseCargoParallelTests-} ]]; then
-        threads=$NIX_BUILD_CORES
+        export RUST_TEST_THREADS=$NIX_BUILD_CORES
     else
-        threads=1
+        export RUST_TEST_THREADS=1
     fi
 
     if [ "${cargoCheckType}" != "debug" ]; then
@@ -36,7 +36,6 @@ cargoCheckHook() {
         cargo test \
               -j $NIX_BUILD_CORES \
               ${argstr} -- \
-              --test-threads=${threads} \
               ${checkFlags} \
               ${checkFlagsArray+"${checkFlagsArray[@]}"}
     )

--- a/pkgs/servers/search/sonic-server/default.nix
+++ b/pkgs/servers/search/sonic-server/default.nix
@@ -21,8 +21,15 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-9XSRb5RB82L72RzRWPJ45AJahkRnLwAL7lI2QFqbeko=";
 
-  # Found argument '--test-threads' which wasn't expected, or isn't valid in this context
-  doCheck = false;
+  checkFlags = [
+    "--skip=store::fst::tests::it_acquires_graph"
+    "--skip=store::fst::tests::it_janitors_graph"
+    "--skip=store::fst::tests::it_proceeds_primitives"
+    "--skip=store::kv::tests::it_acquires_database"
+    "--skip=store::kv::tests::it_janitors_database"
+    "--skip=store::kv::tests::it_proceeds_actions"
+    "--skip=store::kv::tests::it_proceeds_primitives"
+  ];
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook

--- a/pkgs/tools/misc/lsd/default.nix
+++ b/pkgs/tools/misc/lsd/default.nix
@@ -8,6 +8,7 @@
 , pandoc
 , testers
 , lsd
+, git
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -45,8 +46,7 @@ rustPlatform.buildRustPackage rec {
       --zsh $releaseDir/build/lsd-*/out/_lsd
   '';
 
-  # Found argument '--test-threads' which wasn't expected, or isn't valid in this context
-  doCheck = false;
+  nativeCheckInputs = [ git ];
 
   passthru.tests.version = testers.testVersion {
     package = lsd;

--- a/pkgs/tools/misc/sfz/default.nix
+++ b/pkgs/tools/misc/sfz/default.nix
@@ -13,9 +13,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-MgbK39xAr8g9F+1MXZiw5rE/PsgQPcLZ2ZV6LiQbA24=";
 
-  # error: Found argument '--test-threads' which wasn't expected, or isn't valid in this context
-  doCheck = false;
-
   meta = with lib; {
     description = "Simple static file serving command-line tool written in Rust";
     homepage = "https://github.com/weihanglo/sfz";

--- a/pkgs/tools/text/pomsky/default.nix
+++ b/pkgs/tools/text/pomsky/default.nix
@@ -31,9 +31,6 @@ rustPlatform.buildRustPackage rec {
     RUSTONIG_SYSTEM_LIBONIG = true;
   };
 
-  # thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: invalid option '--test-threads''
-  doCheck = false;
-
   meta = with lib; {
     description = "A portable, modern regular expression language";
     mainProgram = "pomsky";

--- a/pkgs/tools/text/tidy-viewer/default.nix
+++ b/pkgs/tools/text/tidy-viewer/default.nix
@@ -13,12 +13,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-pIGuBP0a4jWFzkQfqvxQUrBmqYjhERVyEbZvL7g5hRM=";
 
-  # this test parses command line arguments
-  # error: Found argument '--test-threads' which wasn't expected, or isn't valid in this context
-  checkFlags = [
-    "--skip=build_reader_can_create_reader_without_file_specified"
-  ];
-
   meta = with lib; {
     description = "A cross-platform CLI csv pretty printer that uses column styling to maximize viewer enjoyment";
     mainProgram = "tidy-viewer";


### PR DESCRIPTION
## Description of changes

Some integration tests capture CLI arguments, and thus fail with our current approach of setting `--test-threads`. This commit changes cargo-check-hook implementation to use `RUST_TEST_THREADS` environment variable instead.

Also re-enable tests that were previously disabled due to that issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
