### PR TITLE
erlang_27: init 27.0; erlang_27-rc3: remove

### DIFF
--- a/pkgs/development/interpreters/erlang/27-rc3.nix
+++ b/pkgs/development/interpreters/erlang/27-rc3.nix
@@ -1,6 +1,0 @@
-{ mkDerivation }:
-
-mkDerivation {
-  version = "27.0-rc3";
-  sha256 = "sha256-c2DTIqBd7UxpSv84F1cCB9K+MkJb5OwnWSghtewnw/4=";
-}

--- a/pkgs/development/interpreters/erlang/27.nix
+++ b/pkgs/development/interpreters/erlang/27.nix
@@ -1,0 +1,6 @@
+{ mkDerivation }:
+
+mkDerivation {
+  version = "27.0";
+  sha256 = "sha256-YZWBLcpkm8B4sjoQO7I9ywXcmxXL+Dvq/JYsLsr7TO0=";
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -341,6 +341,7 @@ mapAliases ({
   erlangR22 = erlang_22;
   erlang_23 = throw "erlangR23 has been removed in favor of newer versions."; # added 2023-09-11
   erlangR23 = erlang_23;
+  erlang_27-rc3 = throw "erlang_27-rc3 has been removed in favor of erlang_27"; # added 2024-05-20
   etcd_3_3 = throw "etcd_3_3 has been removed because upstream no longer maintains it"; # Added 2023-09-29
   etcher = throw "'etcher' has been removed because it depended on an insecure version of Electron"; # Added 2024-03-14
   eterm = throw "eterm was removed because it is still insecure: https://github.com/mej/Eterm/issues/7"; # Added 2023-09-10

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17180,7 +17180,7 @@ with pkgs;
   };
 
   inherit (beam.interpreters)
-    erlang erlang_27-rc3 erlang_26 erlang_25 erlang_24
+    erlang erlang_27-rc3 erlang_27 erlang_26 erlang_25 erlang_24
     erlang_odbc erlang_javac erlang_odbc_javac
     elixir elixir_1_16 elixir_1_15 elixir_1_14 elixir_1_13 elixir_1_12 elixir_1_11 elixir_1_10
     elixir-ls;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17180,7 +17180,7 @@ with pkgs;
   };
 
   inherit (beam.interpreters)
-    erlang erlang_27-rc3 erlang_27 erlang_26 erlang_25 erlang_24
+    erlang erlang_27 erlang_26 erlang_25 erlang_24
     erlang_odbc erlang_javac erlang_odbc_javac
     elixir elixir_1_16 elixir_1_15 elixir_1_14 elixir_1_13 elixir_1_12 elixir_1_11 elixir_1_10
     elixir-ls;

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -41,6 +41,15 @@ in
 
     # Standard Erlang versions, using the generic builder.
 
+    erlang_27 = self.beamLib.callErlang ../development/interpreters/erlang/27.nix {
+      wxGTK = wxGTK32;
+      parallelBuild = true;
+      autoconf = buildPackages.autoconf269;
+      exdocSupport = true;
+      exdoc = self.packages.erlang_26.ex_doc;
+      inherit wxSupport systemdSupport;
+    };
+
     erlang_27-rc3 = self.beamLib.callErlang ../development/interpreters/erlang/27-rc3.nix {
       wxGTK = wxGTK32;
       parallelBuild = true;

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -50,15 +50,6 @@ in
       inherit wxSupport systemdSupport;
     };
 
-    erlang_27-rc3 = self.beamLib.callErlang ../development/interpreters/erlang/27-rc3.nix {
-      wxGTK = wxGTK32;
-      parallelBuild = true;
-      autoconf = buildPackages.autoconf269;
-      exdocSupport = true;
-      exdoc = self.packages.erlang_26.ex_doc;
-      inherit wxSupport systemdSupport;
-    };
-
     erlang_26 = self.beamLib.callErlang ../development/interpreters/erlang/26.nix {
       wxGTK = wxGTK32;
       parallelBuild = true;


### PR DESCRIPTION
## Description of changes

Erlang 27 was officially released https://erlangforums.com/t/erlang-otp-27-0-released/3636

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

```
> nix-build -A erlang_27
/nix/store/70y7d02jfqh6nfpaydd6dkwbnpcm9mfx-erlang-27.0
> ./result/bin/erl
Erlang/OTP 27 [erts-15.0] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

Eshell V15.0 (press Ctrl+G to abort, type help(). for help)
1> io:format("hello world~n").
hello world
ok
2> q().
ok
```

```
[nix-shell:~/.cache/nixpkgs-review/rev-a251d7e27849119564bb72e3ab157128f4200add]$ erl
Erlang/OTP 27 [erts-15.0] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

Eshell V15.0 (press Ctrl+G to abort, type help(). for help)
1> io:format(~"hello world~n").
hello world
ok
```

The deprecation,

```
> nix-build -A erlang_27-rc3
error:
       … while evaluating a branch condition

         at /Users/chiroptical/programming/nix/nixpkgs/pkgs/top-level/aliases.nix:33:5:

           32|   removeDistribute = alias: with lib;
           33|     if isDerivation alias then
             |     ^
           34|       dontDistribute alias

       … while evaluating a branch condition

         at /Users/chiroptical/programming/nix/nixpkgs/pkgs/top-level/aliases.nix:26:5:

           25|   removeRecurseForDerivations = alias: with lib;
           26|     if alias.recurseForDerivations or false
             |     ^
           27|     then removeAttrs alias [ "recurseForDerivations" ]

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: erlang_27-rc3 has been removed in favor of erlang_27
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
