### PR TITLE
jdk: misc cleanup

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk15-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk15-darwin.nix
@@ -4,8 +4,8 @@ let
   sources = lib.importJSON ./sources.json;
 in
 {
-  jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jdk.hotspot; };
-  jre-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jre.hotspot; };
-  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jdk.openj9; };
-  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jre.openj9; };
+  jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jdk.hotspot; knownVulnerabilities = [ "Support ended" ]; };
+  jre-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jre.hotspot; knownVulnerabilities = [ "Support ended" ]; };
+  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jdk.openj9; knownVulnerabilities = [ "Support ended" ]; };
+  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jre.openj9; knownVulnerabilities = [ "Support ended" ]; };
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk15-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk15-linux.nix
@@ -5,8 +5,8 @@ let
   sources = lib.importJSON ./sources.json;
 in
 {
-  jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jdk.hotspot; };
-  jre-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jre.hotspot; };
-  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jdk.openj9; };
-  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jre.openj9; };
+  jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jdk.hotspot; knownVulnerabilities = [ "Support ended" ]; };
+  jre-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jre.hotspot; knownVulnerabilities = [ "Support ended" ]; };
+  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jdk.openj9; knownVulnerabilities = [ "Support ended" ]; };
+  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jre.openj9; knownVulnerabilities = [ "Support ended" ]; };
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk16-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk16-darwin.nix
@@ -4,8 +4,8 @@ let
   sources = lib.importJSON ./sources.json;
 in
 {
-  jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jdk.hotspot; };
-  jre-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jre.hotspot; };
-  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jdk.openj9; };
-  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jre.openj9; };
+  jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jdk.hotspot; knownVulnerabilities = [ "Support ended" ]; };
+  jre-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jre.hotspot; knownVulnerabilities = [ "Support ended" ]; };
+  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jdk.openj9; knownVulnerabilities = [ "Support ended" ]; };
+  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jre.openj9; knownVulnerabilities = [ "Support ended" ]; };
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk16-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk16-linux.nix
@@ -5,8 +5,8 @@ let
   sources = lib.importJSON ./sources.json;
 in
 {
-  jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jdk.hotspot; };
-  jre-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jre.hotspot; };
-  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jdk.openj9; };
-  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jre.openj9; };
+  jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jdk.hotspot; knownVulnerabilities = [ "Support ended" ]; };
+  jre-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jre.hotspot; knownVulnerabilities = [ "Support ended" ]; };
+  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jdk.openj9; knownVulnerabilities = [ "Support ended" ]; };
+  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jre.openj9; knownVulnerabilities = [ "Support ended" ]; };
 }

