### PR TITLE
[24.05] Haskell backports (cabal2nix, GHC expression refactor)

### DIFF
--- a/pkgs/data/misc/hackage/pin.json
+++ b/pkgs/data/misc/hackage/pin.json
@@ -1,6 +1,6 @@
 {
-  "commit": "bf587f9f9cf315bd6a757bdf65e157addfbaa4d0",
-  "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/bf587f9f9cf315bd6a757bdf65e157addfbaa4d0.tar.gz",
-  "sha256": "0rvl17w5d47rn7zfyjk6b9v2cq62m393l77413ldmvvqhmlrsr26",
-  "msg": "Update from Hackage at 2024-05-19T16:27:24Z"
+  "commit": "a71af8d538cda614baa0bcb3e44600061f815d57",
+  "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/a71af8d538cda614baa0bcb3e44600061f815d57.tar.gz",
+  "sha256": "0hsqzdfb89rqmplipz39x7m80czcvrmk42y05ifnqjhxn6q4v91l",
+  "msg": "Update from Hackage at 2024-05-20T16:06:03Z"
 }

--- a/pkgs/data/misc/hackage/pin.json
+++ b/pkgs/data/misc/hackage/pin.json
@@ -1,6 +1,6 @@
 {
-  "commit": "88d42dc0129b0e3f4f702149a58667c66add9262",
-  "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/88d42dc0129b0e3f4f702149a58667c66add9262.tar.gz",
-  "sha256": "0imff76qbg1hsvsdds6dc2wfip0prdsa0bixd5b575jr6yjlkirh",
-  "msg": "Update from Hackage at 2024-05-15T11:29:34Z"
+  "commit": "bf587f9f9cf315bd6a757bdf65e157addfbaa4d0",
+  "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/bf587f9f9cf315bd6a757bdf65e157addfbaa4d0.tar.gz",
+  "sha256": "0rvl17w5d47rn7zfyjk6b9v2cq62m393l77413ldmvvqhmlrsr26",
+  "msg": "Update from Hackage at 2024-05-19T16:27:24Z"
 }

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -187,17 +187,7 @@ stdenv.mkDerivation (rec {
 
   outputs = [ "out" "doc" ];
 
-  # FIXME(@sternenseemann): This can be simplified a lot (causing a rebuild)
-  patches = (if lib.versions.majorMinor version == "9.0" then [
-    # Fix docs build with sphinx >= 6.0
-    # https://gitlab.haskell.org/ghc/ghc/-/issues/22766
-    (fetchpatch {
-      name = "ghc-docs-sphinx-6.0.patch";
-      url = "https://gitlab.haskell.org/ghc/ghc/-/commit/10e94a556b4f90769b7fd718b9790d58ae566600.patch";
-      sha256 = "0kmhfamr16w8gch0lgln2912r8aryjky1hfcda3jkcwa5cdzgjdv";
-    })
-    # Fix docs build with Sphinx >= 7 https://gitlab.haskell.org/ghc/ghc/-/issues/24129
-    ./docs-sphinx-7.patch
+  patches = lib.optionals (lib.versionOlder version "9.4") [
     # fix hyperlinked haddock sources: https://github.com/haskell/haddock/pull/1482
     (fetchpatch {
       url = "https://patch-diff.githubusercontent.com/raw/haskell/haddock/pull/1482.patch";
@@ -205,7 +195,24 @@ stdenv.mkDerivation (rec {
       extraPrefix = "utils/haddock/";
       stripLen = 1;
     })
+  ]
 
+  ++ lib.optionals (lib.versionOlder version "9.4.6") [
+    # Fix docs build with sphinx >= 6.0
+    # https://gitlab.haskell.org/ghc/ghc/-/issues/22766
+    (fetchpatch {
+      name = "ghc-docs-sphinx-6.0.patch";
+      url = "https://gitlab.haskell.org/ghc/ghc/-/commit/10e94a556b4f90769b7fd718b9790d58ae566600.patch";
+      sha256 = "0kmhfamr16w8gch0lgln2912r8aryjky1hfcda3jkcwa5cdzgjdv";
+    })
+  ]
+
+  ++ [
+    # Fix docs build with Sphinx >= 7 https://gitlab.haskell.org/ghc/ghc/-/issues/24129
+    ./docs-sphinx-7.patch
+  ]
+
+  ++ lib.optionals (lib.versionOlder version "9.2.2") [
     # Add flag that fixes C++ exception handling; opt-in. Merged in 9.4 and 9.2.2.
     # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/7423
     (fetchpatch {
@@ -214,60 +221,25 @@ stdenv.mkDerivation (rec {
       url = "https://gitlab.haskell.org/ghc/ghc/-/commit/c6132c782d974a7701e7f6447bdcd2bf6db4299a.patch?merge_request_iid=7423";
       sha256 = "sha256-b4feGZIaKDj/UKjWTNY6/jH4s2iate0wAgMxG3rAbZI=";
     })
-  ] else if lib.versions.majorMinor version == "9.2" then [
-    # Fix docs build with sphinx >= 6.0
-    # https://gitlab.haskell.org/ghc/ghc/-/issues/22766
-    (fetchpatch {
-      name = "ghc-docs-sphinx-6.0.patch";
-      url = "https://gitlab.haskell.org/ghc/ghc/-/commit/10e94a556b4f90769b7fd718b9790d58ae566600.patch";
-      sha256 = "0kmhfamr16w8gch0lgln2912r8aryjky1hfcda3jkcwa5cdzgjdv";
-    })
-    # Fix docs build with Sphinx >= 7 https://gitlab.haskell.org/ghc/ghc/-/issues/24129
-    ./docs-sphinx-7.patch
-    # fix hyperlinked haddock sources: https://github.com/haskell/haddock/pull/1482
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/haskell/haddock/pull/1482.patch";
-      sha256 = "sha256-8w8QUCsODaTvknCDGgTfFNZa8ZmvIKaKS+2ZJZ9foYk=";
-      extraPrefix = "utils/haddock/";
-      stripLen = 1;
-    })
-    # Don't generate code that doesn't compile when --enable-relocatable is passed to Setup.hs
-    # Can be removed if the Cabal library included with ghc backports the linked fix
-    (fetchpatch {
-      url = "https://github.com/haskell/cabal/commit/6c796218c92f93c95e94d5ec2d077f6956f68e98.patch";
-      stripLen = 1;
-      extraPrefix = "libraries/Cabal/";
-      sha256 = "sha256-yRQ6YmMiwBwiYseC5BsrEtDgFbWvst+maGgDtdD0vAY=";
-    })
-  ] else if lib.versions.majorMinor version == "9.4" then [
-    # Don't generate code that doesn't compile when --enable-relocatable is passed to Setup.hs
-    # Can be removed if the Cabal library included with ghc backports the linked fix
-    (fetchpatch {
-      url = "https://github.com/haskell/cabal/commit/6c796218c92f93c95e94d5ec2d077f6956f68e98.patch";
-      stripLen = 1;
-      extraPrefix = "libraries/Cabal/";
-      sha256 = "sha256-yRQ6YmMiwBwiYseC5BsrEtDgFbWvst+maGgDtdD0vAY=";
-    })
   ]
-  ++ lib.optionals (version == "9.4.5") [
-    # Fix docs build with sphinx >= 6.0
-    # https://gitlab.haskell.org/ghc/ghc/-/issues/22766
-    (fetchpatch {
-      name = "ghc-docs-sphinx-6.0.patch";
-      url = "https://gitlab.haskell.org/ghc/ghc/-/commit/10e94a556b4f90769b7fd718b9790d58ae566600.patch";
-      sha256 = "0kmhfamr16w8gch0lgln2912r8aryjky1hfcda3jkcwa5cdzgjdv";
-    })
-  ]
-  ++ [
 
-    # Fix docs build with Sphinx >= 7 https://gitlab.haskell.org/ghc/ghc/-/issues/24129
-    ./docs-sphinx-7.patch
+  ++ lib.optionals (lib.versionAtLeast version "9.2") [
+    # Don't generate code that doesn't compile when --enable-relocatable is passed to Setup.hs
+    # Can be removed if the Cabal library included with ghc backports the linked fix
+    (fetchpatch {
+      url = "https://github.com/haskell/cabal/commit/6c796218c92f93c95e94d5ec2d077f6956f68e98.patch";
+      stripLen = 1;
+      extraPrefix = "libraries/Cabal/";
+      sha256 = "sha256-yRQ6YmMiwBwiYseC5BsrEtDgFbWvst+maGgDtdD0vAY=";
+    })
   ]
+
   ++ lib.optionals (version == "9.4.6") [
     # Work around a type not being defined when including Rts.h in bytestring's cbits
     # due to missing feature macros. See https://gitlab.haskell.org/ghc/ghc/-/issues/23810.
     ./9.4.6-bytestring-posix-source.patch
-  ] else [ ])
+  ]
+
   ++ lib.optionals (stdenv.targetPlatform.isDarwin && stdenv.targetPlatform.isAarch64) [
     # Prevent the paths module from emitting symbols that we don't use
     # when building with separate outputs.

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -285,12 +285,8 @@ stdenv.mkDerivation (rec {
     # LLVM backend on Darwin needs clang: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/codegens.html#llvm-code-generator-fllvm
     export CLANG="${buildTargetLlvmPackages.clang}/bin/${buildTargetLlvmPackages.clang.targetPrefix}clang"
   ''
-  + lib.optionalString (version == "9.0.2" || lib.versionAtLeast version "9.4") ''
-
-  '' + ''
+  + ''
     echo -n "${buildMK}" > mk/build.mk
-  '' + lib.optionalString (lib.versionAtLeast version "9.4") ''
-
   ''
   + lib.optionalString (lib.versionOlder version "9.2" || lib.versionAtLeast version "9.4") ''
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure

--- a/pkgs/development/haskell-modules/cabal2nix-unstable.nix
+++ b/pkgs/development/haskell-modules/cabal2nix-unstable.nix
@@ -8,10 +8,10 @@
 }:
 mkDerivation {
   pname = "cabal2nix";
-  version = "unstable-2024-04-21";
+  version = "unstable-2024-05-20";
   src = fetchzip {
-    url = "https://github.com/NixOS/cabal2nix/archive/f8e6bf749a158a5ed866c57deee907b5f16c38e5.tar.gz";
-    sha256 = "0c73mvza65iy46fv8c8cadsy7klk4jzmimm1mfdavvm8i2cr5476";
+    url = "https://github.com/NixOS/cabal2nix/archive/79b73778680e2ae27302dce430beee302299f496.tar.gz";
+    sha256 = "0xjrnf9x1f4jl4bsxc6kv5q7rsbn3vs0ddidj9qf6mzzzqxq14p3";
   };
   postUnpack = "sourceRoot+=/cabal2nix; echo source root reset to $sourceRoot";
   isLibrary = true;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
@@ -95,7 +95,7 @@ self: super: {
   ghc-lib-parser-ex = addBuildDepend self.ghc-lib-parser super.ghc-lib-parser-ex;
 
   # This became a core library in ghc 8.10., so we don’t have an "exception" attribute anymore.
-  exceptions = self.exceptions_0_10_7;
+  exceptions = self.exceptions_0_10_8;
 
   # vector 0.12.2 indroduced doctest checks that don’t work on older compilers
   vector = dontCheck super.vector;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -60,7 +60,7 @@ self: super: {
   # TODO: remove when aeson updates or launches a revision
   # see https://github.com/haskell/aeson/issues/1089 and https://github.com/haskell/aeson/pulls/1088
   aeson = doJailbreak (doDistribute self.aeson_2_2_2_0);
-  attoparsec-aeson = doDistribute self.attoparsec-aeson_2_2_0_1;
+  attoparsec-aeson = doDistribute self.attoparsec-aeson_2_2_2_0;
   xmonad = doDistribute self.xmonad_0_18_0;
   apply-refact = self.apply-refact_0_14_0_0;
   ormolu = self.ormolu_0_7_4_0;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -59,7 +59,7 @@ self: super: {
   megaparsec = doDistribute self.megaparsec_9_6_1;
   # TODO: remove when aeson updates or launches a revision
   # see https://github.com/haskell/aeson/issues/1089 and https://github.com/haskell/aeson/pulls/1088
-  aeson = doJailbreak (doDistribute self.aeson_2_2_1_0);
+  aeson = doJailbreak (doDistribute self.aeson_2_2_2_0);
   attoparsec-aeson = doDistribute self.attoparsec-aeson_2_2_0_1;
   xmonad = doDistribute self.xmonad_0_18_0;
   apply-refact = self.apply-refact_0_14_0_0;

--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -27,7 +27,7 @@ self: super:
   # GHCJS does not ship with the same core packages as GHC.
   # https://github.com/ghcjs/ghcjs/issues/676
   stm = doJailbreak self.stm_2_5_3_1;
-  exceptions = dontCheck self.exceptions_0_10_7;
+  exceptions = dontCheck self.exceptions_0_10_8;
 
 ## OTHER PACKAGES
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5795,7 +5795,6 @@ broken-packages:
   - supplemented # failure in job https://hydra.nixos.org/build/233237397 at 2023-09-02
   - supply-chain-core # failure in job https://hydra.nixos.org/build/252715612 at 2024-03-16
   - surjective # failure in job https://hydra.nixos.org/build/233242908 at 2023-09-02
-  - sv2v # failure in job https://hydra.nixos.org/build/233190750 at 2023-09-02
   - sv-core # failure in job https://hydra.nixos.org/build/233217245 at 2023-09-02
   - SVD2HS # failure in job https://hydra.nixos.org/build/233248575 at 2023-09-02
   - svfactor # failure in job https://hydra.nixos.org/build/233256743 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -764,7 +764,6 @@ broken-packages:
   - ChristmasTree # failure in job https://hydra.nixos.org/build/233259648 at 2023-09-02
   - chronograph # failure in job https://hydra.nixos.org/build/233232822 at 2023-09-02
   - chr-parse # failure in job https://hydra.nixos.org/build/233243933 at 2023-09-02
-  - chs-cabal # failure in job https://hydra.nixos.org/build/259964491 at 2024-05-19
   - chunky # failure in job https://hydra.nixos.org/build/233216440 at 2023-09-02
   - church # failure in job https://hydra.nixos.org/build/233223920 at 2023-09-02
   - church-maybe # failure in job https://hydra.nixos.org/build/233258572 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -742,6 +742,7 @@ broken-packages:
   - changelog-d # failure in job https://hydra.nixos.org/build/257082502 at 2024-04-27
   - changelog-d # failure in job https://hydra.nixos.org/build/259607598 at 2024-05-15
   - changelog-d # failure in job https://hydra.nixos.org/build/259957724 at 2024-05-19
+  - changelog-d # failure in job https://hydra.nixos.org/build/260724402 at 2024-05-25
   - changelogged # failure in job https://hydra.nixos.org/build/233211675 at 2023-09-02
   - character-cases # failure in job https://hydra.nixos.org/build/233197636 at 2023-09-02
   - charter # failure in job https://hydra.nixos.org/build/233237264 at 2023-09-02
@@ -1991,6 +1992,7 @@ broken-packages:
   - ghci-history-parser # failure in job https://hydra.nixos.org/build/233204448 at 2023-09-02
   - ghci-lib # failure in job https://hydra.nixos.org/build/233216644 at 2023-09-02
   - ghci-ng # failure in job https://hydra.nixos.org/build/233229533 at 2023-09-02
+  - ghc-internal # failure in job https://hydra.nixos.org/build/260723678 at 2024-05-25
   - ghcitui # failure in job https://hydra.nixos.org/build/252737339 at 2024-03-16
   - ghcjs-base-stub # timeout
   - ghcjs-dom-javascript # failure in job https://hydra.nixos.org/build/255688382 at 2024-04-16
@@ -4118,6 +4120,7 @@ broken-packages:
   - non-empty-zipper # failure in job https://hydra.nixos.org/build/233244341 at 2023-09-02
   - nonlinear-optimization # failure in job https://hydra.nixos.org/build/233204674 at 2023-09-02
   - noodle # failure in job https://hydra.nixos.org/build/233195125 at 2023-09-02
+  - no-recursion # failure in job https://hydra.nixos.org/build/260711915 at 2024-05-25
   - normalization-insensitive # failure in job https://hydra.nixos.org/build/233239612 at 2023-09-02
   - no-role-annots # failure in job https://hydra.nixos.org/build/233229589 at 2023-09-02
   - notcpp # failure in job https://hydra.nixos.org/build/233216543 at 2023-09-02
@@ -4932,6 +4935,7 @@ broken-packages:
   - readline-statevar # failure in job https://hydra.nixos.org/build/233226053 at 2023-09-02
   - readme-lhs # failure in job https://hydra.nixos.org/build/233248229 at 2023-09-02
   - readshp # failure in job https://hydra.nixos.org/build/233197835 at 2023-09-02
+  - real-dice # failure in job https://hydra.nixos.org/build/260725788 at 2024-05-25
   - really-simple-xml-parser # failure in job https://hydra.nixos.org/build/233195945 at 2023-09-02
   - reanimate-svg # failure in job https://hydra.nixos.org/build/233242271 at 2023-09-02
   - reasonable-lens # failure in job https://hydra.nixos.org/build/233233111 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -64,6 +64,7 @@ extra-packages:
   - ghc-exactprint == 0.6.*             # 2022-12-12: needed for GHC < 9.2
   - ghc-exactprint == 1.5.*             # 2023-03-30: needed for GHC == 9.2
   - ghc-exactprint == 1.6.*             # 2023-03-30: needed for GHC == 9.4
+  - ghc-exactprint == 1.8.*             # 2024-05-20: needed for GHC == 9.8
   - ghc-lib == 9.2.*                    # 2022-02-17: preserve for GHC 9.2
   - ghc-lib-parser == 9.2.*             # 2022-02-17: preserve for GHC 9.2
   - ghc-lib-parser == 9.8.*             # 2024-05-19: preserve for GHC 9.8

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -35,6 +35,7 @@ default-package-overrides:
   - extensions < 0.1.0.2 # Incompatible with Cabal < 3.12, the newest extensions version is only needed on ghc 9.10
   # 2024-05-10: need to match hlegder from stackage
   - hledger-ui < 1.33
+  - chs-cabal < 0.1.1.2 # Incompatible with Cabal < 3.12
 
 
 extra-packages:

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -532,7 +532,6 @@ dont-distribute-packages:
  - apotiki
  - approx-rand-test
  - arbor-monad-metric-datadog
- - archive-libarchive
  - archive-tar-bytestring
  - archlinux-web
  - arduino-copilot
@@ -2567,7 +2566,6 @@ dont-distribute-packages:
  - lha
  - lhae
  - lhe
- - libarchive
  - libconfig
  - libcspm
  - libgraph

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -616,6 +616,7 @@ dont-distribute-packages:
  - bamstats
  - barley
  - base32-bytestring
+ - base_4_20_0_0
  - baserock-schema
  - basic
  - batchd
@@ -636,6 +637,7 @@ dont-distribute-packages:
  - bearriver
  - beautifHOL
  - bech32-th
+ - bech32-th_1_1_7
  - bein
  - belka
  - bff
@@ -1513,6 +1515,7 @@ dont-distribute-packages:
  - geolite-csv
  - getemx
  - ghc-dump-util
+ - ghc-experimental
  - ghc-imported-from
  - ghc-instances
  - ghc-mod
@@ -2815,7 +2818,6 @@ dont-distribute-packages:
  - mps
  - mptcp-pm
  - mptcpanalyzer
- - ms-tds
  - msgpack-aeson
  - msgpack-arbitrary
  - msgpack-binary
@@ -2825,7 +2827,6 @@ dont-distribute-packages:
  - msgpack-rpc-conduit
  - msgpack-testsuite
  - msi-kb-backlit
- - mssql-simple
  - mstate
  - mtgoxapi
  - mu-avro
@@ -4226,6 +4227,7 @@ dont-distribute-packages:
  - werewolf-slack
  - wgpu-hs
  - what4
+ - what4_1_6
  - wheb-mongo
  - wheb-redis
  - wheb-strapped


### PR DESCRIPTION
## Description of changes

Backport of #312934. We mainly want

- The GHC expression refactors (which only change patch order / whitespace), so we can backport future GHC changes.
- A new (minor) version of distribution-nixpkgs, so cabal2nix deals with `javascript-unknown-ghcjs` as it should. Sadly, this requires a Hackage bump and some unrelated changes to keep the package set working properly.