### PR TITLE
python312Packages.distorm3: disable on Python 3.12

### DIFF
--- a/pkgs/development/python-modules/distorm3/default.nix
+++ b/pkgs/development/python-modules/distorm3/default.nix
@@ -1,9 +1,10 @@
-{ lib
-, buildPythonPackage
-, fetchFromGitHub
-, pythonOlder
-, pytestCheckHook
-, yasm
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  pytestCheckHook,
+  yasm,
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/distorm3/default.nix
+++ b/pkgs/development/python-modules/distorm3/default.nix
@@ -2,9 +2,10 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
   pythonOlder,
   pytestCheckHook,
-  setuptools, 
+  setuptools,
   yasm,
 }:
 
@@ -13,7 +14,8 @@ buildPythonPackage rec {
   version = "3.5.2";
   pyproject = true;
 
-  disabled = pythonOlder "3.5";
+  # Still uses distutils, https://github.com/gdabah/distorm/issues/191
+  disabled = pythonOlder "3.5" || pythonAtLeast "3.12";
 
   src = fetchFromGitHub {
     owner = "gdabah";

--- a/pkgs/development/python-modules/distorm3/default.nix
+++ b/pkgs/development/python-modules/distorm3/default.nix
@@ -4,22 +4,27 @@
   fetchFromGitHub,
   pythonOlder,
   pytestCheckHook,
+  setuptools, 
   yasm,
 }:
 
 buildPythonPackage rec {
   pname = "distorm3";
   version = "3.5.2";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "gdabah";
     repo = "distorm";
-    rev = version;
-    sha256 = "012bh1l2w7i9q8rcnznj3x0lra09d5yxd3r42cbrqdwl1mmg26qn";
+    rev = "refs/tags/${version}";
+    hash = "sha256-Fhvxag2UN5wXEySP1n1pCahMQR/SfssywikeLmiASwQ=";
   };
+
+  build-system = [
+    setuptools
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook
@@ -31,11 +36,14 @@ buildPythonPackage rec {
     "test_dummy"
   ];
 
-  pythonImportsCheck = [ "distorm3" ];
+  pythonImportsCheck = [
+    "distorm3"
+  ];
 
   meta = with lib; {
     description = "Disassembler library for x86/AMD64";
     homepage = "https://github.com/gdabah/distorm";
+    changelog = "https://github.com/gdabah/distorm/releases/tag/${version}";
     license = licenses.bsd3;
     maintainers = with maintainers; [ fab ];
   };


### PR DESCRIPTION
## Description of changes
Still uses distutils, https://github.com/gdabah/distorm/issues/191

ZHF: https://github.com/NixOS/nixpkgs/issues/309482
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
