### PR TITLE
python311Packages.flask-mail: 0.9.1 -> 0.10.0

### DIFF
--- a/pkgs/development/python-modules/flask-mail/default.nix
+++ b/pkgs/development/python-modules/flask-mail/default.nix
@@ -1,40 +1,34 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   blinker,
+  flit-core,
   flask,
-  mock,
-  nose,
-  speaklater,
 }:
 
 buildPythonPackage rec {
   pname = "flask-mail";
-  version = "0.9.1";
-  format = "setuptools";
-
+  version = "0.10.0";
   meta = {
     description = "Flask-Mail is a Flask extension providing simple email sending capabilities.";
     homepage = "https://pypi.python.org/pypi/Flask-Mail";
     license = lib.licenses.bsd3;
   };
+  pyproject = true;
 
-  src = fetchPypi {
-    pname = "Flask-Mail";
-    inherit version;
-    hash = "sha256-IuXrmpQL9Ae88wQQ7MNwjzxWzESynDThcm/oUAaTX0E=";
+  src = fetchFromGitHub {
+    owner = "pallets-eco";
+    repo = "flask-mail";
+    rev = "refs/tags/${version}";
+    hash = "sha256-G2Z8dj1/IuLsZoNJVrL6LYu0XjTEHtWB9Z058aqG9Ic=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ flit-core ];
+
+  dependencies = [
     blinker
     flask
-  ];
-  buildInputs = [
-    blinker
-    mock
-    nose
-    speaklater
   ];
 
   doCheck = false;

--- a/pkgs/development/python-modules/flask-mail/default.nix
+++ b/pkgs/development/python-modules/flask-mail/default.nix
@@ -5,16 +5,12 @@
   blinker,
   flit-core,
   flask,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "flask-mail";
   version = "0.10.0";
-  meta = {
-    description = "Flask-Mail is a Flask extension providing simple email sending capabilities.";
-    homepage = "https://pypi.python.org/pypi/Flask-Mail";
-    license = lib.licenses.bsd3;
-  };
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -31,5 +27,14 @@ buildPythonPackage rec {
     flask
   ];
 
-  doCheck = false;
+  pythonImportsCheck = [ "flask_mail" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Flask extension providing simple email sending capabilities";
+    homepage = "https://github.com/pallets-eco/flask-mail";
+    changelog = "https://github.com/pallets-eco/flask-mail/blob/${src.rev}/CHANGES.md";
+    license = lib.licenses.bsd3;
+  };
 }


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/pallets-eco/flask-mail/compare/0.9.1...0.10.0
Changelog: https://github.com/pallets-eco/flask-mail/blob/0.10.0/CHANGES.md

part of https://github.com/NixOS/nixpkgs/issues/311054

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