--- a/pkgs/development/compilers/corretto/11.nix
+++ b/pkgs/development/compilers/corretto/11.nix
@@ -1,5 +1,4 @@
-{ corretto11
-, fetchFromGitHub
+{ fetchFromGitHub
 , gradle_7
 , jdk11
 , lib

--- a/pkgs/development/compilers/corretto/17.nix
+++ b/pkgs/development/compilers/corretto/17.nix
@@ -1,5 +1,4 @@
-{ corretto17
-, fetchFromGitHub
+{ fetchFromGitHub
 , gradle_7
 , jdk17
 , lib

--- a/pkgs/development/compilers/corretto/19.nix
+++ b/pkgs/development/compilers/corretto/19.nix
@@ -10,7 +10,7 @@
 }:
 
 let
-  corretto = import ./mk-corretto.nix {
+  corretto = import ./mk-corretto.nix rec {
     inherit lib stdenv rsync runCommand testers;
     jdk = jdk19;
     gradle = gradle_7;
@@ -18,7 +18,7 @@ let
     src = fetchFromGitHub {
       owner = "corretto";
       repo = "corretto-19";
-      rev = "72f064a1d716272bd17d4e425d4a264b2c2c7d36";
+      rev = version;
       sha256 = "sha256-mEj/MIbdXU0+fF5RhqjPuSeyclstesGaXB0e48YlKuw=";
     };
   };

--- a/pkgs/development/compilers/corretto/19.nix
+++ b/pkgs/development/compilers/corretto/19.nix
@@ -1,5 +1,4 @@
-{ corretto19
-, fetchFromGitHub
+{ fetchFromGitHub
 , gradle_7
 , jdk19
 , lib

--- a/pkgs/development/compilers/corretto/21.nix
+++ b/pkgs/development/compilers/corretto/21.nix
@@ -10,7 +10,7 @@
 }:
 
 let
-  corretto = import ./mk-corretto.nix {
+  corretto = import ./mk-corretto.nix rec {
     inherit lib stdenv rsync runCommand testers;
     jdk = jdk21;
     gradle = gradle_7;
@@ -18,7 +18,7 @@ let
     src = fetchFromGitHub {
       owner = "corretto";
       repo = "corretto-21";
-      rev = "97b366227b4dc8f5a89bbedea88b0b18c9e21886";
+      rev = version;
       sha256 = "sha256-V8UDyukDCQVTWUg4IpSKoY0qnnQ5fePbm3rxcw06Vr0=";
     };
   };

--- a/pkgs/development/compilers/openjdk/meta.nix
+++ b/pkgs/development/compilers/openjdk/meta.nix
@@ -2,7 +2,7 @@ lib: version: with lib; {
   homepage = "https://openjdk.java.net/";
   license = licenses.gpl2Only;
   description = "The open-source Java Development Kit";
-  maintainers = with maintainers; [ edwtjo ];
+  maintainers = with maintainers; [ edwtjo infinidoge ];
   platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" "powerpc64le-linux" ];
   mainProgram = "java";
   knownVulnerabilities = optionals (builtins.elem (versions.major version) [ "12" "13" "14" "15" "16" "18" "19" "20" ]) [

--- a/pkgs/development/compilers/openjdk/meta.nix
+++ b/pkgs/development/compilers/openjdk/meta.nix
@@ -5,7 +5,7 @@ lib: version: with lib; {
   maintainers = with maintainers; [ edwtjo ];
   platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" "powerpc64le-linux" ];
   mainProgram = "java";
-  knownVulnerabilities = optionals (builtins.elem (versions.major version) [ "12" "13" "14" "15" "16" "18" ]) [
+  knownVulnerabilities = optionals (builtins.elem (versions.major version) [ "12" "13" "14" "15" "16" "18" "19" "20" ]) [
     "This OpenJDK version has reached its end of life."
   ];
 }

--- a/pkgs/development/compilers/openjdk/openjfx/19.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/19.nix
@@ -141,5 +141,8 @@ in makePackage {
     description = "The next-generation Java client toolkit";
     maintainers = with maintainers; [ abbradar ];
     platforms = platforms.unix;
+    knownVulnerabilities = [
+      "This OpenJFX version has reached its end of life."
+    ];
   };
 }

--- a/pkgs/development/compilers/openjdk/openjfx/20.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/20.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, writeText, openjdk17_headless
-, openjdk19_headless, gradle_7, pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst
+, openjdk20_headless, gradle_7, pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst
 , libXxf86vm, glib, alsa-lib, ffmpeg_4, python3, ruby, fetchurl, runCommand
 , withMedia ? true
 , withWebKit ? false
@@ -49,7 +49,7 @@ let
 
     config = writeText "gradle.properties" (''
       CONF = Release
-      JDK_HOME = ${openjdk19_headless.home}
+      JDK_HOME = ${openjdk20_headless.home}
     '' + args.gradleProperties or "");
 
     buildPhase = ''
@@ -111,14 +111,14 @@ in makePackage {
 
   postFixup = ''
     # Remove references to bootstrap.
-    export openjdkOutPath='${openjdk19_headless.outPath}'
+    export openjdkOutPath='${openjdk20_headless.outPath}'
     find "$out" -name \*.so | while read lib; do
       new_refs="$(patchelf --print-rpath "$lib" | perl -pe 's,:?\Q$ENV{openjdkOutPath}\E[^:]*,,')"
       patchelf --set-rpath "$new_refs" "$lib"
     done
   '';
 
-  disallowedReferences = [ openjdk17_headless openjdk19_headless ];
+  disallowedReferences = [ openjdk17_headless openjdk20_headless ];
 
   passthru.deps = deps;
 

--- a/pkgs/development/compilers/openjdk/openjfx/20.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/20.nix
@@ -128,5 +128,8 @@ in makePackage {
     description = "The next-generation Java client toolkit";
     maintainers = with maintainers; [ abbradar ];
     platforms = platforms.unix;
+    knownVulnerabilities = [
+      "This OpenJFX version has reached its end of life."
+    ];
   };
 }

--- a/pkgs/development/compilers/openjdk/openjfx/21.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/21.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, writeText, openjdk17_headless
-, openjdk19_headless, gradle_7, pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst
+, openjdk21_headless, gradle_7, pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst
 , libXxf86vm, glib, alsa-lib, ffmpeg_4, python3, ruby, fetchurl, runCommand
 , withMedia ? true
 , withWebKit ? false
@@ -49,7 +49,7 @@ let
 
     config = writeText "gradle.properties" (''
       CONF = Release
-      JDK_HOME = ${openjdk19_headless.home}
+      JDK_HOME = ${openjdk21_headless.home}
     '' + args.gradleProperties or "");
 
     buildPhase = ''
@@ -111,14 +111,14 @@ in makePackage {
 
   postFixup = ''
     # Remove references to bootstrap.
-    export openjdkOutPath='${openjdk19_headless.outPath}'
+    export openjdkOutPath='${openjdk21_headless.outPath}'
     find "$out" -name \*.so | while read lib; do
       new_refs="$(patchelf --print-rpath "$lib" | perl -pe 's,:?\Q$ENV{openjdkOutPath}\E[^:]*,,')"
       patchelf --set-rpath "$new_refs" "$lib"
     done
   '';
 
-  disallowedReferences = [ openjdk17_headless openjdk19_headless ];
+  disallowedReferences = [ openjdk17_headless openjdk21_headless ];
 
   passthru.deps = deps;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16094,8 +16094,6 @@ with pkgs;
   jdk17 = openjdk17;
   jdk17_headless = openjdk17_headless;
 
-  openjdk16-bootstrap = javaPackages.compiler.openjdk16-bootstrap;
-
   openjdk19 = javaPackages.compiler.openjdk19;
   openjdk19_headless = javaPackages.compiler.openjdk19.headless;
   jdk19 = openjdk19;


### PR DESCRIPTION
## Description of changes

Split from #286267

CCing @thiagokokada @philiptaron as previous reviewers

~~Bumps the JDK/JFX 21 versions to their respective latest versions, as well as miscellaneous cleanup of both~~

Rebased out version bump in favor of #313928, folded in #314384 to make this a cleanup PR.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
