### PR TITLE
isisdl: init at 1.3.20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2369,6 +2369,13 @@
     githubId = 164148;
     name = "Ben Darwin";
   };
+  bchmnn = {
+    email = "jacob.bachmann@posteo.de";
+    matrix = "@trilloyd:matrix.tu-berlin.de";
+    github = "bchmnn";
+    githubId = 34620799;
+    name = "Jacob Bachmann";
+  };
   bdd = {
     email = "bdd@mindcast.org";
     github = "bdd";

--- a/pkgs/by-name/is/isisdl/package.nix
+++ b/pkgs/by-name/is/isisdl/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  fetchPypi,
+  python3Packages,
+  util-linux,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "isisdl";
+  version = "1.3.20";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-s0vGCJVSa6hf6/sIhzmaxpziP4izoRwcZfxvm//5inY=";
+  };
+
+  pyproject = true;
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    cryptography
+    requests
+    pyyaml
+    packaging
+    colorama
+    pyinotify
+    distro
+    psutil
+  ];
+
+  pythonRelaxDeps = [
+    "cryptography"
+    "requests"
+    "packaging"
+    "distro"
+    "psutil"
+  ];
+
+  buildInputs = [
+    util-linux # for runtime dependency `lsblk`
+  ];
+
+  # disable tests since they require valid login credentials
+  doCheck = false;
+
+  meta = {
+    homepage = "https://github.com/Emily3403/isisdl";
+    description = "Downloader for ISIS of TU-Berlin";
+    longDescription = ''
+      A downloading utility for ISIS of TU-Berlin.
+      Download all your files and videos from ISIS.
+    '';
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ bchmnn ];
+    mainProgram = "isisdl";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`isisdl` is a downloading utility for ISIS of TU-Berlin. Download all your files and videos from ISIS.

Homepage: https://github.com/Emily3403/isisdl

```
$ ./result/bin/isisdl -v
isisdl version 1.3.20

Running on Linux
This is not the compiled version

working directory: /home/<...>/isisdl
python executable: /nix/store/k3701zl6gmx3la7y4dnflcvf3xfy88kh-python3-3.11.9/bin/python3.11

database_version = 2
has_ffmpeg = True
forbidden_chars = {'\x00', '/'}
fstype = 'btrfs'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
