### PR TITLE
nixos/etc: don't recurse into /etc to cleanup symlinks

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -293,6 +293,7 @@ in {
   eris-server = handleTest ./eris-server.nix {};
   esphome = handleTest ./esphome.nix {};
   etc = pkgs.callPackage ../modules/system/etc/test.nix { inherit evalMinimalConfig; };
+  etc-cleanup = handleTest ./etc-cleanup.nix {};
   activation = pkgs.callPackage ../modules/system/activation/test.nix { };
   activation-var = runTest ./activation/var.nix;
   activation-nix-channel = runTest ./activation/nix-channel.nix;

--- a/nixos/tests/etc-cleanup.nix
+++ b/nixos/tests/etc-cleanup.nix
@@ -1,0 +1,110 @@
+# Test the etc modules file cleanup.
+
+import ./make-test-python.nix ( { ... } : {
+  name = "etc-cleanup";
+  meta = {
+    maintainers = [ ];
+  };
+
+  nodes =
+    { initial =
+        { ... }:
+        {
+          environment.etc = {
+            "remove" = {
+              # this symlink should be removed after switching
+              text = "remove";
+            };
+
+            "change" = {
+              # this symlinks contents should change after switching
+              text = "previous";
+            };
+
+            "persist" = {
+              # this symlinks contents should stay the same after switching
+              text = "persist";
+            };
+
+            # test direct symlinks get updated
+            # non direct symlinks dont need to be updated as the point to /etc/static/*
+            # which contains the updated files after a rebuild, however direct symlinks dont have this indirection
+            "direct-change" = {
+              text = "state1";
+              mode = "direct-symlink";
+            };
+          };
+        };
+
+      # Dummy configuration to check whether firewall.service will be honored
+      # during system activation. This only needs to be different to the
+      # original walled configuration so that there is a change in the service
+      # file.
+      swap =
+        { ... }:
+        {
+          environment.etc = {
+            "created" = {
+              # this symlink should be added after switching
+              text = "created";
+            };
+
+            "change" = {
+              text = "next";
+            };
+
+            "persist" = {
+              text = "persist";
+            };
+
+            "direct-change" = {
+              text = "state2";
+              mode = "direct-symlink";
+            };
+          };
+        };
+    };
+
+  testScript = { nodes, ... }: let
+    newSystem = nodes.swap.system.build.toplevel;
+  in ''
+    # wait for startup
+    initial.wait_for_file("/etc/remove")
+
+    # test that symlinks get created
+    initial.succeed("test -L /etc/remove")
+    initial.succeed("test -L /etc/change")
+    initial.succeed("test -L /etc/persist")
+
+    # test that symlinks that get added after switching
+    # are not already present
+    initial.succeed("test ! -L /etc/added")
+
+    initial.succeed("test -L /etc/direct-change")
+    initial.succeed("grep state1 /etc/direct-change")
+
+    # switch
+    initial.succeed("${newSystem}/bin/switch-to-configuration test")
+
+    # test that the expected changes happend
+
+    # test for removal
+    initial.succeed("test ! -L /etc/remove")
+
+    # test for creation
+    initial.succeed("test -L /etc/created")
+    initial.succeed("grep 'created' /etc/created")
+
+    # test for persistence
+    initial.succeed("test -L /etc/persist")
+    initial.succeed("grep 'persist' /etc/persist")
+
+    # test for modification
+    initial.succeed("test -L /etc/change")
+    initial.succeed("grep 'next' /etc/change")
+
+    # test direct-symlink
+    initial.succeed("test -L /etc/direct-change")
+    initial.succeed("grep state2 /etc/direct-change")
+  '';
+})


### PR DESCRIPTION
## Description of changes

currently when switching generations setup-etc.pl will search recursively in /etc for old symlinks, this is obviously not ideal.
This pr instead makes it track symlinks the same way it currently tracks copied files.
This pr also adds a test to make sure it still cleans up symlinks properly.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
