### PR TITLE
interception-tools: apply patch that fix udevmon

### DIFF
--- a/pkgs/tools/inputmethods/interception-tools/default.nix
+++ b/pkgs/tools/inputmethods/interception-tools/default.nix
@@ -22,6 +22,9 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Fix PATH forwarding to child processes.
+    # See #126681 issue for more information
+    ./interception-tools-udevmon-path-fix.patch
     (fetchpatch {
       name = "Bump-CMake-minimum-version-to-3.10";
       url = "https://gitlab.com/interception/linux/tools/-/commit/110c9b39b54eae9acd16fa6d64539ce9886b5684.patch";

--- a/pkgs/tools/inputmethods/interception-tools/interception-tools-udevmon-path-fix.patch
+++ b/pkgs/tools/inputmethods/interception-tools/interception-tools-udevmon-path-fix.patch
@@ -1,0 +1,28 @@
+diff --git a/udevmon.cpp b/udevmon.cpp
+index 70a28be..60fcbe2 100644
+--- a/udevmon.cpp
++++ b/udevmon.cpp
+@@ -101,7 +101,11 @@ struct cmd {
+                     for (size_t j = 0; j < cmds[i].size(); ++j)
+                         command[j] = const_cast<char *>(cmds[i][j].c_str());
+                     command[cmds[i].size()] = nullptr;
+-                    char *environment[]     = {nullptr};
++                    std::string path_env = "PATH=";
++                    path_env += std::getenv("PATH");
++                    char *environment[]     = {
++                        const_cast<char *>(path_env.c_str()),
++                        nullptr};
+                     setpgid(0, 0);
+                     execvpe(command[0], command.get(), environment);
+                     std::string e = "exec failed for \"";
+@@ -348,7 +352,10 @@ struct job {
+                         command[j] = const_cast<char *>(cmds[i][j].c_str());
+                     command[cmds[i].size()] = nullptr;
+                     std::string variables   = "DEVNODE=" + devnode;
++                    std::string path_env = "PATH=";
++                    path_env += std::getenv("PATH");
+                     char *environment[]     = {
++                        const_cast<char *>(path_env.c_str()),
+                         const_cast<char *>(variables.c_str()), nullptr};
+                     setpgid(0, 0);
+                     execvpe(command[0], command.get(), environment);


### PR DESCRIPTION
## Description of changes

That PR fix bug with PATH forwarding inside udevmon.

Related:
- issue: #126681 
- discourse: https://discourse.nixos.org/t/troubleshooting-help-services-interception-tools/20389

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
