### PR TITLE
kube-state-metrics: init at 2.12.0

### DIFF
--- a/pkgs/by-name/ku/kube-state-metrics/package.nix
+++ b/pkgs/by-name/ku/kube-state-metrics/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule rec {
   pname = "kube-state-metrics";
-
   version = "2.12.0";
-  vendorHash = "sha256-A/oiFEWM3TOtk4V3xpehJ+5oKSyzYKZHVlp3wjykFRA=";
 
   src = fetchFromGitHub {
     owner = "kubernetes";
     repo = "kube-state-metrics";
     rev = "v${version}";
-    sha256 = "sha256-EBSlufgzT4zgxTO5B0/RHHJJ2GgtU3U9ypd1QjC3knE=";
+    hash = "sha256-EBSlufgzT4zgxTO5B0/RHHJJ2GgtU3U9ypd1QjC3knE=";
   };
+
+  vendorHash = "sha256-A/oiFEWM3TOtk4V3xpehJ+5oKSyzYKZHVlp3wjykFRA=";
 
   excludedPackages = [
     "./tests/e2e"

--- a/pkgs/by-name/ku/kube-state-metrics/package.nix
+++ b/pkgs/by-name/ku/kube-state-metrics/package.nix
@@ -1,0 +1,34 @@
+{
+  stdenv,
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "kube-state-metrics";
+
+  version = "2.12.0";
+  vendorHash = "sha256-A/oiFEWM3TOtk4V3xpehJ+5oKSyzYKZHVlp3wjykFRA=";
+
+  src = fetchFromGitHub {
+    owner = "kubernetes";
+    repo = "kube-state-metrics";
+    rev = "v${version}";
+    sha256 = "sha256-EBSlufgzT4zgxTO5B0/RHHJJ2GgtU3U9ypd1QjC3knE=";
+  };
+
+  excludedPackages = [ "./tools" ];
+
+  preCheck = ''
+    rm -r tests/e2e
+  '';
+
+  meta = {
+    homepage = "https://github.com/kubernetes/kube-state-metrics";
+    description = "Add-on agent to generate and expose k8s cluster-level metrics";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.eskytthe ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/ku/kube-state-metrics/package.nix
+++ b/pkgs/by-name/ku/kube-state-metrics/package.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildGoModule,
   fetchFromGitHub,
@@ -18,11 +17,10 @@ buildGoModule rec {
     sha256 = "sha256-EBSlufgzT4zgxTO5B0/RHHJJ2GgtU3U9ypd1QjC3knE=";
   };
 
-  excludedPackages = [ "./tools" ];
-
-  preCheck = ''
-    rm -r tests/e2e
-  '';
+  excludedPackages = [
+    "./tests/e2e"
+    "./tools"
+  ];
 
   meta = {
     homepage = "https://github.com/kubernetes/kube-state-metrics";


### PR DESCRIPTION
## Description of changes
This add the k8s kube-state-metrics server. It is used to generating metrics from Kubernetes API objects such as deployments, nodes and pods. It is one of the main sources used to get prometheus metrics out of a k8s cluster.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
