### PR TITLE
itk: 5.3.0 -> 5.4.0

### DIFF
--- a/pkgs/development/libraries/itk/5.x.nix
+++ b/pkgs/development/libraries/itk/5.x.nix
@@ -1,5 +1,5 @@
 import ./generic.nix rec {
-  version = "5.3.0";
-  rev = "v${version}";
-  sourceSha256 = "sha256-+qCd8Jzpl5fEPTUpLyjjFBkfgCn3+Lf4pi8QnjCwofs=";
+  version = "5.4.0";
+  rev = "refs/tags/v${version}";
+  sourceSha256 = "sha256-1RSWgH0iQ2NQNsieW2m37udXWQlqYslJNM3TXC9xeP4=";
 }

--- a/pkgs/development/libraries/itk/generic.nix
+++ b/pkgs/development/libraries/itk/generic.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
     sha256 = sourceSha256;
   };
 
-  patches = [
+  patches = lib.optionals (lib.versionOlder version "5.4") [
     (fetchpatch {
       name = "fix-gcc13-build";
       url = "https://github.com/InsightSoftwareConsortium/ITK/commit/9a719a0d2f5f489eeb9351b0ef913c3693147a4f.patch";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37953,7 +37953,7 @@ with pkgs;
 
   minia = callPackage ../applications/science/biology/minia { };
 
-  mirtk = callPackage ../development/libraries/science/biology/mirtk { };
+  mirtk = callPackage ../development/libraries/science/biology/mirtk { itk = itk_5_2; };
 
   muscle = callPackage ../applications/science/biology/muscle { };
 


### PR DESCRIPTION
mirtk: pin itk = itk_5_2

## Description of changes

Routine update. ~Required updated `gdcm`, so cherry-picked from #308953~. All but one depending package, `mirtk`, worked with the new version; downgraded it to use the existing ITK 5.2 in tree.

Open to moving the conditional patching into the `5.<...>.nix` files instead of `generic.nix` but it seems not too important.

Results of nixpkgs-review on x86_64-Linux (note `python3{1,2}Packages.pydicom-seg` is already broken on `master`, so no new failures):

```
1 package marked as broken and skipped:
ezminc

4 packages failed to build:
python311Packages.pydicom-seg python311Packages.pydicom-seg.dist python312Packages.pydicom-seg python312Packages.pydicom-seg.dist

38 packages built:
ants c3d elastix gdcm intensity-normalization intensity-normalization.dist itk itk_5_2 mirtk mrtrix octavePackages.dicom python311Packages.dicom2nifti python311Packages.dicom2nifti.dist python311Packages.gdcm python311Packages.medpy python311Packages.medpy.dist python311Packages.pymedio python311Packages.pymedio.dist python311Packages.pyradiomics python311Packages.pyradiomics.dist python311Packages.simpleitk python311Packages.simpleitk.dist python311Packages.torchio python311Packages.torchio.dist python312Packages.dicom2nifti python312Packages.dicom2nifti.dist python312Packages.gdcm python312Packages.medpy python312Packages.medpy.dist python312Packages.pymedio python312Packages.pymedio.dist python312Packages.pyradiomics python312Packages.pyradiomics.dist python312Packages.simpleitk python312Packages.simpleitk.dist python312Packages.torchio python312Packages.torchio.dist simpleitk
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
