### PR TITLE
Simplify tensorflow-build by aligning its protobuf with rest of nixpkgs

### DIFF
--- a/pkgs/development/python-modules/tensorflow/com_google_absl_add_log.patch
+++ b/pkgs/development/python-modules/tensorflow/com_google_absl_add_log.patch
@@ -1,7 +1,7 @@
 diff -Naurd x/third_party/absl/system.absl.base.BUILD y/third_party/absl/system.absl.base.BUILD
 --- x/third_party/absl/system.absl.base.BUILD	2023-09-17 09:12:05.499753364 +0000
 +++ y/third_party/absl/system.absl.base.BUILD	2023-09-17 09:16:01.200082822 +0000
-@@ -22,7 +22,12 @@
+@@ -22,7 +22,13 @@
  
  cc_library(
      name = "raw_logging_internal",
@@ -11,6 +11,7 @@ diff -Naurd x/third_party/absl/system.absl.base.BUILD y/third_party/absl/system.
 +        "-labsl_log_internal_conditions",
 +        "-labsl_log_internal_message",
 +        "-labsl_log_internal_nullguard",
++        "-labsl_log_internal_check_op",
 +    ],
      visibility = [
          "//absl:__subpackages__",

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -343,6 +343,12 @@ let
         url = "https://raw.githubusercontent.com/conda-forge/tensorflow-feedstock/0a63c5a962451b4da99a9948323d8b3ed462f461/recipe/patches/0001-Omit-linking-to-layout_proto_cc-if-protobuf-linkage-.patch";
         hash = "sha256-/7buV6DinKnrgfqbe7KKSh9rCebeQdXv2Uj+Xg/083w=";
       })
+      # https://github.com/wangjiezhe/gentoo-local/commit/e0d4c42879a45d4d772ba0f2e735ba3cd77dc7ba#diff-1b47c7fc3c0a9ebd0f5e377aa655533743b78b6125f43e1886cac1109570f9c6
+      (fetchpatch {
+        name = "fix-gcc-13-build-issue.patch";
+        url = "https://raw.githubusercontent.com/wangjiezhe/gentoo-local/e0d4c42879a45d4d772ba0f2e735ba3cd77dc7ba/sci-libs/tensorflow/files/tensorflow-2.13.0-0013-Fixing-build-issue-with-Clang-16-and-GCC-13.patch";
+        hash = "sha256-HQ4NlxoiTjvFHlj9qb7zVaDG5uR8sgzzou4tiqD9ZmI=";
+      })
       ./com_google_absl_add_log.patch
       ./absl_py_argparse_flags.patch
       ./protobuf_python.patch

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14577,69 +14577,15 @@ self: super: with self; {
     inherit (pkgs.config) cudaSupport;
   };
 
