### PR TITLE
protobuf_25.tests.pythonProtobuf: disable faulty test

### DIFF
--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -104,6 +104,8 @@ buildPythonPackage {
     #   https://github.com/protocolbuffers/protobuf/commit/5abab0f47e81ac085f0b2d17ec3b3a3b252a11f1
     #
     "google/protobuf/internal/generator_test.py"
+  ] ++ lib.optionals (lib.versionAtLeast protobuf.version "25") [
+    "minimal_test.py" # ModuleNotFoundError: No module named 'google3'
   ];
 
   pythonImportsCheck = [
@@ -122,6 +124,6 @@ buildPythonPackage {
     maintainers = with maintainers; [ knedlsepp ];
     # Tests are currently failing because backend is unavailable and causes tests to fail
     # Progress tracked in https://github.com/NixOS/nixpkgs/pull/264902
-    broken = lib.versionAtLeast protobuf.version "25";
+    broken = lib.versionAtLeast protobuf.version "26";
   };
 }


### PR DESCRIPTION
## Description of changes

In order to enable bumping the default protobuf version from protobuf_24 to protobuf_25, we address the build failure of pythonPackages.protobuf against that version.
Protobuf's python package is moving away from cpp backend in favor of a µpb backend.
(See: https://github.com/protocolbuffers/protobuf/tree/main/upb) The work on that seems to have lead to the introduction of a broken test in "minimal_test.py":
https://github.com/protocolbuffers/protobuf/commit/501ececd39fed69f0c50c2c87f04ce75932dde72 I suspect that this is not an issue on the nixpkgs packaging end but rather that this file is uncovered code upstream. I don't know enough about Bazel to be sure, but it looks like that file is not part of their protobuf/python/BUILD.bazel file.
(I wanted to prove that in
https://github.com/protocolbuffers/protobuf/pull/16888 but couldn't trigger upstream's CI)
So for now let's just skip that file.
Note that protobuf_26.tests.pythonProtobuf is still broken. This is due to the fact that upstream removed support for building the library directly from the GitHub repo. (See:
https://github.com/protocolbuffers/protobuf/pull/15708) Conda packaging is also currently struggling with this: https://github.com/conda-forge/protobuf-feedstock/pull/215

Related: #264902


cc @GaetanLepage, we may be able to rebase #264902 on this.


### Next steps

I also looked into how to get the same working for the newer protobuf 26 and the upcoming 27 releases. I gave up on the option to generate the source package via `bazel`. Instead we will probably want to use the PyPI tarballs generated from the GitHub repo via bazel. One downside is however that these tarballs don't ship any tests, which makes verifying the correctness of the build harder.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
