### PR TITLE
nixos: Don't set `!allowSubstitutes`

### DIFF
--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -33,7 +33,8 @@ let
     '';
 
   babelfishTranslate = path: name:
-    pkgs.runCommandLocal "${name}.fish" {
+    pkgs.runCommand "${name}.fish" {
+      preferLocalBuild = true;
       nativeBuildInputs = [ pkgs.babelfish ];
     } "babelfish < ${path} > $out;";
 
@@ -258,12 +259,14 @@ in
             preferLocalBuild = true;
             allowSubstitutes = false;
           };
-          generateCompletions = package: pkgs.runCommandLocal
+          generateCompletions = package: pkgs.runCommand
             ( with lib.strings; let
                 storeLength = stringLength storeDir + 34; # Nix' StorePath::HashLen + 2 for the separating slash and dash
                 pathName = substring storeLength (stringLength package - storeLength) package;
               in (package.name or pathName) + "_fish-completions")
-            ( { inherit package; } //
+            ( { inherit package;
+                preferLocalBuild = true;
+              } //
               lib.optionalAttrs (package ? meta.priority) { meta.priority = package.meta.priority; })
             ''
               mkdir -p $out

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -321,9 +321,9 @@ in
     };
 
     ###### wrappers consistency checks
-    system.checks = lib.singleton (pkgs.runCommandLocal
-      "ensure-all-wrappers-paths-exist" { }
-      ''
+    system.checks = lib.singleton (pkgs.runCommand "ensure-all-wrappers-paths-exist" {
+      preferLocalBuild = true;
+    } ''
         # make sure we produce output
         mkdir -p $out
 

--- a/nixos/modules/services/continuous-integration/buildkite-agents.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agents.nix
@@ -9,7 +9,9 @@ let
         ln --symbolic ${pkgs.writeShellApplication { inherit name text; }}/bin/${name} $out/${name}
       '';
     in
-    pkgs.runCommandLocal "buildkite-agent-hooks" { } ''
+    pkgs.runCommand "buildkite-agent-hooks" {
+      preferLocalBuild = true;
+    } ''
       mkdir $out
       ${lib.concatStringsSep "\n" (lib.mapAttrsToList mkHookEntry hooks)}
     '';

--- a/nixos/modules/services/games/archisteamfarm.nix
+++ b/nixos/modules/services/games/archisteamfarm.nix
@@ -228,7 +228,9 @@ in
 
         preStart =
           let
-            createBotsScript = pkgs.runCommandLocal "ASF-bots" { } ''
+            createBotsScript = pkgs.runCommand "ASF-bots" {
+              preferLocalBuild = true;
+            } ''
               mkdir -p $out
               # clean potential removed bots
               rm -rf $out/*.json

--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -10,7 +10,9 @@ let
   # secrets or includes, by naively unquoting strings with leading bangs
   # and at least one space-separated parameter.
   # https://www.home-assistant.io/docs/configuration/secrets/
-  renderYAMLFile = fn: yaml: pkgs.runCommandLocal fn { } ''
+  renderYAMLFile = fn: yaml: pkgs.runCommand fn {
+    preferLocalBuilds = true;
+  } ''
     cp ${format.generate fn yaml} $out
     sed -i -e "s/'\!\([a-z_]\+\) \(.*\)'/\!\1 \2/;s/^\!\!/\!/;" $out
   '';

--- a/nixos/modules/services/misc/ananicy.nix
+++ b/nixos/modules/services/misc/ananicy.nix
@@ -114,24 +114,27 @@ in
   config = lib.mkIf cfg.enable {
     environment = {
       systemPackages = [ finalPackage ];
-      etc."ananicy.d".source = pkgs.runCommand "ananicyfiles" {
-        preferLocalBuild = true;
-      } ''
-        mkdir -p $out
-        # ananicy-cpp does not include rules or settings on purpose
-        if [[ -d "${cfg.rulesProvider}/etc/ananicy.d/00-default" ]]; then
-          cp -r ${cfg.rulesProvider}/etc/ananicy.d/* $out
-        else
-          cp -r ${cfg.rulesProvider}/* $out
-        fi
+      etc."ananicy.d".source =
+        pkgs.runCommand "ananicyfiles"
+          {
+            preferLocalBuild = true;
+          }
+          ''
+            mkdir -p $out
+            # ananicy-cpp does not include rules or settings on purpose
+            if [[ -d "${cfg.rulesProvider}/etc/ananicy.d/00-default" ]]; then
+              cp -r ${cfg.rulesProvider}/etc/ananicy.d/* $out
+            else
+              cp -r ${cfg.rulesProvider}/* $out
+            fi
 
-        # configured through .setings
-        rm -f $out/ananicy.conf
-        cp ${configFile} $out/ananicy.conf
-        ${lib.optionalString (cfg.extraRules != [ ]) "cp ${extraRules} $out/nixRules.rules"}
-        ${lib.optionalString (cfg.extraTypes != [ ]) "cp ${extraTypes} $out/nixTypes.types"}
-        ${lib.optionalString (cfg.extraCgroups != [ ]) "cp ${extraCgroups} $out/nixCgroups.cgroups"}
-      '';
+            # configured through .setings
+            rm -f $out/ananicy.conf
+            cp ${configFile} $out/ananicy.conf
+            ${lib.optionalString (cfg.extraRules != [ ]) "cp ${extraRules} $out/nixRules.rules"}
+            ${lib.optionalString (cfg.extraTypes != [ ]) "cp ${extraTypes} $out/nixTypes.types"}
+            ${lib.optionalString (cfg.extraCgroups != [ ]) "cp ${extraCgroups} $out/nixCgroups.cgroups"}
+          '';
     };
 
     # ananicy and ananicy-cpp have different default settings

--- a/nixos/modules/services/misc/ananicy.nix
+++ b/nixos/modules/services/misc/ananicy.nix
@@ -114,7 +114,9 @@ in
   config = lib.mkIf cfg.enable {
     environment = {
       systemPackages = [ finalPackage ];
-      etc."ananicy.d".source = pkgs.runCommandLocal "ananicyfiles" { } ''
+      etc."ananicy.d".source = pkgs.runCommand "ananicyfiles" {
+        preferLocalBuild = true;
+      } ''
         mkdir -p $out
         # ananicy-cpp does not include rules or settings on purpose
         if [[ -d "${cfg.rulesProvider}/etc/ananicy.d/00-default" ]]; then

--- a/nixos/modules/services/monitoring/apcupsd.nix
+++ b/nixos/modules/services/monitoring/apcupsd.nix
@@ -60,9 +60,10 @@ let
   );
 
   # Ensure the CLI uses our generated configFile
-  wrappedBinaries = pkgs.runCommandLocal "apcupsd-wrapped-binaries"
-    { nativeBuildInputs = [ pkgs.makeWrapper ]; }
-    ''
+  wrappedBinaries = pkgs.runCommand "apcupsd-wrapped-binaries" {
+    preferLocalBuild = true;
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+  } ''
       for p in "${lib.getBin pkgs.apcupsd}/bin/"*; do
           bname=$(basename "$p")
           makeWrapper "$p" "$out/bin/$bname" --add-flags "-f ${configFile}"

--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -29,9 +29,10 @@ let
   # a wrapper that verifies that the configuration is valid
   promtoolCheck = what: name: file:
     if checkConfigEnabled then
-      pkgs.runCommandLocal
-        "${name}-${replaceStrings [" "] [""] what}-checked"
-        { nativeBuildInputs = [ cfg.package.cli ]; } ''
+      pkgs.runCommand "${name}-${replaceStrings [" "] [""] what}-checked" {
+        preferLocalBuild = true;
+        nativeBuildInputs = [ cfg.package.cli ];
+      } ''
         ln -s ${file} $out
         promtool ${what} $out
       '' else file;

--- a/nixos/modules/services/monitoring/prometheus/exporters/snmp.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/snmp.nix
@@ -23,7 +23,8 @@ let
         '' /. + file);
 
   checkConfig = file:
-    pkgs.runCommandLocal "checked-snmp-exporter-config.yml" {
+    pkgs.runCommand "checked-snmp-exporter-config.yml" {
+      preferLocalBuild = true;
       nativeBuildInputs = [ pkgs.buildPackages.prometheus-snmp-exporter ];
     } ''
       ln -s ${coerceConfigFile file} $out

--- a/nixos/modules/services/networking/thelounge.nix
+++ b/nixos/modules/services/networking/thelounge.nix
@@ -11,7 +11,9 @@ let
   pluginManifest = {
     dependencies = builtins.listToAttrs (builtins.map (pkg: { name = getName pkg; value = getVersion pkg; }) cfg.plugins);
   };
-  plugins = pkgs.runCommandLocal "thelounge-plugins" { } ''
+  plugins = pkgs.runCommand "thelounge-plugins" {
+    preferLocalBuild = true;
+  } ''
     mkdir -p $out/node_modules
     echo ${escapeShellArg (builtins.toJSON pluginManifest)} >> $out/package.json
     ${concatMapStringsSep "\n" (pkg: ''

--- a/nixos/modules/services/networking/unbound.nix
+++ b/nixos/modules/services/networking/unbound.nix
@@ -30,7 +30,9 @@ let
     ${confServer}
     ${confNoServer}
   '';
-  confFile = if cfg.checkconf then pkgs.runCommandLocal "unbound-checkconf" { } ''
+  confFile = if cfg.checkconf then pkgs.runCommand "unbound-checkconf" {
+    preferLocalBuild = true;
+  } ''
     cp ${confFileUnchecked} unbound.conf
 
     # fake stateDir which is not accessible in the sandbox

--- a/nixos/modules/services/web-apps/akkoma.nix
+++ b/nixos/modules/services/web-apps/akkoma.nix
@@ -336,7 +336,9 @@ let
           exec "${cfg.package}/bin/$(basename "$0")" "$@"
       '';
     };
-  in pkgs.runCommandLocal "akkoma-env" { } ''
+  in pkgs.runCommand "akkoma-env" {
+    preferLocalBuild = true;
+  } ''
     mkdir -p "$out/bin"
 
     ln -r -s ${escapeShellArg script} "$out/bin/pleroma"
@@ -379,7 +381,9 @@ let
   staticDir = ex.":pleroma".":instance".static_dir;
   uploadDir = ex.":pleroma".":instance".upload_dir;
 
-  staticFiles = pkgs.runCommandLocal "akkoma-static" { } ''
+  staticFiles = pkgs.runCommand "akkoma-static" {
+    preferLocalBuild = true;
+  } ''
     ${concatStringsSep "\n" (mapAttrsToList (key: val: ''
       mkdir -p $out/frontends/${escapeShellArg val.name}/
       ln -s ${escapeShellArg val.package} $out/frontends/${escapeShellArg val.name}/${escapeShellArg val.ref}

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -44,10 +44,9 @@ let
     };
   };
 
-  webroot = pkgs.runCommandLocal
-    "${cfg.package.name or "nextcloud"}-with-apps"
-    { }
-    ''
+  webroot = pkgs.runCommand "${cfg.package.name or "nextcloud"}-with-apps" {
+    preferLocalBuild = true;
+  } ''
       mkdir $out
       ln -sfv "${cfg.package}"/* "$out"
       ${concatStrings

--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -24,7 +24,8 @@ let
         inherit (cfg) ghcArgs;
       } cfg.config;
     in
-      pkgs.runCommandLocal "xmonad" {
+      pkgs.runCommand "xmonad" {
+        preferLocalBuild = true;
         nativeBuildInputs = [ pkgs.makeWrapper ];
       } (''
         install -D ${xmonadEnv}/share/man/man1/xmonad.1.gz $out/share/man/man1/xmonad.1.gz


### PR DESCRIPTION
## Description of changes

Went through `nixos/modules` and replaced (most) uses of `runCommandLocal`:
it [sets `allowSubstitutes` to `false`][runCL], forcing users to rebuild the drvs locally, even in cases where the configuration is left to defaults etc.

[runCL]: https://nixos.org/manual/nixpkgs/unstable/#trivial-builder-runCommandLocal


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - [x] akkoma
    - [x] apcupsd
    - [x] fish
    - [x] home-assistant
    - [x] nextcloud
    - [x] prometheus
    - [x] unbound
    - [x] xmonad
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
