### PR TITLE
Revert "neovim: 0.9.5 -> 0.10.0"

### DIFF
--- a/pkgs/by-name/ne/neovide/package.nix
+++ b/pkgs/by-name/ne/neovide/package.nix
@@ -26,16 +26,16 @@
 
 rustPlatform.buildRustPackage.override { stdenv = clangStdenv; } rec {
   pname = "neovide";
-  version = "0.13.0";
+  version = "0.12.2";
 
   src = fetchFromGitHub {
     owner = "neovide";
     repo = "neovide";
     rev = version;
-    sha256 = "sha256-lYahMSaagT6DloFMXT2lLPM1xX/9IEGNIPvbo1MQgSw=";
+    sha256 = "sha256-M19LKNjUmC0WkVGm4t7vjxgMMe0FdMTmB1mLcG33OUg=";
   };
 
-  cargoHash = "sha256-g/Ezyz2gC1YaPMdIy/WdoOvezJUH3aB2FA87viahRzc=";
+  cargoHash = "sha256-2fPprZVT7V+Ot8aCpWj6WTdyFylmzlujFdTJCrtE0rk=";
 
   SKIA_SOURCE_DIR =
     let
@@ -43,8 +43,8 @@ rustPlatform.buildRustPackage.override { stdenv = clangStdenv; } rec {
         owner = "rust-skia";
         repo = "skia";
         # see rust-skia:skia-bindings/Cargo.toml#package.metadata skia
-        rev = "m124-0.72.3";
-        sha256 = "sha256-zlHUJUXukE4CsXwwmVl3KHf9mnNPT8lC/ETEE15Gb4s=";
+        rev = "m119-0.67.3";
+        sha256 = "sha256-U75NuJnQa5+SNlOrsBmdlvflGdjo3el63EeIsbnE7ms=";
       };
       # The externals for skia are taken from skia/DEPS
       externals = linkFarm "skia-externals" (lib.mapAttrsToList

--- a/pkgs/by-name/ne/neovide/skia-externals.json
+++ b/pkgs/by-name/ne/neovide/skia-externals.json
@@ -16,13 +16,13 @@
   },
   "zlib": {
     "url": "https://chromium.googlesource.com/chromium/src/third_party/zlib",
-    "rev": "646b7f569718921d7d4b5b8e22572ff6c76f2596",
-    "sha256": "sha256-jNj6SuTZ5/a7crtYhxW3Q/TlfRMNMfYIVxDlr7bYdzQ="
+    "rev": "c876c8f87101c5a75f6014b0f832499afeb65b73",
+    "sha256": "sha256-mwozVo8ymyrYN4tw+/ZnSI+xogSTZQ6PUBba/jQqRkE="
   },
   "harfbuzz": {
     "url": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git",
-    "rev": "c053e8f29257814e11ad61493dbbe29f27656de4",
-    "sha256": "sha256-D8DNcZH/oiJqWvfWFHvQ8AwQ3OrMwyZdfGmZ5y30Hvg="
+    "rev": "4cfc6d8e173e800df086d7be078da2e8c5cfca19",
+    "sha256": "sha256-rrstyAz7Eb8ZgFJZKUASY8nU4YFZAptd5VS9B2cs2Yg="
   },
   "wuffs": {
     "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
@@ -31,7 +31,7 @@
   },
   "libpng": {
     "url": "https://skia.googlesource.com/third_party/libpng.git",
-    "rev": "144b348e072a78e8130ed0acc452c9f039a67bf2",
-    "sha256": "sha256-eTF7q7hR4S1OqV2oPQKmcHujA5Od4rGMc5879kT0SkE="
+    "rev": "386707c6d19b974ca2e3db7f5c61873813c6fe44",
+    "sha256": "sha256-67kf5MBsnBBi0bOfX/RKL52xpaCWm/ampltAI+EeQ+c="
   }
 }

