### PR TITLE
gnu-efi: 3.0.15 -> 3.0.18

### DIFF
--- a/pkgs/development/libraries/gnu-efi/default.nix
+++ b/pkgs/development/libraries/gnu-efi/default.nix
@@ -1,13 +1,15 @@
-{ lib, stdenv, buildPackages, fetchurl, pciutils
+{ lib, stdenv, buildPackages, fetchFromGitHub, pciutils
 , gitUpdater }:
 
 stdenv.mkDerivation rec {
   pname = "gnu-efi";
-  version = "3.0.15";
+  version = "3.0.18";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/gnu-efi/${pname}-${version}.tar.bz2";
-    hash = "sha256-kxole5xcG6Zf9Rnxg3PEOKJoJfLbeGaxY+ltGxaPIOo=";
+  src = fetchFromGitHub {
+    owner = "ncroxon";
+    repo = "gnu-efi";
+    rev = version;
+    hash = "sha256-xtiKglLXm9m4li/8tqbOsyM6ThwGhyu/g4kw5sC4URY=";
   };
 
   buildInputs = [ pciutils ];

--- a/pkgs/os-specific/linux/firmware/fwupd-efi/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd-efi/default.nix
@@ -19,14 +19,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-r9CAWirQgafK/y71vABM46AUe1OAFejsqWY0FxaxJg4=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/fwupd/fwupd-efi/commit/26c6ec5c1e7765fb5dc6a4df511ab21ee6c6e67a.patch";
-      revert = true;
-      hash = "sha256-vTdYExd7OlrrZ/LhlEO1zcvpKzeT5OeOeosD8/LUkMg=";
-    })
-  ];
-
   nativeBuildInputs = [
     meson
     ninja

--- a/pkgs/tools/security/efitools/aarch64.patch
+++ b/pkgs/tools/security/efitools/aarch64.patch
@@ -1,0 +1,16 @@
+diff --git a/Make.rules b/Make.rules
+index 903a5a4..59eca2f 100644
+--- a/Make.rules
++++ b/Make.rules
+@@ -51,11 +51,6 @@ ifeq ($(ARCH),arm)
+   FORMAT = -O binary
+ endif
+ 
+-ifeq ($(ARCH),aarch64)
+-  LDFLAGS += --defsym=EFI_SUBSYSTEM=0x0a
+-  FORMAT = -O binary
+-endif
+-
+ %.efi: %.so
+ 	$(OBJCOPY) -j .text -j .sdata -j .data -j .dynamic -j .dynsym \
+ 		   -j .rel -j .rela -j .rel.* -j .rela.* -j .rel* -j .rela* \

--- a/pkgs/tools/security/efitools/default.nix
+++ b/pkgs/tools/security/efitools/default.nix
@@ -21,6 +21,11 @@ stdenv.mkDerivation rec {
     sha256 = "0jabgl2pxvfl780yvghq131ylpf82k7banjz0ksjhlm66ik8gb1i";
   };
 
+  # https://github.com/ncroxon/gnu-efi/issues/7#issuecomment-2122741592
+  patches = [
+    ./aarch64.patch
+  ];
+
   postPatch = ''
     sed -i -e 's#/usr/include/efi#${gnu-efi}/include/efi/#g' Make.rules
     sed -i -e 's#/usr/lib64/gnuefi#${gnu-efi}/lib/#g' Make.rules


### PR DESCRIPTION
## Description of changes

https://github.com/ncroxon/gnu-efi/issues/7#issuecomment-2122741592

Supersedes #313052.
Reverts #308502.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
