### PR TITLE
siyuan: add darwin support

### DIFF
--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -19,6 +19,8 @@ let
   platformIds = {
     "x86_64-linux" = "linux";
     "aarch64-linux" = "linux-arm64";
+    "x86_64-darwin" = "darwin";
+    "aarch64-darwin" = "darwin-arm64";
   };
 
   platformId = platformIds.${stdenv.system} or (throw "Unsupported platform: ${stdenv.system}");
@@ -79,8 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     nodejs
     pnpm.configHook
     makeWrapper
-    copyDesktopItems
-  ];
+  ] ++ lib.optionals stdenv.isLinux [ copyDesktopItems ];
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs)
@@ -96,6 +97,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
+  # disable code signing on Darwin
+  env.CSC_IDENTITY_AUTO_DISCOVERY = lib.optionalString stdenv.isDarwin "false";
+
   postConfigure = ''
     # remove prebuilt pandoc archives
     rm -r pandoc
@@ -110,10 +114,13 @@ stdenv.mkDerivation (finalAttrs: {
 
     pnpm build
 
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
     npm exec electron-builder -- \
         --dir \
         --config electron-builder-${platformId}.yml \
-        -c.electronDist=${electron.dist} \
+        -c.electronDist=electron-dist \
         -c.electronVersion=${electron.version}
 
     runHook postBuild
@@ -122,17 +129,25 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/share/siyuan
-    cp -r build/*-unpacked/{locales,resources{,.pak}} $out/share/siyuan
+    ${lib.optionalString stdenv.isLinux ''
+      mkdir -p $out/share/siyuan
+      cp -r build/*-unpacked/{locales,resources{,.pak}} $out/share/siyuan
 
-    makeWrapper ${lib.getExe electron} $out/bin/siyuan \
-        --chdir $out/share/siyuan/resources \
-        --add-flags $out/share/siyuan/resources/app \
-        --set ELECTRON_FORCE_IS_PACKAGED 1 \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime}}" \
-        --inherit-argv0
+      makeWrapper ${lib.getExe electron} $out/bin/siyuan \
+          --chdir $out/share/siyuan/resources \
+          --add-flags $out/share/siyuan/resources/app \
+          --set ELECTRON_FORCE_IS_PACKAGED 1 \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime}}" \
+          --inherit-argv0
 
-    install -Dm644 src/assets/icon.svg $out/share/icons/hicolor/scalable/apps/siyuan.svg
+      install -Dm644 src/assets/icon.svg $out/share/icons/hicolor/scalable/apps/siyuan.svg
+    ''}
+
+    ${lib.optionalString stdenv.isDarwin ''
+      mkdir -p $out/Applications
+      cp -r build/mac*/SiYuan.app $out/Applications
+      makeWrapper $out/Applications/SiYuan.app/Contents/MacOS/SiYuan $out/bin/siyuan
+    ''}
 
     runHook postInstall
   '';

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -104,6 +104,11 @@ stdenv.mkDerivation (finalAttrs: {
     # remove prebuilt pandoc archives
     rm -r pandoc
 
+    substituteInPlace electron-builder-darwin.yml \
+        --replace-fail 'provisioningProfile: "../../SiYuan.provisionprofile"' "" \
+        --replace-fail 'entitlements: "../../entitlements.mas.plist"' "" \
+        --replace-fail 'entitlementsInherit: "../../entitlements.mas.plist"' ""
+
     # link kernel into the correct starting place so that electron-builder can copy it to it's final location
     mkdir kernel-${platformId}
     ln -s ${finalAttrs.kernel}/bin/kernel kernel-${platformId}/SiYuan-Kernel


### PR DESCRIPTION
## Description of changes

This PR adds support for building the `siyuan` package on Darwin platforms.

To make it work on darwin, I needed to set the `electronDist` config value to an editable copy of the electron files.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
