### PR TITLE
python312Packages.pyxnat: 1.6 -> 1.6.2

### DIFF
--- a/pkgs/development/python-modules/pyxnat/default.nix
+++ b/pkgs/development/python-modules/pyxnat/default.nix
@@ -9,13 +9,14 @@
   networkx,
   pandas,
   requests,
-  six,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "pyxnat";
-  version = "1.6";
-  format = "setuptools";
+  version = "1.6.2";
+  pyproject = true;
+
   disabled = pythonOlder "3.8";
 
   # PyPI dist missing test configuration files:
@@ -23,21 +24,19 @@ buildPythonPackage rec {
     owner = "pyxnat";
     repo = "pyxnat";
     rev = "refs/tags/${version}";
-    hash = "sha256-QejYisvQFN7CsDOx9wAgTHmRZcSEqgIr8twG4XucfZ4=";
+    hash = "sha256-21nTIYbIYlFWNJTxqsuijamqRunpdc7/VBawvrWadWI=";
   };
+
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [
     lxml
     requests
-    six
   ];
 
-  # future is not used, and pathlib is installed part of python38+
-  # w/o an external package
+  # pathlib is installed part of python38+ w/o an external package
   prePatch = ''
-    substituteInPlace setup.py \
-      --replace "pathlib>=1.0" "" \
-      --replace "future>=0.16" ""
+    substituteInPlace setup.py --replace-fail "pathlib>=1.0" ""
     sed -i '/--cov/d' setup.cfg
   '';
 
@@ -52,15 +51,24 @@ buildPythonPackage rec {
   '';
   pytestFlagsArray = [ "pyxnat" ];
   disabledTestPaths = [
-    # try to access network even though PYXNAT_SKIP_NETWORK_TESTS is set:
+    # require a running local XNAT instance e.g. in a docker container:
+    "pyxnat/tests/attributes_test.py"
+    "pyxnat/tests/custom_variables_test.py"
+    "pyxnat/tests/interfaces_test.py"
     "pyxnat/tests/pipelines_test.py"
+    "pyxnat/tests/provenance_test.py"
+    "pyxnat/tests/prearchive_test.py"
+    "pyxnat/tests/repr_test.py"
+    "pyxnat/tests/resources_test.py"
     "pyxnat/tests/search_test.py"
+    "pyxnat/tests/sessionmirror_test.py"
+    "pyxnat/tests/test_resource_functions.py"
     "pyxnat/tests/user_and_project_management_test.py"
   ];
   disabledTests = [
     # try to access network even though PYXNAT_SKIP_NETWORK_TESTS is set:
-    "test_ashs_volumes"
     "test_inspector_structure"
+    "test_project_manager"
   ];
 
   pythonImportsCheck = [ "pyxnat" ];


### PR DESCRIPTION
## Description of changes

Unbreak and fix test failures which for some reason only affected the Darwin build; routine update.

For ZHF (#309482).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
