### PR TITLE
mixxx: 2.4.0 -> 2.4.1

### DIFF
--- a/pkgs/applications/audio/mixxx/default.nix
+++ b/pkgs/applications/audio/mixxx/default.nix
@@ -147,7 +147,7 @@ mkDerivation rec {
     description = "Digital DJ mixing software";
     mainProgram = "mixxx";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ goibhniu bfortz ];
+    maintainers = with maintainers; [ goibhniu bfortz benley ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/audio/mixxx/default.nix
+++ b/pkgs/applications/audio/mixxx/default.nix
@@ -57,13 +57,13 @@
 
 mkDerivation rec {
   pname = "mixxx";
-  version = "2.4.0";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "mixxxdj";
     repo = "mixxx";
     rev = version;
-    hash = "sha256-JSWUzerm7D6AKq6g/9eRrt3EE2movRdM+VLUg07sLHo=";
+    hash = "sha256-BOdXgA+z3sFE4ngAEhSbp1gDbsti1STJY2Yy6Hp+zTE=";
   };
 
   nativeBuildInputs = [ cmake pkg-config wrapGAppsHook3 ];

--- a/pkgs/by-name/li/libdjinterop/package.nix
+++ b/pkgs/by-name/li/libdjinterop/package.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "xsco";
     repo = "libdjinterop";
-    rev = "0.20.1";
-    hash = "sha256-/iXSRJVFPWqUTVz7z0BNWCq5LOqdNuTI+wx/34JAZfc=";
+    rev = "0.20.2";
+    hash = "sha256-eTr9ax/bZWazLhLLQG6XUgqiM+7LVieh5ruA0EaUaj0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

- mixxx version bump
- add benley to maintainers
- libdjinterop version bump

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
