### PR TITLE
signal-backup-deduplicator: init at 0-unstable-2024-05-24

### DIFF
--- a/pkgs/by-name/si/signal-backup-deduplicator/package.nix
+++ b/pkgs/by-name/si/signal-backup-deduplicator/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cmake,
+  cryptopp,
+  protobuf,
+}:
+
+stdenv.mkDerivation {
+  pname = "signal-backup-deduplicator";
+  version = "0-unstable-2024-05-24";
+
+  src = fetchFromGitLab {
+    owner = "gerum";
+    repo = "signal-backup-deduplicator";
+    rev = "6c09f14b16ff47c2ed0914c68102e45c93ebbfa6";
+    hash = "sha256-JR2Qu4EtTMObM/BvxQS5WwGFqWj9g0bqOpKt4y5UNaM=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    protobuf
+    cryptopp
+  ];
+
+  meta = {
+    description = "Generate chunked backups for Signal messages";
+    homepage = "https://gitlab.com/gerum/signal-backup-deduplicator";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "signal_backup_deduplicate";
+    platforms = lib.platforms.all;
+    # ld: symbol(s) not found for architecture ...
+    broken = stdenv.isDarwin;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add [signal-backup-deduplicator](https://gitlab.com/gerum/signal-backup-deduplicator).
Motivation: https://github.com/signalapp/Signal-Android/pull/11900#issuecomment-2129772218

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
