### PR TITLE
android-studio-full: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -524,6 +524,10 @@ Use `services.pipewire.extraConfig` or `services.pipewire.configPackages` for Pi
   - to get previous behaviour of upstream defaults, set it to `null`
   - default value has changed from `[]` to `null`, in order to preserve default behaviour
 
+- `androidenv.androidPkgs_9_0` has been removed, and replaced with `androidenv.androidPkgs` for a more complete Android SDK including support for Android 9 and later.
+
+- `gtest` package has been updated past v1.13.0, which requires C++14 or higher.
+
 - `services.vikunja` systemd service now uses `vikunja` as dynamic user instead of `vikunja-api`. Database users might need to be changed.
 
 - `services.vikunja.setupNginx` setting has been removed. Users now need to set up the webserver configuration on their own with a proxy pass to the vikunja service.

--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -276,9 +276,9 @@ let
       # source-code itself).
       platforms = [ "x86_64-linux" ];
       maintainers = with maintainers; rec {
-        stable = [ alapshin ];
-        beta = [ alapshin ];
-        canary = [ alapshin ];
+        stable = [ alapshin numinit ];
+        beta = [ alapshin numinit ];
+        canary = [ alapshin numinit ];
         dev = canary;
       }."${channel}";
       mainProgram = pname;

--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -65,6 +65,7 @@
 , zlib
 , makeDesktopItem
 , tiling_wm # if we are using a tiling wm, need to set _JAVA_AWT_WM_NONREPARENTING in wrapper
+, androidenv
 }:
 
 let
@@ -253,9 +254,12 @@ let
     '';
     preferLocalBuild = true;
     allowSubstitutes = false;
-    passthru = {
-      unwrapped = androidStudio;
+    passthru = let
       withSdk = androidSdk: mkAndroidStudioWrapper { inherit androidStudio androidSdk; };
+    in {
+      unwrapped = androidStudio;
+      full = withSdk androidenv.androidPkgs.androidsdk;
+      inherit withSdk;
     };
     meta = with lib; {
       description = "The Official IDE for Android (${channel} channel)";

--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -260,6 +260,7 @@ let
       unwrapped = androidStudio;
       full = withSdk androidenv.androidPkgs.androidsdk;
       inherit withSdk;
+      sdk = androidSdk;
     };
     meta = with lib; {
       description = "The Official IDE for Android (${channel} channel)";

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -11,8 +11,8 @@
 , platformVersions ? []
 , includeSources ? false
 , includeSystemImages ? false
-, systemImageTypes ? [ "google_apis_playstore" ]
-, abiVersions ? [ "armeabi-v7a" "arm64-v8a" ]
+, systemImageTypes ? [ "google_apis" "google_apis_playstore" ]
+, abiVersions ? [ "x86" "x86_64" "armeabi-v7a" "arm64-v8a" ]
 , cmakeVersions ? [ ]
 , includeNDK ? false
 , ndkVersion ? "26.3.11579264"

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -15,9 +15,11 @@ rec {
     inherit composeAndroidPackages;
   };
 
-  androidPkgs_9_0 = composeAndroidPackages {
-    platformVersions = [ "28" ];
-    abiVersions = [ "x86" "x86_64"];
+  androidPkgs = composeAndroidPackages {
+    platformVersions = [ "28" "29" "30" "31" "32" "33" "34" ];
+    includeEmulator = true;
+    includeSystemImages = true;
+    includeNDK = true;
   };
 
   test-suite = pkgs.callPackage ./test-suite.nix {};

--- a/pkgs/tools/graphics/snapdragon-profiler/default.nix
+++ b/pkgs/tools/graphics/snapdragon-profiler/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     cp -r * $out/lib/snapdragon-profiler
     makeWrapper "${mono}/bin/mono" $out/bin/snapdragon-profiler \
       --add-flags "$out/lib/snapdragon-profiler/SnapdragonProfiler.exe" \
-      --suffix PATH : ${lib.makeBinPath [ jre androidenv.androidPkgs_9_0.platform-tools coreutils ]} \
+      --suffix PATH : ${lib.makeBinPath [ jre androidenv.androidPkgs.platform-tools coreutils ]} \
       --prefix MONO_GAC_PREFIX : ${gtk-sharp-2_0} \
       --suffix LD_LIBRARY_PATH : $(echo $NIX_LDFLAGS | sed 's/ -L/:/g;s/ -rpath /:/g;s/-rpath //') \
       --chdir "$out/lib/snapdragon-profiler" # Fixes themes not loading correctly

--- a/pkgs/tools/networking/gnirehtet/default.nix
+++ b/pkgs/tools/networking/gnirehtet/default.nix
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage rec {
   postInstall = ''
     wrapProgram $out/bin/gnirehtet \
     --set GNIREHTET_APK ${apk}/gnirehtet.apk \
-    --set ADB ${androidenv.androidPkgs_9_0.platform-tools}/bin/adb
+    --set ADB ${androidenv.androidPkgs.platform-tools}/bin/adb
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4069,7 +4069,7 @@ with pkgs;
   adbfs-rootless = callPackage ../development/mobile/adbfs-rootless { };
 
   adb-sync = callPackage ../development/mobile/adb-sync {
-    inherit (androidenv.androidPkgs_9_0) platform-tools;
+    inherit (androidenv.androidPkgs) platform-tools;
   };
 
   amoco = callPackage ../tools/security/amoco { };
@@ -4085,7 +4085,7 @@ with pkgs;
   androidndkPkgs_23b = (callPackage ../development/androidndk-pkgs {})."23b";
   androidndkPkgs_24 = (callPackage ../development/androidndk-pkgs {})."24";
 
-  androidsdk_9_0 = androidenv.androidPkgs_9_0.androidsdk;
+  androidsdk = androidenv.androidPkgs.androidsdk;
 
   webos = recurseIntoAttrs {
     cmake-modules = callPackage ../development/mobile/webos/cmake-modules.nix { };
@@ -29556,6 +29556,7 @@ with pkgs;
   androidStudioPackages = recurseIntoAttrs
     (callPackage ../applications/editors/android-studio { });
   android-studio = androidStudioPackages.stable;
+  android-studio-full = android-studio.full;
 
   antfs-cli = callPackage ../applications/misc/antfs-cli { };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Create the following APIs that bridge the gap between Android Studio and androidenv:

- `androidStudioPackages.<flavor>.withSdk`: Wraps Android Studio in an Android SDK created with androidenv. Exports ANDROID_SDK_ROOT and ANDROID_NDK_ROOT to the environment of the Android Studio process, if detected. This makes new projects default to the androidenv composition instead of needing to download SDKs separately, which causes emulators to break with dynamic linker errors when users try to run Android Studio out of the box on nixpkgs. Since androidenv already solves this problem, this improves the out of the box experience with Android Studio in nixpkgs.
- `androidStudioPackages.<flavor>.full`: Wraps Android Studio in a default "full" SDK composition
- `android-studio-full`: Alias for android-studio.full

Remove the following old androidenv composition:

- `androidenv.androidPkgs_9_0`

Add the following new androidenv composition:

- `androidenv.androidPkgs`

We should probably discuss this API change since it downloads a ton of Android system images, but is a way to have a relatively "full" version of androidPkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
