### PR TITLE
nixos/terraria: use config file instead of passing flags

### DIFF
--- a/nixos/modules/services/games/terraria.nix
+++ b/nixos/modules/services/games/terraria.nix
@@ -5,29 +5,71 @@
   pkgs,
   ...
 }:
+
 let
   cfg = config.services.terraria;
   opt = options.services.terraria;
+
   worldSizeMap = {
     small = 1;
     medium = 2;
     large = 3;
   };
-  valFlag =
-    name: val:
-    lib.optionalString (val != null) "-${name} \"${lib.escape [ "\\" "\"" ] (toString val)}\"";
-  boolFlag = name: val: lib.optionalString val "-${name}";
-  flags = [
-    (valFlag "port" cfg.port)
-    (valFlag "maxPlayers" cfg.maxPlayers)
-    (valFlag "password" cfg.password)
-    (valFlag "motd" cfg.messageOfTheDay)
-    (valFlag "world" cfg.worldPath)
-    (valFlag "autocreate" (builtins.getAttr cfg.autoCreatedWorldSize worldSizeMap))
-    (valFlag "banlist" cfg.banListPath)
-    (boolFlag "secure" cfg.secure)
-    (boolFlag "noupnp" cfg.noUPnP)
+
+  difficultyMap = {
+    normal = 0;
+    expert = 1;
+    master = 2;
+    journey = 3;
+  };
+
+  mkLineIf =
+    cond: name: val:
+    if (cond && val != null) then "${name}=${toString val}" else "# ${name}=";
+  mkLine = mkLineIf true;
+  mkLineAC = mkLineIf cfg.autocreate.enable;
+  mkTodo = name: "# ${name}= # TODO: add option";
+
+  # Based on https://terraria.wiki.gg/wiki/Server#Server_config_file
+  # Keys should be in the same order as listed on the website
+  configLines = [
+    (mkLine "world" cfg.worldPath)
+    (mkLineAC "autocreate" (builtins.getAttr cfg.autocreate.size worldSizeMap))
+    (mkLineAC "seed" cfg.autocreate.seed)
+    (mkTodo "worldname")
+    (mkLineAC "difficulty" (builtins.getAttr cfg.autocreate.difficulty difficultyMap))
+    (mkLine "maxplayers" cfg.maxPlayers)
+    (mkLine "port" cfg.port)
+    (mkLine "password" cfg.password)
+    (mkLine "motd" cfg.messageOfTheDay)
+    (mkTodo "worldpath")
+    (mkLine "banlist" cfg.banListPath)
+    (mkLine "secure" (if cfg.secure then "1" else "0"))
+    (mkTodo "language")
+    (mkLine "upnp" (if cfg.noUPnP then "0" else "1")) # should probably be inverted in the option name instead
+    (mkTodo "npcstream")
+    (mkTodo "priority")
+    (mkTodo "journeypermission_time_setfrozen")
+    (mkTodo "journeypermission_time_setdawn")
+    (mkTodo "journeypermission_time_setnoon")
+    (mkTodo "journeypermission_time_setdusk")
+    (mkTodo "journeypermission_time_setmidnight")
+    (mkTodo "journeypermission_godmode")
+    (mkTodo "journeypermission_wind_setstrength")
+    (mkTodo "journeypermission_rain_setstrength")
+    (mkTodo "journeypermission_time_setspeed")
+    (mkTodo "journeypermission_rain_setfrozen")
+    (mkTodo "journeypermission_wind_setfrozen")
+    (mkTodo "journeypermission_increaseplacementrange")
+    (mkTodo "journeypermission_setdifficulty")
+    (mkTodo "journeypermission_biomespread_setfrozen")
+    (mkTodo "journeypermission_setspawnrate")
   ];
+
+  configFile = pkgs.writeText "serverconfig.txt" ''
+    # This file was created by the services.terraria NixOS module
+    ${lib.concatStringsSep "\n" configLines}
+  '';
 
   tmuxCmd = "${lib.getExe pkgs.tmux} -S ${lib.escapeShellArg cfg.dataDir}/terraria.sock";
 
@@ -53,6 +95,13 @@ let
   '';
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule [
+      "services"
+      "terraria"
+      "autoCreatedWorldSize"
+    ] "Configure services.terraria.autocreate instead")
+  ];
   options = {
     services.terraria = {
       enable = lib.mkOption {
@@ -100,6 +149,40 @@ in
         '';
       };
 
+      autocreate = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Whether to auto-create a world if `worldPath` does not point to an existing world.
+          '';
+        };
+
+        size = lib.mkOption {
+          type = lib.types.enum (lib.attrNames worldSizeMap);
+          default = "medium";
+          description = ''
+            Specifies the size of the auto-created world.
+          '';
+        };
+
+        difficulty = lib.mkOption {
+          type = lib.types.enum (lib.attrNames difficultyMap);
+          default = "normal";
+          description = ''
+            Specifies the difficulty of the auto-created world.
+          '';
+        };
+
+        seed = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            Specifies the seed of the auto-created world.
+          '';
+        };
+      };
+
       worldPath = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
         default = null;
@@ -107,19 +190,6 @@ in
           The path to the world file (`.wld`) which should be loaded.
           If no world exists at this path, one will be created with the size
           specified by `autoCreatedWorldSize`.
-        '';
-      };
-
-      autoCreatedWorldSize = lib.mkOption {
-        type = lib.types.enum [
-          "small"
-          "medium"
-          "large"
-        ];
-        default = "medium";
-        description = ''
-          Specifies the size of the auto-created world if `worldPath` does not
-          point to an existing world.
         '';
       };
 
@@ -181,8 +251,8 @@ in
         Group = "terraria";
         Type = "forking";
         GuessMainPID = true;
-        UMask = 7;
-        ExecStart = "${tmuxCmd} new -d ${lib.getExe cfg.package} ${lib.concatStringsSep " " flags}";
+        UMask = "007";
+        ExecStart = "${tmuxCmd} new -d ${lib.getExe cfg.package} -config ${configFile}";
         ExecStop = "${stopScript} $MAINPID";
       };
     };


### PR DESCRIPTION
## Description of changes

This PR revamps the `services.terraria` NixOS module.


This PR migrates the module over to using a config file, instead of passing a bunch of command line flags.
The benefit of this other than readability is that the config file has more settings than what could be configured using the flags.

I added all supported flags to the list, but didn't implement all of them. I'll do that in another PR.

---


@ncfavier - the other maintainer of the `terraria-server` package.
Not sure how else I should ping, since this module is very outdated.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
