### PR TITLE
ninja: add `--verbose` to build flags

### DIFF
--- a/pkgs/by-name/ni/ninja/setup-hook.sh
+++ b/pkgs/by-name/ni/ninja/setup-hook.sh
@@ -9,6 +9,7 @@ ninjaBuildPhase() {
     fi
 
     local flagsArray=(
+        --verbose
         -j$buildCores
         $ninjaFlags "${ninjaFlagsArray[@]}"
     )
@@ -38,6 +39,7 @@ ninjaCheckPhase() {
         fi
 
         local flagsArray=(
+            --verbose
             -j$buildCores
             $ninjaFlags "${ninjaFlagsArray[@]}"
             $checkTarget
@@ -62,6 +64,7 @@ ninjaInstallPhase() {
 
     # shellcheck disable=SC2086
     local flagsArray=(
+        --verbose
         -j$buildCores
         $ninjaFlags "${ninjaFlagsArray[@]}"
         ${installTargets:-install}


### PR DESCRIPTION
this makes ninja print out all command invocations, which can be useful for debugging. at least [Debian] and [Fedora] also include this in their build logs.

[Debian]: https://salsa.debian.org/debian/debhelper/-/blob/d3bc4c31453aabea565f8991dcbe1d9e1a0fc737/lib/Debian/Debhelper/Buildsystem/ninja.pm#L45
[Fedora]: https://src.fedoraproject.org/rpms/ninja-build/blob/1e9774b06f7dfed8ae150805f02f762c29edc704/f/macros.ninja#_2

## Description of changes

Here is an example of how an output looks now, vs how it looks with the verbose flag added:

```console
$ nix-build --expr '(import <nixpkgs> {}).libinput'
...
build flags: -j16
[1/111] Compiling C object test-build-util-list.h.p/meson-generated_.._test-util-includes-util-list.h.c.o
[2/111] Compiling C object test-build-util-macros.h.p/meson-generated_.._test-util-includes-util-macros.h.c.o
[3/111] Compiling C object test-build-util-bits.h.p/meson-generated_.._test-util-includes-util-bits.h.c.o
[4/111] Compiling C object test-build-util-prop-parsers.h.p/meson-generated_.._test-util-includes-util-prop-parsers.h.c.o
[5/111] Compiling C object test-build-util-ratelimit.h.p/meson-generated_.._test-util-includes-util-ratelimit.h.c.o
[6/111] Compiling C object test-build-util-input-event.h.p/meson-generated_.._test-util-includes-util-input-event.h.c.o
[7/111] Compiling C object liblibinput-util.a.p/src_util-list.c.o
[8/111] Compiling C object test-build-util-time.h.p/meson-generated_.._test-util-includes-util-time.h.c.o
[9/111] Compiling C object test-build-util-matrix.h.p/meson-generated_.._test-util-includes-util-matrix.h.c.o
[10/111] Compiling C object libinput-fuzz-to-zero.p/udev_libinput-fuzz-to-zero.c.o
...

$ nix-build --expr '(import <nixpkgs> {}).libinput.overrideAttrs { ninjaFlags = [ "--verbose" ];}'
...
build flags: -j16 --verbose
[1/111] gcc -Itest-build-util-macros.h.p -I. -I.. -I../src -I../include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu99 -Wno-unused-parameter -Wmissing-prototypes -Wstrict-prototypes -Wundef -Wlogical-op -Wpointer-arith -Wuninitialized -Winit-self -Wstrict-prototypes -Wimplicit-fallthrough -Wredundant-decls -Wincompatible-pointer-types -Wformat=2 -Wno-missing-field-initializers -Wmissing-declarations -fvisibility=hidden -MD -MQ test-build-util-macros.h.p/meson-generated_.._test-util-includes-util-macros.h.c.o -MF test-build-util-macros.h.p/meson-generated_.._test-util-includes-util-macros.h.c.o.d -o test-build-util-macros.h.p/meson-generated_.._test-util-includes-util-macros.h.c.o -c test-util-includes-util-macros.h.c
[2/111] gcc -Itest-build-util-list.h.p -I. -I.. -I../src -I../include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu99 -Wno-unused-parameter -Wmissing-prototypes -Wstrict-prototypes -Wundef -Wlogical-op -Wpointer-arith -Wuninitialized -Winit-self -Wstrict-prototypes -Wimplicit-fallthrough -Wredundant-decls -Wincompatible-pointer-types -Wformat=2 -Wno-missing-field-initializers -Wmissing-declarations -fvisibility=hidden -MD -MQ test-build-util-list.h.p/meson-generated_.._test-util-includes-util-list.h.c.o -MF test-build-util-list.h.p/meson-generated_.._test-util-includes-util-list.h.c.o.d -o test-build-util-list.h.p/meson-generated_.._test-util-includes-util-list.h.c.o -c test-util-includes-util-list.h.c
[3/111] gcc -Itest-build-util-bits.h.p -I. -I.. -I../src -I../include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu99 -Wno-unused-parameter -Wmissing-prototypes -Wstrict-prototypes -Wundef -Wlogical-op -Wpointer-arith -Wuninitialized -Winit-self -Wstrict-prototypes -Wimplicit-fallthrough -Wredundant-decls -Wincompatible-pointer-types -Wformat=2 -Wno-missing-field-initializers -Wmissing-declarations -fvisibility=hidden -MD -MQ test-build-util-bits.h.p/meson-generated_.._test-util-includes-util-bits.h.c.o -MF test-build-util-bits.h.p/meson-generated_.._test-util-includes-util-bits.h.c.o.d -o test-build-util-bits.h.p/meson-generated_.._test-util-includes-util-bits.h.c.o -c test-util-includes-util-bits.h.c
[4/111] gcc -Itest-build-util-ratelimit.h.p -I. -I.. -I../src -I../include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu99 -Wno-unused-parameter -Wmissing-prototypes -Wstrict-prototypes -Wundef -Wlogical-op -Wpointer-arith -Wuninitialized -Winit-self -Wstrict-prototypes -Wimplicit-fallthrough -Wredundant-decls -Wincompatible-pointer-types -Wformat=2 -Wno-missing-field-initializers -Wmissing-declarations -fvisibility=hidden -MD -MQ test-build-util-ratelimit.h.p/meson-generated_.._test-util-includes-util-ratelimit.h.c.o -MF test-build-util-ratelimit.h.p/meson-generated_.._test-util-includes-util-ratelimit.h.c.o.d -o test-build-util-ratelimit.h.p/meson-generated_.._test-util-includes-util-ratelimit.h.c.o -c test-util-includes-util-ratelimit.h.c
[5/111] gcc -Itest-build-util-prop-parsers.h.p -I. -I.. -I../src -I../include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu99 -Wno-unused-parameter -Wmissing-prototypes -Wstrict-prototypes -Wundef -Wlogical-op -Wpointer-arith -Wuninitialized -Winit-self -Wstrict-prototypes -Wimplicit-fallthrough -Wredundant-decls -Wincompatible-pointer-types -Wformat=2 -Wno-missing-field-initializers -Wmissing-declarations -fvisibility=hidden -MD -MQ test-build-util-prop-parsers.h.p/meson-generated_.._test-util-includes-util-prop-parsers.h.c.o -MF test-build-util-prop-parsers.h.p/meson-generated_.._test-util-includes-util-prop-parsers.h.c.o.d -o test-build-util-prop-parsers.h.p/meson-generated_.._test-util-includes-util-prop-parsers.h.c.o -c test-util-includes-util-prop-parsers.h.c
[6/111] gcc -Iliblibinput-util.a.p -I. -I.. -I../include -I/nix/store/axvmifip8rq7w2caw42sgi23lzh8ff5m-systemd-minimal-libs-255.4-dev/include -I/nix/store/1kgwg8rnckdwrpxh63w662nrlcqsi0kr-libevdev-1.13.1/include/libevdev-1.0/ -I/nix/store/fk3433191sivfy6yldqy8bhhng7m12ph-libwacom-2.11.0-dev/include/libwacom-1.0 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu99 -Wno-unused-parameter -Wmissing-prototypes -Wstrict-prototypes -Wundef -Wlogical-op -Wpointer-arith -Wuninitialized -Winit-self -Wstrict-prototypes -Wimplicit-fallthrough -Wredundant-decls -Wincompatible-pointer-types -Wformat=2 -Wno-missing-field-initializers -Wmissing-declarations -fvisibility=hidden -fPIC -MD -MQ liblibinput-util.a.p/src_util-list.c.o -MF liblibinput-util.a.p/src_util-list.c.o.d -o liblibinput-util.a.p/src_util-list.c.o -c ../src/util-list.c
[7/111] gcc -Itest-build-util-input-event.h.p -I. -I.. -I../src -I../include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu99 -Wno-unused-parameter -Wmissing-prototypes -Wstrict-prototypes -Wundef -Wlogical-op -Wpointer-arith -Wuninitialized -Winit-self -Wstrict-prototypes -Wimplicit-fallthrough -Wredundant-decls -Wincompatible-pointer-types -Wformat=2 -Wno-missing-field-initializers -Wmissing-declarations -fvisibility=hidden -MD -MQ test-build-util-input-event.h.p/meson-generated_.._test-util-includes-util-input-event.h.c.o -MF test-build-util-input-event.h.p/meson-generated_.._test-util-includes-util-input-event.h.c.o.d -o test-build-util-input-event.h.p/meson-generated_.._test-util-includes-util-input-event.h.c.o -c test-util-includes-util-input-event.h.c
[8/111] gcc -Itest-build-util-time.h.p -I. -I.. -I../src -I../include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu99 -Wno-unused-parameter -Wmissing-prototypes -Wstrict-prototypes -Wundef -Wlogical-op -Wpointer-arith -Wuninitialized -Winit-self -Wstrict-prototypes -Wimplicit-fallthrough -Wredundant-decls -Wincompatible-pointer-types -Wformat=2 -Wno-missing-field-initializers -Wmissing-declarations -fvisibility=hidden -MD -MQ test-build-util-time.h.p/meson-generated_.._test-util-includes-util-time.h.c.o -MF test-build-util-time.h.p/meson-generated_.._test-util-includes-util-time.h.c.o.d -o test-build-util-time.h.p/meson-generated_.._test-util-includes-util-time.h.c.o -c test-util-includes-util-time.h.c
[9/111] gcc -Iliblibinput-util.a.p -I. -I.. -I../include -I/nix/store/axvmifip8rq7w2caw42sgi23lzh8ff5m-systemd-minimal-libs-255.4-dev/include -I/nix/store/1kgwg8rnckdwrpxh63w662nrlcqsi0kr-libevdev-1.13.1/include/libevdev-1.0/ -I/nix/store/fk3433191sivfy6yldqy8bhhng7m12ph-libwacom-2.11.0-dev/include/libwacom-1.0 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu99 -Wno-unused-parameter -Wmissing-prototypes -Wstrict-prototypes -Wundef -Wlogical-op -Wpointer-arith -Wuninitialized -Winit-self -Wstrict-prototypes -Wimplicit-fallthrough -Wredundant-decls -Wincompatible-pointer-types -Wformat=2 -Wno-missing-field-initializers -Wmissing-declarations -fvisibility=hidden -fPIC -MD -MQ liblibinput-util.a.p/src_util-ratelimit.c.o -MF liblibinput-util.a.p/src_util-ratelimit.c.o.d -o liblibinput-util.a.p/src_util-ratelimit.c.o -c ../src/util-ratelimit.c
[10/111] gcc  -o test-build-util-list.h test-build-util-list.h.p/meson-generated_.._test-util-includes-util-list.h.c.o -Wl,--as-needed -Wl,--no-undefined
...
```



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
