### PR TITLE
stdenv: allow for jobservers across multiple nix builds

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1368,8 +1368,8 @@ Helper function for running a command as a client of the global jobserver, if ap
 but separators must always be given.
 
 **Note**:
-The global jobserver must be bound to `/jobserver` in the Nix sandbox to be found by this function.
-If the provided `/jobserver` is not a `nixos-jobserver` token file it will not be used.
+The global jobserver must be bound to `/build-support/jobserver` in the Nix sandbox to be found by this function.
+If the provided `/build-support/jobserver` is not a `nixos-jobserver` token file it will not be used.
 
 Example:
 

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1355,6 +1355,30 @@ name="/nix/store/9s9r019176g7cvn2nvcw41gsp862y6b4-coreutils-8.24"
 someVar=$(stripHash $name)
 ```
 
+### `runInJobserver` \<command\> \-\-\-\- \<defArgs\> \-\-\-\- \<args\> {#fun-runInJobServer}
+
+Helper function for running a command as a client of the global jobserver, if applicable.
+
+ - If a global jobserver is available, runs `<command> <args>` with a GNU Make compatible jobserver made
+   available in `MAKEFLAGS`. The client is automatically limited to `NIX_BUILD_CORES` tokens.
+ - If no global jobserver is available, runs `<command> <defArgs> <args>` instead.
+
+\<command\>, \<defArgs\> and \<args\> may be more than one shell word each, hence they are separated by
+`----`. \<command\> and \<defArgs\> may not contain `----`. Each set except \<command\> may be empty,
+but separators must always be given.
+
+**Note**:
+The global jobserver must be bound to `/jobserver` in the Nix sandbox to be found by this function.
+If the provided `/jobserver` is not a `nixos-jobserver` token file it will not be used.
+
+Example:
+
+```bash
+runInJobserver cargo build ---- \
+    -j $NIX_BUILD_CORES ---- \
+    ${cargoBuildFlags}
+```
+
 ### `wrapProgram` \<executable\> \<makeWrapperArgs\> {#fun-wrapProgram}
 
 Convenience function for `makeWrapper` that replaces `<executable>` with a wrapper that executes the original program. It takes all the same arguments as `makeWrapper`, except for `--inherit-argv0` (used by the `makeBinaryWrapper` implementation) and `--argv0` (used by both `makeWrapper` and `makeBinaryWrapper` wrapper implementations).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -759,6 +759,7 @@
   ./services/misc/nitter.nix
   ./services/misc/nix-gc.nix
   ./services/misc/nix-optimise.nix
+  ./services/misc/nixos-jobserver.nix
   ./services/misc/nix-ssh-serve.nix
   ./services/misc/novacomd.nix
   ./services/misc/ntfy-sh.nix

--- a/nixos/modules/services/misc/nixos-jobserver.nix
+++ b/nixos/modules/services/misc/nixos-jobserver.nix
@@ -1,0 +1,80 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.nixos.jobserver;
+  tokenDir = "/run/nixos-jobserver";
+  tokenFile = "${tokenDir}/tokens";
+in
+{
+  options = {
+    nixos.jobserver = {
+      enable = mkEnableOption "the global NixOS jobserver";
+
+      owner = mkOption {
+        type = types.str;
+        default = "root";
+        description = ''
+          Owner of the jobserver token file.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "nixbld";
+        description = ''
+          Group of the jobserver token file.
+        '';
+      };
+
+      tokens = mkOption {
+        type = types.ints.unsigned;
+        default = 0;
+        description = ''
+          Number of tokens to provide via the jobserver. Uses the number of CPUs in the
+          system when set to 0.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    nix.settings.extra-sandbox-paths = [ "/build-support/jobserver=${tokenFile}?" ];
+
+    systemd.services.nixos-jobserver = {
+      wantedBy = [ "multi-user.target" ];
+
+      path = [ pkgs.nixos-jobserver pkgs.util-linux ];
+
+      preStart = ''
+        umask 0777
+        touch ${tokenFile}
+      '';
+
+      script = ''
+        exec nixos-jobserver \
+          -t ${toString cfg.tokens} \
+          -u ${escapeShellArg cfg.owner} \
+          -g ${escapeShellArg cfg.group} \
+          ${tokenFile}
+      '';
+
+      # we explicitly *do not* kill the jobserver.
+      # doing so would cause all running builds to fail.
+      # instead we want to make the jobserver unavailable to new builds, but allow
+      # running builds to finish and the jobserver to exit once they're all done.
+      # systemd *does not* want to allow this kind of thing, so we instruct it to
+      # only kill the wrapper script. with the token file unmounted the jobserver
+      # process will exit once all builds have finished.
+      preStop = ''
+        umount ${tokenFile}
+      '';
+      serviceConfig = {
+        RuntimeDirectory = "nixos-jobserver";
+        RuntimeDirectoryMode = "700";
+        KillMode = "process";
+      };
+    };
+  };
+}

--- a/pkgs/build-support/rust/hooks/cargo-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-build-hook.sh
@@ -37,7 +37,8 @@ cargoBuildHook() {
 
     (
     set -x
-    @setEnv@ cargo build -j $NIX_BUILD_CORES \
+    runInJobserver -F CARGO_MAKEFLAGS @setEnv@ \
+      cargo build ---- -j $NIX_BUILD_CORES ---- \
         --target @rustHostPlatformSpec@ \
         --offline \
         ${cargoBuildProfileFlag} \

--- a/pkgs/build-support/rust/hooks/cargo-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-check-hook.sh
@@ -33,8 +33,8 @@ cargoCheckHook() {
 
     (
         set -x
-        cargo test \
-              -j $NIX_BUILD_CORES \
+        runInJobserver cargo test ---- \
+              -j $NIX_BUILD_CORES ---- \
               ${argstr} -- \
               --test-threads=${threads} \
               ${checkFlags} \

--- a/pkgs/by-name/ni/nixos-jobserver/nixos-jobserver.cpp
+++ b/pkgs/by-name/ni/nixos-jobserver/nixos-jobserver.cpp
@@ -1,0 +1,476 @@
+/* the nixos-jobserver FUSE filesystem.
+ *
+ * provides a single file (the token file) from which a client can pull tokens
+ * out of a global pool, and to which clients return tokens when they are done
+ * with them. if a client exits without returning all tokens they are returned
+ * to the global pool. the token file is compatible with the GNU Make jobserver
+ * protocol.
+ *
+ * the original make jobserver uses simple pipes for token storage and transfer.
+ * this works fine for make, where one job does not substantially outlive its first
+ * failing component. it is not suitable for global jobservers, since a job may
+ * have failed without being able to return its tokens (eg because it was killed
+ * by SIGKILL, as nix-daemon does). we thus have to track how many tokens a client
+ * has acquired and return them if the client goes away, but to do this we also
+ * need to know when a client dies. this can be done with FUSE as done here, but
+ * could also be achieved with simple pipes or unix domain sockets. neither of
+ * these are a good choice for this problem:
+ *
+ * pipes are a resource shared between all processes that have opened said pipe.
+ * to be useful for a global jobserver we'd have to provide a unique pipe for
+ * each client, which requires more invasive changes to a nix configuration than
+ * using FUSE.
+ *
+ * both pipes and sockets have buffers. it is not possible to poll a pipe or
+ * socket for "the other end wants to read a byte", it is only possible to poll
+ * for available buffer space. distributing tokens among multiple clients of the
+ * jobserver must then be done by partitioning the available tokens and giving
+ * one partition to each client and periodically rebalancing according to actual
+ * usage. this periodic process necessarily causes more overhead than using the
+ * kernel as a notification source for "the other end wants to read a byte" and
+ * introduces unnecessary latency into token transfers between jobs.
+ */
+
+#define FUSE_USE_VERSION 35
+
+#include <errno.h>
+#include <fuse.h>
+#include <fuse_lowlevel.h>
+#include <grp.h>
+#include <poll.h>
+#include <pwd.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/sysinfo.h>
+#include <sys/xattr.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <limits>
+#include <list>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+// This parses an unsigned with no trailing whitespace.
+// This returns 1 if it's valid.
+// 2 or more if it's invalid.
+#define parse_unsigned(input, dst) sscanf(input, "%u%c", &dst, (char*) &dst)
+
+// 0x0A is ^J :)
+#define JOBSRV_IOC_SET_LIMIT _IOW(0x0A, 0, unsigned)
+
+struct PollHandleDestroy {
+    void operator()(fuse_pollhandle* ph) { fuse_pollhandle_destroy(ph); }
+};
+
+using PollHandle = std::unique_ptr<fuse_pollhandle, PollHandleDestroy>;
+
+struct Context {
+    unsigned tokens_held{0};
+    unsigned limit{std::numeric_limits<unsigned>::max()};
+    PollHandle poll;
+};
+
+struct stat jobserver_st = {
+    .st_ino = FUSE_ROOT_ID,
+    .st_mode = S_IFREG | 0666,
+    .st_uid = getuid(),
+    .st_gid = getgid(),
+};
+static const std::string acl_name = "system.posix_acl_access";
+static std::optional<std::vector<char>> acl;
+
+static unsigned tokens = 0;
+static std::unordered_set<Context*> poll_waiters;
+static std::unordered_map<fuse_req_t, Context*> read_waiters;
+
+/*
+ * NOTE:
+ *
+ * This will wake up everyone instead of just waking up someone waiting,
+ * causing a thundering herd on `read()`.
+ * Additionally, this will prioritize blocking IO consumers compared to poll/async IO consumers.
+ *
+ */
+static void wake_waiters()
+{
+    for (auto it = read_waiters.begin(); it != read_waiters.end() && tokens > 0; ) {
+        auto& ctx = *it->second;
+
+        if (ctx.tokens_held >= ctx.limit) {
+            it++;
+            continue;
+        }
+
+        fuse_reply_buf(it->first, "+", 1);
+        ctx.tokens_held++;
+        tokens--;
+        read_waiters.erase(it++);
+    }
+
+    if (tokens > 0) {
+        for (auto it = poll_waiters.begin(); it != poll_waiters.end(); ) {
+            auto waiter = *it;
+
+            if (waiter->tokens_held >= waiter->limit) {
+                it++;
+                continue;
+            }
+
+            fuse_lowlevel_notify_poll(waiter->poll.get());
+            poll_waiters.erase(it++);
+        }
+    }
+}
+
+static void interrupt_func(fuse_req_t req, void* data)
+{
+    fuse_reply_err(req, EINTR);
+    read_waiters.erase(req);
+}
+
+static Context* fi_ctx(fuse_file_info* fi)
+{
+    static_assert(sizeof(fi->fh) >= sizeof(Context*));
+    return reinterpret_cast<Context*>(fi->fh);
+}
+
+static void jobserver_getattr(fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi)
+{
+    // long attribute cache times are preferrable for purely local systems like this.
+    // this also affects xattr caching, which in turn affects acl caching.
+    fuse_reply_attr(req, &jobserver_st, 120);
+}
+
+static void jobserver_setattr(fuse_req_t req, fuse_ino_t ino, struct stat* attr, int to_set, fuse_file_info* fi)
+{
+    if ((to_set & ~(FUSE_SET_ATTR_MODE | FUSE_SET_ATTR_UID | FUSE_SET_ATTR_GID))
+            || !S_ISREG(attr->st_mode)) {
+        fuse_reply_err(req, EINVAL);
+        return;
+    }
+
+    if (to_set & FUSE_SET_ATTR_MODE) {
+        jobserver_st.st_mode = attr->st_mode;
+    }
+    if (to_set & FUSE_SET_ATTR_UID) {
+        jobserver_st.st_uid = attr->st_uid;
+    }
+    if (to_set & FUSE_SET_ATTR_GID) {
+        jobserver_st.st_gid = attr->st_gid;
+    }
+
+    fuse_reply_attr(req, &jobserver_st, 120);
+}
+
+static void jobserver_open(fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi)
+{
+    auto ctx = new Context;
+    static_assert(sizeof(fi->fh) >= sizeof(ctx));
+    fi->fh = reinterpret_cast<uint64_t>(ctx);
+    fi->direct_io = 1;
+    fuse_reply_open(req, fi);
+}
+
+static void jobserver_release(fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi)
+{
+    auto ctx = fi_ctx(fi);
+    poll_waiters.erase(ctx);
+    tokens += ctx->tokens_held;
+    delete ctx;
+    fuse_reply_err(req, 0);
+    wake_waiters();
+}
+
+static void jobserver_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off, fuse_file_info* fi)
+{
+    if (size == 0) {
+        fuse_reply_buf(req, "", 0);
+        return;
+    }
+
+    auto& ctx = *fi_ctx(fi);
+
+    if (tokens > 0 && ctx.tokens_held < ctx.limit) {
+        tokens--;
+        ctx.tokens_held++;
+        fuse_reply_buf(req, "+", 1);
+    } else if (fi->flags & O_NONBLOCK) {
+        fuse_reply_err(req, EAGAIN);
+    } else {
+        read_waiters.emplace(req, &ctx);
+        // if we're already interrupted the emplace will be undone
+        fuse_req_interrupt_func(req, interrupt_func, nullptr);
+    }
+}
+
+static void jobserver_write(fuse_req_t req, fuse_ino_t ino, const char* buf, size_t size, off_t off,
+        fuse_file_info* fi)
+{
+    auto& ctx = *fi_ctx(fi);
+
+    size = std::min<size_t>(size, ctx.tokens_held);
+    tokens += size;
+    ctx.tokens_held -= size;
+    fuse_reply_write(req, size);
+    wake_waiters();
+}
+
+static void jobserver_setxattr(fuse_req_t req, fuse_ino_t ino, const char* name, const char* value,
+        size_t size, int flags)
+{
+    if (name != acl_name) {
+        fuse_reply_err(req, EINVAL);
+    } else if ((flags & XATTR_CREATE) && acl) {
+        fuse_reply_err(req, EEXIST);
+    } else if ((flags & XATTR_REPLACE) && !acl) {
+        fuse_reply_err(req, ENODATA);
+    } else {
+        // we need to update file permission bits according to the new acl.
+        // parsing an acl is not pretty and setting this acl should be rare, so we'll just
+        // be incredibly lazy about it and let the kernel do the heavy lifting.
+        int mfd = memfd_create("acl_tmp", 0);
+        std::unique_ptr<int, void(*)(int*)> const _mfd(&mfd, [] (int* fd) { close(*fd); });
+        struct stat tmp;
+
+        if (fsetxattr(mfd, name, value, size, 0) == 0
+                && fstat(mfd, &tmp) == 0) {
+            jobserver_st.st_mode = S_IFREG | (tmp.st_mode & 07777);
+            acl.emplace(value, value + size);
+            fuse_reply_err(req, 0);
+        } else {
+            fuse_reply_err(req, errno);
+        }
+    }
+}
+
+static void jobserver_getxattr(fuse_req_t req, fuse_ino_t ino, const char* name, size_t size)
+{
+    if (name != acl_name) {
+        fuse_reply_err(req, EINVAL);
+    } else if (!acl) {
+        fuse_reply_err(req, ENODATA);
+    } else if (size == 0) {
+        fuse_reply_xattr(req, acl->size());
+    } else if (size < acl->size()) {
+        fuse_reply_err(req, ERANGE);
+    } else {
+        fuse_reply_buf(req, acl->data(), acl->size());
+    }
+}
+
+static void jobserver_listxattr(fuse_req_t req, fuse_ino_t ino, size_t size)
+{
+    if (size == 0) {
+        fuse_reply_xattr(req, acl_name.size() + 1);
+    } else if (size < acl_name.size() + 1) {
+        fuse_reply_err(req, ERANGE);
+    } else {
+        fuse_reply_buf(req, acl_name.c_str(), acl_name.size() + 1);
+    }
+}
+
+static void jobserver_removexattr(fuse_req_t req, fuse_ino_t ino, const char* name)
+{
+    if (name != acl_name) {
+        fuse_reply_err(req, EINVAL);
+    } else if (acl) {
+        acl.reset();
+        fuse_reply_err(req, 0);
+    } else {
+        fuse_reply_err(req, ENODATA);
+    }
+}
+
+static void jobserver_ioctl(fuse_req_t req, fuse_ino_t ino, unsigned int cmd, void* arg,
+        fuse_file_info* fi, unsigned flags, const void* in_buf, size_t in_bufsz, size_t out_bufsz)
+{
+    auto& ctx = *fi_ctx(fi);
+
+    if (flags & FUSE_IOCTL_COMPAT) {
+        fuse_reply_err(req, ENOSYS);
+        return;
+    }
+
+    switch (cmd) {
+    case JOBSRV_IOC_SET_LIMIT:
+        ctx.limit = *reinterpret_cast<const unsigned*>(in_buf);
+        if (ctx.limit == 0) {
+            ctx.limit = std::numeric_limits<unsigned>::max();
+        }
+        fuse_reply_ioctl(req, 0, nullptr, 0);
+        break;
+
+    default:
+        fuse_reply_err(req, ENOTTY);
+    }
+}
+
+static void jobserver_poll(fuse_req_t req, fuse_ino_t ino, fuse_file_info* fi, fuse_pollhandle* ph)
+{
+    auto& ctx = *fi_ctx(fi);
+
+    ctx.poll.reset(ph);
+    if (ph) {
+        poll_waiters.insert(&ctx);
+    }
+    const auto avail = tokens > 0 && ctx.tokens_held < ctx.limit;
+    fuse_reply_poll(req, ((avail ? POLLIN : 0) | POLLOUT) & fi->poll_events);
+}
+
+static const struct fuse_lowlevel_ops jobserver_ops = {
+    .init = [] (void* userdata, fuse_conn_info* conn) {
+        conn->want = FUSE_CAP_POSIX_ACL;
+    },
+    .getattr = jobserver_getattr,
+    .setattr = jobserver_setattr,
+    .open = jobserver_open,
+    .read = jobserver_read,
+    .write = jobserver_write,
+    .release = jobserver_release,
+    .setxattr = jobserver_setxattr,
+    .getxattr = jobserver_getxattr,
+    .listxattr = jobserver_listxattr,
+    .removexattr = jobserver_removexattr,
+    .ioctl = jobserver_ioctl,
+    .poll = jobserver_poll,
+};
+
+static void print_help(std::ostream& to)
+{
+    to << R"(usage: nixos-jobserver -t <tokens> <mount point>
+
+starts a job server with the given number of tokens at the specified mount
+point. must be started as root to allow other users access to the jobserver.
+
+arguments:
+
+  -h           print help text
+  -t <tokens>  set number of tokens available (uses number of CPUs when 0)
+  -u <user>    mount jobserver with owner <user>
+  -g <group>   mount jobserver with group <group>
+  -d           debug mode (log fuse requests)
+)";
+}
+
+int main(int argc, char* argv[])
+{
+    std::string mount, user, group;
+    std::vector<std::string> args{
+        argv[0],
+        "-odefault_permissions",
+    };
+
+    if (geteuid() == 0) {
+        args.push_back("-oallow_other");
+    }
+
+    for (;;) {
+        int opt = getopt(argc, argv, "hdu:g:t:");
+        if (opt == -1)
+            break;
+        switch (opt) {
+        case 'd':
+            args.push_back("-d");
+            break;
+        case 'u':
+            user = optarg;
+            break;
+        case 'g':
+            group = optarg;
+            break;
+        case 't': {
+            char* end;
+            auto res = strtoul(optarg, &end, 10);
+            if (errno || isspace(optarg[0]) || *end || res > std::numeric_limits<unsigned>::max()) {
+                std::cerr << "bad argument for -t" << std::endl;
+                return 1;
+            }
+            tokens = res;
+            break;
+        }
+        case 'h':
+            print_help(std::cout);
+            return 0;
+        default:
+            print_help(std::cerr);
+            return 1;
+        }
+    }
+
+    if (optind >= argc) {
+        std::cerr << "missing mount point" << std::endl;
+        return 1;
+    } else if (optind + 1 < argc) {
+        std::cerr << "extraneous arguments after mount point" << std::endl;
+        return 1;
+    } else {
+        mount = argv[optind];
+    }
+
+    if (tokens == 0) {
+        tokens = get_nprocs_conf();
+    }
+
+    if (!user.empty()) {
+        if (auto pw = getpwnam(user.c_str()); pw) {
+            jobserver_st.st_uid = pw->pw_uid;
+        } else if (uid_t uid; parse_unsigned(user.c_str(), uid) == 1) {
+            jobserver_st.st_uid = uid;
+        } else {
+            std::cerr << "invalid argument for -u" << std::endl;
+            return 1;
+        }
+    }
+
+    if (!group.empty()) {
+        if (auto gr = getgrnam(group.c_str()); gr) {
+            jobserver_st.st_gid = gr->gr_gid;
+        } else if (gid_t gid; parse_unsigned(group.c_str(), gid) == 1) {
+            jobserver_st.st_gid = gid;
+        } else {
+            std::cerr << "invalid argument for -g" << std::endl;
+            return 1;
+        }
+    }
+
+    using Session = std::unique_ptr<fuse_session, void(*)(fuse_session*)>;
+
+    std::vector<char*> args_ptrs(args.size());
+    std::transform(args.begin(), args.end(), args_ptrs.begin(),
+            [] (auto& str) { return &str[0]; });
+    fuse_args fuse_args = FUSE_ARGS_INIT(int(args_ptrs.size()), args_ptrs.data());
+
+    Session se{
+        fuse_session_new(&fuse_args, &jobserver_ops, sizeof(jobserver_ops), nullptr),
+        fuse_session_destroy
+    };
+    if (!se) {
+        std::cerr << "fuse_session failed" << std::endl;
+        return 1;
+    }
+
+    if (fuse_set_signal_handlers(&*se) != 0) {
+        std::cerr << "fuse_set_signal_handlers failed" << std::endl;
+        return 1;
+    }
+    const Session _signals{&*se, fuse_remove_signal_handlers};
+
+    if (fuse_session_mount(&*se, mount.c_str()) != 0) {
+        std::cerr << "fuse_session_mount failed" << std::endl;
+        return 1;
+    }
+    const Session _unmount{&*se, fuse_session_unmount};
+
+    return fuse_session_loop(&*se) ? 2 : 0;
+}

--- a/pkgs/by-name/ni/nixos-jobserver/package.nix
+++ b/pkgs/by-name/ni/nixos-jobserver/package.nix
@@ -1,0 +1,42 @@
+{ acl
+, fuse3
+, pkg-config
+, lib
+, stdenv
+}:
+
+stdenv.mkDerivation {
+  pname = "nixos-jobserver";
+  version = "unstable-2021-11-14";
+
+  src = ./nixos-jobserver.cpp;
+
+  buildInputs = [ fuse3 ];
+  nativeBuildInputs = [ pkg-config ];
+
+  dontUnpack = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    (
+      set -x
+      $CXX -std=c++17 -c -Wall -Werror -O2 $(pkg-config --cflags fuse3) -o nixos-jobserver.o $src
+      $CXX $(pkg-config --libs fuse3) -o nixos-jobserver nixos-jobserver.o
+    )
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preBuild
+
+    install -D nixos-jobserver $out/bin/nixos-jobserver
+
+    runHook postBuild
+  '';
+
+  meta = with lib; {
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/stdenv/generic/jscall.c
+++ b/pkgs/stdenv/generic/jscall.c
@@ -1,0 +1,224 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define JOBSRV_IOC_SET_LIMIT _IOW(0x0A, 0, unsigned)
+
+static int r = -1, w = -1;
+static char token = 0;
+
+static void return_token()
+{
+    for (;;) {
+        ssize_t written = written = write(w, &token, 1);
+        if (written < 0 && errno == EINTR) {
+            continue;
+        } else if (written < 1) {
+            perror("jscall token return failed");
+        }
+        break;
+    }
+}
+
+static void handle_signal(int sig)
+{
+    if (w >= 0 && token != 0) {
+        return_token();
+        w = -1;
+    }
+    signal(sig, SIG_DFL);
+    raise(sig);
+}
+
+static int find_separator(char** argv)
+{
+    for (int i = 0; argv[i]; i++) {
+        if (strcmp(argv[i], "----") == 0) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+static void shift_args(char** low, char** high)
+{
+    for (; high[0]; low++, high++) {
+        low[0] = high[0];
+    }
+    low[0] = NULL;
+}
+
+static void shift_once(char** args)
+{
+    shift_args(args, args + 1);
+}
+
+static int run_child(char** argv)
+{
+    execvp(argv[0], argv);
+    perror("execvp");
+    return 1;
+}
+
+static const char* usage =
+    "invocation: jscall [-F flags] <jobserver> <token-limit> <main...> ---- [def-args...] ---- [args...]\n"
+    "\n"
+    "runs `main... args...` with a GNU jobserver fd set in MAKEFLAGS if `jobserver`\n"
+    "exists on is a nixos-jobserver endpoint. otherwise runs\n"
+    "`main... def-args... args...`. if -F is given, `flags` is a space-separated\n"
+    "of environment variables to add jobserver arguments to instead of MAKEFLAGS.\n"
+    "\n"
+    "when running with nixos-jobserver available `main` and its children are\n"
+    "limited to `token-limit` tokens, which may be less than the system limit.\n"
+    "\n"
+    "arguments beginning with ---- are not allowed except in `args`.\n";
+
+int main(int argc, char* argv[])
+{
+    // we'll later pass this to strtok, which needs it to be mutable
+    char vars_raw[] = "MAKEFLAGS";
+    char* vars = vars_raw;
+
+    for (int opt; (opt = getopt(argc, argv, "+F:")) != -1; ) {
+        switch (opt) {
+        case 'F':
+            vars = optarg;
+            break;
+        case '?':
+        default:
+            fprintf(stderr, "%s", usage);
+            return 1;
+        }
+    }
+
+    shift_args(argv + 1, argv + optind);
+    argc -= optind - 1;
+
+    // create a default command first by removing the separators.
+    // if we can use the jobserver we'll shift the default args out of the arguments
+    // list.
+
+    char** cmd = argv + 3;
+    int cmd_length = find_separator(cmd);
+    if (cmd_length < 0) {
+        fprintf(stderr, "main command not terminated\n\n%s", usage);
+        return 1;
+    } else if (cmd_length == 0) {
+        fprintf(stderr, "main command not given\n\n%s", usage);
+        return 1;
+    }
+    shift_once(cmd + cmd_length);
+
+    char** def_args = cmd + cmd_length;
+    int def_args_length = find_separator(def_args);
+    if (def_args_length < 0) {
+        fprintf(stderr, "def-args command not terminated\n\n%s", usage);
+        return 1;
+    }
+    shift_once(def_args + def_args_length);
+
+    char** args = def_args + def_args_length;
+
+    struct stat st;
+    if (stat(argv[1], &st)) {
+        perror("stat() jobserver pipe");
+        return 1;
+    }
+
+    unsigned token_limit;
+    if (sscanf(argv[2], "%u%c", &token_limit, (char*) &token_limit) != 1) {
+        fprintf(stderr, "token limit must be an unsigned integer\n");
+        return 1;
+    }
+
+    // we only support nixos-jobserver files here. supporting named pipes would be possible,
+    // but since we're a part of stdenv and stdenv is occasionally SIGKILLed by nix we would
+    // lose tokens when using normal pipes.
+    r = open(argv[1], O_RDWR);
+    w = dup(r);
+
+    if (r < 0 || w < 0) {
+        fprintf(stderr, "failed to open jobserver pipe, executing without jobserver\n");
+        close(r);
+        close(w);
+        return run_child(cmd);
+    }
+    if (ioctl(r, JOBSRV_IOC_SET_LIMIT, &token_limit)) {
+        perror("failed to set token limit");
+        fprintf(stderr, "is %s a nixos-jobserver instance? attempting to run without jobserver\n", argv[1]);
+        close(r);
+        close(w);
+        return run_child(cmd);
+    }
+
+    for (char* flag, *toks = NULL;
+            (flag = strtok_r(toks ? NULL : vars, " ", &toks)); ) {
+        char* flags = getenv(flag);
+        if (!flags) {
+            flags = "";
+        }
+        if (asprintf(&flags, "%s -j --jobserver-auth=%i,%i", flags, r, w) < 0) {
+            perror("asprintf");
+            return 1;
+        }
+        if (setenv(flag, flags, 1)) {
+            fprintf(stderr, "invalid environment variable %s\n", flag);
+            return 1;
+        }
+    }
+
+    signal(SIGINT, handle_signal);
+    signal(SIGHUP, handle_signal);
+    signal(SIGTERM, handle_signal);
+
+    // older make versions use blocking read fds, newer version use nonblocking.
+    // we don't need to worry about that here since we are the server and haven't given
+    // any tokens to children yet.
+    if (read(r, &token, 1) != 1) {
+        perror("failed to acquire initial job token");
+        return 1;
+    }
+
+    // set O_NONBLOCK on the jobserver file description.
+    // make itself does not need this, but other tools (like cargo) expect to receive
+    // nonblocking fds and get stuck when given a blocking fd.
+    if (fcntl(r, F_SETFL, O_NONBLOCK)) {
+        perror("fcntl");
+        return 1;
+    }
+
+    pid_t p = fork();
+    if (p < 0) {
+        return_token();
+        perror("fork");
+        return 1;
+    } else if (p == 0) {
+        shift_args(def_args, args);
+        return run_child(cmd);
+    } else {
+        int status;
+        waitpid(p, &status, 0);
+
+        if (WIFEXITED(status)) {
+            return_token();
+            return WEXITSTATUS(status);
+        } else if (WIFSIGNALED(status)) {
+            raise(WTERMSIG(status));
+        } else {
+            return_token();
+            fprintf(stderr, "unexpected return from waitpid: %i\n", status);
+            return 1;
+        }
+    }
+}

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -397,6 +397,8 @@ else let
       inherit doCheck doInstallCheck;
 
       inherit outputs;
+    } // optionalAttrs (stdenv ? jscall) {
+      inherit (stdenv) jscall;
     } // optionalAttrs (__contentAddressed) {
       inherit __contentAddressed;
       # Provide default values for outputHashMode and outputHashAlgo because

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1032,8 +1032,8 @@ runInJobserver() {
     done
     shift
 
-    if [[ -n "$jscall" && -e /jobserver ]]; then
-        cmd=("$jscall" "${opts[@]}" /jobserver $NIX_BUILD_CORES "${cmd[@]}"
+    if [[ -n "$jscall" && -e /build-support/jobserver ]]; then
+        cmd=("$jscall" "${opts[@]}" /build-support/jobserver $NIX_BUILD_CORES "${cmd[@]}"
             ---- "${defArgs[@]}" ----)
         kind='with'
     else

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -631,6 +631,19 @@ in
       extraAttrs = {
         inherit bootstrapTools;
         shellPackage = prevStage.bash;
+
+        # jobserver call program (jscall)
+        jscall = derivation {
+          inherit system;
+          name = "jscall";
+          src = ../generic/jscall.c;
+          builder = cc.shell;
+          args = [
+            "-e"
+            "-c"
+            "${cc}/bin/cc -Wall -o $out $src"
+          ];
+        };
       };
 
       disallowedRequisites = [ bootstrapTools.out ];


### PR DESCRIPTION
## Description of changes

Retake of https://github.com/NixOS/nixpkgs/pull/143820 where I unfortunately fucked up trying to debug kernel issues and btrfs.

### Original motivations by @pennae: 

`make -jN -lN` in stdenv is a very blunt instrument. it works well when max-jobs=1, but as nix-level paralellism increases it becomes increasingly deficient. starting from a low-load situation we start max-jobs * N compilers, loadavg goes through the roof, the `-lN` load limit kicks in and inhibits new compilers starting until loadavg has fallen below N—at which point all make instances spawn a lot of new compilers and loadavg goes through the roof again. this oscillation leaves the system underutilized in low phases and overcommitted in high phases.

testing the current stdenv against a jobserver with 26 tokens on a 12C/24T machine shows that parallel builds of llvm_{8..11} run about 7% faster (35:52min for stdenv, 33:30min with jobserver), a larger build of llvm{5..13} is about about 11% faster (1:27h for stdenv, 1:17h with jobserver). (<del>removing the `-l` from stdenv also improves utilization but is less efficient. preliminary testing here shows that `-l${1.5 * N}` may be a good alternative to `-lN` as used currently, #141266 could be a good vector to go for that instead of this whole mess.</del> [more testing says that `-l2N` would be a minimum to get better utilization, but so far every `-l` setting we've tried has produced *some* underutilization except excessive large numbers like 6N or higher])

nothing in here should be regarded as a final suggestion in any way, it's more of a "hey look, this might just work". as such it's extremely rough around the edges, eg to use the jobserver the experimenter currently has to bring a `/jobserver` fifo filled with tokens into the nix sandbox:
```sh
nix-build -E 'with import ./. {}; pkgs.callPackage ./pkgs/os-specific/linux/nixos-jobserver {}'
touch /tmp/jobserver
sudo ./result -t 24 -g nixbld /tmp/jobserver&
nix build --extra-sandbox-paths "/jobserver=/tmp/jobserver" #...
```

is this something worth pursuing? a 10% speedup for hydra does seem tempting

todos before this is more generally usable:
 - [x] re-add $NIX_BUILD_CORES support (ioctl on the jobserver fd should do it)
 - [x] maybe port from cuse to fuse to not require root for everything (mmap problems may be solved by reporting jobserver file size as 0 at all times, needs testing)
 - [x] usability of tools (error messages, runtime configuration, etc)
 - [x] add support for other build systems (cargo can honor MAKEFLAGS, maybe others too)
 - [x] nixos module
 - [x] make configurable which env var(s) jscall adds jobserver information to
 - [ ] metrics?
 - [ ] \<your suggestion here\>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
    - [ ] Build without a job server
    - [ ] Build with a job server
    - [ ] ~Reproducibility of ISO image
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).