### PR TITLE
zelda64recomp: init at 1.2.2

### DIFF
--- a/pkgs/by-name/z6/z64decompress/package.nix
+++ b/pkgs/by-name/z6/z64decompress/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  installShellFiles,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "z64decompress";
+  version = "1.0.3-unstable-2023-12-21";
+
+  src = fetchFromGitHub {
+    owner = "z64tools";
+    repo = "z64decompress";
+    rev = "e2b3707271994a2a1b3afc6c3997a7cf6b479765";
+    hash = "sha256-PHiOeEB9njJPsl6ScdoDVwJXGqOdIIJCZRbIXSieBIY=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin z64decompress
+    install -Dm644 -t $out/share/licenses/z64decompress LICENSE
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
+
+  meta = {
+    description = "Zelda 64 rom decompressor";
+    homepage = "https://github.com/z64tools/z64decompress";
+    license = with lib.licenses; [
+      gpl3Only
+
+      # Reverse engineering
+      unfree
+    ];
+    maintainers = with lib.maintainers; [ qubitnano ];
+    mainProgram = "z64decompress";
+    platforms = lib.platforms.linux;
+    hydraPlatforms = [ ];
+  };
+})

--- a/pkgs/by-name/ze/zelda64recomp/package.nix
+++ b/pkgs/by-name/ze/zelda64recomp/package.nix
@@ -1,0 +1,165 @@
+{
+  lib,
+  mm64baserom ? null,
+  requireFile,
+  fetchFromGitHub,
+  llvmPackages_19,
+  cmake,
+  copyDesktopItems,
+  installShellFiles,
+  makeWrapper,
+  ninja,
+  pkg-config,
+  wrapGAppsHook3,
+  SDL2,
+  gtk3,
+  vulkan-loader,
+  makeDesktopItem,
+  z64decompress,
+  n64recomp,
+  directx-shader-compiler,
+  forceX11 ? false,
+}:
+
+let
+
+  baseRom =
+    if mm64baserom != null then
+      mm64baserom
+    else
+      requireFile {
+        name = "mm.us.rev1.rom.z64";
+        message = ''
+          zelda64recomp currently only supports the US version of Majora's Mask.
+          Please dump your copy and rename it to mm.us.rev1.rom.z64
+          and add it to the nix store using
+          nix-store --add-fixed sha256 mm.us.rev1.rom.z64
+          See https://dumping.guide/carts/nintendo/n64 for more details.
+        '';
+        hash = "sha256-77E2WzrjYmBFFMD5oaLRH13IaIulvmYKN96/XjvkPys=";
+      };
+
+in
+
+llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
+  pname = "zelda64recomp";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "Zelda64Recomp";
+    repo = "Zelda64Recomp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lsGnxgQqQ8wFc/qSVRFYxF0COir+eeH/flf4ePo98WA=";
+    fetchSubmodules = true;
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    copyDesktopItems
+    installShellFiles
+    llvmPackages_19.lld
+    makeWrapper
+    ninja
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    SDL2
+    gtk3
+    vulkan-loader
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Zelda64Recompiled";
+      icon = "zelda64recomp";
+      exec = "Zelda64Recompiled";
+      comment = "Static recompilation of Majora's Mask";
+      genericName = "Static recompilation of Majora's Mask";
+      desktopName = "Zelda 64: Recompiled";
+      categories = [ "Game" ];
+    })
+  ];
+
+  preConfigure = ''
+    ln -s ${baseRom} ./mm.us.rev1.rom.z64
+    ${lib.getExe z64decompress} mm.us.rev1.rom.z64 mm.us.rev1.rom_uncompressed.z64
+    cp ${n64recomp}/bin/* .
+
+    ./N64Recomp us.rev1.toml
+    ./RSPRecomp aspMain.us.rev1.toml
+    ./RSPRecomp njpgdspMain.us.rev1.toml
+
+    substituteInPlace lib/rt64/CMakeLists.txt \
+      --replace-fail "\''${PROJECT_SOURCE_DIR}/src/contrib/dxc/lib/x64" "${directx-shader-compiler}/lib/" \
+      --replace-fail "\''${PROJECT_SOURCE_DIR}/src/contrib/dxc/bin/x64/dxc-linux" "${directx-shader-compiler}/bin/dxc" \
+      --replace-fail "\''${PROJECT_SOURCE_DIR}/src/contrib/dxc/inc" "${directx-shader-compiler.src}/include/dxc"
+
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "\''${PROJECT_SOURCE_DIR}/lib/rt64/src/contrib/dxc/lib/x64" "${directx-shader-compiler}/lib/" \
+      --replace-fail "\''${PROJECT_SOURCE_DIR}/lib/rt64/src/contrib/dxc/bin/x64/dxc-linux" "${directx-shader-compiler}/bin/dxc"
+  '';
+
+  # This is required or else nothing will build
+  hardeningDisable = [
+    "format"
+    "pic"
+    "stackprotector"
+    "zerocallusedregs"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin Zelda64Recompiled
+    install -Dm644 -t $out/share ../recompcontrollerdb.txt
+    install -Dm644 ../icons/512.png $out/share/icons/hicolor/scalable/apps/zelda64recomp.png
+    cp -r ../assets $out/share/
+    ln -s $out/share/recompcontrollerdb.txt $out/bin/recompcontrollerdb.txt
+    ln -s $out/share/assets $out/bin/assets
+
+    install -Dm644 -t $out/share/licenses/zelda64recomp ../COPYING
+    install -Dm644 -t $out/share/licenses/zelda64recomp/N64ModernRuntime ../lib/N64ModernRuntime/COPYING
+    install -Dm644 -t $out/share/licenses/zelda64recomp/RmlUi ../lib/RmlUi/LICENSE.txt
+    install -Dm644 -t $out/share/licenses/zelda64recomp/lunasvg ../lib/lunasvg/LICENSE
+    install -Dm644 -t $out/share/licenses/zelda64recomp/rt64 ../lib/rt64/LICENSE
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
+     )
+  '';
+
+  # This is needed as Zelda64Recompiled will segfault when not run from the same
+  # directory as the binary. It also used to exit when run without X11. Recent rt64
+  # updates enabled wayland support, but leave the option to disable this on the
+  # application level if desired.
+  postFixup = ''
+    wrapProgram $out/bin/Zelda64Recompiled --chdir "$out/bin/" \
+        ${lib.optionalString forceX11 ''--set SDL_VIDEODRIVER x11''}
+  '';
+
+  meta = {
+    description = "Static recompilation of Majora's Mask (and soon Ocarina of Time) for PC (Windows/Linux)";
+    homepage = "https://github.com/Zelda64Recomp/Zelda64Recomp";
+    license = with lib.licenses; [
+      # Zelda64Recomp, N64ModernRuntime
+      gpl3Only
+
+      # RT64, RmlUi, lunasvg, sse2neon
+      mit
+
+      # reverse engineering
+      unfree
+    ];
+    maintainers = with lib.maintainers; [ qubitnano ];
+    mainProgram = "Zelda64Recompiled";
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/310947

https://github.com/Zelda64Recomp/Zelda64Recomp

Zelda 64: Recompiled is a project that uses [N64: Recompiled](https://github.com/Mr-Wiseguy/N64Recomp) to statically recompile Majora's Mask (and soon Ocarina of Time) into a native port with many new features and enhancements. This project uses [RT64](https://github.com/rt64/rt64) as the rendering engine to provide some of these enhancements.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
