### PR TITLE
nixos: Replace custom cfg format handling with `pkgs.formats`

### DIFF
--- a/nixos/modules/services/databases/influxdb.nix
+++ b/nixos/modules/services/databases/influxdb.nix
@@ -93,11 +93,7 @@ let
     };
   } cfg.extraConfig;
 
-  configFile = pkgs.runCommandLocal "config.toml" { } ''
-    ${pkgs.buildPackages.remarshal}/bin/remarshal -if json -of toml \
-      < ${pkgs.writeText "config.json" (builtins.toJSON configOptions)} \
-      > $out
-  '';
+  configFile = (pkgs.formats.toml {}).generate "config.toml" configOptions;
 in
 {
 

--- a/nixos/modules/services/development/athens.nix
+++ b/nixos/modules/services/development/athens.nix
@@ -140,12 +140,10 @@ let
     }
   );
 
-  configFile = pkgs.runCommandLocal "config.toml" { } ''
-    ${pkgs.buildPackages.jq}/bin/jq 'del(..|nulls)' \
-      < ${pkgs.writeText "config.json" (builtins.toJSON athensConfig)} | \
-    ${pkgs.buildPackages.remarshal}/bin/remarshal -if json -of toml \
-      > $out
-  '';
+  configFile = lib.pipe athensConfig [
+    (lib.filterAttrsRecursive (_k: v: v != null))
+    ((pkgs.formats.toml {}).generate "config.toml")
+  ];
 in
 {
   meta = {

--- a/nixos/modules/services/networking/ncdns.nix
+++ b/nixos/modules/services/networking/ncdns.nix
@@ -6,23 +6,7 @@ let
   dataDir  = "/var/lib/ncdns";
   username = "ncdns";
 
-  valueType = with lib.types; oneOf [ int str bool path ]
-    // { description = "setting type (integer, string, bool or path)"; };
-
-  configType = with lib.types; attrsOf (nullOr (either valueType configType))
-    // { description = ''
-          ncdns.conf configuration type. The format consists of an
-          attribute set of settings. Each setting can be either `null`,
-          a value or an attribute set. The allowed values are integers,
-          strings, booleans or paths.
-         '';
-       };
-
-  configFile = pkgs.runCommand "ncdns.conf"
-    { json = builtins.toJSON cfg.settings;
-      passAsFile = [ "json" ];
-    }
-    "${pkgs.remarshal}/bin/json2toml < $jsonPath > $out";
+  format = pkgs.formats.toml {};
 
   defaultFiles = {
     public  = "${dataDir}/bit.key";
@@ -160,7 +144,7 @@ in
       };
 
       settings = lib.mkOption {
-        type = configType;
+        type = format.type;
         default = { };
         example = lib.literalExpression ''
           { # enable webserver
@@ -257,7 +241,7 @@ in
         User = "ncdns";
         StateDirectory = "ncdns";
         Restart = "on-failure";
-        ExecStart = "${pkgs.ncdns}/bin/ncdns -conf=${configFile}";
+        ExecStart = "${pkgs.ncdns}/bin/ncdns -conf=${format.generate "ncdns.conf" cfg.settings}";
       };
 
       preStart = lib.optionalString (cfg.dnssec.enable && needsKeygen) ''

--- a/nixos/modules/services/networking/ncdns.nix
+++ b/nixos/modules/services/networking/ncdns.nix
@@ -4,7 +4,6 @@ let
   cfg  = cfgs.ncdns;
 
   dataDir  = "/var/lib/ncdns";
-  username = "ncdns";
 
   format = pkgs.formats.toml {};
 
@@ -19,7 +18,7 @@ let
   needsKeygen = lib.all lib.id (lib.flip lib.mapAttrsToList cfg.dnssec.keys
     (n: v: v == lib.getAttr n defaultFiles));
 
-  mkDefaultAttrs = lib.mapAttrs (n: v: lib.mkDefault v);
+  mkDefaultAttrs = lib.mapAttrs (_n: v: lib.mkDefault v);
 
 in
 


### PR DESCRIPTION
## Description of changes

Replaced custom serializers and types with those from `pkgs.formats`, in the following NixOS modules:
- [x] athens
- [x] influxdb
- [x] ncdns
- [x] promtail
- [x] traefik

This is far from exhaustive, but I figured I could get the ball rolling, so to speak.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests):
    - [x] influxdb, influxdb2
    - [x] loki (exercises the `services.promtail`)
    - [x] ncdns
    - [x] traefik
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
