### PR TITLE
python3Packages.bilibili-api-python: init

### DIFF
--- a/pkgs/development/python-modules/bilibili-api-python/default.nix
+++ b/pkgs/development/python-modules/bilibili-api-python/default.nix
@@ -1,0 +1,76 @@
+{
+  aiohttp,
+  apscheduler,
+  beautifulsoup4,
+  brotli,
+  buildPythonPackage,
+  colorama,
+  fetchPypi,
+  httpx,
+  lib,
+  lxml,
+  pillow,
+  pycryptodomex,
+  pyyaml,
+  qrcode,
+  qrcode-terminal,
+  requests,
+  rsa,
+  setuptools,
+  setuptools-scm,
+  tqdm,
+  yarl,
+}:
+buildPythonPackage rec {
+  pname = "bilibili-api-python";
+  version = "16.2.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ecv9lzp2L13seBosahgnglaZP8YZCD/13nlTPP8LCs0=";
+  };
+
+  postPatch = ''
+    # The upstream uses requirements.txt, which overly strict version constraints.
+    substituteInPlace requirements.txt \
+      --replace-fail "~=" ">="
+  '';
+
+  build-system = [
+    setuptools-scm
+    setuptools
+  ];
+
+  dependencies = [
+    aiohttp
+    beautifulsoup4
+    colorama
+    lxml
+    pyyaml
+    brotli
+    httpx
+    qrcode
+    requests
+    apscheduler
+    rsa
+    pillow
+    tqdm
+    yarl
+    pycryptodomex
+    qrcode-terminal
+  ];
+
+  # tests require network
+  doCheck = false;
+
+  pythonImportsCheck = [ "bilibili_api" ];
+
+  meta = {
+    changelog = "https://github.com/Nemo2011/bilibili-api/releases/tag/${version}";
+    description = "A python module providing convenient integration for various Bilibili API along with some additional common features";
+    homepage = "https://nemo2011.github.io/bilibili-api";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ moraxyc ];
+  };
+}

--- a/pkgs/development/python-modules/qrcode-terminal/default.nix
+++ b/pkgs/development/python-modules/qrcode-terminal/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  qrcode,
+  pillow,
+}:
+buildPythonPackage rec {
+  pname = "qrcode-terminal";
+  version = "0.8";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-Hitp5mK5NG6Y3ZWYMDPp1Dz/BkPYr9oSYF9RVCjmZsA=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    qrcode
+    pillow
+  ];
+
+  # have no test
+  doCheck = false;
+
+  pythonImportsCheck = [ "qrcode_terminal" ];
+
+  meta = {
+    description = "Display QRCode in Terminal";
+    homepage = "https://github.com/alishtory/qrcode-terminal";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ moraxyc ];
+    mainProgram = "qrcode-terminal-py";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12891,6 +12891,8 @@ self: super: with self; {
 
   qrcode = callPackage ../development/python-modules/qrcode { };
 
+  qrcode-terminal = callPackage ../development/python-modules/qrcode-terminal { };
+
   qreactor = callPackage ../development/python-modules/qreactor { };
 
   qscintilla-qt5 = pkgs.libsForQt5.callPackage ../development/python-modules/qscintilla-qt5 {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1523,6 +1523,8 @@ self: super: with self; {
 
   biliass = callPackage ../development/python-modules/biliass { };
 
+  bilibili-api-python = callPackage ../development/python-modules/bilibili-api-python { };
+
   billiard = callPackage ../development/python-modules/billiard { };
 
   bimmer-connected = callPackage ../development/python-modules/bimmer-connected { };


### PR DESCRIPTION
## Description of changes

init `python3Packages.bilibili-api-python` at 16.2.0
https://github.com/Nemo2011/bilibili-api

init `python3Packages.qrcode-terminal` at 0.8
https://github.com/alishtory/qrcode-terminal

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
