### PR TITLE
nixos/tests/stalwart-mail: Add test for server version >= 0.7

### DIFF
--- a/nixos/modules/services/mail/stalwart-mail.nix
+++ b/nixos/modules/services/mail/stalwart-mail.nix
@@ -70,7 +70,9 @@ in {
       storage.lookup = mkDefault "db";
       storage.blob = mkDefault "blob";
       resolver.type = mkDefault "system";
-      resolver.public-suffix = mkDefault ["https://publicsuffix.org/list/public_suffix_list.dat"];
+      resolver.public-suffix = lib.mkDefault [
+        "file://${pkgs.publicsuffix-list}/share/publicsuffix/public_suffix_list.dat"
+      ];
     };
 
     systemd.services.stalwart-mail = {

--- a/nixos/tests/stalwart-mail.nix
+++ b/nixos/tests/stalwart-mail.nix
@@ -1,122 +1,147 @@
 # Rudimentary test checking that the Stalwart email server can:
 # - receive some message through SMTP submission, then
 # - serve this message through IMAP.
+{
+  system ? builtins.currentSystem,
+  config ? { },
+  pkgs ? import ../../.. { inherit system config; },
 
+  lib ? pkgs.lib,
+}:
 let
   certs = import ./common/acme/server/snakeoil-certs.nix;
   domain = certs.domain;
+  makeTest = import ./make-test-python.nix;
+  mkTestName =
+    pkg: "${pkg.pname}_${pkg.version}";
+  stalwartPackages = {
+    inherit (pkgs) stalwart-mail_0_6 stalwart-mail;
+  };
+  stalwartAtLeast = lib.versionAtLeast;
+  makeStalwartTest =
+    {
+      package,
+      name ? mkTestName package,
+    }:
+    makeTest {
+      inherit name;
+      meta.maintainers = with lib.maintainers; [
+        happysalada pacien onny
+      ];
 
-in import ./make-test-python.nix ({ lib, ... }: {
-  name = "stalwart-mail";
+      nodes.machine = { lib, ... }: {
 
-  nodes.main = { pkgs, ... }: {
-    security.pki.certificateFiles = [ certs.ca.cert ];
+        security.pki.certificateFiles = [ certs.ca.cert ];
 
-    services.stalwart-mail = {
-      enable = true;
-      settings = {
-        server.hostname = domain;
-
-        certificate."snakeoil" = {
-          cert = "file://${certs.${domain}.cert}";
-          private-key = "file://${certs.${domain}.key}";
-        };
-
-        server.tls = {
-          certificate = "snakeoil";
+        services.stalwart-mail = {
           enable = true;
-          implicit = false;
-        };
+          inherit package;
+          settings = {
+            server.hostname = domain;
 
-        server.listener = {
-          "smtp-submission" = {
-            bind = [ "[::]:587" ];
-            protocol = "smtp";
+            # TODO: Remove backwards compatibility as soon as we drop legacy version 0.6.0
+            certificate."snakeoil" = let
+              certPath = if stalwartAtLeast package.version "0.7.0" then "%{file://${certs.${domain}.cert}}%" else "file://${certs.${domain}.cert}";
+              keyPath = if stalwartAtLeast package.version "0.7.0" then "%{file:${certs.${domain}.key}}%" else "file://${certs.${domain}.key}";
+            in {
+              cert = certPath;
+              private-key = keyPath;
+            };
+
+            server.tls = {
+              certificate = "snakeoil";
+              enable = true;
+              implicit = false;
+            };
+
+            server.listener = {
+              "smtp-submission" = {
+                bind = [ "[::]:587" ];
+                protocol = "smtp";
+              };
+
+              "imap" = {
+                bind = [ "[::]:143" ];
+                protocol = "imap";
+              };
+            };
+
+            session.auth.mechanisms = "[plain]";
+            session.auth.directory = "'in-memory'";
+            storage.directory = "in-memory";
+
+            session.rcpt.directory = "'in-memory'";
+            queue.outbound.next-hop = "'local'";
+
+            directory."in-memory" = {
+              type = "memory";
+              # TODO: Remove backwards compatibility as soon as we drop legacy version 0.6.0
+              principals = let
+                condition = if stalwartAtLeast package.version "0.7.0" then "class" else "type";
+              in builtins.map (p: p // { ${condition} = "individual"; }) [
+                {
+                  name = "alice";
+                  secret = "foobar";
+                  email = [ "alice@${domain}" ];
+                }
+                {
+                  name = "bob";
+                  secret = "foobar";
+                  email = [ "bob@${domain}" ];
+                }
+              ];
+            };
           };
-
-          "imap" = {
-            bind = [ "[::]:143" ];
-            protocol = "imap";
-          };
         };
 
-        resolver.public-suffix = [ ];  # do not fetch from web in sandbox
+        environment.systemPackages = [
+          (pkgs.writers.writePython3Bin "test-smtp-submission" { } ''
+            from smtplib import SMTP
 
-        session.auth.mechanisms = "[plain]";
-        session.auth.directory = "'in-memory'";
-        storage.directory = "in-memory";
+            with SMTP('localhost', 587) as smtp:
+                smtp.starttls()
+                smtp.login('alice', 'foobar')
+                smtp.sendmail(
+                    'alice@${domain}',
+                    'bob@${domain}',
+                    """
+                        From: alice@${domain}
+                        To: bob@${domain}
+                        Subject: Some test message
 
-        session.rcpt.directory = "'in-memory'";
-        queue.outbound.next-hop = "'local'";
+                        This is a test message.
+                    """.strip()
+                )
+          '')
 
-        directory."in-memory" = {
-          type = "memory";
-          principals = [
-            {
-              type = "individual";
-              name = "alice";
-              secret = "foobar";
-              email = [ "alice@${domain}" ];
-            }
-            {
-              type = "individual";
-              name = "bob";
-              secret = "foobar";
-              email = [ "bob@${domain}" ];
-            }
-          ];
-        };
+          (pkgs.writers.writePython3Bin "test-imap-read" { } ''
+            from imaplib import IMAP4
+
+            with IMAP4('localhost') as imap:
+                imap.starttls()
+                status, [caps] = imap.login('bob', 'foobar')
+                assert status == 'OK'
+                imap.select()
+                status, [ref] = imap.search(None, 'ALL')
+                assert status == 'OK'
+                [msgId] = ref.split()
+                status, msg = imap.fetch(msgId, 'BODY[TEXT]')
+                assert status == 'OK'
+                assert msg[0][1].strip() == b'This is a test message.'
+          '')
+        ];
+
       };
+
+      testScript = ''
+        start_all()
+        machine.wait_for_unit("stalwart-mail.service")
+        machine.wait_for_open_port(587)
+        machine.wait_for_open_port(143)
+
+        machine.succeed("test-smtp-submission")
+        machine.succeed("test-imap-read")
+      '';
     };
-
-    environment.systemPackages = [
-      (pkgs.writers.writePython3Bin "test-smtp-submission" { } ''
-        from smtplib import SMTP
-
-        with SMTP('localhost', 587) as smtp:
-            smtp.starttls()
-            smtp.login('alice', 'foobar')
-            smtp.sendmail(
-                'alice@${domain}',
-                'bob@${domain}',
-                """
-                    From: alice@${domain}
-                    To: bob@${domain}
-                    Subject: Some test message
-
-                    This is a test message.
-                """.strip()
-            )
-      '')
-
-      (pkgs.writers.writePython3Bin "test-imap-read" { } ''
-        from imaplib import IMAP4
-
-        with IMAP4('localhost') as imap:
-            imap.starttls()
-            status, [caps] = imap.login('bob', 'foobar')
-            assert status == 'OK'
-            imap.select()
-            status, [ref] = imap.search(None, 'ALL')
-            assert status == 'OK'
-            [msgId] = ref.split()
-            status, msg = imap.fetch(msgId, 'BODY[TEXT]')
-            assert status == 'OK'
-            assert msg[0][1].strip() == b'This is a test message.'
-      '')
-    ];
-  };
-
-  testScript = /* python */ ''
-    main.wait_for_unit("stalwart-mail.service")
-    main.wait_for_open_port(587)
-    main.wait_for_open_port(143)
-
-    main.succeed("test-smtp-submission")
-    main.succeed("test-imap-read")
-  '';
-
-  meta = {
-    maintainers = with lib.maintainers; [ happysalada pacien ];
-  };
-})
+in
+lib.mapAttrs (_: package: makeStalwartTest { inherit package; }) stalwartPackages


### PR DESCRIPTION
## Description of changes

Going to add test for stalwart-mail 0.8 beside already implemented test for stalwart-mail_0_6

Continuation of https://github.com/NixOS/nixpkgs/pull/304812
Fixes https://github.com/NixOS/nixpkgs/issues/303156

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
