### PR TITLE
lib.modules: add mkForAllItems

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -137,7 +137,7 @@ let
       mkRenamedOptionModule mkRenamedOptionModuleWith
       mkMergedOptionModule mkChangedOptionModule
       mkAliasOptionModule mkDerivedConfig doRename
-      mkAliasOptionModuleMD;
+      mkAliasOptionModuleMD mkForAllItems;
     evalOptionValue = lib.warn "External use of `lib.evalOptionValue` is deprecated. If your use case isn't covered by non-deprecated functions, we'd like to know more and perhaps support your use case well, instead of providing access to these low level functions. In this case please open an issue in https://github.com/nixos/nixpkgs/issues/." self.modules.evalOptionValue;
     inherit (self.options) isOption mkEnableOption mkSinkUndeclaredOptions
       mergeDefaultOption mergeOneOption mergeEqualOption mergeUniqueOption

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1036,6 +1036,17 @@ let
   defaultOrderPriority = 1000;
   mkAfter = mkOrder 1500;
 
+  /*
+    For use with options of type `attrsOf *`, `lazyAttrsOf *`, or `listOf *`.
+    Accepts a value that is merged with every element defined elsewhere. May
+    also accept a function that takes the attribute name or index (1-based),
+    the result of which is used as above.
+  */
+  mkForAllItems = content:
+    { _type = "forAllItems";
+      content = if isFunction content then content else _: content;
+    };
+
   # Convenient property used to transfer all definitions and their
   # properties from one option to another. This property is useful for
   # renaming options, and also for including properties from another module
@@ -1421,6 +1432,7 @@ private //
     mkDefault
     mkDerivedConfig
     mkFixStrictness
+    mkForAllItems
     mkForce
     mkIf
     mkImageMediaOverride

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -513,6 +513,9 @@ checkConfigOutput '^34|23$' options.submoduleLine34.declarationPositions.1.line 
 # nested options work
 checkConfigOutput '^30$' options.nested.nestedLine30.declarationPositions.0.line ./declaration-positions.nix
 
+# mkForAllItems
+checkConfigOutput '^true$' config.result ./for-all-items.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/for-all-items.nix
+++ b/lib/tests/modules/for-all-items.nix
@@ -1,0 +1,74 @@
+{ config, lib, ... }:
+let
+  inherit (lib.types) attrsOf bool either int lazyAttrsOf listOf str submodule;
+  testSubmodule = submodule {
+    options = {
+      x = lib.mkOption { type = listOf int; };
+      y = lib.mkOption { type = int; };
+      z = lib.mkOption { type = either int str; };
+    };
+  };
+  testAttrDefs = lib.mkMerge [
+    {
+      a.x = lib.mkBefore [ 0 ];
+      b.y = lib.mkForce 3;
+      b.z = "4";
+    }
+    (lib.modules.mkForAllItems {
+      x = [ 1 ];
+      y = 2;
+    })
+    (lib.modules.mkForAllItems (name: {
+      z = lib.mkDefault name;
+    }))
+  ];
+  testListDefs = lib.mkMerge [
+    [
+      {
+        x = lib.mkBefore [ 0 ];
+      }
+      {
+        y = lib.mkForce 3;
+        z = "4";
+      }
+    ]
+    (lib.modules.mkForAllItems {
+      x = [ 1 ];
+      y = 2;
+    })
+    (lib.modules.mkForAllItems (name: {
+      z = lib.mkDefault name;
+    }))
+  ];
+  expected = {
+    a = {
+      x = [ 0 1 ];
+      y = 2;
+      z = "a";
+    };
+    b = {
+      x = [ 1 ];
+      y = 3;
+      z = "4";
+    };
+  };
+in
+{
+  options = {
+    testAttrs = lib.mkOption { type = attrsOf testSubmodule; };
+    testLazyAttrs = lib.mkOption { type = lazyAttrsOf testSubmodule; };
+    testList = lib.mkOption { type = listOf testSubmodule; };
+    result = lib.mkOption { type = bool; };
+  };
+
+  config = {
+    testAttrs = testAttrDefs;
+    testLazyAttrs = testAttrDefs;
+    testList = testListDefs;
+
+    result =
+      config.testAttrs == expected &&
+      config.testLazyAttrs == expected &&
+      config.testList == [ (expected.a // { z = 1; }) expected.b ];
+  };
+}

--- a/nixos/doc/manual/development/option-def.section.md
+++ b/nixos/doc/manual/development/option-def.section.md
@@ -123,3 +123,38 @@ they were declared in separate modules. This can be done using
     ];
 }
 ```
+
+## Defining Over All Elements/Attributes {#sec-option-definitions-for-all-items}
+
+For options that take lists or attrsets, it may be useful to define
+defaults or overrides on all of the elements or attributes of that option
+independently of the population of the list or set. For example, one
+module can define a list of `swapDevices`, while another module can
+define that for every element of the list of `swapDevices`,
+`swapDevices.*.discardPolicy` should have a particular value. This can be
+done using `mkForAllItems`:
+
+```nix
+{
+  swapDevices = mkForAllItems {
+    discardPolicy = mkDefault "once";
+  };
+}
+```
+
+The argument to `mkForAllItems` will be merged with every element of the
+list, or every attribute of the attrset. As usual, use `mkDefault`,
+`mkForce`, `mkBefore`, `mkAfter`, etc. to control how multiple
+definitions of an option are combined.
+
+`mkForAllItems` can also accept a function which will receive the element
+index (starting at 1) or attribute name for each element or attribute on
+which it is used. The result of this function is used as described above. For example:
+
+```nix
+{
+  services.wordpress.sites = mkForAllItems (name: {
+    uploadsDir = mkDefault "/mnt/wordpress-data/${name}/uploads";
+  });
+}
+```

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -56,6 +56,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- New library function `lib.mkForAllItems` allows for defining values uniformly on lists and attrsets; see [documentation](#sec-option-definitions-for-all-items).
+
 - To facilitate dependency injection, the `imgui` package now builds a static archive using vcpkg' CMake rules.
   The derivation now installs "impl" headers selectively instead of by a wildcard.
   Use `imgui.src` if you just want to access the unpacked sources.


### PR DESCRIPTION
## Description of changes

For motivation, see [Discourse](https://discourse.nixos.org/t/how-to-change-the-default-nixos-option-in-a-list-of-attrsets-described-as/45561).

For explanation, see additions to nixos/doc/manual/development/option-def.section.md

**tl;dr:** if you wish you could write (pseudocode)
```nix
swapDevices.*.options = mkDefault [ /* ... */ ];
```

you can now do that without the dreaded infinite recursion by writing
```nix
swapDevices = mkForAllItems {
  options = mkDefault [ /* ... */ ];
};
```

Is this stupid? Nixpkgs has gotten by this far without it, and there are some alternative patterns available:
* Defining a template function somewhere and using that on every element (disadvantage: undesirable coupling?)
* Redefining the option itself and injecting defaults into its type (disadvantage: overly verbose, not intuitive?)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
