### PR TITLE
libideviceactivation: init at 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3808,6 +3808,15 @@
     githubId = 199180;
     name = "Claes Wallin";
   };
+  clebs = {
+    email = "borja.clemente@gmail.com";
+    github = "clebs";
+    githubId = 1059661;
+    name = "Borja Clemente";
+    keys = [{
+      fingerprint = "C4E1 58BD FD33 3C77 B6C7  178E 2539 757E F64C 60DD";
+    }];
+  };
   cleeyv = {
     email = "cleeyv@riseup.net";
     github = "cleeyv";

--- a/pkgs/by-name/li/libideviceactivation/package.nix
+++ b/pkgs/by-name/li/libideviceactivation/package.nix
@@ -1,0 +1,55 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  pkg-config,
+  automake,
+  autoreconfHook,
+  libtool,
+  libplist,
+  libimobiledevice,
+  libxml2,
+  curl,
+  usbmuxd,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libideviceactivation";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "libimobiledevice";
+    repo = "libideviceactivation";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-owcQpCN4+A785oy9pCboJIyfpgZ6X+8PRzqGtWpYl2w=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    automake
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    libtool
+    libplist
+    libimobiledevice
+    libxml2
+    curl
+    usbmuxd
+  ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    description = "A library to manage the activation process of Apple iOS devices.";
+    homepage = "https://libimobiledevice.org";
+    license = with lib.licenses; [
+      lgpl21
+      gpl3
+    ];
+    mainProgram = "ideviceactivation";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ clebs ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Closes #310787

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
