### PR TITLE
pulseview: 0.4.2-unstable-2024-01-26 -> 0.4.2-unstable-2024-03-14

### DIFF
--- a/pkgs/applications/science/electronics/pulseview/default.nix
+++ b/pkgs/applications/science/electronics/pulseview/default.nix
@@ -1,25 +1,55 @@
-{ lib, stdenv, fetchgit, pkg-config, cmake, glib, boost, libsigrok
-, libsigrokdecode, libserialport, libzip, libftdi1, hidapi, glibmm
-, pcre, python3, qtsvg, qttools, bluez
-, wrapQtAppsHook, desktopToDarwinBundle
+{ lib
+, stdenv
+, fetchgit
+, pkg-config
+, cmake
+, glib
+, boost
+, libsigrok
+, libsigrokdecode
+, libserialport
+, libzip
+, libftdi1
+, hidapi
+, glibmm
+, pcre
+, python3
+, qtsvg
+, qttools
+, bluez
+, wrapQtAppsHook
+, desktopToDarwinBundle
 }:
 
 stdenv.mkDerivation rec {
   pname = "pulseview";
-  version = "0.4.2-unstable-2024-01-26";
+  version = "0.4.2-unstable-2024-03-14";
 
   src = fetchgit {
     url = "git://sigrok.org/pulseview";
-    rev = "9b8b7342725491d626609017292fa9259f7d5e0e";
-    hash = "sha256-UEJunADzc1WRRfchO/n8qqxnyrSo4id1p7gLkD3CKaM=";
+    rev = "d00efc65ef47090b71c4da12797056033bee795f";
+    hash = "sha256-MwfMUqV3ejxesg+3cFeXVB5hwg4r0cOCgHJuH3ZLmNE=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config qttools wrapQtAppsHook ]
-    ++ lib.optional stdenv.isDarwin desktopToDarwinBundle;
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qttools
+    wrapQtAppsHook
+  ] ++ lib.optional stdenv.isDarwin desktopToDarwinBundle;
 
   buildInputs = [
-    glib boost libsigrok libsigrokdecode libserialport libzip libftdi1 hidapi glibmm
-    pcre python3
+    glib
+    boost
+    libsigrok
+    libsigrokdecode
+    libserialport
+    libzip
+    libftdi1
+    hidapi
+    glibmm
+    pcre
+    python3
     qtsvg
   ] ++ lib.optionals stdenv.isLinux [ bluez ];
 


### PR DESCRIPTION
## Description of changes

Bump pulseview by a single commit which includes a fix for a crash when a broken sr file is opened.
See the commit at https://sigrok.org/gitweb/?p=pulseview.git;a=summary and https://github.com/sigrokproject/pulseview/issues/67#issuecomment-1998539224.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
