### PR TITLE
haven-cli: 3.0.7 -> 3.3.4

### DIFF
--- a/pkgs/applications/blockchains/haven-cli/default.nix
+++ b/pkgs/applications/blockchains/haven-cli/default.nix
@@ -1,22 +1,20 @@
-{ lib, stdenv, fetchFromGitHub
-, cmake, pkg-config
-, boost179, miniupnpc, openssl, unbound
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
+, boost, miniupnpc, openssl, unbound
 , zeromq, pcsclite, readline, libsodium, hidapi
-, randomx, rapidjson
-, easyloggingpp
+, randomx, rapidjson, easyloggingpp
 , CoreData, IOKit, PCSC
 , trezorSupport ? true, libusb1, protobuf, python3
 }:
 
 stdenv.mkDerivation rec {
   pname = "haven-cli";
-  version = "3.0.7";
+  version = "3.3.4";
 
   src = fetchFromGitHub {
     owner = "haven-protocol-org";
     repo = "haven-main";
     rev = "v${version}";
-    sha256 = "sha256-HLZ9j75MtF7FkHA4uefkrYp07pVZe1Ac1wny7T0CMpA=";
+    sha256 = "sha256-jKeLFWJDwS8WWRynkDgBjvjq2EDpTEJadwkNsANQXws=";
     fetchSubmodules = true;
   };
 
@@ -26,39 +24,38 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     # remove vendored libraries
-    rm -r external/{miniupnp,randomx,rapidjson,unbound}
+    rm -r external/{miniupnp,randomx,rapidjson}
     # export patched source for haven-gui
     cp -r . $source
-    # fix build on aarch64-darwin
-    substituteInPlace CMakeLists.txt --replace "-march=x86-64" ""
   '';
 
   nativeBuildInputs = [ cmake pkg-config ];
 
   buildInputs = [
-    boost179 miniupnpc openssl unbound
+    boost miniupnpc openssl unbound
     zeromq pcsclite readline
     libsodium hidapi randomx rapidjson
-    protobuf
-    readline easyloggingpp
-  ]
+    protobuf readline easyloggingpp
+  ] ++ lib.optionals stdenv.isDarwin [ IOKit CoreData PCSC ]
     ++ lib.optionals trezorSupport [ libusb1 protobuf python3 ];
 
   cmakeFlags = [
-    "-DUSE_DEVICE_TREZOR=ON"
     "-DBUILD_GUI_DEPS=ON"
     "-DReadline_ROOT_DIR=${readline.dev}"
     "-DReadline_INCLUDE_DIR=${readline.dev}/include/readline"
     "-DRandomX_ROOT_DIR=${randomx}"
-  ] ++ lib.optional stdenv.isDarwin "-DBoost_USE_MULTITHREADED=OFF";
+  ] ++ lib.optional stdenv.isDarwin "-DBoost_USE_MULTITHREADED=OFF"
+    ++ lib.optional (!trezorSupport) "-DUSE_DEVICE_TREZOR=OFF";
 
   outputs = [ "out" "source" ];
 
   meta = with lib; {
-    description = "Haven Protocol is the world's only network of private stable asset";
-    homepage    = "https://havenprotocol.org/";
-    license     = licenses.bsd3;
-    platforms   = platforms.all;
-    maintainers = with maintainers; [ kim0 ];
+    description  = "Haven Protocol is the world's only network of private stable asset";
+    homepage     = "https://havenprotocol.org/";
+    license      = licenses.bsd3;
+    platforms    = platforms.all;
+    badPlatforms = [ "x86_64-darwin" ];
+    maintainers  = with maintainers; [ kim0 ];
+    mainProgram  = "haven-wallet-cli";
   };
 }

--- a/pkgs/applications/blockchains/haven-cli/use-system-libraries.patch
+++ b/pkgs/applications/blockchains/haven-cli/use-system-libraries.patch
@@ -2,19 +2,18 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index fb71d2d..3a710a4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -200,11 +200,11 @@ if(NOT MANUAL_SUBMODULES)
+@@ -364,10 +364,10 @@ if(NOT MANUAL_SUBMODULES)
      endfunction ()
      
      message(STATUS "Checking submodules")
 -    check_submodule(external/miniupnp)
--    check_submodule(external/unbound)
 -    check_submodule(external/rapidjson)
 +    # check_submodule(external/miniupnp)
-+    # check_submodule(external/unbound)
 +    # check_submodule(external/rapidjson)
      check_submodule(external/trezor-common)
 -    check_submodule(external/randomx)
 +    # check_submodule(external/randomx)
+     check_submodule(external/supercop)
    endif()
  endif()
  
@@ -45,13 +44,15 @@ diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
 index 71b165f..10189ce 100644
 --- a/external/CMakeLists.txt
 +++ b/external/CMakeLists.txt
-@@ -37,19 +37,9 @@
+@@ -37,21 +37,9 @@
  
  find_package(Miniupnpc REQUIRED)
  
 -message(STATUS "Using in-tree miniupnpc")
+-set(UPNPC_NO_INSTALL TRUE CACHE BOOL "Disable miniupnp installation" FORCE)
 -add_subdirectory(miniupnp/miniupnpc)
 -set_property(TARGET libminiupnpc-static PROPERTY FOLDER "external")
+-set_property(TARGET libminiupnpc-static PROPERTY POSITION_INDEPENDENT_CODE ON)
 -if(MSVC)
 -  set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -wd4244 -wd4267")
 -elseif(NOT MSVC)
@@ -68,10 +69,11 @@ index 71b165f..10189ce 100644
  
  find_package(Unbound)
  
-@@ -80,4 +70,3 @@ endif()
+@@ -69,5 +69,4 @@ endif()
  
  add_subdirectory(db_drivers)
  add_subdirectory(easylogging++)
+ add_subdirectory(qrcodegen)
 -add_subdirectory(randomx EXCLUDE_FROM_ALL)
 diff --git a/src/p2p/net_node.inl b/src/p2p/net_node.inl
 index c626e22..be570ed 100644


### PR DESCRIPTION
## Description of changes

Updated Haven to 3.3.4, fixed building on x86_64-linux, aarch64-darwin and possibly other systems.

UPD: Marked as broken on x86_64-darwin, reason:
![image](https://github.com/NixOS/nixpkgs/assets/54859825/332301f4-a89e-4893-bbdd-25cc426dd044)


ZHF: #309482

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin (bad platform)
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
