### PR TITLE
python311Packages.vmprof: remove patches, enable checks, clean up

### DIFF
--- a/pkgs/development/python-modules/vmprof/default.nix
+++ b/pkgs/development/python-modules/vmprof/default.nix
@@ -1,57 +1,55 @@
-{ stdenv
-, lib
-, buildPythonPackage
-, fetchpatch
-, fetchPypi
-, colorama
-, libunwind
-, pytz
-, requests
-, six
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  pythonAtLeast,
+  fetchFromGitHub,
+  setuptools,
+  colorama,
+  pytz,
+  requests,
+  six,
+  libunwind,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
-  version = "0.4.17";
-  format = "setuptools";
   pname = "vmprof";
+  version = "0.4.17";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-ACYj7Lb/QT6deG0uuiPCj850QXhaw4XuQX6aZu8OM2U=";
+  disabled = pythonOlder "3.6" || pythonAtLeast "3.12";
+
+  src = fetchFromGitHub {
+    owner = "vmprof";
+    repo = "vmprof-python";
+    rev = "refs/tags/${version}";
+    hash = "sha256-7k6mtEdPmp1eNzB4l/k/ExSYtRJVmRxcx50ql8zR36k=";
   };
 
-  buildInputs = [ libunwind ];
-  propagatedBuildInputs = [ colorama requests six pytz ];
+  build-system = [ setuptools ];
 
-  patches = [
-    (fetchpatch {
-      name = "${pname}-python-3.10-compat.patch";
-      # https://github.com/vmprof/vmprof-python/pull/198
-      url = "https://github.com/vmprof/vmprof-python/commit/e4e99e5aa677f96d1970d88c8a439f995f429f85.patch";
-      hash = "sha256-W/c6WtVuKi7xO2sCOr71mrZTWqI86bWg5a0FeDNolh0=";
-    })
-    (fetchpatch {
-      name = "${pname}-python-3.11-compat.patch";
-      # https://github.com/vmprof/vmprof-python/pull/251 (not yet merged)
-      url = "https://github.com/matthiasdiener/vmprof-python/compare/a1a1b5264ec0b197444c0053e44f8ae4ffed9353...13c39166363b960017393b614270befe01230be8.patch";
-      excludes = [ "test_requirements.txt" ];
-      hash = "sha256-3+0PVdAf83McNd93Q9dD4HLXt39UinVU5BA8jWfT6F4=";
-    })
+  dependencies = [
+    colorama
+    requests
+    six
+    pytz
   ];
 
-  # No tests included
-  doCheck = false;
+  buildInputs = [ libunwind ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTests = [
+    "test_gzip_call"
+    "test_is_enabled"
+    "test_get_profile_path"
+    "test_get_runtime"
+  ];
+
   pythonImportsCheck = [ "vmprof" ];
 
-  # Workaround build failure on -fno-common toolchains:
-  #   ld: src/vmprof_unix.o:src/vmprof_common.h:92: multiple definition of
-  #     `_PyThreadState_Current'; src/_vmprof.o:src/vmprof_common.h:92: first defined here
-  # TODO: can be removed once next release contains:
-  #   https://github.com/vmprof/vmprof-python/pull/203
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
-
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
     description = "A vmprof client";
     mainProgram = "vmprofshow";
     license = licenses.mit;


### PR DESCRIPTION
## Description of changes

ZHF: #309482

The build was failing because some upstreamed patches were not removed after the version bump.
This PR removes those patches.

Other than that, this PR moves over to using GitHub as the source to also fetch test files.

I disabled python >=3.12 as some of the generated binaries were not finding some symbols, and also, upstream didn't mark 3.12 as supported yet.

I disabled some tests which were failing due to some gcc errors. I didn't have time to check out why exactly they happen.

I also removed the `meta.broken` to see if it's still broken.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
