### PR TITLE
everforest-gtk-theme: init at 0-unstable-2023-03-20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15392,6 +15392,12 @@
     githubId = 108072;
     name = "Slawomir Gonet";
   };
+  OulipianSummer = {
+    email = "amb@disroot.org";
+    name = "Andrew Benbow";
+    github = "OulipianSummer";
+    githubId = 47955980;
+  };
   ovlach = {
     email = "ondrej@vlach.xyz";
     name = "Ondrej Vlach";

--- a/pkgs/data/themes/everforest-gtk-theme/default.nix
+++ b/pkgs/data/themes/everforest-gtk-theme/default.nix
@@ -1,25 +1,31 @@
-{ lib, stdenv, fetchurl}:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
-  pname = "Everforest-GTK-Theme";
-  version = "1.0";
+stdenvNoCC.mkDerivation rec {
+  pname = "everforest-gtk-theme";
+  version = "0-unstable-2023-03-20";
 
-  src = fetchurl {
-    url = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme/archive/refs/heads/master.tar.gz";
-    sha256 = "2gmSMW/yUdinvZ/Jaw6GyfEL/CBqYKtw0QrYWy9KrL0=";
+  src = fetchFromGitHub {
+    owner = "Fausto-Korpsvart";
+    repo = "Everforest-GTK-Theme";
+    rev = "8481714cf9ed5148694f1916ceba8fe21e14937b";
+    sha256 = "NO12ku8wnW/qMHKxi5TL/dqBxH0+cZbe+fU0iicb9JU=";
   };
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/themes
     rm -rf README.md LICENSE icons extra
     cp -r themes/* $out/share/themes/
+
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "Everforest theme for GTK based desktop environments";
     homepage = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme";
-    license = licenses.gpl3Only;
-    platforms = platforms.unix;
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
     maintainers = [ maintainers.OulipianSummer ];
   };
 }

--- a/pkgs/data/themes/everforest-gtk-theme/default.nix
+++ b/pkgs/data/themes/everforest-gtk-theme/default.nix
@@ -20,5 +20,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme";
     license = licenses.gpl3Only;
     platforms = platforms.unix;
+    maintainers = [ maintainers.OulipianSummer ];
   };
 }

--- a/pkgs/data/themes/everforest-gtk-theme/default.nix
+++ b/pkgs/data/themes/everforest-gtk-theme/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchurl}:
+
+stdenv.mkDerivation rec {
+  pname = "Everforest-GTK-Theme";
+  version = "1.0";
+
+  src = fetchurl {
+    url = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme/archive/refs/heads/master.tar.gz";
+    sha256 = "2gmSMW/yUdinvZ/Jaw6GyfEL/CBqYKtw0QrYWy9KrL0=";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/themes
+    rm -rf README.md LICENSE icons extra
+    cp -r themes/* $out/share/themes/
+  '';
+
+  meta = with lib; {
+    description = "Everforest theme for GTK based desktop environments";
+    homepage = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Everforest GTK Theme

This pull request adds the [Everforest GTK Theme](https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme/) by [Fausto-Korpsvart](https://github.com/Fausto-Korpsvart). This user has also made a number of other Vim inspired GTK themes like Gruvbox and Catppuccin which are already a part of Nixpkgs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
