### PR TITLE
The great python3.8 purge [1] (python == 3.5) 

### DIFF
--- a/pkgs/applications/audio/pulseaudio-dlna/zeroconf.nix
+++ b/pkgs/applications/audio/pulseaudio-dlna/zeroconf.nix
@@ -2,8 +2,6 @@
 , buildPythonPackage
 , fetchPypi
 , ifaddr
-, typing
-, pythonOlder
 , netifaces
 , six
 , enum-compat
@@ -18,8 +16,7 @@ buildPythonPackage rec {
     sha256 = "0ykzg730n915qbrq9bn5pn06bv6rb5zawal4sqjyfnjjm66snkj3";
   };
 
-  propagatedBuildInputs = [ netifaces six enum-compat ifaddr ]
-    ++ lib.optionals (pythonOlder "3.5") [ typing ];
+  propagatedBuildInputs = [ netifaces six enum-compat ifaddr ];
 
   meta = with lib; {
     description = "A pure python implementation of multicast DNS service discovery";

--- a/pkgs/applications/networking/protonvpn-cli/2.nix
+++ b/pkgs/applications/networking/protonvpn-cli/2.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonApplication
 , fetchFromGitHub
-, pythonOlder
 , requests
 , docopt
 , pythondialog
@@ -15,8 +14,6 @@ buildPythonApplication rec {
   pname = "protonvpn-cli_2";
   version = "2.2.12";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "Rafficer";

--- a/pkgs/applications/networking/protonvpn-cli/default.nix
+++ b/pkgs/applications/networking/protonvpn-cli/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonApplication
-, pythonOlder
 , fetchFromGitHub
 , protonvpn-nm-lib
 , pythondialog
@@ -11,8 +10,6 @@ buildPythonApplication rec {
   pname = "protonvpn-cli";
   version = "3.13.0";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "protonvpn";

--- a/pkgs/applications/version-management/peru/default.nix
+++ b/pkgs/applications/version-management/peru/default.nix
@@ -4,8 +4,6 @@ python3Packages.buildPythonApplication rec {
   pname = "peru";
   version = "1.2.0";
 
-  disabled = python3Packages.pythonOlder "3.5";
-
   src = fetchFromGitHub {
     owner = "buildinspace";
     repo = "peru";

--- a/pkgs/development/python-modules/aiohttp-cors/default.nix
+++ b/pkgs/development/python-modules/aiohttp-cors/default.nix
@@ -1,6 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder
-, typing ? null, aiohttp
-}:
+{ lib, buildPythonPackage, fetchPypi, aiohttp }:
 
 buildPythonPackage rec {
   pname = "aiohttp-cors";
@@ -12,10 +10,7 @@ buildPythonPackage rec {
     sha256 = "0pczn54bqd32v8zhfbjfybiza6xh1szwxy6as577dn8g23bwcfad";
   };
 
-  disabled = pythonOlder "3.5";
-
-  propagatedBuildInputs = [ aiohttp ]
-  ++ lib.optional (pythonOlder "3.5") typing;
+  propagatedBuildInputs = [ aiohttp ];
 
   # Requires network access
   doCheck = false;

--- a/pkgs/development/python-modules/aioimaplib/default.nix
+++ b/pkgs/development/python-modules/aioimaplib/default.nix
@@ -1,6 +1,5 @@
 { lib
 , pythonOlder
-, pythonAtLeast
 , asynctest
 , buildPythonPackage
 , docutils
@@ -18,8 +17,6 @@ buildPythonPackage rec {
   pname = "aioimaplib";
   version = "1.0.1";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "bamthomas";

--- a/pkgs/development/python-modules/aiolip/default.nix
+++ b/pkgs/development/python-modules/aiolip/default.nix
@@ -2,14 +2,12 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pytestCheckHook
-, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "aiolip";
   version = "1.1.6";
   format = "setuptools";
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "bdraco";

--- a/pkgs/development/python-modules/aioprocessing/default.nix
+++ b/pkgs/development/python-modules/aioprocessing/default.nix
@@ -2,15 +2,12 @@
 , buildPythonPackage
 , fetchPypi
 , flit-core
-, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "aioprocessing";
   version = "2.0.1";
   format = "pyproject";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/aioresponses/default.nix
+++ b/pkgs/development/python-modules/aioresponses/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pythonOlder
 
 # build-system
 , pbr
@@ -19,8 +18,6 @@ buildPythonPackage rec {
   pname = "aioresponses";
   version = "0.7.6";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/async-generator/default.nix
+++ b/pkgs/development/python-modules/async-generator/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchPypi
 , pythonAtLeast
-, pythonOlder
 , pytestCheckHook
 }:
 
@@ -10,8 +9,6 @@ buildPythonPackage rec {
   pname = "async-generator";
   version = "1.10";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     pname = "async_generator";

--- a/pkgs/development/python-modules/base58/default.nix
+++ b/pkgs/development/python-modules/base58/default.nix
@@ -3,14 +3,12 @@
 , fetchPypi
 , pyhamcrest
 , pytestCheckHook
-, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "base58";
   version = "2.1.1";
   format = "setuptools";
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/bech32/default.nix
+++ b/pkgs/development/python-modules/bech32/default.nix
@@ -1,15 +1,11 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pytestCheckHook
-, pythonOlder
 }:
 buildPythonPackage rec {
   pname = "bech32";
   version = "1.2.0";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/boltztrap2/default.nix
+++ b/pkgs/development/python-modules/boltztrap2/default.nix
@@ -7,8 +7,6 @@
 , matplotlib
 , ase
 , netcdf4
-, pytest
-, pythonOlder
 , cython
 , cmake
 }:
@@ -17,8 +15,6 @@ buildPythonPackage rec {
   pname = "boltztrap2";
   version = "24.1.1";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     pname = "BoltzTraP2";

--- a/pkgs/development/python-modules/bugsnag/default.nix
+++ b/pkgs/development/python-modules/bugsnag/default.nix
@@ -3,7 +3,6 @@
 , buildPythonPackage
 , fetchPypi
 , flask
-, pythonOlder
 , webob
 }:
 
@@ -11,8 +10,6 @@ buildPythonPackage rec {
   pname = "bugsnag";
   version = "4.7.0";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/calver/default.nix
+++ b/pkgs/development/python-modules/calver/default.nix
@@ -12,7 +12,7 @@ let
     version = "2022.06.26";
     format = "setuptools";
 
-    disabled = pythonOlder "3.5";
+    disabled = pythonOlder "3.7";
 
     src = fetchFromGitHub {
       owner = "di";

--- a/pkgs/development/python-modules/cement/default.nix
+++ b/pkgs/development/python-modules/cement/default.nix
@@ -9,7 +9,7 @@ buildPythonPackage rec {
   version = "3.0.10";
   format = "setuptools";
 
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/charset-normalizer/default.nix
+++ b/pkgs/development/python-modules/charset-normalizer/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   version = "3.3.2";
   format = "setuptools";
 
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "Ousret";

--- a/pkgs/development/python-modules/clifford/default.nix
+++ b/pkgs/development/python-modules/clifford/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pythonOlder
 , h5py
 , ipython
 , numba
@@ -16,8 +15,6 @@ buildPythonPackage rec {
   pname = "clifford";
   version = "1.4.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/coverage/default.nix
+++ b/pkgs/development/python-modules/coverage/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchPypi
 , mock
-, pythonOlder
 , setuptools
 }:
 
@@ -10,9 +9,6 @@ buildPythonPackage rec {
   pname = "coverage";
   version = "7.4.4";
   pyproject = true;
-
-  # uses f strings
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/crc32c/default.nix
+++ b/pkgs/development/python-modules/crc32c/default.nix
@@ -1,11 +1,9 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, pytestCheckHook }:
+{ lib, buildPythonPackage, fetchFromGitHub, pytestCheckHook }:
 
 buildPythonPackage rec {
   version = "2.3.post0";
   pname = "crc32c";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "ICRAR";

--- a/pkgs/development/python-modules/cssselect2/default.nix
+++ b/pkgs/development/python-modules/cssselect2/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , flit-core
-, pythonOlder
 , fetchPypi
 , tinycss2
 , pytestCheckHook
@@ -11,7 +10,6 @@ buildPythonPackage rec {
   pname = "cssselect2";
   version = "0.7.0";
   format = "pyproject";
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/debian/default.nix
+++ b/pkgs/development/python-modules/debian/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchPypi
 , chardet
 }:
@@ -9,8 +8,6 @@ buildPythonPackage rec {
   pname = "python-debian";
   version = "0.1.49";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/distorm3/default.nix
+++ b/pkgs/development/python-modules/distorm3/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pythonOlder
 , pytestCheckHook
 , yasm
 }:
@@ -10,8 +9,6 @@ buildPythonPackage rec {
   pname = "distorm3";
   version = "3.5.2";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "gdabah";

--- a/pkgs/development/python-modules/django-haystack/default.nix
+++ b/pkgs/development/python-modules/django-haystack/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchPypi
 
 # build dependencies
@@ -24,8 +23,6 @@ buildPythonPackage rec {
   pname = "django-haystack";
   version = "3.2.1";
   format = "pyproject";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/django-modelcluster/default.nix
+++ b/pkgs/development/python-modules/django-modelcluster/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pythonOlder
 
 # dependencies
 , django
@@ -19,8 +18,6 @@ buildPythonPackage rec {
   pname = "django-modelcluster";
   version = "6.3";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "wagtail";

--- a/pkgs/development/python-modules/django-timezone-field/default.nix
+++ b/pkgs/development/python-modules/django-timezone-field/default.nix
@@ -14,7 +14,8 @@
 buildPythonPackage rec {
   pname = "django-timezone-field";
   version = "5.1";
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.7";
+
   format = "pyproject";
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/dllogger/default.nix
+++ b/pkgs/development/python-modules/dllogger/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pythonOlder
 , setuptools
 , wheel
 }:
@@ -10,8 +9,6 @@ buildPythonPackage rec {
   pname = "dllogger";
   version = "1.0.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";

--- a/pkgs/development/python-modules/dpcontracts/default.nix
+++ b/pkgs/development/python-modules/dpcontracts/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchFromGitHub
 }:
 
@@ -8,7 +7,6 @@ buildPythonPackage rec {
   pname = "dpcontracts";
   version = "unstable-2018-11-20";
   format = "setuptools";
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "deadpixi";

--- a/pkgs/development/python-modules/eth-hash/default.nix
+++ b/pkgs/development/python-modules/eth-hash/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   pname = "eth-hash";
   version = "0.5.2";
   format = "setuptools";
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "ethereum";

--- a/pkgs/development/python-modules/ezdxf/default.nix
+++ b/pkgs/development/python-modules/ezdxf/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchFromGitHub
 , pyparsing
 , typing-extensions
@@ -11,8 +10,6 @@ buildPythonPackage rec {
   version = "0.18.1";
   pname = "ezdxf";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "mozman";

--- a/pkgs/development/python-modules/falcon/default.nix
+++ b/pkgs/development/python-modules/falcon/default.nix
@@ -31,7 +31,6 @@ buildPythonPackage rec {
   pname = "falcon";
   version = "3.1.3";
   format = "pyproject";
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "falconry";

--- a/pkgs/development/python-modules/fastimport/default.nix
+++ b/pkgs/development/python-modules/fastimport/default.nix
@@ -1,5 +1,4 @@
 { lib
-, pythonOlder
 , buildPythonPackage
 , fetchPypi
 , unittestCheckHook
@@ -9,8 +8,6 @@ buildPythonPackage rec {
   pname = "fastimport";
   version = "0.9.14";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/finvizfinance/default.nix
+++ b/pkgs/development/python-modules/finvizfinance/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchFromGitHub
 , beautifulsoup4
 , datetime
@@ -15,8 +14,6 @@ buildPythonPackage rec {
   pname = "finvizfinance";
   version = "0.14.7";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "lit26";

--- a/pkgs/development/python-modules/foobot-async/default.nix
+++ b/pkgs/development/python-modules/foobot-async/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchPypi
 , aiohttp
 , async-timeout
@@ -12,8 +11,6 @@ buildPythonPackage rec {
   pname = "foobot-async";
   version = "1.0.0";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     pname = "foobot_async";

--- a/pkgs/development/python-modules/git-filter-repo/default.nix
+++ b/pkgs/development/python-modules/git-filter-repo/default.nix
@@ -4,7 +4,6 @@
 , fetchPypi
 , fetchpatch
 , installShellFiles
-, pythonOlder
 , setuptools-scm
 , writeScript
 }:
@@ -14,8 +13,6 @@ buildPythonPackage rec {
   version = "2.38.0";
   docs_version = "01ead411966a83dfcfb35f9d2e8a9f7f215eaa65";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/googlemaps/default.nix
+++ b/pkgs/development/python-modules/googlemaps/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , pytest-cov
 , pytestCheckHook
-, pythonOlder
 , requests
 , responses
 }:
@@ -12,8 +11,6 @@ buildPythonPackage rec {
   pname = "googlemaps";
   version = "4.10.0";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "googlemaps";

--- a/pkgs/development/python-modules/gunicorn/default.nix
+++ b/pkgs/development/python-modules/gunicorn/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pythonOlder
 
 # build-system
 , setuptools
@@ -22,8 +21,6 @@ buildPythonPackage rec {
   pname = "gunicorn";
   version = "21.2.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "benoitc";

--- a/pkgs/development/python-modules/hickle/default.nix
+++ b/pkgs/development/python-modules/hickle/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pythonOlder,
   h5py,
   numpy,
   dill,
@@ -17,8 +16,6 @@ buildPythonPackage rec {
   pname = "hickle";
   version = "5.0.3";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/hjson/default.nix
+++ b/pkgs/development/python-modules/hjson/default.nix
@@ -5,7 +5,6 @@
   makeWrapper,
   pytestCheckHook,
   python,
-  pythonOlder,
   setuptools,
 }:
 
@@ -13,8 +12,6 @@ buildPythonPackage rec {
   pname = "hjson";
   version = "3.0.2";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "hjson";

--- a/pkgs/development/python-modules/imap-tools/default.nix
+++ b/pkgs/development/python-modules/imap-tools/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchFromGitHub
 , pytestCheckHook
 }:
@@ -8,8 +7,6 @@
 buildPythonPackage rec {
   pname = "imap-tools";
   version = "1.5.0";
-
-  disabled = pythonOlder "3.5";
 
   format = "setuptools";
 

--- a/pkgs/development/python-modules/ipympl/default.nix
+++ b/pkgs/development/python-modules/ipympl/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchPypi
 , ipykernel
 , ipython-genutils
@@ -15,8 +14,6 @@ buildPythonPackage rec {
   pname = "ipympl";
   version = "0.9.4";
   format = "wheel";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version format;

--- a/pkgs/development/python-modules/jupyter-telemetry/default.nix
+++ b/pkgs/development/python-modules/jupyter-telemetry/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pythonOlder
 , python-json-logger
 , jsonschema
 , ruamel-yaml
@@ -11,7 +10,6 @@
 buildPythonPackage rec {
   pname = "jupyter_telemetry";
   version = "0.1.0";
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/keyrings-cryptfile/default.nix
+++ b/pkgs/development/python-modules/keyrings-cryptfile/default.nix
@@ -5,15 +5,12 @@
 , keyring
 , pycryptodome
 , pytestCheckHook
-, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "keyrings-cryptfile";
   version = "1.3.9";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     pname = "keyrings.cryptfile";

--- a/pkgs/development/python-modules/lime/default.nix
+++ b/pkgs/development/python-modules/lime/default.nix
@@ -10,15 +10,12 @@
 , scikit-image
 
 , pytestCheckHook
-, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "lime";
   version = "0.2.0.1";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/logfury/default.nix
+++ b/pkgs/development/python-modules/logfury/default.nix
@@ -3,7 +3,6 @@
 , fetchPypi
 , setuptools-scm
 , pytestCheckHook
-, pythonOlder
 , testfixtures
 }:
 
@@ -11,8 +10,6 @@ buildPythonPackage rec {
   pname = "logfury";
   version = "1.0.1";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/lz4/default.nix
+++ b/pkgs/development/python-modules/lz4/default.nix
@@ -5,7 +5,6 @@
 , psutil
 , pytestCheckHook
 , python
-, pythonOlder
 , setuptools
 , setuptools-scm
 }:
@@ -14,8 +13,6 @@ buildPythonPackage rec {
   pname = "lz4";
   version = "4.3.3";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   # get full repository in order to run tests
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/markdown2/default.nix
+++ b/pkgs/development/python-modules/markdown2/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , python
 , pygments
-, pythonOlder
 , wavedrom
 }:
 
@@ -11,8 +10,6 @@ buildPythonPackage rec {
   pname = "markdown2";
   version = "2.4.10";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   # PyPI does not contain tests, so using GitHub instead.
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/mat2/default.nix
+++ b/pkgs/development/python-modules/mat2/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , buildPythonPackage
 , pytestCheckHook
-, pythonOlder
 , fetchFromGitLab
 , substituteAll
 , bubblewrap
@@ -24,8 +23,6 @@
 buildPythonPackage rec {
   pname = "mat2";
   version = "0.13.4";
-
-  disabled = pythonOlder "3.5";
 
   format = "setuptools";
 

--- a/pkgs/development/python-modules/mattermostdriver/default.nix
+++ b/pkgs/development/python-modules/mattermostdriver/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pythonOlder
 , websockets
 , requests
 }:
@@ -10,8 +9,6 @@ buildPythonPackage rec {
   pname = "mattermostdriver";
   version = "7.3.2";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/meeko/default.nix
+++ b/pkgs/development/python-modules/meeko/default.nix
@@ -4,7 +4,6 @@
 , fetchpatch
 , numpy
 , pytestCheckHook
-, pythonOlder
 , rdkit
 , scipy
 }:
@@ -13,8 +12,6 @@ buildPythonPackage rec {
   pname = "meeko";
   version = "0.5.0";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "forlilab";

--- a/pkgs/development/python-modules/mmcif-pdbx/default.nix
+++ b/pkgs/development/python-modules/mmcif-pdbx/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pythonOlder
 , setuptools
 , pytestCheckHook
 }:
@@ -10,8 +9,6 @@ buildPythonPackage rec {
   pname = "mmcif-pdbx";
   version = "2.0.1";
   format = "pyproject";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "Electrostatics";

--- a/pkgs/development/python-modules/mortgage/default.nix
+++ b/pkgs/development/python-modules/mortgage/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchPypi
 , pytestCheckHook
-, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -20,8 +19,6 @@ buildPythonPackage rec {
   ];
 
   doCheck = false; # No tests in sdist
-
-  disabled = pythonOlder "3.5";
 
   meta = {
     description = "Mortgage calculator";

--- a/pkgs/development/python-modules/moviepy/default.nix
+++ b/pkgs/development/python-modules/moviepy/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pythonOlder
 , numpy
 , decorator
 , imageio
@@ -22,8 +21,6 @@ buildPythonPackage rec {
   pname = "moviepy";
   version = "1.0.3";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/msgraph-core/default.nix
+++ b/pkgs/development/python-modules/msgraph-core/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchFromGitHub
 , setuptools
 , httpx
@@ -17,9 +16,6 @@ buildPythonPackage rec {
   pname = "msgraph-core";
   version = "1.0.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
-
 
   src = fetchFromGitHub {
     owner = "microsoftgraph";

--- a/pkgs/development/python-modules/mypy/extensions.nix
+++ b/pkgs/development/python-modules/mypy/extensions.nix
@@ -1,10 +1,8 @@
 { lib
 , fetchFromGitHub
 , buildPythonPackage
-, typing
 , pytestCheckHook
 , pythonAtLeast
-, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -17,8 +15,6 @@ buildPythonPackage rec {
     rev = version;
     hash = "sha256-gOfHC6dUeBE7SsWItpUHHIxW3wzhPM5SuGW1U8P7DD0=";
   };
-
-  propagatedBuildInputs = lib.optional (pythonOlder "3.5") typing;
 
   # make the testsuite run with pytest, so we can disable individual tests
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/od/default.nix
+++ b/pkgs/development/python-modules/od/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pythonOlder
 , repeated-test
 }:
 
@@ -9,8 +8,6 @@ buildPythonPackage rec {
   pname = "od";
   version = "2.0.2";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/openhomedevice/default.nix
+++ b/pkgs/development/python-modules/openhomedevice/default.nix
@@ -5,15 +5,12 @@
 , fetchFromGitHub
 , lxml
 , pytestCheckHook
-, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "openhomedevice";
   version = "2.2";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "bazwilliams";

--- a/pkgs/development/python-modules/pathlib2/default.nix
+++ b/pkgs/development/python-modules/pathlib2/default.nix
@@ -2,10 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , six
-, pythonOlder
-, scandir ? null
 , glibcLocales
-, typing
 }:
 
 buildPythonPackage rec {
@@ -18,8 +15,7 @@ buildPythonPackage rec {
     hash = "sha256-n+DtrYmLg8DD4ZnIQrJ+0hZkXS4Xd1ey3Wc4TUETxkE=";
   };
 
-  propagatedBuildInputs = [ six ]
-    ++ lib.optionals (pythonOlder "3.5") [ scandir typing ];
+  propagatedBuildInputs = [ six ];
   nativeCheckInputs = [ glibcLocales ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/periodiq/default.nix
+++ b/pkgs/development/python-modules/periodiq/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchFromGitLab
 , poetry-core
 , dramatiq
@@ -14,8 +13,6 @@ buildPythonPackage rec {
   pname = "periodiq";
   version = "0.12.1";
   format = "pyproject";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitLab {
     owner = "bersace";

--- a/pkgs/development/python-modules/phx-class-registry/default.nix
+++ b/pkgs/development/python-modules/phx-class-registry/default.nix
@@ -2,13 +2,11 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pytestCheckHook
-, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "class-registry";
   version = "4.1.0";
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "todofixthis";

--- a/pkgs/development/python-modules/pvextractor/default.nix
+++ b/pkgs/development/python-modules/pvextractor/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pythonOlder
 , astropy
 , qtpy
 , pyqt6
@@ -19,8 +18,6 @@ buildPythonPackage rec {
   pname = "pvextractor";
   version = "0.4";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "radio-astro-tools";

--- a/pkgs/development/python-modules/py-cid/default.nix
+++ b/pkgs/development/python-modules/py-cid/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pythonOlder
 , pytestCheckHook
 , base58
 , py-multibase
@@ -15,7 +14,6 @@ buildPythonPackage rec {
   pname = "py-cid";
   version = "0.3.0";
   format = "setuptools";
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "ipld";

--- a/pkgs/development/python-modules/py-multiaddr/default.nix
+++ b/pkgs/development/python-modules/py-multiaddr/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pythonOlder
 , varint
 , base58
 , netaddr
@@ -15,7 +14,6 @@ buildPythonPackage rec {
   pname = "py-multiaddr";
   version = "0.0.9";
   format = "setuptools";
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "multiformats";

--- a/pkgs/development/python-modules/pycarwings2/default.nix
+++ b/pkgs/development/python-modules/pycarwings2/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pytestCheckHook
-, pythonOlder
 , pyyaml
 , iso8601
 , requests
@@ -13,8 +12,6 @@ buildPythonPackage rec {
   pname = "pycarwings2";
   version = "2.14";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "filcole";

--- a/pkgs/development/python-modules/pycm/default.nix
+++ b/pkgs/development/python-modules/pycm/default.nix
@@ -4,7 +4,6 @@
 , matplotlib
 , numpy
 , pytestCheckHook
-, pythonOlder
 , seaborn
 }:
 
@@ -12,8 +11,6 @@ buildPythonPackage rec {
   pname = "pycm";
   version = "4.0";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "sepandhaghighi";

--- a/pkgs/development/python-modules/pycurl/default.nix
+++ b/pkgs/development/python-modules/pycurl/default.nix
@@ -3,7 +3,6 @@
 , buildPythonPackage
 , isPyPy
 , fetchPypi
-, pythonOlder
 , curl
 , openssl
 , bottle
@@ -15,7 +14,7 @@ buildPythonPackage rec {
   pname = "pycurl";
   version = "7.45.3";
   format = "setuptools";
-  disabled = isPyPy || (pythonOlder "3.5"); # https://github.com/pycurl/pycurl/issues/208
+  disabled = isPyPy; # https://github.com/pycurl/pycurl/issues/208
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pydot/default.nix
+++ b/pkgs/development/python-modules/pydot/default.nix
@@ -3,10 +3,8 @@
 , fetchPypi
 , substituteAll
 , graphviz
-, python
 , pytestCheckHook
 , chardet
-, pythonOlder
 , pyparsing
 }:
 
@@ -14,8 +12,6 @@ buildPythonPackage rec {
   pname = "pydot";
   version = "2.0.0";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pyfakefs/default.nix
+++ b/pkgs/development/python-modules/pyfakefs/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , buildPythonPackage
 , fetchPypi
-, pythonOlder
 
 # build-system
 , setuptools
@@ -17,8 +16,6 @@ buildPythonPackage rec {
   pname = "pyfakefs";
   version = "5.4.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pygatt/default.nix
+++ b/pkgs/development/python-modules/pygatt/default.nix
@@ -6,7 +6,6 @@
 , pexpect
 , pyserial
 , pytestCheckHook
-, pythonOlder
 , setuptools
 }:
 
@@ -14,8 +13,6 @@ buildPythonPackage rec {
   pname = "pygatt";
   version = "4.0.5";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "peplin";

--- a/pkgs/development/python-modules/pymediaroom/default.nix
+++ b/pkgs/development/python-modules/pymediaroom/default.nix
@@ -2,7 +2,6 @@
 , async-timeout
 , buildPythonPackage
 , fetchPypi
-, pythonOlder
 , xmltodict
 }:
 
@@ -10,7 +9,6 @@ buildPythonPackage rec {
   pname = "pymediaroom";
   version = "0.6.5.4";
   format = "setuptools";
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pymitv/default.nix
+++ b/pkgs/development/python-modules/pymitv/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pythonOlder
 , requests
 }:
 
@@ -9,7 +8,6 @@ buildPythonPackage rec {
   pname = "pymitv";
   version = "1.5.0";
   format = "setuptools";
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pypca/default.nix
+++ b/pkgs/development/python-modules/pypca/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , colorlog
 , fetchPypi
-, pythonOlder
 , pyserial
 }:
 
@@ -10,7 +9,6 @@ buildPythonPackage rec {
   pname = "pypca";
   version = "0.0.13";
   format = "setuptools";
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pyrender/default.nix
+++ b/pkgs/development/python-modules/pyrender/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchFromGitHub
 , fetchpatch
 , setuptools
@@ -21,8 +20,6 @@ buildPythonPackage rec {
   pname = "pyrender";
   version = "0.1.45";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "mmatl";

--- a/pkgs/development/python-modules/pysbd/default.nix
+++ b/pkgs/development/python-modules/pysbd/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pythonOlder
 , tqdm
 , spacy
 }:
@@ -10,7 +9,6 @@ buildPythonPackage rec {
   pname = "pysbd";
   version = "0.3.4";
   format = "setuptools";
-  disabled = pythonOlder "3.5";
 
   # provides no sdist on pypi
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/pyserial-asyncio/default.nix
+++ b/pkgs/development/python-modules/pyserial-asyncio/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pythonOlder
 , pyserial
 }:
 
@@ -9,8 +8,6 @@ buildPythonPackage rec {
   pname = "pyserial-asyncio";
   version = "0.6";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pytest-cid/default.nix
+++ b/pkgs/development/python-modules/pytest-cid/default.nix
@@ -1,7 +1,6 @@
 { lib
 , fetchFromGitHub
 , buildPythonPackage
-, pythonOlder
 , flit-core
 , py-cid
 , pytestCheckHook
@@ -12,7 +11,6 @@ buildPythonPackage rec {
   pname = "pytest-cid";
   version = "1.1.2";
   format = "pyproject";
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "ntninja";

--- a/pkgs/development/python-modules/pytest-click/default.nix
+++ b/pkgs/development/python-modules/pytest-click/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pythonOlder
 , pytest
 , click
 , pytestCheckHook
@@ -11,7 +10,6 @@ buildPythonPackage rec {
   pname = "pytest-click";
   version = "1.1.0";
   format = "setuptools";
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "Stranger6667";

--- a/pkgs/development/python-modules/pytest-flakes/default.nix
+++ b/pkgs/development/python-modules/pytest-flakes/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder
+{ lib, buildPythonPackage, fetchPypi
 , pytest
 , pyflakes
 }:
@@ -9,7 +9,6 @@ buildPythonPackage rec {
   pname = "pytest-flakes";
   version = "4.0.5";
   format = "setuptools";
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pytest-random-order/default.nix
+++ b/pkgs/development/python-modules/pytest-random-order/default.nix
@@ -5,7 +5,6 @@
 , pytest
 , pytest-xdist
 , pytestCheckHook
-, pythonOlder
 , setuptools
 }:
 
@@ -13,8 +12,6 @@ buildPythonPackage rec {
   pname = "pytest-random-order";
   version = "1.1.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pytest-resource-path/default.nix
+++ b/pkgs/development/python-modules/pytest-resource-path/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchFromGitHub
 , colorama
 , pytest
@@ -11,7 +10,6 @@ buildPythonPackage rec {
   pname = "pytest-resource-path";
   version = "1.3.0";
   format = "setuptools";
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "yukihiko-shinoda";

--- a/pkgs/development/python-modules/pytest-snapshot/default.nix
+++ b/pkgs/development/python-modules/pytest-snapshot/default.nix
@@ -5,15 +5,12 @@
 , pytest
 , setuptools-scm
 , pytest7CheckHook
-, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pytest-snapshot";
   version = "0.9.0";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "joseph-roitman";

--- a/pkgs/development/python-modules/python-gammu/default.nix
+++ b/pkgs/development/python-modules/python-gammu/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchFromGitHub
   #, pytestCheckHook
-, pythonOlder
 , pkg-config
 , gammu
 }:
@@ -11,8 +10,6 @@ buildPythonPackage rec {
   pname = "python-gammu";
   version = "3.2.4";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "gammu";

--- a/pkgs/development/python-modules/python-tado/default.nix
+++ b/pkgs/development/python-modules/python-tado/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
-  pythonOlder,
   requests,
   setuptools,
 }:
@@ -12,8 +11,6 @@ buildPythonPackage rec {
   pname = "python-tado";
   version = "0.17.6";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "wmalgadey";

--- a/pkgs/development/python-modules/pytikz-allefeld/default.nix
+++ b/pkgs/development/python-modules/pytikz-allefeld/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , fetchFromGitHub
 , buildPythonPackage
-, pythonOlder
 , setuptools
 , pymupdf
 , numpy
@@ -14,8 +13,6 @@ buildPythonPackage rec {
   pname = "pytikz-allefeld"; # "pytikz" on pypi is a different module
   version = "unstable-2022-11-01";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "allefeld";

--- a/pkgs/development/python-modules/pywebview/default.nix
+++ b/pkgs/development/python-modules/pywebview/default.nix
@@ -20,8 +20,6 @@ buildPythonPackage rec {
   version = "5.0.5";
   pyproject = true;
 
-  disabled = pythonOlder "3.5";
-
   src = fetchFromGitHub {
     owner = "r0x0r";
     repo = "pywebview";

--- a/pkgs/development/python-modules/qudida/default.nix
+++ b/pkgs/development/python-modules/qudida/default.nix
@@ -3,7 +3,6 @@
 , fetchPypi
 , numpy
 , opencv4
-, pythonOlder
 , pythonRelaxDepsHook
 , scikit-learn
 , typing-extensions
@@ -13,8 +12,6 @@ buildPythonPackage rec {
   pname = "qudida";
   version = "0.0.4";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/relatorio/default.nix
+++ b/pkgs/development/python-modules/relatorio/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchPypi
 , genshi
 , lxml
@@ -12,8 +11,6 @@
 buildPythonPackage rec {
   pname = "relatorio";
   version = "0.10.2";
-
-  disabled = pythonOlder "3.5";
 
   format = "setuptools";
 

--- a/pkgs/development/python-modules/repeated-test/default.nix
+++ b/pkgs/development/python-modules/repeated-test/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pythonOlder
 , setuptools-scm
 , pytestCheckHook
 }:
@@ -10,8 +9,6 @@ buildPythonPackage rec {
   pname = "repeated-test";
   version = "2.3.3";
   format = "pyproject";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     pname = "repeated_test";

--- a/pkgs/development/python-modules/rzpipe/default.nix
+++ b/pkgs/development/python-modules/rzpipe/default.nix
@@ -1,15 +1,12 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "rzpipe";
   version = "0.6.0";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/sdkmanager/default.nix
+++ b/pkgs/development/python-modules/sdkmanager/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitLab
-, pythonOlder
 , pythonAtLeast
 , argcomplete
 , requests
@@ -13,8 +12,6 @@ buildPythonPackage rec {
   pname = "sdkmanager";
   version = "0.6.7";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitLab {
     owner = "fdroid";

--- a/pkgs/development/python-modules/seekpath/default.nix
+++ b/pkgs/development/python-modules/seekpath/default.nix
@@ -1,10 +1,9 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, numpy, future, spglib, glibcLocales, pytest, scipy }:
+{ lib, buildPythonPackage, fetchFromGitHub, numpy, future, spglib, glibcLocales, pytest, scipy }:
 
 buildPythonPackage rec {
   pname = "seekpath";
   version = "2.0.1";
   format = "setuptools";
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "giovannipizzi";

--- a/pkgs/development/python-modules/sentence-splitter/default.nix
+++ b/pkgs/development/python-modules/sentence-splitter/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchFromGitHub
 
 , pytestCheckHook
@@ -11,8 +10,6 @@ buildPythonPackage rec {
   pname = "sentence-splitter";
   version = "1.4";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "mediacloud";

--- a/pkgs/development/python-modules/sentinels/default.nix
+++ b/pkgs/development/python-modules/sentinels/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchPypi
 , setuptools
 , pytestCheckHook
@@ -10,8 +9,6 @@ buildPythonPackage rec {
   pname = "sentinels";
   version = "1.0.0";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/somfy-mylink-synergy/default.nix
+++ b/pkgs/development/python-modules/somfy-mylink-synergy/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchFromGitHub
 }:
 
@@ -8,8 +7,6 @@ buildPythonPackage rec {
   pname = "somfy-mylink-synergy";
   version = "1.0.6";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "bendews";

--- a/pkgs/development/python-modules/starline/default.nix
+++ b/pkgs/development/python-modules/starline/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchPypi
 , fetchpatch
 , setuptools
@@ -10,8 +9,6 @@
 buildPythonPackage rec {
   pname = "starline";
   version = "0.1.5";
-
-  disabled = pythonOlder "3.5";
 
   pyproject = true;
 

--- a/pkgs/development/python-modules/synergy/default.nix
+++ b/pkgs/development/python-modules/synergy/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pytestCheckHook
-, pythonOlder
 , numpy
 , scipy
 , matplotlib
@@ -14,7 +13,6 @@ buildPythonPackage rec {
   pname = "synergy";
   version = "0.5.1";
   format = "setuptools";
-  disabled = pythonOlder "3.5";
 
   # Pypi does not contain unit tests
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/telethon/default.nix
+++ b/pkgs/development/python-modules/telethon/default.nix
@@ -4,7 +4,6 @@
 , openssl
 , rsa
 , pyaes
-, pythonOlder
 , setuptools
 , pytest-asyncio
 , pytestCheckHook
@@ -14,7 +13,6 @@ buildPythonPackage rec {
   pname = "telethon";
   version = "1.26.1";
   format = "pyproject";
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "LonamiWebs";

--- a/pkgs/development/python-modules/tinydb/default.nix
+++ b/pkgs/development/python-modules/tinydb/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchFromGitHub
 , poetry-core
 , pytestCheckHook
@@ -11,7 +10,6 @@
 buildPythonPackage rec {
   pname = "tinydb";
   version = "4.8.0";
-  disabled = pythonOlder "3.5";
   format = "pyproject";
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/ufonormalizer/default.nix
+++ b/pkgs/development/python-modules/ufonormalizer/default.nix
@@ -1,11 +1,9 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder, setuptools-scm }:
+{ lib, buildPythonPackage, fetchPypi, setuptools-scm }:
 
 buildPythonPackage rec {
   pname = "ufonormalizer";
   version = "0.6.1";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/uharfbuzz/default.nix
+++ b/pkgs/development/python-modules/uharfbuzz/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , buildPythonPackage
 , fetchFromGitHub
-, pythonOlder
 , cython
 , setuptools
 , setuptools-scm
@@ -14,8 +13,6 @@ buildPythonPackage rec {
   pname = "uharfbuzz";
   version = "0.39.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "harfbuzz";

--- a/pkgs/development/python-modules/unidecode/default.nix
+++ b/pkgs/development/python-modules/unidecode/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pytestCheckHook
-, pythonOlder
 , setuptools
 }:
 
@@ -10,8 +9,6 @@ buildPythonPackage rec {
   pname = "unidecode";
   version = "1.3.8";
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "avian2";

--- a/pkgs/development/python-modules/wrapio/default.nix
+++ b/pkgs/development/python-modules/wrapio/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchPypi
 }:
 
@@ -8,8 +7,6 @@ buildPythonPackage rec {
   pname = "wrapio";
   version = "2.0.0";
   format = "setuptools";
-
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/xpath-expressions/default.nix
+++ b/pkgs/development/python-modules/xpath-expressions/default.nix
@@ -4,7 +4,6 @@
 , fetchpatch
 , lxml
 , poetry-core
-, pythonOlder
 , pytestCheckHook
 }:
 
@@ -12,7 +11,6 @@ buildPythonPackage rec {
   pname = "xpath-expressions";
   version = "1.1.0";
   format = "pyproject";
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "orf";

--- a/pkgs/development/python-modules/yanc/default.nix
+++ b/pkgs/development/python-modules/yanc/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, pythonOlder, fetchPypi, nose }:
+{ lib, buildPythonPackage, fetchPypi, nose }:
 
 buildPythonPackage rec {
   pname = "yanc";
@@ -11,7 +11,7 @@ buildPythonPackage rec {
   };
 
   # Tests fail on Python>=3.5. See: https://github.com/0compute/yanc/issues/10
-  doCheck = pythonOlder "3.5";
+  doCheck = false;
 
   nativeCheckInputs = [ nose ];
 

--- a/pkgs/development/tools/bashate/default.nix
+++ b/pkgs/development/tools/bashate/default.nix
@@ -6,7 +6,6 @@
 , mock
 , pbr
 , pytestCheckHook
-, pythonOlder
 , setuptools
 , testtools
 }:
@@ -14,7 +13,6 @@
 buildPythonApplication rec {
   pname = "bashate";
   version = "2.1.1";
-  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
## Description of changes

part of: https://github.com/NixOS/nixpkgs/issues/312288

This pr removes all the mention of `pythonOlder 3.5`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
