### PR TITLE
catppuccinifier-gui: init at 8.0.0

### DIFF
--- a/pkgs/by-name/ca/catppuccinifier-gui/package.nix
+++ b/pkgs/by-name/ca/catppuccinifier-gui/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  gtk3,
+  glib,
+  dbus,
+  curl,
+  wget,
+  cairo,
+  stdenv,
+  librsvg,
+  libsoup,
+  fetchzip,
+  openssl_3,
+  webkitgtk,
+  gdk-pixbuf,
+  pkg-config,
+  makeDesktopItem,
+  copyDesktopItems,
+  autoPatchelfHook,
+}:
+let
+  version = "8.0.0";
+in
+stdenv.mkDerivation {
+  pname = "catppuccinifier-gui";
+  inherit version;
+
+  src = fetchzip {
+    url = "https://github.com/lighttigerXIV/catppuccinifier/releases/download/${version}/Catppuccinifer-Linux-${version}.zip";
+    hash = "sha256-fG6YhLsjvMUIWsOnm+GSOh6LclCAISPSRiDQdWLlAR4=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    pkg-config
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    curl
+    wget
+    webkitgtk
+    gtk3
+    cairo
+    gdk-pixbuf
+    libsoup
+    glib
+    dbus
+    openssl_3
+    librsvg
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm555 installation-files/catppuccinifier-gui "$out/bin/catppuccinifier-gui"
+    install -Dm644 installation-files/catppuccinifier.png "$out/share/pixmaps/catppuccinifier.png"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = "catppuccinifier";
+      name = "catppuccinifier";
+      exec = "catppuccinifier-gui";
+      icon = "catppuccinifier";
+      comment = "Apply catppuccin flavors to your wallpapers";
+    })
+  ];
+
+  meta = {
+    description = "Apply catppuccin flavors to your wallpapers";
+    homepage = "https://github.com/lighttigerXIV/catppuccinifier";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ isabelroses ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "catppuccinifier-gui";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Description of changes

One of the issues with building catppuccinifier from source is that it uses `pngquant-bin` which needs to get remote binaries. Meaning its not able to properly reproduce using nix, so I used the native binaries instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
