### PR TITLE
dssat: init at 4.8.2.12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15752,6 +15752,12 @@
     githubId = 817039;
     name = "Paulo Casaretto";
   };
+  pcboy = {
+    email = "david@joynetiks.com";
+    github = "pcboy";
+    githubId = 943430;
+    name = "David Hagege";
+  };
   pedrohlc = {
     email = "root@pedrohlc.com";
     github = "PedroHLC";

--- a/pkgs/by-name/ds/dssat/package.nix
+++ b/pkgs/by-name/ds/dssat/package.nix
@@ -1,0 +1,74 @@
+{
+  stdenv,
+  lib,
+  cmake,
+  glibc,
+  gfortran,
+  makeWrapper,
+  fetchFromGitHub,
+  fetchpatch,
+  dos2unix,
+  dataRepo ? fetchFromGitHub {
+    owner = "DSSAT";
+    repo = "dssat-csm-data";
+    rev = "v4.8.2.8";
+    hash = "sha256-hbSBKEvdSd1lfbemfp4Lk4/JcGMXGVjm1x7P7lmmuA0=";
+  },
+}:
+let
+  # Temporary patch to fix 80 chars limit on paths
+  # https://github.com/DSSAT/dssat-csm-os/pull/417/
+  charLimitPatch = fetchpatch {
+    url = "https://github.com/DSSAT/dssat-csm-os/pull/417/commits/9215012a297c074f392b5e7eb90b8c20495f13f7.patch";
+    hash = "sha256-WwJR5lnWtR3aYWZmk8pBC0/qaRqY0UrWHIaYp2ajImE=";
+  };
+in
+stdenv.mkDerivation (final: {
+  pname = "dssat";
+  version = "4.8.2.12";
+
+  src = fetchFromGitHub {
+    owner = "DSSAT";
+    repo = "dssat-csm-os";
+    rev = "refs/tags/v${final.version}";
+    sha256 = "sha256-8OaTM7IXFZjlelx5O4O+bVNQj4dIhGzIk2iCfpqI8uA=";
+  };
+
+  # maintainers are on windows and have CRLF endings in their files
+  # And github returns a patch file in unix format only.
+  patchPhase = ''
+    runHook prePatch
+    cp ${charLimitPatch} ./limit-path.patch
+    unix2dos ./limit-path.patch
+    patch --binary -p1 < ./limit-path.patch
+    runHook postPatch
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    dos2unix
+    gfortran
+    makeWrapper
+  ];
+
+  buildInputs = lib.optionals stdenv.isLinux [ glibc.static ];
+
+  cmakeFlags = [ "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}/share/dssat/" ];
+
+  postInstall = ''
+    mkdir -p $out/share/dssat/Data
+    cp -r $src/Data/* $out/share/dssat/Data/
+    cp -r ${dataRepo}/* $out/share/dssat/Data/
+    makeWrapper $out/share/dssat/dscsm048 $out/bin/dscsm048
+  '';
+
+  meta = {
+    homepage = "https://github.com/DSSAT/dssat-csm-os";
+    description = "Cropping System Model";
+    mainProgram = "dscsm048";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ pcboy ];
+    platforms = lib.platforms.unix;
+    broken = stdenv.isAarch64 && stdenv.isLinux;
+  };
+})


### PR DESCRIPTION
## Description of changes

DSSAT is a famous tool used for crop modeling. The first release was in 1989 but this is still in use today. It's in Fortran.

https://en.wikipedia.org/wiki/DSSAT

This package is only for the CLI version.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


## Notes

~~This is for DSSAT47. DSSAT 48 also exists. Instead of naming the package dssat, I decided to call it dssat47 as this is common to have both dssat47 and dssat48 on the same system right now as some model files only work for dssat47.  
I don't have yet a working package for DSSAT48 (yet).  
What is the recommended way to deal with this situation? Should I have 2 folders dssat47 and dssat48 in `pkgs/by-name/dss/` and use `dssat47.override{}` in the dssat48 package?  
Or should I maybe have a `dssat` package pointing to latest (48), and a separate `dssat47` package?~~

Not valid anymore. Now it is only DSSAT48.