### PR TITLE
jitsi-meet-electron: fix darwin build

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jitsi-meet-electron/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jitsi-meet-electron/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildNpmPackage
 , fetchFromGitHub
 , copyDesktopItems
@@ -9,9 +10,15 @@
 , libXi
 , libXtst
 , zlib
+, darwin
 , electron
 }:
 
+let
+  inherit (darwin.apple_sdk.frameworks) Carbon CoreFoundation ApplicationServices OpenGL;
+
+  electronDist = electron + (if stdenv.isDarwin then "/Applications" else "/libexec/electron");
+in
 buildNpmPackage rec {
   pname = "jitsi-meet-electron";
   version = "2024.3.0";
@@ -24,17 +31,23 @@ buildNpmPackage rec {
   };
 
   nativeBuildInputs = [
-    copyDesktopItems
     makeWrapper
+  ] ++ lib.optionals stdenv.isLinux [
+    copyDesktopItems
   ];
 
   # robotjs node-gyp dependencies
-  buildInputs = [
+  buildInputs = lib.optionals stdenv.isLinux [
     libpng
     libX11
     libXi
     libXtst
     zlib
+  ] ++ lib.optionals stdenv.isDarwin [
+    Carbon
+    CoreFoundation
+    ApplicationServices
+    OpenGL
   ];
 
   npmDepsHash = "sha256-KanG8y+tYzswCCXjSkOlk+p9XKaouP2Z7IhsD5bDtRk=";
@@ -43,34 +56,54 @@ buildNpmPackage rec {
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
 
+  # disable code signing on Darwin
+  env.CSC_IDENTITY_AUTO_DISCOVERY = "false";
+
   preBuild = ''
     # remove some prebuilt binaries
     find node_modules -type d -name prebuilds -exec rm -r {} +
+
+    # don't force both darwin architectures together
+    substituteInPlace node_modules/@jitsi/robotjs/binding.gyp \
+        --replace-fail "-arch x86_64" "" \
+        --replace-fail "-arch arm64" ""
   '';
 
   postBuild = ''
-    # generate .asar file
+    cp -r ${electronDist} electron-dist
+    chmod -R u+w electron-dist
+
+    # npmRebuild is needed because robotjs won't be built on darwin otherwise
     # asarUnpack makes sure to unwrap binaries so that nix can see the RPATH
     npm exec electron-builder -- \
         --dir \
+        -c.npmRebuild=true \
         -c.asarUnpack="**/*.node" \
-        -c.electronDist=${electron}/libexec/electron \
+        -c.electronDist=electron-dist \
         -c.electronVersion=${electron.version}
   '';
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/share/jitsi-meet-electron
-    cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/jitsi-meet-electron
+    ${lib.optionalString stdenv.isLinux ''
+      mkdir -p $out/share/jitsi-meet-electron
+      cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/jitsi-meet-electron
 
-    makeWrapper ${lib.getExe electron} $out/bin/jitsi-meet-electron \
-        --add-flags $out/share/jitsi-meet-electron/resources/app.asar \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
-        --set-default ELECTRON_IS_DEV 0 \
-        --inherit-argv0
+      makeWrapper ${lib.getExe electron} $out/bin/jitsi-meet-electron \
+          --add-flags $out/share/jitsi-meet-electron/resources/app.asar \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+          --set-default ELECTRON_IS_DEV 0 \
+          --inherit-argv0
 
-    install -Dm644 resources/icons/512x512.png $out/share/icons/hicolor/512x512/apps/jitsi-meet-electron.png
+      install -Dm644 resources/icons/512x512.png $out/share/icons/hicolor/512x512/apps/jitsi-meet-electron.png
+    ''}
+
+    ${lib.optionalString stdenv.isDarwin ''
+      mkdir -p $out/Applications
+      cp -r dist/mac*/"Jitsi Meet.app" $out/Applications
+      makeWrapper "$out/Applications/Jitsi Meet.app/Contents/MacOS/Jitsi Meet" $out/bin/jitsi-meet-electron
+    ''}
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Description of changes

This PR adds support for building `jitsi-meet-electron` on darwin.

Note:
since the `.app` name has spaces in it, on of the fixup phase hooks shows many errors/warning because it simply can't handle spaces. (This issue should probably be reported) Luckily, the patching isn't really needed for it to run.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
