### PR TITLE
ntpd-rs: 1.1.0 -> 1.1.2; passthru tests; adopt

### DIFF
--- a/pkgs/tools/networking/ntpd-rs/default.nix
+++ b/pkgs/tools/networking/ntpd-rs/default.nix
@@ -2,10 +2,12 @@
 , stdenv
 , rustPlatform
 , fetchFromGitHub
+, ntpd-rs
 , installShellFiles
 , pandoc
 , Security
 , nixosTests
+, testers
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -54,6 +56,10 @@ rustPlatform.buildRustPackage rec {
   passthru = {
     tests = {
       nixos = lib.optionalAttrs stdenv.isLinux nixosTests.ntpd-rs;
+      version = testers.testVersion {
+        package = ntpd-rs;
+        inherit version;
+      };
     };
   };
 

--- a/pkgs/tools/networking/ntpd-rs/default.nix
+++ b/pkgs/tools/networking/ntpd-rs/default.nix
@@ -69,7 +69,7 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/pendulum-project/ntpd-rs/blob/v${version}/CHANGELOG.md";
     mainProgram = "ntp-ctl";
     license = with licenses; [ mit /* or */ asl20 ];
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ fpletz getchoo ];
     # note: Undefined symbols for architecture x86_64: "_ntp_adjtime"
     broken = stdenv.isDarwin && stdenv.isx86_64;
   };

--- a/pkgs/tools/networking/ntpd-rs/default.nix
+++ b/pkgs/tools/networking/ntpd-rs/default.nix
@@ -1,13 +1,14 @@
-{ lib
-, stdenv
-, rustPlatform
-, fetchFromGitHub
-, ntpd-rs
-, installShellFiles
-, pandoc
-, Security
-, nixosTests
-, testers
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  ntpd-rs,
+  installShellFiles,
+  pandoc,
+  Security,
+  nixosTests,
+  testers,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -23,14 +24,15 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-Badq3GYr7BoF8VNGGtKTT4/ksuds1zBcSxx5O3vLbzg=";
 
-  buildInputs = lib.optionals stdenv.isDarwin [
-    Security
+  buildInputs = lib.optionals stdenv.isDarwin [ Security ];
+  nativeBuildInputs = [
+    pandoc
+    installShellFiles
   ];
-  nativeBuildInputs = [ pandoc installShellFiles ];
 
   postPatch = ''
     substituteInPlace utils/generate-man.sh \
-      --replace 'utils/pandoc.sh' 'pandoc'
+      --replace-fail 'utils/pandoc.sh' 'pandoc'
   '';
 
   postBuild = ''
@@ -51,7 +53,10 @@ rustPlatform.buildRustPackage rec {
     installManPage docs/precompiled/man/{ntp.toml.5,ntp-ctl.8,ntp-daemon.8,ntp-metrics-exporter.8}
   '';
 
-  outputs = [ "out" "man" ];
+  outputs = [
+    "out"
+    "man"
+  ];
 
   passthru = {
     tests = {
@@ -68,8 +73,14 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://tweedegolf.nl/en/pendulum";
     changelog = "https://github.com/pendulum-project/ntpd-rs/blob/v${version}/CHANGELOG.md";
     mainProgram = "ntp-ctl";
-    license = with licenses; [ mit /* or */ asl20 ];
-    maintainers = with maintainers; [ fpletz getchoo ];
+    license = with licenses; [
+      mit # or
+      asl20
+    ];
+    maintainers = with maintainers; [
+      fpletz
+      getchoo
+    ];
     # note: Undefined symbols for architecture x86_64: "_ntp_adjtime"
     broken = stdenv.isDarwin && stdenv.isx86_64;
   };

--- a/pkgs/tools/networking/ntpd-rs/default.nix
+++ b/pkgs/tools/networking/ntpd-rs/default.nix
@@ -5,6 +5,7 @@
 , installShellFiles
 , pandoc
 , Security
+, nixosTests
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -49,6 +50,12 @@ rustPlatform.buildRustPackage rec {
   '';
 
   outputs = [ "out" "man" ];
+
+  passthru = {
+    tests = {
+      nixos = lib.optionalAttrs stdenv.isLinux nixosTests.ntpd-rs;
+    };
+  };
 
   meta = with lib; {
     description = "A full-featured implementation of the Network Time Protocol";

--- a/pkgs/tools/networking/ntpd-rs/default.nix
+++ b/pkgs/tools/networking/ntpd-rs/default.nix
@@ -61,6 +61,7 @@ rustPlatform.buildRustPackage rec {
     description = "A full-featured implementation of the Network Time Protocol";
     homepage = "https://tweedegolf.nl/en/pendulum";
     changelog = "https://github.com/pendulum-project/ntpd-rs/blob/v${version}/CHANGELOG.md";
+    mainProgram = "ntp-ctl";
     license = with licenses; [ mit /* or */ asl20 ];
     maintainers = with maintainers; [ fpletz ];
     # note: Undefined symbols for architecture x86_64: "_ntp_adjtime"

--- a/pkgs/tools/networking/ntpd-rs/default.nix
+++ b/pkgs/tools/networking/ntpd-rs/default.nix
@@ -9,20 +9,20 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "ntpd-rs";
-  version = "1.1.0";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "pendulum-project";
     repo = "ntpd-rs";
     rev = "v${version}";
-    hash = "sha256-IoTuI0M+stZNUVpaVsf7JR7uHcamSSVDMJxJ+7n5ayA=";
+    hash = "sha256-0ykJruuyD1Z/QcmrogodNlMZp05ocXIo3wdygB/AnT0=";
   };
 
-  cargoHash = "sha256-iZuDNFy8c2UZUh3J11lEtfHlDFN+qPl4iZg+ps7AenE=";
+  cargoHash = "sha256-Badq3GYr7BoF8VNGGtKTT4/ksuds1zBcSxx5O3vLbzg=";
 
-  buildInputs = lib.optionals stdenv.isDarwin ([
+  buildInputs = lib.optionals stdenv.isDarwin [
     Security
-  ]);
+  ];
   nativeBuildInputs = [ pandoc installShellFiles ];
 
   postPatch = ''
@@ -34,11 +34,9 @@ rustPlatform.buildRustPackage rec {
     source utils/generate-man.sh
   '';
 
-  doCheck = true;
-
   checkFlags = [
     # doesn't find the testca
-    "--skip=keyexchange::tests::key_exchange_roundtrip"
+    "--skip=daemon::keyexchange::tests"
     # seems flaky?
     "--skip=algorithm::kalman::peer::tests::test_offset_steering_and_measurements"
     # needs networking


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/pendulum-project/ntpd-rs/compare/v1.1.0...v1.1.2

Changelog: https://github.com/pendulum-project/ntpd-rs/blob/v1.1.2/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
