### PR TITLE
qt5.qtsvg: Fix cross

### DIFF
--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -25,8 +25,14 @@ mkDerivation (args // {
 
   nativeBuildInputs =
     (args.nativeBuildInputs or []) ++ [
-      perl qmake
+      perl
+      # `qmake`(`pkgsBuildHost.qt5.qmake`) propagates `qtbase` which causes there to be
+      # `pkgsBuildHost.qt5.qtbase` and the `pkgsHostTarget.qt5.qtbase.dev` in the build environment
+      (if (stdenv.buildPlatform != stdenv.hostPlatform) then pkgsHostTarget.qt5.qmake else qmake)
     ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+      # .dev is required for binaries
+      # qmake propagates `qtbase` but on cross it's in `depsTargetTargetPropagated` so it's treated as a `buildInput`
+      # when qmake is in nativeBuildInputs
       pkgsHostTarget.qt5.qtbase.dev
     ];
   propagatedBuildInputs =


### PR DESCRIPTION
qt cross is really a mess.

```
$ nix build ".#pkgsCross.aarch64-multiplatform.qt5.qtsvg"
qtsvg-aarch64-unknown-linux-gnu> Error: detected mismatched Qt dependencies:
qtsvg-aarch64-unknown-linux-gnu>     /nix/store/.-qtbase-aarch64-unknown-linux-gnu-5.15.11-dev
qtsvg-aarch64-unknown-linux-gnu>     /nix/store/.-qtbase-5.15.11-dev
```

```
/nix/store/xm6g4inrfph2nh0m5g9p1ppqrkn1ca7k-qtsvg-aarch64-unknown-linux-gnu-5.15.12.drv
└───/nix/store/r6yh8h14hqbcx23zdvmsyj15gvhbvdwz-qmake-hook.drv
    └───/nix/store/0bkp01mapjqirs5f61255vwgpi306rm6-qtbase-5.15.12.drv
```


https://github.com/NixOS/nixpkgs/pull/264964 might work too or could be broken in more ways but qt cross is a mess

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
