### PR TITLE
salt-lint: add 0.9.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14841,6 +14841,12 @@
     githubId = 13085275;
     name = "Juozas Norkus";
   };
+  norepercussions = {
+    name = "Tucker Shea";
+    email = "nix@tuckershea.com";
+    github = "NoRePercussions";
+    githubId = 66567994;
+  };
   norfair = {
     email = "syd@cs-syd.eu";
     github = "NorfairKing";

--- a/pkgs/by-name/sa/salt-lint/package.nix
+++ b/pkgs/by-name/sa/salt-lint/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchPypi,
+  python3Packages,
+  testers,
+  salt-lint,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "salt-lint";
+  version = "0.9.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-f3Tmguf9eHIqbTkeqO3J/HlRE+z9QGV9aAV9QE7nvo4=";
+  };
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    pathspec
+    pyyaml
+  ];
+
+  pythonImportsCheck = [ "saltlint" ];
+
+  passthru.tests = {
+    version = testers.testVersion { package = salt-lint; };
+  };
+
+  meta = with lib; {
+    description = "Command-line utility that checks for best practices in SaltStack";
+    homepage = "https://salt-lint.readthedocs.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ norepercussions ];
+    mainProgram = "salt-lint";
+  };
+}


### PR DESCRIPTION
## Description of changes

Add the [`salt-lint` python application](https://github.com/warpnet/salt-lint) v0.9.2.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] **(See below)** Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

Note: I had trouble getting pytest to find any tests. CDing into `$out` did not work, nor did pointing pytest specifically at `tests/unit`
