### PR TITLE
python3Packages.myst-parser: 2.0.0 -> 3.0.1

### DIFF
--- a/pkgs/development/python-modules/myst-parser/default.nix
+++ b/pkgs/development/python-modules/myst-parser/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   flit-core,
   pythonOlder,
   defusedxml,
@@ -20,10 +19,9 @@
   pytestCheckHook,
   pythonRelaxDepsHook,
 }:
-
 buildPythonPackage rec {
   pname = "myst-parser";
-  version = "2.0.0";
+  version = "3.0.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -32,16 +30,8 @@ buildPythonPackage rec {
     owner = "executablebooks";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-1BW7Z+0rs5Up+VZ3vDygnhLzE9Y2BqEMnTnflboweu0=";
+    hash = "sha256-TKo1lanZNM+XrOKZ0ZmtlhEPoAYQUspkyHXZm1wNTFE=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "myst-parser-sphinx7.2-compat.patch";
-      url = "https://github.com/executablebooks/MyST-Parser/commit/4f670fc04c438b57a9d4014be74e9a62cc0deba4.patch";
-      hash = "sha256-FCvFSsD7qQwqWjSW7R4Gx+E2jaGkifSZqaRbAglt9Yw=";
-    })
-  ];
 
   nativeBuildInputs = [
     flit-core
@@ -70,24 +60,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "myst_parser" ];
 
   pythonRelaxDeps = [ "docutils" ];
-
-  disabledTests = [
-    # AssertionError due to different files
-    "test_basic"
-    "test_footnotes"
-    "test_gettext_html"
-    "test_fieldlist_extension"
-    # docutils 0.19 expectation mismatches
-    "test_docutils_roles"
-    # sphinx 7.0 expectation mismatches
-    "test_heading_slug_func"
-    "test_references_singlehtml"
-    # sphinx 6.0 expectation mismatches
-    "test_sphinx_directives"
-    # sphinx 5.3 expectation mismatches
-    "test_render"
-    "test_includes"
-  ];
 
   meta = with lib; {
     description = "Sphinx and Docutils extension to parse MyST";


### PR DESCRIPTION
## Description of changes

Update MyST parser to 3.0.1:

- Sphinx 7.2 compatibility patch has been removed since https://github.com/executablebooks/MyST-Parser/pull/811 has been merged
- All tests seem to pass now and are now all enabled

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
