### PR TITLE
nginx: make geoip, image filter optional

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -12,6 +12,8 @@
 
 ## Backward Incompatibilities {#sec-release-24.11-incompatibilities}
 
+- `nginx` package no longer includes `gd` and `geoip` dependencies. For enabling it, override `nginx` package with the optionals `withImageFilter` and `withGeoIP`.
+
 - `nvimpager` was updated to version 0.13.0, which changes the order of user and
   nvimpager settings: user commands in `-c` and `--cmd` now override the
   respective default settings because they are executed later.

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -4,6 +4,7 @@ outer@{ lib, stdenv, fetchurl, fetchpatch, openssl, zlib, pcre, libxml2, libxslt
 , nixosTests
 , installShellFiles, substituteAll, removeReferencesTo, gd, geoip, perl
 , withDebug ? false
+, withImageFilter ? false
 , withKTLS ? true
 , withStream ? true
 , withMail ? false
@@ -64,9 +65,10 @@ stdenv.mkDerivation {
     removeReferencesTo
   ] ++ nativeBuildInputs;
 
-  buildInputs = [ openssl zlib pcre libxml2 libxslt gd geoip perl ]
+  buildInputs = [ openssl zlib pcre libxml2 libxslt geoip perl ]
     ++ buildInputs
-    ++ mapModules "inputs";
+    ++ mapModules "inputs"
+    ++ lib.optional withImageFilter gd;
 
   configureFlags = [
     "--sbin-path=bin/nginx"
@@ -112,8 +114,8 @@ stdenv.mkDerivation {
     "--with-http_perl_module"
     "--with-perl=${perl}/bin/perl"
     "--with-perl_modules_path=lib/perl5"
-  ] ++ lib.optional withSlice "--with-http_slice_module"
-    ++ lib.optional (gd != null) "--with-http_image_filter_module"
+  ] ++ lib.optional withImageFilter "--with-http_image_filter_module"
+    ++ lib.optional withSlice "--with-http_slice_module"
     ++ lib.optional (geoip != null) "--with-http_geoip_module"
     ++ lib.optional (withStream && geoip != null) "--with-stream_geoip_module"
     ++ lib.optional (with stdenv.hostPlatform; isLinux || isFreeBSD) "--with-file-aio"


### PR DESCRIPTION
nginx: make geoip, image filter optional

Initial goal was to make `libgd` optional. Because it reduces nginx package size from 109.88 MiB to 41.99 MiB. (Reduction of -67.88 MiB.) [GD](https://libgd.github.io) is a library for the dynamic creation of images.

With libgd:
![nginx-with-libgd](https://github.com/NixOS/nixpkgs/assets/5861043/0f999d10-ce6d-4d8c-8666-a18c5419e861)

Without libgd:
![nginx-without-libgd](https://github.com/NixOS/nixpkgs/assets/5861043/86c26fd2-01e6-4c04-9c4e-f692b0951c50)

Tests runs:
> nix build .#nixosTests.{nginx,nginx-auth,nginx-etag,nginx-etag-compression,nginx-globalredirect,nginx-proxyprotocol,nginx-pubhtml,nginx-sso,nginx-status-page,nginx-unix-socket}

CC nginx: @fpletz @raitobezarius