### PR TITLE
pass: add `extraExtensions` argument

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -241,6 +241,9 @@
   - Nemo is now built with gtk-layer-shell support, note that for now it will be expected to see nemo-desktop
     listed as a regular entry in Cinnamon Wayland session's window list applet.
 
+- `pass` has now the `extraExtensions` argument. With it, overlays may easily
+  add new extensions by just passing derivations to it, as its attributes.
+
 - Support for *runner registration tokens* has been [deprecated](https://gitlab.com/gitlab-org/gitlab/-/issues/380872)
   in `gitlab-runner` 15.6 and is expected to be removed in `gitlab-runner` 18.0. Configuration of existing runners
   should be changed to using *runner authentication tokens* by configuring

--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -1,34 +1,54 @@
-{ stdenv, lib, pkgs, fetchurl, buildEnv
-, coreutils, findutils, gnugrep, gnused, getopt, git, tree, gnupg, openssl
-, which, openssh, procps, qrencode, makeWrapper, pass
+{
+  stdenv,
+  lib,
+  pkgs,
+  fetchurl,
+  buildEnv,
+  coreutils,
+  findutils,
+  gnugrep,
+  gnused,
+  getopt,
+  git,
+  tree,
+  gnupg,
+  openssl,
+  which,
+  openssh,
+  procps,
+  qrencode,
+  makeWrapper,
+  pass,
 
-, xclip ? null, xdotool ? null, dmenu ? null
-, x11Support ? !stdenv.isDarwin , dmenuSupport ? (x11Support || waylandSupport)
-, waylandSupport ? false, wl-clipboard ? null
-, ydotool ? null, dmenu-wayland ? null
+  xclip,
+  xdotool,
+  dmenu,
+  x11Support ? !stdenv.isDarwin,
+  dmenuSupport ? (x11Support || waylandSupport),
+  waylandSupport ? false,
+  wl-clipboard,
+  ydotool,
+  dmenu-wayland,
 
-# For backwards-compatibility
-, tombPluginSupport ? false
+  # For backwards-compatibility
+  tombPluginSupport ? false,
+
+  extraExtensions ? { },
 }:
 
-assert x11Support -> xclip != null;
-assert waylandSupport -> wl-clipboard != null;
-
 assert dmenuSupport -> x11Support || waylandSupport;
-assert dmenuSupport && x11Support
-  -> dmenu != null && xdotool != null;
-assert dmenuSupport && waylandSupport
-  -> dmenu-wayland != null && ydotool != null;
-
 
 let
-  passExtensions = import ./extensions { inherit pkgs; };
+  passExtensions = import ./extensions { inherit pkgs; } // extraExtensions;
 
-  env = extensions:
+  env =
+    extensions:
     let
-      selected = [ pass ] ++ extensions passExtensions
-        ++ lib.optional tombPluginSupport passExtensions.tomb;
-    in buildEnv {
+      selected = [
+        pass
+      ] ++ extensions passExtensions ++ lib.optional tombPluginSupport passExtensions.tomb;
+    in
+    buildEnv {
       name = "pass-env";
       paths = selected;
       nativeBuildInputs = [ makeWrapper ];
@@ -54,12 +74,12 @@ let
     };
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "1.7.4";
   pname = "password-store";
 
   src = fetchurl {
-    url    = "https://git.zx2c4.com/password-store/snapshot/${pname}-${version}.tar.xz";
+    url = "https://git.zx2c4.com/password-store/snapshot/password-store-${finalAttrs.version}.tar.xz";
     sha256 = "1h4k6w7g8pr169p5w9n6mkdhxl3pw51zphx7www6pvgjb7vgmafg";
   };
 
@@ -70,70 +90,87 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  installFlags = [ "PREFIX=$(out)" "WITH_ALLCOMP=yes" ];
+  installFlags = [
+    "PREFIX=$(out)"
+    "WITH_ALLCOMP=yes"
+  ];
 
   postInstall = lib.optionalString dmenuSupport ''
     cp "contrib/dmenu/passmenu" "$out/bin/"
   '';
 
-  wrapperPath = with lib; makeBinPath ([
-    coreutils
-    findutils
-    getopt
-    git
-    gnugrep
-    gnupg
-    gnused
-    tree
-    which
-    openssh
-    procps
-    qrencode
-  ] ++ optional stdenv.isDarwin openssl
-    ++ optional x11Support xclip
-    ++ optional waylandSupport wl-clipboard
-    ++ optionals (waylandSupport && dmenuSupport) [ ydotool dmenu-wayland ]
-    ++ optionals (x11Support && dmenuSupport) [ xdotool dmenu ]
-  );
+  wrapperPath =
+    with lib;
+    makeBinPath (
+      [
+        coreutils
+        findutils
+        getopt
+        git
+        gnugrep
+        gnupg
+        gnused
+        tree
+        which
+        openssh
+        procps
+        qrencode
+      ]
+      ++ optional stdenv.isDarwin openssl
+      ++ optional x11Support xclip
+      ++ optional waylandSupport wl-clipboard
+      ++ optionals (waylandSupport && dmenuSupport) [
+        ydotool
+        dmenu-wayland
+      ]
+      ++ optionals (x11Support && dmenuSupport) [
+        xdotool
+        dmenu
+      ]
+    );
 
-  postFixup = ''
-    # Fix program name in --help
-    substituteInPlace $out/bin/pass \
-      --replace 'PROGRAM="''${0##*/}"' "PROGRAM=pass"
+  postFixup =
+    ''
+        # Fix program name in --help
+        substituteInPlace $out/bin/pass \
+          --replace 'PROGRAM="''${0##*/}"' "PROGRAM=pass"
 
-    # Ensure all dependencies are in PATH
-    wrapProgram $out/bin/pass \
-      --prefix PATH : "${wrapperPath}"
-  '' + lib.optionalString dmenuSupport ''
-    # We just wrap passmenu with the same PATH as pass. It doesn't
-    # need all the tools in there but it doesn't hurt either.
-    wrapProgram $out/bin/passmenu \
-      --prefix PATH : "$out/bin:${wrapperPath}"
-  '';
+      # Ensure all dependencies are in PATH
+      wrapProgram $out/bin/pass \
+        --prefix PATH : "${finalAttrs.wrapperPath}"
+    ''
+    + lib.optionalString dmenuSupport ''
+      # We just wrap passmenu with the same PATH as pass. It doesn't
+      # need all the tools in there but it doesn't hurt either.
+      wrapProgram $out/bin/passmenu \
+        --prefix PATH : "$out/bin:${finalAttrs.wrapperPath}"
+    '';
 
   # Turn "check" into "installcheck", since we want to test our pass,
   # not the one before the fixup.
-  postPatch = ''
-    patchShebangs tests
+  postPatch =
+    ''
+      patchShebangs tests
 
-    substituteInPlace src/password-store.sh \
-      --replace "@out@" "$out"
+      substituteInPlace src/password-store.sh \
+        --replace "@out@" "$out"
 
-    # the turning
-    sed -i -e 's@^PASS=.*''$@PASS=$out/bin/pass@' \
-           -e 's@^GPGS=.*''$@GPG=${gnupg}/bin/gpg2@' \
-           -e '/which gpg/ d' \
-      tests/setup.sh
-  '' + lib.optionalString stdenv.isDarwin ''
-    # 'pass edit' uses hdid, which is not available from the sandbox.
-    rm -f tests/t0200-edit-tests.sh
-    rm -f tests/t0010-generate-tests.sh
-    rm -f tests/t0020-show-tests.sh
-    rm -f tests/t0050-mv-tests.sh
-    rm -f tests/t0100-insert-tests.sh
-    rm -f tests/t0300-reencryption.sh
-    rm -f tests/t0400-grep.sh
-  '';
+      # the turning
+      sed -i -e 's@^PASS=.*''$@PASS=$out/bin/pass@' \
+             -e 's@^GPGS=.*''$@GPG=${gnupg}/bin/gpg2@' \
+             -e '/which gpg/ d' \
+        tests/setup.sh
+    ''
+    + lib.optionalString stdenv.isDarwin ''
+      # 'pass edit' uses hdid, which is not available from the sandbox.
+      rm -f tests/t0200-edit-tests.sh
+      rm -f tests/t0010-generate-tests.sh
+      rm -f tests/t0020-show-tests.sh
+      rm -f tests/t0050-mv-tests.sh
+      rm -f tests/t0100-insert-tests.sh
+      rm -f tests/t0300-reencryption.sh
+      rm -f tests/t0400-grep.sh
+    '';
 
   doCheck = false;
 
@@ -148,11 +185,17 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Stores, retrieves, generates, and synchronizes passwords securely";
-    homepage    = "https://www.passwordstore.org/";
-    license     = licenses.gpl2Plus;
+    homepage = "https://www.passwordstore.org/";
+    license = licenses.gpl2Plus;
     mainProgram = "pass";
-    maintainers = with maintainers; [ lovek323 fpletz tadfisher globin ma27 ];
-    platforms   = platforms.unix;
+    maintainers = with maintainers; [
+      lovek323
+      fpletz
+      tadfisher
+      globin
+      ma27
+    ];
+    platforms = platforms.unix;
 
     longDescription = ''
       pass is a very simple password store that keeps passwords inside gpg2
@@ -162,4 +205,4 @@ stdenv.mkDerivation rec {
       synchronize, generate, and manipulate passwords.
     '';
   };
-}
+})


