### PR TITLE
ocamlPackages.riot: 0.0.7 → 0.0.8

### DIFF
--- a/pkgs/development/ocaml-modules/bytestring/default.nix
+++ b/pkgs/development/ocaml-modules/bytestring/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, ppxlib
+, rio
+, sedlex
+, spices
+, uutf
+, qcheck
+}:
+
+buildDunePackage rec {
+  pname = "bytestring";
+  version = "0.0.8";
+
+  minimalOCamlVersion = "5.1";
+
+  src = fetchurl {
+    url = "https://github.com/riot-ml/riot/releases/download/${version}/riot-${version}.tbz";
+    hash = "sha256-SsiDz53b9bMIT9Q3IwDdB3WKy98WSd9fiieU41qZpeE=";
+  };
+
+  propagatedBuildInputs = [
+    ppxlib
+    sedlex
+    spices
+    rio
+    uutf
+  ];
+
+  checkInputs = [
+    qcheck
+  ];
+
+  # Checks fail with OCaml 5.2
+  doCheck = false;
+
+  meta = {
+    description = "Efficient, immutable, pattern-matchable, UTF friendly byte strings";
+    homepage = "https://github.com/riot-ml/riot";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+  };
+}
+

--- a/pkgs/development/ocaml-modules/colors/default.nix
+++ b/pkgs/development/ocaml-modules/colors/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, mdx
+}:
+
+buildDunePackage rec {
+  pname = "colors";
+  version = "0.0.1";
+
+  minimalOCamlVersion = "4.13";
+
+  src = fetchurl {
+    url = "https://github.com/leostera/colors/releases/download/${version}/colors-${version}.tbz";
+    hash = "sha256-fY1j9FODVnifwsI8qkKm0QSmssgWqYFXJ7y8o7/KmEY=";
+  };
+
+  doCheck = true;
+
+  checkInputs = [
+    mdx
+  ];
+
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+
+  meta = {
+    description = "A pure OCaml library for manipulating colors across color spaces";
+    homepage = "https://github.com/leostera/colors";
+    changelog = "https://github.com/leostera/colors/blob/${version}/CHANGES.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/development/ocaml-modules/config/default.nix
+++ b/pkgs/development/ocaml-modules/config/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, ppxlib
+, spices
+}:
+
+buildDunePackage rec {
+  pname = "config";
+  version = "0.0.3";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-sys/config.ml/releases/download/${version}/config-${version}.tbz";
+    hash = "sha256-bcRCfLX2ro8vnQTJiX2aYGJC+eD26vkPynMYg817YFM=";
+  };
+
+  propagatedBuildInputs = [
+    ppxlib
+    spices
+  ];
+
+  meta = {
+    description = "Ergonomic, lightweight conditional compilation through attributes";
+    homepage = "https://github.com/ocaml-sys/config.ml";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/development/ocaml-modules/gluon/default.nix
+++ b/pkgs/development/ocaml-modules/gluon/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, bytestring
+, config
+, libc
+, rio
+, uri
+}:
+
+buildDunePackage rec {
+  pname = "gluon";
+  version = "0.0.9";
+
+  minimalOCamlVersion = "5.1";
+
+  src = fetchurl {
+    url = "https://github.com/riot-ml/gluon/releases/download/${version}/gluon-${version}.tbz";
+    hash = "sha256-YWJCPokY1A7TGqCGoxJl14oKDVeMNybEEB7KiK92WSo=";
+  };
+
+  buildInputs = [
+    config
+  ];
+
+  propagatedBuildInputs = [
+    bytestring
+    libc
+    rio
+    uri
+  ];
+
+  meta = {
+    description = "A minimal, portable, and fast API on top of the operating-system's evented I/O API";
+    homepage = "https://github.com/riot-ml/gluon";
+    changelog = "https://github.com/riot-ml/gluon/blob/${version}/CHANGES.md";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}
+
+

--- a/pkgs/development/ocaml-modules/libc/default.nix
+++ b/pkgs/development/ocaml-modules/libc/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, config
+}:
+
+buildDunePackage rec {
+  pname = "libc";
+  version = "0.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-sys/libc.ml/releases/download/${version}/libc-${version}.tbz";
+    hash = "sha256-e5x5Yae7V6qOpq+aLZaV+6L9ldy9qDqd9Kc8nkAsENg=";
+  };
+
+  buildInputs = [
+    config
+  ];
+
+  meta = {
+    description = "Raw definitions and bindings to platforms system libraries";
+    homepage = "https://github.com/ocaml-sys/libc.ml";
+    license = lib.licenses.mit;
+  };
+}
+

