### PR TITLE
CoreFoundation: apply hook to correct platform

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
@@ -215,7 +215,10 @@ in rec {
     # Overrides for framework derivations.
     overrides = super: {
       CoreFoundation = lib.overrideDerivation super.CoreFoundation (drv: {
-        setupHook = ./cf-setup-hook.sh;
+        setupHooks = [
+          ../../../build-support/setup-hooks/role.bash
+          ./cf-setup-hook.sh
+        ];
       });
 
       # This framework doesn't exist in newer SDKs (somewhere around 10.13), but

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/cf-setup-hook.sh
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/cf-setup-hook.sh
@@ -1,6 +1,14 @@
 forceLinkCoreFoundationFramework() {
-  NIX_CFLAGS_COMPILE="-F@out@/Library/Frameworks${NIX_CFLAGS_COMPILE:+ }${NIX_CFLAGS_COMPILE-}"
-  NIX_LDFLAGS+=" @out@/Library/Frameworks/CoreFoundation.framework/CoreFoundation.tbd"
+  local role_post
+  getHostRole
+
+  local cflags_compile_role_var="NIX_CFLAGS_COMPILE${role_post}"
+  local cflags_compile_role="${!cflags_compile_role_var-}"
+  export NIX_CFLAGS_COMPILE${role_post}="-F@out@/Library/Frameworks${cflags_compile_role:+ $cflags_compile_role}"
+
+  local ldflags_role_var="NIX_LDFLAGS${role_post}"
+  local ldflags_role="${!ldflags_role_var-}"
+  export NIX_LDFLAGS${role_post}+="${ldflags_role:+ }@out@/Library/Frameworks/CoreFoundation.framework/CoreFoundation.tbd"
 }
 
-preConfigureHooks+=(forceLinkCoreFoundationFramework)
+forceLinkCoreFoundationFramework

--- a/pkgs/os-specific/darwin/apple-sdk/cf-setup-hook.sh
+++ b/pkgs/os-specific/darwin/apple-sdk/cf-setup-hook.sh
@@ -1,9 +1,17 @@
 linkSystemCoreFoundationFramework() {
-  NIX_CFLAGS_COMPILE="-F@out@/Library/Frameworks${NIX_CFLAGS_COMPILE:+ }${NIX_CFLAGS_COMPILE-}"
+  local role_post
+  getHostRole
+
+  local cflags_compile_role_var="NIX_CFLAGS_COMPILE${role_post}"
+  local cflags_compile_role="${!cflags_compile_role_var-}"
+  export NIX_CFLAGS_COMPILE${role_post}="-F@out@/Library/Frameworks${cflags_compile_role:+ $cflags_compile_role}"
+
   # gross! many symbols (such as _OBJC_CLASS_$_NSArray) are defined in system CF, but not
   # in the opensource release
   # if the package needs private headers, we assume they also want to link with system CF
-  NIX_LDFLAGS+=" @out@/Library/Frameworks/CoreFoundation.framework/CoreFoundation.tbd"
+  local ldflags_role_var="NIX_LDFLAGS${role_post}"
+  local ldflags_role="${!ldflags_role_var-}"
+  export NIX_LDFLAGS${role_post}+="${ldflags_role:+ }@out@/Library/Frameworks/CoreFoundation.framework/CoreFoundation.tbd"
 }
 
-preConfigureHooks+=(linkSystemCoreFoundationFramework)
+linkSystemCoreFoundationFramework

--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -277,7 +277,10 @@ in rec {
     });
 
     CoreFoundation = lib.overrideDerivation super.CoreFoundation (drv: {
-      setupHook = ./cf-setup-hook.sh;
+      setupHooks = [
+        ../../../build-support/setup-hooks/role.bash
+        ./cf-setup-hook.sh
+      ];
     });
 
     CoreMedia = lib.overrideDerivation super.CoreMedia (drv: {


### PR DESCRIPTION
## Description of changes

> Cross-compiling from darwin to linux is broken if the derivation includes CoreFoundation somewhere in its (native) input deps. This change makes the cf-setup-hook aware of its platform role, replacing NIX_LDFLAGS with NIX_LDFLAGS_FOR_BUILD when necessary.
>
> Fixes https://github.com/NixOS/nixpkgs/issues/278348 in `23.11` without getting rid of the hook in case anyone was relying on it.
>
> In `unstable` we probably want to get rid of the hook entirely. See #284629.

This was already merged into `23.11` a few months back as #284706, with the plan to remove the CoreFoundation hook entirely by `24.05` in #284629.

Unfortunately #284629 didn't make it into 24.05, so this is now a regression. This PR is cherry-picked from `23.11`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