### PR DESCRIPTION
## Description of changes

The current implementation is cumbersome for extension overlays for the
reason that it passes the `passExtensions` attribute set to the user
function; thus, any addition to `pass.passthru.extensions` is ignored.

By adding the `extraExtensions` argument, we allow overlays to easily
add or override pass' extensions without the need of overriding the
`withExtensions` function.

### `nixpkgs-review rev HEAD`

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>23 packages built:</summary>
  <ul>
    <li>git-credential-manager</li>
    <li>krunner-pass</li>
    <li>pass</li>
    <li>pass-nodmenu</li>
    <li>pass-wayland</li>
    <li>passExtensions.pass-audit</li>
    <li>passExtensions.pass-audit.man</li>
    <li>passExtensions.pass-import</li>
    <li>passExtensions.pass-import.dist</li>
    <li>passff-host</li>
    <li>python311Packages.bundlewrap-pass</li>
    <li>python311Packages.bundlewrap-pass.dist</li>
    <li>python311Packages.keyring-pass</li>
    <li>python311Packages.keyring-pass.dist</li>
    <li>python312Packages.bundlewrap-pass</li>
    <li>python312Packages.bundlewrap-pass.dist</li>
    <li>python312Packages.keyring-pass</li>
    <li>python312Packages.keyring-pass.dist</li>
    <li>qtpass</li>
    <li>rofi-pass</li>
    <li>rofi-pass-wayland</li>
    <li>tessen</li>
    <li>wofi-pass</li>
  </ul>
</details>

### Note for reviewers

The following code may be used to test the addition of new extensions --- or any
package for the purposes of testing, as is the case below with the `hello`
package:

```bash
nix-build -E '
    let
        pkgs = import ./. {};
        overwrittenPass = pkgs.pass.override (_: {
          extraExtensions = {
            inherit (pkgs) hello;
          };
        });
    in
    overwrittenPass.withExtensions (ext: [ext.pass-otp ext.hello])
'
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
