### PR TITLE
python3Packages.rio-tiler: init at 6.6.1

### DIFF
--- a/pkgs/development/python-modules/color-operations/default.nix
+++ b/pkgs/development/python-modules/color-operations/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  pythonOlder,
+
+  colormath,
+  cython,
+  oldest-supported-numpy,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "color-operations";
+  version = "0.1.3";
+  pyproject = true;
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "vincentsarago";
+    repo = "color-operations";
+    rev = version;
+    hash = "sha256-KsrgilcNK2ufPKrhtGdf8mdlFzhsHB2jHN+WDlZqabc=";
+  };
+
+  nativeBuildInputs = [
+    cython
+    setuptools
+  ];
+
+  propagatedBuildInputs = [ oldest-supported-numpy ];
+
+  nativeCheckInputs = [
+    colormath
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    python setup.py build_ext --inplace
+  '';
+
+  pythonImportsCheck = [ "color_operations" ];
+
+  meta = {
+    description = "Apply basic color-oriented image operations. Fork of rio-color";
+    homepage = "https://github.com/vincentsarago/color-operations";
+    license = lib.licenses.mit;
+    maintainers = lib.teams.geospatial.members;
+  };
+}

--- a/pkgs/development/python-modules/morecantile/default.nix
+++ b/pkgs/development/python-modules/morecantile/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  pythonOlder,
+
+  attrs,
+  click,
+  flit,
+  mercantile,
+  pydantic,
+  pyproj,
+  rasterio,
+}:
+
+buildPythonPackage rec {
+  pname = "morecantile";
+  version = "5.3.0";
+  pyproject = true;
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "developmentseed";
+    repo = "morecantile";
+    rev = version;
+    hash = "sha256-F7xYQrOngoRsZjmS6ZHRGN0/GD53AYcMQzyY1LZ1O7I=";
+  };
+
+  nativeBuildInputs = [ flit ];
+
+  propagatedBuildInputs = [
+    attrs
+    click
+    pydantic
+    pyproj
+  ];
+
+  nativeCheckInputs = [
+    mercantile
+    pytestCheckHook
+    rasterio
+  ];
+
+  pythonImportsCheck = [ "morecantile" ];
+
+  meta = {
+    description = "Construct and use map tile grids in different projection";
+    homepage = "https://developmentseed.org/morecantile/";
+    license = lib.licenses.mit;
+    maintainers = lib.teams.geospatial.members;
+    mainProgram = "morecantile";
+  };
+}

--- a/pkgs/development/python-modules/pystac/default.nix
+++ b/pkgs/development/python-modules/pystac/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  pythonOlder,
+
+  html5lib,
+  jsonschema,
+  pytest-cov,
+  pytest-mock,
+  pytest-recording,
+  python-dateutil,
+  requests-mock,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pystac";
+  version = "1.10.1";
+  pyproject = true;
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "stac-utils";
+    repo = "pystac";
+    rev = "v${version}";
+    hash = "sha256-zJGDhKRX50Muo1YDEzfwypMLISnYBYKkPvUULYkUf68=";
+  };
+
+  build-system = [ setuptools ];
+
+  propagatedBuildInputs = [ python-dateutil ];
+
+  nativeCheckInputs = [
+    html5lib
+    jsonschema
+    pytestCheckHook
+    pytest-cov
+    pytest-mock
+    pytest-recording
+    requests-mock
+  ];
+
+  pythonImportsCheck = [ "pystac" ];
+
+  meta = {
+    description = "Python library for working with any SpatioTemporal Asset Catalog (STAC)";
+    homepage = "https://github.com/stac-utils/pystac";
+    license = lib.licenses.asl20;
+    maintainers = lib.teams.geospatial.members;
+  };
+}

