### PR TITLE
python312Packages.limits: 3.10.1 -> 3.12.0

### DIFF
--- a/pkgs/development/python-modules/limits/default.nix
+++ b/pkgs/development/python-modules/limits/default.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "limits";
-  version = "3.10.1";
+  version = "3.12.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     postFetch = ''
       rm "$out/limits/_version.py"
     '';
-    hash = "sha256-Ax0P9rYTPOrhtOw7FLElSNTGQ3WWCboM3FodTOGZWu8=";
+    hash = "sha256-EH2/75tcKuS11XKuo4lCQrFe4/XJZpcWhuGlSuhIk18=";
   };
 
   postPatch = ''
@@ -93,12 +93,14 @@ buildPythonPackage rec {
     ];
   };
 
+  doCheck = pythonOlder "3.12"; # SystemError in protobuf
+
   nativeCheckInputs = [
     hiro
     pytest-asyncio
     pytest-lazy-fixture
     pytestCheckHook
-  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
 
   pythonImportsCheck = [
     "limits"


### PR DESCRIPTION
Disable tests, as they currently crash somewhere in protobuf on all platforms.

https://github.com/alisaifee/limits/releases/tag/3.11.0 
https://github.com/alisaifee/limits/releases/tag/3.12.0

ZHF: #309482


```
> Executing pytestCheckPhase
> ImportError while loading conftest '/build/source/tests/conftest.py'.
> tests/conftest.py:6: in <module>
>     import etcd3
> /nix/store/igi8m0plx03g2pmr4y1cpahxngp7hs0v-python3.12-etcd3-0.12.0/lib/python3.12/site-packages/etcd3/__init__.py:3: in <module>
>     import etcd3.etcdrpc as etcdrpc
> /nix/store/igi8m0plx03g2pmr4y1cpahxngp7hs0v-python3.12-etcd3-0.12.0/lib/python3.12/site-packages/etcd3/etcdrpc/__init__.py:1: in <module>
>     from .rpc_pb2 import *
> /nix/store/igi8m0plx03g2pmr4y1cpahxngp7hs0v-python3.12-etcd3-0.12.0/lib/python3.12/site-packages/etcd3/etcdrpc/rpc_pb2.py:7: in <module>
>     from google.protobuf import descriptor as _descriptor
> /nix/store/cc45x4fzn45fgwynwd4ayw03r5cxivwz-python3.12-protobuf-4.24.4/lib/python3.12/site-packages/google/protobuf/descriptor.py:40: in <module>
>     from google.protobuf.internal import api_implementation
> /nix/store/cc45x4fzn45fgwynwd4ayw03r5cxivwz-python3.12-protobuf-4.24.4/lib/python3.12/site-packages/google/protobuf/internal/api_implementation.py:104: in
>     from google.protobuf.pyext import _message
> E   SystemError: <built-in function __import__> returned a result with an exception set
> /nix/store/xfhkjnpqjwlf6hlk1ysmq3aaq80f3bjj-stdenv-linux/setup: line 1579: pop_var_context: head of shell_variables not a function context
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
