### PR TITLE
python3Packages.plugp100: init at 5.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16708,6 +16708,12 @@
     github = "PhilippWoelfel";
     githubId = 19400064;
   };
+  pyle = {
+    name = "Adam Pyle";
+    email = "adam@pyle.dev";
+    github = "pyle";
+    githubId = 7279609;
+  };
   pyrolagus = {
     email = "pyrolagus@gmail.com";
     github = "PyroLagus";

--- a/pkgs/development/python-modules/plugp100/default.nix
+++ b/pkgs/development/python-modules/plugp100/default.nix
@@ -1,0 +1,51 @@
+{
+  stdenv,
+  pkgs,
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  certifi,
+  scapy,
+  urllib3,
+  semantic-version,
+  aiohttp,
+  jsons,
+  requests,
+  # Test inputs
+  pytestCheckHook,
+  pyyaml,
+  pytest-asyncio,
+  async-timeout,
+  }:
+
+buildPythonPackage rec {
+  pname = "plugp100";
+  version = "5.1.3";
+
+  src = fetchFromGitHub {
+    owner = "petretiandrea";
+    repo = "plugp100";
+    rev = version;
+    sha256 = "sha256-V+9cVBMN8H4oFU51T9BDrLF46xgQHqIsMj8nuPedUGA=";
+  };
+
+  propagatedBuildInputs =
+    [ certifi jsons requests aiohttp semantic-version scapy urllib3 pyyaml ];
+
+  nativeCheckInputs = [ pytestCheckHook pytest-asyncio async-timeout ];
+
+  disabledTestPaths = [
+    "tests/integration/"
+    "tests/unit/hub_child/"
+    "tests/unit/test_plug_strip.py"
+    "tests/unit/test_hub.py "
+    "tests/unit/test_klap_protocol.py"
+  ];
+
+  meta = with lib; {
+    description = "Python library to control Tapo Plug P100 devices";
+    homepage = "https://github.com/petretiandrea/plugp100";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ pyle ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8965,6 +8965,8 @@ self: super: with self; {
 
   nxt-python = callPackage ../development/python-modules/nxt-python { };
 
+  plugp100 = callPackage ../development/python-modules/plugp100 {};
+
   python-ndn = callPackage ../development/python-modules/python-ndn { };
 
   python-nvd3 = callPackage ../development/python-modules/python-nvd3 { };


### PR DESCRIPTION
## Description of changes

Adds [plugp100](https://github.com/petretiandrea/plugp100) python module in preperation for adding custom home-assistant component for TP-Link Tapo devices ([component](https://github.com/petretiandrea/home-assistant-tapo-p100))

- https://github.com/petretiandrea/plugp100
- https://pypi.org/project/plugp100/

Notes:

- Disabled integration tests as they require a device on the network.
- Disabled some unit tests that were already failing.
- Added self as maintainer (no other suitable person?)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