--- a/pkgs/development/python-modules/rio-tiler/default.nix
+++ b/pkgs/development/python-modules/rio-tiler/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  pythonOlder,
+
+  attrs,
+  boto3,
+  cachetools,
+  color-operations,
+  hatchling,
+  httpx,
+  morecantile,
+  numexpr,
+  numpy,
+  pydantic,
+  pystac,
+  rasterio,
+  rioxarray,
+}:
+
+buildPythonPackage rec {
+  pname = "rio-tiler";
+  version = "6.6.1";
+  pyproject = true;
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "cogeotiff";
+    repo = "rio-tiler";
+    rev = version;
+    hash = "sha256-MR6kyoGM3uXt6JiIEfGcsmTmxqlLxUF9Wn+CFuK5LtQ=";
+  };
+
+  build-system = [ hatchling ];
+
+  propagatedBuildInputs = [
+    attrs
+    cachetools
+    color-operations
+    httpx
+    morecantile
+    numexpr
+    numpy
+    pydantic
+    pystac
+    rasterio
+  ];
+
+  nativeCheckInputs = [
+    boto3
+    pytestCheckHook
+    rioxarray
+  ];
+
+  pythonImportsCheck = [ "rio_tiler" ];
+
+  meta = with lib; {
+    description = "User friendly Rasterio plugin to read raster datasets";
+    homepage = "https://cogeotiff.github.io/rio-tiler/";
+    license = licenses.bsd3;
+    maintainers = lib.teams.geospatial.members;
+  };
+}

--- a/pkgs/development/python-modules/rioxarray/default.nix
+++ b/pkgs/development/python-modules/rioxarray/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  pythonOlder,
+
+  dask,
+  netcdf4,
+  numpy,
+  packaging,
+  pyproj,
+  rasterio,
+  setuptools,
+  xarray,
+}:
+
+buildPythonPackage rec {
+  pname = "rioxarray";
+  version = "0.15.5";
+  pyproject = true;
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "corteva";
+    repo = "rioxarray";
+    rev = version;
+    hash = "sha256-bumFZQktgUqo2lyoLtDXkh6Vv5oS/wobqYpvNYy7La0=";
+  };
+
+  build-system = [ setuptools ];
+
+  propagatedBuildInputs = [
+    numpy
+    packaging
+    pyproj
+    rasterio
+    xarray
+  ];
+
+  nativeCheckInputs = [
+    dask
+    netcdf4
+    pytestCheckHook
+  ];
+
+  disabledTests = [ "test_clip_geojson__no_drop" ];
+
+  pythonImportsCheck = [ "rioxarray" ];
+
+  meta = {
+    description = "geospatial xarray extension powered by rasterio";
+    homepage = "https://corteva.github.io/rioxarray/";
+    license = lib.licenses.asl20;
+    maintainers = lib.teams.geospatial.members;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2358,6 +2358,8 @@ self: super: with self; {
 
   collidoscope = callPackage ../development/python-modules/collidoscope { };
 
+  color-operations = callPackage ../development/python-modules/color-operations { };
+
   colorama = callPackage ../development/python-modules/colorama { };
 
   colorcet = callPackage ../development/python-modules/colorcet { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10052,6 +10052,8 @@ self: super: with self; {
 
   pysolcast = callPackage ../development/python-modules/pysolcast { };
 
+  pystac = callPackage ../development/python-modules/pystac { };
+
   pysubs2 = callPackage ../development/python-modules/pysubs2 { };
 
   pysuez = callPackage ../development/python-modules/pysuez { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7671,6 +7671,8 @@ self: super: with self; {
 
   more-properties = callPackage ../development/python-modules/more-properties { };
 
+  morecantile = callPackage ../development/python-modules/morecantile { };
+
   moreorless = callPackage ../development/python-modules/moreorless { };
 
   moretools = callPackage ../development/python-modules/moretools { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13285,6 +13285,8 @@ self: super: with self; {
 
   ring-doorbell = callPackage ../development/python-modules/ring-doorbell { };
 
+  rioxarray = callPackage ../development/python-modules/rioxarray { };
+
   ripe-atlas-cousteau = callPackage ../development/python-modules/ripe-atlas-cousteau { };
 
   ripe-atlas-sagan = callPackage ../development/python-modules/ripe-atlas-sagan { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13289,6 +13289,8 @@ self: super: with self; {
 
   ring-doorbell = callPackage ../development/python-modules/ring-doorbell { };
 
+  rio-tiler = callPackage ../development/python-modules/rio-tiler { };
+
   rioxarray = callPackage ../development/python-modules/rioxarray { };
 
   ripe-atlas-cousteau = callPackage ../development/python-modules/ripe-atlas-cousteau { };


### PR DESCRIPTION
## Description of changes
[**rio-tiler**](https://github.com/cogeotiff/rio-tiler) - user friendly Rasterio plugin to read raster datasets.

Added missed dependencies: morecantile, rioxarray, color-operations, pystac.

Closes #287477 (@frafra)

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
