### PR TITLE
netcdffortran: fix darwin build

### DIFF
--- a/pkgs/development/libraries/netcdf-fortran/default.nix
+++ b/pkgs/development/libraries/netcdf-fortran/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, netcdf, hdf5, curl, gfortran, CoreFoundation }:
+{ lib, stdenv, fetchFromGitHub, netcdf, hdf5, curl, gfortran, CoreFoundation, CoreServices, SystemConfiguration }:
 stdenv.mkDerivation rec {
   pname = "netcdf-fortran";
   version = "4.4.5";
@@ -12,7 +12,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ gfortran ];
   buildInputs = [ netcdf hdf5 curl ]
-    ++ lib.optional stdenv.isDarwin CoreFoundation;
+    ++ lib.optionals stdenv.isDarwin [
+      CoreFoundation
+      CoreServices
+      SystemConfiguration
+    ];
+  NIX_LDFLAGS = lib.optionalString stdenv.isDarwin ("-F${CoreServices}/Library/Frameworks -F${SystemConfiguration}/Library/Frameworks");
   doCheck = true;
 
   FFLAGS = [ "-std=legacy" ];

--- a/pkgs/development/libraries/netcdf-fortran/default.nix
+++ b/pkgs/development/libraries/netcdf-fortran/default.nix
@@ -17,7 +17,10 @@ stdenv.mkDerivation rec {
       CoreServices
       SystemConfiguration
     ];
-  NIX_LDFLAGS = lib.optionalString stdenv.isDarwin ("-F${CoreServices}/Library/Frameworks -F${SystemConfiguration}/Library/Frameworks");
+  env.NIX_LDFLAGS = toString (lib.optionals stdenv.isDarwin [
+    "-F${CoreServices}/Library/Frameworks"
+    "-F${SystemConfiguration}/Library/Frameworks"
+  ]);
   doCheck = true;
 
   FFLAGS = [ "-std=legacy" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10841,7 +10841,7 @@ with pkgs;
   netcdfcxx4 = callPackage ../development/libraries/netcdf-cxx4 { };
 
   netcdffortran = callPackage ../development/libraries/netcdf-fortran {
-    inherit (darwin.apple_sdk.frameworks) CoreFoundation;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation CoreServices SystemConfiguration;
   };
 
   networking-ts-cxx = callPackage ../development/libraries/networking-ts-cxx { };


### PR DESCRIPTION
## Description of changes

Package would fail initially with:

```
ld: framework not found CoreServices
collect2: error: ld returned 1 exit status
```

`NIX_LGFLAGS` is needed as per https://github.com/NixOS/nixpkgs/pull/41914.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
