### PR TITLE
share-preview: init at 0.5.0

### DIFF
--- a/pkgs/by-name/sh/share-preview/package.nix
+++ b/pkgs/by-name/sh/share-preview/package.nix
@@ -12,6 +12,7 @@
   desktop-file-utils,
   libadwaita,
   openssl,
+  darwin,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -45,7 +46,14 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     libadwaita
     openssl
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Foundation
+    darwin.apple_sdk.frameworks.SystemConfiguration
   ];
+
+  env.NIX_CFLAGS_COMPILE = toString (
+    lib.optionals stdenv.isDarwin [ "-Wno-error=incompatible-function-pointer-types" ]
+  );
 
   meta = {
     description = "Preview and debug websites metadata tags for social media share";

--- a/pkgs/by-name/sh/share-preview/package.nix
+++ b/pkgs/by-name/sh/share-preview/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  meson,
+  ninja,
+  pkg-config,
+  rustc,
+  cargo,
+  wrapGAppsHook4,
+  desktop-file-utils,
+  libadwaita,
+  openssl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "share-preview";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "rafaelmardojai";
+    repo = "share-preview";
+    rev = finalAttrs.version;
+    hash = "sha256-FqualaTkirB+gBcgkThQpSBHhM4iaXkiGujwBUnUX0E=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit (finalAttrs) src;
+    name = "share-preview-${finalAttrs.version}";
+    hash = "sha256-Gh6bQZD1mlkj3XeGp+fF/NShC4PZCZSEqymrsSdX4Ec=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    rustPlatform.cargoSetupHook
+    rustc
+    cargo
+    wrapGAppsHook4
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    libadwaita
+    openssl
+  ];
+
+  meta = {
+    description = "Preview and debug websites metadata tags for social media share";
+    homepage = "https://apps.gnome.org/SharePreview";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "share-preview";
+    maintainers = with lib.maintainers; [ aleksana ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

Tested

![image](https://github.com/NixOS/nixpkgs/assets/42209822/b2c4d9f7-ad20-4b0c-8a9f-18da41741978)

Closes https://github.com/NixOS/nixpkgs/pull/256453
Closes https://github.com/NixOS/nixpkgs/issues/208917
part of https://github.com/NixOS/nixpkgs/issues/195280

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
