### PR TITLE
Revert "boehmgc: disable tests on aarch64-linux"

### DIFF
--- a/pkgs/by-name/bo/boehmgc/package.nix
+++ b/pkgs/by-name/bo/boehmgc/package.nix
@@ -50,9 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
       "CFLAGS_EXTRA=-DNO_SOFT_VDB"
     ];
 
-  # `gctest` fails under x86_64 emulation on aarch64-darwin
-  # and also on aarch64-linux (qemu-user)
-  doCheck = !((stdenv.isDarwin && stdenv.isx86_64) || (stdenv.isLinux && stdenv.isAarch64));
+  # `gctest` fails under emulation on aarch64-darwin
+  doCheck = !(stdenv.isDarwin && stdenv.isx86_64);
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#314255