### PR TITLE
maa-assistant-arknights: 5.2.3 -> 5.3.1

### DIFF
--- a/pkgs/by-name/ma/maa-assistant-arknights/fastdeploy-ppocr.nix
+++ b/pkgs/by-name/ma/maa-assistant-arknights/fastdeploy-ppocr.nix
@@ -23,11 +23,11 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   version = "0-unstable-2023-10-09";
 
   src = fetchFromGitHub {
-    owner = "Cryolitia";
+    owner = "MaaAssistantArknights";
     repo = "FastDeploy";
-    # follows https://github.com/MaaAssistantArknights/MaaDeps/blob/master/vcpkg-overlay/ports/maa-fastdeploy/portfile.cmake#L4
-    rev = "2e68908141f6950bc5d22ba84f514e893cc238ea";
-    hash = "sha256-BWO4lKZhwNG6mbkC70hPgMNjabTnEV5XMo0bLV/gvQs=";
+    # follows but not fully follows https://github.com/MaaAssistantArknights/MaaDeps/blob/master/vcpkg-overlay/ports/maa-fastdeploy/portfile.cmake#L4
+    rev = "0db6000aaac250824266ac37451f43ce272d80a3";
+    hash = "sha256-5TItnPDc5WShpZAgBYeqgI9KKkk3qw/M8HPMlq/H4BM=";
   };
 
   outputs = [ "out" "cmake" ];

--- a/pkgs/by-name/ma/maa-assistant-arknights/package.nix
+++ b/pkgs/by-name/ma/maa-assistant-arknights/package.nix
@@ -29,27 +29,6 @@ stdenv.mkDerivation (finalAttr: {
     hash = if isBeta then sources.beta.hash else sources.stable.hash;
   };
 
-  # https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=maa-assistant-arknights
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'RUNTIME DESTINATION .' ' ' \
-      --replace-fail 'LIBRARY DESTINATION .' ' ' \
-      --replace-fail 'PUBLIC_HEADER DESTINATION .' ' '
-
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'find_package(asio ' '# find_package(asio ' \
-      --replace-fail 'asio::asio' ' '
-
-    shopt -s globstar nullglob
-
-    substituteInPlace src/MaaCore/**/{*.h,*.cpp,*.hpp,*.cc} \
-      --replace 'onnxruntime/core/session/' ""
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'ONNXRuntime' 'onnxruntime'
-
-    cp -v ${fastdeploy.cmake}/Findonnxruntime.cmake cmake/
-  '';
-
   nativeBuildInputs = [
     asio
     cmake

--- a/pkgs/by-name/ma/maa-assistant-arknights/pin.json
+++ b/pkgs/by-name/ma/maa-assistant-arknights/pin.json
@@ -1,10 +1,10 @@
 {
   "stable": {
-    "version": "5.2.3",
-    "hash": "sha256-fjlvP5PPmSSNYefYRrEBVdhbN3yZ0pCbvIe763U5y5o="
+    "version": "5.3.1",
+    "hash": "sha256-4Bz9r4UcaUI5v1upwdD0HclXIUBcNpfnA2iWwofk1zw="
   },
   "beta": {
-    "version": "5.2.3",
-    "hash": "sha256-fjlvP5PPmSSNYefYRrEBVdhbN3yZ0pCbvIe763U5y5o="
+    "version": "5.3.1",
+    "hash": "sha256-4Bz9r4UcaUI5v1upwdD0HclXIUBcNpfnA2iWwofk1zw="
   }
 }


### PR DESCRIPTION
Upstream break change:

- https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/8939 introduced a third-party header, which is `No License` and useless on Linux and macOS.

- https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/9168 reduced the extra patch to build without `MaaDeps` aka `Maa self-built dependencies big gift pack`.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
