### PR TITLE
pkgsMusl.nginx: fix build

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -130,6 +130,9 @@ stdenv.mkDerivation {
     "-Wno-error=deprecated-declarations"
     "-Wno-error=gnu-folding-constant"
     "-Wno-error=unused-but-set-variable"
+  ] ++ lib.optionals stdenv.hostPlatform.isMusl [
+    # fix sys/cdefs.h is deprecated
+    "-Wno-error=cpp"
   ]);
 
   configurePlatforms = [];


### PR DESCRIPTION
pkgsMusl.nginx: fix build

Fixes:

> error: #warning usage of non-standard #include <sys/cdefs.h> is deprecated [-Werror=cpp]

CC Musl: @yu-re-ka @alyssais @ulrikstrid
CC Nginx: @fpletz @raitobezarius @helsinki-systems