### PR TITLE
electron{,-bin}: add passthru.dist attribute and use treewide

### DIFF
--- a/pkgs/applications/audio/youtube-music/default.nix
+++ b/pkgs/applications/audio/youtube-music/default.nix
@@ -33,13 +33,13 @@ stdenv.mkDerivation (finalAttrs: {
   ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
 
   postBuild = lib.optionalString stdenv.isDarwin ''
-    cp -R ${electron}/Applications/Electron.app Electron.app
+    cp -R ${electron.dist}/Electron.app Electron.app
     chmod -R u+w Electron.app
   '' + ''
     pnpm build
     ./node_modules/.bin/electron-builder \
       --dir \
-      -c.electronDist=${if stdenv.isDarwin then "." else "${electron}/libexec/electron"} \
+      -c.electronDist=${if stdenv.isDarwin then "." else electron.dist} \
       -c.electronVersion=${electron.version}
   '';
 

--- a/pkgs/applications/graphics/drawio/default.nix
+++ b/pkgs/applications/graphics/drawio/default.nix
@@ -63,14 +63,14 @@ stdenv.mkDerivation rec {
     runHook preBuild
 
   '' + lib.optionalString stdenv.isDarwin ''
-    cp -R ${electron}/Applications/Electron.app Electron.app
+    cp -R ${electron.dist}/Electron.app Electron.app
     chmod -R u+w Electron.app
     export CSC_IDENTITY_AUTO_DISCOVERY=false
     sed -i "/afterSign/d" electron-builder-linux-mac.json
   '' + ''
     yarn --offline run electron-builder --dir \
-      ${if stdenv.isDarwin then "--config electron-builder-linux-mac.json" else ""} \
-      -c.electronDist=${if stdenv.isDarwin then "." else "${electron}/libexec/electron"} \
+      ${lib.optionalString stdenv.isDarwin "--config electron-builder-linux-mac.json"} \
+      -c.electronDist=${if stdenv.isDarwin then "." else electron.dist} \
       -c.electronVersion=${electron.version}
 
     runHook postBuild

--- a/pkgs/applications/misc/kuro/default.nix
+++ b/pkgs/applications/misc/kuro/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   yarnBuildScript = "electron-builder";
   yarnBuildFlags = [
     "--dir"
-    "-c.electronDist=${electron}/libexec/electron"
+    "-c.electronDist=${electron.dist}"
     "-c.electronVersion=${electron.version}"
   ];
 

--- a/pkgs/applications/misc/whalebird/default.nix
+++ b/pkgs/applications/misc/whalebird/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
     yarn run nextron build --no-pack
     yarn run electron-builder --dir \
       --config electron-builder.yml \
-      -c.electronDist="${electron}/libexec/electron" \
+      -c.electronDist="${electron.dist}" \
       -c.electronVersion=${electron.version}
 
     runHook postBuild

--- a/pkgs/applications/networking/instant-messengers/armcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/armcord/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
     npm exec electron-builder -- \
       --dir \
-      -c.electronDist="${electron_30}/libexec/electron" \
+      -c.electronDist="${electron_30.dist}" \
       -c.electronVersion="${electron_30.version}"
 
     runHook postBuild

--- a/pkgs/applications/networking/instant-messengers/jitsi-meet-electron/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jitsi-meet-electron/default.nix
@@ -16,8 +16,6 @@
 
 let
   inherit (darwin.apple_sdk.frameworks) Carbon CoreFoundation ApplicationServices OpenGL;
-
-  electronDist = electron + (if stdenv.isDarwin then "/Applications" else "/libexec/electron");
 in
 buildNpmPackage rec {
   pname = "jitsi-meet-electron";
@@ -70,7 +68,7 @@ buildNpmPackage rec {
   '';
 
   postBuild = ''
-    cp -r ${electronDist} electron-dist
+    cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
 
     # npmRebuild is needed because robotjs won't be built on darwin otherwise

--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     yarn --offline electron-builder \
       --dir ${if stdenv.isDarwin then "--macos" else "--linux"} ${if stdenv.hostPlatform.isAarch64 then "--arm64" else "--x64"} \
-      -c.electronDist=${electron}/libexec/electron \
+      -c.electronDist=${electron.dist} \
       -c.electronVersion=${electron.version}
 
     runHook postBuild

--- a/pkgs/applications/virtualization/podman-desktop/default.nix
+++ b/pkgs/applications/virtualization/podman-desktop/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     yarn --offline run build
     yarn --offline run electron-builder --dir \
       --config .electron-builder.config.cjs \
-      -c.electronDist=${electron}/libexec/electron \
+      -c.electronDist=${electron.dist} \
       -c.electronVersion=${electron.version}
 
     runHook postBuild

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -120,7 +120,7 @@ in buildNpmPackage rec {
 
     npm exec electron-builder -- \
       --dir \
-      -c.electronDist=${electron}/libexec/electron \
+      -c.electronDist=${electron.dist} \
       -c.electronVersion=${electron.version}
 
     popd

--- a/pkgs/by-name/bl/blockbench/package.nix
+++ b/pkgs/by-name/bl/blockbench/package.nix
@@ -10,9 +10,6 @@
   electron,
 }:
 
-let
-  electronDist = "${electron}/${if stdenv.isDarwin then "Applications" else "libexec/electron"}";
-in
 buildNpmPackage rec {
   pname = "blockbench";
   version = "4.10.4";
@@ -45,7 +42,7 @@ buildNpmPackage rec {
 
   postBuild = ''
     # electronDist needs to be modifiable on Darwin
-    cp -r ${electronDist} electron-dist
+    cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
 
     npm exec electron-builder -- \

--- a/pkgs/by-name/br/bruno/package.nix
+++ b/pkgs/by-name/br/bruno/package.nix
@@ -103,7 +103,7 @@ buildNpmPackage' rec {
     ${
       if stdenv.isDarwin then
         ''
-          cp -r ${electron}/Applications/Electron.app ./
+          cp -r ${electron.dist}/Electron.app ./
           find ./Electron.app -name 'Info.plist' | xargs -d '\n' chmod +rw
 
           substituteInPlace electron-builder-config.js \
@@ -121,7 +121,7 @@ buildNpmPackage' rec {
         ''
           npm exec electron-builder -- \
             --dir \
-            -c.electronDist=${electron}/libexec/electron \
+            -c.electronDist=${electron.dist} \
             -c.electronVersion=${electron.version} \
             -c.npmRebuild=false
         ''

--- a/pkgs/by-name/ca/caprine/package.nix
+++ b/pkgs/by-name/ca/caprine/package.nix
@@ -8,9 +8,6 @@
   electron,
 }:
 
-let
-  electronDist = electron + (if stdenv.isDarwin then "/Applications" else "/libexec/electron");
-in
 buildNpmPackage rec {
   pname = "caprine";
   version = "2.60.1";
@@ -29,7 +26,7 @@ buildNpmPackage rec {
   nativeBuildInputs = [ copyDesktopItems ];
 
   postBuild = ''
-    cp -r ${electronDist} electron-dist
+    cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
 
     npm exec electron-builder -- \

--- a/pkgs/by-name/fe/feishin/package.nix
+++ b/pkgs/by-name/fe/feishin/package.nix
@@ -79,7 +79,7 @@ buildNpmPackage {
   postBuild =
     lib.optionalString stdenv.isDarwin ''
       # electron-builder appears to build directly on top of Electron.app, by overwriting the files in the bundle.
-      cp -r ${electron}/Applications/Electron.app ./
+      cp -r ${electron.dist}/Electron.app ./
       find ./Electron.app -name 'Info.plist' | xargs -d '\n' chmod +rw
 
       # Disable code signing during build on macOS.
@@ -90,7 +90,7 @@ buildNpmPackage {
     + ''
       npm exec electron-builder -- \
         --dir \
-        -c.electronDist=${if stdenv.isDarwin then "./" else "${electron}/libexec/electron"} \
+        -c.electronDist=${if stdenv.isDarwin then "./" else electron.dist} \
         -c.electronVersion=${electron.version} \
         -c.npmRebuild=false
     '';

--- a/pkgs/by-name/go/goofcord/package.nix
+++ b/pkgs/by-name/go/goofcord/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     npm exec electron-builder -- \
       --dir \
-      -c.electronDist="${electron}/libexec/electron" \
+      -c.electronDist="${electron.dist}" \
       -c.electronVersion="${electron.version}"
 
     runHook postBuild

--- a/pkgs/by-name/ko/koodo-reader/package.nix
+++ b/pkgs/by-name/ko/koodo-reader/package.nix
@@ -13,9 +13,6 @@
   electron,
 }:
 
-let
-  electronDist = electron + (if stdenv.isDarwin then "/Applications" else "/libexec/electron");
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "koodo-reader";
   version = "1.6.7";
@@ -52,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   env.CSC_IDENTITY_AUTO_DISCOVERY = "false";
 
   postBuild = ''
-    cp -r ${electronDist} electron-dist
+    cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
     yarn --offline run electron-builder --dir \
       -c.electronDist=electron-dist \
@@ -117,7 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     changelog = "https://github.com/troyeguo/koodo-reader/releases/tag/v${finalAttrs.version}";
-    description = "A cross-platform ebook reader";
+    description = "Cross-platform ebook reader";
     longDescription = ''
       A modern ebook manager and reader with sync and backup capacities
       for Windows, macOS, Linux and Web

--- a/pkgs/by-name/mq/mqtt-explorer/package.nix
+++ b/pkgs/by-name/mq/mqtt-explorer/package.nix
@@ -12,9 +12,6 @@
   makeDesktopItem,
   copyDesktopItems,
 }:
-let
-  electronDist = electron + (if stdenv.isDarwin then "/Applications" else "/libexec/electron");
-in
 # NOTE mqtt-explorer has 3 yarn subpackages and uses relative links
 # between them, which makes it hard to package them via 3 `mkYarnPackage`
 # since the resulting `node_modules` directories don't have the same structure
@@ -88,7 +85,7 @@ stdenv.mkDerivation rec {
 
     patchShebangs {node_modules,app/node_modules,backend/node_modules}
 
-    cp -r ${electronDist} electron-dist
+    cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
 
     runHook postConfigure

--- a/pkgs/by-name/ri/ride/package.nix
+++ b/pkgs/by-name/ri/ride/package.nix
@@ -32,8 +32,6 @@ let
   };
 
   platformInfo = platformInfos.${stdenv.system};
-
-  electronDist = electron + (if stdenv.isDarwin then "/Applications" else "/libexec/electron");
 in
 buildNpmPackage rec {
   pname = "ride";
@@ -109,7 +107,7 @@ buildNpmPackage rec {
     mkdir local-cache
 
     # electron files need to be writable on Darwin
-    cp -r ${electronDist} electron-dist
+    cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
 
     pushd electron-dist

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -101,7 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
     npm exec electron-builder -- \
         --dir \
         --config electron-builder-${platformId}.yml \
-        -c.electronDist=${electron}/libexec/electron \
+        -c.electronDist=${electron.dist} \
         -c.electronVersion=${electron.version}
 
     runHook postBuild

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # electron builds must be writable on darwin
   preBuild = lib.optionalString stdenv.isDarwin ''
-    cp -r ${electron}/Applications/Electron.app .
+    cp -r ${electron.dist}/Electron.app .
     chmod -R u+w Electron.app
   '';
 
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm exec electron-builder \
       --dir \
       -c.asarUnpack="**/*.node" \
-      -c.electronDist=${if stdenv.isDarwin then "." else "${electron}/libexec/electron"} \
+      -c.electronDist=${if stdenv.isDarwin then "." else electron.dist} \
       -c.electronVersion=${electron.version}
 
     runHook postBuild

--- a/pkgs/development/tools/electron-fiddle/default.nix
+++ b/pkgs/development/tools/electron-fiddle/default.nix
@@ -61,7 +61,7 @@ let
       patchShebangs node_modules
 
       mkdir -p ~/.cache/electron/${electronDummyHash}
-      cp -ra '${electron}/libexec/electron' "$TMPDIR/electron"
+      cp -ra '${electron.dist}' "$TMPDIR/electron"
       chmod -R u+w "$TMPDIR/electron"
       (cd "$TMPDIR/electron" && zip -0Xr ~/.cache/electron/${electronDummyHash}/${electronDummyFilename} .)
 

--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -27,7 +27,7 @@ let
 
   fetchedDeps = lib.mapAttrs (name: fetchdep) info.deps;
 
-in (chromium.override { upstream-info = info.chromium; }).mkDerivation (base: {
+in ((chromium.override { upstream-info = info.chromium; }).mkDerivation (base: {
   packageName = "electron";
   inherit (info) version;
   buildTargets = [ "electron:electron_dist_zip" ];
@@ -243,5 +243,10 @@ in (chromium.override { upstream-info = info.chromium; }).mkDerivation (base: {
     mainProgram = "electron";
     hydraPlatforms = lib.optionals (!(hasInfix "alpha" info.version) && !(hasInfix "beta" info.version)) ["aarch64-linux" "x86_64-linux"];
     timeout = 172800; # 48 hours (increased from the Hydra default of 10h)
+  };
+})).overrideAttrs (finalAttrs: prevAttrs: {
+  # this was the only way I could get the package to properly reference itself
+  passthru = prevAttrs.passthru // {
+    dist = finalAttrs.finalPackage + "/libexec/electron";
   };
 })

--- a/pkgs/development/tools/electron/wrapper.nix
+++ b/pkgs/development/tools/electron/wrapper.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
 
   passthru = {
     unwrapped = electron-unwrapped;
-    inherit (electron-unwrapped) headers;
+    inherit (electron-unwrapped) headers dist;
   };
   inherit (electron-unwrapped) meta;
 }

--- a/pkgs/development/tools/redisinsight/default.nix
+++ b/pkgs/development/tools/redisinsight/default.nix
@@ -116,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     yarn --offline electron-builder \
       --dir \
-      -c.electronDist=${electron}/libexec/electron \
+      -c.electronDist=${electron.dist} \
       -c.electronVersion=${electron.version}
 
     runHook postBuild

--- a/pkgs/tools/security/bitwarden-directory-connector/default.nix
+++ b/pkgs/tools/security/bitwarden-directory-connector/default.nix
@@ -66,7 +66,7 @@ in {
 
       npm exec electron-builder -- \
         --dir \
-        -c.electronDist=${electron}/libexec/electron \
+        -c.electronDist=${electron.dist} \
         -c.electronVersion=${electron.version} \
         -c.npmRebuild=false
 


### PR DESCRIPTION
## Description of changes

Now that I have more experience with packaging electron apps on Darwin, I think it would be useful to have a common interface between the platforms for accessing the electron files.

Previously you'd something like `electron + (if stdenv.isDarwin then "/Applications" else "/libexec/electron")` if you wanted to get the electron directory that's expected by electron-builder or electron-packager.

With this PR, you'll be able to just write `electron.dist` to access the directory.

I implemented this using `passthru`, but an extra `"dist"` output would essentially be the same, though that would require a rebuild.

@yayayayaka what do you think of this?


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
