### PR TITLE
turtle: init at 0.8

### DIFF
--- a/pkgs/by-name/tu/turtle/package.nix
+++ b/pkgs/by-name/tu/turtle/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitLab,
+  gobject-introspection,
+  wrapGAppsHook4,
+  libadwaita,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "turtle";
+  version = "0.8";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "philippun1";
+    repo = "turtle";
+    rev = version;
+    hash = "sha256-YacuT5S6WrhSz031XXCQTo++r+DBozrIIXrn9BwmrR0=";
+  };
+
+  postPatch = ''
+    substituteInPlace ./install.py \
+      --replace-fail "/usr" "$out" \
+      --replace-fail "gtk-update-icon-cache" "gtk4-update-icon-cache"
+  '';
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [ libadwaita ];
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    pygobject3
+    pygit2
+  ];
+
+  postInstall = ''
+    python ./install.py install
+  '';
+
+  # Avoid wrapping two times
+  dontWrapGApps = true;
+
+  # Make sure we patch other scripts after wrapper is generated
+  # to get $program_PYTHONPATH
+  dontWrapPythonPrograms = true;
+
+  postFixup =
+    ''
+      makeWrapperArgs+=(''${gappsWrapperArgs[@]})
+      wrapPythonPrograms
+    ''
+    # Dialogs are not imported, but executed. The same does
+    # nautilus-python plugins. So we need to patch them as well.
+    + ''
+      for dialog_scripts in $out/lib/python*/site-packages/turtlevcs/dialogs/*.py; do
+        patchPythonScript $dialog_scripts
+      done
+      for nautilus_extensions in $out/share/nautilus-python/extensions/*.py; do
+        patchPythonScript $nautilus_extensions
+      done
+    '';
+
+  meta = {
+    description = "A graphical interface for version control intended to run on gnome and nautilus";
+    homepage = "https://gitlab.gnome.org/philippun1/turtle";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "turtle_cli";
+    maintainers = with lib.maintainers; [ aleksana ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

Tested turtle_cli, not tested nautilus extensions.

![image](https://github.com/NixOS/nixpkgs/assets/42209822/5fe871fa-64d2-4eff-9363-d754ee966ee8)

Closes https://github.com/NixOS/nixpkgs/pull/257062
Closes https://github.com/NixOS/nixpkgs/issues/252317

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
