### PR TITLE
blockbench: fix darwin build

### DIFF
--- a/pkgs/by-name/bl/blockbench/package.nix
+++ b/pkgs/by-name/bl/blockbench/package.nix
@@ -1,16 +1,18 @@
-{ lib
-, stdenv
-, buildNpmPackage
-, fetchFromGitHub
-, imagemagick
-, makeWrapper
-, makeDesktopItem
-, copyDesktopItems
-, electron_28
+{
+  lib,
+  stdenv,
+  buildNpmPackage,
+  fetchFromGitHub,
+  makeWrapper,
+  imagemagick,
+  copyDesktopItems,
+  makeDesktopItem,
+  electron_28,
 }:
 
 let
   electron = electron_28;
+  electronDist = "${electron}/${if stdenv.isDarwin then "Applications" else "libexec/electron"}";
 in
 buildNpmPackage rec {
   pname = "blockbench";
@@ -23,40 +25,59 @@ buildNpmPackage rec {
     hash = "sha256-pycRC+ZpN2P5Z66/aGA4gykLF7IwdeToRadaJSA1L9w=";
   };
 
-  nativeBuildInputs = [
-    imagemagick # for icon resizing
-    makeWrapper
-    copyDesktopItems
-  ];
+  nativeBuildInputs =
+    [ makeWrapper ]
+    ++ lib.optionals (!stdenv.isDarwin) [
+      imagemagick # for icon resizing
+      copyDesktopItems
+    ];
 
   npmDepsHash = "sha256-CHZdCiewkmToDHhTTvOqQfWrphOw1oGLgwSRRH3YFWE=";
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
 
+  # disable code signing on Darwin
+  postConfigure = lib.optionalString stdenv.isDarwin ''
+    export CSC_IDENTITY_AUTO_DISCOVERY=false
+    sed -i "/afterSign/d" package.json
+  '';
+
   npmBuildScript = "bundle";
 
   postBuild = ''
+    # electronDist needs to be modifiable on Darwin
+    cp -r ${electronDist} electron-dist
+    chmod -R u+w electron-dist
+
     npm exec electron-builder -- \
         --dir \
-        -c.electronDist=${electron}/libexec/electron \
+        -c.electronDist=electron-dist \
         -c.electronVersion=${electron.version}
   '';
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/share/blockbench
-    cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/blockbench
+    ${lib.optionalString stdenv.isDarwin ''
+      mkdir -p $out/Applications
+      cp -r dist/mac*/Blockbench.app $out/Applications
+      makeWrapper $out/Applications/Blockbench.app/Contents/MacOS/Blockbench $out/bin/blockbench
+    ''}
 
-    for size in 16 32 48 64 128 256 512; do
-      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-      convert -resize "$size"x"$size" icon.png $out/share/icons/hicolor/"$size"x"$size"/apps/blockbench.png
-    done
+    ${lib.optionalString (!stdenv.isDarwin) ''
+      mkdir -p $out/share/blockbench
+      cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/blockbench
 
-    makeWrapper ${lib.getExe electron} $out/bin/blockbench \
-        --add-flags $out/share/blockbench/resources/app.asar \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
-        --inherit-argv0
+      for size in 16 32 48 64 128 256 512; do
+        mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+        convert -resize "$size"x"$size" icon.png $out/share/icons/hicolor/"$size"x"$size"/apps/blockbench.png
+      done
+
+      makeWrapper ${lib.getExe electron} $out/bin/blockbench \
+          --add-flags $out/share/blockbench/resources/app.asar \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+          --inherit-argv0
+    ''}
 
     runHook postInstall
   '';
@@ -81,7 +102,9 @@ buildNpmPackage rec {
     homepage = "https://blockbench.net/";
     license = lib.licenses.gpl3Only;
     mainProgram = "blockbench";
-    maintainers = with lib.maintainers; [ ckie tomasajt ];
-    broken = stdenv.isDarwin;
+    maintainers = with lib.maintainers; [
+      ckie
+      tomasajt
+    ];
   };
 }


### PR DESCRIPTION
## Description of changes

This PR adds darwin support for the `blockbench` package.
It is mostly based off of how the `drawio` package does it.

Please note that I don't have a Mac so I couldn't test if the package could be run.
If you stumble across this PR and are able to try this package out on Darwin, please do.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
