### PR TITLE
zsh-wd: init at 0.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22741,6 +22741,12 @@
     githubId = 3248;
     name = "zimbatm";
   };
+  zimeg = {
+    email = "zim@o526.net";
+    github = "zimeg";
+    githubId = 18134219;
+    name = "zimeg";
+  };
   Zimmi48 = {
     email = "theo.zimmermann@telecom-paris.fr";
     github = "Zimmi48";

--- a/pkgs/by-name/zs/zsh-wd/package.nix
+++ b/pkgs/by-name/zs/zsh-wd/package.nix
@@ -1,0 +1,37 @@
+{ lib, stdenvNoCC, fetchFromGitHub, installShellFiles }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "wd";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "mfaerevaag";
+    repo = "wd";
+    rev = "v${version}";
+    sha256 = "sha256-u3n+JzInv8VajWAFXECuEOWuQurX8iWklwV2LG4Tj24=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  installPhase = ''
+    install -Dm755 wd.plugin.zsh $out/share/wd/wd.plugin.zsh
+    install -Dm755 wd.sh $out/share/wd/wd.sh
+    installManPage wd.1
+    installShellCompletion --zsh _wd.sh
+  '';
+
+  meta = with lib; {
+    description = "Jump to custom directories in zsh";
+    longDescription = ''
+      `wd` (warp directory) lets you jump to custom directories in zsh, without
+      using `cd`. Why? Because `cd` seems inefficient when the folder is
+      frequently visited or has a long path.
+    '';
+    homepage = "https://github.com/mfaerevaag/wd";
+    changelog = "https://github.com/mfaerevaag/wd/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = [ maintainers.zimeg ];
+    mainProgram = "wd";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

This PR adds the `wd` zsh plugin to the zsh shell packages. `wd` is a command that lets you jump to custom directories instead of navigating with `cd`. It's a super cool tool!

Repository link: https://github.com/mfaerevaag/wd

This is also my first contribution so please let me know if anything needs adjustments!

### Testing

If you're using home manager with zsh, this can be added as a plugin after building with the following:

```sh
$ nix-build -A zsh-wd
```

```nix
  programs.zsh = {
    enable = true;
    initExtraBeforeCompInit = '' fpath+=("/path/to/result/share/zsh/site-functions") '';
    plugins = [
      {
        name = "wd";
        src = "/path/to/result";
        file = "share/wd/wd.plugin.zsh";
      }
    ];
  };
```

Then tested with:

```sh
$ wd --version
$ wd --help
$ man wd

# Warp to a custom directory
$ wd add asdf
$ pwd
$ cd ..
$ wd asdf
$ pwd
```

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
