### PR TITLE
python311Packages.pythonfinder: fix build

### DIFF
--- a/pkgs/development/python-modules/pythonfinder/default.nix
+++ b/pkgs/development/python-modules/pythonfinder/default.nix
@@ -3,9 +3,7 @@
 , cached-property
 , click
 , fetchFromGitHub
-, fetchpatch
 , packaging
-, pydantic
 , pytest-timeout
 , pytestCheckHook
 , pythonOlder
@@ -21,19 +19,10 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "sarugaku";
-    repo = pname;
+    repo = "pythonfinder";
     rev = "refs/tags/${version}";
     hash = "sha256-CbaKXD7Sde8euRqvc/IHoXoSMF+dNd7vT9LkLWq4/IU=";
   };
-
-  patches = [
-    # https://github.com/sarugaku/pythonfinder/issues/142
-    (fetchpatch {
-      name = "pydantic_2-compatibility.patch";
-      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/python-pythonfinder/-/raw/2.0.6-1/python-pythonfinder-2.0.6-pydantic2.patch";
-      hash = "sha256-mON1MeA+pj6VTB3zpBjF3LfB30wG0QH9nU4bD1djWwg=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \
@@ -46,7 +35,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     packaging
-    pydantic
   ] ++ lib.optionals (pythonOlder "3.8") [
     cached-property
   ];
@@ -65,13 +53,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "pythonfinder"
   ];
-
-  # these tests invoke git in a subprocess and
-  # for some reason git can't be found even if included in nativeCheckInputs
-  # disabledTests = [
-  #   "test_shims_are_kept"
-  #   "test_shims_are_removed"
-  # ];
 
   meta = with lib; {
     description = "Cross platform search tool for finding Python";


### PR DESCRIPTION
## Description of changes

The build was broken as can be seen [here](https://hydra.nixos.org/build/259553907/nixlog/4). The Pydantic patch no longer worked because [the project no longer uses pydantic](https://github.com/sarugaku/pythonfinder/pull/157).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
