### PR TITLE
polkit: fix build with !useSystemd

### DIFF
--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -53,6 +53,8 @@ stdenv.mkDerivation rec {
     # Allow changing base for paths in pkg-config file as before.
     # https://gitlab.freedesktop.org/polkit/polkit/-/merge_requests/100
     ./0001-build-Use-datarootdir-in-Meson-generated-pkg-config-.patch
+
+    ./elogind.patch
   ];
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/polkit/elogind.patch
+++ b/pkgs/development/libraries/polkit/elogind.patch
@@ -1,0 +1,66 @@
+From 78e625dbafa8543b17ffaf9c42cf90c9cf9a612e Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Wed, 8 May 2024 11:20:42 +0200
+Subject: [PATCH] Fix configuration with elogind
+
+Previously, it would try to get sysusers_dir from systemd even though
+systemd_dep was undefined.  Determining systemd_systemdsystemunitdir
+from systemd was already checking for systemd logind specifically, and
+systemd_sysusers_dir is only used in the systemd logind case, so move
+both of those into the systemd-logind-specific branch above.
+
+(cherry picked from commit b58b58af10c390ab9a11a4cfe6a4ff3d50cc0fa5)
+---
+ meson.build | 22 +++++++++++-----------
+ 1 file changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 2f81c90..0888322 100644
+--- a/meson.build
++++ b/meson.build
+@@ -202,6 +202,16 @@ if enable_logind
+     if not logind_dep.found()
+       logind_dep = dependency('libsystemd-login', not_found_message: 'libsystemd support requested but libsystemd or libsystemd-login library not found')
+     endif
++
++    # systemd unit / service files
++    systemd_systemdsystemunitdir = get_option('systemdsystemunitdir')
++    if systemd_systemdsystemunitdir == '' and session_tracking == 'libsystemd-login'
++      systemd_dep = dependency('systemd', not_found_message: 'systemd required but not found, please provide a valid systemd user unit dir or disable it')
++      # FIXME: systemd.pc file does not use variables with relative paths, so `define_variable` cannot be used
++      systemd_systemdsystemunitdir = systemd_dep.get_pkgconfig_variable('systemdsystemunitdir')
++    endif
++
++    systemd_sysusers_dir = systemd_dep.get_pkgconfig_variable('sysusers_dir', default: '/usr/lib/sysusers.d')
+   else
+     logind_dep = dependency('libelogind', not_found_message: 'libelogind support requested but libelogind library not found')
+   endif
+@@ -210,16 +220,6 @@ if enable_logind
+   config_h.set10('HAVE_' + func.to_upper(), cc.has_function(func, dependencies: logind_dep))
+   func = 'sd_pidfd_get_session'
+   config_h.set10('HAVE_' + func.to_upper(), cc.has_function(func, dependencies: logind_dep))
+-
+-  # systemd unit / service files
+-  systemd_systemdsystemunitdir = get_option('systemdsystemunitdir')
+-  if systemd_systemdsystemunitdir == '' and session_tracking == 'libsystemd-login'
+-    systemd_dep = dependency('systemd', not_found_message: 'systemd required but not found, please provide a valid systemd user unit dir or disable it')
+-    # FIXME: systemd.pc file does not use variables with relative paths, so `define_variable` cannot be used
+-    systemd_systemdsystemunitdir = systemd_dep.get_pkgconfig_variable('systemdsystemunitdir')
+-  endif
+-
+-  systemd_sysusers_dir = systemd_dep.get_pkgconfig_variable('sysusers_dir', default: '/usr/lib/sysusers.d')
+ endif
+ config_h.set('HAVE_LIBSYSTEMD', enable_logind)
+ 
+@@ -404,7 +404,7 @@ output += '        introspection:            ' + enable_introspection.to_string(
+ output += '        Distribution/OS:          ' + os_type + '\n'
+ output += '        Authentication framework: ' + auth_fw + '\n'
+ output += '        Session tracking:         ' + session_tracking + '\n'
+-if enable_logind
++if session_tracking == 'logind'
+   output += '        systemdsystemunitdir:     ' + systemd_systemdsystemunitdir + '\n'
+ endif
+ output += '        polkitd user:             ' + polkitd_user + ' \n'
+-- 
+2.44.0
+


### PR DESCRIPTION
## Description of changes

Patch is [upstream](https://github.com/polkit-org/polkit/pull/449), but doesn't apply cleanly to 124.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
