### PR TITLE
pietrasanta-traceroute: init at `0.0.5-unstable-2023-11-28`

### DIFF
--- a/pkgs/by-name/pi/pietrasanta-traceroute/package.nix
+++ b/pkgs/by-name/pi/pietrasanta-traceroute/package.nix
@@ -1,0 +1,40 @@
+{ lib
+, fetchFromGitHub
+, unstableGitUpdater
+, stdenv
+, openssl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pietrasanta-traceroute";
+  version = "0.0.5-unstable-2023-11-28";
+
+  src = fetchFromGitHub {
+    owner = "catchpoint";
+    repo = "Networking.traceroute";
+    rev = "c870c7bd7bafeab815f8564a67a281892c3a6230";
+    hash = "sha256-CKqm8b6qNLEpso25+uTvtiR/hFMKJzuXUZkQ7lWzGd8=";
+  };
+  passthru.updateScript = unstableGitUpdater { };
+
+  buildInputs = [ openssl ];
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = with lib; {
+    description = "ECN-aware version of traceroute";
+    longDescription = ''
+      An enhanced version of Dmitry Butskoy's traceroute, developed by Catchpoint.
+      - Support for "TCP InSession": opens a TCP connection with the destination and sends TCP probes with
+        increasing TTL values, to prevent false packet loss introduced by firewalls, and ensure packets
+        follow a single flow, akin to a normal TCP session.
+      - Similar QUIC-based traceroute.
+      - Enhanced ToS (DSCP/ECN) field report.
+    '';
+    homepage = "https://github.com/catchpoint/Networking.traceroute/";
+    changelog = "https://github.com/catchpoint/Networking.traceroute/blob/${src.rev}/ChangeLog";
+    license = with licenses; [ gpl2Only lgpl21Only ];
+    mainProgram = "traceroute";
+    maintainers = with maintainers; [ nicoo ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

init `pietrasanta-traceroute` at `0.0.5-unstable-2023-11-28`

This tool was just presented at RIPE88

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
