### PR TITLE
Fix haskellPackages.{chs-cabal,libarchive,archive-libarchive}

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -764,7 +764,6 @@ broken-packages:
   - ChristmasTree # failure in job https://hydra.nixos.org/build/233259648 at 2023-09-02
   - chronograph # failure in job https://hydra.nixos.org/build/233232822 at 2023-09-02
   - chr-parse # failure in job https://hydra.nixos.org/build/233243933 at 2023-09-02
-  - chs-cabal # failure in job https://hydra.nixos.org/build/259964491 at 2024-05-19
   - chunky # failure in job https://hydra.nixos.org/build/233216440 at 2023-09-02
   - church # failure in job https://hydra.nixos.org/build/233223920 at 2023-09-02
   - church-maybe # failure in job https://hydra.nixos.org/build/233258572 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -35,6 +35,7 @@ default-package-overrides:
   - extensions < 0.1.0.2 # Incompatible with Cabal < 3.12, the newest extensions version is only needed on ghc 9.10
   # 2024-05-10: need to match hlegder from stackage
   - hledger-ui < 1.33
+  - chs-cabal < 0.1.1.2 # Incompatible with Cabal < 3.12
 
 
 extra-packages:

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -532,7 +532,6 @@ dont-distribute-packages:
  - apotiki
  - approx-rand-test
  - arbor-monad-metric-datadog
- - archive-libarchive
  - archive-tar-bytestring
  - archlinux-web
  - arduino-copilot
@@ -2567,7 +2566,6 @@ dont-distribute-packages:
  - lha
  - lhae
  - lhe
- - libarchive
  - libconfig
  - libcspm
  - libgraph


### PR DESCRIPTION
## Description of changes

`chs-cabal 0.1.1.2` requires Cabal 3.12, which we do not use yet to maintain GHC compatibility. It also has no features beyond upgrading its Cabal dependency. Downgrade to unbreak it and some transitive dependencies.

This is my first PR in `haskellPackages`. I ran `./maintainers/scripts/haskell/regenerate-hackage-packages.sh --do-commit` to update the autogenerated files.

Discussed with @maralorn in the Haskell matrix channel.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
