### PR TITLE
buf: 1.31.0 -> 1.32.2

### DIFF
--- a/pkgs/development/tools/buf/default.nix
+++ b/pkgs/development/tools/buf/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, protobuf
+, protobuf_26
 , git
 , testers
 , buf
@@ -10,20 +10,19 @@
 
 buildGoModule rec {
   pname = "buf";
-  version = "1.31.0";
+  version = "1.32.2";
 
   src = fetchFromGitHub {
     owner = "bufbuild";
-    repo = pname;
+    repo = "buf";
     rev = "v${version}";
-    hash = "sha256-CNt7ZfUMRQNNVusaBgEW64WH1TFYz8yEBfKksGVRVUM=";
+    hash = "sha256-lSK1ETeCnK/NeCHaZoHcgFO5OhbE6XcvbJg1+p9x4Hg=";
   };
 
-  vendorHash = "sha256-kagSvwxVE+URRY2C5tRtdRwtHBIdQh3BWUG1b3+L8Os=";
+  vendorHash = "sha256-LMjDR8tTZPLiIKxvdGjeaVMOh76eYhmAlI7lDJ7HG7I=";
 
   patches = [
-    # Skip a test that requires networking to be available to work,
-    # and a test which requires the source checkout to be part of a git repository
+    # Skip a test that requires networking to be available to work.
     ./skip_broken_tests.patch
   ];
 
@@ -33,7 +32,11 @@ buildGoModule rec {
 
   nativeCheckInputs = [
     git # Required for TestGitCloner
-    protobuf # Required for buftesting.GetProtocFilePaths
+    protobuf_26 # Required for buftesting.GetProtocFilePaths
+  ];
+
+  checkFlags = [
+    "-skip=TestWorkspaceGit"
   ];
 
   preCheck = ''
@@ -74,5 +77,6 @@ buildGoModule rec {
     description = "Create consistent Protobuf APIs that preserve compatibility and comply with design best-practices";
     license = licenses.asl20;
     maintainers = with maintainers; [ jk lrewega ];
+    mainProgram = "buf";
   };
 }

--- a/pkgs/development/tools/buf/skip_broken_tests.patch
+++ b/pkgs/development/tools/buf/skip_broken_tests.patch
@@ -1,21 +1,8 @@
-diff --git a/private/buf/cmd/buf/workspace_unix_test.go b/private/buf/cmd/buf/workspace_unix_test.go
-index 22c84385..22548555 100644
---- a/private/buf/cmd/buf/workspace_unix_test.go
-+++ b/private/buf/cmd/buf/workspace_unix_test.go
-@@ -93,6 +93,8 @@ func TestWorkspaceAbsoluteFail(t *testing.T) {
- // Workflow run: https://github.com/bufbuild/buf/actions/runs/6510804063/job/17685247791.
- // Potential fix: https://stackoverflow.com/questions/22575662/filename-too-long-in-git-for-windows.
- func TestWorkspaceGit(t *testing.T) {
-+	// Fails because the source checkout is not part of a git repository while building with nix
-+	t.Skip()
- 	// Directory paths specified as a git reference within a workspace.
- 	t.Parallel()
- 	testRunStdout(
-diff --git a/private/bufpkg/buftesting/buftesting.go b/private/bufpkg/buftesting/buftesting.go
-index d9e1fdc6..6e08c439 100644
---- a/private/bufpkg/buftesting/buftesting.go
-+++ b/private/bufpkg/buftesting/buftesting.go
-@@ -104,6 +104,10 @@ func RunActualProtoc(
+diff --git a/private/buf/buftesting/buftesting.go b/private/buf/buftesting/buftesting.go
+index 1c650077..5422f703 100644
+--- a/private/buf/buftesting/buftesting.go
++++ b/private/buf/buftesting/buftesting.go
+@@ -106,6 +106,10 @@ func RunActualProtoc(
  
  // GetGoogleapisDirPath gets the path to a clone of googleapis.
  func GetGoogleapisDirPath(t *testing.T, buftestingDirPath string) string {


### PR DESCRIPTION
## Description of changes

https://github.com/bufbuild/buf/releases/tag/v1.32.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
