### PR TITLE
gitlab: 16.10.5 -> 16.10.6

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,15 +1,15 @@
 {
-  "version": "16.10.5",
-  "repo_hash": "sha256-w2cXFIm588Q/SB1kO9dGCmxO3+Xee7BaCCipuVcnfXg=",
+  "version": "16.10.6",
+  "repo_hash": "sha256-+nEUyD+ryZicH7suh4MnQRDKMC3M3VWRdO4nZCi2LGs=",
   "yarn_hash": "0yzywfg4lqxjwm5cqsm4bn97zcrfvpnrs8rjrv9wv3xqvi9h9skd",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v16.10.5-ee",
+  "rev": "v16.10.6-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "16.10.5",
-    "GITLAB_PAGES_VERSION": "16.10.5",
+    "GITALY_SERVER_VERSION": "16.10.6",
+    "GITLAB_PAGES_VERSION": "16.10.6",
     "GITLAB_SHELL_VERSION": "14.34.0",
     "GITLAB_ELASTICSEARCH_INDEXER_VERSION": "4.8.0",
-    "GITLAB_WORKHORSE_VERSION": "16.10.5"
+    "GITLAB_WORKHORSE_VERSION": "16.10.6"
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  version = "16.10.5";
+  version = "16.10.6";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -18,7 +18,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      hash = "sha256-ctJfw4aU5qsv+I3rR9xZPGssYQpTnbn4MdTVOYapHqQ=";
+      hash = "sha256-C57p3H1L6ZQfjipGoQJup8u6ofir3rrxORtzUA1afL0=";
     };
 
     vendorHash = "sha256-6gZr0/0ZGcFwwAY4IuW2puL/7akMZvaU0ONJGYyyJas=";

--- a/pkgs/applications/version-management/gitlab/gitlab-pages/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-pages/default.nix
@@ -2,14 +2,14 @@
 
 buildGoModule rec {
   pname = "gitlab-pages";
-  version = "16.10.5";
+  version = "16.10.6";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-pages";
     rev = "v${version}";
-    hash = "sha256-wuEYcwAKYO7YZs88NvE0AI5+aZ9JeLBAeXITc2jLGVo=";
+    hash = "sha256-30ojS+TBIJ4Qzg1jh2Bpdd2s2Yo2S+UqxRRdvNBvB/k=";
   };
 
   vendorHash = "sha256-WrR4eZRAuYkhr7ZqP7OXqJ6uwvxzn+t+3OdBNcNaq0M=";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "16.10.5";
+  version = "16.10.6";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {


### PR DESCRIPTION


## Description of changes
- https://gitlab.com/gitlab-org/gitlab/-/blob/v16.10.5-ee/CHANGELOG.md
- https://about.gitlab.com/releases/2024/05/08/patch-release-gitlab-16-11-2-released/
- Fixes CVE-2023-6195
- Fixes CVE-2023-6682
- Fixes CVE-2023-6688
- Fixes CVE-2024-1211
- Fixes CVE-2024-1539
- Fixes CVE-2024-2454
- Fixes CVE-2024-2651
- Fixes CVE-2024-2878
- Fixes CVE-2024-3976
- Fixes CVE-2024-4539
- Fixes CVE-2024-4597
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
