### PR TITLE
Improve the retry attempts, error conditions, and IPv6 attempts for fetching ec2 metadata from IMDS

### DIFF
--- a/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
+++ b/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
@@ -2,20 +2,74 @@ metaDir=/etc/ec2-metadata
 mkdir -m 0755 -p "$metaDir"
 rm -f "$metaDir/*"
 
+# See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-metadata-v2-how-it-works.html
+imds_ipv4_addr="169.254.169.254"
+imds_ipv6_addr="[fd00:ec2::254]"
+
+# modified by get_imds_token()
+IMDS_USE_IPV6=false
+
+# formats the URL for the IMDSv2 service
+# based on connectivity to ipv4 vs ipv6
+imds_url() {
+    # replace path's leading slash with nothing
+    path=$(echo "$@" | sed 's|^/||')
+
+    if [ "$IMDS_USE_IPV6" = true ]; then
+        echo "http://${imds_ipv6_addr}/${path}"
+    else
+        echo "http://${imds_ipv4_addr}/${path}"
+    fi
+}
+
+# tests for both ipv4 and ipv6 connectivity to IMDSv2
+# then retrieves a token and configures the rest of
+# the script to use whichever address was available
 get_imds_token() {
-  # retry-delay of 1 selected to give the system a second to get going,
-  # but not add a lot to the bootup time
-  curl \
-    --silent \
-    --show-error \
-    --retry 5 \
-    --retry-delay 1 \
-    --retry-connrefused \
-    --fail \
-    -X PUT \
-    --connect-timeout 1 \
-    -H "X-aws-ec2-metadata-token-ttl-seconds: 600" \
-    http://169.254.169.254/latest/api/token
+  # use a longer retry time to test for both ipv4 and ipv6 connectivity
+  token=""
+
+  # first test ipv4
+  token=$(
+    curl \
+      --silent \
+      --globoff \
+      --show-error \
+      --retry 10 \
+      --retry-delay 1 \
+      --retry-connrefused \
+      --fail \
+      -X PUT \
+      --connect-timeout 1 \
+      -H "X-aws-ec2-metadata-token-ttl-seconds: 600" \
+      http://$imds_ipv4_addr/latest/api/token
+  )
+
+  if [ "x$token" == "x" ]; then
+    # ipv4 failed, try ipv6
+    IMDS_USE_IPV6=true
+    token=$(
+      curl \
+        --silent \
+        --globoff \
+        --show-error \
+        --retry 10 \
+        --retry-delay 1 \
+        --retry-connrefused \
+        --fail \
+        -X PUT \
+        --connect-timeout 1 \
+        -H "X-aws-ec2-metadata-token-ttl-seconds: 600" \
+        http://$imds_ipv6_addr/latest/api/token
+    )
+  fi
+
+  if [ "x$token" == "x" ]; then
+    # indicate failure
+    return 1
+  fi
+
+  echo "$token"
 }
 
 preflight_imds_token() {
@@ -23,6 +77,7 @@ preflight_imds_token() {
   # but not add a lot to the bootup time
   curl \
     --silent \
+    --globoff \
     --show-error \
     --retry 5 \
     --retry-delay 1 \
@@ -31,7 +86,7 @@ preflight_imds_token() {
     --connect-timeout 1 \
     -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" \
     -o /dev/null \
-    http://169.254.169.254/1.0/meta-data/instance-id
+    $(imds_url /latest/meta-data/instance-id)
 }
 
 try=1
@@ -72,6 +127,7 @@ get_imds() {
   # || true to allow the script to continue even when encountering a 404
   curl \
       --silent \
+      --globoff \
       --show-error \
       --retry 3 \
       --retry-delay 1 \
@@ -81,7 +137,7 @@ get_imds() {
       "$@" || true
 }
 
-get_imds -o "$metaDir/ami-manifest-path" http://169.254.169.254/1.0/meta-data/ami-manifest-path
-(umask 077 && get_imds -o "$metaDir/user-data" http://169.254.169.254/1.0/user-data)
-get_imds -o "$metaDir/hostname" http://169.254.169.254/1.0/meta-data/hostname
-get_imds -o "$metaDir/public-keys-0-openssh-key" http://169.254.169.254/1.0/meta-data/public-keys/0/openssh-key
+get_imds -o "$metaDir/ami-manifest-path" $(imds_url /latest/meta-data/ami-manifest-path)
+(umask 077 && get_imds -o "$metaDir/user-data" $(imds_url /latest/user-data))
+get_imds -o "$metaDir/hostname" $(imds_url /latest/meta-data/hostname)
+get_imds -o "$metaDir/public-keys-0-openssh-key" $(imds_url /latest/meta-data/public-keys/0/openssh-key)

--- a/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
+++ b/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
@@ -44,15 +44,26 @@ done
 
 if [ "x$IMDS_TOKEN" == "x" ]; then
   echo "failed to fetch an IMDS2v token."
+  exit 1
 fi
 
 try=1
+last_exit_code=""
 while [ $try -le 10 ]; do
   echo "(attempt $try/10) validating the EC2 instance metadata service v2 token..."
-  preflight_imds_token && break
+  preflight_imds_token
+  last_exit_code="$?"
+  if [ "$last_exit_code" -eq 0 ]; then
+    break
+  fi
   try=$((try + 1))
   sleep 1
 done
+
+if [ "$last_exit_code" -ne 0 ]; then
+  echo "failed to validate the IMDS2v token."
+  exit 1
+fi
 
 echo "getting EC2 instance metadata..."
 

--- a/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
+++ b/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
@@ -8,8 +8,9 @@ get_imds_token() {
   curl \
     --silent \
     --show-error \
-    --retry 3 \
+    --retry 5 \
     --retry-delay 1 \
+    --retry-connrefused \
     --fail \
     -X PUT \
     --connect-timeout 1 \
@@ -23,8 +24,9 @@ preflight_imds_token() {
   curl \
     --silent \
     --show-error \
-    --retry 3 \
+    --retry 5 \
     --retry-delay 1 \
+    --retry-connrefused \
     --fail \
     --connect-timeout 1 \
     -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" \
@@ -57,7 +59,15 @@ echo "getting EC2 instance metadata..."
 get_imds() {
   # --fail to avoid populating missing files with 404 HTML response body
   # || true to allow the script to continue even when encountering a 404
-  curl --silent --show-error --fail --header "X-aws-ec2-metadata-token: $IMDS_TOKEN" "$@" || true
+  curl \
+      --silent \
+      --show-error \
+      --retry 3 \
+      --retry-delay 1 \
+      --retry-connrefused \
+      --fail \
+      --header "X-aws-ec2-metadata-token: $IMDS_TOKEN" \
+      "$@" || true
 }
 
 get_imds -o "$metaDir/ami-manifest-path" http://169.254.169.254/1.0/meta-data/ami-manifest-path


### PR DESCRIPTION
## Description of changes

Why: https://github.com/NixOS/amis/issues/137


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Add ipv6 awareness to the script
- Add additional retry options to all curl commands
- Add exit conditions for failures during boot

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
