### PR TITLE
electrs: 0.10.1 -> 0.10.5

### DIFF
--- a/pkgs/applications/blockchains/electrs/default.nix
+++ b/pkgs/applications/blockchains/electrs/default.nix
@@ -12,16 +12,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "electrs";
-  version = "0.10.1";
+  version = "0.10.5";
 
   src = fetchFromGitHub {
     owner = "romanz";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-cRnCo/N0k5poiOh308Djw6bySFQFIY3GiD2qjRyMjLM=";
+    hash = "sha256-tAHN5HWI9XsiCQzqLNtiib9wMskjfogc44+b4Bsjpog=";
   };
 
-  cargoHash = "sha256-fsYJ+80se5VsIaRkFgwJaPPgRw/WdsecRTt6EIjoQTQ=";
+  cargoHash = "sha256-M0DIKt41K3BcP43+fBhv3HbRcIh8U9nhQYA/sm+bNow=";
 
   # needed for librocksdb-sys
   nativeBuildInputs = [ rustPlatform.bindgenHook ];


### PR DESCRIPTION
https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#0105-may-18-2024

## Things done
- [x] Built and run on `x86_64-linux`

cc @prusnak