### PR TITLE
gnumake: do not use MAKE_CXX

### DIFF
--- a/pkgs/development/tools/build-managers/gnumake/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/default.nix
@@ -22,17 +22,18 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-3Rb7HWe/q3mnL16DkHNcSePo5wtJRaFasfgd23hlj7M=";
   };
 
-  # to update apply these patches with `git am *.patch` to https://git.savannah.gnu.org/git/make.git
-  patches = [
-    # See patch message.
-    ./make-cxx.patch
-    # Replaces /bin/sh with sh, see patch file for reasoning
-    ./0001-No-impure-bin-sh.patch
-    # Purity: don't look for library dependencies (of the form `-lfoo') in /lib
-    # and /usr/lib. It's a stupid feature anyway. Likewise, when searching for
-    # included Makefiles, don't look in /usr/include and friends.
-    ./0002-remove-impure-dirs.patch
-  ];
+  # To update patches:
+  #  $ version=4.4.1
+  #  $ git clone https://git.savannah.gnu.org/git/make.git
+  #  $ cd make && git checkout -b nixpkgs $version
+  #  $ git am --directory=../patches
+  #  $ # make changes, resolve conflicts, etc.
+  #  $ git format-patch --output-directory ../patches --diff-algorithm=histogram $version
+  #
+  # TODO: stdenv’s setup.sh should be aware of patch directories. It’s very
+  # convenient to keep them in a separate directory but we can defer listing the
+  # directory until derivation realization to avoid unnecessary Nix evaluations.
+  patches = lib.filesystem.listFilesRecursive ./patches;
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = lib.optionals guileEnabled [ guile ];

