### PR TITLE
fossil: 2.23 -> 2.24

### DIFF
--- a/pkgs/applications/version-management/fossil/default.nix
+++ b/pkgs/applications/version-management/fossil/default.nix
@@ -3,6 +3,7 @@
 , tcl
 , libiconv
 , fetchurl
+, fetchpatch
 , buildPackages
 , zlib
 , openssl
@@ -17,11 +18,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fossil";
-  version = "2.23";
+  version = "2.24";
 
   src = fetchurl {
     url = "https://www.fossil-scm.org/home/tarball/version-${finalAttrs.version}/fossil-${finalAttrs.version}.tar.gz";
-    hash = "sha256-dfgI6BNRAYqXFnRtnvGh/huxkEcz6LQYZDiB04GYhZM=";
+    hash = "sha256-lc08F2g1vrm4lwdvpYFx/jCwspH2OHu1R0nvvfqWL0w=";
   };
 
   # required for build time tool `./tools/translate.c`
@@ -40,6 +41,27 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags =
     lib.optional (!withInternalSqlite) "--disable-internal-sqlite"
     ++ lib.optional withJson "--json";
+
+  patches = [
+    (fetchpatch {
+       url = "https://fossil-scm.org/home/vpatch?from=8be0372c10510437&to=5ad708085a90365f";
+       extraPrefix = "";
+       hash = "sha256-KxF40wiEY3R1RFM0/YOmdNiedQHzs+vyMXslnqLtqQ4=";
+       name = "fossil-disable-tests.patch";
+    })
+    (fetchpatch {
+       url = "https://fossil-scm.org/home/vpatch?from=fb4e90b662803e47&to=17c01c549e73c6b8";
+       extraPrefix = "";
+       hash = "sha256-b0JSDWEBTlLWFr5rO+g0biPzUfVsdeAw71DR7/WQKzU=";
+       name = "fossil-fix-json-test.patch";
+    })
+    (fetchpatch {
+       url = "https://fossil-scm.org/home/vpatch?from=5ad708085a90365f&to=fb4e90b662803e47";
+       extraPrefix = "";
+       hash = "sha256-bbWUrlhPxC/DQQDeC3gG0jGfxQ6F7YkxINqg3baf+j0=";
+       name = "fossil-comment-utf-tests.patch";
+    })
+  ];
 
   preBuild = ''
     export USER=nonexistent-but-specified-user


### PR DESCRIPTION
## Description of changes

https://fossil-scm.org/home/doc/trunk/www/changes.wiki#v2_24

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
