### PR TITLE
remnote: 1.16.4 -> 1.16.18

### DIFF
--- a/pkgs/applications/misc/remnote/default.nix
+++ b/pkgs/applications/misc/remnote/default.nix
@@ -1,50 +1,25 @@
-{ lib, stdenv, fetchurl, appimageTools, makeDesktopItem }:
-
-stdenv.mkDerivation (finalAttrs: let
-  inherit (finalAttrs) pname version src appexec icon desktopItem;
-
-in
 {
+  lib,
+  fetchurl,
+  appimageTools,
+}:
+let
   pname = "remnote";
   version = "1.16.4";
-
   src = fetchurl {
     url = "https://download.remnote.io/remnote-desktop/RemNote-${version}.AppImage";
     hash = "sha256-dgbQ0cbPq7BSQ9VwwH6+GoAxb85HDxRixfjeDJBtOrg=";
   };
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
 
-  appexec = appimageTools.wrapType2 {
-    inherit pname version src;
-  };
-
-  icon = fetchurl {
-    url = "https://www.remnote.io/icon.png";
-    hash = "sha256-r5D7fNefKPdjtmV7f/88Gn3tqeEG8LGuD4nHI/sCk94=";
-  };
-
-  desktopItem = makeDesktopItem {
-    type = "Application";
-    name = "remnote";
-    desktopName = "RemNote";
-    comment = "Spaced Repetition";
-    icon = "remnote";
-    exec = "remnote %u";
-    categories = [ "Office" ];
-    mimeTypes = [ "x-scheme-handler/remnote" "x-scheme-handler/rn" ];
-  };
-
-  dontUnpack = true;
-  dontConfigure = true;
-  dontBuild = true;
-
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm755 ${appexec}/bin/remnote $out/bin/remnote
-    install -Dm444 "${desktopItem}/share/applications/"* -t $out/share/applications/
-    install -Dm444 ${icon} $out/share/pixmaps/remnote.png
-
-    runHook postInstall
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/remnote.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/remnote.desktop \
+      --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=remnote %u'
+    install -Dm444 ${appimageContents}/remnote.png -t $out/share/pixmaps
   '';
 
   meta = with lib; {
@@ -55,4 +30,4 @@ in
     platforms = [ "x86_64-linux" ];
     mainProgram = "remnote";
   };
-})
+}

--- a/pkgs/applications/misc/remnote/default.nix
+++ b/pkgs/applications/misc/remnote/default.nix
@@ -5,10 +5,10 @@
 }:
 let
   pname = "remnote";
-  version = "1.16.4";
+  version = "1.16.18";
   src = fetchurl {
-    url = "https://download.remnote.io/remnote-desktop/RemNote-${version}.AppImage";
-    hash = "sha256-dgbQ0cbPq7BSQ9VwwH6+GoAxb85HDxRixfjeDJBtOrg=";
+    url = "https://download2.remnote.io/remnote-desktop2/RemNote-${version}.AppImage";
+    hash = "sha256-ps7Rl1oA2QOPvO2XeCY8DrWtCV9WPlX9jbhypz2ZARA=";
   };
   appimageContents = appimageTools.extractType2 { inherit pname version src; };
 in


### PR DESCRIPTION
## Description of changes
- Refactored / simplified code (e.g. icon and .desktop file now come directly from appimage)
- Updated from 1.16.4 to 1.16.18
https://feedback.remnote.com/changelog/1-16-14

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
