### PR TITLE
hexapdf: init at 1.0.2

### DIFF
--- a/pkgs/by-name/he/hexapdf/Gemfile
+++ b/pkgs/by-name/he/hexapdf/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'hexapdf'

--- a/pkgs/by-name/he/hexapdf/Gemfile.lock
+++ b/pkgs/by-name/he/hexapdf/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    cmdparse (3.0.7)
+    geom2d (0.4.1)
+    hexapdf (1.0.2)
+      cmdparse (~> 3.0, >= 3.0.3)
+      geom2d (~> 0.4, >= 0.4.1)
+      openssl (>= 2.2.1)
+    openssl (3.2.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  hexapdf
+
+BUNDLED WITH
+   2.5.9

--- a/pkgs/by-name/he/hexapdf/gemset.nix
+++ b/pkgs/by-name/he/hexapdf/gemset.nix
@@ -1,0 +1,47 @@
+{
+  cmdparse = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0f87jny4zk21iyrkyyw4kpnq8ymrwjay02ipagwapimy237cmigp";
+      type = "gem";
+    };
+    version = "3.0.7";
+  };
+  geom2d = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1nafcfznjqycxd062cais64ydgl99xddh4zy4hp7bwn4j3m9h2ga";
+      type = "gem";
+    };
+    version = "0.4.1";
+  };
+  hexapdf = {
+    dependencies = [
+      "cmdparse"
+      "geom2d"
+      "openssl"
+    ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "13dbscnf7c3jlghlkgl01b7hzgx2ps26m57qmhyv5g626n342i4c";
+      type = "gem";
+    };
+    version = "1.0.2";
+  };
+  openssl = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "054d6ybgjdzxw567m7rbnd46yp6gkdbc5ihr536vxd3p15vbhjrw";
+      type = "gem";
+    };
+    version = "3.2.0";
+  };
+}

--- a/pkgs/by-name/he/hexapdf/package.nix
+++ b/pkgs/by-name/he/hexapdf/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  bundlerApp,
+  bundlerUpdateScript,
+  ruby,
+}:
+
+bundlerApp {
+  pname = "hexapdf";
+  exes = [ "hexapdf" ];
+
+  inherit ruby;
+  gemdir = ./.;
+
+  passthru.updateScript = bundlerUpdateScript "hexapdf";
+
+  meta = with lib; {
+    description = "Versatile PDF creation and manipulation library";
+    homepage = "https://hexapdf.gettalong.org/";
+    changelog = "https://github.com/gettalong/hexapdf/blob/master/CHANGELOG.md";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ bbenno ];
+    platforms = platforms.unix;
+    mainProgram = "hexapdf";
+  };
+}


### PR DESCRIPTION
## Description of changes

According to its [website](https://hexapdf.gettalong.org/), hexapdf is a _versatile PDF creation and manipulation library for Ruby_. 
It can be used as a CLI tool for manipulating or optimizing PDF files.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
