### PR TITLE
python312Packages.webssh: fix test case

### DIFF
--- a/pkgs/development/python-modules/webssh/default.nix
+++ b/pkgs/development/python-modules/webssh/default.nix
@@ -17,6 +17,10 @@ buildPythonPackage rec {
     hash = "sha256-mRestRJukaf7ti3vIs/MM/R+zpGmK551j5HAM2chBsE=";
   };
 
+  patches = [
+    ./remove-typo-in-test-case.patch
+  ];
+
   propagatedBuildInputs = [
     paramiko
     tornado
@@ -28,11 +32,6 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [
     "webssh"
-  ];
-
-  disabledTests = [
-    # Test fails with AttributeError (possibly related to paramiko update)
-    "test_app_with_bad_host_key"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/webssh/remove-typo-in-test-case.patch
+++ b/pkgs/development/python-modules/webssh/remove-typo-in-test-case.patch
@@ -1,0 +1,18 @@
+---
+ tests/test_handler.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/test_handler.py b/tests/test_handler.py
+index a9ad924..950e672 100644
+--- a/tests/test_handler.py
++++ b/tests/test_handler.py
+@@ -336,5 +336,5 @@ class TestIndexHandler(unittest.TestCase):
+         ssh.exec_command.return_value = (stdin, stdout, stderr)
+ 
+         encoding = IndexHandler.get_default_encoding(handler, ssh)
+-        self.assertEquals("utf-8", encoding)
++        self.assertEqual("utf-8", encoding)
+ 
+-- 
+2.44.0
+


### PR DESCRIPTION
## Description of changes
Fix build (https://hydra.nixos.org/build/260338267)

ZHF: https://github.com/NixOS/nixpkgs/issues/309482
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
