### PR TITLE
fjordlauncher: init at 8.3.1

### DIFF
--- a/pkgs/games/fjordlauncher/default.nix
+++ b/pkgs/games/fjordlauncher/default.nix
@@ -1,0 +1,85 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, stripJavaArchivesHook
+, cmake
+, cmark
+, Cocoa
+, ninja
+, jdk17
+, zlib
+, qtbase
+, quazip
+, extra-cmake-modules
+, tomlplusplus
+, ghc_filesystem
+, gamemode
+, msaClientID ? null
+, gamemodeSupport ? stdenv.isLinux
+,
+}:
+let
+  libnbtplusplus = fetchFromGitHub {
+    owner = "PrismLauncher";
+    repo = "libnbtplusplus";
+    rev = "a5e8fd52b8bf4ab5d5bcc042b2a247867589985f";
+    hash = "sha256-A5kTgICnx+Qdq3Fir/bKTfdTt/T1NQP2SC+nhN1ENug=";
+  };
+in
+
+assert lib.assertMsg (stdenv.isLinux || !gamemodeSupport) "gamemodeSupport is only available on Linux";
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fjordlauncher-unwrapped";
+  version = "8.3.1";
+
+  src = fetchFromGitHub {
+    owner = "unmojang";
+    repo = "FjordLauncher";
+    rev = finalAttrs.version;
+    hash = "sha256-YP2U2Eqyty8uPTEoNdsz9JtF8qLtb98D+Majz8pu2ZI=";
+  };
+
+  nativeBuildInputs = [ extra-cmake-modules cmake jdk17 ninja stripJavaArchivesHook ];
+  buildInputs =
+    [
+      qtbase
+      zlib
+      quazip
+      ghc_filesystem
+      tomlplusplus
+      cmark
+    ]
+    ++ lib.optional gamemodeSupport gamemode
+    ++ lib.optionals stdenv.isDarwin [ Cocoa ];
+
+  hardeningEnable = lib.optionals stdenv.isLinux [ "pie" ];
+
+  cmakeFlags = [
+    # downstream branding
+    "-DLauncher_BUILD_PLATFORM=nixpkgs"
+  ] ++ lib.optionals (msaClientID != null) [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ]
+  ++ lib.optionals (lib.versionOlder qtbase.version "6") [ "-DLauncher_QT_VERSION_MAJOR=5" ]
+  ++ lib.optionals stdenv.isDarwin [
+    "-DINSTALL_BUNDLE=nodeps"
+    "-DMACOSX_SPARKLE_UPDATE_FEED_URL=''"
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}/Applications/"
+  ];
+
+  postUnpack = ''
+    rm -rf source/libraries/libnbtplusplus
+    ln -s ${libnbtplusplus} source/libraries/libnbtplusplus
+  '';
+
+  dontWrapQtApps = true;
+
+  meta = {
+    mainProgram = "fjordlauncher";
+    homepage = "https://github.com/unmojang/FjordLauncher";
+    description = "Prism Launcher fork with support for alternative auth servers";
+    platforms = with lib.platforms; linux ++ darwin;
+    changelog = "https://github.com/unmojang/FjordLauncher/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ evan-goode ];
+  };
+})

