### PR TITLE
nextcloudPackages.richdocuments: init

### DIFF
--- a/pkgs/servers/nextcloud/packages/27.json
+++ b/pkgs/servers/nextcloud/packages/27.json
@@ -269,6 +269,16 @@
       "agpl"
     ]
   },
+  "richdocuments": {
+    "sha256": "161v7gb0zg3anr3322ar2m3f6y0zf5cqrwfdsb04p6pqvfpsy9wh",
+    "url": "https://github.com/nextcloud-releases/richdocuments/releases/download/v8.2.10/richdocuments-v8.2.10.tar.gz",
+    "version": "8.2.10",
+    "description": "This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.\n\nYou can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.",
+    "homepage": "https://collaboraoffice.com/",
+    "licenses": [
+      "agpl"
+    ]
+  },
   "spreed": {
     "sha256": "0699c9xfmzk48q0f48lxw16h9l2300w6vp1sn2vb8wr76fbhm9kf",
     "url": "https://github.com/nextcloud-releases/spreed/releases/download/v17.1.8/spreed-v17.1.8.tar.gz",

--- a/pkgs/servers/nextcloud/packages/28.json
+++ b/pkgs/servers/nextcloud/packages/28.json
@@ -239,6 +239,16 @@
       "agpl"
     ]
   },
+  "richdocuments": {
+    "sha256": "1rpbzcxi6n656351rlx1gpg2nwz0z5i4107adls9fh1cdvj9vqs6",
+    "url": "https://github.com/nextcloud-releases/richdocuments/releases/download/v8.3.7/richdocuments-v8.3.7.tar.gz",
+    "version": "8.3.7",
+    "description": "This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.\n\nYou can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.",
+    "homepage": "https://collaboraoffice.com/",
+    "licenses": [
+      "agpl"
+    ]
+  },
   "spreed": {
     "sha256": "1d6y473xnlc2n3k9hqb2n2zk780pran77k4frbgfyikinbadd1ci",
     "url": "https://github.com/nextcloud-releases/spreed/releases/download/v18.0.7/spreed-v18.0.7.tar.gz",

--- a/pkgs/servers/nextcloud/packages/29.json
+++ b/pkgs/servers/nextcloud/packages/29.json
@@ -239,6 +239,16 @@
       "agpl"
     ]
   },
+  "richdocuments": {
+    "sha256": "1gbgygb7ymsg7gjb29r3caglsrimcrk7yn4kka5f8swv9b1k0qx6",
+    "url": "https://github.com/nextcloud-releases/richdocuments/releases/download/v8.4.2/richdocuments-v8.4.2.tar.gz",
+    "version": "8.4.2",
+    "description": "This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.\n\nYou can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.",
+    "homepage": "https://collaboraoffice.com/",
+    "licenses": [
+      "agpl"
+    ]
+  },
   "spreed": {
     "sha256": "07zjf8ci2jysrv0bagcrdfz2afzafha7fs3045p5kzb9zr6yvpy5",
     "url": "https://github.com/nextcloud-releases/spreed/releases/download/v19.0.0/spreed-v19.0.0.tar.gz",

--- a/pkgs/servers/nextcloud/packages/nextcloud-apps.json
+++ b/pkgs/servers/nextcloud/packages/nextcloud-apps.json
@@ -26,6 +26,7 @@
 , "previewgenerator": "agpl3Plus"
 , "qownnotesapi": "agpl3Plus"
 , "registration": "agpl3Plus"
+, "richdocuments": "agpl3Only"
 , "spreed": "agpl3Plus"
 , "tasks": "agpl3Plus"
 , "twofactor_nextcloud_notification": "agpl3Only"


### PR DESCRIPTION
This is the "Nextcloud Office" app that offers Collabora CODE integration.

You still need Collabora CODE itself running somewhere but this is one step towards https://github.com/NixOS/nixpkgs/issues/218878.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
