### PR TITLE
python3Packages.import-expression: 1.1.4 -> 1.1.5

### DIFF
--- a/pkgs/development/python-modules/import-expression/default.nix
+++ b/pkgs/development/python-modules/import-expression/default.nix
@@ -18,8 +18,8 @@ buildPythonPackage rec {
     hash = "sha256-mVlYj8/I3LFEoHJRds/vbCjH2x/C1oNiUCXmh1FtQME=";
   };
 
-  nativeBuildInputs = [ setuptools ];
-  propagatedBuildInputs = [ astunparse ];
+  build-system = [ setuptools ];
+  dependencies = [ astunparse ];
   nativeCheckInputs = [ pytestCheckHook ];
   pytestFlagsArray = [ "tests.py" ];
 

--- a/pkgs/development/python-modules/import-expression/default.nix
+++ b/pkgs/development/python-modules/import-expression/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchPypi,
   fetchpatch,
   pytestCheckHook,
   astunparse,
@@ -9,22 +9,14 @@
 }:
 buildPythonPackage rec {
   pname = "import-expression";
-  version = "1.1.4";
+  version = "1.1.5";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "ioistired";
-    repo = "import-expression-parser";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-mll2NePB7fthzltLOk6D9BgaDpH6GaW4psqcGun/0qM=";
+  src = fetchPypi {
+    inherit version;
+    pname = "import_expression";
+    hash = "sha256-mVlYj8/I3LFEoHJRds/vbCjH2x/C1oNiUCXmh1FtQME=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/ioistired/import-expression-parser/commit/3daf968c3163b64685aa529740e132f0df5ab262.patch";
-      hash = "sha256-2Ubv3onor2D26udZbDDMb3iNLopEIRnIcO/X6WUVmJU=";
-    })
-  ];
 
   nativeBuildInputs = [ setuptools ];
   propagatedBuildInputs = [ astunparse ];


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

updates version to 1.1.5, the main change this version is that tests are included in the pypi source dists so we don't need to pull from github anymore

the patch is also no longer needed as it was merged in this version

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
