### PR TITLE
evdevhook2: init at 1.0.2

### DIFF
--- a/pkgs/by-name/ev/evdevhook2/package.nix
+++ b/pkgs/by-name/ev/evdevhook2/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  vala,
+  glib,
+  libevdev,
+  libgee,
+  udev,
+  testers,
+  nix-update-script,
+}:
+
+let
+  # https://github.com/v1993/evdevhook2/blob/main/subprojects/gcemuhook.wrap
+  gcemuhook = fetchFromGitHub {
+    name = "gcemuhook";
+    owner = "v1993";
+    repo = "gcemuhook";
+    rev = "91ef61cca809f5f3b9fa6e5304aba284a56c06dc";
+    hash = "sha256-CPjSuKtoqSDKd+vEBgFy3qh33TkCVbxBEnwiBAkaADs=";
+  };
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "evdevhook2";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "v1993";
+    repo = "evdevhook2";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-6CnUYLgrGUM1ndGpbn/T7wkREUzQ1LsLMpkRRxyUZ50=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    vala
+  ];
+
+  buildInputs = [
+    glib
+    libevdev
+    libgee
+    udev
+  ];
+
+  postUnpack = ''
+    ln -sf ${gcemuhook} source/subprojects/gcemuhook
+  '';
+
+  mesonBuildType = "release";
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      version = "Evdevhook ${finalAttrs.version}";
+    };
+
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    changelog = "https://github.com/v1993/evdevhook2/releases/tag/v${finalAttrs.version}";
+    description = "Cemuhook UDP server for devices with modern Linux drivers";
+    homepage = "https://github.com/v1993/evdevhook2";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "evdevhook2";
+    maintainers = with lib.maintainers; [ azuwis ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Cemuhook UDP server for devices with modern Linux drivers

homepage: https://github.com/v1993/evdevhook2/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
