### PR TITLE
[23.11] cve-bin-tool: apply patch to avoid a patch traversal when opening a tar file

### DIFF
--- a/pkgs/tools/security/cve-bin-tool/default.nix
+++ b/pkgs/tools/security/cve-bin-tool/default.nix
@@ -89,6 +89,19 @@ buildPythonApplication rec {
       url = "https://github.com/intel/cve-bin-tool/commit/6f9bd565219932c565c1443ac467fe4163408dd8.patch";
       hash = "sha256-Glj6qiOvmvsuetXn4tysyiN/vrcOPFLORh+u3BoGzCI=";
     })
+    # https://github.com/intel/cve-bin-tool/issues/2977 and https://github.com/intel/cve-bin-tool/issues/2969
+    (fetchpatch {
+      name = "fix-curl-datasource.patch";
+      url = "https://github.com/intel/cve-bin-tool/commit/499e0a036e8abf39b3dcdae5377dc61eb8d4a26f.patch";
+      hash = "sha256-fwvlKwOGiD2Bqr8tjTreukF1ZqaSEspQlVnLbmxYEOk=";
+    })
+    # https://www.openwall.com/lists/oss-security/2024/05/26/1
+    (fetchpatch {
+      name = "path-traversal-tar-extract.patch";
+      url = "https://github.com/intel/cve-bin-tool/commit/b4feb03f19acecc1bb8b18db192d87a510819c24.patch";
+      hash = "sha256-r7WBnuunZoKlq3404kkoaPrTD+QQRw3H2SNsWXC8GUs=";
+      excludes = [ ".pre-commit-config.yaml" ];
+    })
   ];
 
   # Wants to open a sqlite database, access the internet, etc


### PR DESCRIPTION
## Description of changes

https://www.openwall.com/lists/oss-security/2024/05/26/1

Also applied the fix to download CVE information from curl datasources. The issue  prevented me to properly test the change. Upgrading to 3.2.1 required more work.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
