### PR TITLE
box64: LoongArch dynarec, modernisations, formatting

### DIFF
--- a/pkgs/applications/emulators/box64/default.nix
+++ b/pkgs/applications/emulators/box64/default.nix
@@ -4,13 +4,13 @@
 , gitUpdater
 , cmake
 , python3
-, withDynarec ? (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isRiscV64)
+, withDynarec ? (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isRiscV64 || stdenv.hostPlatform.isLoongArch64)
 , runCommand
 , hello-x86_64
 }:
 
-# Currently only supported on ARM & RISC-V
-assert withDynarec -> (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isRiscV64);
+# Currently only supported on specific archs
+assert withDynarec -> (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isRiscV64 || stdenv.hostPlatform.isLoongArch64);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "box64";
@@ -44,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Arch dynarec
     "-DARM_DYNAREC=${lib.boolToString (withDynarec && stdenv.hostPlatform.isAarch64)}"
     "-DRV64_DYNAREC=${lib.boolToString (withDynarec && stdenv.hostPlatform.isRiscV64)}"
+    "-DLARCH64_DYNAREC=${lib.boolToString (withDynarec && stdenv.hostPlatform.isLoongArch64)}"
   ];
 
   installPhase = ''
@@ -79,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
     } ''
       # There is no actual "Hello, world!" with any of the logging enabled, and with all logging disabled it's hard to
       # tell what problems the emulator has run into.
-      BOX64_NOBANNER=0 BOX64_LOG=1 box64 ${hello-x86_64}/bin/hello --version | tee $out
+      BOX64_NOBANNER=0 BOX64_LOG=1 box64 ${lib.getExe hello-x86_64} --version | tee $out
     '';
   };
 

--- a/pkgs/applications/emulators/box64/default.nix
+++ b/pkgs/applications/emulators/box64/default.nix
@@ -1,16 +1,23 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, gitUpdater
-, cmake
-, python3
-, withDynarec ? (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isRiscV64 || stdenv.hostPlatform.isLoongArch64)
-, runCommand
-, hello-x86_64
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gitUpdater,
+  cmake,
+  python3,
+  withDynarec ? (
+    stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isRiscV64 || stdenv.hostPlatform.isLoongArch64
+  ),
+  runCommand,
+  hello-x86_64,
 }:
 
 # Currently only supported on specific archs
-assert withDynarec -> (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isRiscV64 || stdenv.hostPlatform.isLoongArch64);
+assert
+  withDynarec
+  -> (
+    stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isRiscV64 || stdenv.hostPlatform.isLoongArch64
+  );
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "box64";
@@ -28,24 +35,27 @@ stdenv.mkDerivation (finalAttrs: {
     python3
   ];
 
-  cmakeFlags = [
-    (lib.cmakeBool "NOGIT" true)
+  cmakeFlags =
+    [
+      (lib.cmakeBool "NOGIT" true)
 
-    # Arch mega-option
-    (lib.cmakeBool "ARM64" stdenv.hostPlatform.isAarch64)
-    (lib.cmakeBool "RV64" stdenv.hostPlatform.isRiscV64)
-    (lib.cmakeBool "PPC64LE" (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian))
-    (lib.cmakeBool "LARCH64" stdenv.hostPlatform.isLoongArch64)
-  ] ++ lib.optionals stdenv.hostPlatform.isx86_64 [
-    # x86_64 has no arch-specific mega-option, manually enable the options that apply to it
-    (lib.cmakeBool "LD80BITS" true)
-    (lib.cmakeBool "NOALIGN" true)
-  ] ++ [
-    # Arch dynarec
-    (lib.cmakeBool "ARM_DYNAREC" (withDynarec && stdenv.hostPlatform.isAarch64))
-    (lib.cmakeBool "RV64_DYNAREC" (withDynarec && stdenv.hostPlatform.isRiscV64))
-    (lib.cmakeBool "LARCH64_DYNAREC" (withDynarec && stdenv.hostPlatform.isLoongArch64))
-  ];
+      # Arch mega-option
+      (lib.cmakeBool "ARM64" stdenv.hostPlatform.isAarch64)
+      (lib.cmakeBool "RV64" stdenv.hostPlatform.isRiscV64)
+      (lib.cmakeBool "PPC64LE" (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian))
+      (lib.cmakeBool "LARCH64" stdenv.hostPlatform.isLoongArch64)
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isx86_64 [
+      # x86_64 has no arch-specific mega-option, manually enable the options that apply to it
+      (lib.cmakeBool "LD80BITS" true)
+      (lib.cmakeBool "NOALIGN" true)
+    ]
+    ++ [
+      # Arch dynarec
+      (lib.cmakeBool "ARM_DYNAREC" (withDynarec && stdenv.hostPlatform.isAarch64))
+      (lib.cmakeBool "RV64_DYNAREC" (withDynarec && stdenv.hostPlatform.isRiscV64))
+      (lib.cmakeBool "LARCH64_DYNAREC" (withDynarec && stdenv.hostPlatform.isLoongArch64))
+    ];
 
   installPhase = ''
     runHook preInstall
@@ -72,17 +82,14 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = gitUpdater {
-      rev-prefix = "v";
-    };
-    tests.hello = runCommand "box64-test-hello" {
-        nativeBuildInputs = [ finalAttrs.finalPackage ];
-      }
-      # There is no actual "Hello, world!" with any of the logging enabled, and with all logging disabled it's hard to
-      # tell what problems the emulator has run into.
-      ''
-        BOX64_NOBANNER=0 BOX64_LOG=1 box64 ${lib.getExe hello-x86_64} --version | tee $out
-      '';
+    updateScript = gitUpdater { rev-prefix = "v"; };
+    tests.hello =
+      runCommand "box64-test-hello" { nativeBuildInputs = [ finalAttrs.finalPackage ]; }
+        # There is no actual "Hello, world!" with any of the logging enabled, and with all logging disabled it's hard to
+        # tell what problems the emulator has run into.
+        ''
+          BOX64_NOBANNER=0 BOX64_LOG=1 box64 ${lib.getExe hello-x86_64} --version | tee $out
+        '';
   };
 
   meta = {
@@ -90,8 +97,18 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Lets you run x86_64 Linux programs on non-x86_64 Linux systems";
     changelog = "https://github.com/ptitSeb/box64/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ gador OPNA2608 ];
+    maintainers = with lib.maintainers; [
+      gador
+      OPNA2608
+    ];
     mainProgram = "box64";
-    platforms = [ "x86_64-linux" "aarch64-linux" "riscv64-linux" "powerpc64le-linux" "loongarch64-linux" "mips64el-linux" ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "riscv64-linux"
+      "powerpc64le-linux"
+      "loongarch64-linux"
+      "mips64el-linux"
+    ];
   };
 })

