### PR TITLE
nvimpager: 0.12.0 -> 0.13.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -12,7 +12,9 @@
 
 ## Backward Incompatibilities {#sec-release-24.11-incompatibilities}
 
-- Create the first release note entry in this section!
+- `nvimpager` was updated to version 0.13.0, which changes the order of user and
+  nvimpager settings: user commands in `-c` and `--cmd` now override the
+  respective default settings because they are executed later.
 
 ## Other Notable Changes {#sec-release-24.11-notable-changes}
 

--- a/pkgs/tools/misc/nvimpager/default.nix
+++ b/pkgs/tools/misc/nvimpager/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nvimpager";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lucc";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-RmpPWS9gnBnR+Atw6uzBmeDSgoTOFSdKzHoJ84O+gyA=";
+    sha256 = "sha256-Au9rRZMZfU4qHi/ng6JO8FnMpySKDbKzr75SBPY3QiA=";
   };
 
   buildInputs = [
@@ -25,18 +25,15 @@ stdenv.mkDerivation rec {
   buildFlags = [ "nvimpager.configured" "nvimpager.1" ];
   preBuild = ''
     patchShebangs nvimpager
-    substituteInPlace nvimpager --replace ':-nvim' ':-${neovim}/bin/nvim'
+    substituteInPlace nvimpager --replace-fail ':-nvim' ':-${lib.getExe neovim}'
     '';
 
   doCheck = true;
   nativeCheckInputs = [ lua51Packages.busted util-linux neovim ];
-  # filter out one test that fails in the sandbox of nix
-  checkPhase = let
-    exclude-tags = if stdenv.isDarwin then "nix,mac" else "nix";
-  in ''
-    runHook preCheck
-    make test BUSTED='busted --output TAP --exclude-tags=${exclude-tags}'
-    runHook postCheck
+  # filter out one test that fails in the sandbox of nix or with neovim v0.10
+  # or on macOS
+  preCheck = ''
+    checkFlagsArray+=('BUSTED=busted --output TAP --exclude-tags=${"nix,v10" + lib.optionalString stdenv.isDarwin ",mac"}')
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

https://github.com/lucc/nvimpager/releases/tag/v0.13.0

Breaking changes:
- Change order of nvimpager's and user supplied options, user code in --cmd and -c overwrites nvimpager code from --cmd and -c respectively.

This fixes #313134.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
