### PR TITLE
flawz: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1174,6 +1174,15 @@
     githubId = 18249234;
     name = "Christopher Crouse";
   };
+  anas = {
+    email = "anas.elgarhy.dev@gmail.com";
+    github = "0x61nas";
+    githubId = 44965145;
+    name = "Anas Elgarhy";
+    keys = [{
+      fingerprint = "E10B D192 9231 08C7 3C35 7EC3 83E0 3DC6 F383 4086";
+    }];
+  };
   AnatolyPopov = {
     email = "aipopov@live.ru";
     github = "AnatolyPopov";

--- a/pkgs/by-name/fl/flawz/package.nix
+++ b/pkgs/by-name/fl/flawz/package.nix
@@ -1,0 +1,57 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, openssl
+, sqlite
+, installShellFiles
+, stdenv
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "flawz";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "orhun";
+    repo = "flawz";
+    rev = "v${version}";
+    hash = "sha256-eIZUKI/fdaSPHHEEaN/5s4I2LRX44FijUlKzzvuD42E=";
+  };
+
+  cargoHash = "sha256-UWjrVA5T78QLJtMug38y+egLnM+G7zmAIsNmqn2ZE5I=";
+
+  nativeBuildInputs = [ pkg-config installShellFiles ];
+
+  buildInputs = [ openssl sqlite ];
+  outputs = [ "out" "man" ];
+
+  postInstall = ''
+    export OUT_DIR=$(mktemp -d)
+
+    # Generate the man pages
+    cargo run --bin flawz-mangen
+    installManPage $OUT_DIR/flawz.1
+
+    # Generate shell completions
+    cargo run --bin flawz-completions
+    installShellCompletion \
+      --bash $OUT_DIR/flawz.bash \
+      --fish $OUT_DIR/flawz.fish \
+      --zsh $OUT_DIR/_flawz
+
+    # Clean up temporary directory
+    rm -rf $OUT_DIR
+  '';
+
+  meta = {
+    description = "Terminal UI for browsing CVEs";
+    homepage = "https://github.com/orhun/flawz";
+    changelog = "https://github.com/orhun/flawz/releases/tag/v${version}";
+    license = with lib.licenses; [ mit asl20 ];
+    mainProgram = "flawz";
+    maintainers = with lib.maintainers; [ anas ];
+    platforms = with lib.platforms; unix ++ windows;
+    broken = stdenv.isDarwin; # needing some apple_sdk packages
+  };
+}


### PR DESCRIPTION
## Description of changes

Create a new package, and add myself to the maintainers list.

[**flawz**](https://github.com/orhun/flawz) is a Terminal User Interface (TUI) written in Rust for browsing the security vulnerabilities (also known as CVEs)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
