### PR TITLE
ftx-prog: init at 0.4

### DIFF
--- a/pkgs/by-name/ft/ftx-prog/package.nix
+++ b/pkgs/by-name/ft/ftx-prog/package.nix
@@ -1,0 +1,42 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  libftdi,
+  libusb1,
+  pkg-config,
+}:
+stdenv.mkDerivation (finalAttrs: {
+
+  pname = "ftx-prog";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "richardeoin";
+    repo = "ftx-prog";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-wBOzsJ1XIkswuwuCwGQk2Q+RUsGe5EOlbAhcf0R7rfc=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    libftdi
+    libusb1
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    mv ftx_prog $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Command-line alternative to the FTDI FTProg utility for FTDI's FT-X series";
+    mainProgram = "ftx_prog";
+    homepage = "https://github.com/richardeoin/ftx-prog";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = [ lib.maintainers.funkeleinhorn ];
+  };
+})


### PR DESCRIPTION
I need a utility to simply change the USB Descriptor in the EEPROM of FTDI Chips. Thats why I add this utility to have an easy option available on Nix.

## Description of changes

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
