### PR TITLE
xgen: init at 0-unstable-2023-07-02

### DIFF
--- a/pkgs/by-name/xg/xgen/package.nix
+++ b/pkgs/by-name/xg/xgen/package.nix
@@ -1,0 +1,28 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+
+buildGoModule rec {
+  pname = "xgen";
+
+  # This is a pseudoversion including the fetch date and git hash.
+  # The upstream project does not provide official releases or version tags.
+  version = "v0-unstable-2023-07-02";
+
+  src = fetchFromGitHub {
+    owner = "xuri";
+    repo = "xgen";
+    rev = "db840e1a460537cf4f90c2a88cffe11ef354dd9f";
+    sha256 = "sha256-S5F7I6rDxtLSVlq7VLJkfghX+scudK9WZmOcDHmehM8=";
+  };
+
+  vendorHash = "sha256-YU/iQnZs4/oUiJw3syW1jxEpeQLyOMElsjzWCNsucds=";
+
+  meta = with lib; {
+    description = "A XSD to Go/C/Java/Rust/TypeScript code generator";
+    homepage = "https://github.com/xuri/xgen";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ imalsogreg ];
+    mainProgram = "xgen";
+  };
+}
+


### PR DESCRIPTION
## Description of changes

Adds support for [xgen](https://github.com/xuri/xgen), a tool that generates Go/C/Java/Rust/TypeScript code from an .xsd (XML Schema Description) file.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

