### PR TITLE
timescaledb_toolkit: Bump dependency cargo-pgrx to 0.11.3 to fix aarch64-linux build failure.

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
@@ -1,15 +1,16 @@
 { lib
 , fetchFromGitHub
+, fetchpatch
 , buildPgrxExtension
 , postgresql
 , nixosTests
-, cargo-pgrx_0_10_2
+, cargo-pgrx_0_11_3
 , fetchCrate
 , nix-update-script
 , stdenv
 }:
 
-(buildPgrxExtension.override { cargo-pgrx = cargo-pgrx_0_10_2; }) rec {
+(buildPgrxExtension.override { cargo-pgrx = cargo-pgrx_0_11_3; }) rec {
   inherit postgresql;
 
   pname = "timescaledb_toolkit";
@@ -22,7 +23,16 @@
     hash = "sha256-Lm/LFBkG91GeWlJL9RBqP8W0tlhBEeGQ6kXUzzv4xRE=";
   };
 
-  cargoHash = "sha256-LME8oftHmmiN8GU3eTBTSB6m0CE+KtDFRssL1g2Cjm8=";
+  # TODO: Remove this patch when upstream updates to a newer pgrx version.
+  cargoPatches = [
+    (fetchpatch {
+      name = "cargo-pgrx-0.11.3.patch";
+      url = "https://github.com/sdier/timescaledb-toolkit/commit/c05d87f33516a25a5346fe67ed43e98786204ab1.patch";
+      hash = "sha256-Y2mLI1cDmx47Kgf6f/FS1ziNtcGEju+wSkegl0qwOhE=";
+    })
+  ];
+
+  cargoHash = "sha256-3FJW7y+RH++6dkcs3CskKvPAmqpZX8rsBGoHcxUcQYY=";
   buildAndTestSubdir = "extension";
 
   passthru = {


### PR DESCRIPTION
## Description of changes

Moving to 0.11.3 fixes compilation errors on aarch64-linux for non-JIT builds.  Something else is wrong with the JIT builds, unfortunately.
\
eg: https://hydra.nixos.org/build/259899040/nixlog/2
` Invalid or unknown abi 16 for function "_ZGVnN4vv_atan2f" (Function { name: "_ZGVnN4vv_atan2f", mangled_name: Some("_ZGVnN4vv_atan2f"), link_name: None, signature: TypeId(ItemId(24894)), kind: Function, linkage: External })`

This was fixed upstream in pgrx in https://github.com/pgcentralfoundation/pgrx/issues/1429

#ZurichZHF

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
