### PR TITLE
inochi-creator: 0.8.4 -> 0.8.5; inochi-session: 0.8.3 -> 0.8.4

### DIFF
--- a/pkgs/applications/misc/inochi2d/creator-dub-lock.json
+++ b/pkgs/applications/misc/inochi2d/creator-dub-lock.json
@@ -37,8 +37,8 @@
       "sha256": "0p5vmkw29ksh5wdxz1ijms1wblq288pv15vnbl93z7q2vgnq995w"
     },
     "eventcore": {
-      "version": "0.9.29",
-      "sha256": "1993mibxqb4v7lbsq3kbfwxfpi0d1gzzmzvx6y01907aqz933isa"
+      "version": "0.9.30",
+      "sha256": "1n8wdcjhas0y99pf9fvwwsydkmy9g7gvfjhlwpjh158c7pfjwlaq"
     },
     "facetrack-d": {
       "version": "0.7.8",
@@ -69,8 +69,8 @@
       "sha256": "0kzk55ilbnl6qypjk60zwd5ibys5n47128hbbr0mbc7bpj9ppfg4"
     },
     "inochi2d": {
-      "version": "0.8.3",
-      "sha256": "1m9dalm6sb518yi9mbphq1fdax90fc5rmskah19l7slnplbhli4l"
+      "version": "0.8.4",
+      "sha256": "1bj0c6i9kcw1vfm6lf8lyxpf1lhhslg3f182jycdmzms15i3jb3y"
     },
     "kra-d": {
       "version": "0.5.5",
@@ -85,12 +85,12 @@
       "sha256": "0hm31birbw59sw1bi9syjhbcdgwwwyyx6r9jg7ar9i6a74cjr52c"
     },
     "mir-algorithm": {
-      "version": "3.22.0",
-      "sha256": "0pl1vwyyhr2hrxlj060khzhg33dkgyrzi3f5qqxz6xj3hcp7axxq"
+      "version": "3.22.1",
+      "sha256": "1bvvf3dm26x1h10pg1s4kyhxiyrmd96kk2lmchyady39crpjj5cf"
     },
     "mir-core": {
-      "version": "1.7.0",
-      "sha256": "14k7y2r06pwzf29shymyjrk7l582bh181rc07bnwgjn3f84ayn62"
+      "version": "1.7.1",
+      "sha256": "15m1n48fcmh5pw3w4ww5qfzwkdglflpzc3xmxmrlvd30swyyr85j"
     },
     "mir-linux-kernel": {
       "version": "1.0.1",
@@ -105,8 +105,8 @@
       "sha256": "1fwhd5fkvgbqf3y8gwmrnd42kzi4k3mibpxijw5j82jxgfp1rzsf"
     },
     "openssl-static": {
-      "version": "1.0.3+3.0.8",
-      "sha256": "1z977ghlnczxky2q2gislfi68jnbp2zf4pifv8rzrcs0nx3va2jr"
+      "version": "1.0.5+3.0.8",
+      "sha256": "0wpqz29yrbbh39g3cwlgd6h6hh1msws7w5baw1kywdkgj761gx2k"
     },
     "psd-d": {
       "version": "0.6.3",
@@ -121,20 +121,20 @@
       "sha256": "1g8382wr49sjyar0jay8j7y2if7h1i87dhapkgxphnizp24d7kaj"
     },
     "taggedalgebraic": {
-      "version": "0.11.22",
-      "sha256": "1kc39sdnk2ybhrwxiwyw1mqcw0qzjr0vr54yvyp3gkkaad373k4r"
+      "version": "0.11.23",
+      "sha256": "1bialmbdwjpqhgs95inkwzin7xbhx7sngjf7viq90vzma497l59k"
     },
     "tinyfiledialogs": {
       "version": "0.10.1",
       "sha256": "1k3gq9y7912x5b30h60nvlfdr61as1f187b8rsilkxliizcmbhfi"
     },
     "vibe-container": {
-      "version": "1.3.0",
-      "sha256": "02gdw7ma93fdvgx3fngmfjd074jh2rzm9qsxakr3zn81p6qnzair"
+      "version": "1.3.1",
+      "sha256": "12mfm49bjnh2pvm51dzna625kzgwznm9kcv6qhazc4il9j0224wd"
     },
     "vibe-core": {
-      "version": "2.8.2",
-      "sha256": "1g9l8hmjx4dzzwh7pqasc9s16zzbdfvciswbv0gnrvmjsb0pi9xr"
+      "version": "2.8.4",
+      "sha256": "1pik6vympgwxpyxb75g1f8409cd6hw952gbflqvwaj18shz6dwjm"
     },
     "vibe-d": {
       "version": "0.9.8",

--- a/pkgs/applications/misc/inochi2d/default.nix
+++ b/pkgs/applications/misc/inochi2d/default.nix
@@ -22,13 +22,13 @@ in
   inochi-creator = mkGeneric rec {
     pname = "inochi-creator";
     appname = "Inochi Creator";
-    version = "0.8.4";
+    version = "0.8.5";
 
     src = fetchFromGitHub {
       owner = "Inochi2D";
       repo = "inochi-creator";
       rev = "v${version}";
-      hash = "sha256-wsB9KIZyot2Y+6QpQlIXRzv3cPCdwp2Q/ZfDizAKJc4=";
+      hash = "sha256-qrSHyvFE55xRbcA79lngOHJOdv54rNlUTHlxT9jjPEY=";
     };
 
     dubLock = ./creator-dub-lock.json;

--- a/pkgs/applications/misc/inochi2d/default.nix
+++ b/pkgs/applications/misc/inochi2d/default.nix
@@ -54,13 +54,13 @@ in
   inochi-session = mkGeneric rec {
     pname = "inochi-session";
     appname = "Inochi Session";
-    version = "0.8.3";
+    version = "0.8.4";
 
     src = fetchFromGitHub {
       owner = "Inochi2D";
       repo = "inochi-session";
       rev = "v${version}";
-      hash = "sha256-yq/uMWEeydZun07/7hgUaAw3IruRqrDuGgbe5NzNYxw=";
+      hash = "sha256-BRA5qODHhyHBeZYT5MQwcFmr/zVokfO5SrbcbQa6w7w=";
     };
 
     dubLock = ./session-dub-lock.json;

--- a/pkgs/applications/misc/inochi2d/session-dub-lock.json
+++ b/pkgs/applications/misc/inochi2d/session-dub-lock.json
@@ -33,8 +33,8 @@
       "sha256": "0p9g4h5qanbg6281x1068mdl5p7zvqig4zmmi72a2cay6dxnbvxb"
     },
     "eventcore": {
-      "version": "0.9.29",
-      "sha256": "1993mibxqb4v7lbsq3kbfwxfpi0d1gzzmzvx6y01907aqz933isa"
+      "version": "0.9.30",
+      "sha256": "1n8wdcjhas0y99pf9fvwwsydkmy9g7gvfjhlwpjh158c7pfjwlaq"
     },
     "facetrack-d": {
       "version": "0.7.8",
@@ -65,8 +65,8 @@
       "sha256": "0kzk55ilbnl6qypjk60zwd5ibys5n47128hbbr0mbc7bpj9ppfg4"
     },
     "inochi2d": {
-      "version": "0.8.3",
-      "sha256": "1m9dalm6sb518yi9mbphq1fdax90fc5rmskah19l7slnplbhli4l"
+      "version": "0.8.4",
+      "sha256": "1bj0c6i9kcw1vfm6lf8lyxpf1lhhslg3f182jycdmzms15i3jb3y"
     },
     "inui": {
       "version": "1.2.1",
@@ -85,12 +85,12 @@
       "sha256": "0hm31birbw59sw1bi9syjhbcdgwwwyyx6r9jg7ar9i6a74cjr52c"
     },
     "mir-algorithm": {
-      "version": "3.22.0",
-      "sha256": "0pl1vwyyhr2hrxlj060khzhg33dkgyrzi3f5qqxz6xj3hcp7axxq"
+      "version": "3.22.1",
+      "sha256": "1bvvf3dm26x1h10pg1s4kyhxiyrmd96kk2lmchyady39crpjj5cf"
     },
     "mir-core": {
-      "version": "1.7.0",
-      "sha256": "14k7y2r06pwzf29shymyjrk7l582bh181rc07bnwgjn3f84ayn62"
+      "version": "1.7.1",
+      "sha256": "15m1n48fcmh5pw3w4ww5qfzwkdglflpzc3xmxmrlvd30swyyr85j"
     },
     "mir-linux-kernel": {
       "version": "1.0.1",
@@ -101,8 +101,8 @@
       "sha256": "1fwhd5fkvgbqf3y8gwmrnd42kzi4k3mibpxijw5j82jxgfp1rzsf"
     },
     "openssl-static": {
-      "version": "1.0.3+3.0.8",
-      "sha256": "1z977ghlnczxky2q2gislfi68jnbp2zf4pifv8rzrcs0nx3va2jr"
+      "version": "1.0.5+3.0.8",
+      "sha256": "0wpqz29yrbbh39g3cwlgd6h6hh1msws7w5baw1kywdkgj761gx2k"
     },
     "silly": {
       "version": "1.1.1",
@@ -113,20 +113,20 @@
       "sha256": "1g8382wr49sjyar0jay8j7y2if7h1i87dhapkgxphnizp24d7kaj"
     },
     "taggedalgebraic": {
-      "version": "0.11.22",
-      "sha256": "1kc39sdnk2ybhrwxiwyw1mqcw0qzjr0vr54yvyp3gkkaad373k4r"
+      "version": "0.11.23",
+      "sha256": "1bialmbdwjpqhgs95inkwzin7xbhx7sngjf7viq90vzma497l59k"
     },
     "tinyfiledialogs": {
       "version": "0.10.1",
       "sha256": "1k3gq9y7912x5b30h60nvlfdr61as1f187b8rsilkxliizcmbhfi"
     },
     "vibe-container": {
-      "version": "1.3.0",
-      "sha256": "02gdw7ma93fdvgx3fngmfjd074jh2rzm9qsxakr3zn81p6qnzair"
+      "version": "1.3.1",
+      "sha256": "12mfm49bjnh2pvm51dzna625kzgwznm9kcv6qhazc4il9j0224wd"
     },
     "vibe-core": {
-      "version": "2.8.2",
-      "sha256": "1g9l8hmjx4dzzwh7pqasc9s16zzbdfvciswbv0gnrvmjsb0pi9xr"
+      "version": "2.8.4",
+      "sha256": "1pik6vympgwxpyxb75g1f8409cd6hw952gbflqvwaj18shz6dwjm"
     },
     "vibe-d": {
       "version": "0.9.8",


### PR DESCRIPTION
## Description of changes

Releases:
https://github.com/Inochi2D/inochi-creator/releases
https://github.com/Inochi2D/inochi-session/releases

One notable fix in these releases is fixing support for newer Dlang versions.
Related PR, where this was manually patched in: https://github.com/NixOS/nixpkgs/pull/293417

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
