### PR TITLE
sanjuuni: add run-on-nixos-artwork test

### DIFF
--- a/pkgs/by-name/sa/sanjuuni/package.nix
+++ b/pkgs/by-name/sa/sanjuuni/package.nix
@@ -8,6 +8,7 @@
   poco,
   ocl-icd,
   opencl-clhpp,
+  callPackage,
 }:
 
 stdenv.mkDerivation rec {
@@ -37,6 +38,10 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  passthru.tests = {
+    run-on-nixos-artwork = callPackage ./tests/run-on-nixos-artwork.nix { };
+  };
 
   meta = with lib; {
     homepage = "https://github.com/MCJack123/sanjuuni";

--- a/pkgs/by-name/sa/sanjuuni/tests/run-on-nixos-artwork.nix
+++ b/pkgs/by-name/sa/sanjuuni/tests/run-on-nixos-artwork.nix
@@ -1,0 +1,34 @@
+{
+  runCommand,
+  sanjuuni,
+  nixos-artwork,
+  lua5_2,
+}:
+let
+  makeCommand = derivation: baseFilename: ''
+    echo "sanjuuni-test-run-on-nixos-artwork: Running Sanjuuni on ${derivation}/share/backgrounds/nixos/${baseFilename}.png"
+    sanjuuni --lua --disable-opencl \
+      --input ${derivation}/share/backgrounds/nixos/${baseFilename}.png \
+      --output $out/${baseFilename}.lua
+    echo "sanjuuni-test-run-on-nixos-artwork: Checking syntax on $out/${baseFilename}.lua"
+    lua -e "loadfile(\"$out/${baseFilename}.lua\")"
+  '';
+in
+runCommand "sanjuuni-test-run-on-nixos-artwork"
+  {
+    nativeBuildInputs = [
+      sanjuuni
+      lua5_2
+      nixos-artwork.wallpapers.simple-blue
+      nixos-artwork.wallpapers.simple-red
+      nixos-artwork.wallpapers.simple-dark-gray
+      nixos-artwork.wallpapers.stripes
+    ];
+  }
+  ''
+    mkdir -p $out
+    ${makeCommand nixos-artwork.wallpapers.simple-blue "nix-wallpaper-simple-blue"}
+    ${makeCommand nixos-artwork.wallpapers.simple-red "nix-wallpaper-simple-red"}
+    ${makeCommand nixos-artwork.wallpapers.simple-dark-gray "nix-wallpaper-simple-dark-gray"}
+    ${makeCommand nixos-artwork.wallpapers.stripes "nix-wallpaper-stripes"}
+  ''


### PR DESCRIPTION
## Description of changes

Tests the program by running it on a handful of entries from the `nixos-artwork` attrset, and then test that the resulting Lua files can be evaluated with `loadfile` in standard Lua.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
