### PR TITLE
pmbootstrap: switch to pyproject

### DIFF
--- a/pkgs/tools/misc/pmbootstrap/default.nix
+++ b/pkgs/tools/misc/pmbootstrap/default.nix
@@ -3,13 +3,13 @@
 
 buildPythonApplication rec {
   pname = "pmbootstrap";
-  version = "2.2.0";
+  version = "2.3.1";
 
   src = fetchFromGitLab {
     owner = "postmarketos";
     repo = pname;
     rev = version;
-    hash = "sha256-wRJvvABIUPh79QfS8VcwRueB/vO9oGcqyE/OugfTsd8=";
+    hash = "sha256-0hC84Gyfr1FOpZGAc7pAhz/QBSTA5A/Lu/ZJdzlEcX4=";
   };
 
   pmb_test = "${src}/test";

--- a/pkgs/tools/misc/pmbootstrap/default.nix
+++ b/pkgs/tools/misc/pmbootstrap/default.nix
@@ -1,9 +1,12 @@
-{ stdenv, lib, git, openssl, buildPythonApplication, pytestCheckHook, ps
+{ stdenv, lib, git, openssl, python3Packages, pytestCheckHook, ps
 , fetchPypi, fetchFromGitLab, sudo }:
 
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "pmbootstrap";
   version = "2.3.1";
+  pythonproject = true;
+
+  nativeBuildInputs = with python3Packages; [ setuptools ];
 
   src = fetchFromGitLab {
     owner = "postmarketos";


### PR DESCRIPTION
Update pmbootstrap from 2.2.0 to 2.3.1.

## Description of changes

https://gitlab.com/postmarketOS/pmbootstrap/-/tags/2.3.0
and
https://gitlab.com/postmarketOS/pmbootstrap/-/tags/2.3.1

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
