### PR TITLE
foma: 0.10.0alpha -> 0.10.0alpha-unstable-03-13-2024; fix darwin

### DIFF
--- a/pkgs/tools/misc/foma/default.nix
+++ b/pkgs/tools/misc/foma/default.nix
@@ -1,34 +1,31 @@
-{ lib, stdenv, fetchFromGitHub, zlib, flex, bison, readline, darwin }:
+{ lib, stdenv, fetchFromGitHub, bison, cmake, flex, pkg-config, readline, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "foma";
-  version = "0.10.0alpha";
+  version = "0.10.0alpha-unstable-03-13-2024";
 
   src = fetchFromGitHub {
     owner = "mhulden";
     repo = "foma";
-    rev = "82f9acdef234eae8b7619ccc3a386cc0d7df62bc";
-    sha256 = "1vf01l18j8cksnavbabcckp9gg692w6v5lg81xrzv6f5v14zp4nr";
+    rev = "e0d8122bda4bbd56f18510bdfe840617f9736ae7";
+    hash = "sha256-UbwuHTilKWo4sVD3igcSlTqH78N6JQFvRD35QwfoX10=";
   };
 
   sourceRoot = "${src.name}/foma";
 
-  nativeBuildInputs = [ flex bison ]
-    ++ lib.optional stdenv.isDarwin darwin.cctools;
-  buildInputs = [ zlib readline ];
+  outputs = [ "out" "dev" ];
 
-  makeFlags = [
-    "CC:=$(CC)"
-    "RANLIB:=$(RANLIB)"
-    "prefix=$(out)"
-  ] ++ lib.optionals (!stdenv.isDarwin) [
-    "AR:=$(AR)" # libtool is used for darwin
+  nativeBuildInputs = [ bison cmake flex pkg-config ];
+  buildInputs = [ readline zlib ];
+
+  cmakeFlags = [
+    # the cmake package does not handle absolute CMAKE_INSTALL_XXXDIR
+    # correctly (setting it to an absolute path causes include files to go to
+    # $out/$out/include, because the absolute path is interpreted with root at
+    # $out).
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
   ];
-
-  patchPhase = ''
-    substituteInPlace Makefile \
-      --replace '-ltermcap' ' '
-  '';
 
   meta = with lib; {
     description = "A multi-purpose finite-state toolkit designed for applications ranging from natural language processing to research in automata theory";


### PR DESCRIPTION
*needs backport-24.05 label*

## Description of changes

- https://github.com/mhulden/foma/compare/82f9acdef234eae8b7619ccc3a386cc0d7df62bc...e0d8122bda4bbd56f18510bdfe840617f9736ae7
- build switched from make to cmake
- fixes darwin

https://hydra.nixos.org/build/259684404
ZHF: https://github.com/NixOS/nixpkgs/issues/309482

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
