### PR TITLE
bant: init at 0.1.5

### DIFF
--- a/pkgs/by-name/ba/bant/package.nix
+++ b/pkgs/by-name/ba/bant/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  buildBazelPackage,
+  fetchFromGitHub,
+  bazel_6,
+  jdk,
+  git,
+}:
+
+buildBazelPackage rec {
+  pname = "bant";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "hzeller";
+    repo = "bant";
+    rev = "v${version}";
+    hash = "sha256-3xGAznR/IHQHY1ISqmU8NxI90Pl57cdYeRDeLVh9L08=";
+  };
+
+  postPatch = ''
+    patchShebangs scripts/create-workspace-status.sh
+  '';
+
+  fetchAttrs = {
+    sha256 = "sha256-k9yCzs9atdBNMH4r2RF8TfHS3+p5u8u8oY9Zzl9c8dA=";
+  };
+
+  nativeBuildInputs = [
+    jdk
+    git
+  ];
+  bazel = bazel_6;
+
+  bazelBuildFlags = [ "-c opt" ];
+  bazelTestTargets = [ "//..." ];
+  bazelTargets = [ "//bant:bant" ];
+
+  buildAttrs = {
+    installPhase = ''
+      install -D --strip bazel-bin/bant/bant "$out/bin/bant"
+    '';
+  };
+
+  meta = with lib; {
+    description = "Bazel/Build Analysis and Navigation Tool";
+    homepage = "http://bant.build/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hzeller ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

From the [README](https://github.com/hzeller/bant/blob/main/README.md) : Utility to support projects using the bazel build system, in particular C++ projects.

  * Cleaning up BUILD files by adding missing, and removing superflous, dependencies.
  * Extract interesting project information such as the dependency graph, headers provided by which libraries ....

Upstream [v0.1.5 Release Notes](https://github.com/hzeller/bant/releases/tag/v0.1.5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
