### PR TITLE
apx: 2.4.0 -> 2.4.2

### DIFF
--- a/pkgs/tools/package-management/apx/default.nix
+++ b/pkgs/tools/package-management/apx/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   installShellFiles,
   distrobox,
+  podman,
 }:
 
 buildGoModule rec {
@@ -19,7 +20,8 @@ buildGoModule rec {
 
   vendorHash = "sha256-hGi+M5RRUL2oyxFGVeR0sum93/CA+FGYy0m4vDmlXTc=";
 
-  nativeBuildInputs = [ installShellFiles ];
+  # podman needed for apx to not error when building shell completions
+  nativeBuildInputs = [ installShellFiles podman ];
 
   ldflags = [ "-s" "-w" ];
 
@@ -36,6 +38,15 @@ buildGoModule rec {
     installManPage man/man1/*
     install -Dm444 README.md -t $out/share/docs/apx
     install -Dm444 COPYING.md $out/share/licenses/apx/LICENSE
+
+    # Create a temp writable home-dir so apx outputs completions without error
+    export HOME=$(mktemp -d)
+    # apx command now works (for completions)
+    # though complains "Error: no such file or directory"
+    installShellCompletion --cmd apx \
+      --bash <($out/bin/apx completion bash) \
+      --fish <($out/bin/apx completion fish) \
+      --zsh <($out/bin/apx completion zsh)
   '';
 
   meta = with lib; {

--- a/pkgs/tools/package-management/apx/default.nix
+++ b/pkgs/tools/package-management/apx/default.nix
@@ -1,22 +1,23 @@
-{ lib
-, buildGoModule
-, fetchFromGitHub
-, distrobox
-, installShellFiles
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  distrobox,
 }:
 
 buildGoModule rec {
   pname = "apx";
-  version = "2.4.0";
+  version = "2.4.2";
 
   src = fetchFromGitHub {
     owner = "Vanilla-OS";
     repo = "apx";
     rev = "v${version}";
-    hash = "sha256-OLJrwibw9uX5ty7FRZ0q8zx0i1vQXRKK8reQsJFFxAI=";
+    hash = "sha256-X6nphUzJc/R3Egw09eRQbza1QebpLGsMIfV7BpLOXTc=";
   };
 
-  vendorHash = null;
+  vendorHash = "sha256-hGi+M5RRUL2oyxFGVeR0sum93/CA+FGYy0m4vDmlXTc=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -24,10 +25,10 @@ buildGoModule rec {
 
   postPatch = ''
     substituteInPlace config/apx.json \
-      --replace "/usr/share/apx/distrobox/distrobox" "${distrobox}/bin/distrobox" \
-      --replace "/usr/share/apx" "$out/bin/apx"
+      --replace-fail "/usr/share/apx/distrobox/distrobox" "${distrobox}/bin/distrobox" \
+      --replace-fail "/usr/share/apx" "$out/bin/apx"
     substituteInPlace settings/config.go \
-      --replace "/usr/share/apx/" "$out/share/apx/"
+      --replace-fail "/usr/share/apx/" "$out/share/apx/"
   '';
 
   postInstall = ''


### PR DESCRIPTION
## Description of changes
- 2.4.0 -> 2.4.2
https://github.com/Vanilla-OS/apx/releases/tag/v2.4.1
https://github.com/Vanilla-OS/apx/compare/v2.4.1...v2.4.2

- Install shell completions

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
