### PR TITLE
gawk: move gawkbug to gawkInteractive

### DIFF
--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, fetchurl
+, removeReferencesTo
 , runtimeShellPackage
 # TODO: links -lsigsegv but loses the reference for some reason
 , withSigsegv ? (false && stdenv.hostPlatform.system != "x86_64-cygwin"), libsigsegv
@@ -36,15 +37,25 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "info" ]
     ++ lib.optional (!interactive) "man";
 
-  # no-pma fix
-  nativeBuildInputs = [ autoreconfHook ]
-    ++ lib.optional (doCheck && stdenv.isLinux) glibcLocales;
+  strictDeps = true;
 
-  buildInputs = [
+  # no-pma fix
+  nativeBuildInputs = [
+    autoreconfHook
+  ] ++ lib.optionals interactive [
+    removeReferencesTo
+  ] ++ lib.optionals (doCheck && stdenv.isLinux) [
+    glibcLocales
+  ];
+
+  buildInputs = lib.optionals interactive [
     runtimeShellPackage
-  ] ++ lib.optional withSigsegv libsigsegv
-    ++ lib.optional interactive readline
-    ++ lib.optional stdenv.isDarwin locale;
+    readline
+  ] ++ lib.optionals withSigsegv [
+    libsigsegv
+  ] ++ lib.optionals stdenv.isDarwin [
+    locale
+  ];
 
   configureFlags = [
     (if withSigsegv then "--with-libsigsegv-prefix=${libsigsegv}" else "--without-libsigsegv")
@@ -57,7 +68,12 @@ stdenv.mkDerivation rec {
 
   inherit doCheck;
 
-  postInstall = ''
+  postInstall = (if interactive then ''
+    remove-references-to -t "$NIX_CC" "$out"/bin/gawkbug
+    patchShebangs --host "$out"/bin/gawkbug
+  '' else ''
+    rm "$out"/bin/gawkbug
+  '') + ''
     rm "$out"/bin/gawk-*
     ln -s gawk.1 "''${!outputMan}"/share/man/man1/awk.1
   '';


### PR DESCRIPTION
## Description of changes

This change removes gawkbug program from non-interactive build, similar to the bash{,Interactive} package.

**Parent PR:**
- #314920

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
