### PR TITLE
hardware/nvidia-container-toolkit: mount `nvidia-driver/share`

### DIFF
--- a/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
+++ b/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
@@ -69,14 +69,18 @@
     virtualisation.docker.daemon.settings = lib.mkIf
       (config.hardware.nvidia-container-toolkit.enable &&
        (lib.versionAtLeast config.virtualisation.docker.package.version "25")) {
-      features.cdi = true;
-    };
+         features.cdi = true;
+       };
 
     hardware.nvidia-container-toolkit.mounts = let
       nvidia-driver = config.hardware.nvidia.package;
     in (lib.mkMerge [
       [{ hostPath = pkgs.addDriverRunpath.driverLink;
          containerPath = pkgs.addDriverRunpath.driverLink; }
+       { hostPath = "${lib.getLib nvidia-driver}/etc";
+         containerPath = "${lib.getLib nvidia-driver}/etc"; }
+       { hostPath = "${lib.getLib nvidia-driver}/share";
+         containerPath = "${lib.getLib nvidia-driver}/share"; }
        { hostPath = "${lib.getLib pkgs.glibc}/lib";
          containerPath = "${lib.getLib pkgs.glibc}/lib"; }
        { hostPath = "${lib.getLib pkgs.glibc}/lib64";


### PR DESCRIPTION
## Description of changes

Fixes: https://github.com/NixOS/nixpkgs/issues/297537
Related: https://github.com/NixOS/nixpkgs/issues/290609

Mount the nvidia-driver/share folder inside the container so that EGL works as expected.

Thanks to https://github.com/SomeoneSerge/cdi-vtk-egl-repro it is very easy to reproduce the issue and validate that the fix works.

This is not using `exportReferencesGraph` as https://github.com/NixOS/nixpkgs/issues/290609 suggests. With this change, we are mounting the `share` directory, and the `cdi-generator` takes care of cherry-picking the needed libraries from `lib`.

@SomeoneSerge: I didn't find a way to use `exportReferencesGraph` successfully here; I am not familiar with it, let me know if you think I should adapt this PR to use `exportReferencesGraph` instead, although I might need a tip on how to use it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
