### PR TITLE
treewide: fix darwin build errors due to missing `IOKit` framework

### DIFF
--- a/pkgs/by-name/rc/rcp/package.nix
+++ b/pkgs/by-name/rc/rcp/package.nix
@@ -1,6 +1,8 @@
 { lib
+, stdenv
 , fetchFromGitHub
 , rustPlatform
+, darwin
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -13,6 +15,10 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     hash = "sha256-kVO2WMwB/Lv4fCcdXaWL/Gfmenky6uMNVrUwhWU9y7A=";
   };
+
+  buildInputs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    IOKit
+  ]);
 
   cargoHash = "sha256-Pa8YgFAT9nue/QLhHQm6PlTJU/myK60UcND5TthMOxc=";
 

--- a/pkgs/by-name/rc/rcp/package.nix
+++ b/pkgs/by-name/rc/rcp/package.nix
@@ -36,5 +36,7 @@ rustPlatform.buildRustPackage rec {
     license = with licenses; [ mit ];
     mainProgram = "rcp";
     maintainers = with maintainers; [ wykurz ];
+    # = note: Undefined symbols for architecture x86_64: "_utimensat"
+    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 }

--- a/pkgs/development/python-modules/pystatgrab/default.nix
+++ b/pkgs/development/python-modules/pystatgrab/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , cython
 , fetchFromGitHub
@@ -8,6 +9,7 @@
 , setuptools
 , unittestCheckHook
 , wheel
+, darwin
 }:
 
 buildPythonPackage rec {
@@ -33,7 +35,9 @@ buildPythonPackage rec {
 
   buildInputs = [
     libstatgrab
-  ];
+  ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    IOKit
+  ]);
 
   nativeCheckInputs = [
     unittestCheckHook

--- a/pkgs/development/tools/nufmt/default.nix
+++ b/pkgs/development/tools/nufmt/default.nix
@@ -1,8 +1,10 @@
 
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   rustPlatform,
+  darwin,
   ...
 }:
 rustPlatform.buildRustPackage rec {
@@ -15,6 +17,10 @@ rustPlatform.buildRustPackage rec {
     rev = "796ee834c1e31ead4c5479bf2827a4339c5d61d1";
     hash = "sha256-BwKLl8eMCrqVt9PA5SHAXxu3ypP2ePcSuljKL+wSkvw=";
   };
+
+  buildInputs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    IOKit
+  ]);
 
   cargoSha256 = "sha256-16Z20opeZpoa7h258um+grL3ktPmY4P0M/tqMTr5hYc=";
 


### PR DESCRIPTION
## Description of changes

Solves packages failing due to:

```
  = note: ld: framework not found IOKit
```

All modified packages should build just fine, except `rcp` which fails (and thus marked as broken) due to:

```
       >   = note: Undefined symbols for architecture x86_64:
       >             "_utimensat", referenced from:
       >                 nix::sys::stat::utimensat::hcbcd556c98a2ad7f in rcp-3d56da0b226b7fd3.common-0e282218e2519163.common.efff97c1573bd2a8-cgu.3.rcgu.o.rcgu.o
       >                 nix::with_nix_path_allocating::h8d4a1aa59714ebfc (.llvm.13116499662928166544) in rcp-3d56da0b226b7fd3.common-0e282218e2519163.common.efff97c1573bd2a8-cgu.4.rcgu.o.rcgu.o
       >           ld: symbol(s) not found for architecture x86_64
       >           clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
