### PR TITLE
challenger: init at 0.10.0

### DIFF
--- a/pkgs/by-name/ch/challenger/package.nix
+++ b/pkgs/by-name/ch/challenger/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  autoreconfHook,
+  libgcrypt,
+  pkg-config,
+  texinfo,
+  curl,
+  gnunet,
+  jansson,
+  libgnurl,
+  libmicrohttpd,
+  libsodium,
+  libtool,
+  postgresql,
+  taler-exchange,
+  taler-merchant,
+  runtimeShell,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "challenger";
+  version = "0.10.0";
+
+  src = fetchgit {
+    url = "https://git.taler.net/challenger.git";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-fjT3igPQ9dQtOezwZVfK5fBaL22FKOCbjUF0U1urK0g=";
+  };
+
+  # https://git.taler.net/challenger.git/tree/bootstrap
+  preAutoreconf = ''
+    # Generate Makefile.am in contrib/
+    pushd contrib
+    rm -f Makefile.am
+    find wallet-core/challenger/ -type f -printf '  %p \\\n' | sort > Makefile.am.ext
+    # Remove extra '\' at the end of the file
+    truncate -s -2 Makefile.am.ext
+    cat Makefile.am.in Makefile.am.ext >> Makefile.am
+    # Prevent accidental editing of the generated Makefile.am
+    chmod -w Makefile.am
+    popd
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    libgcrypt
+    pkg-config
+    texinfo
+  ];
+
+  buildInputs = [
+    curl
+    gnunet
+    jansson
+    libgcrypt
+    libgnurl
+    libmicrohttpd
+    libsodium
+    libtool
+    postgresql
+    taler-exchange
+    taler-merchant
+  ];
+
+  preFixup = ''
+    substituteInPlace $out/bin/challenger-{dbconfig,send-post.sh} \
+      --replace-fail "/bin/bash" "${runtimeShell}"
+  '';
+
+  meta = {
+    description = "OAuth 2.0-based authentication service that validates user can receive messages at a certain address";
+    homepage = "https://git.taler.net/challenger.git";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ wegank ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

https://git.taler.net/challenger.git
https://taler.net/en/news/2024-06.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
