### PR TITLE
python311Packages.mne-python: 1.6.1 -> 1.7.0

### DIFF
--- a/pkgs/development/python-modules/mne-python/default.nix
+++ b/pkgs/development/python-modules/mne-python/default.nix
@@ -2,20 +2,18 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  setuptools,
-  setuptools-scm,
+  hatchling,
+  hatch-vcs,
   numpy,
   scipy,
   pytestCheckHook,
   pytest-timeout,
-  pytest-harvest,
   matplotlib,
   decorator,
   jinja2,
   pooch,
   tqdm,
   packaging,
-  importlib-resources,
   lazy-loader,
   h5io,
   pymatreader,
@@ -24,27 +22,27 @@
 
 buildPythonPackage rec {
   pname = "mne-python";
-  version = "1.6.1";
+  version = "1.7.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "mne-tools";
     repo = "mne-python";
     rev = "refs/tags/v${version}";
-    hash = "sha256-U1aMqcUZ3BcwqwOYh/qfG5PhacwBVioAgNc52uaoJL0";
+    hash = "sha256-Nrar6Iw/jROuo4QTI7TktJSR5IdPSOQcbR+lycH52LI=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml  \
-      --replace "--cov-report=" ""  \
-      --replace "--cov-branch" ""
+      --replace-fail "--cov-report=" ""  \
+      --replace-fail "--cov-branch" ""
   '';
 
   nativeBuildInputs = [
-    setuptools
-    setuptools-scm
+    hatchling
+    hatch-vcs
   ];
 
   propagatedBuildInputs = [
@@ -57,19 +55,16 @@ buildPythonPackage rec {
     packaging
     jinja2
     lazy-loader
-  ] ++ lib.optionals (pythonOlder "3.9") [ importlib-resources ];
+  ];
 
-  passthru.optional-dependencies = {
-    hdf5 = [
-      h5io
-      pymatreader
-    ];
-  };
+  passthru.optional-dependencies.hdf5 = [
+    h5io
+    pymatreader
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook
     pytest-timeout
-    pytest-harvest
   ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
 
   preCheck = ''


### PR DESCRIPTION
## Description of changes

Routine update; unbreaks the package.

For ZHF (#309482).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
