### PR TITLE
sonarlint-ls: init at 3.5.1.75119

### DIFF
--- a/pkgs/by-name/so/sonarlint-ls/package.nix
+++ b/pkgs/by-name/so/sonarlint-ls/package.nix
@@ -1,0 +1,118 @@
+{ lib
+, fetchFromGitHub
+, jre_headless
+, maven
+, jdk17
+, makeWrapper
+, writeShellApplication
+, runCommand
+, sonarlint-ls
+, curl
+, pcre
+, common-updater-scripts
+, jq
+, gnused
+}:
+
+let
+  mavenJdk17 = maven.override { jdk = jdk17; };
+in
+mavenJdk17.buildMavenPackage rec {
+  pname = "sonarlint-ls";
+  version = "3.5.1.75119";
+
+  src = fetchFromGitHub {
+    owner = "SonarSource";
+    repo = "sonarlint-language-server";
+    rev = version;
+    hash = "sha256-6tbuX0wUpqbTyM44e7PqZHL0/XjN8hTFCgfzV+qc1m0=";
+  };
+
+  manualMvnArtifacts = [
+    "org.apache.maven.surefire:surefire-junit-platform:3.1.2"
+    "org.junit.platform:junit-platform-launcher:1.8.2"
+  ];
+
+  mvnHash = "sha256-ZhAQtpi0wQP8+QPeYaor2MveY+DZ9RPENb3kITnuWd8=";
+
+  buildOffline = true;
+
+
+  # disable node and npm module installation because the need network access
+  # for the tests.
+  mvnDepsParameters = "-Dskip.installnodenpm=true -Dskip.npm -DskipTests package";
+
+  # disable failing tests which either need network access or are flaky
+  mvnParameters = lib.escapeShellArgs [
+    "-Dskip.installnodenpm=true"
+    "-Dskip.npm"
+    "-Dtest=!LanguageServerMediumTests,
+    !LanguageServerWithFoldersMediumTests,
+    !NotebookMediumTests,
+    !ConnectedModeMediumTests,
+    !JavaMediumTests"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/plugins}
+    install -Dm644 target/sonarlint-language-server-*.jar \
+      $out/share/sonarlint-ls.jar
+    install -Dm644 target/plugins/* \
+      $out/share/plugins
+
+
+    makeWrapper ${jre_headless}/bin/java $out/bin/sonarlint-ls \
+      --add-flags "-jar $out/share/sonarlint-ls.jar" \
+      --add-flags "-stdio" \
+      --add-flags "-analyzers $(ls -1 $out/share/plugins | tr '\n' ' ')"
+
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  passthru = {
+    tests = {
+      sonarlint-ls-starts-successfully = runCommand "${pname}-test" { } ''
+        ${sonarlint-ls}/bin/sonarlint-ls > $out
+        cat $out | grep "SonarLint backend started"
+      '';
+    };
+
+    updateScript =
+      let
+        pkgFile = builtins.toString ./package.nix;
+      in
+      lib.getExe (writeShellApplication {
+        name = "update-${pname}";
+        runtimeInputs = [ curl pcre common-updater-scripts jq gnused ];
+        text = ''
+          LATEST_TAG=$(curl https://api.github.com/repos/${src.owner}/${src.repo}/tags | \
+            jq -r '[.[] | select(.name | test("^[0-9]"))] | sort_by(.name | split(".") |
+            map(tonumber)) | reverse | .[0].name')
+          update-source-version ${pname} "$LATEST_TAG"
+          sed -i '0,/mvnHash *= *"[^"]*"/{s/mvnHash = "[^"]*"/mvnHash = ""/}' ${pkgFile}
+
+          echo -e "\nFetching all mvn dependencies to calculate the mvnHash. This may take a while ..."
+          nix-build -A ${pname}.fetchedMavenDeps 2> ${pname}-stderr.log || true
+
+          NEW_MVN_HASH=$(grep "got:" ${pname}-stderr.log | awk '{print ''$2}')
+          rm ${pname}-stderr.log
+          # escaping double quotes looks ugly but is needed for variable substitution
+          # use # instead of / as separator because the sha256 might contain the / character
+          sed -i "0,/mvnHash *= *\"[^\"]*\"/{s#mvnHash = \"[^\"]*\"#mvnHash = \"$NEW_MVN_HASH\"#}" ${pkgFile}
+        '';
+      });
+  };
+
+  meta = {
+    description = "Sonarlint language server";
+    mainProgram = "sonarlint-ls";
+    homepage = "https://github.com/SonarSource/sonarlint-language-server";
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ tricktron ];
+  };
+}
+


### PR DESCRIPTION
## Description of changes

The [Sonarlint language server](https://github.com/SonarSource/sonarlint-language-server) builds the basis for the [sonarlint neovim plugin](https://gitlab.com/schrieveslaach/sonarlint.nvim) and the [Sonarlint VS code extension](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarlint-vscode).
 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
