### PR TITLE
libdvdnav_4_2_1: fix cross-compilation

### DIFF
--- a/pkgs/development/libraries/libdvdnav/4.2.1.nix
+++ b/pkgs/development/libraries/libdvdnav/4.2.1.nix
@@ -31,6 +31,12 @@ stdenv.mkDerivation rec {
     mkdir -p $out
   '';
 
+  makeFlags = [
+    "AR=${stdenv.cc.targetPrefix}ar"
+    "LD=${stdenv.cc.targetPrefix}ld"
+    "RANLIB=${stdenv.cc.targetPrefix}ranlib"
+  ];
+
   meta = {
     homepage = "http://dvdnav.mplayerhq.hu/";
     description = "A library that implements DVD navigation features such as DVD menus";

--- a/pkgs/development/libraries/libdvdnav/4.2.1.nix
+++ b/pkgs/development/libraries/libdvdnav/4.2.1.nix
@@ -20,6 +20,10 @@ stdenv.mkDerivation rec {
   # See INSTALL inside the upstream source for detail.
   configureScript = "./configure2";
 
+  configureFlags = [
+    "--cc=${stdenv.cc.targetPrefix}cc"
+  ];
+
   preConfigure = ''
     mkdir -p $out
   '';

--- a/pkgs/development/libraries/libdvdnav/4.2.1.nix
+++ b/pkgs/development/libraries/libdvdnav/4.2.1.nix
@@ -12,7 +12,13 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [libdvdread];
 
-  configureScript = "./configure2"; # wtf?
+  # The upstream supports two configuration workflow:
+  # one is to generate ./configure via `autoconf`,
+  # the other is to run ./configure2.
+  # ./configure2 is a configureation script included in the upstream source
+  # that supports common "--<name>" flags and generates config.mak and config.h.
+  # See INSTALL inside the upstream source for detail.
+  configureScript = "./configure2";
 
   preConfigure = ''
     mkdir -p $out

--- a/pkgs/development/libraries/libdvdnav/4.2.1.nix
+++ b/pkgs/development/libraries/libdvdnav/4.2.1.nix
@@ -22,6 +22,9 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--cc=${stdenv.cc.targetPrefix}cc"
+    # Let's strip the binaries ourselves,
+    # as unprefixed `strip` command is not available during cross compilation.
+    "--disable-strip"
   ];
 
   preConfigure = ''


### PR DESCRIPTION
## Description of changes

Fix cross-compilation by specifying proper compile flags.

Cc: @wmertens (`libdvdnav_4_2_1` maintainer)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) (I don't have enough computation power to run nixpkgs-review locally. Could someone help me run it?)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
