### PR TITLE
python3Packages.pywlroots: 0.16.8 -> 0.17.0, python3Packages.qtile: 0.25.0 -> 0.26.0, python3Packages.qtile-extras: 0.25.0 -> 0.26.0

### DIFF
--- a/pkgs/development/python-modules/pywlroots/default.nix
+++ b/pkgs/development/python-modules/pywlroots/default.nix
@@ -21,14 +21,14 @@
 
 buildPythonPackage rec {
   pname = "pywlroots";
-  version = "0.16.8";
+  version = "0.17.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-jAkDZKAm75MlAMNuX+21ZV6kHb53zgIOJctJC2bXH1k=";
+    hash = "sha256-cssr4UBIwMvInM8bV4YwE6mXf9USSMMAzMcgAefEPbs=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/python-modules/qtile-extras/default.nix
+++ b/pkgs/development/python-modules/qtile-extras/default.nix
@@ -11,6 +11,7 @@
   pytest-asyncio,
   pytest-lazy-fixture,
   pytestCheckHook,
+  python-dateutil,
   qtile,
   requests,
   setuptools-scm,
@@ -19,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "qtile-extras";
-  version = "0.25.0";
+  version = "0.26.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "elParaguayo";
     repo = "qtile-extras";
     rev = "refs/tags/v${version}";
-    hash = "sha256-OYzSKOVg4D5gKxaEreclYq3D16dl8ddLipSdifokDNY=";
+    hash = "sha256-ywqZggn1k7zezk5CS1y6EWZfLoIWMHmGO8mvqxBaB9g=";
   };
 
   build-system = [ setuptools-scm ];
@@ -41,6 +42,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytest-lazy-fixture
     pytestCheckHook
+    python-dateutil
     qtile
     requests
     xorgserver

--- a/pkgs/development/python-modules/qtile/default.nix
+++ b/pkgs/development/python-modules/qtile/default.nix
@@ -4,9 +4,9 @@
   fetchFromGitHub,
   cairocffi,
   dbus-next,
-  dbus-python,
   glib,
   iwlib,
+  libcst,
   libdrm,
   libinput,
   libxkbcommon,
@@ -17,7 +17,7 @@
   psutil,
   pulsectl-asyncio,
   pygobject3,
-  python-dateutil,
+  pytz,
   pywayland,
   pywlroots,
   pyxdg,
@@ -34,14 +34,14 @@
 
 buildPythonPackage rec {
   pname = "qtile";
-  version = "0.25.0";
+  version = "0.26.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "qtile";
     repo = "qtile";
     rev = "refs/tags/v${version}";
-    hash = "sha256-j5hpXfUSDUT9nBr6CafIzqdTYQxSWok+ZlQA7bGdVvk=";
+    hash = "sha256-htgrfGBGRlJSm88mmwW92ikXR/M1lr0OTom16TIvdpo=";
   };
 
   patches = [
@@ -50,14 +50,14 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace libqtile/pangocffi.py \
-      --replace libgobject-2.0.so.0 ${glib.out}/lib/libgobject-2.0.so.0 \
-      --replace libpangocairo-1.0.so.0 ${pango.out}/lib/libpangocairo-1.0.so.0 \
-      --replace libpango-1.0.so.0 ${pango.out}/lib/libpango-1.0.so.0
+      --replace-fail libgobject-2.0.so.0 ${glib.out}/lib/libgobject-2.0.so.0 \
+      --replace-fail libpangocairo-1.0.so.0 ${pango.out}/lib/libpangocairo-1.0.so.0 \
+      --replace-fail libpango-1.0.so.0 ${pango.out}/lib/libpango-1.0.so.0
     substituteInPlace libqtile/backend/x11/xcursors.py \
-      --replace libxcb-cursor.so.0 ${xcbutilcursor.out}/lib/libxcb-cursor.so.0
+      --replace-fail libxcb-cursor.so.0 ${xcbutilcursor.out}/lib/libxcb-cursor.so.0
     substituteInPlace libqtile/backend/wayland/cffi/build.py \
-        --replace /usr/include/pixman-1 ${lib.getDev pixman}/include \
-        --replace /usr/include/libdrm ${lib.getDev libdrm}/include/libdrm
+        --replace-fail /usr/include/pixman-1 ${lib.getDev pixman}/include \
+        --replace-fail /usr/include/libdrm ${lib.getDev libdrm}/include/libdrm
   '';
 
   build-system = [
@@ -69,13 +69,13 @@ buildPythonPackage rec {
   dependencies = [
     (cairocffi.override { withXcffib = true; })
     dbus-next
-    dbus-python
     iwlib
+    libcst
     mpd2
     psutil
     pulsectl-asyncio
     pygobject3
-    python-dateutil
+    pytz
     pywayland
     pywlroots
     pyxdg

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12780,7 +12780,7 @@ self: super: with self; {
   pywizlight = callPackage ../development/python-modules/pywizlight { };
 
   pywlroots = callPackage ../development/python-modules/pywlroots {
-    wlroots = pkgs.wlroots_0_16;
+    wlroots = pkgs.wlroots_0_17;
   };
 
   pyws66i = callPackage ../development/python-modules/pyws66i { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12906,7 +12906,7 @@ self: super: with self; {
   qtconsole = callPackage ../development/python-modules/qtconsole { };
 
   qtile = callPackage ../development/python-modules/qtile {
-    wlroots = pkgs.wlroots_0_16;
+    wlroots = pkgs.wlroots_0_17;
   };
   qtile-extras = callPackage ../development/python-modules/qtile-extras { };
 


### PR DESCRIPTION
## Description of changes
Update `pywlroots`, `qtile` and `qtile-extras` in tandem. These releases are tightly coupled, hence the combined PR.

https://github.com/flacjacket/pywlroots/releases/tag/v0.17.0
https://github.com/qtile/qtile/releases/tag/v0.26.0
https://github.com/elParaguayo/qtile-extras/releases/tag/v0.26.0

Everything builds fine, I'll test using the new version tonight.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
