### PR TITLE
tinymist: 0.11.9 -> 0.11.10

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/myriad-dreamin.tinymist/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/myriad-dreamin.tinymist/default.nix
@@ -10,10 +10,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "tinymist";
     publisher = "myriad-dreamin";
-    # Please update the corresponding binary (tinymist) when updating
-    # this extension.
-    version = "0.11.9";
-    hash = "sha256-h49SI/KoA5sbLIkJreZoux7mTIhGZ7HqtgE1EAh3vYM=";
+    inherit (tinymist) version;
+    hash = "sha256-etPjbmcBhS1dgq5wEoRIekZlRxYoC6KrsV/+owjHu4I=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ti/tinymist/Cargo.lock
+++ b/pkgs/by-name/ti/tinymist/Cargo.lock
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "insta",
  "lsp-server",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-query"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "anyhow",
  "biblatex",
@@ -3935,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "tinymist-render"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -4530,9 +4530,9 @@ dependencies = [
 
 [[package]]
 name = "typstyle"
-version = "0.11.21"
+version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9697d141856bfe6c865c9ef74d04c62dd6cd1b3b63c1e284b96974871a2fc7"
+checksum = "bb15ec2ba1f804eab4f8f2ae1bbbe8a7d2f882bb8acabaee0b101de46ee28c56"
 dependencies = [
  "anyhow",
  "clap",

--- a/pkgs/by-name/ti/tinymist/package.nix
+++ b/pkgs/by-name/ti/tinymist/package.nix
@@ -13,13 +13,13 @@ rustPlatform.buildRustPackage rec {
   pname = "tinymist";
   # Please update the corresponding vscode extension when updating
   # this derivation.
-  version = "0.11.9";
+  version = "0.11.10";
 
   src = fetchFromGitHub {
     owner = "Myriad-Dreamin";
     repo = "tinymist";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Oa88WBkV9q17KNJuc/sGSQS39yVyqme66SfB0ZZw7b8=";
+    hash = "sha256-lmT0da517dVaXGeObyCXZyte8DNBh+/vaqV7hA+SJR4=";
   };
 
   cargoLock = {
@@ -50,12 +50,12 @@ rustPlatform.buildRustPackage rec {
     "--skip=e2e"
   ];
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/Myriad-Dreamin/tinymist/blob/${src.rev}/CHANGELOG.md";
     description = "Tinymist is an integrated language service for Typst";
     homepage = "https://github.com/Myriad-Dreamin/tinymist";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     mainProgram = "tinymist";
-    maintainers = with maintainers; [ lampros ];
+    maintainers = with lib.maintainers; [ lampros ];
   };
 }


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/Myriad-Dreamin/tinymist/releases/tag/v0.11.10

cc @LamprosPitsillos @drupol 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
