### PR TITLE
nomacs: fix build with CUDA support

### DIFF
--- a/pkgs/by-name/no/nomacs/package.nix
+++ b/pkgs/by-name/no/nomacs/package.nix
@@ -38,7 +38,10 @@ stdenv.mkDerivation (finalAttrs: {
     exiv2
     libraw
     libtiff
-    opencv4
+    # Once python stops relying on `propagatedBuildInputs` (https://github.com/NixOS/nixpkgs/issues/272178), deprecate `cxxdev` and switch to `dev`;
+    # note `dev` is selected by `mkDerivation` automatically, so one should omit `getOutput "dev"`;
+    # see: https://github.com/NixOS/nixpkgs/pull/314186#issuecomment-2129974277
+    (lib.getOutput "cxxdev" opencv4)
   ] ++ (with libsForQt5; [
     qtbase
     qtimageformats


### PR DESCRIPTION
## Description of changes

nomacs failed to be built at configure phase, if CUDA is enabled in nixOS (`config.nixpkgs.config.cudaSupport = true;`).

```
nomacs> CMake Error at /nix/store/bi9wn96vwxshzix8y4xwrqij91m06ppp-cmake-3.29.2/share/cmake-3.29/Modules/FindCUDA.cmake:883 (message):
nomacs>   Specify CUDA_TOOLKIT_ROOT_DIR
nomacs> Call Stack (most recent call first):
nomacs>   /nix/store/p1rp77lyvpsczzi7xpksf46ms0nrf2zj-opencv-4.9.0/lib/cmake/opencv4/OpenCVConfig.cmake:86 (find_package)
nomacs>   /nix/store/p1rp77lyvpsczzi7xpksf46ms0nrf2zj-opencv-4.9.0/lib/cmake/opencv4/OpenCVConfig.cmake:108 (find_host_package)
nomacs>   cmake/Unix.cmake:41 (find_package)
nomacs>   CMakeLists.txt:121 (include)
```

This PR fixed it.

I only tested this PR on my machine (x86-64). It was built successfully, and the binary works properly. Sorry if I lost some other test steps.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
