### PR TITLE
stalwart-mail_0_6: drop

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -16,6 +16,11 @@
   nvimpager settings: user commands in `-c` and `--cmd` now override the
   respective default settings because they are executed later.
 
+- Legacy package `stalwart-mail_0_6` was dropped, please note the
+  [manual upgrade process](https://github.com/stalwartlabs/mail-server/blob/main/UPGRADING.md)
+  before changing the package to `pkgs.stalwart-mail` in
+  [`services.stalwart-mail.package`](#opt-services.stalwart-mail.package).
+
 ## Other Notable Changes {#sec-release-24.11-notable-changes}
 
 - Create the first release note entry in this section!

--- a/nixos/modules/services/mail/stalwart-mail.nix
+++ b/nixos/modules/services/mail/stalwart-mail.nix
@@ -7,28 +7,12 @@ let
   configFormat = pkgs.formats.toml { };
   configFile = configFormat.generate "stalwart-mail.toml" cfg.settings;
   dataDir = "/var/lib/stalwart-mail";
-  stalwartAtLeast = versionAtLeast cfg.package.version;
 
 in {
   options.services.stalwart-mail = {
     enable = mkEnableOption "the Stalwart all-in-one email server";
 
-    package = mkOption {
-      type = types.package;
-      description = ''
-        Which package to use for the Stalwart mail server.
-
-        ::: {.note}
-        Upgrading from version 0.6.0 to version 0.7.0 or higher requires manual
-        intervention. See <https://github.com/stalwartlabs/mail-server/blob/main/UPGRADING.md>
-        for upgrade instructions.
-        :::
-      '';
-      default = pkgs.stalwart-mail_0_6;
-      defaultText = lib.literalExpression "pkgs.stalwart-mail_0_6";
-      example = lib.literalExpression "pkgs.stalwart-mail";
-      relatedPackages = [ "stalwart-mail_0_6" "stalwart-mail" ];
-    };
+    package = mkPackageOption pkgs "stalwart-mail" { };
 
     settings = mkOption {
       inherit (configFormat) type;
@@ -43,17 +27,6 @@ in {
   };
 
   config = mkIf cfg.enable {
-
-    warnings = lib.optionals (!stalwartAtLeast "0.7.0") [
-      ''
-        Versions of stalwart-mail < 0.7.0 will get deprecated in NixOS 24.11.
-        Please set services.stalwart-mail.package to pkgs.stalwart-mail to
-        upgrade to the latest version.
-        Please note that upgrading to version >= 0.7 requires manual
-        intervention, see <https://github.com/stalwartlabs/mail-server/blob/main/UPGRADING.md>
-        for upgrade instructions.
-      ''
-    ];
 
     # Default config: all local
     services.stalwart-mail.settings = {

--- a/nixos/modules/services/mail/stalwart-mail.nix
+++ b/nixos/modules/services/mail/stalwart-mail.nix
@@ -111,6 +111,6 @@ in {
   };
 
   meta = {
-    maintainers = with maintainers; [ happysalada pacien ];
+    maintainers = with maintainers; [ happysalada pacien onny ];
   };
 }

--- a/nixos/tests/stalwart-mail.nix
+++ b/nixos/tests/stalwart-mail.nix
@@ -115,6 +115,6 @@ in import ./make-test-python.nix ({ lib, ... }: {
   '';
 
   meta = {
-    maintainers = with lib.maintainers; [ happysalada pacien ];
+    maintainers = with lib.maintainers; [ happysalada pacien onny ];
   };
 })

--- a/pkgs/by-name/st/stalwart-mail/package.nix
+++ b/pkgs/by-name/st/stalwart-mail/package.nix
@@ -75,6 +75,6 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/stalwartlabs/mail-server";
     changelog = "https://github.com/stalwartlabs/mail-server/blob/${version}/CHANGELOG";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ happysalada ];
+    maintainers = with maintainers; [ happysalada onny ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26586,23 +26586,6 @@ with pkgs;
 
   thttpd = callPackage ../servers/http/thttpd { };
 
-  stalwart-mail_0_6 = (stalwart-mail.override { rocksdb_8_11 = rocksdb_8_3; }).overrideAttrs (old: rec {
-    pname = "stalwart-mail_0_6";
-    version = "0.6.0";
-    src = fetchFromGitHub {
-      owner = "stalwartlabs";
-      repo = "mail-server";
-      rev = "v${version}";
-      hash = "sha256-OHwUWSUW6ovLQTxnuUrolQGhxbhp4YqKSH+ZTpe2WXc=";
-      fetchSubmodules = true;
-    };
-    cargoDeps = old.cargoDeps.overrideAttrs (_: {
-      inherit src;
-      name = "${pname}-${version}-vendor.tar.gz";
-      outputHash = "sha256-mW3OXQj6DcIMO1YlTG3G+a1ORRcuvp5/h7BU+b4QbnE=";
-    });
-  });
-
   static-web-server = callPackage ../servers/static-web-server { };
 
   stone = callPackage ../servers/stone { };


### PR DESCRIPTION
## Description of changes

remove old stalwart-mail_0_6 version for the NixOS 24.11 release

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
