### PR TITLE
firefly-iii: 6.1.15 -> 6.1.16

### DIFF
--- a/nixos/tests/firefly-iii.nix
+++ b/nixos/tests/firefly-iii.nix
@@ -1,14 +1,19 @@
-import ./make-test-python.nix ({ lib, pkgs, ... }: {
+import ./make-test-python.nix ({ lib, ... }:
+
+let
+  db-pass = "Test2Test2";
+  app-key = "TestTestTestTestTestTestTestTest";
+in
+{
   name = "firefly-iii";
   meta.maintainers = [ lib.maintainers.savyajha ];
 
-  nodes.machine = { config, ... }: {
+  nodes.fireflySqlite = { config, ... }: {
     environment.etc = {
-      "firefly-iii-appkey".text = "TestTestTestTestTestTestTestTest";
+      "firefly-iii-appkey".text = app-key;
     };
     services.firefly-iii = {
       enable = true;
-      virtualHost = "http://localhost";
       enableNginx = true;
       settings = {
         APP_KEY_FILE = "/etc/firefly-iii-appkey";
@@ -18,9 +23,87 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
     };
   };
 
+  nodes.fireflyPostgresql = { config, pkgs, ... }: {
+    environment.etc = {
+      "firefly-iii-appkey".text = app-key;
+      "postgres-pass".text = db-pass;
+    };
+    services.firefly-iii = {
+      enable = true;
+      enableNginx = true;
+      settings = {
+        APP_KEY_FILE = "/etc/firefly-iii-appkey";
+        LOG_CHANNEL = "stdout";
+        SITE_OWNER = "mail@example.com";
+        DB_CONNECTION = "pgsql";
+        DB_DATABASE = "firefly";
+        DB_USERNAME = "firefly";
+        DB_PASSWORD_FILE = "/etc/postgres-pass";
+      };
+    };
+
+    services.postgresql = {
+      enable = true;
+      package = pkgs.postgresql_15;
+      authentication = ''
+        local all postgres peer
+        local firefly firefly password
+      '';
+      initialScript = pkgs.writeText "firefly-init.sql" ''
+        CREATE USER "firefly" WITH LOGIN PASSWORD '${db-pass}';
+        CREATE DATABASE "firefly" WITH OWNER "firefly";
+        CREATE SCHEMA AUTHORIZATION firefly;
+      '';
+    };
+  };
+
+  nodes.fireflyMysql = { config, pkgs, ... }: {
+    environment.etc = {
+      "firefly-iii-appkey".text = app-key;
+      "mysql-pass".text = db-pass;
+    };
+    services.firefly-iii = {
+      enable = true;
+      enableNginx = true;
+      settings = {
+        APP_KEY_FILE = "/etc/firefly-iii-appkey";
+        LOG_CHANNEL = "stdout";
+        SITE_OWNER = "mail@example.com";
+        DB_CONNECTION = "mysql";
+        DB_DATABASE = "firefly";
+        DB_USERNAME = "firefly";
+        DB_PASSWORD_FILE = "/etc/mysql-pass";
+        DB_SOCKET = "/run/mysqld/mysqld.sock";
+      };
+    };
+
+    services.mysql = {
+      enable = true;
+      package = pkgs.mariadb;
+      initialScript = pkgs.writeText "firefly-init.sql" ''
+        create database firefly DEFAULT CHARACTER SET utf8mb4;
+        create user 'firefly'@'localhost' identified by '${db-pass}';
+        grant all on firefly.* to 'firefly'@'localhost';
+      '';
+      settings.mysqld.character-set-server = "utf8mb4";
+    };
+  };
+
   testScript = ''
-    machine.wait_for_unit("phpfpm-firefly-iii.service")
-    machine.wait_for_unit("nginx.service")
-    machine.succeed("curl -fvvv -Ls http://localhost/ | grep 'Firefly III'")
+    fireflySqlite.wait_for_unit("phpfpm-firefly-iii.service")
+    fireflySqlite.wait_for_unit("nginx.service")
+    fireflySqlite.succeed("curl -fvvv -Ls http://localhost/ | grep 'Firefly III'")
+    fireflySqlite.succeed("curl -fvvv -Ls http://localhost/v1/js/app.js")
+    fireflySqlite.succeed("systemctl start firefly-iii-cron.service")
+    fireflyPostgresql.wait_for_unit("phpfpm-firefly-iii.service")
+    fireflyPostgresql.wait_for_unit("nginx.service")
+    fireflyPostgresql.wait_for_unit("postgresql.service")
+    fireflyPostgresql.succeed("curl -fvvv -Ls http://localhost/ | grep 'Firefly III'")
+    fireflyPostgresql.succeed("systemctl start firefly-iii-cron.service")
+    fireflyMysql.wait_for_unit("phpfpm-firefly-iii.service")
+    fireflyMysql.wait_for_unit("nginx.service")
+    fireflyMysql.wait_for_unit("mysql.service")
+    fireflyMysql.succeed("curl -fvvv -Ls http://localhost/ | grep 'Firefly III'")
+    fireflyMysql.succeed("systemctl start firefly-iii-cron.service")
   '';
 })

--- a/pkgs/by-name/fi/firefly-iii/package.nix
+++ b/pkgs/by-name/fi/firefly-iii/package.nix
@@ -8,20 +8,20 @@
 
 let
   pname = "firefly-iii";
-  version = "6.1.15";
+  version = "6.1.16";
   phpPackage = php83;
 
   src = fetchFromGitHub {
     owner = "firefly-iii";
     repo = "firefly-iii";
     rev = "v${version}";
-    hash = "sha256-9Od8tR8X2OZ2hu81tHWDpBX8snWCRvTnlY1AwjIcMug=";
+    hash = "sha256-1I4Wm10mmloqeWcpc4XloNATpvroiw6m8MiSVsoB6xo=";
   };
 
   assets = buildNpmPackage {
     pname = "${pname}-assets";
     inherit version src;
-    npmDepsHash = "sha256-UVySgcj1tQLQIxlsZuig4ixkfxfsYWYPKWLz5zHA+Dg=";
+    npmDepsHash = "sha256-Ff7pDKoXvyj/gR+ljQsCjtyzxzJ7/zN6hRMEAderqOg=";
     dontNpmBuild = true;
     installPhase = ''
       runHook preInstall
@@ -36,7 +36,7 @@ in
 phpPackage.buildComposerProject (finalAttrs: {
   inherit pname src version;
 
-  vendorHash = "sha256-RDkAbTKj7M7lE8bVRxb+RR5CA6hJIMp61U0+aRtFE50=";
+  vendorHash = "sha256-BanSEqE3KN46VtEZH0TVWUBrgPCwmd2TjheYq+e+lzo=";
 
   passthru = {
     inherit phpPackage;


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/firefly-iii/firefly-iii/compare/v6.1.15...v6.1.16

Module has been fixed and now uses the maintenance service to cache settings so as to not require environment files wherever possible.

The tests now test using mariadb and postgresql as well as sqlite to be more complete. A test has been added for testing whether app.js has been compiled successfully, as well as to check whether the cronjob fires successfully.

I'm going to mark this as draft until the 24.05 release is over.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Pinging @drupol and @PatrickDaG for review.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
