### PR TITLE
ch341eeprom: 0-unstable-2021-01-05 -> 0-unstable-2024-05-06

### DIFF
--- a/pkgs/by-name/ch/ch341eeprom/package.nix
+++ b/pkgs/by-name/ch/ch341eeprom/package.nix
@@ -1,25 +1,25 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, libusb1
-,
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libusb1,
+  unstableGitUpdater,
 }:
+
 stdenv.mkDerivation {
   pname = "ch341eeprom";
-  version = "0-unstable-2021-01-05";
+  version = "0-unstable-2024-05-06";
 
   src = fetchFromGitHub {
     owner = "command-tab";
     repo = "ch341eeprom";
-    rev = "d5b2fba35a33a1cddd7a3e920e1df933f21ba9b0";
-    hash = "sha256-QUl5ErOfEfDhk1fF+BNu6n0Bake3IagNfn4I43b6Uns=";
+    rev = "7cffbef7552d93162bd90cae836a45e94acb93fb";
+    hash = "sha256-8pvQ2hBP3Rf8+MWsmMY53BghFiC5/b9k8vUjU2K6Ib4=";
   };
 
   buildInputs = [ libusb1 ];
 
-  makeFlags = [
-    "CC=${stdenv.cc.targetPrefix}cc"
-  ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     runHook preInstall
@@ -27,12 +27,16 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  passthru = {
+    updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
+  };
+
+  meta = {
     description = "A libusb based programming tool for 24Cxx serial EEPROMs using the WinChipHead CH341A IC";
     homepage = "https://github.com/command-tab/ch341eeprom";
-    license = licenses.gpl3Plus;
-    platforms = platforms.darwin ++ platforms.linux;
+    license = lib.licenses.gpl3Plus;
     mainProgram = "ch341eeprom";
-    maintainers = with maintainers; [ xokdvium ];
+    maintainers = with lib.maintainers; [ xokdvium ];
+    platforms = with lib.platforms; darwin ++ linux;
   };
 }


### PR DESCRIPTION
Added passthru.updateScript. Reformatted with `nixfmt-rfc-style`. Removed `with lib;` usage. Sorted meta attributes lexicographically.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
