### PR TITLE
readsb: init at 3.14.1641

### DIFF
--- a/pkgs/by-name/re/readsb/package.nix
+++ b/pkgs/by-name/re/readsb/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  ncurses,
+  rtl-sdr,
+  zlib,
+  zstd,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "readsb";
+  version = "3.14.1641";
+
+  src = fetchFromGitHub {
+    owner = "wiedehopf";
+    repo = "readsb";
+    rev = "refs/tags/v${finalAttrs.version}";
+    hash = "sha256-viz/oADxdduan6W0FsetEqifR6fcyeoEZvEnoO/K5/g=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    ncurses
+    rtl-sdr
+    zlib
+    zstd
+  ];
+
+  # remove version string magic that utilizes git and current time
+  postPatch = ''
+    sed --in-place '/^READSB_VERSION :=/d' Makefile
+  '';
+
+  enableParallelBuilding = true;
+  makeFlags = [
+    # set something for version, we removed the original value in postPatch
+    "READSB_VERSION=${finalAttrs.version}"
+  ] ++ (lib.lists.optional (rtl-sdr != null) "RTLSDR=yes");
+
+  doCheck = true;
+  checkTarget = "cprtest";
+  # TODO there is a crctests target in Make, it describes how to compile ./crctests, but doesn't run
+  # it. Compilation also fails with:
+  #
+  # ld: /build/cc9NI2Fd.o: in function `malloc_or_exit':
+  # > /build/source/readsb.h:407:(.text+0xbad): undefined reference to `setExit'
+  #
+  # Comment this test in once this has been fixed upstream.
+  # postCheck = ''
+  #   make crctests && ./crctests
+  # '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir --parent -- $out/bin
+    mv readsb viewadsb $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "ADS-B decoder swiss knife";
+    homepage = "https://github.com/wiedehopf/readsb";
+    license = with lib.licenses; [ gpl3Plus ];
+    maintainers = with lib.maintainers; [ wucke13 ];
+    platforms = lib.platforms.linux; # uses epoll, hence its linux only
+  };
+})


### PR DESCRIPTION
This fixes packaging request #300833.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
