### PR TITLE
zathura: 0.5.5 -> 0.5.6; zathura-pdf-mupdf: 0.4.1 -> 0.4.2

### DIFF
--- a/pkgs/applications/misc/zathura/cb/default.nix
+++ b/pkgs/applications/misc/zathura/cb/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://pwmt.org/projects/${pname}/download/${pname}-${version}.tar.xz";
-    sha256 = "1j5v32f9ki35v1jc7a067anhlgqplzrp4fqvznlixfhcm0bwmc49";
+    hash = "sha256-ibDKF6gMuh6p/Rs7cvOnFz8KrToGqMNk2GXEmZwYu8g=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/zathura/cb/default.nix
+++ b/pkgs/applications/misc/zathura/cb/default.nix
@@ -1,5 +1,15 @@
-{ stdenv, lib, fetchurl, meson, ninja, pkg-config, zathura_core
-, girara, gettext, libarchive }:
+{
+  stdenv,
+  lib,
+  fetchurl,
+  meson,
+  ninja,
+  pkg-config,
+  zathura_core,
+  girara,
+  gettext,
+  libarchive,
+}:
 
 stdenv.mkDerivation rec {
   pname = "zathura-cb";
@@ -10,8 +20,17 @@ stdenv.mkDerivation rec {
     sha256 = "1j5v32f9ki35v1jc7a067anhlgqplzrp4fqvznlixfhcm0bwmc49";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config gettext ];
-  buildInputs = [ libarchive zathura_core girara ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gettext
+  ];
+  buildInputs = [
+    libarchive
+    zathura_core
+    girara
+  ];
 
   PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
 
@@ -20,7 +39,7 @@ stdenv.mkDerivation rec {
     description = "A zathura CB plugin";
     longDescription = ''
       The zathura-cb plugin adds comic book support to zathura.
-      '';
+    '';
     license = licenses.zlib;
     platforms = platforms.unix;
     maintainers = with maintainers; [ jlesquembre ];

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = gitUpdater { };
 
   meta = with lib; {
-    homepage = "https://git.pwmt.org/pwmt/zathura";
+    homepage = "https://pwmt.org/projects/zathura";
     description = "A core component for zathura PDF viewer";
     license = licenses.zlib;
     platforms = platforms.unix;

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitLab,
+  fetchFromGitHub,
   meson,
   ninja,
   wrapGAppsHook3,
@@ -28,14 +28,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zathura";
-  version = "0.5.5";
+  version = "0.5.6";
 
-  src = fetchFromGitLab {
-    domain = "git.pwmt.org";
+  src = fetchFromGitHub {
     owner = "pwmt";
     repo = "zathura";
     rev = finalAttrs.version;
-    hash = "sha256-mHEYqgBB55p8nykFtvYtP5bWexp/IqFbeLs7gZmXCeE=";
+    hash = "sha256-lTEBIZ3lkzjJ+L1qecrcL8iseo8AvSIo3Wh65/ikwac=";
   };
 
   outputs = [

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -1,9 +1,29 @@
-{ lib, stdenv, fetchFromGitLab, meson, ninja, wrapGAppsHook3, pkg-config, gitUpdater
-, appstream-glib, json-glib, desktop-file-utils, python3
-, gtk, girara, gettext, libxml2, check
-, sqlite, glib, texlive, libintl, libseccomp
-, file, librsvg
-, gtk-mac-integration
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  wrapGAppsHook3,
+  pkg-config,
+  gitUpdater,
+  appstream-glib,
+  json-glib,
+  desktop-file-utils,
+  python3,
+  gtk,
+  girara,
+  gettext,
+  libxml2,
+  check,
+  sqlite,
+  glib,
+  texlive,
+  libintl,
+  libseccomp,
+  file,
+  librsvg,
+  gtk-mac-integration,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -18,7 +38,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-mHEYqgBB55p8nykFtvYtP5bWexp/IqFbeLs7gZmXCeE=";
   };
 
-  outputs = [ "bin" "man" "dev" "out" ];
+  outputs = [
+    "bin"
+    "man"
+    "dev"
+    "out"
+  ];
 
   # Flag list:
   # https://github.com/pwmt/zathura/blob/master/meson_options.txt
@@ -33,15 +58,29 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    meson ninja pkg-config desktop-file-utils python3.pythonOnBuildForHost.pkgs.sphinx
-    gettext wrapGAppsHook3 libxml2 appstream-glib
+    meson
+    ninja
+    pkg-config
+    desktop-file-utils
+    python3.pythonOnBuildForHost.pkgs.sphinx
+    gettext
+    wrapGAppsHook3
+    libxml2
+    appstream-glib
   ];
 
   buildInputs = [
-    gtk girara libintl sqlite glib file librsvg check json-glib
+    gtk
+    girara
+    libintl
+    sqlite
+    glib
+    file
+    librsvg
+    check
+    json-glib
     texlive.bin.core
-  ] ++ lib.optional stdenv.isLinux libseccomp
-    ++ lib.optional stdenv.isDarwin gtk-mac-integration;
+  ] ++ lib.optional stdenv.isLinux libseccomp ++ lib.optional stdenv.isDarwin gtk-mac-integration;
 
   doCheck = !stdenv.isDarwin;
 

--- a/pkgs/applications/misc/zathura/default.nix
+++ b/pkgs/applications/misc/zathura/default.nix
@@ -1,6 +1,9 @@
-{ config, pkgs
-# zathura_pdf_mupdf fails to load _opj_create_decompress at runtime on Darwin (https://github.com/NixOS/nixpkgs/pull/61295#issue-277982980)
-, useMupdf ? config.zathura.useMupdf or (!pkgs.stdenv.isDarwin) }:
+{
+  config,
+  pkgs,
+  # zathura_pdf_mupdf fails to load _opj_create_decompress at runtime on Darwin (https://github.com/NixOS/nixpkgs/pull/61295#issue-277982980)
+  useMupdf ? config.zathura.useMupdf or (!pkgs.stdenv.isDarwin),
+}:
 
 let
   callPackage = pkgs.newScope self;
@@ -29,5 +32,5 @@ let
       ];
     };
   };