--- a/pkgs/applications/emulators/box64/default.nix
+++ b/pkgs/applications/emulators/box64/default.nix
@@ -29,22 +29,22 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DNOGIT=ON"
+    (lib.cmakeBool "NOGIT" true)
 
     # Arch mega-option
-    "-DARM64=${lib.boolToString stdenv.hostPlatform.isAarch64}"
-    "-DRV64=${lib.boolToString stdenv.hostPlatform.isRiscV64}"
-    "-DPPC64LE=${lib.boolToString (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian)}"
-    "-DLARCH64=${lib.boolToString stdenv.hostPlatform.isLoongArch64}"
+    (lib.cmakeBool "ARM64" stdenv.hostPlatform.isAarch64)
+    (lib.cmakeBool "RV64" stdenv.hostPlatform.isRiscV64)
+    (lib.cmakeBool "PPC64LE" (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian))
+    (lib.cmakeBool "LARCH64" stdenv.hostPlatform.isLoongArch64)
   ] ++ lib.optionals stdenv.hostPlatform.isx86_64 [
     # x86_64 has no arch-specific mega-option, manually enable the options that apply to it
-    "-DLD80BITS=ON"
-    "-DNOALIGN=ON"
+    (lib.cmakeBool "LD80BITS" true)
+    (lib.cmakeBool "NOALIGN" true)
   ] ++ [
     # Arch dynarec
-    "-DARM_DYNAREC=${lib.boolToString (withDynarec && stdenv.hostPlatform.isAarch64)}"
-    "-DRV64_DYNAREC=${lib.boolToString (withDynarec && stdenv.hostPlatform.isRiscV64)}"
-    "-DLARCH64_DYNAREC=${lib.boolToString (withDynarec && stdenv.hostPlatform.isLoongArch64)}"
+    (lib.cmakeBool "ARM_DYNAREC" (withDynarec && stdenv.hostPlatform.isAarch64))
+    (lib.cmakeBool "RV64_DYNAREC" (withDynarec && stdenv.hostPlatform.isRiscV64))
+    (lib.cmakeBool "LARCH64_DYNAREC" (withDynarec && stdenv.hostPlatform.isLoongArch64))
   ];
 
   installPhase = ''
@@ -76,19 +76,21 @@ stdenv.mkDerivation (finalAttrs: {
       rev-prefix = "v";
     };
     tests.hello = runCommand "box64-test-hello" {
-      nativeBuildInputs = [ finalAttrs.finalPackage ];
-    } ''
+        nativeBuildInputs = [ finalAttrs.finalPackage ];
+      }
       # There is no actual "Hello, world!" with any of the logging enabled, and with all logging disabled it's hard to
       # tell what problems the emulator has run into.
-      BOX64_NOBANNER=0 BOX64_LOG=1 box64 ${lib.getExe hello-x86_64} --version | tee $out
-    '';
+      ''
+        BOX64_NOBANNER=0 BOX64_LOG=1 box64 ${lib.getExe hello-x86_64} --version | tee $out
+      '';
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://box86.org/";
     description = "Lets you run x86_64 Linux programs on non-x86_64 Linux systems";
-    license = licenses.mit;
-    maintainers = with maintainers; [ gador OPNA2608 ];
+    changelog = "https://github.com/ptitSeb/box64/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gador OPNA2608 ];
     mainProgram = "box64";
     platforms = [ "x86_64-linux" "aarch64-linux" "riscv64-linux" "powerpc64le-linux" "loongarch64-linux" "mips64el-linux" ];
   };


### PR DESCRIPTION
## Description of changes

https://github.com/NixOS/nixpkgs/pull/313955#issuecomment-2131404095

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
