### PR TITLE
mygui: 3.4.2 -> 3.4.3

### DIFF
--- a/pkgs/development/libraries/mygui/default.nix
+++ b/pkgs/development/libraries/mygui/default.nix
@@ -5,14 +5,15 @@
 , pkg-config
 , boost
 , freetype
-, libuuid
-, ois
 , withOgre ? false
+, withTools ? false
 , ogre
 , libGL
 , libGLU
-, libX11
 , Cocoa
+, SDL2
+, SDL2_image
+, zlib
 }:
 
 let
@@ -20,13 +21,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "mygui";
-  version = "3.4.2";
+  version = "3.4.3";
 
   src = fetchFromGitHub {
     owner = "MyGUI";
     repo = "mygui";
     rev = "MyGUI${version}";
-    hash = "sha256-yBV0ImOFJlqBPqqOjXYe4SFO2liSGZCEwvehED5Ubj4=";
+    hash = "sha256-qif9trHgtWpYiDVXY3cjRsXypjjjgStX8tSWCnXhXlk=";
   };
 
   patches = [
@@ -39,25 +40,24 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    boost
+    SDL2
+    SDL2_image
     freetype
-    libuuid
-    ois
+    zlib
   ] ++ lib.optionals withOgre [
     ogre
+    boost
   ] ++ lib.optionals (!withOgre && stdenv.isLinux) [
     libGL
     libGLU
-  ] ++ lib.optionals stdenv.isLinux [
-    libX11
   ] ++ lib.optionals stdenv.isDarwin [
     Cocoa
   ];
 
-  # Tools are disabled due to compilation failures.
   cmakeFlags = [
-    "-DMYGUI_BUILD_TOOLS=OFF"
+    "-DMYGUI_BUILD_TOOLS=${if withTools then "ON" else "OFF"}"
     "-DMYGUI_BUILD_DEMOS=OFF"
+    "-DMYGUI_INSTALL_TOOLS=${if withTools then "ON" else "OFF"}"
     "-DMYGUI_RENDERSYSTEM=${renderSystem}"
   ];
 

--- a/pkgs/development/libraries/mygui/disable-framework.patch
+++ b/pkgs/development/libraries/mygui/disable-framework.patch
@@ -1,11 +1,11 @@
 diff --git a/CMake/Utils/MyGUIConfigTargets.cmake b/CMake/Utils/MyGUIConfigTargets.cmake
-index 7e279c986..b33f097c0 100644
+index 871ef84..6a594cf 100644
 --- a/CMake/Utils/MyGUIConfigTargets.cmake
 +++ b/CMake/Utils/MyGUIConfigTargets.cmake
-@@ -418,15 +418,6 @@ function(mygui_config_lib PROJECTNAME)
- 		if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+@@ -421,15 +421,6 @@ function(mygui_config_lib PROJECTNAME)
  			# add GCC visibility flags to shared library build
- 			set_target_properties(${PROJECTNAME} PROPERTIES COMPILE_FLAGS "${MYGUI_GCC_VISIBILITY_FLAGS}")
+ 			target_compile_options(${PROJECTNAME} PRIVATE ${MYGUI_GCC_VISIBILITY_OPTIONS})
+ 			target_compile_definitions(${PROJECTNAME} PRIVATE ${MYGUI_GCC_VISIBILITY_DEFINITIONS})
 -			if (APPLE)
 -				# deal with Mac OS X's framework system
 -				set_target_properties(${PROJECTNAME} PROPERTIES FRAMEWORK TRUE)


### PR DESCRIPTION
## Description of changes
Updates mygui to version 3.4.3 (latest) and adds an option to also enable tools building which were previously disabled due to a bug .

Also updated the buildInputs with proper dependencied, removed packages not needed libuuid, ois, libX11 and added needed dependencied SDL2, SDL2_image, zlib
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
