### PR TITLE
nodejs: run JS test suite as part of the checks

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -137,10 +137,16 @@ let
       "build-node-api-tests"
       "tooltest"
       "cctest"
+      "test-ci-js"
     ];
 
-    # Do not create __pycache__ when running tests.
-    checkFlags = [ "PYTHONDONTWRITEBYTECODE=1" ];
+    checkFlags = [
+      # Do not create __pycache__ when running tests.
+      "PYTHONDONTWRITEBYTECODE=1"
+      "FLAKY_TESTS=skip"
+      # Skip some tests that are not passing in this context
+      "CI_SKIP_TESTS=test-setproctitle,test-tls-cli-max-version-1.3,test-tls-client-auth,test-child-process-exec-env,test-fs-write-stream-eagain,test-tls-sni-option,test-https-foafssl,test-child-process-uid-gid,test-process-euid-egid,test-process-initgroups,test-process-uid-gid,test-process-setgroups"
+    ];
 
     postInstall = ''
       HOST_PATH=$out/bin patchShebangs --host $out

--- a/pkgs/development/web/nodejs/use-correct-env-in-tests.patch
+++ b/pkgs/development/web/nodejs/use-correct-env-in-tests.patch
@@ -1,0 +1,24 @@
+`/usr/bin/env` is not available.
+
+--- old/test/common/assertSnapshot.js
++++ new/test/common/assertSnapshot.js
+@@ -81,2 +81,2 @@ async function spawnAndAssert(filename, transform = (x) => x, { tty = false, ...
+-  const executable = tty ? 'tools/pseudo-tty.py' : process.execPath;
+-  const args = tty ? [process.execPath, ...flags, filename] : [...flags, filename];
++  const executable = tty ? 'python3' : process.execPath;
++  const args = tty ? ['tools/pseudo-tty.py', process.execPath, ...flags, filename] : [...flags, filename];
+--- old/test/parallel/test-child-process-default-options.js
++++ new/test/parallel/test-child-process-default-options.js
+@@ -35 +35 @@ if (isWindows) {
+-  child = spawn('/usr/bin/env', [], {});
++  child = spawn('env', [], {});
+--- old/test/parallel/test-child-process-env.js
++++ new/test/parallel/test-child-process-env.js
+@@ -51 +51 @@ if (isWindows) {
+-  child = spawn('/usr/bin/env', [], { env });
++  child = spawn('env', [], { env });
+--- old/test/parallel/test-child-process-exec-env.js
++++ new/test/parallel/test-child-process-exec-env.js
+@@ -47 +47 @@ if (!isWindows) {
+-  child = exec('/usr/bin/env', { env: { 'HELLO': 'WORLD' } }, after);
++  child = exec('env', { env: { 'HELLO': 'WORLD' } }, after);

--- a/pkgs/development/web/nodejs/v18.nix
+++ b/pkgs/development/web/nodejs/v18.nix
@@ -1,4 +1,4 @@
-{ callPackage, lib, overrideCC, pkgs, buildPackages, openssl, python3, enableNpm ? true }:
+{ callPackage, lib, overrideCC, pkgs, buildPackages, openssl, python3, fetchpatch2, enableNpm ? true }:
 
 let
   # Clang 16+ cannot build Node v18 due to -Wenum-constexpr-conversion errors.
@@ -27,5 +27,10 @@ buildNodejs {
     ./revert-arm64-pointer-auth.patch
     ./node-npm-build-npm-package-logic.patch
     ./trap-handler-backport.patch
+    ./use-correct-env-in-tests.patch
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/534c122de166cb6464b489f3e6a9a544ceb1c913.patch";
+      hash = "sha256-4q4LFsq4yU1xRwNsM1sJoNVphJCnxaVe2IyL6AeHJ/I=";
+    })
   ];
 }

--- a/pkgs/development/web/nodejs/v20.nix
+++ b/pkgs/development/web/nodejs/v20.nix
@@ -1,4 +1,4 @@
-{ callPackage, openssl, python3, enableNpm ? true }:
+{ callPackage, fetchpatch2, openssl, python3, enableNpm ? true }:
 
 let
   buildNodejs = callPackage ./nodejs.nix {
@@ -15,5 +15,10 @@ buildNodejs {
     ./disable-darwin-v8-system-instrumentation-node19.patch
     ./bypass-darwin-xcrun-node16.patch
     ./node-npm-build-npm-package-logic.patch
+    ./use-correct-env-in-tests.patch
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/534c122de166cb6464b489f3e6a9a544ceb1c913.patch";
+      hash = "sha256-4q4LFsq4yU1xRwNsM1sJoNVphJCnxaVe2IyL6AeHJ/I=";
+    })
   ];
 }

--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -1,4 +1,4 @@
-{ callPackage, openssl, python3, enableNpm ? true }:
+{ callPackage, fetchpatch2, openssl, python3, enableNpm ? true }:
 
 let
   buildNodejs = callPackage ./nodejs.nix {
@@ -14,5 +14,10 @@ buildNodejs {
     ./disable-darwin-v8-system-instrumentation-node19.patch
     ./bypass-darwin-xcrun-node16.patch
     ./node-npm-build-npm-package-logic.patch
+    ./use-correct-env-in-tests.patch
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/534c122de166cb6464b489f3e6a9a544ceb1c913.patch";
+      hash = "sha256-4q4LFsq4yU1xRwNsM1sJoNVphJCnxaVe2IyL6AeHJ/I=";
+    })
   ];
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I noticed the JS test suite of Node.js wasn't run as part of the check phase, so I spent some time making it work. I've opened https://github.com/nodejs/node/pull/53105 and https://github.com/nodejs/node/pull/53104 to land the fixes upstream.

I've only the changes with `nix-build -A nodejs-slim_20`. I think there are some improvements that could be made (e.g. currently the list of skip tests is shared for all versions, it would probably make more sense to have per-version specific lists instead).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
