### PR TITLE
raycast: remove `with lib;` from meta; raycast: sort meta; raycast: refactor license in meta; raycast: format with nixfmt-rfc-style; raycast: 1.74.1 -> 1.75.1

### DIFF
--- a/pkgs/os-specific/darwin/raycast/default.nix
+++ b/pkgs/os-specific/darwin/raycast/default.nix
@@ -50,7 +50,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = {
     description = "Control your tools with a few keystrokes";
     homepage = "https://raycast.app/";
-    license = with lib.licenses; [ unfree ];
+    license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [ lovesegfault stepbrobd donteatoreo ];
     platforms = [ "aarch64-darwin" "x86_64-darwin" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/os-specific/darwin/raycast/default.nix
+++ b/pkgs/os-specific/darwin/raycast/default.nix
@@ -1,11 +1,12 @@
-{ lib
-, stdenvNoCC
-, fetchurl
-, writeShellApplication
-, curl
-, jq
-, common-updater-scripts
-, undmg
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  writeShellApplication,
+  curl,
+  jq,
+  common-updater-scripts,
+  undmg,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -38,7 +39,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   passthru.updateScript = lib.getExe (writeShellApplication {
     name = "raycast-update-script";
-    runtimeInputs = [ curl jq common-updater-scripts ];
+    runtimeInputs = [
+      curl
+      jq
+      common-updater-scripts
+    ];
     text = ''
       set -eo pipefail
       url=$(curl --silent "https://releases.raycast.com/releases/latest?build=universal")
@@ -51,8 +56,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Control your tools with a few keystrokes";
     homepage = "https://raycast.app/";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ lovesegfault stepbrobd donteatoreo ];
-    platforms = [ "aarch64-darwin" "x86_64-darwin" ];
+    maintainers = with lib.maintainers; [
+      lovesegfault
+      stepbrobd
+      donteatoreo
+    ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 })

--- a/pkgs/os-specific/darwin/raycast/default.nix
+++ b/pkgs/os-specific/darwin/raycast/default.nix
@@ -47,12 +47,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     '';
   });
 
-  meta = with lib; {
+  meta = {
     description = "Control your tools with a few keystrokes";
     homepage = "https://raycast.app/";
-    license = with licenses; [ unfree ];
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    maintainers = with maintainers; [ lovesegfault stepbrobd donteatoreo ];
+    license = with lib.licenses; [ unfree ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ lovesegfault stepbrobd donteatoreo ];
     platforms = [ "aarch64-darwin" "x86_64-darwin" ];
   };
 })

--- a/pkgs/os-specific/darwin/raycast/default.nix
+++ b/pkgs/os-specific/darwin/raycast/default.nix
@@ -51,8 +51,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Control your tools with a few keystrokes";
     homepage = "https://raycast.app/";
     license = with lib.licenses; [ unfree ];
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with lib.maintainers; [ lovesegfault stepbrobd donteatoreo ];
     platforms = [ "aarch64-darwin" "x86_64-darwin" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 })

--- a/pkgs/os-specific/darwin/raycast/default.nix
+++ b/pkgs/os-specific/darwin/raycast/default.nix
@@ -11,12 +11,12 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "raycast";
-  version = "1.74.1";
+  version = "1.75.1";
 
   src = fetchurl {
     name = "Raycast.dmg";
     url = "https://releases.raycast.com/releases/${finalAttrs.version}/download?build=universal";
-    hash = "sha256-vIhuXZ9FxpWLPoOciyl4Qe0G8vXY+to+CGxp+nRmyp8=";
+    hash = "sha256-lHGKWj4nn0GsviV83MKgCaQ6HW/CfeP8gg4VXlVXaXg=";
   };
 
   dontPatch = true;


### PR DESCRIPTION
## Description of changes

Changelog: https://www.raycast.com/changelog/1-75-0

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc