### PR TITLE
google-chrome: 125.0.6422.76 -> 125.0.6422.112

### DIFF
--- a/pkgs/by-name/go/google-chrome/package.nix
+++ b/pkgs/by-name/go/google-chrome/package.nix
@@ -64,11 +64,11 @@ let
 
 in stdenv.mkDerivation (finalAttrs: {
   pname = "google-chrome";
-  version = "125.0.6422.76";
+  version = "125.0.6422.112";
 
   src = fetchurl {
     url = "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${finalAttrs.version}-1_amd64.deb";
-    hash = "sha256-hLGEwaTx11tqiS7skoNVwCEw+1GZ0pNHpfe11IFjTFc=";
+    hash = "sha256-Tx9SGob0b4mndk+zIhSL8MAuCUdwz2HrbnhfXYYfEUo=";
   };
 
   nativeBuildInputs = [ patchelf makeWrapper ];


### PR DESCRIPTION
Fixes:
High CVE-2024-5274: Type Confusion in V8. Reported by Clément Lecigne of Google's Threat Analysis Group and Brendon Tiszka of Chrome Security on 2024-05-20

See https://chromereleases.googleblog.com/2024/05/stable-channel-update-for-desktop_23.html

@jnsgruk I saw that you committed the last version bump. Could you take a look? Thank you! 