### PR TITLE
java: Populate `$out/lib/jvm`

### DIFF
--- a/nixos/modules/programs/java.nix
+++ b/nixos/modules/programs/java.nix
@@ -61,6 +61,8 @@ in
       };
     };
 
+    environment.pathsToLink = [ "/lib/jvm" ];
+
     environment.systemPackages = [ cfg.package ];
 
     environment.shellInit = ''

--- a/pkgs/by-name/ho/hookLibJvm/hook.sh
+++ b/pkgs/by-name/ho/hookLibJvm/hook.sh
@@ -1,0 +1,13 @@
+# shellcheck shell=bash
+
+postInstallHooks+=(libJvm)
+
+libJvm() {
+    if [ "${dontLibJvm-}" = 1 ]; then return; fi
+
+    if [ ! -d "${!outputBin:?}" ]; then return; fi
+
+    base="/lib/jvm"
+    mkdir -p "${!outputBin:?}${base}"
+    ln -fs "${!outputBin:?}" "${!outputBin:?}${base}/${name}"
+}

--- a/pkgs/by-name/ho/hookLibJvm/package.nix
+++ b/pkgs/by-name/ho/hookLibJvm/package.nix
@@ -1,0 +1,1 @@
+{ makeSetupHook }: makeSetupHook { name = "hook-lib-jvm"; } ./hook.sh

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
@@ -4,6 +4,7 @@
 , lib, stdenv
 , fetchurl
 , setJavaClassPath
+, hookLibJvm
 }:
 
 assert (stdenv.isDarwin && stdenv.isx86_64);
@@ -19,10 +20,14 @@ let cpuName = stdenv.hostPlatform.parsed.cpu.name;
     inherit (sourcePerArch.${cpuName}) url sha256;
   };
 
+  nativeBuildInputs = [ hookLibJvm ];
+
   # See: https://github.com/NixOS/patchelf/issues/10
   dontStrip = 1;
 
   installPhase = ''
+    runHook preInstall
+
     cd ..
 
     mv $sourceRoot $out
@@ -47,6 +52,8 @@ let cpuName = stdenv.hostPlatform.parsed.cpu.name;
     cat <<EOF >> $out/nix-support/setup-hook
     if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
     EOF
+
+    runHook postInstall
   '';
 
   # FIXME: use multiple outputs or return actual JRE package

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -20,6 +20,7 @@
 , cairo
 , glib
 , gtk3
+, hookLibJvm
 }:
 
 let
@@ -56,12 +57,14 @@ let result = stdenv.mkDerivation rec {
     zlib
   ] ++ lib.optional stdenv.isAarch32 libffi;
 
-  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper hookLibJvm ];
 
   # See: https://github.com/NixOS/patchelf/issues/10
   dontStrip = 1;
 
   installPhase = ''
+    runHook preInstall
+
     cd ..
 
     mv $sourceRoot $out
@@ -98,6 +101,8 @@ let result = stdenv.mkDerivation rec {
         wrapProgram "$bin" --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}"
       fi
     done
+
+    runHook postInstall
   '';
 
   preFixup = ''

--- a/pkgs/development/compilers/openjdk/21.nix
+++ b/pkgs/development/compilers/openjdk/21.nix
@@ -4,6 +4,7 @@
 , libXi, libXinerama, libXcursor, libXrandr, fontconfig, openjdk21-bootstrap
 , ensureNewerSourcesForZipFilesHook
 , setJavaClassPath
+, hookLibJvm
 # TODO(@sternenseemann): gtk3 fails to evaluate in pkgsCross.ghcjs.buildPackages
 # which should be fixable, this is a no-rebuild workaround for GHC.
 , headless ? stdenv.targetPlatform.isGhcjs
@@ -32,7 +33,7 @@ let
       hash = "sha256-fA8nRWBuTL87S8mwapmNfCPPQoI2aKHjbHJ6PDN3khs=";
     };
 
