### PR TITLE
k3s: documentation updates

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/README.md
+++ b/pkgs/applications/networking/cluster/k3s/README.md
@@ -1,114 +1,21 @@
-# k3s versions
+# K3s
 
-K3s, Kubernetes, and other clustered software has the property of not being able to update atomically. Most software in nixpkgs, like for example bash, can be updated as part of a "nixos-rebuild switch" without having to worry about the old and the new bash interacting in some way.
+K3s is a simplified [Kubernetes](https://wiki.nixos.org/wiki/Kubernetes) version that bundles  Kubernetes cluster components into a few small binaries optimized for Edge and IoT devices.
 
-K3s/Kubernetes, on the other hand, is typically run across several NixOS machines, and each NixOS machine is updated independently. As such, different versions of the package and NixOS module must maintain compatibility with each other through temporary version skew during updates.
+## Usage
 
-The upstream Kubernetes project [documents this in their version-skew policy](https://kubernetes.io/releases/version-skew-policy/#supported-component-upgrade-order).
+* [Module Usage](docs/USAGE.md).
 
-Within nixpkgs, we strive to maintain a valid "upgrade path" that does not run
-afoul of the upstream version skew policy.
+## Configuration Examples
 
-## Upstream release cadence and support
+* [Nvidia GPU Passthru](docs/examples/NVIDIA.md)
+* [Storage Examples](docs/examples/STORAGE.md)
 
-K3s is built on top of K8s, and typically provides a similar release cadence and support window (simply by cherry-picking over k8s patches). As such, we assume k3s's support lifecycle is identical to upstream K8s.
+## Cluster Maintenance and Troubleshooting
 
-This is documented upstream [here](https://kubernetes.io/releases/patch-releases/#support-period).
+* [Cluster Upkeep](docs/CLUSTER_UPKEEP.md).
 
-In short, a new Kubernetes version is released roughly every 4 months, and each release is supported for a little over 1 year.
+## K3s Package Upkeep
 
-Any version that is not supported by upstream should be dropped from nixpkgs.
-
-## Versions in NixOS releases
-
-NixOS releases should avoid having deprecated software, or making major version upgrades, wherever possible.
-
-As such, we would like to have only the newest K3s version in each NixOS
-release at the time the release branch is branched off, which will ensure the
-K3s version in that release will receive updates for the longest duration
-possible.
-
-However, this conflicts with another desire: we would like people to be able to upgrade between NixOS stable releases without needing to make a large enough k3s version jump that they violate the Kubernetes version skew policy.
-
-To give an example, we may have the following timeline for k8s releases:
-
-(Note, the exact versions and dates may be wrong, this is an illustrative example, reality may differ).
-
-```mermaid
-gitGraph
-    branch k8s
-    commit
-    branch "k8s-1.24"
-    checkout "k8s-1.24"
-    commit id: "1.24.0" tag: "2022-05-03"
-    branch "k8s-1.25"
-    checkout "k8s-1.25"
-    commit id: "1.25.0" tag: "2022-08-23"
-    branch "k8s-1.26"
-    checkout "k8s-1.26"
-    commit id: "1.26.0" tag: "2022-12-08"
-    checkout k8s-1.24
-    commit id: "1.24-EOL" tag: "2023-07-28"
-    checkout k8s-1.25
-    commit id: "1.25-EOL" tag: "2023-10-27"
-    checkout k8s-1.26
-    commit id: "1.26-EOL" tag: "2024-02-28"
-```
-
-(Note: the above graph will render if you view this markdown on GitHub, or when using [mermaid](https://mermaid.js.org/))
-
-In this scenario even though k3s 1.24 is still technically supported when the NixOS 23.05
-release is cut, since it goes EOL before the NixOS 23.11 release is made, we would
-not want to include it. Similarly, k3s 1.25 would go EOL before NixOS 23.11.
-
-As such, we should only include k3s 1.26 in the 23.05 release.
-
-We can then make a similar argument when NixOS 23.11 comes around to not
-include k3s 1.26 or 1.27. However, that means someone upgrading from the NixOS
-22.05 release to the NixOS 23.11 would not have a supported upgrade path.
-
-In order to resolve this issue, we propose backporting not just new patch releases to older NixOS releases, but also new k3s versions, up to one version before the first version that is included in the next NixOS release.
-
-In the above example, where NixOS 23.05 included k3s 1.26, and 23.11 included k3s 1.28, that means we would backport 1.27 to the NixOS 23.05 release, and backport all patches for 1.26 and 1.27.
-This would allow someone to upgrade between those NixOS releases in a supported configuration.
-
-
-## K3s upkeep for nixpkgs maintainers
-
-* After every nixos release, K3s maintainers should remove from `nixos-unstable` all K3s versions that exist in `nixos-stable` except the latest version (to allow decoupling system upgrade from k3s upgrade).
-
-* Whenever adding a new major/minor K3s version to nixpkgs:
-  - update `k3s` alias to the latest version.
-  - add a NixOS release note scheduling the removal of deprecated K3s packages
-  - include migration information from both Kubernetes and K3s projects
-
-* For version patch upgrades, use the K3s update script.
-
-  To execute the update script, from nixpkgs git repository, run:
-
-  > ./pkgs/applications/networking/cluster/k3s/update-script.sh "29"
-
-  "29" being the target minor version to be updated.
-
-  On failure, the update script should be fixed. On failing to fix, open an issue reporting the update script breakage.
-
-  RyanTM bot can automatically do patch upgrades. Update logs are available at: https://r.ryantm.com/log/k3s_1_29/
-
-* When reviewing upgrades, check:
-
-  - At top-level, every K3s version should have the Go compiler pinned according to `go.mod` file.
-
-    Notice the update script does not automatically pin the Go version.
-
-  - K3s passthru.tests (Currently: single-node, multi-node, etcd) works for all architectures (linux-x86_64, aarch64-linux).
-
-    For GitHub CI, [OfBorg](https://github.com/NixOS/ofborg) can be used to test all platforms.
-
-    To test locally, at nixpkgs repository, run:
-    > nix build .#k3s_1_29.passthru.tests.{etcd,single-node,multi-node}
-
-    Replace "29" according to the version that you are testing.
-
-  - Read the nix build logs to check for anything unusual. (Obvious but underrated.)
-
-* Thanks for reading the documentation and your continued contribution.
+* [Package Versioning Rationale](docs/VERSIONING.md)
+* [Package Maintenance Documentation](docs/PKG_UPKEEP.md)

--- a/pkgs/applications/networking/cluster/k3s/docs/CLUSTER_UPKEEP.md
+++ b/pkgs/applications/networking/cluster/k3s/docs/CLUSTER_UPKEEP.md
@@ -1,0 +1,86 @@
+
+# K3s Upkeep for Users
+
+General documentation for the K3s user for cluster tasks and troubleshooting steps.
+
+## Upkeep
+
+### Changing K3s Token
+
+Changing the K3s token requires resetting cluster. To reset the cluster, you must do the following:
+
+#### Stopping K3s
+
+Disabling K3s NixOS module won't stop K3s related dependencies, such as containerd or networking. For stopping everything, either run "k3s-killall.sh" script (available on $PATH under `/run/current-system/sw/bin/k3s-killall.sh`) or reboot host.
+
+### Syncing K3s in multiple hosts
+
+Nix automatically syncs hosts to `configuration.nix`, for syncing configuration.nix's git repository and triggering `nixos-rebuild switch` in multiple hosts, it is commonly used `ansible`, which enables automation of cluster provisioning, upgrade and reset.
+
+### Cluster Reset
+
+As upstream "k3s-uninstall.sh" is yet to be packaged for NixOS, it's necessary to run manual steps for resetting cluster.
+
+Disable K3s instances in **all** hosts:
+
+In NixOS configuration, set:
+```
+ services.k3s.enable = false;
+```
+Rebuild NixOS. This is going to remove K3s service files. But it won't delete K3s data.
+
+To delete K3s files:
+
+Dismount kubelet:
+```
+ KUBELET_PATH=$(mount | grep kubelet | cut -d' ' -f3);
+ ${KUBELET_PATH:+umount $KUBELET_PATH}
+```
+Delete k3s data:
+```
+ rm -rf /etc/rancher/{k3s,node};
+ rm -rf /var/lib/{rancher/k3s,kubelet,longhorn,etcd,cni}
+```
+When using Etcd, Reset Etcd:
+
+Certify **all** K3s instances are stopped, because a single instance can re-seed etcd database with previous cryptographic key.
+
+Disable etcd database in NixOS configuration:
+```
+ services.etcd.enable = false;
+```
+Rebuild NixOS.
+
+Delete etcd files:
+```
+ rm -rf /var/lib/etcd/
+```
+Reboot hosts.
+
+In NixOS configuration:
+```
+ Re-enable Etcd first. Rebuild NixOS. Certify service health. (systemctl status etcd)
+ Re-enable K3s second. Rebuild NixOS. Certify service health. (systemctl status k3s)
+```
+Etcd & K3s cluster will be provisioned new.
+
+Tip: Use Ansible to automate reset routine, like this.
+
+## Troubleshooting
+
+### Raspberry Pi not working
+
+If the k3s.service/k3s server does not start and gives you the error FATA[0000] failed to find memory cgroup (v2) Here's the github issue: https://github.com/k3s-io/k3s/issues/2067 .
+
+To fix the problem, you can add these things to your configuration.nix.
+```
+  boot.kernelParams = [
+    "cgroup_enable=cpuset" "cgroup_memory=1" "cgroup_enable=memory"
+  ];
+```
+
+### FailedKillPod: failed to get network "cbr0" cached result
+
+> KillPodSandboxError: failed to get network "cbr0" cached result: decoding version from network config: unexpected end of JSON input
+
+Workaround: https://github.com/k3s-io/k3s/issues/6185#issuecomment-1581245331

--- a/pkgs/applications/networking/cluster/k3s/docs/PKG_UPKEEP.md
+++ b/pkgs/applications/networking/cluster/k3s/docs/PKG_UPKEEP.md
@@ -1,0 +1,60 @@
+
+# K3s Upkeep for Maintainers
+
+General documentation for the K3s maintainer and reviewer use for consistency in maintenance processes.
+
+## NixOS Release Maintenance
+
+This process split into two sections and adheres to the versioning policy outlined in [VERSIONING.md](VERSIONING.md).
+
+### Pre-Release
+
+* Prior to the breaking change window of the next release being closed:
+  * `nixos-unstable`: Ensure k3s points to latest versioned release
+  * `nixos-unstable`: Ensure release notes are up to date
+  * `nixos-unstable`: Remove k3s releases which will be end of life upstream prior to end-of-life for the next NixOS stable release are removed with proper deprecation notice (process listed below)
+
+### Post-Release
+
+* For major/minor releases of k3s:
+  * `nixos-unstable`: Create a new versioned k3s package
+  * `nixos-unstable`: Update k3s alias to point to new versioned k3s package
+  * `nixos-unstable`: Add NixOS Release note denoting:
+    * Removal of deprecated K3s packages
+    * Migration information from the Kubernetes and K3s projects
+  * `nixos-stable`: Backport the versioned package
+* For patch releases of existing packages:
+  * `nixos-unstable`: Update package version (process listed below)
+  * `nixos-stable`: Backport package update done to nixos-unstable
+
+## Patch Upgrade Process
+
+Patch upgrades can use the [update script](../update-script.sh) in the root of the package. To update k3s 1.30.x, for example, you can run the following from the root of the nixpkgs git repo:
+
+> ./pkgs/applications/networking/cluster/k3s/update-script.sh "30"
+
+To update another version, just replace the `"30"` with the appropriate minor revision.
+
+If the script should fail, the first goal would be to fix the script. If you are unable to fix the script, open an issue reporting the update script failure with the exact command used and the failure observed.
+
+RyanTM bot can automatically do patch upgrades. Update logs are available at versioned urls, e.g. for 1.30.x: https://r.ryantm.com/log/k3s_1_30
+
+## Package Removal Process
+
+Package removal policy and timelines follow our reasoning in the [versioning documentation](VERSIONING.md#patch-release-support-lifecycle). In order to remove a versioned k3s package, create a PR achieving the following:
+
+* Remove the versioned folder containing the chart and package version files (e.g. `./1_30/`)
+* Remove the package block from [default.nix](../default.nix) (e.g. `k3s_1_30 = ...`)
+* Remove the package reference from [pkgs/top-level/all-packages.nix](/pkgs/top-level/all-packages.nix)
+* Add a deprecation notice in [pkgs/top-level/aliases.nix](/pkgs/top-level/aliases.nix), such as `k3s_1_26 = throw "'k3s_1_26' has been removed from nixpkgs as it has reached end of life"; # Added 2024-05-20`.
+
+## Change Request Review Process
+
+Quick checklist for reviewers of the k3s package:
+
+* Is the version of the Go compiler pinned according to the go.mod file for the release?
+  * Update script will not pin nor change the go version.
+* Do the K3s passthru.tests work for all architectures supported? (linux-x86_64, aarch64-linux)
+  * For GitHub CI, [OfBorg](https://github.com/NixOS/ofborg) can be used to test all platforms.
+  * For Local testing, the following can be run in nixpkgs root on the upgrade branch: `nix build .#k3s_1_29.passthru.tests.{etcd,single-node,multi-node}` (Replace "29" to the version tested)
+* Anything unusual in the nix build logs or test logs?

--- a/pkgs/applications/networking/cluster/k3s/docs/USAGE.md
+++ b/pkgs/applications/networking/cluster/k3s/docs/USAGE.md
@@ -1,0 +1,57 @@
+# K3s Usage
+
+## Single Node
+
+```
+{
+  networking.firewall.allowedTCPPorts = [
+    6443 # k3s: required so that pods can reach the API server (running on port 6443 by default)
+    # 2379 # k3s, etcd clients: required if using a "High Availability Embedded etcd" configuration
+    # 2380 # k3s, etcd peers: required if using a "High Availability Embedded etcd" configuration
+  ];
+  networking.firewall.allowedUDPPorts = [
+    # 8472 # k3s, flannel: required if using multi-node for inter-node networking
+  ];
+  services.k3s.enable = true;
+  services.k3s.role = "server";
+  services.k3s.extraFlags = toString [
+    # "--kubelet-arg=v=4" # Optionally add additional args to k3s
+  ];
+}
+```
+
+Once the above changes are active, you can access your cluster through `sudo k3s kubectl` (e.g. `sudo k3s kubectl cluster-info`) or by using the generated kubeconfig file in `/etc/rancher/k3s/k3s.yaml`.
+Multi-node setup
+
+## Multi-Node
+
+it is simple to create a cluster of multiple nodes in a highly available setup (all nodes are in the control-plane and are a part of the etcd cluster).
+
+The first node is configured like this:
+```
+{
+  services.k3s = {
+    enable = true;
+    role = "server";
+    token = "<randomized common secret>";
+    clusterInit = true;
+  };
+}
+```
+
+Any other subsequent nodes can be added with a slightly different config:
+
+```
+{
+  services.k3s = {
+    enable = true;
+    role = "server"; # Or "agent" for worker only nodes
+    token = "<randomized common secret>";
+    serverAddr = "https://<ip of first node>:6443";
+  };
+}
+```
+
+For this to work you need to open the aforementioned API, etcd, and flannel ports in the firewall. Official documentation on what ports need to be opened for specific use cases can be found on [k3s' documentation site](https://docs.k3s.io/installation/requirements#inbound-rules-for-k3s-nodes). Note that it is [recommended](https://etcd.io/docs/v3.3/faq/#why-an-odd-number-of-cluster-members) to use an odd number of nodes in such a cluster.
+
+Tip: If you run into connectivity issues between nodes for specific applications (e.g. ingress controller), please verify the firewall settings you have enabled (example under [Single Node](#single-node)) against the documentation for that specific application. In the ingress controller example, you may want to open 443 or 80 depending on your use case.

--- a/pkgs/applications/networking/cluster/k3s/docs/VERSIONING.md
+++ b/pkgs/applications/networking/cluster/k3s/docs/VERSIONING.md
@@ -1,0 +1,46 @@
+# Versioning
+
+K3s, Kubernetes, and other clustered software has the property of not being able to update atomically. Most software in nixpkgs, like for example bash, can be updated as part of a "nixos-rebuild switch" without having to worry about the old and the new bash interacting in some way.
+
+K3s/Kubernetes, on the other hand, is typically run across several NixOS machines, and each NixOS machine is updated independently. As such, different versions of the package and NixOS module must maintain compatibility with each other through temporary version skew during updates.
+
+The upstream Kubernetes project [documents this in their version-skew policy](https://kubernetes.io/releases/version-skew-policy/#supported-component-upgrade-order).
+
+Within nixpkgs, we strive to maintain a valid "upgrade path" that does not run
+afoul of the upstream version skew policy.
+
+## Patch Release Support Lifecycle
+
+K3s is built on top of K8s and typically provides a similar release cadence and support window (simply by cherry-picking over k8s patches). As such, we assume k3s's support lifecycle is identical to upstream K8s. The upstream K8s release and support lifecycle, including maintenance and end-of-life dates for current releases, is documented [on their suppport site](https://kubernetes.io/releases/patch-releases/#support-period). A more tabular view of the current support timeline can also be found on [endoflife.date](https://endoflife.date/kubernetes).
+
+In short, a new Kubernetes version is released roughly every 4 months and each release is supported for a little over 1 year.
+
+## Versioning in nixpkgs
+
+There are two package types that are maintained within nixpkgs when we are looking at the `nixos-unstable` branch. A standard `k3s` package and versioned releases such as `k3s_1_28`, `k3s_1_29`, and `k3s_1_30`.
+
+The standard `k3s` package will be updated as new versions of k3s are released upstream. Versioned releases, on the other hand, will follow the path release support lifecycle as detailed in the previous section and be removed from `nixos-unstable` when they are either end-of-life upstream or older than the current `k3s` package in `nixos-stable`.
+
+## Versioning in NixOS Releases
+
+Those same package types are also maintained on the release branches of NixOS, but have some special considerations within a release.
+
+NixOS releases (24.05, 24.11, etc) should avoid having deprecated software or major version upgrades during the support lifecycle of that release wherever possible. As such, each NixOS release should only ever have one version of `k3s` when it is released. An example for the NixOS 24.05 release would be that `k3s` package points to `k3s_1_30` for the full lifecycle of its release with no other versions present at release.
+
+However, this conflicts with our desire for users to be able to upgrade between stable NixOS releases without needing to make a large enough k3s version jump as to violate the skew policy listed previously. Given NixOS 24.05 has 1.30.x as its k3s version and the NixOS 24.11 release would have 1.32.x as its k3s version, we need to provide a way for users to upgrade k3s to 1.32.x before upgrading to the next NixOS stable release.
+
+To be able to achieve the goal above, the k3s maintainers would backport `k3s_1_31` and `k3s_1_32` from `nixos-unstable` to NixOS 24.05 as they release. This means that when NixOS 24.11 is released with only the `k3s` package pointing to `k3s_1_32`, users will have an upgrade path on 24.05 to first upgrade locally to `k3s_1_31` and then to `k3s_1_32` (e.g. pointing `services.k3s.package` from `k3s` to `k3s_1_31`, upgrading the cluster, and repeating the process through versions).
+
+Using the above as the example, a three NixOS release example would look like:
+
+* NixOS 23.11
+  * k3s/k3s_1_27 (Release Version, patches backported)
+  * k3s_1_28 (Backported)
+  * k3s_1_29 (Backported)
+  * k3s_1_30 (Backported)
+* NixOS 24.05
+  * k3s/k3s_1_30 (Release Version, patches backported)
+  * k3s_1_31 (Backported)
+  * k3s_1_32 (Backported)
+* NixOS 24.11
+  * k3s/k3s_1_32 (Release Version, patches backported)

--- a/pkgs/applications/networking/cluster/k3s/docs/examples/NVIDIA.md
+++ b/pkgs/applications/networking/cluster/k3s/docs/examples/NVIDIA.md
@@ -1,0 +1,55 @@
+# Nvidia GPU Support
+
+To use Nvidia GPU in the cluster the nvidia-container-runtime and runc are needed. To get the two components it suffices to add the following to the configuration
+
+```
+virtualisation.docker = {
+  enable = true;
+  enableNvidia = true;
+};
+environment.systemPackages = with pkgs; [ docker runc ];
+```
+
+Note, using docker here is a workaround, it will install nvidia-container-runtime and that will cause it to be accessible via /run/current-system/sw/bin/nvidia-container-runtime, currently its not directly accessible in nixpkgs.
+
+You now need to create a new file in `/var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl` with the following
+
+```
+{{ template "base" . }}
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+  privileged_without_host_devices = false
+  runtime_engine = ""
+  runtime_root = ""
+  runtime_type = "io.containerd.runc.v2"
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
+  BinaryName = "/run/current-system/sw/bin/nvidia-container-runtime"
+```
+
+Update: As of 12/03/2024 It appears that the last two lines above are added by default, and if the two lines are present (as shown above) it will refuse to start the server. You will need to remove the two lines from that point onward.
+
+Note here we are pointing the nvidia runtime to "/run/current-system/sw/bin/nvidia-container-runtime".
+
+Now apply the following runtime class to k3s cluster:
+
+```
+apiVersion: node.k8s.io/v1
+handler: nvidia
+kind: RuntimeClass
+metadata:
+  labels:
+    app.kubernetes.io/component: gpu-operator
+  name: nvidia
+```
+
+Following [k8s-device-plugin](https://github.com/NVIDIA/k8s-device-plugin#deployment-via-helm) install the helm chart with `runtimeClassName: nvidia` set. In order to passthrough the nvidia card into the container, your deployments spec must contain - runtimeClassName: nvidia - env:
+
+```
+   - name: NVIDIA_VISIBLE_DEVICES
+     value: all
+   - name: NVIDIA_DRIVER_CAPABILITIES
+     value: all
+```
+
+to test its working exec onto a pod and run nvidia-smi. For more configurability of nvidia related matters in k3s look in [k3s-docs](https://docs.k3s.io/advanced#nvidia-container-runtime-support).

--- a/pkgs/applications/networking/cluster/k3s/docs/examples/STORAGE.md
+++ b/pkgs/applications/networking/cluster/k3s/docs/examples/STORAGE.md
@@ -1,0 +1,122 @@
+# Storage Examples
+
+The following are some NixOS specific considerations for specific storage mechanisms with kubernetes/k3s.
+
+## Longhorn
+
+NixOS configuration required for Longhorn:
+
+```
+environment.systemPackages = [ pkgs.nfs-utils ];
+services.openiscsi = {
+  enable = true;
+  name = "${config.networking.hostName}-initiatorhost";
+};
+```
+
+Longhorn container has trouble with NixOS path. Solution is to override PATH environment variable, such as:
+
+```
+PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/run/wrappers/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin
+```
+
+**Kyverno Policy for Fixing Longhorn Container for NixOS**
+
+```
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: longhorn-nixos-path
+  namespace: longhorn-system
+data:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/run/wrappers/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: longhorn-add-nixos-path
+  annotations:
+    policies.kyverno.io/title: Add Environment Variables from ConfigMap
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/description: >-
+      Longhorn invokes executables on the host system, and needs
+      to be aware of the host systems PATH. This modifies all
+      deployments such that the PATH is explicitly set to support
+      NixOS based systems.
+spec:
+  rules:
+    - name: add-env-vars
+      match:
+        resources:
+          kinds:
+            - Pod
+          namespaces:
+            - longhorn-system
+      mutate:
+        patchStrategicMerge:
+          spec:
+            initContainers:
+              - (name): "*"
+                envFrom:
+                  - configMapRef:
+                      name: longhorn-nixos-path
+            containers:
+              - (name): "*"
+                envFrom:
+                  - configMapRef:
+                      name: longhorn-nixos-path
+---
+```
+
+## NFS
+
+NixOS configuration required for NFS:
+
+```
+boot.supportedFilesystems = [ "nfs" ];
+services.rpcbind.enable = true;
+```
+
+## Rook/Ceph
+
+In order to support Rook/Ceph, the following NixOS kernelModule configuration is required:
+
+```
+  boot.kernelModules = [ "rbd" ];
+```
+
+## ZFS Snapshot Support
+
+K3s's builtin containerd does not support the zfs snapshotter. However, it is possible to configure it to use an external containerd:
+
+```
+virtualisation.containerd = {
+  enable = true;
+  settings =
+    let
+      fullCNIPlugins = pkgs.buildEnv {
+        name = "full-cni";
+        paths = with pkgs;[
+          cni-plugins
+          cni-plugin-flannel
+        ];
+      };
+    in {
+      plugins."io.containerd.grpc.v1.cri".cni = {
+        bin_dir = "${fullCNIPlugins}/bin";
+        conf_dir = "/var/lib/rancher/k3s/agent/etc/cni/net.d/";
+      };
+      # Optionally set private registry credentials here instead of using /etc/rancher/k3s/registries.yaml
+      # plugins."io.containerd.grpc.v1.cri".registry.configs."registry.example.com".auth = {
+      #  username = "";
+      #  password = "";
+      # };
+    };
+};
+# TODO describe how to enable zfs snapshotter in containerd
+services.k3s.extraFlags = toString [
+  "--container-runtime-endpoint unix:///run/containerd/containerd.sock"
+];
+```


### PR DESCRIPTION
This PR is meant for the k3s maintainers and interested parties to contribute to the overhaul of the k3s documentation included in our package directory. This is an extension of the issue #313252

## Description of changes

* Overhaul existing versioning and packaging documentation
* Incorporate current NixOS Wiki content with the intention of directing the wiki to the repo
* Establish pattern for real world examples to be included in the documentation and eliminate link-rot

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
