### PR TITLE
duckdb: 0.10.2 -> 1.0.0

### DIFF
--- a/pkgs/development/libraries/duckdb/versions.json
+++ b/pkgs/development/libraries/duckdb/versions.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.2",
-  "rev": "1601d94f94a7e0d2eb805a94803eb1e3afbbe4ed",
-  "hash": "sha256-CTZ90KJvLPQqu1FYciEWsxJbvybCjeBsi/12bkfVd9Q="
+  "version": "1.0.0",
+  "rev": "1f98600c2cf8722a6d2f2d805bb4af5e701319fc",
+  "hash": "sha256-bzFxWv8+Ac8vZLd2OWJyu4T0/0dc7wykdOORMpx92Ic="
 }

--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -80,7 +80,7 @@ in
 
 buildPythonPackage rec {
   pname = "ibis-framework";
-  version = "9.0.0";
+  version = "9.0.0-unstable-2024-06-03";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -89,8 +89,8 @@ buildPythonPackage rec {
     name = "ibis-source";
     repo = "ibis";
     owner = "ibis-project";
-    rev = "refs/tags/${version}";
-    hash = "sha256-ebTYCBL1zm2Rmwg998x2kYvKhyQDk8Di1pcx5lR37xo=";
+    rev = "395c8b539bcd541d36892d95f413dcc3f93ca0bc";
+    hash = "sha256-PPjp8HOwM4IaBz7TBGDgkVytHmX9fKO+ZBR33BoB55s=";
   };
 
   nativeBuildInputs = [
@@ -98,7 +98,8 @@ buildPythonPackage rec {
     poetry-dynamic-versioning
   ];
 
-  POETRY_DYNAMIC_VERSIONING_BYPASS = version;
+  dontBypassPoetryDynamicVersioning = true;
+  env.POETRY_DYNAMIC_VERSIONING_BYPASS = lib.head (lib.strings.splitString "-" version);
 
   propagatedBuildInputs = [
     atpublic


### PR DESCRIPTION
## Description of changes

duckdb: 0.10.2 -> 1.0.0
https://github.com/duckdb/duckdb/releases/tag/v1.0.0

python311Packages.ibis-framework: 9.0.0 -> 9.0.0-unstable-2024-06-03
add duckdb 1.0.0 support
https://github.com/ibis-project/ibis/compare/9.0.0..395c8b539bcd541d36892d95f413dcc3f93ca0bc

~duckdb: 0.10.2 -> 0.10.3
https://github.com/duckdb/duckdb/releases/tag/v0.10.3
due to https://github.com/duckdb/duckdb/pull/12223 the python build is broken as a source file is missing in the build list and fixed using  substituteInPlace.~

~python311Packages.ibis-framework: disable failing test
duckdb 0.10.3 causes test_null_literal to fail so use strategy to fix as described in https://github.com/NixOS/nixpkgs/pull/297147#issuecomment-2007055201~

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
