### PR TITLE
cutter: fix build error caused by pyside 6.7.0

### DIFF
--- a/pkgs/development/tools/analysis/rizin/cutter-pyside-6.7.0.patch
+++ b/pkgs/development/tools/analysis/rizin/cutter-pyside-6.7.0.patch
@@ -1,0 +1,12 @@
+git --diff a/src/plugins/PluginManager.cpp b/src/plugins/PluginManager.cpp
+--- a/src/plugins/PluginManager.cpp
++++ b/src/plugins/PluginManager.cpp
+@@ -215,7 +215,7 @@
+     }
+ 
+     PythonToCppFunc pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(
+-            reinterpret_cast<SbkObjectType *>(SbkCutterBindingsTypes[SBK_CUTTERPLUGIN_IDX]),
++            reinterpret_cast<SbkObjectType *>(SbkCutterBindingsTypeStructs[SBK_CUTTERPLUGIN_IDX].type),
+             pluginObject);
+     if (!pythonToCpp) {
+         qWarning() << "Plugin's create_cutter_plugin() function did not return an instance of "

--- a/pkgs/development/tools/analysis/rizin/cutter.nix
+++ b/pkgs/development/tools/analysis/rizin/cutter.nix
@@ -32,6 +32,8 @@ let cutter = stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [ ./cutter-pyside-6.7.0.patch ];
+
   nativeBuildInputs = [
     cmake
     pkg-config


### PR DESCRIPTION
Pyside 6.7.0 (more specific 5d05065b57f5e37c2229ff6a2d98d936c5c7f2bb) introduced a change incompatible with the current version of Cutter. Pyside deprecated 'SbkCutterBindingsTypes' and does not emit it to 'cutterbindings_python.cpp' during code generation.

## Description of changes
ZHF: #309482
- fixes https://github.com/NixOS/nixpkgs/issues/308262
- failing build https://hydra.nixos.org/build/260309589
- should be back ported to 24.05

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
