### PR TITLE
python311Packages.freud: init at 3.0.0

### DIFF
--- a/pkgs/development/python-modules/freud/default.nix
+++ b/pkgs/development/python-modules/freud/default.nix
@@ -1,0 +1,90 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, cmake
+, cython
+, oldest-supported-numpy
+, scikit-build
+, setuptools
+, tbb
+, numpy
+, rowan
+, scipy
+, pytest
+, gsd
+, matplotlib
+, sympy
+}:
+
+buildPythonPackage rec {
+  pname = "freud";
+  version = "3.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "glotzerlab";
+    repo = "freud";
+    rev = "v${version}";
+    hash = "sha256-aKh2Gub1vU/wzvWkCl8yzlIswp8CtR975USiCr6ijUI=";
+    fetchSubmodules = true;
+  };
+  # Because we prefer to not `leaveDotGit`, we need to fool upstream into
+  # thinking we left the .git files in the submodules, so cmake won't think we
+  # didn't initialize them. Upstream doesn't support using the system wide
+  # installed version of these libraries, and it's probably aint's worth the
+  # hassle, because upstream also doesn't distribute all of these dependencies'
+  # libraries, and probably it uses only what it needs.
+  preConfigure = ''
+    touch extern/{voro++,fsph,Eigen}/.git
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    cython
+    oldest-supported-numpy
+    scikit-build
+    setuptools
+  ];
+  dontUseCmakeConfigure = true;
+  buildInputs = [
+    tbb
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    rowan
+    scipy
+  ];
+
+  nativeCheckInputs = [
+    # Encountering circular ImportError issues with pytestCheckHook, see also:
+    # https://github.com/NixOS/nixpkgs/issues/255262
+    pytest
+    gsd
+    matplotlib
+    sympy
+  ];
+  checkPhase = ''
+    runHook preCheck
+
+    pytest
+
+    runHook postCheck
+  '';
+  # Some tests fail on aarch64. If we could have used pytestCheckHook, we would
+  # have disabled only the tests that fail with the disabledTests attribute.
+  # But that is not possible unfortunately. See upstream report for the
+  # failure: https://github.com/glotzerlab/freud/issues/961
+  doCheck = !stdenv.isAarch64;
+
+  pythonImportsCheck = [ "freud" ];
+
+  meta = with lib; {
+    description = "Powerful, efficient particle trajectory analysis in scientific Python";
+    homepage = "https://github.com/glotzerlab/freud";
+    changelog = "https://github.com/glotzerlab/freud/blob/${src.rev}/ChangeLog.md";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/rowan/default.nix
+++ b/pkgs/development/python-modules/rowan/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, pytestCheckHook
+, scipy
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "rowan";
+  version = "1.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "glotzerlab";
+    repo = "rowan";
+    rev = "v${version}";
+    hash = "sha256-klIqyX04w1xYmYtAbLF5jwpcJ83oKOaENboxyCL70EY=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    scipy
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  pythonImportsCheck = [ "rowan" ];
+
+  meta = with lib; {
+    description = "A Python package for working with quaternions";
+    homepage = "https://github.com/glotzerlab/rowan";
+    changelog = "https://github.com/glotzerlab/rowan/blob/${src.rev}/ChangeLog.rst";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4530,6 +4530,8 @@ self: super: with self; {
 
   frelatage = callPackage ../development/python-modules/frelatage { };
 
+  freud = callPackage ../development/python-modules/freud { };
+
   frida-python = callPackage ../development/python-modules/frida-python { };
 
   frigidaire = callPackage ../development/python-modules/frigidaire { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13412,6 +13412,8 @@ self: super: with self; {
 
   rova = callPackage ../development/python-modules/rova { };
 
+  rowan = callPackage ../development/python-modules/rowan { };
+
   rpcq = callPackage ../development/python-modules/rpcq { };
 
   rpdb = callPackage ../development/python-modules/rpdb { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
