### PR TITLE
 spectacle: use minimal opencv 

### DIFF
--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -80,6 +80,9 @@
 , doxygen
 , graphviz-nox
 
+, runAccuracyTests ? true
+, runPerformanceTests ? false
+
 , AVFoundation
 , Cocoa
 , VideoDecodeAcceleration
@@ -234,8 +237,6 @@ let
 
   opencvFlag = name: enabled: "-DWITH_${name}=${printEnabled enabled}";
 
-  runAccuracyTests = true;
-  runPerformanceTests = false;
   printEnabled = enabled: if enabled then "ON" else "OFF";
   withOpenblas = (enableBlas && blas.provider.pname == "openblas");
   #multithreaded openblas conflicts with opencv multithreading, which manifest itself in hung tests
@@ -254,6 +255,7 @@ effectiveStdenv.mkDerivation {
   outputs = [
     "out"
     "cxxdev"
+  ] ++ lib.optionals (runAccuracyTests || runPerformanceTests) [
     "package_tests"
   ];
   cudaPropagateToOutput = "cxxdev";

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -82,6 +82,9 @@
 
 , runAccuracyTests ? true
 , runPerformanceTests ? false
+# Modules to enable via BUILD_LIST to build a customized opencv.
+# An empty lists means this setting is ommited which matches upstreams default.
+, enabledModules ? [ ]
 
 , AVFoundation
 , Cocoa
@@ -481,6 +484,8 @@ effectiveStdenv.mkDerivation {
     "-DOPENCL_LIBRARY=${ocl-icd}/lib/libOpenCL.so"
   ] ++ lib.optionals enablePython [
     "-DOPENCV_SKIP_PYTHON_LOADER=ON"
+  ] ++ lib.optionals (enabledModules != [ ]) [
+    "-DBUILD_LIST=${lib.concatStringsSep "," enabledModules}"
   ];
 
   postBuild = lib.optionalString enableDocs ''

--- a/pkgs/kde/gear/spectacle/default.nix
+++ b/pkgs/kde/gear/spectacle/default.nix
@@ -7,6 +7,14 @@
 mkKdeDerivation {
   pname = "spectacle";
 
-  extraBuildInputs = [qtwayland qtmultimedia opencv];
+  extraBuildInputs = [
+    qtwayland
+    qtmultimedia
+    (opencv.override {
+      enableCuda = false;                    # fails to compile, disabled in case someone sets config.cudaSupport
+      enabledModules = [ "core" "imgproc" ]; # https://invent.kde.org/graphics/spectacle/-/blob/master/CMakeLists.txt?ref_type=heads#L83
+      runAccuracyTests = false;              # tests will fail because of missing plugins but that's okay
+    })
+  ];
   meta.mainProgram = "spectacle";
 }


### PR DESCRIPTION
## Description of changes

nix store diff-closure:

```
abseil-cpp: 20210324.2 → ∅, -5315.3 KiB
hdf5-cpp: 1.14.3 → ∅, -6032.4 KiB
opencv: -44588.1 KiB
protobuf: 21.12 → ∅, -11380.2 KiB
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
