### PR TITLE
coreutils: enable single-binary build on FreeBSD

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -16,7 +16,7 @@
 , minimal ? true
 , withOpenssl ? !minimal, openssl
 , withPrefix ? false
-, singleBinary ? if stdenv.isFreeBSD then false else "symlinks" # you can also pass "shebangs" or false
+, singleBinary ? "symlinks" # you can also pass "shebangs" or false
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus cannot use
@@ -39,7 +39,13 @@ stdenv.mkDerivation rec {
     hash = "sha256-zTKO3qyS9qZl3p8yPJO3Eq8YWLwuDYjz9xAEaUcKG4o=";
   };
 
-  patches = lib.optionals stdenv.hostPlatform.isMusl [
+  patches = [
+    # https://lists.gnu.org/archive/html/bug-coreutils/2024-05/msg00037.html
+    # This is not precisely the patch provided - this is a diff of the Makefile.in
+    # after the patch was applied and autoreconf was run, since adding autoreconf
+    # here causes infinite recursion.
+    ./fix-mix-flags-deps-libintl.patch
+  ] ++ lib.optionals stdenv.hostPlatform.isMusl [
     # https://lists.gnu.org/archive/html/bug-coreutils/2024-03/msg00089.html
     ./fix-test-failure-musl.patch
   ];

--- a/pkgs/tools/misc/coreutils/fix-mix-flags-deps-libintl.patch
+++ b/pkgs/tools/misc/coreutils/fix-mix-flags-deps-libintl.patch
@@ -1,0 +1,49 @@
+--- a/Makefile.in	2024-05-21 17:03:50.488979000 -0700
++++ b/Makefile.in	2024-05-21 17:18:56.243091000 -0700
+@@ -692,8 +692,6 @@
+ @USE_PCLMUL_CRC32_TRUE@am__append_211 = $(cksum_pclmul_ldadd)
+ @USE_AVX2_WC_LINECOUNT_TRUE@am__append_212 = src/libwc_avx2.a
+ @USE_AVX2_WC_LINECOUNT_TRUE@am__append_213 = $(wc_avx2_ldadd)
+-@SINGLE_BINARY_FALSE@src_coreutils_DEPENDENCIES =  \
+-@SINGLE_BINARY_FALSE@	$(am__DEPENDENCIES_2)
+ # Command arch
+ # Command hostname
+ # Command chroot
+@@ -2825,6 +2823,12 @@
+ nodist_src_coreutils_OBJECTS =
+ src_coreutils_OBJECTS = $(am_src_coreutils_OBJECTS) \
+ 	$(nodist_src_coreutils_OBJECTS)
++@SINGLE_BINARY_FALSE@src_coreutils_DEPENDENCIES =  \
++@SINGLE_BINARY_FALSE@	$(am__DEPENDENCIES_2)
++@SINGLE_BINARY_TRUE@src_coreutils_DEPENDENCIES =  \
++@SINGLE_BINARY_TRUE@	$(am__DEPENDENCIES_1) \
++@SINGLE_BINARY_TRUE@	$(am__DEPENDENCIES_2) \
++@SINGLE_BINARY_TRUE@	$(am__DEPENDENCIES_1)
+ src_coreutils_LINK = $(CCLD) $(src_coreutils_CFLAGS) $(CFLAGS) \
+ 	$(AM_LDFLAGS) $(LDFLAGS) -o $@
+ am__objects_221 = src/copy.$(OBJEXT) src/cp-hash.$(OBJEXT) \
+@@ -7492,7 +7496,12 @@
+ src_libstdbuf_so_CFLAGS = -fPIC $(AM_CFLAGS)
+ # Single binary dependencies
+ @SINGLE_BINARY_TRUE@src_coreutils_CFLAGS = -DSINGLE_BINARY $(AM_CFLAGS)
+-@SINGLE_BINARY_TRUE@src_coreutils_DEPENDENCIES = $(LDADD) $(single_binary_deps)
++
++# Creates symlinks or shebangs to the installed programs when building
++# coreutils single binary.
++@SINGLE_BINARY_TRUE@EXTRA_src_coreutils_DEPENDENCIES =  \
++@SINGLE_BINARY_TRUE@	$(single_binary_deps) \
++@SINGLE_BINARY_TRUE@	src/coreutils_$(single_binary_install_type)
+ @SINGLE_BINARY_TRUE@src_libsinglebin_dir_a_DEPENDENCIES = src/libsinglebin_ls.a
+ @SINGLE_BINARY_TRUE@src_libsinglebin_vdir_a_DEPENDENCIES = src/libsinglebin_ls.a
+ @SINGLE_BINARY_TRUE@src_libsinglebin_arch_a_DEPENDENCIES = src/libsinglebin_uname.a
+@@ -7880,10 +7889,6 @@
+ @SINGLE_BINARY_TRUE@src_libsinglebin_yes_a_DEPENDENCIES = $(src_yes_DEPENDENCIES)
+ @SINGLE_BINARY_TRUE@src_libsinglebin_yes_a_CFLAGS = "-Dmain=single_binary_main_yes (int, char **);  int single_binary_main_yes"  -Dusage=_usage_yes $(src_coreutils_CFLAGS)
+ 
+-# Creates symlinks or shebangs to the installed programs when building
+-# coreutils single binary.
+-@SINGLE_BINARY_TRUE@EXTRA_src_coreutils_DEPENDENCIES = src/coreutils_$(single_binary_install_type)
+-
+ # false exits nonzero even with --help or --version.
+ # test doesn't support --help or --version.
+ # Tell automake to exempt then from that installcheck test.


### PR DESCRIPTION
## Description of changes

[We got a patch from the coreutils maintainers!](https://lists.gnu.org/archive/html/bug-coreutils/2024-05/msg00037.html) I've responded affirmatively, so this should be part of the next coreutils release. In the meantime, applying a patch derived from it allows us to shrink the freebsd stdenv by, uh, a lot.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
