### PR TITLE
kernel/common-config: add MEM_ALLOC_PROFILING by default

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -121,3 +121,6 @@ c759efa5e7f825913f9a69ef20f025f50f56dc4d
 
 # python3Packages: format with nixfmt
 59b1aef59071cae6e87859dc65de973d2cc595c0
+
+# kernel/common-config: reflow equality signs for the debug section
+4c03d1c99fc75fccdd95cc7bbd77399a5bd63ace

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -36,48 +36,44 @@ let
 
     debug = {
       # Necessary for BTF
-      DEBUG_INFO                = mkMerge [
+      DEBUG_INFO                                                         = mkMerge [
         (whenOlder "5.2" (if (features.debug or false) then yes else no))
         (whenBetween "5.2" "5.18" yes)
       ];
-      DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT = whenAtLeast "5.18" yes;
+      DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT                                 = whenAtLeast "5.18" yes;
       # Reduced debug info conflict with BTF and have been enabled in
       # aarch64 defconfig since 5.13
-      DEBUG_INFO_REDUCED        = whenAtLeast "5.13" (option no);
-      DEBUG_INFO_BTF            = whenAtLeast "5.2" (option yes);
+      DEBUG_INFO_REDUCED                                                 = whenAtLeast "5.13" (option no);
+      DEBUG_INFO_BTF                                                     = whenAtLeast "5.2" (option yes);
       # Allow loading modules with mismatched BTFs
       # FIXME: figure out how to actually make BTFs reproducible instead
       # See https://github.com/NixOS/nixpkgs/pull/181456 for details.
-      MODULE_ALLOW_BTF_MISMATCH = whenAtLeast "5.18" (option yes);
-      BPF_LSM                   = whenAtLeast "5.7" (option yes);
-      DEBUG_KERNEL              = yes;
-      DEBUG_DEVRES              = no;
-      DYNAMIC_DEBUG             = yes;
-      DEBUG_STACK_USAGE         = no;
-      RCU_TORTURE_TEST          = no;
-      SCHEDSTATS                = yes;
-      DETECT_HUNG_TASK          = yes;
-      CRASH_DUMP                = option no;
+      MODULE_ALLOW_BTF_MISMATCH                                          = whenAtLeast "5.18" (option yes);
+      BPF_LSM                                                            = whenAtLeast "5.7" (option yes);
+      DEBUG_KERNEL                                                       = yes;
+      DEBUG_DEVRES                                                       = no;
+      DYNAMIC_DEBUG                                                      = yes;
+      DEBUG_STACK_USAGE                                                  = no;
+      RCU_TORTURE_TEST                                                   = no;
+      SCHEDSTATS                                                         = yes;
+      DETECT_HUNG_TASK                                                   = yes;
+      CRASH_DUMP                                                         = option no;
       # Easier debugging of NFS issues.
-      SUNRPC_DEBUG              = yes;
+      SUNRPC_DEBUG                                                       = yes;
       # Provide access to tunables like sched_migration_cost_ns
-      SCHED_DEBUG               = yes;
-
+      SCHED_DEBUG                                                        = yes;
       # Count IRQ and steal CPU time separately
-      IRQ_TIME_ACCOUNTING       = yes;
-      PARAVIRT_TIME_ACCOUNTING  = yes;
-
+      IRQ_TIME_ACCOUNTING                                                = yes;
+      PARAVIRT_TIME_ACCOUNTING                                           = yes;
       # Enable CPU lockup detection
-      LOCKUP_DETECTOR           = yes;
-      SOFTLOCKUP_DETECTOR       = yes;
-      HARDLOCKUP_DETECTOR       = yes;
-
+      LOCKUP_DETECTOR                                                    = yes;
+      SOFTLOCKUP_DETECTOR                                                = yes;
+      HARDLOCKUP_DETECTOR                                                = yes;
       # Enable streaming logs to a remote device over a network
-      NETCONSOLE                = module;
-      NETCONSOLE_DYNAMIC        = yes;
-
+      NETCONSOLE                                                         = module;
+      NETCONSOLE_DYNAMIC                                                 = yes;
       # Export known printks in debugfs
-      PRINTK_INDEX              = whenAtLeast "5.15" yes;
+      PRINTK_INDEX                                                       = whenAtLeast "5.15" yes;
       # According to Kconfig, this has low performance and memory impact.
       # Track memory leaks and performance issues related to allocations.
       MEM_ALLOC_PROFILING                                                = whenAtLeast "6.10" yes;
@@ -192,7 +188,8 @@ let
 
       # Collect ECC errors and retire pages that fail too often
       RAS_CEC                   = yes;
-    } // optionalAttrs (stdenv.is32bit) {
+
+        } // optionalAttrs (stdenv.is32bit) {
       # Enable access to the full memory range (aka PAE) on 32-bit architectures
       # This check isn't super accurate but it's close enough
       HIGHMEM                   = option yes;

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -78,6 +78,10 @@ let
 
       # Export known printks in debugfs
       PRINTK_INDEX              = whenAtLeast "5.15" yes;
+      # According to Kconfig, this has low performance and memory impact.
+      # Track memory leaks and performance issues related to allocations.
+      MEM_ALLOC_PROFILING                                                = whenAtLeast "6.10" yes;
+      MEM_ALLOC_PROFILING_ENABLED_BY_DEFAULT                             = whenAtLeast "6.10" yes;
     };
 
     power-management = {


### PR DESCRIPTION
## Description of changes

Introduced in 22d407b164ff79de42d21f37d99f9ee7abdd51c8 ("lib: add allocation tagging support for memory allocation profiling")
part of 6.10-rc1.

This is a low performance impact feature to track memory leaks and other
allocation-related issues in the kernel.

See:

- https://lwn.net/Articles/974380/
- https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ebdf9ad4ca98

Signed-off-by: Raito Bezarius <masterancpp@gmail.com>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
