### PR TITLE
treewide: drop workarounds for cargo --frozen

### DIFF
--- a/pkgs/applications/display-managers/lemurs/default.nix
+++ b/pkgs/applications/display-managers/lemurs/default.nix
@@ -19,9 +19,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-uuHPJe+1VsnLRGbHtgTMrib6Tk359cwTDVfvtHnDToo=";
 
-  # Fixes a lock issue
-  preConfigure = "cargo update --offline";
-
   buildInputs = [
     linux-pam
   ];

--- a/pkgs/applications/misc/slippy/default.nix
+++ b/pkgs/applications/misc/slippy/default.nix
@@ -53,11 +53,6 @@ rustPlatform.buildRustPackage rec {
     darwin.apple_sdk.frameworks.Security
   ];
 
-  # Cargo.lock is outdated
-  postConfigure = ''
-    cargo metadata --offline
-  '';
-
   meta = with lib; {
     description = "Markdown slideshows in Rust";
     homepage = "https://github.com/axodotdev/slippy";

--- a/pkgs/applications/networking/irc/tiny/default.nix
+++ b/pkgs/applications/networking/irc/tiny/default.nix
@@ -23,11 +23,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-AhQCfLCoJU7o8s+XL3hDOPmZi9QjOxXSA9uglA1KSuY=";
 
-  # Cargo.lock is outdated
-  preConfigure = ''
-    cargo metadata --offline
-  '';
-
   nativeBuildInputs = lib.optional stdenv.isLinux pkg-config;
   buildInputs = lib.optionals dbusSupport [ dbus ]
                 ++ lib.optionals useOpenSSL [ openssl ]

--- a/pkgs/applications/networking/sync/celeste/default.nix
+++ b/pkgs/applications/networking/sync/celeste/default.nix
@@ -47,11 +47,6 @@ rustPlatform.buildRustPackage rec {
     sed -i "#/bin/celeste#d" justfile
   '';
 
-  # Cargo.lock is outdated
-  preConfigure = ''
-    cargo update --offline
-  '';
-
   RUSTC_BOOTSTRAP = 1;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/bu/bunbun/package.nix
+++ b/pkgs/by-name/bu/bunbun/package.nix
@@ -24,11 +24,6 @@ rustPlatform.buildRustPackage rec {
     darwin.apple_sdk.frameworks.SystemConfiguration
   ];
 
-  # Cargo.lock is outdated
-  preConfigure = ''
-    cargo update --offline
-  '';
-
   meta = with lib; {
     description = "A simple and adorable sysinfo utility written in Rust";
     homepage = "https://github.com/devraza/bunbun";

--- a/pkgs/by-name/es/esbuild-config/package.nix
+++ b/pkgs/by-name/es/esbuild-config/package.nix
@@ -16,11 +16,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-Z7uYOjMNxsEmsEXDOIr1zIq4nCgHvHIqpRnRH037b8g=";
 
-  # Cargo.lock is outdated
-  postConfigure = ''
-    cargo metadata --offline
-  '';
-
   meta = with lib; {
     description = "Config files for esbuild";
     homepage = "https://github.com/bpierre/esbuild-config";

--- a/pkgs/development/compilers/rust/cargo-auditable.nix
+++ b/pkgs/development/compilers/rust/cargo-auditable.nix
@@ -22,11 +22,6 @@ let
 
     cargoHash = "sha256-4o3ctun/8VcBRuj+j0Yaawdkyn6Z6LPp+FTyhPxQWU8=";
 
-    # Cargo.lock is outdated
-    preConfigure = ''
-      cargo update --offline
-    '';
-
     meta = with lib; {
       description = "A tool to make production Rust binaries auditable";
       mainProgram = "cargo-auditable";

--- a/pkgs/development/python-modules/quil/default.nix
+++ b/pkgs/development/python-modules/quil/default.nix
@@ -33,10 +33,6 @@ buildPythonPackage rec {
 
   buildAndTestSubdir = "quil-py";
 
-  preConfigure = ''
-    cargo metadata --offline
-  '';
-
   build-system = [
     rustPlatform.cargoSetupHook
     rustPlatform.maturinBuildHook

--- a/pkgs/development/python-modules/tokenizers/default.nix
+++ b/pkgs/development/python-modules/tokenizers/default.nix
@@ -100,12 +100,6 @@ buildPythonPackage rec {
     Security
   ];
 
-  # Cargo.lock is outdated
-  # TODO: remove at next release
-  preConfigure = ''
-    cargo update --offline
-  '';
-
   dependencies = [
     numpy
     huggingface-hub

--- a/pkgs/development/tools/rust/cargo-local-registry/default.nix
+++ b/pkgs/development/tools/rust/cargo-local-registry/default.nix
@@ -42,11 +42,6 @@ rustPlatform.buildRustPackage rec {
   # tests require internet access
   doCheck = false;
 
-  # Cargo.lock is outdated
-  preConfigure = ''
-    cargo metadata --offline
-  '';
-
   meta = with lib; {
     description = "A cargo subcommand to manage local registries";
     mainProgram = "cargo-local-registry";

--- a/pkgs/development/tools/rust/sqlx-cli/default.nix
+++ b/pkgs/development/tools/rust/sqlx-cli/default.nix
@@ -27,12 +27,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-sMyK1v4pJmmlN47mvgUkpLBjcpmT346VSp984IpvVWY=";
 
-  # Prepare the Cargo.lock for offline use.
-  # See https://github.com/NixOS/nixpkgs/issues/261412
-  postConfigure = ''
-    cargo metadata --offline > /dev/null
-  '';
-
   buildNoDefaultFeatures = true;
   buildFeatures = [
     "native-tls"

--- a/pkgs/tools/graphics/gifski/default.nix
+++ b/pkgs/tools/graphics/gifski/default.nix
@@ -44,11 +44,6 @@ rustPlatform.buildRustPackage rec {
   #
   checkType = "debug";
 
-  # Cargo.lock is outdated
-  postPatch = ''
-    cargo metadata --offline
-  '';
-
   meta = with lib; {
     description = "GIF encoder based on libimagequant (pngquant)";
     homepage = "https://gif.ski/";

--- a/pkgs/tools/misc/bartib/default.nix
+++ b/pkgs/tools/misc/bartib/default.nix
@@ -12,9 +12,6 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "sha256-s/oGv7/0LgNpdGu6dnvvbxDgFDvcvcHL01dSPxhMVWE=";
-  preConfigure = ''
-    cargo metadata --offline
-  '';
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/tools/misc/kalker/default.nix
+++ b/pkgs/tools/misc/kalker/default.nix
@@ -23,11 +23,6 @@ rustPlatform.buildRustPackage rec {
 
   outputs = [ "out" "lib" ];
 
-  # Cargo.lock is outdated
-  preConfigure = ''
-    cargo metadata --offline
-  '';
-
   postInstall = ''
     moveToOutput "lib" "$lib"
   '';

--- a/pkgs/tools/misc/pouf/default.nix
+++ b/pkgs/tools/misc/pouf/default.nix
@@ -16,11 +16,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-rVJAaeg27SdM8cTx12rKLIGEYtXUhLHXUYpT78oVNlo=";
 
-  # Cargo.lock is outdated.
-  preConfigure = ''
-    cargo update --offline
-  '';
-
   postInstall = "make PREFIX=$out copy-data";
 
   meta = with lib; {

--- a/pkgs/tools/text/teip/default.nix
+++ b/pkgs/tools/text/teip/default.nix
@@ -23,11 +23,6 @@ rustPlatform.buildRustPackage rec {
 
   nativeCheckInputs = [ perl ];
 
-  # Cargo.lock is outdated
-  preConfigure = ''
-    cargo update --offline
-  '';
-
   # tests are locale sensitive
   preCheck = ''
     export LANG=${if stdenv.isDarwin then "en_US.UTF-8" else "C.UTF-8"}


### PR DESCRIPTION
## Description of changes

Since #310632, these are no longer necessary!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