--- a/pkgs/by-name/ne/neovim-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs:
 
 in {
     pname = "neovim-unwrapped";
-    version = "0.10.0";
+    version = "0.9.5";
 
     __structuredAttrs = true;
 
@@ -74,7 +74,7 @@ in {
       owner = "neovim";
       repo = "neovim";
       rev = "v${finalAttrs.version}";
-      hash = "sha256-FCOipXHkAbkuFw9JjEpOIJ8BkyMkjkI0Dp+SzZ4yZlw=";
+      hash = "sha256-CcaBqA0yFCffNPmXOJTo8c9v1jrEBiqAl8CG5Dj5YxE=";
     };
 
     patches = [

--- a/pkgs/by-name/ne/neovim-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/package.nix
@@ -86,11 +86,7 @@ in {
 
     dontFixCmake = true;
 
-    inherit lua;
-    treesitter-parsers = treesitter-parsers //
-      { markdown = treesitter-parsers.markdown // { location = "tree-sitter-markdown"; }; } //
-      { markdown-inline = treesitter-parsers.markdown // { language = "markdown_inline"; location = "tree-sitter-markdown-inline"; }; }
-      ;
+    inherit lua treesitter-parsers;
 
     buildInputs = [
       gperf
@@ -173,13 +169,11 @@ in {
     '' + ''
       mkdir -p $out/lib/nvim/parser
     '' + lib.concatStrings (lib.mapAttrsToList
-      (language: grammar: ''
+      (language: src: ''
         ln -s \
           ${tree-sitter.buildGrammar {
-            inherit (grammar) src;
+            inherit language src;
             version = "neovim-${finalAttrs.version}";
-            language = grammar.language or language;
-            location = grammar.location or null;
           }}/parser \
           $out/lib/nvim/parser/${language}.so
       '')

--- a/pkgs/by-name/ne/neovim-unwrapped/treesitter-parsers.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/treesitter-parsers.nix
@@ -1,36 +1,24 @@
 { fetchurl }:
 
 {
-  c.src = fetchurl {
-    url = "https://github.com/tree-sitter/tree-sitter-c/archive/v0.21.0.tar.gz";
-    hash = "sha256:6f0f5d1b71cf8ffd8a37fb638c6022fa1245bd630150b538547d52128ce0ea7e";
+  c = fetchurl {
+    url = "https://github.com/tree-sitter/tree-sitter-c/archive/v0.20.2.tar.gz";
+    hash = "sha256:af66fde03feb0df4faf03750102a0d265b007e5d957057b6b293c13116a70af2";
   };
-  lua.src = fetchurl {
-    url = "https://github.com/tree-sitter-grammars/tree-sitter-lua/archive/v0.1.0.tar.gz";
-    hash = "sha256:230cfcbfa74ed1f7b8149e9a1f34c2efc4c589a71fe0f5dc8560622f8020d722";
+  lua = fetchurl {
+    url = "https://github.com/MunifTanjim/tree-sitter-lua/archive/v0.0.14.tar.gz";
+    hash = "sha256:930d0370dc15b66389869355c8e14305b9ba7aafd36edbfdb468c8023395016d";
   };
-  vim.src = fetchurl {
-    url = "https://github.com/neovim/tree-sitter-vim/archive/v0.4.0.tar.gz";
-    hash = "sha256:9f856f8b4a10ab43348550fa2d3cb2846ae3d8e60f45887200549c051c66f9d5";
+  vim = fetchurl {
+    url = "https://github.com/neovim/tree-sitter-vim/archive/v0.3.0.tar.gz";
+    hash = "sha256:403acec3efb7cdb18ff3d68640fc823502a4ffcdfbb71cec3f98aa786c21cbe2";
   };
-  vimdoc.src = fetchurl {
-    url = "https://github.com/neovim/tree-sitter-vimdoc/archive/v2.5.1.tar.gz";
-    hash = "sha256:063645096504b21603585507c41c6d8718ff3c11b2150c5bfc31e8f3ee9afea3";
+  vimdoc = fetchurl {
+    url = "https://github.com/neovim/tree-sitter-vimdoc/archive/v2.0.0.tar.gz";
+    hash = "sha256:1ff8f4afd3a9599dd4c3ce87c155660b078c1229704d1a254433e33794b8f274";
   };
-  query.src = fetchurl {
-    url = "https://github.com/tree-sitter-grammars/tree-sitter-query/archive/v0.3.0.tar.gz";
-    hash = "sha256:f878ff37abcb83250e31a6569e997546f3dbab74dcb26683cb2d613f7568cfc0";
-  };
-  python.src = fetchurl {
-    url = "https://github.com/tree-sitter/tree-sitter-python/archive/v0.21.0.tar.gz";
-    hash = "sha256:720304a603271fa89e4430a14d6a81a023d6d7d1171b1533e49c0ab44f1e1c13";
-  };
-  bash.src = fetchurl {
-    url = "https://github.com/tree-sitter/tree-sitter-bash/archive/v0.21.0.tar.gz";
-    hash = "sha256:f0515efda839cfede851adb24ac154227fbc0dfb60c6c11595ecfa9087d43ceb";
-  };
-  markdown.src = fetchurl {
-    url = "https://github.com/MDeiml/tree-sitter-markdown/archive/v0.2.3.tar.gz";
-    hash = "sha256:4909d6023643f1afc3ab219585d4035b7403f3a17849782ab803c5f73c8a31d5";
+  query = fetchurl {
+    url = "https://github.com/nvim-treesitter/tree-sitter-query/archive/v0.1.0.tar.gz";
+    hash = "sha256:e2b806f80e8bf1c4f4e5a96248393fe6622fc1fc6189d6896d269658f67f914c";
   };
 }

--- a/pkgs/by-name/ne/neovim-unwrapped/update-treesitter-parsers.py
+++ b/pkgs/by-name/ne/neovim-unwrapped/update-treesitter-parsers.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 parsers = {}
 dir = Path(__file__).parent
-regex = re.compile(r"^TREESITTER_([A-Z_]+)_(URL|SHA256)\s+(.+)$")
+regex = re.compile(r"^set\(TREESITTER_([A-Z_]+)_(URL|SHA256)\s+([^ \)]+)\s*\)\s*$")
 
 src = subprocess.check_output(
     [
@@ -20,8 +20,8 @@ src = subprocess.check_output(
     text=True,
 ).strip()
 
-for line in open(f"{src}/cmake.deps/deps.txt"):
-    m = regex.fullmatch(line.strip())
+for line in open(f"{src}/cmake.deps/CMakeLists.txt"):
+    m = regex.fullmatch(line)
     if m is None:
         continue
 
@@ -37,7 +37,7 @@ with open(dir / "treesitter-parsers.nix", "w") as f:
     f.write("{ fetchurl }:\n\n{\n")
     for lang, src in parsers.items():
         f.write(
-            f"""  {lang}.src = fetchurl {{
+            f"""  {lang} = fetchurl {{
     url = "{src["URL"]}";
     hash = "sha256:{src["SHA256"]}";
   }};


### PR DESCRIPTION
Please refer to https://github.com/NixOS/nixpkgs/issues/303285.

Reverts NixOS/nixpkgs#311047 as it was not supposed to happen for this release cycle.

A full message is provided in the commit message.