### PR TITLE
openrefine: 3.7.9 -> 3.8.1

### DIFF
--- a/pkgs/applications/science/misc/openrefine/default.nix
+++ b/pkgs/applications/science/misc/openrefine/default.nix
@@ -15,12 +15,12 @@ let
     inherit jdk;
   };
 
-  version = "3.7.9";
+  version = "3.8.1";
   src = fetchFromGitHub {
     owner = "openrefine";
     repo = "openrefine";
     rev = version;
-    hash = "sha256-wtg0BOGr/aJPZeFQbJSBHtTVfpcSCSHP++8AnpS8pgQ=";
+    hash = "sha256-MnFwFJdKIU7D8GQgnDvCO+P8r8h1Se/wmbt/Z3EX+3Q=";
   };
 
   npmPkg = buildNpmPackage {
@@ -29,7 +29,7 @@ let
     pname = "openrefine-npm";
     sourceRoot = "${src.name}/main/webapp";
 
-    npmDepsHash = "sha256-8GhcL4tohQ5u2HeYN6JyTMMobUOqAL8ETCLiP1SoDSk=";
+    npmDepsHash = "sha256-u9qledNFqGgMmOIsm2T8w3UoaLbb7WtksUw6xLoRgU8=";
 
     # package.json doesn't supply a version, which npm doesn't like - fix this.
     # directly referencing jq because buildNpmPackage doesn't pass
@@ -56,19 +56,11 @@ in maven'.buildMavenPackage {
     cp -r ${npmPkg} main/webapp/modules/core/3rdparty
   '';
   mvnParameters = "-DskipTests=true -pl !packaging";
-  mvnHash = "sha256-MqE+iloqzBav6E3/rf1LP5BlKhW/FBIt6+6U+S8UJWA=";
+  mvnHash = "sha256-0qsKUMV9M0ZaddR5ust8VikSrsutdxVNNezKqR+F/6M=";
 
   nativeBuildInputs = [ makeWrapper ];
 
-  installPhase = let
-    gitProperties = writeText "git.properties" (builtins.toJSON {
-      "git.build.version" = version;
-      "git.branch" = "none";
-      "git.build.time" = "1970-01-01T00:00:00+0000";
-      "git.commit.id.abbrev" = "none";
-      "git.commit.id.describe" = "none";
-    });
-  in ''
+  installPhase = ''
     mkdir -p $out/lib/server/target/lib
     cp -r server/target/lib/* $out/lib/server/target/lib/
     cp server/target/openrefine-*-server.jar $out/lib/server/target/lib/
@@ -84,8 +76,6 @@ in maven'.buildMavenPackage {
         fi
       done
     )
-
-    cp ${gitProperties} $out/lib/webapp/WEB-INF/classes/git.properties
 
     mkdir -p $out/etc
     cp refine.ini $out/etc/


### PR DESCRIPTION
## Description of changes

Addresses #314633

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
