### PR TITLE
check-by-name: remove concurrency group

### DIFF
--- a/.github/workflows/check-by-name.yml
+++ b/.github/workflows/check-by-name.yml
@@ -14,16 +14,16 @@ on:
     # While `edited` is also triggered when the PR title/body is changed,
     # this PR action is fairly quick, and PR's don't get edited that often,
     # so it shouldn't be a problem
+    # There is a feature request for adding a `base_changed` event:
+    # https://github.com/orgs/community/discussions/35058
     types: [opened, synchronize, reopened, edited]
 
 permissions: {}
 
-# Create a check-by-name concurrency group based on the pull request number. if
-# an event triggers a run on the same PR while a previous run is still in
-# progress, the previous run will be canceled and the new one will start.
-concurrency:
-  group: check-by-name-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+# We don't use a concurrency group here, because the action is triggered quite often (due to the PR edit
+# trigger), and contributers would get notified on any canceled run.
+# There is a feature request for supressing notifications on concurrency-canceled runs:
+# https://github.com/orgs/community/discussions/13015
 
 jobs:
   check:


### PR DESCRIPTION
Due to the trigger on PR edit, every change to the PR body will trigger a re-run of the check-by-name workflow. This is needed to catch of the base branch. However, an action like ticking the checkbox of a PR will also trigger a re-run. Furthermore, due to the concurrency group, any already running check-by-name workflow will be canceled, leading to a notification sent to the PR author.

To reduce the noise, remove the concurrency group. As a consequence, multiple runs will run to completion on the same PR/commit. While concurrent runs are often canceled after a few seconds, the workflow will take about a minute to complete.

![image](https://github.com/NixOS/nixpkgs/assets/49727155/06869f87-a9d4-4465-8d4f-095738f17664)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
