### PR TITLE
buildDotnetModule: fix cross-compilation and remove dotnet-test-sdk

### DIFF
--- a/doc/languages-frameworks/dotnet.section.md
+++ b/doc/languages-frameworks/dotnet.section.md
@@ -117,7 +117,6 @@ For more detail about managing the `deps.nix` file, see [Generating and updating
 * `useDotnetFromEnv` will change the binary wrapper so that it uses the .NET from the environment. The runtime specified by `dotnet-runtime` is given as a fallback in case no .NET is installed in the user's environment. This is most useful for .NET global tools and LSP servers, which often extend the .NET CLI and their runtime should match the users' .NET runtime.
 * `dotnet-sdk` is useful in cases where you need to change what dotnet SDK is being used. You can also set this to the result of `dotnetSdkPackages.combinePackages`, if the project uses multiple SDKs to build.
 * `dotnet-runtime` is useful in cases where you need to change what dotnet runtime is being used. This can be either a regular dotnet runtime, or an aspnetcore.
-* `dotnet-test-sdk` is useful in cases where unit tests expect a different dotnet SDK. By default, this is set to the `dotnet-sdk` attribute.
 * `testProjectFile` is useful in cases where the regular project file does not contain the unit tests. It gets restored and build, but not installed. You may need to regenerate your nuget lockfile after setting this. Note that if set, only tests from this project are executed.
 * `disabledTests` is used to disable running specific unit tests. This gets passed as: `dotnet test --filter "FullyQualifiedName!={}"`, to ensure compatibility with all unit test frameworks.
 * `dotnetRestoreFlags` can be used to pass flags to `dotnet restore`.

--- a/pkgs/build-support/dotnet/build-dotnet-module/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/default.nix
@@ -84,8 +84,6 @@
 , dotnet-sdk ? dotnetCorePackages.sdk_6_0
   # The dotnet runtime to use.
 , dotnet-runtime ? dotnetCorePackages.runtime_6_0
-  # The dotnet SDK to run tests against. This can differentiate from the SDK compiled against.
-, dotnet-test-sdk ? dotnet-sdk
 , ...
 } @ args:
 
