### PR TITLE
xbill, motif: fix clang build

### DIFF
--- a/pkgs/development/libraries/motif/default.nix
+++ b/pkgs/development/libraries/motif/default.nix
@@ -40,6 +40,13 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  env = lib.optionalAttrs stdenv.cc.isClang {
+    CFLAGS = toString [
+      "-Wno-error=implicit-function-declaration"
+      "-Wno-error=incompatible-function-pointer-types"
+    ];
+  };
+
   enableParallelBuilding = true;
 
   meta = with lib; {

--- a/pkgs/games/xbill/default.nix
+++ b/pkgs/games/xbill/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, lib, makeDesktopItem, copyDesktopItems, fetchurl, libX11, libXpm, libXt, motif, ... }:
+{ stdenv, lib, autoreconfHook, makeDesktopItem, copyDesktopItems, fetchurl, libX11, libXpm, libXt, motif, ... }:
 
 stdenv.mkDerivation rec {
   pname = "xbill";
   version = "2.1";
 
-  nativeBuildInputs = [ copyDesktopItems ];
+  nativeBuildInputs = [ autoreconfHook copyDesktopItems ];
   buildInputs = [ libX11 libXpm libXt motif ];
 
   NIX_CFLAGS_LINK = "-lXpm";
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-x"
     "--enable-motif"
+  ] ++ lib.optionals stdenv.cc.isClang [
+    "CFLAGS=-Wno-error=implicit-function-declaration"
   ];
 
   src = fetchurl {


### PR DESCRIPTION
*needs backport release-24.05 tag*
## Description of changes

motif:
ignore benign clang errors implicit-function-declaration and incompatible-function-pointer-types

xbill depends on motif but was also broken with clang is fixed as well:
ignore implicit-function-declaration errors and regenerate autotools files so configure test programs compile with clang

https://hydra.nixos.org/build/260342733
ZHF: https://github.com/NixOS/nixpkgs/issues/309482

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
