### PR TITLE
nixos/hyprlock, nixos/hypridle: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1326,6 +1326,7 @@
   ./services/video/unifi-video.nix
   ./services/video/v4l2-relayd.nix
   ./services/wayland/cage.nix
+  ./services/wayland/hypridle.nix
   ./services/web-apps/akkoma.nix
   ./services/web-apps/alps.nix
   ./services/web-apps/anuko-time-tracker.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -292,6 +292,7 @@
   ./programs/virt-manager.nix
   ./programs/wavemon.nix
   ./programs/wayland/cardboard.nix
+  ./programs/wayland/hyprlock.nix
   ./programs/wayland/hyprland.nix
   ./programs/wayland/labwc.nix
   ./programs/wayland/river.nix

--- a/nixos/modules/programs/wayland/hyprlock.nix
+++ b/nixos/modules/programs/wayland/hyprlock.nix
@@ -1,0 +1,32 @@
+{ lib, pkgs, config, ... }:
+
+let
+  cfg = config.programs.hyprlock;
+in
+{
+  options.programs.hyprlock = {
+    enable = lib.mkEnableOption "hyprlock, Hyprland's GPU-accelerated screen locking utility";
+    package = lib.mkPackageOption pkgs "hyprlock" { };
+    hypridlePackage = lib.mkPackageOption pkgs "hypridle" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+      cfg.hypridlePackage
+    ];
+
+    # Hyprlock needs Hypridle systemd service to be running to detect idle time
+    systemd.user.services.hypridle = {
+      description = "Hypridle idle daemon";
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+      script = lib.getExe cfg.hypridlePackage;
+    };
+
+    # Hyprlock needs PAM access to authenticate, else it fallbacks to su
+    security.pam.services.hyprlock = {};
+  };
+
+  meta.maintainers = with lib.maintainers; [ johnrtitor ];
+}

--- a/nixos/modules/programs/wayland/hyprlock.nix
+++ b/nixos/modules/programs/wayland/hyprlock.nix
@@ -7,22 +7,15 @@ in
   options.programs.hyprlock = {
     enable = lib.mkEnableOption "hyprlock, Hyprland's GPU-accelerated screen locking utility";
     package = lib.mkPackageOption pkgs "hyprlock" { };
-    hypridlePackage = lib.mkPackageOption pkgs "hypridle" { };
   };
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [
       cfg.package
-      cfg.hypridlePackage
     ];
 
     # Hyprlock needs Hypridle systemd service to be running to detect idle time
-    systemd.user.services.hypridle = {
-      description = "Hypridle idle daemon";
-      wantedBy = [ "graphical-session.target" ];
-      partOf = [ "graphical-session.target" ];
-      script = lib.getExe cfg.hypridlePackage;
-    };
+    services.hypridle.enable = true;
 
     # Hyprlock needs PAM access to authenticate, else it fallbacks to su
     security.pam.services.hyprlock = {};

--- a/nixos/modules/services/wayland/hypridle.nix
+++ b/nixos/modules/services/wayland/hypridle.nix
@@ -1,0 +1,26 @@
+{ lib, pkgs, config, ... }:
+
+let
+  cfg = config.services.hypridle;
+in
+{
+  options.services.hypridle = {
+    enable = lib.mkEnableOption "hypridle, Hyprland's idle daemon";
+    package = lib.mkPackageOption pkgs "hypridle" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+    ];
+
+    systemd.user.services.hypridle = {
+      description = "Hypridle idle daemon";
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+      script = lib.getExe cfg.package;
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ johnrtitor ];
+}


### PR DESCRIPTION
## Description of changes

Adds `config.programs.hyprlock` option
Adds `config.services.hypridle` option

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
