### PR TITLE
 python311Packages.netbox-documents: init at 0.7.0; python311Packages.drf-extra-fields: init at 3.7.0

### DIFF
--- a/pkgs/development/python-modules/drf-extra-fields/default.nix
+++ b/pkgs/development/python-modules/drf-extra-fields/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  django,
+  djangorestframework,
+  filetype,
+  pillow,
+  psycopg2,
+  pytestCheckHook,
+  pytest-django,
+}:
+
+buildPythonPackage rec {
+  pname = "drf-extra-fields";
+  version = "3.7.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hipo";
+    repo = "drf-extra-fields";
+    rev = "v${version}";
+    hash = "sha256-Ym4vnZ/t0ZdSxU53BC0ducJl1YiTygRSWql/35PNbOU";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    django
+    djangorestframework
+    filetype
+  ];
+
+  optional-dependencies = {
+    Base64ImageField = [ pillow ];
+  };
+
+  nativeCheckInputs = [
+    (django.override { withGdal = true; })
+    psycopg2
+    pytestCheckHook
+    pytest-django
+  ] ++ optional-dependencies.Base64ImageField;
+
+  pythonImportsCheck = [ "drf_extra_fields" ];
+
+  meta = {
+    description = "Extra Fields for Django Rest Framework";
+    homepage = "https://github.com/Hipo/drf-extra-fields";
+    changelog = "https://github.com/Hipo/drf-extra-fields/releases/tag/${src.rev}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+}

--- a/pkgs/development/python-modules/netbox-documents/default.nix
+++ b/pkgs/development/python-modules/netbox-documents/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  drf-extra-fields,
+  python,
+  netbox,
+}:
+
+buildPythonPackage rec {
+  pname = "netbox-documents";
+  version = "0.7.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jasonyates";
+    repo = "netbox-documents";
+    rev = "v${version}";
+    hash = "sha256-Uijdaicbx9A9fBgFx3zyhhFlokFdb9TSolnExbfkkc4=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ drf-extra-fields ];
+
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  pythonImportsCheck = [ "netbox_documents" ];
+
+  meta = {
+    description = "Plugin designed to faciliate the storage of site, circuit, device type and device specific documents within NetBox";
+    homepage = "https://github.com/jasonyates/netbox-documents";
+    changelog = "https://github.com/jasonyates/netbox-documents/releases/tag/${src.rev}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3724,6 +3724,8 @@ self: super: with self; {
 
   dremel3dpy = callPackage ../development/python-modules/dremel3dpy { };
 
+  drf-extra-fields = callPackage ../development/python-modules/drf-extra-fields { };
+
   drf-jwt = callPackage ../development/python-modules/drf-jwt { };
 
   drf-nested-routers = callPackage ../development/python-modules/drf-nested-routers { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8847,6 +8847,8 @@ self: super: with self; {
 
   netapp-ontap = callPackage ../development/python-modules/netapp-ontap { };
 
+  netbox-documents = callPackage ../development/python-modules/netbox-documents { };
+
   netbox-reorder-rack = callPackage ../development/python-modules/netbox-reorder-rack { };
 
   netcdf4 = callPackage ../development/python-modules/netcdf4 { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Plugin to manage site, circuit and device diagrams and documents in Netbox
https://github.com/jasonyates/netbox-documents

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
