### PR TITLE
lib.strings: deprecate lib.strings.{head,tail}

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -21,7 +21,6 @@ rec {
     filter
     fromJSON
     genList
-    head
     isInt
     isList
     isAttrs
@@ -35,11 +34,21 @@ rec {
     storeDir
     stringLength
     substring
-    tail
     toJSON
     typeOf
     unsafeDiscardStringContext
     ;
+
+  # TODO: warnings added 2025-04-10; remove after NixOS 2025.11
+  head = lib.warn ''
+    lib.strings.head only supports lists; use lib.lists.head instead.
+    The lib.strings.head alias is deprecated and will be removed after the NixOS 2025.11 release.
+  '' lib.head;
+
+  tail = lib.warn ''
+    lib.strings.tail only supports lists; use lib.lists.tail instead.
+    The lib.strings.tail alias is deprecated and will be removed after the NixOS 2025.11 release.
+  '' lib.tail;
 
   /**
     Concatenate a list of strings.
@@ -157,7 +166,7 @@ rec {
     if list == [ ] || length list == 1 then
       list
     else
-      tail (
+      lib.tail (
         lib.concatMap (x: [
           separator
           x
@@ -465,7 +474,7 @@ rec {
       # then the regex may not match and `res` will be `null`.
       res = match regex s;
     in
-    optionalString (res != null) (head res);
+    optionalString (res != null) (lib.head res);
 
   /**
     Construct a Unix-style, colon-separated search path consisting of
@@ -1863,7 +1872,7 @@ rec {
     let
       components = splitString "/" url;
       filename = lib.last components;
-      name = head (splitString sep filename);
+      name = lib.head (splitString sep filename);
     in
     assert name != filename;
     name;
@@ -2532,10 +2541,10 @@ rec {
       strippedInput = matchStripInput str;
 
       # RegEx: Match a leading '0' then one or more digits.
-      isLeadingZero = matchLeadingZero (head strippedInput) == [ ];
+      isLeadingZero = matchLeadingZero (lib.head strippedInput) == [ ];
 
       # Attempt to parse input
-      parsedInput = fromJSON (head strippedInput);
+      parsedInput = fromJSON (lib.head strippedInput);
 
       generalError = "toInt: Could not convert ${escapeNixString str} to int.";
 
@@ -2603,10 +2612,10 @@ rec {
       strippedInput = matchStripInput str;
 
       # RegEx: Match at least one '0'.
-      isZero = matchZero (head strippedInput) == [ ];
+      isZero = matchZero (lib.head strippedInput) == [ ];
 
       # Attempt to parse input
-      parsedInput = fromJSON (head strippedInput);
+      parsedInput = fromJSON (lib.head strippedInput);
 
       generalError = "toIntBase10: Could not convert ${escapeNixString str} to int.";
 


### PR DESCRIPTION
These operate on lists and error if you try to call them on strings... and they're already exposed under `lib` and `lib.lists`

## Description of changes

* `lib.strings.head` is no longer an alias for `builtins.head`, ditto for `tail`

## Things done

I checked (somewhat sloppily) for references with `rg lib.strings.head`, `rg '\(lib.strings\) .*head`, `rg lib.strings.tail`, `rg \(lib.strings\) .*tail` and didn't notice any. I checked that `<nixpkgs>` and `<nixpkgs/nixos>` evaluate (on my system/with my config) as well

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