--- a/pkgs/games/fjordlauncher/wrapper.nix
+++ b/pkgs/games/fjordlauncher/wrapper.nix
@@ -1,0 +1,130 @@
+{ lib
+, stdenv
+, symlinkJoin
+, makeWrapper
+, wrapQtAppsHook
+, addOpenGLRunpath
+
+, fjordlauncher-unwrapped
+
+, qtbase  # needed for wrapQtAppsHook
+, qtsvg
+, qtwayland
+, xorg
+, libpulseaudio
+, libGL
+, glfw
+, glfw-wayland-minecraft
+, openal
+, jdk8
+, jdk17
+, jdk21
+, gamemode
+, flite
+, mesa-demos
+, pciutils
+, udev
+, vulkan-loader
+, libusb1
+
+, msaClientID ? null
+, gamemodeSupport ? stdenv.isLinux
+, textToSpeechSupport ? stdenv.isLinux
+, controllerSupport ? stdenv.isLinux
+
+  # Adds `glfw-wayland-minecraft` to `LD_LIBRARY_PATH`
+  # when launched on wayland, allowing for the game to be run natively.
+  # Make sure to enable "Use system installation of GLFW" in instance settings
+  # for this to take effect
+  #
+  # Warning: This build of glfw may be unstable, and the launcher
+  # itself can take slightly longer to start
+, withWaylandGLFW ? false
+
+, jdks ? [ jdk21 jdk17 jdk8 ]
+, additionalLibs ? [ ]
+, additionalPrograms ? [ ]
+}:
+
+assert lib.assertMsg (withWaylandGLFW -> stdenv.isLinux) "withWaylandGLFW is only available on Linux";
+
+let
+  fjordlauncher' = fjordlauncher-unwrapped.override {
+    inherit msaClientID gamemodeSupport;
+  };
+in
+
+symlinkJoin {
+  name = "fjordlauncher-${fjordlauncher'.version}";
+
+  paths = [ fjordlauncher' ];
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+  ]
+  # purposefully using a shell wrapper here for variable expansion
+  # see https://github.com/NixOS/nixpkgs/issues/172583
+  ++ lib.optional withWaylandGLFW makeWrapper;
+
+  buildInputs = [
+    qtbase
+    qtsvg
+  ]
+  ++ lib.optional (lib.versionAtLeast qtbase.version "6" && stdenv.isLinux) qtwayland;
+
+  waylandPreExec = lib.optionalString withWaylandGLFW ''
+    if [ -n "$WAYLAND_DISPLAY" ]; then
+      export LD_LIBRARY_PATH=${lib.getLib glfw-wayland-minecraft}/lib:"$LD_LIBRARY_PATH"
+    fi
+  '';
+
+  postBuild = ''
+    ${lib.optionalString withWaylandGLFW ''
+      qtWrapperArgs+=(--run "$waylandPreExec")
+    ''}
+
+    wrapQtAppsHook
+  '';
+
+  qtWrapperArgs =
+    let
+      runtimeLibs = [
+        xorg.libX11
+        xorg.libXext
+        xorg.libXcursor
+        xorg.libXrandr
+        xorg.libXxf86vm
+
+        # lwjgl
+        libpulseaudio
+        libGL
+        glfw
+        openal
+        stdenv.cc.cc.lib
+        vulkan-loader # VulkanMod's lwjgl
+
+        # oshi
+        udev
+      ]
+      ++ lib.optional gamemodeSupport gamemode.lib
+      ++ lib.optional textToSpeechSupport flite
+      ++ lib.optional controllerSupport libusb1
+      ++ additionalLibs;
+
+      runtimePrograms = [
+        xorg.xrandr
+        mesa-demos # need glxinfo
+        pciutils # need lspci
+      ]
+      ++ additionalPrograms;
+
+    in
+    [ "--prefix FJORDLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}" ]
+    ++ lib.optionals stdenv.isLinux [
+      "--set LD_LIBRARY_PATH ${addOpenGLRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"
+      # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
+      "--prefix PATH : ${lib.makeBinPath runtimePrograms}"
+    ];
+
+  inherit (fjordlauncher') meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36692,6 +36692,12 @@ with pkgs;
 
   fish-fillets-ng = callPackage ../games/fish-fillets-ng { };
 
+  fjordlauncher-unwrapped = kdePackages.callPackage ../games/fjordlauncher {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
+
+  fjordlauncher = kdePackages.callPackage ../games/fjordlauncher/wrapper.nix { };
+
   jumpy = callPackage ../games/jumpy { };
 
   flightgear = libsForQt5.callPackage ../games/flightgear { };


### PR DESCRIPTION
## Description of changes

[Fjord Launcher](https://github.com/unmojang/FjordLauncher) is a libre [Minecraft](https://minecraft.net) launcher and a fork of [Prism Launcher](https://github.com/PrismLauncher/PrismLauncher) that:

- Reduces dependence on non-free network services
- Adds support for alternative Minecraft API servers, such as [Ely.by](https://github.com/elyby)
- Adds back the ability to download FTB modpacks from within the launcher

This PR supersedes https://github.com/NixOS/nixpkgs/pull/270815, PollyMC was unmaintained so I forked it to Fjord Launcher.

Builds on macOS or aarch64 have not been tested, but this derivation is almost identical to Prism Launcher, which is already in nixpkgs. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
