### PR TITLE
Add nextjs ollama llm UI frontend for Ollama

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12415,6 +12415,11 @@
     githubId = 18661391;
     name = "Malte Janz";
   };
+  malteneuss = {
+    github = "malteneuss";
+    githubId = 5301202;
+    name = "Malte Neuss";
+  };
   malte-v = {
     email = "nixpkgs@mal.tc";
     github = "malte-v";

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -137,6 +137,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [ollama](https://ollama.ai), server for running large language models locally.
 
+- [nextjs-ollama-llm-ui](https://github.com/jakobhoeg/nextjs-ollama-llm-ui), light-weight frontend server to chat with Ollama models through a web app.
+
 - [ownCloud Infinite Scale Stack](https://owncloud.com/infinite-scale-4-0/), a modern and scalable rewrite of ownCloud.
 
 - [PhotonVision](https://photonvision.org/), a free, fast, and easy-to-use computer vision solution for the FIRST® Robotics Competition.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1399,6 +1399,7 @@
   ./services/web-apps/netbox.nix
   ./services/web-apps/nextcloud.nix
   ./services/web-apps/nextcloud-notify_push.nix
+  ./services/web-apps/nextjs-ollama-llm-ui.nix
   ./services/web-apps/nexus.nix
   ./services/web-apps/nifi.nix
   ./services/web-apps/node-red.nix

--- a/nixos/modules/services/web-apps/nextjs-ollama-llm-ui.nix
+++ b/nixos/modules/services/web-apps/nextjs-ollama-llm-ui.nix
@@ -1,0 +1,87 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.nextjs-ollama-llm-ui;
+  # we have to override the URL to a Ollama service here, because it gets baked into the web app.
+  nextjs-ollama-llm-ui = cfg.package.override { ollamaUrl = "https://ollama.lambdablob.com"; };
+in
+{
+  options = {
+    services.nextjs-ollama-llm-ui = {
+      enable = lib.mkEnableOption ''
+        Simple Ollama web UI service; an easy to use web frontend for a Ollama backend service.
+        Run state-of-the-art AI large language models (LLM) similar to ChatGPT locally with privacy
+        on your personal computer.
+        This service is stateless and doesn't store any data on the server; all data is kept
+        locally in your web browser.
+        See https://github.com/jakobhoeg/nextjs-ollama-llm-ui.
+
+        Required: You need the Ollama backend service running by having
+        "services.nextjs-ollama-llm-ui.ollamaUrl" point to the correct url.
+        You can host such a backend service with NixOS through "services.ollama".
+      '';
+      package = lib.mkPackageOption pkgs "nextjs-ollama-llm-ui" { };
+
+      hostname = lib.mkOption {
+        type = lib.types.str;
+        default = "127.0.0.1";
+        example = "ui.example.org";
+        description = ''
+          The hostname under which the Ollama UI interface should be accessible.
+          By default it uses localhost/127.0.0.1 to be accessible only from the local machine.
+          Change to "0.0.0.0" to make it directly accessible from the local network.
+
+          Note: You should keep it at 127.0.0.1 and only serve to the local
+          network or internet from a (home) server behind a reverse-proxy and secured encryption.
+          See https://wiki.nixos.org/wiki/Nginx for instructions on how to set up a reverse-proxy.
+        '';
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 3000;
+        example = 3000;
+        description = ''
+          The port under which the Ollama UI interface should be accessible.
+        '';
+      };
+
+      ollamaUrl = lib.mkOption {
+        type = lib.types.str;
+        default = "127.0.0.1:11434";
+        example = "https://ollama.example.org";
+        description = ''
+          The address (including host and port) under which we can access the Ollama backend server.
+          !Note that if the the UI service is running under a domain "https://ui.example.org",
+          the Ollama backend service must allow "CORS" requests from this domain, e.g. by adding
+          "services.ollama.environment.OLLAMA_ORIGINS = [ ... "https://ui.example.org" ];"!
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services = {
+
+      nextjs-ollama-llm-ui = {
+        wantedBy = [ "multi-user.target" ];
+        description = "Nextjs Ollama LLM Ui.";
+        after = [ "network.target" ];
+        environment = {
+          HOSTNAME = cfg.hostname;
+          PORT = toString cfg.port;
+          NEXT_PUBLIC_OLLAMA_URL = cfg.ollamaUrl;
+        };
+        serviceConfig = {
+          ExecStart = "${lib.getExe nextjs-ollama-llm-ui}";
+          DynamicUser = true;
+        };
+      };
+    };
+  };
+  meta.maintainers = with lib.maintainers; [ malteneuss ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -616,6 +616,7 @@ in {
   # TODO: put in networking.nix after the test becomes more complete
   networkingProxy = handleTest ./networking-proxy.nix {};
   nextcloud = handleTest ./nextcloud {};
+  nextjs-ollama-llm-ui = runTest ./web-apps/nextjs-ollama-llm-ui.nix;
   nexus = handleTest ./nexus.nix {};
   # TODO: Test nfsv3 + Kerberos
   nfs3 = handleTest ./nfs { version = 3; };

--- a/nixos/tests/web-apps/nextjs-ollama-llm-ui.nix
+++ b/nixos/tests/web-apps/nextjs-ollama-llm-ui.nix
@@ -1,0 +1,22 @@
+{ lib, ... }:
+
+{
+  name = "nextjs-ollama-llm-ui";
+  meta.maintainers = with lib.maintainers; [ malteneuss ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.nextjs-ollama-llm-ui = {
+        enable = true;
+        port = 8080;
+      };
+    };
+
+  testScript = ''
+    # Ensure the service is started and reachable
+    machine.wait_for_unit("nextjs-ollama-llm-ui.service")
+    machine.wait_for_open_port(8080)
+    machine.succeed("curl --fail http://127.0.0.1:8080")
+  '';
+}

--- a/pkgs/by-name/ne/nextjs-ollama-llm-ui/0001-update-nextjs.patch
+++ b/pkgs/by-name/ne/nextjs-ollama-llm-ui/0001-update-nextjs.patch
@@ -1,0 +1,879 @@
+diff --git a/package-lock.json b/package-lock.json
+index 11dfbf6..b9470d0 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -30,7 +30,7 @@
+         "framer-motion": "^11.0.3",
+         "langchain": "^0.1.13",
+         "lucide-react": "^0.322.0",
+-        "next": "14.1.0",
++        "next": "^14.2.3",
+         "next-themes": "^0.2.1",
+         "react": "^18",
+         "react-code-blocks": "^0.1.6",
+@@ -40,6 +40,7 @@
+         "react-resizable-panels": "^2.0.3",
+         "react-textarea-autosize": "^8.5.3",
+         "remark-gfm": "^4.0.0",
++        "sharp": "^0.33.4",
+         "sonner": "^1.4.0",
+         "tailwind-merge": "^2.2.1",
+         "tailwindcss-animate": "^1.0.7",
+@@ -139,6 +140,15 @@
+         "node": ">=6.9.0"
+       }
+     },
++    "node_modules/@emnapi/runtime": {
++      "version": "1.1.1",
++      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.1.1.tgz",
++      "integrity": "sha512-3bfqkzuR1KLx57nZfjr2NLnFOobvyS0aTszaEGCGqmYMVDRaGvgIZbjGSV/MHSSmLgQ/b9JFHQ5xm5WRZYd+XQ==",
++      "optional": true,
++      "dependencies": {
++        "tslib": "^2.4.0"
++      }
++    },
+     "node_modules/@emoji-mart/data": {
+       "version": "1.1.2",
+       "resolved": "https://registry.npmjs.org/@emoji-mart/data/-/data-1.1.2.tgz",
+@@ -304,6 +314,437 @@
+       "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
+       "dev": true
+     },
++    "node_modules/@img/sharp-darwin-arm64": {
++      "version": "0.33.4",
++      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.4.tgz",
++      "integrity": "sha512-p0suNqXufJs9t3RqLBO6vvrgr5OhgbWp76s5gTRvdmxmuv9E1rcaqGUsl3l4mKVmXPkTkTErXediAui4x+8PSA==",
++      "cpu": [
++        "arm64"
++      ],
++      "optional": true,
++      "os": [
++        "darwin"
++      ],
++      "engines": {
++        "glibc": ">=2.26",
++        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      },
++      "optionalDependencies": {
++        "@img/sharp-libvips-darwin-arm64": "1.0.2"
++      }
++    },
++    "node_modules/@img/sharp-darwin-x64": {
++      "version": "0.33.4",
++      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.4.tgz",
++      "integrity": "sha512-0l7yRObwtTi82Z6ebVI2PnHT8EB2NxBgpK2MiKJZJ7cz32R4lxd001ecMhzzsZig3Yv9oclvqqdV93jo9hy+Dw==",
++      "cpu": [
++        "x64"
++      ],
++      "optional": true,
++      "os": [
++        "darwin"
++      ],
++      "engines": {
++        "glibc": ">=2.26",
++        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      },
++      "optionalDependencies": {
++        "@img/sharp-libvips-darwin-x64": "1.0.2"
++      }
++    },
++    "node_modules/@img/sharp-libvips-darwin-arm64": {
++      "version": "1.0.2",
++      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.2.tgz",
++      "integrity": "sha512-tcK/41Rq8IKlSaKRCCAuuY3lDJjQnYIW1UXU1kxcEKrfL8WR7N6+rzNoOxoQRJWTAECuKwgAHnPvqXGN8XfkHA==",
++      "cpu": [
++        "arm64"
++      ],
++      "optional": true,
++      "os": [
++        "darwin"
++      ],
++      "engines": {
++        "macos": ">=11",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      }
++    },
++    "node_modules/@img/sharp-libvips-darwin-x64": {
++      "version": "1.0.2",
++      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.2.tgz",
++      "integrity": "sha512-Ofw+7oaWa0HiiMiKWqqaZbaYV3/UGL2wAPeLuJTx+9cXpCRdvQhCLG0IH8YGwM0yGWGLpsF4Su9vM1o6aer+Fw==",
++      "cpu": [
++        "x64"
++      ],
++      "optional": true,
++      "os": [
++        "darwin"
++      ],
++      "engines": {
++        "macos": ">=10.13",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      }
++    },
++    "node_modules/@img/sharp-libvips-linux-arm": {
++      "version": "1.0.2",
++      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.2.tgz",
++      "integrity": "sha512-iLWCvrKgeFoglQxdEwzu1eQV04o8YeYGFXtfWU26Zr2wWT3q3MTzC+QTCO3ZQfWd3doKHT4Pm2kRmLbupT+sZw==",
++      "cpu": [
++        "arm"
++      ],
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "glibc": ">=2.28",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      }
++    },
++    "node_modules/@img/sharp-libvips-linux-arm64": {
++      "version": "1.0.2",
++      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.2.tgz",
++      "integrity": "sha512-x7kCt3N00ofFmmkkdshwj3vGPCnmiDh7Gwnd4nUwZln2YjqPxV1NlTyZOvoDWdKQVDL911487HOueBvrpflagw==",
++      "cpu": [
++        "arm64"
++      ],
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "glibc": ">=2.26",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      }
++    },
++    "node_modules/@img/sharp-libvips-linux-s390x": {
++      "version": "1.0.2",
++      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.2.tgz",
++      "integrity": "sha512-cmhQ1J4qVhfmS6szYW7RT+gLJq9dH2i4maq+qyXayUSn9/3iY2ZeWpbAgSpSVbV2E1JUL2Gg7pwnYQ1h8rQIog==",
++      "cpu": [
++        "s390x"
++      ],
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "glibc": ">=2.28",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      }
++    },
++    "node_modules/@img/sharp-libvips-linux-x64": {
++      "version": "1.0.2",
++      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.2.tgz",
++      "integrity": "sha512-E441q4Qdb+7yuyiADVi5J+44x8ctlrqn8XgkDTwr4qPJzWkaHwD489iZ4nGDgcuya4iMN3ULV6NwbhRZJ9Z7SQ==",
++      "cpu": [
++        "x64"
++      ],
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "glibc": ">=2.26",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      }
++    },
++    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
++      "version": "1.0.2",
++      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.2.tgz",
++      "integrity": "sha512-3CAkndNpYUrlDqkCM5qhksfE+qSIREVpyoeHIU6jd48SJZViAmznoQQLAv4hVXF7xyUB9zf+G++e2v1ABjCbEQ==",
++      "cpu": [
++        "arm64"
++      ],
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "musl": ">=1.2.2",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      }
++    },
++    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
++      "version": "1.0.2",
++      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.2.tgz",
++      "integrity": "sha512-VI94Q6khIHqHWNOh6LLdm9s2Ry4zdjWJwH56WoiJU7NTeDwyApdZZ8c+SADC8OH98KWNQXnE01UdJ9CSfZvwZw==",
++      "cpu": [
++        "x64"
++      ],
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "musl": ">=1.2.2",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      }
++    },
++    "node_modules/@img/sharp-linux-arm": {
++      "version": "0.33.4",
++      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.4.tgz",
++      "integrity": "sha512-RUgBD1c0+gCYZGCCe6mMdTiOFS0Zc/XrN0fYd6hISIKcDUbAW5NtSQW9g/powkrXYm6Vzwd6y+fqmExDuCdHNQ==",
++      "cpu": [
++        "arm"
++      ],
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "glibc": ">=2.28",
++        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      },
++      "optionalDependencies": {
++        "@img/sharp-libvips-linux-arm": "1.0.2"
++      }
++    },
++    "node_modules/@img/sharp-linux-arm64": {
++      "version": "0.33.4",
++      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.4.tgz",
++      "integrity": "sha512-2800clwVg1ZQtxwSoTlHvtm9ObgAax7V6MTAB/hDT945Tfyy3hVkmiHpeLPCKYqYR1Gcmv1uDZ3a4OFwkdBL7Q==",
++      "cpu": [
++        "arm64"
++      ],
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "glibc": ">=2.26",
++        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      },
++      "optionalDependencies": {
++        "@img/sharp-libvips-linux-arm64": "1.0.2"
++      }
++    },
++    "node_modules/@img/sharp-linux-s390x": {
++      "version": "0.33.4",
++      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.4.tgz",
++      "integrity": "sha512-h3RAL3siQoyzSoH36tUeS0PDmb5wINKGYzcLB5C6DIiAn2F3udeFAum+gj8IbA/82+8RGCTn7XW8WTFnqag4tQ==",
++      "cpu": [
++        "s390x"
++      ],
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "glibc": ">=2.31",
++        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      },
++      "optionalDependencies": {
++        "@img/sharp-libvips-linux-s390x": "1.0.2"
++      }
++    },
++    "node_modules/@img/sharp-linux-x64": {
++      "version": "0.33.4",
++      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.4.tgz",
++      "integrity": "sha512-GoR++s0XW9DGVi8SUGQ/U4AeIzLdNjHka6jidVwapQ/JebGVQIpi52OdyxCNVRE++n1FCLzjDovJNozif7w/Aw==",
++      "cpu": [
++        "x64"
++      ],
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "glibc": ">=2.26",
++        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      },
++      "optionalDependencies": {
++        "@img/sharp-libvips-linux-x64": "1.0.2"
++      }
++    },
++    "node_modules/@img/sharp-linuxmusl-arm64": {
++      "version": "0.33.4",
++      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.4.tgz",
++      "integrity": "sha512-nhr1yC3BlVrKDTl6cO12gTpXMl4ITBUZieehFvMntlCXFzH2bvKG76tBL2Y/OqhupZt81pR7R+Q5YhJxW0rGgQ==",
++      "cpu": [
++        "arm64"
++      ],
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "musl": ">=1.2.2",
++        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      },
++      "optionalDependencies": {
++        "@img/sharp-libvips-linuxmusl-arm64": "1.0.2"
++      }
++    },
++    "node_modules/@img/sharp-linuxmusl-x64": {
++      "version": "0.33.4",
++      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.4.tgz",
++      "integrity": "sha512-uCPTku0zwqDmZEOi4ILyGdmW76tH7dm8kKlOIV1XC5cLyJ71ENAAqarOHQh0RLfpIpbV5KOpXzdU6XkJtS0daw==",
++      "cpu": [
++        "x64"
++      ],
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "musl": ">=1.2.2",
++        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      },
++      "optionalDependencies": {
++        "@img/sharp-libvips-linuxmusl-x64": "1.0.2"
++      }
++    },
++    "node_modules/@img/sharp-wasm32": {
++      "version": "0.33.4",
++      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.4.tgz",
++      "integrity": "sha512-Bmmauh4sXUsUqkleQahpdNXKvo+wa1V9KhT2pDA4VJGKwnKMJXiSTGphn0gnJrlooda0QxCtXc6RX1XAU6hMnQ==",
++      "cpu": [
++        "wasm32"
++      ],
++      "optional": true,
++      "dependencies": {
++        "@emnapi/runtime": "^1.1.1"
++      },
++      "engines": {
++        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      }
++    },
++    "node_modules/@img/sharp-win32-ia32": {
++      "version": "0.33.4",
++      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.4.tgz",
++      "integrity": "sha512-99SJ91XzUhYHbx7uhK3+9Lf7+LjwMGQZMDlO/E/YVJ7Nc3lyDFZPGhjwiYdctoH2BOzW9+TnfqcaMKt0jHLdqw==",
++      "cpu": [
++        "ia32"
++      ],
++      "optional": true,
++      "os": [
++        "win32"
++      ],
++      "engines": {
++        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      }
++    },
++    "node_modules/@img/sharp-win32-x64": {
++      "version": "0.33.4",
++      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.4.tgz",
++      "integrity": "sha512-3QLocdTRVIrFNye5YocZl+KKpYKP+fksi1QhmOArgx7GyhIbQp/WrJRu176jm8IxromS7RIkzMiMINVdBtC8Aw==",
++      "cpu": [
++        "x64"
++      ],
++      "optional": true,
++      "os": [
++        "win32"
++      ],
++      "engines": {
++        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
++        "npm": ">=9.6.5",
++        "pnpm": ">=7.1.0",
++        "yarn": ">=3.2.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      }
++    },
+     "node_modules/@isaacs/cliui": {
+       "version": "8.0.2",
+       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+@@ -800,9 +1241,9 @@
+       }
+     },
+     "node_modules/@next/env": {
+-      "version": "14.1.0",
+-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.0.tgz",
+-      "integrity": "sha512-Py8zIo+02ht82brwwhTg36iogzFqGLPXlRGKQw5s+qP/kMNc4MAyDeEwBKDijk6zTIbegEgu8Qy7C1LboslQAw=="
++      "version": "14.2.3",
++      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
++      "integrity": "sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA=="
+     },
+     "node_modules/@next/eslint-plugin-next": {
+       "version": "14.1.0",
+@@ -814,9 +1255,9 @@
+       }
+     },
+     "node_modules/@next/swc-darwin-arm64": {
+-      "version": "14.1.0",
+-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.0.tgz",
+-      "integrity": "sha512-nUDn7TOGcIeyQni6lZHfzNoo9S0euXnu0jhsbMOmMJUBfgsnESdjN97kM7cBqQxZa8L/bM9om/S5/1dzCrW6wQ==",
++      "version": "14.2.3",
++      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.3.tgz",
++      "integrity": "sha512-3pEYo/RaGqPP0YzwnlmPN2puaF2WMLM3apt5jLW2fFdXD9+pqcoTzRk+iZsf8ta7+quAe4Q6Ms0nR0SFGFdS1A==",
+       "cpu": [
+         "arm64"
+       ],
+@@ -829,9 +1270,9 @@
+       }
+     },
+     "node_modules/@next/swc-darwin-x64": {
+-      "version": "14.1.0",
+-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.0.tgz",
+-      "integrity": "sha512-1jgudN5haWxiAl3O1ljUS2GfupPmcftu2RYJqZiMJmmbBT5M1XDffjUtRUzP4W3cBHsrvkfOFdQ71hAreNQP6g==",
++      "version": "14.2.3",
++      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.3.tgz",
++      "integrity": "sha512-6adp7waE6P1TYFSXpY366xwsOnEXM+y1kgRpjSRVI2CBDOcbRjsJ67Z6EgKIqWIue52d2q/Mx8g9MszARj8IEA==",
+       "cpu": [
+         "x64"
+       ],
+@@ -844,9 +1285,9 @@
+       }
+     },
+     "node_modules/@next/swc-linux-arm64-gnu": {
+-      "version": "14.1.0",
+-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.0.tgz",
+-      "integrity": "sha512-RHo7Tcj+jllXUbK7xk2NyIDod3YcCPDZxj1WLIYxd709BQ7WuRYl3OWUNG+WUfqeQBds6kvZYlc42NJJTNi4tQ==",
++      "version": "14.2.3",
++      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.3.tgz",
++      "integrity": "sha512-cuzCE/1G0ZSnTAHJPUT1rPgQx1w5tzSX7POXSLaS7w2nIUJUD+e25QoXD/hMfxbsT9rslEXugWypJMILBj/QsA==",
+       "cpu": [
+         "arm64"
+       ],
+@@ -859,9 +1300,9 @@
+       }
+     },
+     "node_modules/@next/swc-linux-arm64-musl": {
+-      "version": "14.1.0",
+-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.0.tgz",
+-      "integrity": "sha512-v6kP8sHYxjO8RwHmWMJSq7VZP2nYCkRVQ0qolh2l6xroe9QjbgV8siTbduED4u0hlk0+tjS6/Tuy4n5XCp+l6g==",
++      "version": "14.2.3",
++      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.3.tgz",
++      "integrity": "sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==",
+       "cpu": [
+         "arm64"
+       ],
+@@ -874,9 +1315,9 @@
+       }
+     },
+     "node_modules/@next/swc-linux-x64-gnu": {
+-      "version": "14.1.0",
+-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.0.tgz",
+-      "integrity": "sha512-zJ2pnoFYB1F4vmEVlb/eSe+VH679zT1VdXlZKX+pE66grOgjmKJHKacf82g/sWE4MQ4Rk2FMBCRnX+l6/TVYzQ==",
++      "version": "14.2.3",
++      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.3.tgz",
++      "integrity": "sha512-ENPiNnBNDInBLyUU5ii8PMQh+4XLr4pG51tOp6aJ9xqFQ2iRI6IH0Ds2yJkAzNV1CfyagcyzPfROMViS2wOZ9w==",
+       "cpu": [
+         "x64"
+       ],
+@@ -889,9 +1330,9 @@
+       }
+     },
+     "node_modules/@next/swc-linux-x64-musl": {
+-      "version": "14.1.0",
+-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.0.tgz",
+-      "integrity": "sha512-rbaIYFt2X9YZBSbH/CwGAjbBG2/MrACCVu2X0+kSykHzHnYH5FjHxwXLkcoJ10cX0aWCEynpu+rP76x0914atg==",
++      "version": "14.2.3",
++      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.3.tgz",
++      "integrity": "sha512-BTAbq0LnCbF5MtoM7I/9UeUu/8ZBY0i8SFjUMCbPDOLv+un67e2JgyN4pmgfXBwy/I+RHu8q+k+MCkDN6P9ViQ==",
+       "cpu": [
+         "x64"
+       ],
+@@ -904,9 +1345,9 @@
+       }
+     },
+     "node_modules/@next/swc-win32-arm64-msvc": {
+-      "version": "14.1.0",
+-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.0.tgz",
+-      "integrity": "sha512-o1N5TsYc8f/HpGt39OUQpQ9AKIGApd3QLueu7hXk//2xq5Z9OxmV6sQfNp8C7qYmiOlHYODOGqNNa0e9jvchGQ==",
++      "version": "14.2.3",
++      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.3.tgz",
++      "integrity": "sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==",
+       "cpu": [
+         "arm64"
+       ],
+@@ -919,9 +1360,9 @@
+       }
+     },
+     "node_modules/@next/swc-win32-ia32-msvc": {
+-      "version": "14.1.0",
+-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.0.tgz",
+-      "integrity": "sha512-XXIuB1DBRCFwNO6EEzCTMHT5pauwaSj4SWs7CYnME57eaReAKBXCnkUE80p/pAZcewm7hs+vGvNqDPacEXHVkw==",
++      "version": "14.2.3",
++      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.3.tgz",
++      "integrity": "sha512-vga40n1q6aYb0CLrM+eEmisfKCR45ixQYXuBXxOOmmoV8sYST9k7E3US32FsY+CkkF7NtzdcebiFT4CHuMSyZw==",
+       "cpu": [
+         "ia32"
+       ],
+@@ -934,9 +1375,9 @@
+       }
+     },
+     "node_modules/@next/swc-win32-x64-msvc": {
+-      "version": "14.1.0",
+-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.0.tgz",
+-      "integrity": "sha512-9WEbVRRAqJ3YFVqEZIxUqkiO8l1nool1LmNxygr5HWF8AcSYsEpneUDhmjUVJEzO2A04+oPtZdombzzPPkTtgg==",
++      "version": "14.2.3",
++      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.3.tgz",
++      "integrity": "sha512-Q1/zm43RWynxrO7lW4ehciQVj+5ePBhOK+/K2P7pLFX3JaJ/IZVC69SHidrmZSOkqz7ECIOhhy7XhAFG4JYyHA==",
+       "cpu": [
+         "x64"
+       ],
+@@ -1810,11 +2251,17 @@
+       "integrity": "sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA==",
+       "dev": true
+     },
++    "node_modules/@swc/counter": {
++      "version": "0.1.3",
++      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
++      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
++    },
+     "node_modules/@swc/helpers": {
+-      "version": "0.5.2",
+-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+-      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
++      "version": "0.5.5",
++      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
++      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+       "dependencies": {
++        "@swc/counter": "^0.1.3",
+         "tslib": "^2.4.0"
+       }
+     },
+@@ -2930,6 +3377,18 @@
+         "periscopic": "^3.1.0"
+       }
+     },
++    "node_modules/color": {
++      "version": "4.2.3",
++      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
++      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
++      "dependencies": {
++        "color-convert": "^2.0.1",
++        "color-string": "^1.9.0"
++      },
++      "engines": {
++        "node": ">=12.5.0"
++      }
++    },
+     "node_modules/color-convert": {
+       "version": "2.0.1",
+       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+@@ -2946,6 +3405,15 @@
+       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+     },
++    "node_modules/color-string": {
++      "version": "1.9.1",
++      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
++      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
++      "dependencies": {
++        "color-name": "^1.0.0",
++        "simple-swizzle": "^0.2.2"
++      }
++    },
+     "node_modules/combined-stream": {
+       "version": "1.0.8",
+       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+@@ -3152,6 +3620,14 @@
+         "node": ">=6"
+       }
+     },
++    "node_modules/detect-libc": {
++      "version": "2.0.3",
++      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
++      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
++      "engines": {
++        "node": ">=8"
++      }
++    },
+     "node_modules/detect-node-es": {
+       "version": "1.1.0",
+       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+@@ -4677,6 +5153,11 @@
+         "url": "https://github.com/sponsors/ljharb"
+       }
+     },
++    "node_modules/is-arrayish": {
++      "version": "0.3.2",
++      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
++      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
++    },
+     "node_modules/is-async-function": {
+       "version": "2.0.0",
+       "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
+@@ -6676,12 +7157,12 @@
+       "dev": true
+     },
+     "node_modules/next": {
+-      "version": "14.1.0",
+-      "resolved": "https://registry.npmjs.org/next/-/next-14.1.0.tgz",
+-      "integrity": "sha512-wlzrsbfeSU48YQBjZhDzOwhWhGsy+uQycR8bHAOt1LY1bn3zZEcDyHQOEoN3aWzQ8LHCAJ1nqrWCc9XF2+O45Q==",
++      "version": "14.2.3",
++      "resolved": "https://registry.npmjs.org/next/-/next-14.2.3.tgz",
++      "integrity": "sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==",
+       "dependencies": {
+-        "@next/env": "14.1.0",
+-        "@swc/helpers": "0.5.2",
++        "@next/env": "14.2.3",
++        "@swc/helpers": "0.5.5",
+         "busboy": "1.6.0",
+         "caniuse-lite": "^1.0.30001579",
+         "graceful-fs": "^4.2.11",
+@@ -6695,18 +7176,19 @@
+         "node": ">=18.17.0"
+       },
+       "optionalDependencies": {
+-        "@next/swc-darwin-arm64": "14.1.0",
+-        "@next/swc-darwin-x64": "14.1.0",
+-        "@next/swc-linux-arm64-gnu": "14.1.0",
+-        "@next/swc-linux-arm64-musl": "14.1.0",
+-        "@next/swc-linux-x64-gnu": "14.1.0",
+-        "@next/swc-linux-x64-musl": "14.1.0",
+-        "@next/swc-win32-arm64-msvc": "14.1.0",
+-        "@next/swc-win32-ia32-msvc": "14.1.0",
+-        "@next/swc-win32-x64-msvc": "14.1.0"
++        "@next/swc-darwin-arm64": "14.2.3",
++        "@next/swc-darwin-x64": "14.2.3",
++        "@next/swc-linux-arm64-gnu": "14.2.3",
++        "@next/swc-linux-arm64-musl": "14.2.3",
++        "@next/swc-linux-x64-gnu": "14.2.3",
++        "@next/swc-linux-x64-musl": "14.2.3",
++        "@next/swc-win32-arm64-msvc": "14.2.3",
++        "@next/swc-win32-ia32-msvc": "14.2.3",
++        "@next/swc-win32-x64-msvc": "14.2.3"
+       },
+       "peerDependencies": {
+         "@opentelemetry/api": "^1.1.0",
++        "@playwright/test": "^1.41.2",
+         "react": "^18.2.0",
+         "react-dom": "^18.2.0",
+         "sass": "^1.3.0"
+@@ -6715,6 +7197,9 @@
+         "@opentelemetry/api": {
+           "optional": true
+         },
++        "@playwright/test": {
++          "optional": true
++        },
+         "sass": {
+           "optional": true
+         }
+@@ -7928,13 +8413,9 @@
+       }
+     },
+     "node_modules/semver": {
+-      "version": "7.5.4",
+-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+-      "dev": true,
+-      "dependencies": {
+-        "lru-cache": "^6.0.0"
+-      },
++      "version": "7.6.2",
++      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
++      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+       "bin": {
+         "semver": "bin/semver.js"
+       },
+@@ -7942,18 +8423,6 @@
+         "node": ">=10"
+       }
+     },
+-    "node_modules/semver/node_modules/lru-cache": {
+-      "version": "6.0.0",
+-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+-      "dev": true,
+-      "dependencies": {
+-        "yallist": "^4.0.0"
+-      },
+-      "engines": {
+-        "node": ">=10"
+-      }
+-    },
+     "node_modules/seroval": {
+       "version": "1.0.4",
+       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.0.4.tgz",
+@@ -8010,6 +8479,45 @@
+       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+     },
++    "node_modules/sharp": {
++      "version": "0.33.4",
++      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.4.tgz",
++      "integrity": "sha512-7i/dt5kGl7qR4gwPRD2biwD2/SvBn3O04J77XKFgL2OnZtQw+AG9wnuS/csmu80nPRHLYE9E41fyEiG8nhH6/Q==",
++      "hasInstallScript": true,
++      "dependencies": {
++        "color": "^4.2.3",
++        "detect-libc": "^2.0.3",
++        "semver": "^7.6.0"
++      },
++      "engines": {
++        "libvips": ">=8.15.2",
++        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
++      },
++      "funding": {
++        "url": "https://opencollective.com/libvips"
++      },
++      "optionalDependencies": {
++        "@img/sharp-darwin-arm64": "0.33.4",
++        "@img/sharp-darwin-x64": "0.33.4",
++        "@img/sharp-libvips-darwin-arm64": "1.0.2",
++        "@img/sharp-libvips-darwin-x64": "1.0.2",
++        "@img/sharp-libvips-linux-arm": "1.0.2",
++        "@img/sharp-libvips-linux-arm64": "1.0.2",
++        "@img/sharp-libvips-linux-s390x": "1.0.2",
++        "@img/sharp-libvips-linux-x64": "1.0.2",
++        "@img/sharp-libvips-linuxmusl-arm64": "1.0.2",
++        "@img/sharp-libvips-linuxmusl-x64": "1.0.2",
++        "@img/sharp-linux-arm": "0.33.4",
++        "@img/sharp-linux-arm64": "0.33.4",
++        "@img/sharp-linux-s390x": "0.33.4",
++        "@img/sharp-linux-x64": "0.33.4",
++        "@img/sharp-linuxmusl-arm64": "0.33.4",
++        "@img/sharp-linuxmusl-x64": "0.33.4",
++        "@img/sharp-wasm32": "0.33.4",
++        "@img/sharp-win32-ia32": "0.33.4",
++        "@img/sharp-win32-x64": "0.33.4"
++      }
++    },
+     "node_modules/shebang-command": {
+       "version": "2.0.0",
+       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+@@ -8054,6 +8562,14 @@
+         "url": "https://github.com/sponsors/isaacs"
+       }
+     },
++    "node_modules/simple-swizzle": {
++      "version": "0.2.2",
++      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
++      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
++      "dependencies": {
++        "is-arrayish": "^0.3.1"
++      }
++    },
+     "node_modules/slash": {
+       "version": "3.0.0",
+       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+@@ -9369,12 +9885,6 @@
+         "node": ">=0.4"
+       }
+     },
+-    "node_modules/yallist": {
+-      "version": "4.0.0",
+-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+-      "dev": true
+-    },
+     "node_modules/yaml": {
+       "version": "2.3.4",
+       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+diff --git a/package.json b/package.json
+index 4185096..4ab1c58 100644
+--- a/package.json
++++ b/package.json
+@@ -31,7 +31,7 @@
+     "framer-motion": "^11.0.3",
+     "langchain": "^0.1.13",
+     "lucide-react": "^0.322.0",
+-    "next": "14.1.0",
++    "next": "^14.2.3",
+     "next-themes": "^0.2.1",
+     "react": "^18",
+     "react-code-blocks": "^0.1.6",
+@@ -41,6 +41,7 @@
+     "react-resizable-panels": "^2.0.3",
+     "react-textarea-autosize": "^8.5.3",
+     "remark-gfm": "^4.0.0",
++    "sharp": "^0.33.4",
+     "sonner": "^1.4.0",
+     "tailwind-merge": "^2.2.1",
+     "tailwindcss-animate": "^1.0.7",
+-- 
+2.42.0
+

--- a/pkgs/by-name/ne/nextjs-ollama-llm-ui/0002-use-local-google-fonts.patch
+++ b/pkgs/by-name/ne/nextjs-ollama-llm-ui/0002-use-local-google-fonts.patch
@@ -1,0 +1,20 @@
+diff --git a/src/app/layout.tsx b/src/app/layout.tsx
+index 647ed68..b08088e 100644
+--- a/src/app/layout.tsx
++++ b/src/app/layout.tsx
+@@ -1,10 +1,10 @@
+ import type { Metadata } from "next";
+-import { Inter } from "next/font/google";
++import localFont from "next/font/local";
+ import "./globals.css";
+ import { ThemeProvider } from "@/providers/theme-provider";
+ import { Toaster } from "@/components/ui/sonner"
+ 
+-const inter = Inter({ subsets: ["latin"] });
++const inter = localFont({ src: './Inter.ttf' });
+ 
+ export const metadata: Metadata = {
+   title: "Ollama UI",
+-- 
+2.42.0
+

--- a/pkgs/by-name/ne/nextjs-ollama-llm-ui/0003-add-standalone-output.patch
+++ b/pkgs/by-name/ne/nextjs-ollama-llm-ui/0003-add-standalone-output.patch
@@ -1,0 +1,16 @@
+diff --git a/next.config.mjs b/next.config.mjs
+index dc34f1a..f6f90c4 100644
+--- a/next.config.mjs
++++ b/next.config.mjs
+@@ -1,6 +1,7 @@
+ /** @type {import('next').NextConfig} */
+ const nextConfig = {
+-    webpack: (config, { isServer }) => {
++  output: 'standalone',
++  webpack: (config, { isServer }) => {
+         // Fixes npm packages that depend on `fs` module
+         if (!isServer) {
+           config.resolve.fallback = {
+-- 
+2.42.0
+

--- a/pkgs/by-name/ne/nextjs-ollama-llm-ui/package.nix
+++ b/pkgs/by-name/ne/nextjs-ollama-llm-ui/package.nix
@@ -2,6 +2,7 @@
   buildNpmPackage,
   fetchFromGitHub,
   inter,
+  nixosTests,
   lib,
   # This is a app can only be used in a browser and starts a web server only accessible at
   # localhost/127.0.0.1 from the local computer at the given port.
@@ -81,6 +82,12 @@ buildNpmPackage {
 
   doDist = false;
   #######################
+
+  passthru = {
+    tests = {
+      inherit (nixosTests) nextjs-ollama-llm-ui;
+    };
+  };
 
   meta = {
     description = "Simple chat web interface for Ollama LLMs.";

--- a/pkgs/by-name/ne/nextjs-ollama-llm-ui/package.nix
+++ b/pkgs/by-name/ne/nextjs-ollama-llm-ui/package.nix
@@ -1,0 +1,94 @@
+{
+  buildNpmPackage,
+  fetchFromGitHub,
+  inter,
+  lib,
+  # This is a app can only be used in a browser and starts a web server only accessible at
+  # localhost/127.0.0.1 from the local computer at the given port.
+  defaultHostname ? "127.0.0.1",
+  defaultPort ? 3000,
+  # Where to find the Ollama service; this url gets baked into the Nix package
+  ollamaUrl ? "http://127.0.0.1:11434",
+  ...
+}:
+
+let
+  version = "1.0.1";
+in
+buildNpmPackage {
+  pname = "nextjs-ollama-llm-ui";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "jakobhoeg";
+    repo = "nextjs-ollama-llm-ui";
+    rev = "v${version}";
+    hash = "sha256-pZJgiopm0VGwaZxsNcyRawevvzEcK1j5WhngX1Pn6YE=";
+  };
+  npmDepsHash = "sha256-wtHOW0CyEOszgiZwDkF2/cSxbw6WFRLbhDnd2FlY70E=";
+
+  patches = [
+    # Update to a newer nextjs version that buildNpmPackage is able to build.
+    # Remove at nextjs update.
+    ./0001-update-nextjs.patch
+    # nextjs tries to download google fonts from the internet during buildPhase and fails in Nix sandbox.
+    # We patch the code to expect a local font from src/app/Inter.ttf that we load from Nixpkgs in preBuild phase.
+    ./0002-use-local-google-fonts.patch
+    # Modify next.config.js to produce a production "standalone" output at .next/standalone.
+    # This output is easy to package with Nix and run with "node .next/standalone/server.js" later.
+    ./0003-add-standalone-output.patch
+  ];
+
+  # Adjust buildNpmPackage phases with nextjs quirk workarounds.
+  # These are adapted from
+  # https://github.com/NixOS/nixpkgs/blob/485125d667747f971cfcd1a1cfb4b2213a700c79/pkgs/servers/homepage-dashboard/default.nix
+  #######################3
+  preBuild = ''
+    # We have to pass and bake in the Ollama URL into the package
+    echo "NEXT_PUBLIC_OLLAMA_URL=${ollamaUrl}" > .env
+
+    # Replace the googleapis.com Inter font with a local copy from nixpkgs
+    cp "${inter}/share/fonts/truetype/InterVariable.ttf" src/app/Inter.ttf
+  '';
+
+  postBuild = ''
+    # Add a shebang to the server js file, then patch the shebang to use a nixpkgs nodejs binary.
+    sed -i '1s|^|#!/usr/bin/env node\n|' .next/standalone/server.js
+    patchShebangs .next/standalone/server.js
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{share,bin}
+
+    cp -r .next/standalone $out/share/homepage/
+    cp -r .env $out/share/homepage/
+    cp -r public $out/share/homepage/public
+
+    mkdir -p $out/share/homepage/.next
+    cp -r .next/static $out/share/homepage/.next/static
+
+    chmod +x $out/share/homepage/server.js
+
+    # we set a default port to support "nix run ..."
+    makeWrapper $out/share/homepage/server.js $out/bin/nextjs-ollama-llm-ui \
+      --set-default PORT ${toString defaultPort} \
+      --set-default HOSTNAME ${defaultHostname}
+
+    runHook postInstall
+  '';
+
+  doDist = false;
+  #######################
+
+  meta = {
+    description = "Simple chat web interface for Ollama LLMs.";
+    changelog = "https://github.com/jakobhoeg/nextjs-ollama-llm-ui/releases/tag/v${version}";
+    mainProgram = "nextjs-ollama-llm-ui";
+    homepage = "https://github.com/jakobhoeg/nextjs-ollama-llm-ui";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ malteneuss ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

NixOS already has good support for the Ollama backend service. Now we can benefit from having a convenient web frontend as well for it. This is a much simpler (stateless) service with fewer dependencies than e.g. https://github.com/open-webui/open-webui as requested in https://github.com/NixOS/nixpkgs/issues/309567.

## Things done

Add https://github.com/jakobhoeg/nextjs-ollama-llm-ui as a Nix package and add a corresponding NixOS module.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


You can try this module out by adding the following parts to your existing flake.nix file:

```nix
# file: flake.nix
{
   inputs.nixpkgs-nextjs-ollama-llm-ui.url = "github:malteneuss/nixpkgs/add-nextjs-ollama-llm-ui";
  ...
  outputs =
    inputs@{ self
    , nixpkgs-nextjs-ollama-llm-ui
    , ...
    }:
   { 
    nixosConfigurations.elite = nixpkgs.lib.nixosSystem {
        modules = [
          {
            imports = [
              "${nixpkgs-nextjs-ollama-llm-ui}/nixos/modules/services/web-apps/nextjs-ollama-llm-ui.nix"
            ];
            services.nextjs-ollama-llm-ui.
            services.nextjs-ollama-llm-ui = {
              enable = true;
              host = "127.0.0.1";
              port = 11435;
              ollamaUrl = "127.0.0.1:11434";
              package = nixpkgs-nextjs-ollama-llm-ui.legacyPackages.${system}.pkgs.nextjs-ollama-llm-ui;
           };
          }
         ...
        ];
      };
   };
}
```

and visiting "127.0.0.1:11435" in your browser.
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