-  tensorflow-build = let
-    compat = rec {
-      protobufTF = pkgs.protobuf_21.override {
-        abseil-cpp = pkgs.abseil-cpp_202301;
-      };
-      grpcTF = (pkgs.grpc.overrideAttrs (
-        oldAttrs: rec {
-          # nvcc fails on recent grpc versions, so we use the latest patch level
-          #  of the grpc version bundled by upstream tensorflow to allow CUDA
-          #  support
-          version = "1.27.3";
-          src = pkgs.fetchFromGitHub {
-            owner = "grpc";
-            repo = "grpc";
-            rev = "v${version}";
-            hash = "sha256-PpiOT4ZJe1uMp5j+ReQulC9jpT0xoR2sAl6vRYKA0AA=";
-            fetchSubmodules = true;
-          };
-          patches = [ ];
-          postPatch = ''
-            sed -i "s/-std=c++11/-std=c++17/" CMakeLists.txt
-            echo "set(CMAKE_CXX_STANDARD 17)" >> CMakeLists.txt
-          '';
-        })
-      ).override {
-        protobuf = protobufTF;
-      };
-      protobuf-pythonTF = self.protobuf.override {
-        protobuf = protobufTF;
-      };
-      grpcioTF = self.grpcio.override {
-        protobuf = protobufTF;
-        grpc = grpcTF;
-      };
-      tensorboard-plugin-profileTF = self.tensorboard-plugin-profile.override {
-        protobuf = protobuf-pythonTF;
-      };
-      tensorboardTF = self.tensorboard.override {
-        grpcio = grpcioTF;
-        protobuf = protobuf-pythonTF;
-        tensorboard-plugin-profile = tensorboard-plugin-profileTF;
-      };
-    };
-  in
-  callPackage ../development/python-modules/tensorflow {
+  tensorflow-build = callPackage ../development/python-modules/tensorflow {
     inherit (pkgs.darwin) cctools;
     inherit (pkgs.config) cudaSupport;
     inherit (pkgs.darwin.apple_sdk.frameworks) Foundation Security;
     flatbuffers-core = pkgs.flatbuffers;
     flatbuffers-python = self.flatbuffers;
-    protobuf-core = compat.protobufTF;
-    protobuf-python = compat.protobuf-pythonTF;
-    grpc = compat.grpcTF;
-    grpcio = compat.grpcioTF;
-    tensorboard = compat.tensorboardTF;
+    protobuf-core = pkgs.protobuf;
+    protobuf-python = self.protobuf;
     abseil-cpp = pkgs.abseil-cpp_202301;
-
-    # Tensorflow 2.13 doesn't support gcc13:
-    # https://github.com/tensorflow/tensorflow/issues/61289
-    #
-    # We use the nixpkgs' default libstdc++ to stay compatible with other
-    # python modules
-    stdenv = pkgs.stdenvAdapters.useLibsFrom stdenv pkgs.gcc12Stdenv;
   };
 
   tensorflow-datasets = callPackage ../development/python-modules/tensorflow-datasets { };


### PR DESCRIPTION
## Description of changes

Tensorflow's dependencies has complicated overrides due to various grpc / protobuf / nvcc issues. We no longer see these issues are the current versions on nixpkgs.

When using packages like [transformers](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/transformers/default.nix) that depends on both tensorflow & pytorch, we ran into a fatal glibc error because the version of protobuf was not aligned.

```
Fatal glibc error: pthread_mutex_lock.c:94 (___pthread_mutex_lock): assertion failed: mutex->__data.__owner == 0
Error: signal 6:
  0 | libc.so.6             | 
  1 | libc.so.6             | 
  2 | libc.so.6             | raise
  3 | libc.so.6             | abort
  4 | libc.so.6             | 
  5 | libc.so.6             | 
  6 | libc.so.6             | pthread_mutex_lock
  7 | libprotobuf.so.32     | google::protobuf::DescriptorPool::FindFileByName(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const
  8 | libprotobuf.so.32     |
  9 | libc.so.6             |
 10 | libprotobuf.so.32     | google::protobuf::internal::AssignDescriptors(google::protobuf::internal::DescriptorTable const* (*)(), std::once_flag*, google::protobuf::Metadata c
onst&)
 11 | libprotobuf.so.24.4.0 | google::protobuf::TextFormat::Parser::Parse(google::protobuf::io::ZeroCopyInputStream*, google::protobuf::Message*)
 12 | libtensorflow_cc.so.2 | tensorflow::ParseTextProto(std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, google::prot
obuf::Message*)
 13 | libtensorflow_cc.so.2 | tensorflow::LoadProtoFromBuffer(std::basic_string_view<char, std::char_traits<char> >, google::protobuf::Message*)
 14 | libtensorflow_cc.so.2 |
 ```
 
Applying the changes in this PR addressed the issue and simplified tensorflow.

## Things done

I modified the `com_google_absl_add_log.patch` because otherwise fails with this error:

```
.../libtensorflow_framework.so.2: undefined reference to symbol '_ZN4absl12lts_2023012512log_internal21CheckOpMessageBuilder7ForVar2Ev'  
.../libabsl_log_internal_check_op.so.2301.0.0: error adding symbols: DSO missing from command line 
```

Which demangles to:

```
absl::lts_20230125::log_internal::CheckOpMessageBuilder::ForVar2()
```

Which can be addressed by including the linker flag in the appropriate BUILD file in tensorflow:

```
"-labsl_log_internal_check_op",
```

The other change addresses the incompatibility with gcc13 / clang16.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
