### PR TITLE
hol_light: 2023-11-03 → 2024-05-10

### DIFF
--- a/pkgs/applications/science/logic/hol_light/default.nix
+++ b/pkgs/applications/science/logic/hol_light/default.nix
@@ -1,8 +1,12 @@
-{ lib, stdenv, runtimeShell, fetchFromGitHub, fetchpatch, ocaml, findlib, num, camlp5, camlp-streams }:
+{ lib, stdenv, runtimeShell, fetchFromGitHub, fetchpatch, ocaml, findlib, num, zarith, camlp5, camlp-streams }:
 
 let
+  use_zarith = lib.versionAtLeast ocaml.version "4.14";
   load_num =
-    lib.optionalString (num != null) ''
+    if use_zarith then ''
+      -I ${zarith}/lib/ocaml/${ocaml.version}/site-lib/zarith \
+      -I ${zarith}/lib/ocaml/${ocaml.version}/site-lib/stublibs \
+    '' else lib.optionalString (num != null) ''
       -I ${num}/lib/ocaml/${ocaml.version}/site-lib/num \
       -I ${num}/lib/ocaml/${ocaml.version}/site-lib/top-num \
       -I ${num}/lib/ocaml/${ocaml.version}/site-lib/stublibs \
@@ -22,18 +26,15 @@ let
     '';
 in
 
-lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
-  "hol_light is not available for OCaml ${ocaml.version}"
-
 stdenv.mkDerivation {
   pname = "hol_light";
-  version = "unstable-2023-11-03";
+  version = "unstable-2024-05-10";
 
   src = fetchFromGitHub {
     owner = "jrh13";
     repo = "hol-light";
-    rev = "dcd765c6032f52a0c0bf21fce5da4794a823e880";
-    hash = "sha256-k2RBNDo4tc3eobKB84Y2xr0UQJvef0hv6jyFCaDCQFM=";
+    rev = "d8366986e22555c4e4c8ff49667d646d15c35f14";
+    hash = "sha256-dN9X7yQlFof759I5lxxL4DxDe8V3XAhCRaryO9NabY4=";
   };
 
   patches = [
@@ -46,7 +47,10 @@ stdenv.mkDerivation {
   strictDeps = true;
 
   nativeBuildInputs = [ ocaml findlib camlp5 ];
-  propagatedBuildInputs = [ camlp-streams num ];
+  propagatedBuildInputs = [
+    camlp-streams
+    (if use_zarith then zarith else num)
+  ];
 
   installPhase = ''
     mkdir -p "$out/lib/hol_light" "$out/bin"


### PR DESCRIPTION
## Description of changes

Support for OCaml ≥ 5.0. Currently, evaluation fails.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
