### PR TITLE
nb-cli: init at 1.4.1

### DIFF
--- a/pkgs/by-name/nb/nb-cli/package.nix
+++ b/pkgs/by-name/nb/nb-cli/package.nix
@@ -1,0 +1,60 @@
+{
+  fetchPypi,
+  lib,
+  nb-cli,
+  python3,
+  testers,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "nb-cli";
+  version = "1.4.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "nb_cli";
+    inherit version;
+    hash = "sha256-kI3Uy79mv0b+h5wjrRN3My9jOFzryhkStieqaG0YFvM=";
+  };
+
+  build-system = [
+    python3.pkgs.babel
+    python3.pkgs.pdm-backend
+  ];
+
+  dependencies = with python3.pkgs; [
+    anyio
+    cashews
+    click
+    cookiecutter
+    httpx
+    importlib-metadata
+    jinja2
+    noneprompt
+    pydantic
+    pyfiglet
+    tomlkit
+    typing-extensions
+    virtualenv
+    watchfiles
+    wcwidth
+  ];
+
+  # no test
+  doCheck = false;
+
+  pythonImportsCheck = [ "nb_cli" ];
+
+  passthru.tests = {
+    version = testers.testVersion { package = nb-cli; };
+  };
+
+  meta = {
+    description = "CLI for nonebot2";
+    homepage = "https://cli.nonebot.dev";
+    changelog = "https://github.com/nonebot/nb-cli/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ moraxyc ];
+    mainProgram = "nb";
+  };
+}

--- a/pkgs/development/python-modules/cashews/default.nix
+++ b/pkgs/development/python-modules/cashews/default.nix
@@ -1,0 +1,70 @@
+{
+  bitarray,
+  buildPythonPackage,
+  dill,
+  diskcache,
+  fetchFromGitHub,
+  hiredis,
+  hypothesis,
+  lib,
+  pytest,
+  pytest-asyncio,
+  pytest-cov,
+  pytest-rerunfailures,
+  pytestCheckHook,
+  redis,
+  setuptools,
+  xxhash,
+}:
+
+buildPythonPackage rec {
+  pname = "cashews";
+  version = "7.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Krukov";
+    repo = "cashews";
+    rev = "refs/tags/${version}";
+    hash = "sha256-VzIW6/xhKk+ZWd29BYQp6sjpBst8IVz8t/hCLc2LFT4=";
+  };
+
+  build-system = [ setuptools ];
+
+  passthru.optional-dependencies = {
+    dill = [ dill ];
+    diskcache = [ diskcache ];
+    redis = [ redis ];
+    speedup = [
+      bitarray
+      hiredis
+      xxhash
+    ];
+  };
+
+  nativeCheckInputs = [
+    hypothesis
+    pytest
+    pytest-asyncio
+    pytest-cov
+    pytest-rerunfailures
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # these tests require too many dependencies
+    "redis"
+    "diskcache"
+    "integration"
+  ];
+
+  pythonImportsCheck = [ "cashews" ];
+
+  meta = {
+    description = "Cache tools with async power";
+    homepage = "https://github.com/Krukov/cashews/";
+    changelog = "https://github.com/Krukov/cashews/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ moraxyc ];
+  };
+}

--- a/pkgs/development/python-modules/noneprompt/default.nix
+++ b/pkgs/development/python-modules/noneprompt/default.nix
@@ -1,0 +1,39 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  poetry-core,
+  prompt-toolkit,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "noneprompt";
+  version = "0.1.9";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-M4uLuJqNIu818d7bOqfBsijPE5lzvcQ8X/w+72RFfbk=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [ prompt-toolkit ];
+
+  # no test
+  doCheck = false;
+
+  pythonImportsCheck = [ "noneprompt" ];
+
+  meta = {
+    description = "Prompt toolkit for console interaction";
+    homepage = "https://github.com/nonebot/noneprompt";
+    changelog = "https://github.com/nonebot/noneprompt/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ moraxyc ];
+    mainProgram = "noneprompt";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1945,6 +1945,8 @@ self: super: with self; {
 
   cashaddress = callPackage ../development/python-modules/cashaddress { };
 
+  cashews = callPackage ../development/python-modules/cashews {  };
+
   cassandra-driver = callPackage ../development/python-modules/cassandra-driver { };
 
   castepxbin = callPackage ../development/python-modules/castepxbin { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8652,6 +8652,8 @@ self: super: with self; {
 
   nomadnet = callPackage ../development/python-modules/nomadnet { };
 
+  noneprompt = callPackage ../development/python-modules/noneprompt {  };
+
   nox = callPackage ../development/python-modules/nox { };
 
   nanomsg-python = callPackage ../development/python-modules/nanomsg-python {


### PR DESCRIPTION
## Description of changes

`nb-cli` `1.4.1` [Pypi](https://pypi.org/project/nb-cli/)
`python3Packages.cashews` `7.1.0` [Pypi](https://pypi.org/project/cashews/)
`python3Packages.noneprompt` `0.1.9` [Pypi](https://pypi.org/project/noneprompt/)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
