### PR TITLE
[23.11] ghostscript: add patches for CVE-2024-33870, CVE-2024-33869 & CVE-2024-33871

### DIFF
--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , lib
 , fetchurl
+, fetchpatch
 , pkg-config
 , zlib
 , expat
@@ -71,6 +72,26 @@ stdenv.mkDerivation rec {
   patches = [
     ./urw-font-files.patch
     ./doc-no-ref.diff
+    (fetchpatch {
+      name = "CVE-2024-33870.patch";
+      url = "https://cgit.ghostscript.com/cgi-bin/cgit.cgi/ghostpdl.git/patch/?id=79aef19c685984dc3da2dc090450407d9fbcff80";
+      hash = "sha256-EZOtKbAkNujqAPoD1yWTggXYTdLPPR9uC898JByQwVs=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-33869.part-1.patch";
+      url = "https://cgit.ghostscript.com/cgi-bin/cgit.cgi/ghostpdl.git/patch/?id=5ae2e320d69a7d0973011796bd388cd5befa1a43";
+      hash = "sha256-ob2c4aawUxJcsLdhHX9/7CDNnnxO8k1LTqfar5Bgdo8=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-33869.part-2.patch";
+      url = "https://cgit.ghostscript.com/cgi-bin/cgit.cgi/ghostpdl.git/patch/?id=f5336e5b4154f515ac83bc5b9eba94302e6618d4";
+      hash = "sha256-2Kx57WJvALpEjR8+uTbF3CBvO/9Ujl652L4Kf+mNRWo=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-33871.patch";
+      url = "https://cgit.ghostscript.com/cgi-bin/cgit.cgi/ghostpdl.git/patch/?id=7145885041bb52cc23964f0aa2aec1b1c82b5908";
+      hash = "sha256-a5+WY63lmu++cc8BGREWlIY4S1LEvWqeqTTfBnEY+YM=";
+    })
   ];
 
   outputs = [ "out" "man" "doc" ];


### PR DESCRIPTION
## Description of changes
https://security-tracker.debian.org/tracker/CVE-2024-33869
https://security-tracker.debian.org/tracker/CVE-2024-33870
https://security-tracker.debian.org/tracker/CVE-2024-33871

Addressed for unstable and 24.05 by #296602 & #314266 respectively

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
