### PR TITLE
python3Packages.apricot-select: fixup dependency categories and disable tests

### DIFF
--- a/pkgs/development/python-modules/apricot-select/default.nix
+++ b/pkgs/development/python-modules/apricot-select/default.nix
@@ -37,15 +37,15 @@ buildPythonPackage rec {
   dependencies = [
     numba
     numpy
+    scikit-learn
     scipy
+    torchvision
     tqdm
   ];
 
   nativeCheckInputs = [
     pynose
     pytestCheckHook
-    scikit-learn
-    torchvision
   ];
 
   pythonImportsCheck = [ "apricot" ];

--- a/pkgs/development/python-modules/apricot-select/default.nix
+++ b/pkgs/development/python-modules/apricot-select/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  apricot-select,
   numba,
   numpy,
   pynose,
@@ -65,6 +66,11 @@ buildPythonPackage rec {
     "test_digits_sqrt_modular_object"
     "test_digits_sqrt_modular_sparse"
   ];
+
+  # NOTE: Tests are disabled by default because they can run for hours and timeout on Hydra.
+  doCheck = false;
+
+  passthru.tests.check = apricot-select.overridePythonAttrs { doCheck = true; };
 
   meta = with lib; {
     description = "Module for submodular optimization for the purpose of selecting subsets of massive data sets";

--- a/pkgs/development/python-modules/apricot-select/default.nix
+++ b/pkgs/development/python-modules/apricot-select/default.nix
@@ -56,6 +56,16 @@ buildPythonPackage rec {
     "tests/test_optimizers/test_knapsack_feature_based.py"
   ];
 
+  # NOTE: These tests seem to be flaky.
+  disabledTests = [
+    "test_digits_modular"
+    "test_digits_modular_object"
+    "test_digits_modular_sparse"
+    "test_digits_sqrt_modular"
+    "test_digits_sqrt_modular_object"
+    "test_digits_sqrt_modular_sparse"
+  ];
+
   meta = with lib; {
     description = "Module for submodular optimization for the purpose of selecting subsets of massive data sets";
     homepage = "https://github.com/jmschrei/apricot";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR moves `scikit-learn` and `torchvision` to `dependencies` and out of `nativeCheckInputs`, because they are required by the package. This can be observed by trying to build the package with `doCheck = false` -- the build will fail, as they're no longer available.

This PR also disables tests a handful of flaky tests which I've seen fail on and off.

Lastly, this PR disables the test suite by default, as it can take hours (or timeout entirely):

- https://hydra.nixos.org/build/261011861
- https://hydra.nixos.org/build/261026366

ZHF: #309482

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
