### PR TITLE
python311Packages.pefile: fetch from pypi

### DIFF
--- a/pkgs/development/python-modules/pefile/default.nix
+++ b/pkgs/development/python-modules/pefile/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , future
-, fetchFromGitHub
+, fetchPypi
 , setuptools-scm
 , pythonOlder
 }:
@@ -13,11 +13,10 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.6";
 
-  src = fetchFromGitHub {
-    owner = "erocarrera";
-    repo = pname;
-    rev = "refs/tags/v${version}";
-    hash = "sha256-lD8GpNl+cVNYTZUKFRF1/2kDwEbn/ekRBNBTYuFmFW0=";
+  # DON'T fetch from github, the repo is >60 MB due to test artifacts, which we cannot use
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-guYRQASz1pEcd8OVPjg4ZUsEURuLZuhYPbcMZZmAF9w=";
   };
 
   nativeBuildInputs = [
@@ -28,7 +27,7 @@ buildPythonPackage rec {
     future
   ];
 
-  # Test data encrypted
+  # Test data contains properitary executables and malware, and is therefore encrypted
   doCheck = false;
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/virt-firmware/default.nix
+++ b/pkgs/development/python-modules/virt-firmware/default.nix
@@ -1,4 +1,6 @@
 { lib
+, pkgs
+, stdenv
 , buildPythonPackage
 , fetchPypi
 , setuptools
@@ -10,7 +12,6 @@
 buildPythonPackage rec {
   pname = "virt-firmware";
   version = "24.4";
-
   pyproject = true;
 
   src = fetchPypi {
@@ -18,22 +19,27 @@ buildPythonPackage rec {
     hash = "sha256-rqhaKDOQEOj6bcRz3qZJ+a4yG1qTC9SUjuxMhZlnmwU=";
   };
 
-  pythonImportsCheck = [ "virt.firmware.efi" ];
-
-  nativeBuildInputs = [
+  build-system = [
     setuptools
   ];
 
-  nativeCheckInputs = [
-    pytestCheckHook
-  ];
-  pytestFlagsArray = ["tests/tests.py"];
-
-  propagatedBuildInputs = [
+  dependencies = [
     setuptools
     cryptography
     pefile
   ];
+
+  # tests require systemd-detect-virt
+  doCheck = lib.meta.availableOn stdenv.hostPlatform pkgs.systemd;
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pkgs.systemd
+  ];
+
+  pytestFlagsArray = [ "tests/tests.py" ];
+
+  pythonImportsCheck = [ "virt.firmware.efi" ];
 
   meta = with lib; {
     description = "Tools for virtual machine firmware volumes";


### PR DESCRIPTION
The GitHub repository contains a large chunk of unusable test fixtures and there is no point in fetching >60 MB of source, that we cannot use.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
