### PR TITLE
add force-build-new-FODs.sh maintainer script

### DIFF
--- a/maintainers/scripts/force-build-new-FODs.sh
+++ b/maintainers/scripts/force-build-new-FODs.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p coreutils gnugrep gnused nix curl jq
+#
+# Given directories <before-nixpkgs> and <after-nixpkgs>, will find
+# new Fixed-Output-Derivations ("FODs") introduced by <after-nixpkgs>,
+# and attempt to build/download them locally, disregarding any caches
+# that claim to have a substitutable binary with the given hash, and
+# compares the actual hash with the purported output hash.
+#
+# On completion, outputs to stdout a series of json objects, each
+# representing a FOD that has been checked, containing at least
+# an `origDrv` and `status` key.
+#
+# Exit code is nonzero if at least one FOD failed the check.
+#
+# Also recognizes $REALIZE_PROCESSES and $REALIZE_TIMEOUT environment
+# vars
+#
+
+set -e -o pipefail
+
+if [ $# != '2' ] ; then
+  echo "usage: $0 <before-nixpkgs> <after-nixpkgs>" >&2
+  exit 2
+fi
+
+export WORKDIR=$(mktemp -d)
+echo "Putting intermediate files in $WORKDIR" >&2
+NIXPKGS_BEFORE="$(realpath $1)"
+NIXPKGS_AFTER="$(realpath $2)"
+
+OUTPATHS_NIX=$(mktemp)
+cat > "$OUTPATHS_NIX" <<"EOF"
+# originally https://github.com/NixOS/ofborg/blob/74f38efa7ef6f0e8e71ec3bfc675ae4fb57d7491/ofborg/src/outpaths.nix
+{ checkMeta
+, path ? ./.
+, supportedSystems ? [ builtins.currentSystem ]
+}:
+let
+  lib = import (path + "/lib");
+  hydraJobs = import (path + "/pkgs/top-level/release.nix")
+    # Compromise: accuracy vs. resources needed for evaluation.
+    {
+      inherit supportedSystems;
+
+      nixpkgsArgs = {
+        config = {
+          allowAliases = false;
+          allowBroken = true;
+          allowUnfree = true;
+          allowInsecurePredicate = x: true;
+          checkMeta = checkMeta;
+
+          handleEvalIssue = reason: errormsg:
+            let
+              fatalErrors = [
+                "unknown-meta"
+                "broken-outputs"
+              ];
+            in
+            if builtins.elem reason fatalErrors
+            then abort errormsg
+            else true;
+
+          inHydra = true;
+        };
+      };
+    };
+  recurseIntoAttrs = attrs: attrs // { recurseForDerivations = true; };
+
+  # hydraJobs leaves recurseForDerivations as empty attrmaps;
+  # that would break nix-env and we also need to recurse everywhere.
+  tweak = lib.mapAttrs
+    (name: val:
+      if name == "recurseForDerivations" then true
+      else if lib.isAttrs val && val.type or null != "derivation"
+      then recurseIntoAttrs (tweak val)
+      else val
+    );
+
+  # Some of these contain explicit references to platform(s) we want to avoid;
+  # some even (transitively) depend on ~/.nixpkgs/config.nix (!)
+  blacklist = [
+    "tarball"
+    "metrics"
+    "manual"
+    "darwin-tested"
+    "unstable"
+    "stdenvBootstrapTools"
+    "moduleSystem"
+    "lib-tests" # these just confuse the output
+  ];
+
+in
+tweak (builtins.removeAttrs hydraJobs blacklist)
+EOF
+
+export NIX_CURRENTSYSTEM="$(nix eval --impure --raw --expr 'builtins.currentSystem')"
+
+
+echo "Evaluating attr-addressable derivations in after-nixpkgs..." >&2
+# generate json of attr-addressable derivations in "after" nixpkgs mapped to their attrPath
+nix-env -f "$OUTPATHS_NIX" -qa --attr-path --drv-path --no-name \
+  --argstr path "$NIXPKGS_AFTER" \
+  --arg checkMeta false \
+  | jq -Rn '[inputs | split("\\s+"; null) | {key: .[1], value: .[0] | rtrimstr("." + env.NIX_CURRENTSYSTEM)}] | from_entries' \
+  > "$WORKDIR/attrdrvs.after.json"
+echo "Evaluating attr-addressable derivations in before-nixpkgs..." >&2
+# generate json of attr-addressable derivations in "before" nixpkgs mapped to `null`
+nix-env -f "$OUTPATHS_NIX" -qa --attr-path --drv-path --no-name \
+  --argstr path "$NIXPKGS_BEFORE" \
+  --arg checkMeta false \
+  | jq -Rn '[inputs | split("\\s+"; null) | {key: .[1], value: null}] | from_entries' \
+  > "$WORKDIR/attrdrvs.before.json"
+
+
+# generate json array of attrPaths changed (or new) in "after" nixpkgs
+jq -n '[ $after[0] + $before[0] | to_entries | .[] | .value | strings ]' \
+  --slurpfile before "$WORKDIR/attrdrvs.before.json" \
+  --slurpfile after "$WORKDIR/attrdrvs.after.json" \
+  > "$WORKDIR/changedattrdrvs.attrs.json"
+
+echo "Found $(jq -r 'length' < "$WORKDIR/changedattrdrvs.attrs.json") attrPaths with new .drvs" >&2
+
+CHANGEDATTRDRVS_NIX=$(mktemp)
+cat > "$CHANGEDATTRDRVS_NIX" <<"EOF"
+# given a json array of (dot-separated) package attr paths in
+# newdrvsJsonFile, produce an array of those derivations
+
+{ pkgsPath, newdrvsJsonFile, outpathsNix }: let
+  pkgs = import outpathsNix { checkMeta = false; path = pkgsPath;};
+  lib = (import pkgsPath {}).lib;
+in
+  builtins.filter (d: d != null) (
+    builtins.map
+    (p: lib.attrByPath (lib.splitString "." p) null pkgs)
+    (builtins.fromJSON (builtins.readFile newdrvsJsonFile))
+  )
+EOF
+
+
+echo "Instantiating .drvs for affected attrs in after-nixpkgs..." >&2
+# instantiate all .drv files needed for the affected attrs in the "after" nixpkgs,
+# noting the attr-addressable .drv paths
+nix-instantiate "$CHANGEDATTRDRVS_NIX" \
+  --arg pkgsPath "$NIXPKGS_AFTER" \
+  --arg newdrvsJsonFile "$WORKDIR/changedattrdrvs.attrs.json" \
+  --arg outpathsNix "$OUTPATHS_NIX" \
+  | cut -d '!' -f 1 \
+  > "$WORKDIR/changedattrdrvs.after.drvs"
+
+
+echo "Instantiating .drvs for affected attrs in before-nixpkgs..." >&2
+# instantiate all .drv files needed for the affected attrs in the "before" nixpkgs,
+# noting the attr-addressable .drv paths. this won't be perfectly accurate as some
+# of the attrPaths may be new in the "after" nixpkgs. CHANGEDATTRDRVS_NIX makes
+# special provisions to ignore these. this may also miss some .drv files that are
+# present in the "before" nixpkgs, but under a different attrPath.
+nix-instantiate "$CHANGEDATTRDRVS_NIX" \
+  --arg pkgsPath "$NIXPKGS_BEFORE" \
+  --arg newdrvsJsonFile "$WORKDIR/changedattrdrvs.attrs.json" \
+  --arg outpathsNix "$OUTPATHS_NIX" \
+  | cut -d '!' -f 1 \
+  > "$WORKDIR/changedattrdrvs.before.drvs"
+
+
+echo "Gathering requisite .drvs in after-nixpkgs..." >&2
+# list *all* requisite .drvs for the sets of attr-addressable .drvs in the "after"
+# and "before" nixpkgs respectively
+nix-store -qR $(< "$WORKDIR/changedattrdrvs.after.drvs") 2> /dev/null \
+  | grep '.drv$' | sort > "$WORKDIR/allchangeddrvs.after.drvs"
+echo "Gathering requisite .drvs in before-nixpkgs..." >&2
+nix-store -qR $(< "$WORKDIR/changedattrdrvs.before.drvs") 2> /dev/null \
+  | grep '.drv$' | sort > "$WORKDIR/allchangeddrvs.before.drvs"
+
+
+# reduce this list to just those .drvs that are new in the "after" nixpkgs
+comm -13 "$WORKDIR/allchangeddrvs.before.drvs" "$WORKDIR/allchangeddrvs.after.drvs" \
+  > "$WORKDIR/allnewdrvs.drvs"
+
+
+echo "Found $(wc -l "$WORKDIR/allnewdrvs.drvs" | cut -d ' ' -f 1) after-nixpkgs .drvs not present in before-nixpkgs"
+
+# reduce this further to just those that are FODs
+nix derivation show $(< "$WORKDIR/allnewdrvs.drvs") 2> /dev/null \
+  | jq -r 'to_entries | .[] | select(.value.outputs.out.hash) | .key' \
+  > "$WORKDIR/newfods.drvs"
+
+
+echo "Generating tainted clones of $(wc -l "$WORKDIR/newfods.drvs" | cut -d ' ' -f 1) new FOD .drvs..." >&2
+# for each of these "new" FODs, generate a "tainted" clone with an incorrect outhash
+echo -n > "$WORKDIR/taintedfods.jsonl"
+while read ORIGDRV ; do
+  export ORIGDRV
+  HASHALGO=$(
+    nix derivation show "$ORIGDRV" 2> /dev/null \
+      | jq -r '.[env.ORIGDRV].outputs.out.hashAlgo'
+  )
+  export ORIGHASH_SRI="$(
+    nix-hash \
+      --type ${HASHALGO#r:} \
+      --to-sri $(
+        nix derivation show "$ORIGDRV" 2> /dev/null \
+          | jq -r '.[env.ORIGDRV].outputs.out.hash'
+      )
+  )"
+  DRVNAME=$(nix derivation show "$ORIGDRV" 2> /dev/null | jq -r '.[env.ORIGDRV].name')
+  case "$HASHALGO" in
+    *md5)
+      HASHBYTES=16
+      ;;
+    *sha1)
+      HASHBYTES=20
+      ;;
+    *sha256)
+      HASHBYTES=32
+      ;;
+    *sha512)
+      HASHBYTES=64
+      ;;
+  esac
+  export NEWHASH="$(od -N $HASHBYTES -A n -t x1 -w$HASHBYTES < /dev/urandom | tr -d -c '[:xdigit:]')"
+  if [[ "$HASHALGO" = r:* ]] ; then
+    OUTPATHHASH=$(nix-hash --type sha256 --truncate --base32 --flat \
+      <(echo -n "source:${HASHALGO#r:}:$NEWHASH:/nix/store:$DRVNAME") \
+    )
+  else
+    OUTPATHHASH=$(nix-hash --type sha256 --truncate --base32 --flat \
+      <(echo -n "output:out:sha256:$(echo -n "fixed:out:sha256:$NEWHASH:" | sha256sum | tr -d -c '[:xdigit:]'):/nix/store:$DRVNAME") \
+    )
+  fi
+  export OUTPATH="/nix/store/$OUTPATHHASH-$DRVNAME"
+  nix derivation show "$ORIGDRV" 2> /dev/null \
+    | jq '.[env.ORIGDRV] | .outputs.out.hash = env.NEWHASH | .outputs.out.path = env.OUTPATH | .env.out = env.OUTPATH' \
+    | nix derivation add 2> /dev/null \
+    | jq -Rc '{origDrv: env.ORIGDRV, taintedDrv: ., origHashSRI: env.ORIGHASH_SRI}' \
+    >> "$WORKDIR/taintedfods.jsonl"
+done < "$WORKDIR/newfods.drvs"
+
+
+echo "Realizing tainted .drvs..." >&2
+# attempt to realize these tainted .drvs and note whether they produce the
+# originally purported hash in their "got:" line when they fail (they
+# should definitely fail). if we need to retrieve build logs this can be
+# done from `nix log`
+REALIZE_TAINTED_SH=$(mktemp)
+cat > "$REALIZE_TAINTED_SH" <<"EOF"
+# called by each iteration of xargs, expecting a line from taintedfods.jsonl
+# to be supplied as $1. also expects $WORKDIR and $XARGS_PROCESS_SLOT to be
+# set.
+
+ORIG_HASH_SRI=$(jq -r '.origHashSRI' <<<"$1")
+TAINTED_DRV=$(jq -r '.taintedDrv' <<<"$1")
+
+GOT_STRING=$(
+  set +e
+  nix-store --realize --timeout "${REALIZE_TIMEOUT:-900}" -Q "$TAINTED_DRV" 2>&1 | grep -E "got:\s+[[:alnum:]+=-]+\b";
+  exit ${PIPESTATUS[0]}
+)
+export NIX_EXIT_CODE=$?
+export GOT_STRING  # defining and exporting in one command affects exit code
+
+if grep -F "$ORIG_HASH_SRI" <<<"$GOT_STRING" > /dev/null ; then
+  echo "  passed for $TAINTED_DRV" >&2
+  # annotate json with status
+  jq -c '.nixExitCode = env.NIX_EXIT_CODE | .status = "passed"' <<<"$1" >> "$WORKDIR/fragments/$XARGS_PROCESS_SLOT.jsonl"
+else
+  echo "  failed for $TAINTED_DRV with exit code $NIX_EXIT_CODE: $GOT_STRING" >&2
+  # annotate json with status and the string we *actually* got (if anything)
+  jq -c '.nixExitCode = env.NIX_EXIT_CODE | .status = "failed" | .taintedGotString = env.GOT_STRING' <<<"$1" >> "$WORKDIR/fragments/$XARGS_PROCESS_SLOT.jsonl"
+fi
+EOF
+mkdir -p "$WORKDIR/fragments"
+xargs -P "${REALIZE_PROCESSES:-8}" --process-slot-var=XARGS_PROCESS_SLOT -I '{}' -d '\n' \
+  -- bash "$REALIZE_TAINTED_SH" '{}' \
+  < "$WORKDIR/taintedfods.jsonl"
+
+
+if compgen -G "$WORKDIR/fragments/*.jsonl" > /dev/null ; then
+  # output combined results files
+  cat "$WORKDIR"/fragments/*.jsonl
+
+  # allow exit status to exit script
+  cat "$WORKDIR"/fragments/*.jsonl | jq -se 'all(.status == "passed")' > /dev/null
+fi


### PR DESCRIPTION
## Description of changes
See the later discussions in https://github.com/NixOS/nix/issues/969, https://github.com/NixOS/ofborg/issues/68, https://github.com/NixOS/rfcs/pull/171 around concerns that the nixos binary cache could be "seeded" with a malicious source package in a quiet under-reviewed corner of nixpkgs which then gets re-used in a more security-critical place through a hash confusion attack.

The following script can be used as a mitigation to this, enabling reviewers to check whether new or changed Fixed-Output-Derivations actually produce the purported output hash when not pulled from a cache. It actually works by producing a "tainted" copy of any new FODs with a random hash and checking what "`got:`" hash nix lists when the hashes fail to agree.

There are obvious synergies here with what ofborg does - particularly the most computationally intensive part, performing the full nixpkgs evaluation. However it appears that the ofborg team don't have the capacity to act on this now, so it's probably better to get a standalone copy of this script in more peoples' hands.

The script in fact uses a modified version of ofborg's `outpaths.nix`, along with a few other embedded sibling scripts. There are of course downsides with using embedded scripts, but I chose to go this way because it keeps the script very self-contained and means I don't have to solve problems like locating these other scripts at runtime.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
