### PR TITLE
python3Packages.scikit-fmm: fix build on Python 3.12+

### DIFF
--- a/pkgs/development/python-modules/scikit-fmm/default.nix
+++ b/pkgs/development/python-modules/scikit-fmm/default.nix
@@ -1,7 +1,9 @@
 {
   lib,
   buildPythonPackage,
+  fetchpatch,
   fetchPypi,
+  meson-python,
   numpy,
   python,
 }:
@@ -9,14 +11,42 @@
 buildPythonPackage rec {
   pname = "scikit-fmm";
   version = "2023.4.2";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-14ccR/ggdyq6kvJWUe8U5NJ96M45PArjwCqzxuJCPAs=";
   };
 
-  propagatedBuildInputs = [ numpy ];
+  # TODO: Remove these patches after another stable release is made.
+  # For now, these allow us to build with Python 3.12+ by switching to Meson
+  # and off the deprecated distutils.
+  patches = [
+    (fetchpatch {
+      name = "first-try-at-meson-build.patch";
+      hash = "sha256-Kclg4YrQZL6ZSVsLh6X6DqdztPjDK35L5dp5PqYjzaY=";
+      url = "https://github.com/scikit-fmm/scikit-fmm/commit/a52c0eccb70077553607a5084152316d136b668b.patch";
+    })
+    (fetchpatch {
+      name = "work-in-progress-on-meson-build.patch";
+      hash = "sha256-WvSwBz7exqe1H+CqdoMfT5jEoIHnyt/nbc/CryuEKiA=";
+      url = "https://github.com/scikit-fmm/scikit-fmm/commit/db0e7a5f51541745027c3d081d7841e74587793e.patch";
+    })
+    (fetchpatch {
+      name = "re-cythonize-the-heap-wrapper.patch";
+      hash = "sha256-ro97+06R0szXQ9I8/sR4JAnFxoQwJeiImDcl1Yp9P0Y=";
+      url = "https://github.com/scikit-fmm/scikit-fmm/commit/4168323e209343facd5f6ba93a85893242e781a2.patch";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "oldest-supported-numpy" "numpy"
+  '';
+
+  build-system = [ meson-python ];
+
+  dependencies = [ numpy ];
 
   checkPhase = ''
     mkdir testdir; cd testdir


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Applies work-in-progress patches from a development branch to fix the build on Python 3.12+ by switching the build system to Meson.

Fixes:

- https://hydra.nixos.org/build/260955687

ZHF: #309482

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
