### PR TITLE
jupyter updates 2024-05-18

### DIFF
--- a/pkgs/development/python-modules/anywidget/default.nix
+++ b/pkgs/development/python-modules/anywidget/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "anywidget";
-  version = "0.9.10";
+  version = "0.9.11";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-OQpigkCYHAmBPHUjJ53cq4L/T9Moet1UM7eLE2kIkGg=";
+    hash = "sha256-WN3tjobsJ84odgyUVzF2YxE9mvYIlH7mqNDstSiyLNw=";
   };
 
   # We do not need the jupyterlab build dependency, because we do not need to
@@ -46,6 +46,11 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     watchfiles
+  ];
+
+  disabledTests = [
+    # requires package.json
+    "test_version"
   ];
 
   pythonImportsCheck = [ "anywidget" ];

--- a/pkgs/development/python-modules/jupyterlab-git/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-git/default.nix
@@ -20,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "jupyterlab-git";
-  version = "0.50.0";
+  version = "0.50.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "jupyterlab_git";
     inherit version;
-    hash = "sha256-CYWVRtOQE067kYqWXCw/4mBf6v4yfPYWFb592Qtb37s=";
+    hash = "sha256-v08Go/vCsquE6l1SMmqg4LjM9OmjNX+jGKEZVg4cak0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/jupyterlab/default.nix
+++ b/pkgs/development/python-modules/jupyterlab/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "jupyterlab";
-  version = "4.1.8";
+  version = "4.2.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-M4St7YaA585QT9Y7i7iaOd8hycdpTZ59xKaHQs2zD5s=";
+    hash = "sha256-NW6SBaaiq2icR8j+SRnbpsB243bQPya6rcBXSMJDXdU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/marimo/default.nix
+++ b/pkgs/development/python-modules/marimo/default.nix
@@ -3,30 +3,32 @@
 , fetchPypi
 , pythonOlder
 , setuptools
+, black
 , click
+, docutils
+, itsdangerous
 , jedi
 , markdown
-, pymdown-extensions
+, psutil
 , pygments
+, pymdown-extensions
+, starlette
 , tomlkit
 , uvicorn
-, starlette
 , websockets
-, docutils
-, black
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "marimo";
-  version = "0.4.10";
+  version = "0.6.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-F6Hf8KPIkXuRhO/1mVHE1wfU6//vbUK1ghoqANmZjag=";
+    hash = "sha256-L6ICaaMRrMOr/d8CJGcXxOYCWTVh8ObckW7xNeLRB2Q=";
   };
 
   build-system = [
@@ -34,17 +36,19 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
+    black
     click
+    docutils
+    itsdangerous
     jedi
     markdown
-    pymdown-extensions
+    psutil
     pygments
+    pymdown-extensions
+    starlette
     tomlkit
     uvicorn
-    starlette
     websockets
-    docutils
-    black
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/nbdev/default.nix
+++ b/pkgs/development/python-modules/nbdev/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "nbdev";
-  version = "2.3.21";
+  version = "2.3.22";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-H3KHnVOdy+Hdpka+dxp/qPj1HZSXIbXJshnZuXVo9DQ=";
+    hash = "sha256-CO88zk4aPoaYokt98IYXpfTrhdVBgCwM9BSiKqWeKm4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/notebook/default.nix
+++ b/pkgs/development/python-modules/notebook/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "notebook";
-  version = "7.1.3";
+  version = "7.2.0";
   disabled = pythonOlder "3.8";
 
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-Qfzr/0TPe7k3cYCAi8uuBmYptV2MdyLx6751ykT5z8E=";
+    hash = "sha256-NKK6SwitXRnskw23SE+3l0aheEvp4aX4IY+a+GVqFB8=";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Update jupyter-related packages at once to avoid building hundreds of packages over and over again.

This PR is based on the commits generated by the following command.

```
nix search nixpkgs#python311Packages 'ipython|jupyter|notebook' --json | jq -r 'keys | .[]' | cut -d . -f 3,4 | xargs -n 1 nix-update --commit
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
