### PR TITLE
ark-pixel-font: unbreak by suppressing debug logs, and remove extraneous builds

### DIFF
--- a/pkgs/by-name/ar/ark-pixel-font/limit-builds.patch
+++ b/pkgs/by-name/ar/ark-pixel-font/limit-builds.patch
@@ -1,0 +1,34 @@
+diff --git a/build.py b/build.py
+index 48bc757d..88b9ed9b 100644
+--- a/build.py
++++ b/build.py
+@@ -1,6 +1,5 @@
+ from scripts import configs
+ from scripts.configs import path_define
+-from scripts.services import publish_service, info_service, template_service, image_service
+ from scripts.services.font_service import DesignContext, FontContext
+ from scripts.utils import fs_util
+ 
+@@ -21,21 +20,6 @@ def main():
+             font_context.make_pcf()
+             font_context.make_otc()
+             font_context.make_ttc()
+-            publish_service.make_release_zips(font_config, width_mode)
+-            info_service.make_info_file(design_context, width_mode)
+-            info_service.make_alphabet_txt_file(design_context, width_mode)
+-            template_service.make_alphabet_html_file(design_context, width_mode)
+-        template_service.make_demo_html_file(design_context)
+-        image_service.make_preview_image_file(font_config)
+-    template_service.make_index_html_file()
+-    template_service.make_playground_html_file()
+-    image_service.make_readme_banner()
+-    image_service.make_github_banner()
+-    image_service.make_itch_io_banner()
+-    image_service.make_itch_io_background()
+-    image_service.make_itch_io_cover()
+-    image_service.make_afdian_cover()
+-
+ 
+ if __name__ == '__main__':
+     main()
+

--- a/pkgs/by-name/ar/ark-pixel-font/package.nix
+++ b/pkgs/by-name/ar/ark-pixel-font/package.nix
@@ -28,10 +28,15 @@ python312Packages.buildPythonPackage rec {
     gitpython
   ];
 
+  # By default build.py builds a LOT of extraneous artifacts we don't need.
+  patches = [ ./limit-builds.patch ];
+
   buildPhase = ''
     runHook preBuild
 
-    python build.py
+    # Too much debug output would break Hydra, so this jankness has to be here for it to build at all.
+    # I wish there's a builtin way to set the log level without modifying the script itself...
+    python3 build.py 2>&1 >/dev/null | grep -E '^(INFO|WARN|ERROR)'
 
     runHook postBuild
   '';
@@ -43,6 +48,9 @@ python312Packages.buildPythonPackage rec {
     install -Dm444 build/outputs/*.otf -t $out/share/fonts/opentype
     install -Dm444 build/outputs/*.ttf -t $out/share/fonts/truetype
     install -Dm444 build/outputs/*.woff2 -t $out/share/fonts/woff2
+    install -Dm444 build/outputs/*.pcf -t $out/share/fonts/pcf
+    install -Dm444 build/outputs/*.otc -t $out/share/fonts/otc
+    install -Dm444 build/outputs/*.ttc -t $out/share/fonts/ttc
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Description of changes

For some reason build.py builds a lot of stuff that is completely unrelated to the fonts themselves. Let's remove that!

Also the script is generating so much debug output that Hydra refuses to evaluate the package — my fix is to pipe the output through grep to filter out any log message below INFO, but I wish the script has a built-in way to set the log level so that I don't have to do this hack

ZHF #309482

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