@@ -96,7 +94,7 @@ let
     else dotnet-sdk.meta.platforms;
 
   inherit (callPackage ./hooks {
-    inherit dotnet-sdk dotnet-test-sdk disabledTests nuget-source dotnet-runtime runtimeDeps buildType;
+    inherit dotnet-sdk disabledTests nuget-source dotnet-runtime runtimeDeps buildType;
     runtimeId =
       if runtimeId != null
       then runtimeId

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/default.nix
@@ -21,8 +21,8 @@ let
   libraryPath = lib.makeLibraryPath runtimeDeps;
 in
 {
-  dotnetConfigureHook = callPackage ({ }:
-    makeSetupHook {
+  dotnetConfigureHook = makeSetupHook
+    {
       name = "dotnet-configure-hook";
       substitutions = {
         nugetSource = nuget-source;
@@ -36,40 +36,46 @@ in
         ];
         inherit runtimeId;
       };
-    } ./dotnet-configure-hook.sh) { };
+    }
+    ./dotnet-configure-hook.sh;
 
-  dotnetBuildHook = callPackage ({ }:
-    makeSetupHook {
+  dotnetBuildHook = makeSetupHook
+    {
       name = "dotnet-build-hook";
       substitutions = {
         inherit buildType runtimeId;
       };
-    } ./dotnet-build-hook.sh) { };
+    }
+    ./dotnet-build-hook.sh;
 
-  dotnetCheckHook = callPackage ({ }:
-    makeSetupHook {
+  dotnetCheckHook = makeSetupHook
+    {
       name = "dotnet-check-hook";
       substitutions = {
         inherit buildType runtimeId libraryPath;
-        disabledTests = lib.optionalString (disabledTests != [])
-          (let
-            escapedNames = lib.lists.map (n: lib.replaceStrings [","] ["%2C"] n) disabledTests;
-            filters = lib.lists.map (n: "FullyQualifiedName!=${n}") escapedNames;
-          in
-          "${lib.concatStringsSep "&" filters}");
+        disabledTests = lib.optionalString (disabledTests != [ ])
+          (
+            let
+              escapedNames = lib.lists.map (n: lib.replaceStrings [ "," ] [ "%2C" ] n) disabledTests;
+              filters = lib.lists.map (n: "FullyQualifiedName!=${n}") escapedNames;
+            in
+            "${lib.concatStringsSep "&" filters}"
+          );
       };
-    } ./dotnet-check-hook.sh) { };
+    }
+    ./dotnet-check-hook.sh;
 
-  dotnetInstallHook = callPackage ({ }:
-    makeSetupHook {
+  dotnetInstallHook = makeSetupHook
+    {
       name = "dotnet-install-hook";
       substitutions = {
         inherit buildType runtimeId;
       };
-    } ./dotnet-install-hook.sh) { };
+    }
+    ./dotnet-install-hook.sh;
 
-  dotnetFixupHook = callPackage ({ }:
-    makeSetupHook {
+  dotnetFixupHook = makeSetupHook
+    {
       name = "dotnet-fixup-hook";
       substitutions = {
         dotnetRuntime = dotnet-runtime;
@@ -79,5 +85,6 @@ in
         dirname = "${coreutils}/bin/dirname";
         realpath = "${coreutils}/bin/realpath";
       };
-    } ./dotnet-fixup-hook.sh) { };
+    }
+    ./dotnet-fixup-hook.sh;
 }

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/default.nix
@@ -8,7 +8,6 @@
 , makeSetupHook
 , makeWrapper
 , dotnet-sdk
-, dotnet-test-sdk
 , disabledTests
 , nuget-source
 , dotnet-runtime
@@ -25,7 +24,6 @@ in
   dotnetConfigureHook = callPackage ({ }:
     makeSetupHook {
       name = "dotnet-configure-hook";
-      propagatedBuildInputs = [ dotnet-sdk nuget-source ];
       substitutions = {
         nugetSource = nuget-source;
         dynamicLinker = "${stdenv.cc}/nix-support/dynamic-linker";
@@ -43,7 +41,6 @@ in
   dotnetBuildHook = callPackage ({ }:
     makeSetupHook {
       name = "dotnet-build-hook";
-      propagatedBuildInputs = [ dotnet-sdk ];
       substitutions = {
         inherit buildType runtimeId;
       };
@@ -52,7 +49,6 @@ in
   dotnetCheckHook = callPackage ({ }:
     makeSetupHook {
       name = "dotnet-check-hook";
-      propagatedBuildInputs = [ dotnet-test-sdk ];
       substitutions = {
         inherit buildType runtimeId libraryPath;
         disabledTests = lib.optionalString (disabledTests != [])
@@ -67,7 +63,6 @@ in
   dotnetInstallHook = callPackage ({ }:
     makeSetupHook {
       name = "dotnet-install-hook";
-      propagatedBuildInputs = [ dotnet-sdk ];
       substitutions = {
         inherit buildType runtimeId;
       };
@@ -76,7 +71,6 @@ in
   dotnetFixupHook = callPackage ({ }:
     makeSetupHook {
       name = "dotnet-fixup-hook";
-      propagatedBuildInputs = [ dotnet-runtime ];
       substitutions = {
         dotnetRuntime = dotnet-runtime;
         runtimeDeps = libraryPath;

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-build-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-build-hook.sh
@@ -41,7 +41,7 @@ dotnetBuildHook() {
             runtimeIdFlags+=("--runtime @runtimeId@")
         fi
 
-        env dotnet build ${project-} \
+        dotnet build ${project-} \
             -maxcpucount:$maxCpuFlag \
             -p:BuildInParallel=$parallelBuildFlag \
             -p:ContinuousIntegrationBuild=true \

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-check-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-check-hook.sh
@@ -22,7 +22,7 @@ dotnetCheckHook() {
             runtimeIdFlags=("--runtime @runtimeId@")
         fi
 
-        env "LD_LIBRARY_PATH=@libraryPath@" \
+        LD_LIBRARY_PATH="@libraryPath@" \
             dotnet test "$project" \
               -maxcpucount:$maxCpuFlag \
               -p:ContinuousIntegrationBuild=true \

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-configure-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-configure-hook.sh
@@ -15,7 +15,7 @@ dotnetConfigureHook() {
 
     dotnetRestore() {
         local -r project="${1-}"
-        env dotnet restore ${project-} \
+        dotnet restore ${project-} \
             -p:ContinuousIntegrationBuild=true \
             -p:Deterministic=true \
             --runtime "@runtimeId@" \
@@ -43,7 +43,7 @@ EOF
     find -name paket.dependencies -exec sed -i 's+source .*+source @nugetSource@/lib+g' {} \;
     find -name paket.lock -exec sed -i 's+remote:.*+remote: @nugetSource@/lib+g' {} \;
 
-    env dotnet tool restore --add-source "@nugetSource@/lib"
+    dotnet tool restore --add-source "@nugetSource@/lib"
 
     (( "${#projectFile[@]}" == 0 )) && dotnetRestore
 

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-install-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-install-hook.sh
@@ -27,7 +27,7 @@ dotnetInstallHook() {
             runtimeIdFlags+=("--runtime @runtimeId@")
         fi
 
-        env dotnet publish ${project-} \
+        dotnet publish ${project-} \
             -p:ContinuousIntegrationBuild=true \
             -p:Deterministic=true \
             --output "${installPath-$out/lib/$pname}" \
@@ -40,7 +40,7 @@ dotnetInstallHook() {
 
     dotnetPack() {
         local -r project="${1-}"
-        env dotnet pack ${project-} \
+        dotnet pack ${project-} \
             -p:ContinuousIntegrationBuild=true \
             -p:Deterministic=true \
             --output "$out/share" \


### PR DESCRIPTION
## Description of changes

As requested in #313005, split cross-compilation related changes for .NET infrastructure.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
