### PR TITLE
openlp: init at 3.1.2

### DIFF
--- a/pkgs/applications/misc/openlp/default.nix
+++ b/pkgs/applications/misc/openlp/default.nix
@@ -31,7 +31,7 @@ let
   baseLib = pythonPackages.callPackage ./lib.nix { };
 in mkDerivation {
   pname = baseLib.pname + lib.optionalString (pdfSupport && presentationSupport && vlcSupport) "-full";
-  inherit (baseLib) version src;
+  inherit (baseLib) version src meta;
 
   nativeBuildInputs = [ python3Packages.wrapPython wrapGAppsHook3 ];
   buildInputs = [ qtbase ];
@@ -71,10 +71,6 @@ in mkDerivation {
   preFixup = ''
     wrapPythonPrograms
   '';
-
-  meta = baseLib.meta // {
-    hydraPlatforms = [ ]; # this is only the wrapper; baseLib gets built
-  };
 
   passthru = {
     inherit baseLib;

--- a/pkgs/applications/misc/openlp/lib.nix
+++ b/pkgs/applications/misc/openlp/lib.nix
@@ -1,20 +1,43 @@
 # This file contains the base package, some of which is compiled.
 # Runtime glue to optinal runtime dependencies is in 'default.nix'.
-{ fetchurl, lib, qt5
+{ fetchFromGitLab, lib, qt5
 
 # python deps
-, python, buildPythonPackage
-, alembic, beautifulsoup4, chardet, lxml, mako, pyenchant
-, pyqt5-webkit, pyxdg, sip4, sqlalchemy, sqlalchemy-migrate
+, python, pythonPackages, buildPythonPackage
+, alembic
+, beautifulsoup4
+, chardet
+, dbus-python
+, distro
+, flask
+, flask-cors
+, lxml
+, mako
+, packaging
+, platformdirs
+, pyicu
+, pymediainfo
+, pyenchant
+, pytest-runner
+, pyqt5
+, pyqtwebengine
+, qtawesome
+, qrcode
+, requests
+, sqlalchemy
+, waitress
+, websockets
 }:
 
 buildPythonPackage rec {
   pname = "openlp";
-  version = "2.4.6";
+  version = "3.1.2";
 
-  src = fetchurl {
-    url = "https://get.openlp.org/${version}/OpenLP-${version}.tar.gz";
-    sha256 = "f63dcf5f1f8a8199bf55e806b44066ad920d26c9cf67ae432eb8cdd1e761fc30";
+  src = fetchFromGitLab {
+    owner = "openlp";
+    repo = pname;
+    rev = version;
+    hash = "sha256-SdLdgFXTEl1E9zPktnGTzH+qZj7bVZ4QTy1nZuvWc08=";
   };
 
   doCheck = false;
@@ -31,24 +54,31 @@ buildPythonPackage rec {
   # See also https://discourse.nixos.org/t/qt-plugin-path-unset-in-test-phase/
 
   #nativeCheckInputs = [ mock nose ];
-  nativeBuildInputs = [ qt5.qttools ];
+  nativeBuildInputs = [ qt5.qttools pytest-runner ];
   propagatedBuildInputs = [
     alembic
     beautifulsoup4
     chardet
+    dbus-python
+    distro
+    flask
+    flask-cors
     lxml
     mako
+    packaging
+    platformdirs
+    pyicu
+    pymediainfo
     pyenchant
-    pyqt5-webkit
-    pyxdg
-    sip4
+    pyqt5
+    pyqtwebengine
+    qtawesome
+    qrcode
+    requests
     sqlalchemy
-    sqlalchemy-migrate
+    waitress
+    websockets
   ];
-
-  prePatch = ''
-    echo 'from vlc import *' > openlp/core/ui/media/vendor/vlc.py
-  '';
 
   dontWrapQtApps = true;
   dontWrapGApps = true;
@@ -64,7 +94,6 @@ buildPythonPackage rec {
   '';
 
   preFixup = ''
-    rm -r $out/${python.sitePackages}/tests
     rm -r $out/bin
   '';
 
@@ -87,17 +116,13 @@ buildPythonPackage rec {
       * Quickly and easily import songs from other popular presentation packages
       * Easy enough to use to get up and running in less than 10 minutes
 
-      Remark: This pkg only supports sqlite dbs. If you wish to have support for
-            mysql or postgresql dbs, or Jenkins, please contact the maintainer.
+      Remarks:
 
-      Bugs which affect this software packaged in Nixpkgs:
+      1. The web remote is not installed by Nix. It must be installed by OpenLP,
+         as described here: https://manual.openlp.org/configure.html#web-remote
 
-      1. The package must disable checks, because they are lacking the qt env.
-         (see pkg source and https://discourse.nixos.org/t/qt-plugin-path-unset-in-test-phase/)
-      2. There is a segfault on exit. Not a real problem, according to debug log, everything
-         shuts down correctly. Maybe related to https://forums.openlp.org/discussion/3620/crash-on-exit.
-         Plan: Wait for OpenLP-3, since it is already in beta 1
-         (2021-02-09; news: https://openlp.org/blog/).
+      2. This pkg only supports sqlite dbs. If you wish to have support for
+         mysql or postgresql dbs, or Jenkins, please contact the maintainer.
     '';
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37744,7 +37744,6 @@ with pkgs;
     pdfSupport = true;
     presentationSupport = true;
     vlcSupport = true;
-    gstreamerSupport = true;
   };
 
   autodock-vina = callPackage ../applications/science/chemistry/autodock-vina { };


### PR DESCRIPTION
## Description of changes

***looking for additional maintainers**: I don't use OpenLP any more. I can stay a maintainer and help with non-trivial updates, but it would be very helpful to have someone using it, who notices updates and breakages.*

- Major version update to [3.1.2](https://openlp.org/blog/2024/05/19/openlp-312-exemplary-eleazar-released)
- Fixes #296477 and  #312624.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (NixOS)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] ~~Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)~~
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`). Functinality tested:
    - [x] songs
    - [x] bible verses
    - [x] pdfs
    - [x] presentations via libreoffice
    - [x] pictures
    - [x] videos
    - [x] custom slides
    - [x] web remote
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
