### PR TITLE
qt6.qtmultimedia: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmultimedia.nix
@@ -39,6 +39,8 @@ qtModule {
 
   patches = [
     ../patches/fix-qtgui-include-incorrect-case.patch
+    # Remove new constants since macOS 12+, since we build Qt with the macOS 11 SDK
+    ../patches/qtmultimedia-darwin-revert-replace-deprecated-constant.patch
   ] ++ lib.optionals stdenv.hostPlatform.isMinGW [
     ../patches/qtmultimedia-windows-no-uppercase-libs.patch
     ../patches/qtmultimedia-windows-resolve-function-name.patch

--- a/pkgs/development/libraries/qt-6/patches/qtmultimedia-darwin-revert-replace-deprecated-constant.patch
+++ b/pkgs/development/libraries/qt-6/patches/qtmultimedia-darwin-revert-replace-deprecated-constant.patch
@@ -1,0 +1,50 @@
+diff --git a/src/multimedia/darwin/qdarwinmediadevices.mm b/src/multimedia/darwin/qdarwinmediadevices.mm
+index b0a108935..881066928 100644
+--- a/src/multimedia/darwin/qdarwinmediadevices.mm
++++ b/src/multimedia/darwin/qdarwinmediadevices.mm
+@@ -42,7 +42,7 @@ static AudioDeviceID defaultAudioDevice(QAudioDevice::Mode mode)
+     const AudioObjectPropertyAddress propertyAddress = {
+         selector,
+         kAudioObjectPropertyScopeGlobal,
+-        kAudioObjectPropertyElementMain,
++        kAudioObjectPropertyElementMaster,
+     };
+ 
+     if (auto audioDevice = getAudioObject<AudioDeviceID>(kAudioObjectSystemObject, propertyAddress,
+@@ -77,7 +77,7 @@ static QList<QAudioDevice> availableAudioDevices(QAudioDevice::Mode mode)
+ 
+     const AudioObjectPropertyAddress audioDevicesPropertyAddress = {
+         kAudioHardwarePropertyDevices, kAudioObjectPropertyScopeGlobal,
+-        kAudioObjectPropertyElementMain
++        kAudioObjectPropertyElementMaster
+     };
+ 
+     if (auto audioDevices = getAudioData<AudioDeviceID>(
+@@ -130,11 +130,11 @@ static OSStatus audioDeviceChangeListener(AudioObjectID id, UInt32,
+ 
+ static constexpr AudioObjectPropertyAddress listenerAddresses[] = {
+     { kAudioHardwarePropertyDefaultInputDevice, kAudioObjectPropertyScopeGlobal,
+-      kAudioObjectPropertyElementMain },
++      kAudioObjectPropertyElementMaster },
+     { kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyScopeGlobal,
+-      kAudioObjectPropertyElementMain },
++      kAudioObjectPropertyElementMaster },
+     { kAudioHardwarePropertyDevices, kAudioObjectPropertyScopeGlobal,
+-      kAudioObjectPropertyElementMain }
++      kAudioObjectPropertyElementMaster }
+ };
+ 
+ static void setAudioListeners(QDarwinMediaDevices &instance)
+diff --git a/src/multimedia/darwin/qmacosaudiodatautils_p.h b/src/multimedia/darwin/qmacosaudiodatautils_p.h
+index 8cc2f8440..5cd6fced2 100644
+--- a/src/multimedia/darwin/qmacosaudiodatautils_p.h
++++ b/src/multimedia/darwin/qmacosaudiodatautils_p.h
+@@ -44,7 +44,7 @@ void printUnableToReadWarning(const char *logName, AudioObjectID objectID, const
+ 
+ inline static AudioObjectPropertyAddress
+ makePropertyAddress(AudioObjectPropertySelector selector, QAudioDevice::Mode mode,
+-                    AudioObjectPropertyElement element = kAudioObjectPropertyElementMain)
++                    AudioObjectPropertyElement element = kAudioObjectPropertyElementMaster)
+ {
+     return { selector,
+              mode == QAudioDevice::Input ? kAudioDevicePropertyScopeInput


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
