### PR TITLE
ride: add darwin support

### DIFF
--- a/pkgs/by-name/ri/ride/package.nix
+++ b/pkgs/by-name/ri/ride/package.nix
@@ -12,6 +12,7 @@
   copyDesktopItems,
   makeDesktopItem,
   electron,
+  darwin,
 }:
 
 let
@@ -31,6 +32,8 @@ let
   };
 
   platformInfo = platformInfos.${stdenv.system};
+
+  electronDist = electron + (if stdenv.isDarwin then "/Applications" else "/libexec/electron");
 in
 buildNpmPackage rec {
   pname = "ride";
@@ -83,13 +86,20 @@ buildNpmPackage rec {
     popd
   '';
 
-  nativeBuildInputs = [
-    zip
-    makeWrapper
-    copyDesktopItems
-  ];
+  nativeBuildInputs =
+    [
+      zip
+      makeWrapper
+    ]
+    ++ lib.optionals (!stdenv.isDarwin) [ copyDesktopItems ]
+    ++ lib.optionals stdenv.isDarwin [ darwin.cctools ];
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  # Fix error: no member named 'aligned_alloc' in the global namespace
+  env.NIX_CFLAGS_COMPILE = lib.optionalString (
+    stdenv.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinSdkVersion "11.0"
+  ) "-D_LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION=1";
 
   npmBuildFlags = platformInfo.buildCmd;
 
@@ -97,8 +107,12 @@ buildNpmPackage rec {
   # Here, we create a local cache of electron zip-files, so electron-packager can copy from it
   postConfigure = ''
     mkdir local-cache
-    cp -r --no-preserve=all ${electron}/libexec/electron electron
-    pushd electron
+
+    # electron files need to be writable on Darwin
+    cp -r ${electronDist} electron-dist
+    chmod -R u+w electron-dist
+
+    pushd electron-dist
     zip -qr ../local-cache/electron-v${electron.version}-${platformInfo.zipSuffix}.zip *
     popd
   '';
@@ -106,19 +120,27 @@ buildNpmPackage rec {
   installPhase = ''
     runHook preInstall
 
-    install -Dm644 D.png $out/share/icons/hicolor/64x64/apps/ride.png
-    install -Dm644 D.svg $out/share/icons/hicolor/scalable/apps/ride.svg
-
     pushd _/ride*/*
 
     install -Dm644 ThirdPartyNotices.txt -t $out/share/doc/ride
 
-    mkdir -p $out/share/ride
-    cp -r locales resources{,.pak} $out/share/ride
-    makeWrapper ${lib.getExe electron} $out/bin/ride \
-      --add-flags $out/share/ride/resources/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
-      --inherit-argv0
+    ${lib.optionalString (!stdenv.isDarwin) ''
+      install -Dm644 $src/D.png $out/share/icons/hicolor/64x64/apps/ride.png
+      install -Dm644 $src/D.svg $out/share/icons/hicolor/scalable/apps/ride.svg
+
+      mkdir -p $out/share/ride
+      cp -r locales resources{,.pak} $out/share/ride
+      makeWrapper ${lib.getExe electron} $out/bin/ride \
+          --add-flags $out/share/ride/resources/app.asar \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+          --inherit-argv0
+    ''}
+
+    ${lib.optionalString stdenv.isDarwin ''
+      mkdir -p $out/Applications
+      cp -r Ride-*.app $out/Applications
+      makeWrapper $out/Applications/Ride-*.app/Contents/MacOS/Ride-* $out/bin/ride
+    ''}
 
     popd
 
@@ -141,7 +163,6 @@ buildNpmPackage rec {
   ];
 
   meta = {
-    broken = stdenv.isDarwin;
     changelog = "https://github.com/Dyalog/ride/releases/tag/${src.rev}";
     description = "Remote IDE for Dyalog APL";
     homepage = "https://github.com/Dyalog/ride";


### PR DESCRIPTION
## Description of changes

This PR adds darwin support to the `ride` package.

I was working on supporting darwin in https://github.com/NixOS/nixpkgs/pull/250627, but I gave up since I didn't have a darwin machine to do debugging.

I have finally set up a `macos-ventura` VM so I can test on Darwin now. 

Turns out I was very very close, the only thing missing was that I accidentally removed some of the execute permissions from the electron directory, which made it not be able to launch.

Now, instead of doing `cp -r --no-preserve=all` I do `cp -r` with `chmod -R u+w`, this way the directory becomes writable without messing up the other permissions.

---

Note: since `dyalog` is not packaged for Darwin, you'll have to connect to a `dyalog` instance remotely if you want to test it out. (Or just run the non-nix package)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