-
-in self
+in
+self

--- a/pkgs/applications/misc/zathura/djvu/default.nix
+++ b/pkgs/applications/misc/zathura/djvu/default.nix
@@ -1,4 +1,16 @@
-{ lib, stdenv, fetchurl, meson, ninja, pkg-config, gtk, zathura_core, girara, djvulibre, gettext }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  meson,
+  ninja,
+  pkg-config,
+  gtk,
+  zathura_core,
+  girara,
+  djvulibre,
+  gettext,
+}:
 
 stdenv.mkDerivation rec {
   pname = "zathura-djvu";
@@ -9,8 +21,18 @@ stdenv.mkDerivation rec {
     sha256 = "0062n236414db7q7pnn3ccg5111ghxj3407pn9ri08skxskgirln";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config ];
-  buildInputs = [ djvulibre gettext zathura_core gtk girara ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+  buildInputs = [
+    djvulibre
+    gettext
+    zathura_core
+    gtk
+    girara
+  ];
 
   PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
 
@@ -26,4 +48,3 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ];
   };
 }
-

--- a/pkgs/applications/misc/zathura/djvu/default.nix
+++ b/pkgs/applications/misc/zathura/djvu/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://pwmt.org/projects/${pname}/download/${pname}-${version}.tar.xz";
-    sha256 = "0062n236414db7q7pnn3ccg5111ghxj3407pn9ri08skxskgirln";
+    hash = "sha256-lub4pu5TIxBzsvcAMmSHL4RQHmPD2nvwWY0EYoawwgA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -21,12 +21,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.4.1";
+  version = "0.4.2";
   pname = "zathura-pdf-mupdf";
 
   src = fetchurl {
     url = "https://pwmt.org/projects/${pname}/download/${pname}-${version}.tar.xz";
-    hash = "sha256-+YKgHWUj+iVmk4EYTAamJe2/15YcvbBxHcz9ucQCrC8=";
+    hash = "sha256-fFC+z9mJX9ccExsV336Ut+zJJa8UdfUz/qVp9YgcnhM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -1,17 +1,23 @@
-{ stdenv, lib, meson, ninja, fetchurl, cairo
-, girara
-, gtk-mac-integration
-, gumbo
-, jbig2dec
-, libjpeg
-, mupdf
-, openjpeg
-, pkg-config
-, zathura_core
-, tesseract
-, leptonica
-, mujs
-, gitUpdater
+{
+  stdenv,
+  lib,
+  meson,
+  ninja,
+  fetchurl,
+  cairo,
+  girara,
+  gtk-mac-integration,
+  gumbo,
+  jbig2dec,
+  libjpeg,
+  mupdf,
+  openjpeg,
+  pkg-config,
+  zathura_core,
+  tesseract,
+  leptonica,
+  mujs,
+  gitUpdater,
 }:
 
 stdenv.mkDerivation rec {
@@ -23,7 +29,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-+YKgHWUj+iVmk4EYTAamJe2/15YcvbBxHcz9ucQCrC8=";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
 
   buildInputs = [
     cairo
@@ -39,15 +49,13 @@ stdenv.mkDerivation rec {
     mujs
   ] ++ lib.optional stdenv.isDarwin gtk-mac-integration;
 
-  PKG_CONFIG_ZATHURA_PLUGINDIR= "lib/zathura";
+  PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
 
   postPatch = ''
     sed -i -e '/^mupdfthird =/d' -e 's/, mupdfthird//g' meson.build
   '';
 
-  passthru.updateScript = gitUpdater {
-    url = "https://git.pwmt.org/pwmt/zathura-pdf-mupdf.git";
-  };
+  passthru.updateScript = gitUpdater { url = "https://git.pwmt.org/pwmt/zathura-pdf-mupdf.git"; };
 
   meta = with lib; {
     homepage = "https://pwmt.org/projects/zathura-pdf-mupdf/";

--- a/pkgs/applications/misc/zathura/pdf-poppler/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-poppler/default.nix
@@ -1,4 +1,14 @@
-{ stdenv, lib, fetchurl, meson, ninja, pkg-config, zathura_core, girara, poppler }:
+{
+  stdenv,
+  lib,
+  fetchurl,
+  meson,
+  ninja,
+  pkg-config,
+  zathura_core,
+  girara,
+  poppler,
+}:
 
 stdenv.mkDerivation rec {
   pname = "zathura-pdf-poppler";
@@ -9,8 +19,16 @@ stdenv.mkDerivation rec {
     sha256 = "049h8m9swxni7ar6fsbm0hb3fg4ffmjc3m6vyg78ilfi3kayxavi";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config zathura_core ];
-  buildInputs = [ poppler girara ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    zathura_core
+  ];
+  buildInputs = [
+    poppler
+    girara
+  ];
 
   PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
 

--- a/pkgs/applications/misc/zathura/pdf-poppler/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-poppler/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://pwmt.org/projects/${pname}/download/${pname}-${version}.tar.xz";
-    sha256 = "049h8m9swxni7ar6fsbm0hb3fg4ffmjc3m6vyg78ilfi3kayxavi";
+    hash = "sha256-cavu1RzR0YjO89vUwWR1jjw3FgR1aWeyOtF2rlNFMBE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/zathura/ps/default.nix
+++ b/pkgs/applications/misc/zathura/ps/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://pwmt.org/projects/${pname}/download/${pname}-${version}.tar.xz";
-    sha256 = "0ilf63wxn1yzis9m3qs8mxbk316yxdzwxrrv86wpiygm9hhgk5sq";
+    hash = "sha256-WJf5IEz1+Xi5QTvnzn/r3oQxV69I41GTjt8H2/kwjkY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/zathura/ps/default.nix
+++ b/pkgs/applications/misc/zathura/ps/default.nix
@@ -1,4 +1,15 @@
-{ stdenv, lib, fetchurl, meson, ninja, pkg-config, zathura_core, girara, libspectre, gettext }:
+{
+  stdenv,
+  lib,
+  fetchurl,
+  meson,
+  ninja,
+  pkg-config,
+  zathura_core,
+  girara,
+  libspectre,
+  gettext,
+}:
 
 stdenv.mkDerivation rec {
   pname = "zathura-ps";
@@ -9,8 +20,17 @@ stdenv.mkDerivation rec {
     sha256 = "0ilf63wxn1yzis9m3qs8mxbk316yxdzwxrrv86wpiygm9hhgk5sq";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config gettext ];
-  buildInputs = [ libspectre zathura_core girara ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gettext
+  ];
+  buildInputs = [
+    libspectre
+    zathura_core
+    girara
+  ];
 
   PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
 
@@ -20,10 +40,9 @@ stdenv.mkDerivation rec {
     longDescription = ''
       The zathura-ps plugin adds PS support to zathura by using the
       libspectre library.
-      '';
+    '';
     license = licenses.zlib;
     platforms = platforms.unix;
     maintainers = with maintainers; [ ];
   };
 }
-

--- a/pkgs/applications/misc/zathura/wrapper.nix
+++ b/pkgs/applications/misc/zathura/wrapper.nix
@@ -38,7 +38,7 @@ symlinkJoin {
     '';
 
   meta = with lib; {
-    homepage = "https://git.pwmt.org/pwmt/zathura/";
+    homepage = "https://pwmt.org/projects/zathura/";
     description = "A highly customizable and functional PDF viewer";
     longDescription = ''
       Zathura is a highly customizable and functional PDF viewer based on the

--- a/pkgs/applications/misc/zathura/wrapper.nix
+++ b/pkgs/applications/misc/zathura/wrapper.nix
@@ -1,25 +1,41 @@
-{ symlinkJoin, lib, makeWrapper, zathura_core, file, plugins ? [] }:
+{
+  symlinkJoin,
+  lib,
+  makeWrapper,
+  zathura_core,
+  file,
+  plugins ? [ ],
+}:
 symlinkJoin {
   name = "zathura-with-plugins-${zathura_core.version}";
 
-  paths = with zathura_core; [ man dev out ] ++ plugins;
+  paths =
+    with zathura_core;
+    [
+      man
+      dev
+      out
+    ]
+    ++ plugins;
 
   nativeBuildInputs = [ makeWrapper ];
 
-  postBuild = let
-    fishCompletion = "share/fish/vendor_completions.d/zathura.fish";
-  in ''
-    makeWrapper ${zathura_core.bin}/bin/zathura $out/bin/zathura \
-      --prefix PATH ":" "${lib.makeBinPath [ file ]}" \
-      --prefix ZATHURA_PLUGINS_PATH : "$out/lib/zathura"
+  postBuild =
+    let
+      fishCompletion = "share/fish/vendor_completions.d/zathura.fish";
+    in
+    ''
+      makeWrapper ${zathura_core.bin}/bin/zathura $out/bin/zathura \
+        --prefix PATH ":" "${lib.makeBinPath [ file ]}" \
+        --prefix ZATHURA_PLUGINS_PATH : "$out/lib/zathura"
 
-    # zathura fish completion references the zathura_core derivation to
-    # check for supported plugins which live in the wrapper derivation,
-    # so we need to fix the path to reference $out instead.
-    rm "$out/${fishCompletion}"
-    substitute "${zathura_core.out}/${fishCompletion}" "$out/${fishCompletion}" \
-      --replace "${zathura_core.out}" "$out"
-  '';
+      # zathura fish completion references the zathura_core derivation to
+      # check for supported plugins which live in the wrapper derivation,
+      # so we need to fix the path to reference $out instead.
+      rm "$out/${fishCompletion}"
+      substitute "${zathura_core.out}/${fishCompletion}" "$out/${fishCompletion}" \
+        --replace "${zathura_core.out}" "$out"
+    '';
 
   meta = with lib; {
     homepage = "https://git.pwmt.org/pwmt/zathura/";
@@ -32,7 +48,11 @@ symlinkJoin {
     '';
     license = licenses.zlib;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ smironov globin TethysSvensson ];
+    maintainers = with maintainers; [
+      smironov
+      globin
+      TethysSvensson
+    ];
     mainProgram = "zathura";
   };
 }


### PR DESCRIPTION
## Description of changes
pwmt has moved all their repositories to GitHub. I updated zathura to pull from GitHub instead of GitLab alongside any necessary version bumps and made a few drive-by changes to fit common nixpkgs conventions.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
