### PR TITLE
treewide: replace name with pname

### DIFF
--- a/pkgs/applications/emulators/c64-debugger/default.nix
+++ b/pkgs/applications/emulators/c64-debugger/default.nix
@@ -12,7 +12,7 @@
 }:
 
 stdenv.mkDerivation {
-  name = "c64-debugger";
+  pname = "c64-debugger";
   version = "0.64.58.6";
 
   src = fetchgit {

--- a/pkgs/applications/misc/holochain-launcher/default.nix
+++ b/pkgs/applications/misc/holochain-launcher/default.nix
@@ -13,7 +13,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "holochain-launcher";
+  pname = "holochain-launcher";
   version = "0.11.5";
   prerelease = "beta-2";
 

--- a/pkgs/applications/misc/polychromatic/default.nix
+++ b/pkgs/applications/misc/polychromatic/default.nix
@@ -21,7 +21,7 @@
 }:
 
 python3Packages.buildPythonApplication rec {
-  name = "polychromatic";
+  pname = "polychromatic";
   version = "0.9.1";
   format = "other";
 

--- a/pkgs/applications/networking/sync/lcsync/default.nix
+++ b/pkgs/applications/networking/sync/lcsync/default.nix
@@ -7,7 +7,7 @@
   stdenv
 }:
 stdenv.mkDerivation (finalAttrs: {
-  name = "lcsync";
+  pname = "lcsync";
   version = "0.3.0";
 
   src = fetchFromGitea {

--- a/pkgs/by-name/bo/bombsquad/package.nix
+++ b/pkgs/by-name/bo/bombsquad/package.nix
@@ -33,7 +33,7 @@ let
     .${targetPlatform.system} or (throw "${targetPlatform.system} is unsupported.");
 in
 stdenv.mkDerivation (finalAttrs: {
-  name = "bombsquad";
+  pname = "bombsquad";
   version = "1.7.35";
   sourceRoot = ".";
   src = fetchurl {

--- a/pkgs/by-name/ca/cano/package.nix
+++ b/pkgs/by-name/ca/cano/package.nix
@@ -5,7 +5,7 @@
 , ncurses
 }:
 stdenv.mkDerivation (finalAttrs: {
-  name = "cano";
+  pname = "cano";
   version = "0.1.0-alpha";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/di/disko/package.nix
+++ b/pkgs/by-name/di/disko/package.nix
@@ -8,7 +8,7 @@
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
-  name = "disko";
+  pname = "disko";
   version = "1.6.1";
   src = fetchFromGitHub {
     owner = "nix-community";

--- a/pkgs/by-name/do/dorion/package.nix
+++ b/pkgs/by-name/do/dorion/package.nix
@@ -12,7 +12,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  name = "dorion";
+  pname = "dorion";
   version = "4.3.0";
 
   src = fetchurl {

--- a/pkgs/by-name/ja/jailer/package.nix
+++ b/pkgs/by-name/ja/jailer/package.nix
@@ -12,7 +12,7 @@
   wrapGAppsHook4,
 }:
 stdenv.mkDerivation (finalAttrs: {
-  name = "jailer";
+  pname = "jailer";
   version = "16.2";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/jt/jtdx/package.nix
+++ b/pkgs/by-name/jt/jtdx/package.nix
@@ -1,6 +1,6 @@
 { wsjtx, fetchgit, qt5, lib }:
 wsjtx.overrideAttrs (old: {
-  name = "jtdx";
+  pname = "jtdx";
   version = "unstable-2022-03-01";
   src = fetchgit {
     url = "https://github.com/jtdx-project/jtdx.git";

--- a/pkgs/by-name/li/liblapin/package.nix
+++ b/pkgs/by-name/li/liblapin/package.nix
@@ -9,7 +9,7 @@
 }:
 
 stdenv.mkDerivation {
-  name = "liblapin";
+  pname = "liblapin";
   version = "0-unstable-2024-05-20";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/me/menulibre/package.nix
+++ b/pkgs/by-name/me/menulibre/package.nix
@@ -12,7 +12,7 @@
 }:
 
 python3Packages.buildPythonApplication rec {
-  name = "menulibre";
+  pname = "menulibre";
   version = "2.4.0";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/ph/physac/package.nix
+++ b/pkgs/by-name/ph/physac/package.nix
@@ -5,7 +5,7 @@
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
-  name = "physac";
+  pname = "physac";
   version = "2.5-unstable-2023-12-11";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/pi/pixel-code/package.nix
+++ b/pkgs/by-name/pi/pixel-code/package.nix
@@ -1,7 +1,7 @@
 { lib, stdenvNoCC, fetchzip }:
 
 stdenvNoCC.mkDerivation rec {
-  name = "pixel-code";
+  pname = "pixel-code";
   version = "2.2";
 
   src = fetchzip {

--- a/pkgs/development/interpreters/kamilalisp/default.nix
+++ b/pkgs/development/interpreters/kamilalisp/default.nix
@@ -6,7 +6,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "kamilalisp";
+  pname = "kamilalisp";
   version = "0.3.0.1";
 
   src = fetchurl {
@@ -20,9 +20,9 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -pv $out/share/java $out/bin
-    cp ${src} $out/share/java/${name}-${version}.jar
+    cp ${src} $out/share/java/kamilalisp-${version}.jar
     makeWrapper ${jre}/bin/java $out/bin/kamilalisp \
-      --add-flags "-jar $out/share/java/${name}-${version}.jar" \
+      --add-flags "-jar $out/share/java/kamilalisp-${version}.jar" \
       --set _JAVA_OPTIONS '-Dawt.useSystemAAFontSettings=on' \
       --set _JAVA_AWT_WM_NONREPARENTING 1
   '';

--- a/pkgs/development/libraries/lcrq/default.nix
+++ b/pkgs/development/libraries/lcrq/default.nix
@@ -4,7 +4,7 @@
   lib
 }:
 stdenv.mkDerivation (finalAttrs: {
-  name = "lcrq";
+  pname = "lcrq";
   version = "0.1.2";
 
   src = fetchFromGitea {

--- a/pkgs/development/libraries/libgourou/default.nix
+++ b/pkgs/development/libraries/libgourou/default.nix
@@ -10,11 +10,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "libgourou";
+  pname = "libgourou";
   version = "0.8.2";
 
   src = fetchzip {
-    url = "https://indefero.soutade.fr/p/${name}/source/download/v${version}/";
+    url = "https://indefero.soutade.fr/p/libgourou/source/download/v${version}/";
     sha256 = "sha256-adkrvBCgN07Ir+J3JFCy+X9p9609lj1w8nElrlHXTxc";
     extension = "zip";
   };

--- a/pkgs/development/libraries/librecast/default.nix
+++ b/pkgs/development/libraries/librecast/default.nix
@@ -6,7 +6,7 @@
   libsodium,
 }:
 stdenv.mkDerivation (finalAttrs: {
-  name = "librecast";
+  pname = "librecast";
   version = "0.8.0";
 
   src = fetchFromGitea {

--- a/pkgs/development/tools/patcher9x/default.nix
+++ b/pkgs/development/tools/patcher9x/default.nix
@@ -1,7 +1,7 @@
 { fasm, lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation (finalAttr: {
-  name = "patcher9x";
+  pname = "patcher9x";
   version = "0.8.50";
 
   srcs = [

--- a/pkgs/misc/lssecret/default.nix
+++ b/pkgs/misc/lssecret/default.nix
@@ -6,12 +6,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "lssecret";
+  pname = "lssecret";
   version = "unstable-2022-12-02";
 
   src = fetchFromGitLab {
     owner = "GrantMoyer";
-    repo = name;
+    repo = "lssecret";
     rev = "20fd771a";
     hash = "sha256-yU70WZj4EC/sFJxyq2SQ0YQ6RCQHYiW/aQiYWo7+ujk=";
   };

--- a/pkgs/tools/filesystems/kdiskmark/default.nix
+++ b/pkgs/tools/filesystems/kdiskmark/default.nix
@@ -10,7 +10,7 @@
 , fetchFromGitHub
 }:
 stdenv.mkDerivation rec {
-  name = "kdiskmark";
+  pname = "kdiskmark";
   version = "3.1.4";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/package-management/pacup/default.nix
+++ b/pkgs/tools/package-management/pacup/default.nix
@@ -4,13 +4,13 @@
 }:
 
 python3.pkgs.buildPythonApplication rec {
-  name = "pacup";
+  pname = "pacup";
   version = "2.0.0";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "pacstall";
-    repo = name;
+    repo = "pacup";
     rev = "refs/tags/${version}";
     hash = "sha256-ItO38QyxNHftKPQZAPO7596ddBfX0a1nfVVqgx7BfwI=";
   };


### PR DESCRIPTION
## Description of changes
If name is used instead of pname, our [search page](https://search.nixos.org/packages) fails to display the version number for the package.

The build failures are not related to this pr and already happened on master.

Note: there are still more of those flying around.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


Result of `nixpkgs-review pr 315183` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages failed to build:</summary>
  <ul>
    <li>bombsquad</li>
    <li>pacup</li>
    <li>pacup.dist</li>
  </ul>
</details>
<details>
  <summary>26 packages built:</summary>
  <ul>
    <li>c64-debugger</li>
    <li>cano</li>
    <li>disko</li>
    <li>dorion</li>
    <li>holochain-launcher</li>
    <li>jailer</li>
    <li>jtdx</li>
    <li>kamilalisp</li>
    <li>kdiskmark</li>
    <li>lcrq</li>
    <li>lcsync</li>
    <li>libgourou</li>
    <li>liblapin</li>
    <li>liblapin.dev</li>
    <li>librecast</li>
    <li>lssecret</li>
    <li>menulibre</li>
    <li>menulibre.dist</li>
    <li>patcher9x</li>
    <li>physac</li>
    <li>pixel-code</li>
    <li>polychromatic</li>
    <li>python311Packages.raylib-python-cffi</li>
    <li>python311Packages.raylib-python-cffi.dist</li>
    <li>python312Packages.raylib-python-cffi</li>
    <li>python312Packages.raylib-python-cffi.dist</li>
  </ul>
</details>
