### PR TITLE
gpu-screen-recorder: unstable-2023-11-18 -> unstable-2024-05-21

### DIFF
--- a/pkgs/applications/video/gpu-screen-recorder/default.nix
+++ b/pkgs/applications/video/gpu-screen-recorder/default.nix
@@ -11,16 +11,17 @@
 , libva
 , libglvnd
 , libXrandr
+, libXfixes
 }:
 
 stdenv.mkDerivation {
   pname = "gpu-screen-recorder";
-  version = "unstable-2023-11-18";
+  version = "unstable-2024-05-21";
 
   # printf "r%s.%s\n" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
   src = fetchurl {
-    url = "https://dec05eba.com/snapshot/gpu-screen-recorder.git.r418.5a8900e.tar.gz";
-    hash = "sha256-Dal6KxQOTqoNH6e8lYk5XEXGFG/vzbguNFZ9yk9nKe0=";
+    url = "https://dec05eba.com/snapshot/gpu-screen-recorder.git.r594.e572073.tar.gz";
+    hash = "sha256-MTBxhvkoyotmRUx1sRN/7ruXBYwIbOFQNdJHhZ3DdDk=";
   };
   sourceRoot = ".";
 
@@ -37,6 +38,7 @@ stdenv.mkDerivation {
     libdrm
     libva
     libXrandr
+    libXfixes
   ];
 
   buildPhase = ''
@@ -49,14 +51,14 @@ stdenv.mkDerivation {
     mv $out/bin/gpu-screen-recorder $out/bin/.wrapped/
     makeWrapper "$out/bin/.wrapped/gpu-screen-recorder" "$out/bin/gpu-screen-recorder" \
     --prefix LD_LIBRARY_PATH : ${libglvnd}/lib \
-    --prefix PATH : $out/bin
+    --suffix PATH : $out/bin
   '';
 
-  meta = with lib; {
+  meta = {
     description = "A screen recorder that has minimal impact on system performance by recording a window using the GPU only";
     homepage = "https://git.dec05eba.com/gpu-screen-recorder/about/";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ babbaj ];
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.babbaj ];
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
## Description of changes

Just a bump of a version to latest

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
