### PR TITLE
python312Packages.fastparquet: 2024.2.0 -> 2024.5.0

### DIFF
--- a/pkgs/development/python-modules/fastparquet/default.nix
+++ b/pkgs/development/python-modules/fastparquet/default.nix
@@ -1,62 +1,61 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-  python,
-  cython,
-  oldest-supported-numpy,
-  setuptools,
-  setuptools-scm,
-  numpy,
-  pandas,
   cramjam,
+  cython,
+  fetchFromGitHub,
   fsspec,
-  thrift,
-  python-lzo,
-  pytestCheckHook,
-  pythonOlder,
+  git,
+  numpy,
+  oldest-supported-numpy,
   packaging,
+  pandas,
+  pytestCheckHook,
+  python-lzo,
+  python,
+  pythonOlder,
+  setuptools-scm,
+  setuptools,
   wheel,
 }:
 
 buildPythonPackage rec {
   pname = "fastparquet";
-  version = "2024.2.0";
+  version = "2024.5.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "dask";
     repo = "fastparquet";
     rev = "refs/tags/${version}";
-    hash = "sha256-e0gnC/HMYdrYdEwy6qNOD1J52xgN2x81oCG03YNsYjg=";
+    hash = "sha256-YiaVkpPzH8ZmTiEtCom9xLbKzByIt7Ilig/WlmGrYH4=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail '"pytest-runner"' ""
-
-    sed -i \
-      -e "/pytest-runner/d" \
-      -e '/"git", "status"/d' setup.py
+      --replace-fail "numpy>=2.0.0rc1" "oldest-supported-numpy"
   '';
 
-  nativeBuildInputs = [
-    cython
-    oldest-supported-numpy
+  build-system = [
     setuptools
     setuptools-scm
     wheel
   ];
 
-  propagatedBuildInputs = [
+  nativeBuildInputs = [
+    cython
+    git
+    oldest-supported-numpy
+  ];
+
+  dependencies = [
     cramjam
     fsspec
     numpy
-    pandas
-    thrift
     packaging
+    pandas
   ];
 
   passthru.optional-dependencies = {
@@ -82,7 +81,8 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Implementation of the parquet format";
     homepage = "https://github.com/dask/fastparquet";
-    license = with licenses; [ asl20 ];
+    changelog = "https://github.com/dask/fastparquet/blob/${version}/docs/source/releasenotes.rst";
+    license = licenses.asl20;
     maintainers = with maintainers; [ veprbl ];
   };
 }

--- a/pkgs/development/python-modules/intake-parquet/default.nix
+++ b/pkgs/development/python-modules/intake-parquet/default.nix
@@ -1,13 +1,14 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-  pandas,
   dask,
   fastparquet,
+  fetchFromGitHub,
+  pandas,
   pyarrow,
-  setuptools,
   pythonOlder,
+  setuptools,
+  versioneer,
 }:
 
 buildPythonPackage rec {
@@ -28,11 +29,17 @@ buildPythonPackage rec {
     # Break circular dependency
     substituteInPlace requirements.txt \
       --replace-fail "intake" ""
+
+    # Remove vendorized versioneer.py
+    rm versioneer.py
   '';
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [
+    setuptools
+    versioneer
+  ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     pandas
     dask
     fastparquet


### PR DESCRIPTION
Diff: https://github.com/dask/fastparquet/compare/refs/tags/2024.2.0...2024.5.0

Changelog: https://github.com/dask/fastparquet/blob/2024.5.0/docs/source/releasenotes.rst

## Description of changes
This update removes the requirement of `thrift` which doesn't build on Python 3.12 (#313652).
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
