### PR TITLE
pywal16 package added

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14071,6 +14071,11 @@
     githubId = 6295090;
     name = "Mats";
   };
+  mygithubblueberry = {
+    github = "MyGitHubBlueberry";
+    githubId = 105305430;
+    name = "Maksim Brozik";
+  };
   mynacol = {
     github = "Mynacol";
     githubId = 26695166;

--- a/pkgs/development/python-modules/pywal16/convert.patch
+++ b/pkgs/development/python-modules/pywal16/convert.patch
@@ -1,0 +1,21 @@
+diff --git a/pywal/backends/wal.py b/pywal/backends/wal.py
+index a75fdc5..4339680 100644
+--- a/pywal/backends/wal.py
++++ b/pywal/backends/wal.py
+@@ -21,15 +21,7 @@ def imagemagick(color_count, img, magick_command):
+
+ def has_im():
+     """Check to see if the user has im installed."""
+-    if shutil.which("magick"):
+-        return ["magick", "convert"]
+-
+-    if shutil.which("convert"):
+-        return ["convert"]
+-
+-    logging.error("Imagemagick wasn't found on your system.")
+-    logging.error("Try another backend. (wal --backend)")
+-    sys.exit(1)
++    return ["@convert@"]
+
+
+ def gen_colors(img):

--- a/pkgs/development/python-modules/pywal16/default.nix
+++ b/pkgs/development/python-modules/pywal16/default.nix
@@ -3,11 +3,11 @@
 # Please, feel free to maintain this (I don't know what I'm doing)
 
 
-{ lib, 
+{ lib,
   python3,
-  fetchPypi, 
-  imagemagick, 
-  feh, 
+  fetchPypi,
+  imagemagick,
+  feh,
   ...
 }:
 

--- a/pkgs/development/python-modules/pywal16/default.nix
+++ b/pkgs/development/python-modules/pywal16/default.nix
@@ -1,0 +1,56 @@
+# This package is almost copy-paset of original Pywal's
+# So, I give credit to Fresheyeball, as to maintainer
+# Please, feel free to maintain this (I don't know what I'm doing)
+
+
+{ lib, 
+  python3,
+  fetchPypi, 
+  imagemagick, 
+  feh, 
+  ...
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "pywal";
+  version = "3.3.0";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1drha9kshidw908k7h3gd9ws2bl64ms7bjcsa83pwb3hqa9bkspg";
+  };
+
+  patches = [
+    ./feh.patch
+    ./convert.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace pywal/backends/wal.py --subst-var-by convert "${imagemagick}/bin/convert"
+    substituteInPlace pywal/wallpaper.py --subst-var-by feh "${feh}/bin/feh"
+  '';
+
+  preCheck = ''
+    mkdir tmp
+    HOME=$PWD/tmp
+
+    for f in tests/test_export.py tests/test_util.py ; do
+      substituteInPlace "$f" \
+        --replace '/tmp/' "$TMPDIR/"
+    done
+  '';
+
+  # installPhase = ''
+  #   mkdir -p ${HOME}/.local/bin/
+  # '';
+
+  meta = {
+      description = "16 colors fork of pywal";
+      mainProgram = "wal";
+      homepage = "https://github.com/eylles/pywal16";
+      changelog = "https://github.com/eylles/pywal16/blob/${version}/CHANGELOG.md";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ MyGitHubBlueberry ]; /* i am affraid of maintaining this; I would love to change it "Fresheyeball", but idk if i am allowed to */
+  };
+}

--- a/pkgs/development/python-modules/pywal16/feh.patch
+++ b/pkgs/development/python-modules/pywal16/feh.patch
@@ -1,0 +1,39 @@
+commit c31faa212e09aa62c232d9008e05976b1cdc9ee5
+Author: Frederik Rietdijk <fridh@fridh.nl>
+Date:   Wed Dec 26 12:54:32 2018 +0100
+
+    nix: hardcode feh
+
+diff --git a/pywal/wallpaper.py b/pywal/wallpaper.py
+index ba61e66..fad34f7 100644
+--- a/pywal/wallpaper.py
++++ b/pywal/wallpaper.py
+@@ -47,27 +47,7 @@ def xfconf(path, img):
+ 
+ def set_wm_wallpaper(img):
+     """Set the wallpaper for non desktop environments."""
+-    if shutil.which("feh"):
+-        util.disown(["feh", "--bg-fill", img])
+-
+-    elif shutil.which("nitrogen"):
+-        util.disown(["nitrogen", "--set-zoom-fill", img])
+-
+-    elif shutil.which("bgs"):
+-        util.disown(["bgs", "-z", img])
+-
+-    elif shutil.which("hsetroot"):
+-        util.disown(["hsetroot", "-fill", img])
+-
+-    elif shutil.which("habak"):
+-        util.disown(["habak", "-mS", img])
+-
+-    elif shutil.which("display"):
+-        util.disown(["display", "-backdrop", "-window", "root", img])
+-
+-    else:
+-        logging.error("No wallpaper setter found.")
+-        return
++    return util.disown(["@feh@", "--bg-fill", img])
+ 
+ 
+ def set_desktop_wallpaper(desktop, img):


### PR DESCRIPTION
## Description of changes
This is fork of pywal, named [pywal16](https://github.com/eylles/pywal16), maintained by [eylles](https://github.com/eylles).
This package generates color palletes based on wallpaper, but it does it in 16 and not 8 color palette.
Some packages support pywal16 already, as original pywal replacement [wpgtk](https://github.com/deviantfero/wpgtk) will be a good example.

Motivation:
- This package is quite nice, I would use it myself
- Fixes pywal 8 color problem
- eylles, the package developer, is building handy [git repo](https://github.com/eylles/pywal16-libadwaita) whith a templates for gui apps, and as person who uses wallust (pywal alternative), I would love to switch to something with gtk-qt support.

Note:
- I build package on my nixos with nix flakes and it works all right. Idk if it is "applicable" testing, so I won't tick this box. 
- I have read contributing.md, but I'm not sure if I did everything ok, so this box is also unticked.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
