### PR TITLE
[WIP] qobuz-downloader: init at 1.0.32

### DIFF
--- a/pkgs/by-name/qo/qobuz-downloader/package.nix
+++ b/pkgs/by-name/qo/qobuz-downloader/package.nix
@@ -14,7 +14,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "qobuz";
+  pname = "qobuz-downloader";
   version = "1.0.32"; # see usr/share/qobuz_downloader/data/flutter_assets/version.json
 
   src = requireFile {

--- a/pkgs/by-name/qo/qobuz-downloader/package.nix
+++ b/pkgs/by-name/qo/qobuz-downloader/package.nix
@@ -3,6 +3,7 @@
 , autoPatchelfHook
 , cairo
 , dpkg
+, ffmpeg
 , gdk-pixbuf
 , glib
 , gtk3
@@ -13,7 +14,7 @@
 , xdg-user-dirs
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "qobuz-downloader";
   version = "1.0.32"; # see usr/share/qobuz_downloader/data/flutter_assets/version.json
 
@@ -31,6 +32,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     at-spi2-atk
     cairo
+    ffmpeg
     gdk-pixbuf
     glib
     gtk3
@@ -40,9 +42,12 @@ stdenv.mkDerivation rec {
   unpackCmd = "${dpkg}/bin/dpkg-deb -x $curSrc source";
 
   postPatch = ''
-    sed -i s@Exec=qobuz_downloader@Exec=$out/bin/qobuz_downloader@ usr/share/applications/qobuz_downloader.desktop
+    # reduce closure size
     rm usr/share/qobuz_downloader/data/flutter_assets/assets/tools/{ffmpeg.exe,id3-tag-cli,id3-tag-cli.exe}
-    # TODO: unvendor ffmpeg/id3-tags-cli
+    # unvendor ffmpeg
+    rm usr/share/qobuz_downloader/data/flutter_assets/assets/tools/ffmpeg
+    ln -s ${ffmpeg}/bin/ffmpeg usr/share/qobuz_downloader/data/flutter_assets/assets/tools/ffmpeg
+    # TODO: unvendor id3-tag-cli
   '';
 
   installPhase = ''

--- a/pkgs/by-name/qo/qobuz/package.nix
+++ b/pkgs/by-name/qo/qobuz/package.nix
@@ -1,0 +1,67 @@
+{ lib
+, at-spi2-atk
+, autoPatchelfHook
+, cairo
+, dpkg
+, gdk-pixbuf
+, glib
+, gtk3
+, makeWrapper
+, pango
+, requireFile
+, stdenv
+, xdg-user-dirs
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qobuz";
+  version = "1.0.32"; # see usr/share/qobuz_downloader/data/flutter_assets/version.json
+
+  src = requireFile {
+    name = "qobuz_downloader.deb";
+    url = "https://drive.google.com/file/d/1qsKOudlxwhLYxDVHqT17YDwcikoErrmj/view";
+    sha256 = "098ywxydszhbimp6hxdr3rcqp9wsbrpvlzczx2xxdjflfcmlqsk4";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    at-spi2-atk
+    cairo
+    gdk-pixbuf
+    glib
+    gtk3
+    pango
+  ];
+
+  unpackCmd = "${dpkg}/bin/dpkg-deb -x $curSrc source";
+
+  postPatch = ''
+    sed -i s@Exec=qobuz_downloader@Exec=$out/bin/qobuz_downloader@ usr/share/applications/qobuz_downloader.desktop
+    rm usr/share/qobuz_downloader/data/flutter_assets/assets/tools/{ffmpeg.exe,id3-tag-cli,id3-tag-cli.exe}
+    # TODO: unvendor ffmpeg/id3-tags-cli
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r usr/* $out
+  '';
+
+  preFixup = ''
+    makeWrapper $out/share/qobuz_downloader/qobuz_downloader $out/bin/qobuz_downloader \
+      --suffix PATH : ${lib.makeBinPath [ xdg-user-dirs ]}
+  '';
+
+  meta = with lib; {
+    description = "";
+    downloadPage = "https://www.qobuz.com/gb-en/discover/apps-partners";
+    license = with licenses; [ unfree ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ sersorrel ];
+    mainProgram = "qobuz_downloader";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

qobuz-downloader is a small app required to download music from https://www.qobuz.com/ after purchasing it.

Currently the app is in beta and not available from the official website. I'm hopeful (but unfortunately with no basis in reality) that it will be properly launched at some point in the future.

I could wait to open this PR til then, but I figure I may as well work in the open on this. (Also, perhaps it demonstrates to Qobuz that there is actually someone out there who cares enough about their strange little Flutter app to package it.)

Things left to do:

- check that the unvendored ffmpeg actually works
- unvendor id3-tag-cli (I think this might be https://github.com/Zereges/id3-tag-cli?)
- wait for the app to actually become available for download somewhere other than a random Google Drive link... (I promise this (probably) isn't malware! Qobuz sent an email out in December 2023 with the link, to user(s) who expressed "interest and willingness to test this version".)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
