### PR TITLE
bombsquad: 1.7.34 -> 1.7.35

### DIFF
--- a/pkgs/by-name/bo/bombsquad/package.nix
+++ b/pkgs/by-name/bo/bombsquad/package.nix
@@ -16,6 +16,7 @@
   copyDesktopItems,
   writeShellApplication,
   commandLineArgs ? "",
+  genericUpdater,
 }:
 let
   archive =
@@ -86,18 +87,20 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = lib.getExe (writeShellApplication {
-    name = "bombsquad-versionLister";
-    runtimeInputs = [
-      curl
-      gnugrep
-    ];
-    text = ''
-      curl -sL "https://files.ballistica.net/bombsquad/builds/CHANGELOG.md" \
-          | grep -oP '^### \K\d+\.\d+\.\d+' \
-          | head -n 1
-    '';
-  });
+  passthru.updateScript = genericUpdater {
+    versionLister = lib.getExe (writeShellApplication {
+      name = "bombsquad-versionLister";
+      runtimeInputs = [
+        curl
+        gnugrep
+      ];
+      text = ''
+        curl -sL "https://files.ballistica.net/bombsquad/builds/CHANGELOG.md" \
+            | grep -oP '^### \K\d+\.\d+\.\d+' \
+            | head -n 1
+      '';
+    });
+  };
 
   meta = {
     description = "A free, multiplayer, arcade-style game for up to eight players that combines elements of fighting games and first-person shooters (FPS)";
@@ -107,7 +110,10 @@ stdenv.mkDerivation (finalAttrs: {
       mit
       unfree
     ];
-    maintainers = with lib.maintainers; [ syedahkam coffeeispower ];
+    maintainers = with lib.maintainers; [
+      syedahkam
+      coffeeispower
+    ];
     mainProgram = "bombsquad";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/bo/bombsquad/package.nix
+++ b/pkgs/by-name/bo/bombsquad/package.nix
@@ -23,7 +23,7 @@ let
     {
       x86_64-linux = {
         name = "BombSquad_Linux_x86_64";
-        hash = "sha256-VLNO0TxI/KBj8RkpGjo9Rx40f7fuV3pK2kIoKff9sRU=";
+        hash = "sha256-YrbDhdVtNtxeE3fIRPIODwVO3lrxz7OAAYc7doBBQj8=";
       };
       aarch-64-linux = {
         name = "BombSquad_Linux_Arm64";
@@ -34,7 +34,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   name = "bombsquad";
-  version = "1.7.34";
+  version = "1.7.35";
   sourceRoot = ".";
   src = fetchurl {
     url = "https://files.ballistica.net/bombsquad/builds/${archive.name}_${finalAttrs.version}.tar.gz";


### PR DESCRIPTION
This fixes the update script for the recently-merged `bombsquad` package (#309886) and includes a version bump.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
