### PR TITLE
passExtensions.pass-import: 3.2 -> 3.5

### DIFF
--- a/pkgs/tools/security/pass/extensions/import.nix
+++ b/pkgs/tools/security/pass/extensions/import.nix
@@ -1,5 +1,5 @@
 { lib
-, fetchFromGitHub
+, fetchurl
 , fetchpatch
 , python3Packages
 , gnupg
@@ -8,30 +8,23 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "pass-import";
-  version = "3.2";
+  version = "3.5";
 
-  src = fetchFromGitHub {
-    owner = "roddhjav";
-    repo = "pass-import";
-    rev = "v${version}";
-    sha256 = "0hrpg7yiv50xmbajfy0zdilsyhbj5iv0qnlrgkfv99q1dvd5qy56";
+  src = fetchurl {
+    url = "https://github.com/roddhjav/${pname}/releases/download/v${version}/${pname}-${version}.tar.gz";
+    hash = "sha256-+wrff3OxPkAGu1Mn4Kl0KN4FmvIAb+MnaERcD5ScDNc=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "support-for-pykeepass-4.0.3.patch";
-      url = "https://github.com/roddhjav/pass-import/commit/f1b167578916d971ee4f99be99ba0e86ef49015e.patch";
-      hash = "sha256-u6bJbV3/QTfRaPauKSyCWNodpy6CKsreMXUZWKRbee0=";
-    })
-  ];
 
   propagatedBuildInputs = with python3Packages; [
     cryptography
     defusedxml
+    jsonpath-ng
     pyaml
     pykeepass
     python-magic # similar API to "file-magic", but already in nixpkgs.
+    requests
     secretstorage
+    zxcvbn
   ];
 
   nativeCheckInputs = [
@@ -46,12 +39,12 @@ python3Packages.buildPythonApplication rec {
 
   postInstall = ''
     mkdir -p $out/lib/password-store/extensions
-    cp ${src}/import.bash $out/lib/password-store/extensions/import.bash
+    cp import.bash $out/lib/password-store/extensions/import.bash
     wrapProgram $out/lib/password-store/extensions/import.bash \
       --prefix PATH : "${python3Packages.python.withPackages (_: propagatedBuildInputs)}/bin" \
       --prefix PYTHONPATH : "$out/${python3Packages.python.sitePackages}" \
       --run "export PREFIX"
-    cp -r ${src}/share $out/
+    cp -r share $out/
   '';
 
   postCheck = ''


### PR DESCRIPTION
Diff: https://github.com/roddhjav/pass-import/compare/v3.2...v3.5

Changelog: https://github.com/roddhjav/pass-import/blob/v3.5/CHANGELOG.rst

## Description of changes

Needed to switch to a release tarball, because upstream decided to generate some files.

Closes: https://github.com/NixOS/nixpkgs/issues/313573
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