--- a/pkgs/development/ocaml-modules/minttea/default.nix
+++ b/pkgs/development/ocaml-modules/minttea/default.nix
@@ -7,21 +7,19 @@
 
 buildDunePackage rec {
   pname = "minttea";
-  version = "0.0.1";
+  version = "0.0.3";
 
   minimalOCamlVersion = "5.1";
 
   src = fetchurl {
     url = "https://github.com/leostera/minttea/releases/download/${version}/minttea-${version}.tbz";
-    hash = "sha256-+4nVeYKx2A2i2nll/PbStcEa+Dvxd0T7e/KsdJqY4bI=";
+    hash = "sha256-WEaJVCCvsmKcF8+yzovljt8dGWaIv4UmAr74jq6Vo9M=";
   };
 
   propagatedBuildInputs = [
     riot
     tty
   ];
-
-  doCheck = true;
 
   meta = {
     description = "A fun, functional, and stateful way to build terminal apps in OCaml heavily inspired by Go's BubbleTea";

--- a/pkgs/development/ocaml-modules/rio/default.nix
+++ b/pkgs/development/ocaml-modules/rio/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, cstruct
+}:
+
+buildDunePackage rec {
+  pname = "rio";
+  version = "0.0.8";
+
+  minimalOCamlVersion = "5.1";
+
+  src = fetchurl {
+    url = "https://github.com/riot-ml/riot/releases/download/${version}/riot-${version}.tbz";
+    hash = "sha256-SsiDz53b9bMIT9Q3IwDdB3WKy98WSd9fiieU41qZpeE=";
+  };
+
+  propagatedBuildInputs = [
+    cstruct
+  ];
+
+  meta = {
+    description = "Ergonomic, composable, efficient read/write streams";
+    homepage = "https://github.com/riot-ml/riot";
+    changelog = "https://github.com/riot-ml/riot/blob/${version}/CHANGES.md";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}
+

--- a/pkgs/development/ocaml-modules/riot/default.nix
+++ b/pkgs/development/ocaml-modules/riot/default.nix
@@ -1,36 +1,34 @@
 { lib
 , buildDunePackage
-, cstruct
 , fetchurl
-, mdx
-, poll
-, ptime
+, mirage-crypto-rng
+, mtime
+, gluon
+, randomconv
+, rio
 , telemetry
-, uri
+, tls
 }:
 
 buildDunePackage rec {
   pname = "riot";
-  version = "0.0.7";
+  version = "0.0.8";
 
   minimalOCamlVersion = "5.1";
 
   src = fetchurl {
     url = "https://github.com/leostera/riot/releases/download/${version}/riot-${version}.tbz";
-    hash = "sha256-t+PMBh4rZXi82dUljv3nLzZX5o1iagBbQ9FfGnr/dp4=";
+    hash = "sha256-SsiDz53b9bMIT9Q3IwDdB3WKy98WSd9fiieU41qZpeE=";
   };
 
   propagatedBuildInputs = [
-    cstruct
-    poll
-    ptime
+    gluon
+    mirage-crypto-rng
+    mtime
+    randomconv
+    rio
     telemetry
-    uri
-  ];
-
-  checkInputs = [
-    mdx
-    mdx.bin
+    tls
   ];
 
   doCheck = false; # fails on sandbox

--- a/pkgs/development/ocaml-modules/spices/default.nix
+++ b/pkgs/development/ocaml-modules/spices/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildDunePackage
+, fetchurl
+, colors
+, tty
+}:
+
+buildDunePackage rec {
+  pname = "spices";
+  version = "0.0.2";
+
+  minimalOCamlVersion = "5.1";
+
+  src = fetchurl {
+    url = "https://github.com/leostera/minttea/releases/download/${version}/minttea-${version}.tbz";
+    hash = "sha256-0eB7OuxcPdv9bf2aIQEeir44mQfx5W2AJj7Vb4pGtLI=";
+  };
+
+  propagatedBuildInputs = [
+    colors
+    tty
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Declarative styles for TUI applications";
+    homepage = "https://github.com/leostera/minttea";
+    changelog = "https://github.com/leostera/minttea/blob/${version}/CHANGES.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+  };
+}
+

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -956,6 +956,8 @@ let
 
     letsencrypt-mirage = callPackage ../development/ocaml-modules/letsencrypt/mirage.nix { };
 
+    libc = callPackage ../development/ocaml-modules/libc { };
+
     lilv = callPackage ../development/ocaml-modules/lilv {
       inherit (pkgs) lilv;
     };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -245,6 +245,8 @@ let
 
     conduit-mirage = callPackage ../development/ocaml-modules/conduit/mirage.nix { };
 
+    config = callPackage ../development/ocaml-modules/config { };
+
     config-file = callPackage ../development/ocaml-modules/config-file { };
 
     containers = callPackage ../development/ocaml-modules/containers { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -231,6 +231,8 @@ let
 
     color = callPackage ../development/ocaml-modules/color { };
 
+    colors = callPackage ../development/ocaml-modules/colors { };
+
     conduit = callPackage ../development/ocaml-modules/conduit { };
 
     conduit-async = callPackage ../development/ocaml-modules/conduit/async.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -606,6 +606,8 @@ let
     github-jsoo = callPackage ../development/ocaml-modules/github/jsoo.nix {  };
     github-unix = callPackage ../development/ocaml-modules/github/unix.nix {  };
 
+    gluon = callPackage ../development/ocaml-modules/gluon { };
+
     gluten = callPackage ../development/ocaml-modules/gluten { };
     gluten-eio = callPackage ../development/ocaml-modules/gluten/eio.nix { };
     gluten-lwt = callPackage ../development/ocaml-modules/gluten/lwt.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -119,6 +119,8 @@ let
 
     bwd = callPackage ../development/ocaml-modules/bwd { };
 
+    bytestring = callPackage ../development/ocaml-modules/bytestring { };
+
     bz2 = callPackage ../development/ocaml-modules/bz2 { };
 
     ### C ###

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1634,6 +1634,8 @@ let
 
     ringo = callPackage ../development/ocaml-modules/ringo { };
 
+    rio = callPackage ../development/ocaml-modules/rio { };
+
     riot = callPackage ../development/ocaml-modules/riot { };
 
     rock = callPackage ../development/ocaml-modules/rock { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1716,6 +1716,8 @@ let
 
     spelll = callPackage ../development/ocaml-modules/spelll { };
 
+    spices = callPackage ../development/ocaml-modules/spices { };
+
     srt = callPackage ../development/ocaml-modules/srt {
       inherit (pkgs) srt;
     };


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/riot-ml/riot/0.0.8/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
