### PR TITLE
swingmusic: init at 1.4.8

### DIFF
--- a/pkgs/by-name/sw/swingmusic/package.nix
+++ b/pkgs/by-name/sw/swingmusic/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  ffmpeg,
+  libav,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "swingmusic";
+  version = "1.4.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "swingmx";
+    repo = "SwingMusic";
+    rev = "v${version}";
+    hash = "sha256-Bm7RBmVRCRvAxculH9an05yj7Rta0yttCfyJnMvwbjI=";
+  };
+
+  nativeBuildInputs = [ python3.pkgs.poetry-core ];
+  buildInputs = [
+    ffmpeg
+    libav
+  ];
+  propagatedBuildInputs = with python3.pkgs; [
+    colorgram-py
+    flask
+    flask-compress
+    flask-cors
+    flask-restful
+    locust
+    pendulum
+    pillow
+    psutil
+    rapidfuzz
+    requests
+    setproctitle
+    show-in-file-manager
+    tabulate
+    tinytag
+    tqdm
+    unidecode
+    waitress
+    watchdog
+  ];
+
+  meta = with lib; {
+    description = "A beautiful, self-hosted music player for your local audio files";
+    homepage = "https://github.com/swingmx/SwingMusic";
+    license = licenses.mit;
+    maintainers = with maintainers; [ daru-san ];
+    mainProgram = "swing-music";
+  };
+}

--- a/pkgs/development/python-modules/colorgram-py/default.nix
+++ b/pkgs/development/python-modules/colorgram-py/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "colorgram-py";
+  version = "1.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "obskyr";
+    repo = "colorgram.py";
+    rev = "v${version}";
+    hash = "sha256-jF/J6mOklKn+xE38zvFyrPs3WxwRPHGPHXd61b4SkIc=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  dependencies = [ python3.pkgs.pillow ];
+
+  meta = with lib; {
+    description = "A Python module for extracting colors from images. Get a palette of any picture";
+    homepage = "https://github.com/obskyr/colorgram.py";
+    license = licenses.mit;
+    maintainers = with maintainers; [ daru-san ];
+    mainProgram = "colorgram-py";
+  };
+}

--- a/pkgs/development/python-modules/locust/default.nix
+++ b/pkgs/development/python-modules/locust/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "locust";
+  version = "2.28.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "locustio";
+    repo = "locust";
+    rev = version;
+    hash = "sha256-xy4k2stZY1JAxOtyHWfE2KlPAGufTP0un0Pol3Akysg=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.setuptools-scm
+    python3.pkgs.wheel
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    configargparse
+    flask
+    flask-cors
+    flask-login
+    gevent
+    geventhttpclient
+    msgpack
+    psutil
+    pyzmq
+    requests
+    tomli
+    werkzeug
+  ];
+
+  meta = with lib; {
+    description = "Write scalable load tests in plain Python";
+    homepage = "https://github.com/locustio/locust";
+    changelog = "https://github.com/locustio/locust/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ daru-san ];
+    mainProgram = "locust";
+  };
+}

--- a/pkgs/development/python-modules/tinytag/default.nix
+++ b/pkgs/development/python-modules/tinytag/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  wheel,
+}:
+
+buildPythonPackage rec {
+  pname = "tinytag";
+  version = "1.10.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "devsnd";
+    repo = "tinytag";
+    rev = version;
+    hash = "sha256-Kg67EwDIi/Io7KKnNiqPzQKginrfuE6FAeOCjFgEJkY=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  meta = with lib; {
+    description = "Python library for reading audio file metadata, duration of MP3, OGG, OPUS, MP4, M4A, FLAC, WMA, Wave, AIFF and a few more";
+    homepage = "https://github.com/devsnd/tinytag";
+    license = licenses.mit;
+    maintainers = with maintainers; [ daru-san ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15169,6 +15169,8 @@ self: super: with self; {
 
   tiny-proxy = callPackage ../development/python-modules/tiny-proxy { };
 
+  tinytag = callPackage ../development/python-modules/tinytag { };
+
   tinycss2 = callPackage ../development/python-modules/tinycss2 { };
 
   tinycss = callPackage ../development/python-modules/tinycss { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6982,6 +6982,8 @@ self: super: with self; {
 
   lockfile = callPackage ../development/python-modules/lockfile { };
 
+  locust = callPackage ../development/python-modules/locust { };
+
   log-symbols = callPackage ../development/python-modules/log-symbols { };
 
   logbook = callPackage ../development/python-modules/logbook { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2372,6 +2372,8 @@ self: super: with self; {
 
   colorful = callPackage ../development/python-modules/colorful { };
 
+  colorgram-py = callPackage ../development/python-modules/colorgram-py { };
+
   colorlog = callPackage ../development/python-modules/colorlog { };
 
   colorlover = callPackage ../development/python-modules/colorlover { };


### PR DESCRIPTION
## Description of changes

**Currently *NOT* ready for merging**

Adds swing-music, a beautiful and fast music streaming server and UI
Source: https://github.com/swingmx/SwingMusic
Homepage: https://swingmusic.vercel.app 

Also three python dependencies: 

#### colorgram.py
Homepage: https://github.com/obskyr/colorgram.py

#### locust 
Homepage: https://github.com/locustio/locust

#### tinytag 
Homepage: https://github.com/devsnd/tinytag

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
