### PR TITLE
python312Packages.scrapy: 2.11.1 -> 2.11.2

### DIFF
--- a/pkgs/development/python-modules/scrapy/default.nix
+++ b/pkgs/development/python-modules/scrapy/default.nix
@@ -5,8 +5,8 @@
   buildPythonPackage,
   cryptography,
   cssselect,
-  fetchPypi,
-  fetchpatch,
+  defusedxml,
+  fetchFromGitHub,
   glibcLocales,
   installShellFiles,
   itemadapter,
@@ -28,32 +28,25 @@
   testfixtures,
   tldextract,
   twisted,
+  uvloop,
   w3lib,
   zope-interface,
 }:
 
 buildPythonPackage rec {
   pname = "scrapy";
-  version = "2.11.1";
+  version = "2.11.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
-  src = fetchPypi {
-    inherit version;
-    pname = "Scrapy";
-    hash = "sha256-czoDnHQj5StpvygQtTMgk9TkKoSEYDWcB7Auz/j3Pr4=";
+  src = fetchFromGitHub {
+    owner = "scrapy";
+    repo = "scrapy";
+    rev = "refs/tags/${version}";
+    hash = "sha256-EaO1kQ3VSTwEW+r0kSKycOxHNTPwwCVjch1ZBrTU0qQ=";
   };
 
-  patches = [
-    # https://github.com/scrapy/scrapy/pull/6316
-    # fix test_get_func_args. remove on next update
-    (fetchpatch {
-      name = "test_get_func_args.patch";
-      url = "https://github.com/scrapy/scrapy/commit/b1fe97dc6c8509d58b29c61cf7801eeee1b409a9.patch";
-      hash = "sha256-POlmsuW4SD9baKwZieKfmlp2vtdlb7aKQ62VOmNXsr0=";
-    })
-  ];
 
   nativeBuildInputs = [
     installShellFiles
@@ -63,6 +56,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     cryptography
     cssselect
+    defusedxml
     itemadapter
     itemloaders
     lxml
@@ -87,6 +81,7 @@ buildPythonPackage rec {
     pytestCheckHook
     sybil
     testfixtures
+    uvloop
   ];
 
   LC_ALL = "en_US.UTF-8";
@@ -101,11 +96,6 @@ buildPythonPackage rec {
 
   disabledTests =
     [
-      # It's unclear if the failures are related to libxml2, https://github.com/NixOS/nixpkgs/pull/123890
-      "test_nested_css"
-      "test_nested_xpath"
-      "test_flavor_detection"
-      "test_follow_whitespace"
       # Requires network access
       "AnonymousFTPTestCase"
       "FTPFeedStorageTest"
@@ -119,14 +109,6 @@ buildPythonPackage rec {
       "test_timeout_download_from_spider_server_hangs"
       "test_unbounded_response"
       "CookiesMiddlewareTest"
-      # Depends on uvloop
-      "test_asyncio_enabled_reactor_different_loop"
-      "test_asyncio_enabled_reactor_same_loop"
-      # Fails with AssertionError
-      "test_peek_fifo"
-      "test_peek_one_element"
-      "test_peek_lifo"
-      "test_callback_kwargs"
       # Test fails on Hydra
       "test_start_requests_laziness"
     ]


### PR DESCRIPTION
## Description of changes

- Update version from 2.11.1 to 2.11.2
  - Adds `defusedxml` as a dependency
  - Remove unnecessary patch; commit is included in new release
- Change fetchPypi to fetchFromGitHub
  - On PyPI they messed up the tarball name, tag names on GitHub should
    be more reliable
- Re-enable tests that were disabled in the past but have since been
  fixed

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
