### PR TITLE
formats: Set `preferLocalBuild` and `allowSubstitutes`

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -65,6 +65,7 @@ rec {
       nativeBuildInputs = [ jq ];
       value = builtins.toJSON value;
       passAsFile = [ "value" ];
+      preferLocalBuild = true;
     } ''
       jq . "$valuePath"> $out
     '') {};
@@ -77,6 +78,7 @@ rec {
       nativeBuildInputs = [ remarshal ];
       value = builtins.toJSON value;
       passAsFile = [ "value" ];
+      preferLocalBuild = true;
     } ''
       json2yaml "$valuePath" "$out"
     '') {};
@@ -270,6 +272,7 @@ rec {
       nativeBuildInputs = [ remarshal ];
       value = builtins.toJSON value;
       passAsFile = [ "value" ];
+      preferLocalBuild = true;
     } ''
       json2toml "$valuePath" "$out"
     '') {};
@@ -467,6 +470,7 @@ rec {
           value = toConf value;
           passAsFile = [ "value" ];
           nativeBuildInputs = [ elixir ];
+          preferLocalBuild = true;
         } ''
         cp "$valuePath" "$out"
         mix format "$out"
@@ -501,6 +505,7 @@ rec {
                 print(f"{key} = {repr(value)}")
       '';
       passAsFile = [ "value" "pythonGen" ];
+      preferLocalBuild = true;
     } ''
       cat "$valuePath"
       python3 "$pythonGenPath" > $out

--- a/pkgs/pkgs-lib/formats/hocon/default.nix
+++ b/pkgs/pkgs-lib/formats/hocon/default.nix
@@ -153,6 +153,7 @@ in
           inherit name;
 
           dontUnpack = true;
+          preferLocalBuild = true;
 
           json = builtins.toJSON finalValue;
           passAsFile = [ "json" ];

--- a/pkgs/pkgs-lib/formats/java-properties/default.nix
+++ b/pkgs/pkgs-lib/formats/java-properties/default.nix
@@ -46,7 +46,7 @@ in
       in attrsOf elemType;
 
     generate = name: value:
-      pkgs.runCommandLocal name
+      pkgs.runCommand name
         {
           # Requirements
           # ============
@@ -80,6 +80,7 @@ in
           #    libraries, but we can't rely on this in
           #    general.
 
+          preferLocalBuild = true;
           passAsFile = [ "value" ];
           value = builtins.toJSON value;
           nativeBuildInputs = [

--- a/pkgs/pkgs-lib/formats/libconfig/default.nix
+++ b/pkgs/pkgs-lib/formats/libconfig/default.nix
@@ -85,6 +85,7 @@ in
           inherit name;
 
           dontUnpack = true;
+          preferLocalBuild = true;
 
           json = builtins.toJSON value;
           passAsFile = [ "json" ];


### PR DESCRIPTION
## Description of changes

- `formats`: Ensure all builders set `preferLocalBuild`
  Otherwise, the overhead of distributed builds is spent on many trivial format conversions.
- `formats.javaProperties`: Don't set `!allowSubstitutes`
  The `generate` builder was using [`runCommandLocal`], which prevents fetching an already-built version from a remote substituter/cache.

[`runCommandLocal`]: https://nixos.org/manual/nixpkgs/unstable/#trivial-builder-runCommandLocal


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - `pkgs-lib.tests.{formats, java-properties}`
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
