### PR TITLE
Backport 312811 to release 23.11

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -287,6 +287,7 @@ in {
         hardware.opengl = {
           extraPackages = [
             nvidia_x11.out
+            nvidia_x11.settings.libXNVCtrl
           ];
           extraPackages32 = [
             nvidia_x11.lib32

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -287,7 +287,6 @@ in {
         hardware.opengl = {
           extraPackages = [
             nvidia_x11.out
-            nvidia_x11.settings.libXNVCtrl
           ];
           extraPackages32 = [
             nvidia_x11.lib32

--- a/pkgs/os-specific/linux/nvidia-x11/libxnvctrl-build-shared-3xx.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/libxnvctrl-build-shared-3xx.patch
@@ -1,0 +1,24 @@
+--- a/src/libXNVCtrl/Makefile
++++ b/src/libXNVCtrl/Makefile
+@@ -33,6 +33,8 @@
+ 
+ LIBXNVCTRL = libXNVCtrl.a
+ 
++LIBXNVCTRL_SHARED = $(OUTPUTDIR)/libXNVCtrl.so
++
+ LIBXNVCTRL_PROGRAM_NAME = "libXNVCtrl"
+ 
+ LIBXNVCTRL_VERSION := $(NVIDIA_VERSION)
+@@ -62,6 +64,12 @@
+ $(LIBXNVCTRL) : $(OBJS)
+ 	$(AR) ru $@ $(OBJS)
+ 
++$(LIBXNVCTRL_SHARED): $(LIBXNVCTRL_OBJ)
++	$(RM) $@ $@.*
++	$(CC) -shared -Wl,-soname=$(@F).0 -o $@.0.0.0 $(LDFLAGS) $^ -lXext -lX11
++	ln -s $(@F).0.0.0 $@.0
++	ln -s $(@F).0 $@
++
+ # define the rule to build each object file
+ $(foreach src,$(SRC),$(eval $(call DEFINE_OBJECT_RULE,TARGET,$(src))))
+ 

--- a/pkgs/os-specific/linux/nvidia-x11/libxnvctrl-build-shared.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/libxnvctrl-build-shared.patch
@@ -1,0 +1,21 @@
+--- a/src/libXNVCtrl/xnvctrl.mk
++++ b/src/libXNVCtrl/xnvctrl.mk
+@@ -39,6 +39,8 @@
+ 
+ LIBXNVCTRL = $(OUTPUTDIR)/libXNVCtrl.a
+ 
++LIBXNVCTRL_SHARED = $(OUTPUTDIR)/libXNVCtrl.so
++
+ LIBXNVCTRL_SRC = $(XNVCTRL_DIR)/NVCtrl.c
+ 
+ LIBXNVCTRL_OBJ = $(call BUILD_OBJECT_LIST,$(LIBXNVCTRL_SRC))
+@@ -47,3 +49,9 @@
+ 
+ $(LIBXNVCTRL) : $(LIBXNVCTRL_OBJ)
+ 	$(call quiet_cmd,AR) ru $@ $(LIBXNVCTRL_OBJ)
++
++$(LIBXNVCTRL_SHARED): $(LIBXNVCTRL_OBJ)
++	$(RM) $@ $@.*
++	$(CC) -shared -Wl,-soname=$(@F).0 -o $@.0.0.0 $(LDFLAGS) $^ -lXext -lX11
++	ln -s $(@F).0.0.0 $@.0
++	ln -s $(@F).0 $@

--- a/pkgs/os-specific/linux/nvidia-x11/settings.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/settings.nix
@@ -147,6 +147,6 @@ stdenv.mkDerivation {
     license = licenses.unfreeRedistributable;
     platforms = nvidia_x11.meta.platforms;
     mainProgram = "nvidia-settings";
-    maintainers = with maintainers; [ abbradar ];
+    maintainers = with maintainers; [ abbradar aidalgol ];
   };
 }

--- a/pkgs/os-specific/linux/nvidia-x11/settings.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/settings.nix
@@ -43,6 +43,14 @@ let
 
     makeFlags = [
       "OUTPUTDIR=." # src/libXNVCtrl
+      "libXNVCtrl.a"
+      "libXNVCtrl.so"
+    ];
+
+    patches = [
+      # Patch the Makefile to also produce a shared library.
+      (if lib.versionOlder nvidia_x11.settingsVersion "400" then ./libxnvctrl-build-shared-3xx.patch
+      else ./libxnvctrl-build-shared.patch)
     ];
 
     installPhase = ''
@@ -52,6 +60,7 @@ let
       cp libXNVCtrl.a $out/lib
       cp NVCtrl.h     $out/include/NVCtrl
       cp NVCtrlLib.h  $out/include/NVCtrl
+      cp -P libXNVCtrl.so* $out/lib
     '';
   };
 

--- a/pkgs/tools/graphics/mangohud/default.nix
+++ b/pkgs/tools/graphics/mangohud/default.nix
@@ -211,8 +211,9 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace $out/share/vulkan/implicit_layer.d/MangoHud.${layerPlatform}.json \
       --replace "VK_LAYER_MANGOHUD_overlay" "VK_LAYER_MANGOHUD_overlay_${toString stdenv.hostPlatform.parsed.cpu.bits}"
   '' + ''
-    # Add OpenGL driver path to RUNPATH to support NVIDIA cards
+    # Add OpenGL driver and libXNVCtrl paths to RUNPATH to support NVIDIA cards
     addOpenGLRunpath "$out/lib/mangohud/libMangoHud.so"
+    patchelf --add-rpath ${libXNVCtrl}/lib "$out/lib/mangohud/libMangoHud.so"
   '' + lib.optionalString gamescopeSupport ''
     addOpenGLRunpath "$out/bin/mangoapp"
   '' + lib.optionalString finalAttrs.doCheck ''


### PR DESCRIPTION
## Description of changes
Backport #312811 to 23.11.


## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