--- a/pkgs/development/tools/build-managers/gnumake/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , fetchurl
-, updateAutotoolsGnuConfigScriptsHook
+, autoreconfHook
 , guileSupport ? false, guile
 # avoid guile depend on bootstrap to prevent dependency cycles
 , inBootstrap ? false
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
 
   # to update apply these patches with `git am *.patch` to https://git.savannah.gnu.org/git/make.git
   patches = [
+    # See patch message.
+    ./make-cxx.patch
     # Replaces /bin/sh with sh, see patch file for reasoning
     ./0001-No-impure-bin-sh.patch
     # Purity: don't look for library dependencies (of the form `-lfoo') in /lib
@@ -32,7 +34,7 @@ stdenv.mkDerivation rec {
     ./0002-remove-impure-dirs.patch
   ];
 
-  nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ] ++ lib.optionals guileEnabled [ pkg-config ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = lib.optionals guileEnabled [ guile ];
 
   configureFlags = lib.optional guileEnabled "--with-guile"

--- a/pkgs/development/tools/build-managers/gnumake/make-cxx.patch
+++ b/pkgs/development/tools/build-managers/gnumake/make-cxx.patch
@@ -1,0 +1,64 @@
+Do not search for a C++ compiler and set MAKE_CXX.
+
+Removes unnecessary reference to C++ compiler if CXX is set to an
+absolute path. If CXX is not an absolute path, we avoid defaulting CXX
+to a compiler name that was used to build the package.
+
+Context: GNU Make defines default values for CC, CXX and other
+environment variables. For CXX, it usually defaults to g++, however,
+FreeBSD and OpenBSD no longer ship GCC as a system compiler (and use
+Clang instead). For C compiler, POSIX standardizes the name to be "cc",
+but there is no such standard for C++ compiler name. As a fix, GNU Make
+uses CXX set for build as a default (via MAKE_CXX preprocessor macro in
+the source code).
+
+We revert the change that added this behavior and set the default to c++
+or g++ that does not depend on the build platform.
+
+In stdenv, CXX environment variable is always defined and overrides the
+default value.
+
+References:
+• https://savannah.gnu.org/bugs/?63668
+• https://git.savannah.gnu.org/cgit/make.git/commit/?id=ffa28f3914ff402b3915f75e4fed86ac6fb1449d
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -37,6 +37,4 @@ AM_INIT_AUTOMAKE([1.16.1 foreign -Werror -Wall])
+ # Checks for programs.
+ AC_USE_SYSTEM_EXTENSIONS
+ AC_PROG_CC
+-AC_PROG_CXX
+-AC_DEFINE_UNQUOTED(MAKE_CXX, ["$CXX"], [Default C++ compiler.])
+
+--- a/src/default.c
++++ b/src/default.c
+@@ -528,22 +528,15 @@ static const char *default_variables[] =
+ #ifdef GCC_IS_NATIVE
+     "CC", "gcc",
+     "OBJC", "gcc",
++# ifdef __MSDOS__
++    "CXX", "gpp",       /* g++ is an invalid name on MSDOS */
++# else
++    "CXX", "g++",
++# endif /* __MSDOS__ */
+ #else
+     "CC", "cc",
+     "OBJC", "cc",
++    "CXX", "c++",
+ #endif
+-#ifdef MAKE_CXX
+-    "CXX", MAKE_CXX,
+-#else
+-# ifdef GCC_IS_NATIVE
+-#  ifdef __MSDOS__
+-    "CXX", "gpp",       /* g++ is an invalid name on MSDOS */
+-#  else
+-    "CXX", "gcc",
+-#  endif /* __MSDOS__ */
+-# else
+-    "CXX", "g++",
+-# endif
+-#endif
+     /* This expands to $(CO) $(COFLAGS) $< $@ if $@ does not exist,
+        and to the empty string if $@ does exist.  */

--- a/pkgs/development/tools/build-managers/gnumake/patches/0001-No-impure-bin-sh.patch
+++ b/pkgs/development/tools/build-managers/gnumake/patches/0001-No-impure-bin-sh.patch
@@ -1,7 +1,7 @@
-From e00a5257a6ca5fedbf68b09eee7df3502971a057 Mon Sep 17 00:00:00 2001
+From b69e3740e68afaec97b9957d40b9c135db87eaab Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
 Date: Sat, 24 Apr 2021 10:11:40 +0200
-Subject: [PATCH 1/2] No impure bin sh
+Subject: [PATCH 1/3] No impure bin sh
 
 default_shell is used to populuate default shell used to execute jobs.
 Unless SHELL is set to a different value this would be /bin/sh.
@@ -18,10 +18,10 @@ hard-coded has some advantages:
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/job.c b/src/job.c
-index ae1f18b..6b4ddb3 100644
+index ea885614..8a9bd8e0 100644
 --- a/src/job.c
 +++ b/src/job.c
-@@ -77,7 +77,7 @@ char * vms_strsignal (int status);
+@@ -76,7 +76,7 @@ char * vms_strsignal (int status);
  
  #else
  
@@ -31,5 +31,5 @@ index ae1f18b..6b4ddb3 100644
  
  #endif
 -- 
-2.31.1
+2.44.1
 

--- a/pkgs/development/tools/build-managers/gnumake/patches/0002-Remove-impure-dirs.patch
+++ b/pkgs/development/tools/build-managers/gnumake/patches/0002-Remove-impure-dirs.patch
@@ -1,20 +1,24 @@
-From 795d63d3c8b5c0dbb7e544954f75507b371b7228 Mon Sep 17 00:00:00 2001
+From 2db52008be2e2d504889f4f19318c2ba5a2a4797 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
 Date: Sat, 24 Apr 2021 10:20:16 +0200
-Subject: [PATCH 2/2] remove impure dirs
+Subject: [PATCH 2/3] Remove impure dirs
 
+Purity: don't look for library dependencies (of the form `-lfoo') in
+/lib and /usr/lib. It's a stupid feature anyway. Likewise, when
+searching for included Makefiles, don't look in /usr/include and
+friends.
 ---
  src/read.c   | 3 ---
  src/remake.c | 2 --
  2 files changed, 5 deletions(-)
 
 diff --git a/src/read.c b/src/read.c
-index fa197fb..defacfb 100644
+index b0fc1e1f..d6b41c17 100644
 --- a/src/read.c
 +++ b/src/read.c
-@@ -109,9 +109,6 @@ static const char *default_include_directories[] =
- #endif
+@@ -111,9 +111,6 @@ static const char *default_include_directories[] =
      INCLUDEDIR,
+ #endif
  #ifndef _AMIGA
 -    "/usr/gnu/include",
 -    "/usr/local/include",
@@ -23,10 +27,10 @@ index fa197fb..defacfb 100644
      0
    };
 diff --git a/src/remake.c b/src/remake.c
-index fb237c5..94bff7d 100644
+index fe67ab28..1b76560c 100644
 --- a/src/remake.c
 +++ b/src/remake.c
