### PR TITLE
make(Binary)Wrapper: record created wrappers

### DIFF
--- a/pkgs/build-support/setup-hooks/make-binary-wrapper/make-binary-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-binary-wrapper/make-binary-wrapper.sh
@@ -53,6 +53,33 @@ makeBinaryWrapper() {
         -Os \
         -x c \
         -o "$wrapper" -
+
+    recordWrapperLore "$wrapper" "$original"
+}
+
+findWrapperOutputRoot(){
+    local wrapper="$1"
+
+    for output in $(getAllOutputNames); do
+        if [[ "$wrapper" == "${!output}"* ]]; then
+            echo "${!output}"
+            return
+        fi
+    done
+    die "Wrapper path '$wrapper' not within any output"
+}
+
+# document this wrapper in a machine-readable format
+recordWrapperLore(){
+    local wrapper="$1"
+    local original="$2"
+    local ideal_output="$(findWrapperOutputRoot "$wrapper")"
+
+    if [[ ! -d "$ideal_output/nix-support" ]]; then
+        mkdir -p "$ideal_output/nix-support"
+    fi
+
+    echo "$wrapper:$original" >> "$ideal_output/nix-support/wrappers"
 }
 
 # Syntax: wrapProgram <PROGRAM> <MAKE-WRAPPER FLAGS...>

--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -190,6 +190,33 @@ makeShellWrapper() {
          "${flagsBefore-}" '"$@"' "${flagsAfter-}" >> "$wrapper"
 
     chmod +x "$wrapper"
+
+    recordWrapperLore "$wrapper" "$original"
+}
+
+findWrapperOutputRoot(){
+    local wrapper="$1"
+
+    for output in $(getAllOutputNames); do
+        if [[ "$wrapper" == "${!output}"* ]]; then
+            echo "${!output}"
+            return
+        fi
+    done
+    die "Wrapper path '$wrapper' not within any output"
+}
+
+# document this wrapper in a machine-readable format
+recordWrapperLore(){
+    local wrapper="$1"
+    local original="$2"
+    local ideal_output="$(findWrapperOutputRoot "$wrapper")"
+
+    if [[ ! -d "$ideal_output/nix-support" ]]; then
+        mkdir -p "$ideal_output/nix-support"
+    fi
+
+    echo "$wrapper:$original" >> "$ideal_output/nix-support/wrappers"
 }
 
 addSuffix() {


### PR DESCRIPTION
## Description of changes

Write a machine-readable list of wrappers (each line is a `$wrapper:$original` pair) to `${output-wrapper-is-being-written-to}/nix-support/wrappers`.
    
A wrapper -> original mapping makes it easier to see through wrappers, especially binary wrappers, to the original executable.

One case where this helps is when you need to perform analysis on the actual executables and associate that analysis with exec wrappers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
