### PR TITLE
postgresql15Packages.wal2json: 2.5 -> 2.6

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/wal2json.nix
+++ b/pkgs/servers/sql/postgresql/ext/wal2json.nix
@@ -1,14 +1,20 @@
-{ lib, callPackage, stdenv, fetchFromGitHub, postgresql }:
+{
+  lib,
+  stdenv,
+  callPackage,
+  fetchFromGitHub,
+  postgresql,
+}:
 
 stdenv.mkDerivation rec {
   pname = "wal2json";
-  version = "2.5";
+  version = "2.6";
 
   src = fetchFromGitHub {
     owner = "eulerto";
     repo = "wal2json";
-    rev = "wal2json_${builtins.replaceStrings ["."] ["_"] version}";
-    sha256 = "sha256-Gpc9uDKrs/dmVSFgdgHM453+TaEnhRh9t0gDbSn8FUI=";
+    rev = "wal2json_${builtins.replaceStrings [ "." ] [ "_" ] version}";
+    sha256 = "sha256-+QoACPCKiFfuT2lJfSUmgfzC5MXf75KpSoc2PzPxKyM=";
   };
 
   buildInputs = [ postgresql ];
@@ -20,10 +26,12 @@ stdenv.mkDerivation rec {
     install -D -t $out/share/postgresql/extension sql/*.sql
   '';
 
-  passthru.tests.wal2json = lib.recurseIntoAttrs (callPackage ../../../../../nixos/tests/postgresql-wal2json.nix {
-    inherit (stdenv) system;
-    inherit postgresql;
-  });
+  passthru.tests.wal2json = lib.recurseIntoAttrs (
+    callPackage ../../../../../nixos/tests/postgresql-wal2json.nix {
+      inherit (stdenv) system;
+      inherit postgresql;
+    }
+  );
 
   meta = with lib; {
     description = "PostgreSQL JSON output plugin for changeset extraction";


### PR DESCRIPTION
## Description of changes

Upstream changelog: https://github.com/eulerto/wal2json/releases/tag/wal2json_2_6

postgresql 17 support is the big line item there.


I've tested this PR by merging in #315095, and verifying all the tests pass with this update too

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).