### PR TITLE
sequoia-wot: init at 0.11.0

### DIFF
--- a/pkgs/by-name/se/sequoia-wot/package.nix
+++ b/pkgs/by-name/se/sequoia-wot/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitLab,
+  installShellFiles,
+  pkg-config,
+  nettle,
+  openssl,
+  sqlite,
+  darwin,
+  gnupg,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "sequoia-wot";
+  version = "0.11.0";
+
+  src = fetchFromGitLab {
+    owner = "sequoia-pgp";
+    repo = "sequoia-wot";
+    rev = "v${version}";
+    hash = "sha256-qSf2uESsMGUEvAiRefpwxHKyizbq5Sst3SpjKaMIWTQ=";
+  };
+
+  cargoHash = "sha256-vGseKdHqyncScS57UF3SR3EVdUGKVMue8fnRftefSY0=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+    installShellFiles
+  ];
+
+  buildInputs = [
+    openssl
+    sqlite
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.SystemConfiguration
+    # See comment near sequoia-openpgp/crypto- buildFeatures
+  ] ++ lib.optionals (!stdenv.targetPlatform.isWindows) [
+    nettle
+  ];
+
+  buildFeatures = [
+    # Upstream uses the sequoia-openpgp crate, which doesn't force you to use a
+    # specific crypto backend. As recommended by sequoia-openpgp's crate
+    # docs[1], upstream uses `target.'cfg(not(windows))'.dev-dependencies` to
+    # choose a different backend when the target platform is Windows or not. We
+    # propagate this logic here as well.
+    #
+    # [1]: https://crates.io/crates/sequoia-openpgp#user-content-intermediate-crate
+    (if stdenv.targetPlatform.isWindows then
+      "sequoia-openpgp/crypto-cng"
+    else
+      "sequoia-openpgp/crypto-nettle"
+    )
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [ gnupg ];
+
+  # Install shell completion files and manual pages. Unfortunatly it is hard to
+  # predict the paths to all of these files generated during the build, and it
+  # is impossible to control these using `$OUT_DIR` or alike, as implied by
+  # upstream's `build.rs`. This is a general Rust issue also discussed in
+  # https://github.com/rust-lang/cargo/issues/9661, also discussed upstream at:
+  # https://gitlab.com/sequoia-pgp/sequoia-wot/-/issues/56
+  postInstall = ''
+    installShellCompletion --cmd sq-wot \
+      --bash target/*/release/build/sequoia-wot-*/out/sq-wot.bash \
+      --fish target/*/release/build/sequoia-wot-*/out/sq-wot.fish \
+      --zsh  target/*/release/build/sequoia-wot-*/out/_sq-wot
+    # Also elv and powershell are generated there
+    installManPage \
+      target/*/release/build/sequoia-wot-*/out/sq-wot.1 \
+      target/*/release/build/sequoia-wot-*/out/sq-wot-authenticate.1 \
+      target/*/release/build/sequoia-wot-*/out/sq-wot-lookup.1 \
+      target/*/release/build/sequoia-wot-*/out/sq-wot-identify.1 \
+      target/*/release/build/sequoia-wot-*/out/sq-wot-list.1 \
+      target/*/release/build/sequoia-wot-*/out/sq-wot-path.1
+  '';
+
+  meta = with lib; {
+    description = "A Rust CLI tool for authenticating bindings and exploring a web of trust";
+    homepage = "https://gitlab.com/sequoia-pgp/sequoia-wot";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ Cryolitia ];
+    mainProgram = "sq-wot";
+  };
+}


### PR DESCRIPTION
## Description of changes

https://gitlab.com/sequoia-pgp/sequoia-wot

A Rust library for authenticating bindings between User IDs and certificates using OpenPGP's web of trust.  This library is designed around OpenPGP's data structures, but it does not require OpenPGP data.  Instead, it is possible to manually describe a web of trust.

This crate also includes a CLI tool, sq-wot, for authenticating bindings and exploring a web of trust.

An official introduce article here: https://sequoia-pgp.org/blog/2023/03/29/202303-pretty-graphics-for-the-web-of-trust/

Thanks for review!

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
