### PR TITLE
rocksdb: add enableLiburing option

### DIFF
--- a/pkgs/development/libraries/liburing/default.nix
+++ b/pkgs/development/libraries/liburing/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   # Upstream's configure script is not autoconf generated, but a hand written one.
   setOutputFlags = false;
+  dontDisableStatic = true;
+  dontAddStaticConfigureFlags = true;
   configureFlags = [
     "--includedir=${placeholder "dev"}/include"
     "--mandir=${placeholder "man"}/share/man"

--- a/pkgs/development/libraries/liburing/default.nix
+++ b/pkgs/development/libraries/liburing/default.nix
@@ -35,6 +35,12 @@ stdenv.mkDerivation rec {
   ];
 
   postInstall = ''
+    # Always builds both static and dynamic libraries, so we need to remove the
+    # libraries that don't match stdenv type.
+    rm $out/lib/liburing*${
+      if stdenv.hostPlatform.isStatic then ".so*" else ".a"
+    }
+
     # Copy the examples into $bin. Most reverse dependency of
     # this package should reference only the $out output
     for file in $(find ./examples -executable -type f); do

--- a/pkgs/development/libraries/rocksdb/default.nix
+++ b/pkgs/development/libraries/rocksdb/default.nix
@@ -11,6 +11,8 @@
 , windows
 , enableJemalloc ? false
 , jemalloc
+, enableLiburing ? true
+, liburing
 , enableShared ? !stdenv.hostPlatform.isStatic
 , sse42Support ? stdenv.hostPlatform.sse4_2Support
 }:
@@ -26,11 +28,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Zifn5Gu/4h6TaEqSaWQ2mFdryeAarqbHWW3fKUGGFac=";
   };
 
+  patches = [ ./fix-findliburing.patch ];
+
   nativeBuildInputs = [ cmake ninja ];
 
   propagatedBuildInputs = [ bzip2 lz4 snappy zlib zstd ];
 
   buildInputs = lib.optional enableJemalloc jemalloc
+    ++ lib.optional enableLiburing liburing
     ++ lib.optional stdenv.hostPlatform.isMinGW windows.mingw_w64_pthreads;
 
   outputs = [
@@ -45,6 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DPORTABLE=1"
     "-DWITH_JEMALLOC=${if enableJemalloc then "1" else "0"}"
+    "-DWITH_LIBURING=${if enableLiburing then "1" else "0"}"
     "-DWITH_JNI=0"
     "-DWITH_BENCHMARK_TOOLS=0"
     "-DWITH_TESTS=1"

--- a/pkgs/development/libraries/rocksdb/fix-findliburing.patch
+++ b/pkgs/development/libraries/rocksdb/fix-findliburing.patch
@@ -1,0 +1,29 @@
+From 23432b7958ecea64b49ba680767ea5dc696768c9 Mon Sep 17 00:00:00 2001
+From: Benjamin Lee <benjamin@computer.surgery>
+Date: Sun, 26 May 2024 17:17:01 -0700
+Subject: [PATCH] fix findliburing
+
+`find_package(... NAMES lib*)` is basically always wrong. The previous
+code was just hardcoding the static library path to work around the fact
+that this doesn't work. This breaks the build when only dynamic liburing
+builds are available.
+---
+ cmake/modules/Finduring.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/modules/Finduring.cmake b/cmake/modules/Finduring.cmake
+index 8cb14cb27..87f2df474 100644
+--- a/cmake/modules/Finduring.cmake
++++ b/cmake/modules/Finduring.cmake
+@@ -7,7 +7,7 @@
+ find_path(uring_INCLUDE_DIR
+   NAMES liburing.h)
+ find_library(uring_LIBRARIES
+-  NAMES liburing.a liburing)
++  NAMES uring)
+ 
+ include(FindPackageHandleStandardArgs)
+ find_package_handle_standard_args(uring
+-- 
+2.44.0
+


### PR DESCRIPTION
## Description of changes

Rocksdb added support for io-uring in v6.7.0. This PR adds an `enableLiburing` option to the package to enable this.

In the process, I discovered that the `liburing` package is broken in static stdenv, and outputs both static and dynamic libraries unconditionally. This causes rocksdb to link against the static liburing when built in a dynamic stdenv. In [conduwuit](https://github.com/girlbossceo/conduwuit), we are using an overlay to add liburing support to rocksdb and fix the static library issues with liburing, but would like to be able to just use upstream nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
