### PR TITLE
gale: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20189,6 +20189,12 @@
     githubId = 26417242;
     name = "Mikolaj Galkowski";
   };
+  TestAccount666 = {
+    email = "maintenance@iamableto.cyou";
+    github = "Test-Accounbt666";
+    githubId = 36412486;
+    name = "Daniel";
+  };
   TethysSvensson = {
     email = "freaken@freaken.dk";
     github = "TethysSvensson";

--- a/pkgs/by-name/ga/gale/fix_broken_link_handler.patch
+++ b/pkgs/by-name/ga/gale/fix_broken_link_handler.patch
@@ -1,0 +1,13 @@
+diff --git a/src-tauri/src/manager/downloader.rs b/src-tauri/src/manager/downloader.rs
+index 1cbe408..a4d76d8 100644
+--- a/src-tauri/src/manager/downloader.rs
++++ b/src-tauri/src/manager/downloader.rs
+@@ -31,7 +31,7 @@ pub mod updater;
+ pub fn setup(app: &AppHandle) -> Result<()> {
+     app.manage(Mutex::new(InstallState::default()));
+ 
+-    tauri_plugin_deep_link::register("ror2mm", deep_link_handler(app.clone()))?;
++    //tauri_plugin_deep_link::register("ror2mm", deep_link_handler(app.clone()))?;
+ 
+     Ok(())
+ }

--- a/pkgs/by-name/ga/gale/hardcode_changelog.patch
+++ b/pkgs/by-name/ga/gale/hardcode_changelog.patch
@@ -1,0 +1,97 @@
+diff --git a/src/routes/+page.svelte b/src/routes/+page.svelte
+index bc5ff71..926e203 100644
+--- a/src/routes/+page.svelte
++++ b/src/routes/+page.svelte
+@@ -23,11 +23,84 @@
+ </div>
+ 
+ <div class="px-6 overflow-y-auto text-slate-100 w-full">
+-	{#await changelogPromise}
+-		Loading changelog...
+-	{:then changelog}
+-		<Markdown source={changelog} />
+-	{:catch error}
+-		Failed to load changelog: {error.message}
+-	{/await}
++	<Markdown source='# Changelog
++
++## 0.4.0 (2024-05-22)
++
++### Added
++
++- Dialog when enabling a mod which has disabled dependencies
++- Dialog before updating all mods
++- More options when importing profiles (similarly to r2modman/Thunderstore Mod Manager)
++- Close button to all dialogs
++- Confirm dialog when aborting mod installation
++- Zoom preference
++
++### Removed
++
++- Quit button
++
++### Changed
++
++- Config parser now allows invalid semver versions
++- Increased interval between fetching mods from Thunderstore
++- Various UI improvements
++
++### Fixed
++
++- Auto updater not working (*not retroactive; you still need to manually update to this version*)
++- Improve performance for dependency trees
++- Improve performance of config parsing
++- Parsing config entries without a value
++- "Update all" banner showing the wrong number of mods
++- Config files being copied from other profiles when importing from code
++- Launching games with doorstop v4
++- Uninstalled mods sometimes not being deleted from the file system
++
++## 0.3.1 (2024-05-15)
++
++### Fixed
++
++- Compatibility with profiles created prior to 0.3.0
++
++## 0.3.0 (2024-05-15)
++
++### Added
++
++- Profile import from file
++- Profile export to file
++- Ability to cancel mod installation
++- Ability to remove mod without its dependencies
++- Mod disabling and enabling
++
++### Changed
++
++- The config parser now supports untagged entries
++- Decimal config sliders now have a step of 0.01 (instead of 1)
++- Various UI improvements
++
++### Fixed
++
++- Importing profiles with disabled mods
++
++## 0.2.0 (2024-05-08)
++
++### Added 
++
++- Proper logo & icons
++
++### Changed
++
++- Gale itself is now hidden in the mod list
++- Config entries are no longer required to be in the acceptable range
++
++### Fixed 
++
++- Crash when opening on Linux (hopefully) (thanks testaccount666 on discord)
++- Screenshots in the Thunderstore README
++
++## 0.1.0 (2024-05-07)
++
++- Initial release
++' />
+ </div>
+\ No newline at end of file

--- a/pkgs/by-name/ga/gale/package.nix
+++ b/pkgs/by-name/ga/gale/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildNpmPackage,
+  openssl,
+  pkg-config,
+  freetype,
+  libsoup,
+  gtk3,
+  webkitgtk,
+  nodejs-slim,
+  cargo-tauri,
+  cargo,
+  rustPlatform,
+  rustc,
+}:
+
+buildNpmPackage rec {
+
+  pname = "gale";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "Kesomannen";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-yo/Mcvrt/Kn1Zlz7lbL3n7eyT2L9dJA5PTGgWLuxJ9M=";
+  };
+
+  npmDepsHash = "sha256-z0ax5xCDcEtiBKIyM+zdck4tnyeO9TUSpnlB+d3+0xE=";
+
+  cargoDeps = rustPlatform.importCargoLock {
+    lockFile = src + "/src-tauri/Cargo.lock";
+    outputHashes = {
+      "fix-path-env-0.0.0" = "sha256-kSpWO2qMotpsYKJokqUWCUzGGmNOazaREDLjke4/CtE=";
+    };
+  };
+
+  configurePhase = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  preBuild = ''
+    cargo tauri build -b deb
+  '';
+
+  cargoRoot = "src-tauri/";
+
+  preInstall = ''
+    mv src-tauri/target/release/bundle/deb/*/data/usr/ "$out"
+  '';
+
+  prePatch = ''
+    patch -p1 < ${./fix_broken_link_handler.patch}
+    patch -p1 < ${./hardcode_changelog.patch}
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+    cargo-tauri
+    nodejs-slim
+    openssl
+  ];
+
+  buildInputs = [
+    openssl
+    freetype
+    libsoup
+    gtk3
+    webkitgtk
+  ];
+
+  meta = {
+    description = "Lightweight mod manager for Thunderstore written in Rust";
+    homepage = "https://github.com/Kesomannen/gale";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ TestAccount666 ];
+    mainProgram = "gale";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes

See [#313653](https://github.com/NixOS/nixpkgs/pull/313653) for more context.

Gale is a mod manager for thunderstore, just like r2modman, but written in Rust.

Here's the github page:
https://github.com/Kesomannen/gale/

I don't really know much about Rust, so I just uncommented this line in `src-tauri/src/manager/downloader.rs`:
`tauri_plugin_deep_link::register("ror2mm", deep_link_handler(app.clone()))?;`

Otherwise it wouldn't compile.

If there's an actual fix, I'd appreciate instructions :)


I followed most suggestions in my previous PR.

I did not apply the `finalAttrs` change, as I couldn't get it to compile with that.

I also hope that I got everything right this time.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
