### PR TITLE
flutterVersions.stable: pin to flutterVersions.v3_19

### DIFF
--- a/pkgs/by-name/in/intiface-central/package.nix
+++ b/pkgs/by-name/in/intiface-central/package.nix
@@ -1,6 +1,6 @@
 { lib
 , fetchFromGitHub
-, flutterPackages
+, flutter
 , corrosion
 , rustPlatform
 , cargo
@@ -9,7 +9,7 @@
 , copyDesktopItems
 , makeDesktopItem
 }:
-flutterPackages.v3_19.buildFlutterApplication rec {
+flutter.buildFlutterApplication rec {
   pname = "intiface-central";
   version = "2.5.6";
   src = fetchFromGitHub {

--- a/pkgs/desktops/expidus/default.nix
+++ b/pkgs/desktops/expidus/default.nix
@@ -1,10 +1,5 @@
-{ callPackage, flutterPackages }:
+{ callPackage }:
 {
-  calculator = callPackage ./calculator {
-    flutter = flutterPackages.v3_19;
-  };
-
-  file-manager = callPackage ./file-manager {
-    flutter = flutterPackages.v3_19;
-  };
+  calculator = callPackage ./calculator {};
+  file-manager = callPackage ./file-manager {};
 }

--- a/pkgs/development/compilers/flutter/default.nix
+++ b/pkgs/development/compilers/flutter/default.nix
@@ -67,6 +67,7 @@ let
     (builtins.readDir ./versions);
 in
 flutterVersions // {
-  stable = flutterVersions.${lib.last (lib.naturalSort (builtins.attrNames flutterVersions))};
+  latest = flutterVersions.${lib.last (lib.naturalSort (builtins.attrNames flutterVersions))};
+  stable = flutterVersions.v3_19;
   inherit wrapFlutter mkFlutter;
 }


### PR DESCRIPTION
## Description of changes

This partially reverts https://github.com/NixOS/nixpkgs/pull/311815, without removing 3.22 update.

After that PR,

- `fluffychat`: When loading the chat list and settings, the window turns completely black and will only appear when you click anywhere in the list. (@RossComputerGuy claimed the problem has not been reproduced on a hyprland version from January this year. It may be related to hyprland or my AMD iGPU.)
- `yubioath-flutter`, `flet-client-flutter`: See https://github.com/NixOS/nixpkgs/issues/313292. (@LovingMelody claimed to have reproduced the problem of the first package on xorg, but only after the first start.)

After applying a `flutter = prev.flutter319` overlay locally, the above problem are all solved.

I briefly tested `firmware-updater`, and it seemed to work, but displays "no devices found", so no further testing. Didn't test if `hover` is affected.

According to https://github.com/NixOS/nixpkgs/pull/311815#issuecomment-2113823660, there are not many packages that depend on flutter, so this breakage should be considered relatively large (6 out of 8 programs are affected!). I'd like to pin it to flutter319 for now, and then upgrade the flutter version after these subsequent software updates.

Closes https://github.com/NixOS/nixpkgs/issues/313292

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
