### PR TITLE
html2text: 1.3.2a -> 2.2.3

### DIFF
--- a/pkgs/tools/text/html2text/default.nix
+++ b/pkgs/tools/text/html2text/default.nix
@@ -1,35 +1,24 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchFromGitLab, autoreconfHook, libiconv }:
 
 stdenv.mkDerivation rec {
   pname = "html2text";
-  version = "1.3.2a";
+  version = "2.2.3";
 
-  src = fetchurl {
-    url = "http://www.mbayer.de/html2text/downloads/html2text-${version}.tar.gz";
-    sha256 = "000b39d5d910b867ff7e087177b470a1e26e2819920dcffd5991c33f6d480392";
+  src = fetchFromGitLab {
+    owner = "grobian";
+    repo = "html2text";
+    rev = "v${version}";
+    hash = "sha256-7Ch51nJ5BeRqs4PEIPnjCGk+Nm2ydgJQCtkcpihXun8=";
   };
 
-  preConfigure = ''
-    substituteInPlace configure \
-        --replace /bin/echo echo \
-        --replace CXX=unknown ':'
-  '' + lib.optionalString stdenv.cc.isClang ''
-    substituteInPlace HTMLParser.C \
-      --replace "register " ""
-  '';
+  nativeBuildInputs = [ autoreconfHook ];
 
-  # the --prefix has no effect
-  installPhase = ''
-    mkdir -p $out/bin $out/man/man{1,5}
-    cp html2text $out/bin
-    cp html2text.1.gz $out/man/man1
-    cp html2textrc.5.gz $out/man/man5
-  '';
+  buildInputs = lib.optional stdenv.isDarwin libiconv;
 
   meta = {
     description = "Convert HTML to plain text";
     mainProgram = "html2text";
-    homepage = "http://www.mbayer.de/html2text/";
+    homepage = "https://gitlab.com/grobian/html2text";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.eikek ];


### PR DESCRIPTION
(This is my first PR to nixpkgs, it's relatively simple but I'll try to conform to the contributing as best I can)

As noted in old homepage https://www.mbayer.de/html2text/
> html2text is now maintained by Fabian Groffen.

Which points to github https://github.com/grobian/html2text  where it says
> the official home of html2text is at https://gitlab.com/grobian/html2text.

This uses the simple `autoreconfHook` to do all the work with no more preConfigures seeming to be necesary

This is a modification of the previously closed pr #112094, closed because of `iconv` issues on darwin. Since then on [v2.2.2](https://github.com/grobian/html2text/releases/tag/v2.2.2) it has fixe "Fix building on platforms requiring libiconv". But I'm unable to run on darwin as I don't have a mac

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
(via github action runners)

- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages

- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)

Used on github runners, worked! Yay

- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