-    nativeBuildInputs = [ pkg-config autoconf unzip ensureNewerSourcesForZipFilesHook ];
+    nativeBuildInputs = [ pkg-config autoconf unzip ensureNewerSourcesForZipFilesHook hookLibJvm ];
     buildInputs = [
       cpio file which zip perl zlib cups freetype alsa-lib libjpeg giflib
       libpng zlib lcms2 libX11 libICE libXrender libXext libXtst libXt libXtst
@@ -114,6 +115,8 @@ let
     buildFlags = [ "images" ];
 
     installPhase = ''
+      runHook preInstall
+
       mkdir -p $out/lib
 
       mv build/*/images/jdk $out/lib/openjdk
@@ -139,6 +142,8 @@ let
       ''}
 
       ln -s $out/lib/openjdk/bin $out/bin
+
+      runHook postInstall
     '';
 
     preFixup = ''

--- a/pkgs/development/compilers/openjdk/22.nix
+++ b/pkgs/development/compilers/openjdk/22.nix
@@ -34,6 +34,7 @@
 , openjdk22-bootstrap
 , ensureNewerSourcesForZipFilesHook
 , setJavaClassPath
+, hookLibJvm
   # TODO(@sternenseemann): gtk3 fails to evaluate in pkgsCross.ghcjs.buildPackages
   # which should be fixable, this is a no-rebuild workaround for GHC.
 , headless ? stdenv.targetPlatform.isGhcjs
@@ -67,7 +68,7 @@ let
       hash = "sha256-itjvIedPwJl/l3a2gIVpNMs1zkbrjioVqbCj1Z1nCJE=";
     };
 
-    nativeBuildInputs = [ pkg-config autoconf unzip ensureNewerSourcesForZipFilesHook ];
+    nativeBuildInputs = [ pkg-config autoconf unzip ensureNewerSourcesForZipFilesHook hookLibJvm ];
     buildInputs = [
       cpio
       file
@@ -185,6 +186,8 @@ let
     buildFlags = [ "images" ];
 
     installPhase = ''
+      runHook preInstall
+
       mkdir -p $out/lib
 
       mv build/*/images/jdk $out/lib/openjdk
@@ -210,6 +213,8 @@ let
       ''}
 
       ln -s $out/lib/openjdk/bin $out/bin
+
+      runHook postInstall
     '';
 
     preFixup = ''


### PR DESCRIPTION
## Description of changes

This change should make it easier to detect available JDKs by providing symlinks at the canonical location `$out/lib/jvm/$name`.

In the Java ecosystem, this is a common pattern. For example, the [Gradle](https://gradle.org/) build tool supports "crawling" many of those locations:

 - [`/usr/lib{,64}/jvm`, `{/opt,/usr/{,local/}}java`](https://github.com/gradle/gradle/blob/766a6288794e4f5b78ad44e9ba8b0a2204d3c439/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/LinuxInstallationSupplier.java#L36)
 - [`$HOME/.jdks`](https://github.com/gradle/gradle/blob/766a6288794e4f5b78ad44e9ba8b0a2204d3c439/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/IntellijInstallationSupplier.java)
 - [`$HOME/.sdkman/candidates`](https://github.com/gradle/gradle/blob/766a6288794e4f5b78ad44e9ba8b0a2204d3c439/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/SdkmanInstallationSupplier.java)

The Scala tool [sbt](https://www.scala-sbt.org/) follows does [something very similar](https://github.com/sbt/sbt/blob/4e46a331d9b94cf80dfba15fa8466061bd354474/main/src/main/scala/sbt/internal/CrossJava.scala#L486-L492) and an [attempt to integrate with NixOS](https://github.com/sbt/sbt/issues/4260) has stalled.

There's been some discussion about how to make integration of these tools with NixOS easier, see https://discourse.nixos.org/t/4677 and an earlier attempt at https://github.com/NixOS/nixpkgs/pull/76699

Since the attempts by @raboof, I have made some progress with Gradle in https://github.com/NixOS/nixpkgs/pull/119444. The approach gives more control but is not ergonomic since it requires overriding Gradle to pass in JDKs. Note that this proposal is not meant to replace passing toolchains to Gradle but proposed in addition.

Recently @kravemir has reignited the discussion and has suggested to implement detection based on environments/profiles in https://github.com/gradle/gradle/pull/29214#discussion_r1605954040. This PR is an attempt to standardize a detection location per-derivation, namely `$out/lib/jvm/$name` and to enable linking these paths whenever someone sets `programs.java.enable`.

A hook is provided so that all JDKs can use the same code for creating the symlink.

Once this has landed, it'd be possible to have tools like Gradle and sbt crawl `/run/current-system/sw/lib/jvm`, `~/.nix-profile/lib/jvm`, or other locations via `nix-shell`.

For now I have only changed four JDKs, but that should be sufficient to see what's going on and test the approach. Of course I am happy to add the hook to other JDKs too.

## Alternative Considered

I also considered generating a `pkgs.linkFarm` in the Java module, but this solution is not as portable. By creating the link in each derivation, downstream package consumers can also make use of the mechanism, e.g. home-manager could also link them somewhere without having to reimplement linking.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
