### PR TITLE
kyocera-ecosys-3500-4500: init at 9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13000,6 +13000,12 @@
     githubId = 14259816;
     name = "Abin Simon";
   };
+  me-and = {
+    name = "Adam Dinwoodie";
+    email = "nix.thunder.wayne@post.dinwoodie.org";
+    github = "me-and";
+    githubId = 1397507;
+  };
   meatcar = {
     email = "nixpkgs@denys.me";
     github = "meatcar";

--- a/pkgs/by-name/cu/cups-kyocera-3500-4500/package.nix
+++ b/pkgs/by-name/cu/cups-kyocera-3500-4500/package.nix
@@ -1,0 +1,86 @@
+{ lib
+, stdenv
+, fetchzip
+, cups
+, autoPatchelfHook
+, python3Packages
+
+# Sets the default paper format: use "EU" for A4, or "Global" for Letter
+, region ? "EU"
+}:
+
+assert region == "Global" || region == "EU";
+
+let
+  kyodialog_version_short = "9";
+  kyodialog_version_long = "9.0";
+  date = "20221003";
+in
+stdenv.mkDerivation rec {
+  pname = "cups-kyocera-3500-4500";
+  version = "${kyodialog_version_long}-${date}";
+
+  dontStrip = true;
+
+  src = fetchzip {
+    # Steps to find the release download URL:
+    # 1. Go to https://www.kyoceradocumentsolutions.us/en/support/downloads.html
+    # 2. Search for printer model, e.g. "TASKalfa 6053ci"
+    # 3. Locate e.g. "Linux Print Driver (9.3)" in the list
+    urls = [
+      "https://dam.kyoceradocumentsolutions.com/content/dam/gdam_dc/dc_global/executables/driver/product_085/KyoceraLinuxPackages-${date}.tar.gz"
+    ];
+    hash = "sha256-pqBtfKiQo/+cF8fG5vsEQvr8UdxjGsSShXI+6bun03c=";
+    extension = "tar.gz";
+    stripRoot = false;
+    postFetch = ''
+      # delete redundant Linux package dirs to reduce size in the Nix store; only keep Debian
+      rm -r $out/{CentOS,Fedora,OpenSUSE,Redhat,Ubuntu}
+    '';
+  };
+
+  sourceRoot = ".";
+
+  unpackCmd = let
+    platforms = {
+      x86_64-linux = "amd64";
+      i686-linux = "i386";
+    };
+    platform = platforms.${stdenv.hostPlatform.system} or (throw "unsupported system: ${stdenv.hostPlatform.system}");
+  in ''
+    ar p "$src/Debian/${region}/kyodialog_${platform}/kyodialog_${kyodialog_version_long}-0_${platform}.deb" data.tar.gz | tar -xz
+  '';
+
+  nativeBuildInputs = [ autoPatchelfHook python3Packages.wrapPython ];
+
+  buildInputs = [ cups ];
+
+  # For lib/cups/filter/kyofilter_pre_H.
+  # The source already contains a copy of pypdf3, but we use the Nix package
+  propagatedBuildInputs = with python3Packages; [ reportlab pypdf3 setuptools ];
+
+  installPhase = ''
+    # allow cups to find the ppd files
+    mkdir -p $out/share/cups/model
+    mv ./usr/share/kyocera${kyodialog_version_short}/ppd${kyodialog_version_short} $out/share/cups/model/Kyocera
+
+    # remove absolute path prefixes to filters in ppd
+    find $out -name "*.ppd" -exec sed -E -i "s:/usr/lib/cups/filter/::g" {} \;
+
+    mkdir -p $out/lib/cups/
+    mv ./usr/lib/cups/filter/ $out/lib/cups/
+    # for lib/cups/filter/kyofilter_pre_H
+    wrapPythonProgramsIn $out/lib/cups/filter "$propagatedBuildInputs"
+
+    install -Dm444 usr/share/doc/kyodialog/copyright $out/share/doc/${pname}/copyright
+  '';
+
+  meta = with lib; {
+    description = "CUPS drivers for Kyocera ECOSYS MA3500cix, MA3500cifx, MA4000cix, MA4000cifx, PA3500cx, PA4000cx and PA4500cx, for Kyocera CS MA4500ci and PA4500ci, and for Kyocera TASKalfa MA3500ci, MA4500ci and PI4500ci printers";
+    homepage = "https://www.kyoceradocumentsolutions.com";
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = [ maintainers.me-and ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
New package with drivers for various Kyocera printers.

Based heavily on the kyodialog package.

## Description of changes

New driver package for some Kyocera printers, based on the drivers from https://www.kyoceradocumentsolutions.com/download/model_en.html?r=119&s=25&m=391&p=83 and the kyodialog package at https://github.com/NixOS/nixpkgs/tree/master/pkgs/misc/cups/drivers/kyodialog

This is my first attempt at sharing a package; I have it building and working on my test NixOS VM, but I'm still getting the hang of the Nix language, and I'm not 100% certain of the changes I've made as part of rewriting this to work as a derivation rather than an import (or even if those are the right words for what I've done…)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
