### PR TITLE
qwerty-fr: init at 0.7.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16325,6 +16325,11 @@
     githubId = 146413;
     name = "Tobias Poschwatta";
   };
+  potb = {
+    name = "Peïo Thibault";
+    github = "potb";
+    githubId = 10779093;
+  };
   poweredbypie = {
     name = "poweredbypie";
     github = "poweredbypie";

--- a/pkgs/by-name/qw/qwerty-fr/package.nix
+++ b/pkgs/by-name/qw/qwerty-fr/package.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, fetchurl
+, lib
+, unzip
+,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qwerty-fr";
+  version = "0.7.3";
+
+  src = fetchurl {
+    url = "https://github.com/qwerty-fr/qwerty-fr/releases/download/v${version}/qwerty-fr_${version}_linux.zip";
+    sha256 = "0csxzs2gk8l4y5ii1pgad8zxr9m9mfrl9nblywymg01qw74gpvnm";
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  unpackPhase = "unzip $src";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r * $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Qwerty keyboard layout with French accents";
+    homepage = "https://github.com/qwerty-fr/qwerty-fr";
+    license = licenses.mit;
+    maintainers = with maintainers; [ potb ];
+  };
+}

--- a/pkgs/by-name/qw/qwerty-fr/package.nix
+++ b/pkgs/by-name/qw/qwerty-fr/package.nix
@@ -1,32 +1,30 @@
-{ stdenv
-, fetchurl
-, lib
-, unzip
-,
+{
+  stdenvNoCC,
+  fetchFromGitHub,
+  lib,
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "qwerty-fr";
   version = "0.7.3";
 
-  src = fetchurl {
-    url = "https://github.com/qwerty-fr/qwerty-fr/releases/download/v${version}/qwerty-fr_${version}_linux.zip";
-    sha256 = "0csxzs2gk8l4y5ii1pgad8zxr9m9mfrl9nblywymg01qw74gpvnm";
+  src = fetchFromGitHub {
+    owner = "qwerty-fr";
+    repo = "qwerty-fr";
+    rev = "refs/tags/v${finalAttrs.version}";
+    sha256 = "sha256-TD67wKdaPaXzJzjKFCfRZl3WflUfdnUSQl/fnjr9TF8=";
   };
 
-  nativeBuildInputs = [ unzip ];
-
-  unpackPhase = "unzip $src";
-
   installPhase = ''
-    mkdir -p $out/bin
-    cp -r * $out/bin
+    mkdir -p $out/share/X11/xkb/symbols
+    cp $src/linux/us_qwerty-fr $out/share/X11/xkb/symbols
   '';
 
   meta = with lib; {
     description = "Qwerty keyboard layout with French accents";
+    changelog = "https://github.com/qwerty-fr/qwerty-fr/blob/v${finalAttrs.version}/linux/debian/changelog";
     homepage = "https://github.com/qwerty-fr/qwerty-fr";
     license = licenses.mit;
     maintainers = with maintainers; [ potb ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

This PR adds the qwerty-fr package.
It's a qwerty-based keyboard layout which allows typing of special characters present in the French language (é ç « »).

It's a fairly simple package as it simply grabs the latest release and extracts it in the output, as described in their [other distros installation instructions].

See it here: https://github.com/qwerty-fr/qwerty-fr

fixes #298450

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
[other distros installation instructions]: https://github.com/qwerty-fr/qwerty-fr/blob/8593e0f0a22aeb4c84d1440217d5209e0c82f741/README.md#other-distros