-@@ -1601,8 +1601,6 @@ library_search (const char *lib, FILE_TIMESTAMP *mtime_ptr)
+@@ -1690,8 +1690,6 @@ library_search (const char *lib, FILE_TIMESTAMP *mtime_ptr)
    static const char *dirs[] =
      {
  #ifndef _AMIGA
@@ -36,5 +40,5 @@ index fb237c5..94bff7d 100644
  #if defined(WINDOWS32) && !defined(LIBDIR)
  /*
 -- 
-2.31.1
+2.44.1
 

--- a/pkgs/development/tools/build-managers/gnumake/patches/0003-Do-not-search-for-a-C-compiler-and-set-MAKE_CXX.patch
+++ b/pkgs/development/tools/build-managers/gnumake/patches/0003-Do-not-search-for-a-C-compiler-and-set-MAKE_CXX.patch
@@ -1,4 +1,10 @@
-Do not search for a C++ compiler and set MAKE_CXX.
+From 3317b3a78666e6073c63f62a322176e3dc680461 Mon Sep 17 00:00:00 2001
+From: Ivan Trubach <mr.trubach@icloud.com>
+Date: Sat, 17 Aug 2024 22:35:03 +0300
+Subject: [PATCH 3/3] Do not search for a C++ compiler and set MAKE_CXX
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Removes unnecessary reference to C++ compiler if CXX is set to an
 absolute path. If CXX is not an absolute path, we avoid defaulting CXX
@@ -19,18 +25,28 @@ In stdenv, CXX environment variable is always defined and overrides the
 default value.
 
 References:
-• https://savannah.gnu.org/bugs/?63668
-• https://git.savannah.gnu.org/cgit/make.git/commit/?id=ffa28f3914ff402b3915f75e4fed86ac6fb1449d
+ • https://savannah.gnu.org/bugs/?63668
+ • https://git.savannah.gnu.org/cgit/make.git/commit/?id=ffa28f3914ff402b3915f75e4fed86ac6fb1449d
+---
+ configure.ac  |  2 --
+ src/default.c | 19 ++++++-------------
+ 2 files changed, 6 insertions(+), 15 deletions(-)
 
+diff --git a/configure.ac b/configure.ac
+index cd785754..41a65307 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -37,6 +37,4 @@ AM_INIT_AUTOMAKE([1.16.1 foreign -Werror -Wall])
+@@ -37,8 +37,6 @@ AM_INIT_AUTOMAKE([1.16.1 foreign -Werror -Wall])
  # Checks for programs.
  AC_USE_SYSTEM_EXTENSIONS
  AC_PROG_CC
 -AC_PROG_CXX
 -AC_DEFINE_UNQUOTED(MAKE_CXX, ["$CXX"], [Default C++ compiler.])
-
+ 
+ # Configure gnulib
+ gl_EARLY
+diff --git a/src/default.c b/src/default.c
+index e396269b..78ba402f 100644
 --- a/src/default.c
 +++ b/src/default.c
 @@ -528,22 +528,15 @@ static const char *default_variables[] =
@@ -45,8 +61,7 @@ References:
  #else
      "CC", "cc",
      "OBJC", "cc",
-+    "CXX", "c++",
- #endif
+-#endif
 -#ifdef MAKE_CXX
 -    "CXX", MAKE_CXX,
 -#else
@@ -59,6 +74,10 @@ References:
 -# else
 -    "CXX", "g++",
 -# endif
--#endif
++    "CXX", "c++",
+ #endif
      /* This expands to $(CO) $(COFLAGS) $< $@ if $@ does not exist,
         and to the empty string if $@ does exist.  */
+-- 
+2.44.1
+


### PR DESCRIPTION
## Description of changes

Removes unnecessary C++ compiler reference when CXX environment variable is set to an absolute path.

See also https://savannah.gnu.org/bugs/?63668

**Parent PR:**
- #314920

## Motivation

I’m trying to fix cross-compilation for platforms where C/C++ compiler’s `targetPrefix` is identical. It’s common to set
```
depsBuildBuild = [ buildPackages.stdenv.cc ];
```
when cross-compiling, however, cc/bintools wrapper setup hook currently sets {CC,CXX}{,_FOR_BUILD} et cetera to program name instead of absolute path. That obviously doesn’t work because only the first program from `PATH` is used (for example, this is part of the reason why static glibc doesn’t work in Nixpkgs and we have pkgsStatic use musl that has different target prefix). There are a lot of other things that start falling apart in stdenv when we set these variables to absolute paths, this is just one of them: gnumake is part of the stdenv and shouldn’t refer to the bootstrap tools.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
