### PR TITLE
nixos-rebuild: check FQDN for flake attribute

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -93,6 +93,10 @@
   it is set, instead of the previous hardcoded default of
   `${networking.hostName}.${security.ipa.domain}`.
 
+- A missing flake attribute to `nixos-rebuild` (`nixos-rebuild --flake .`) will
+  default to using the full 'hostname.domainname' if domain name is set
+  (`hostname -d`).
+
 - The fcgiwrap module now allows multiple instances running as distinct users.
   The option `services.fgciwrap` now takes an attribute set of the
   configuration of each individual instance.

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -419,10 +419,16 @@ if [[ -n $flake ]]; then
     fi
     if [[ -z $flakeAttr ]]; then
         hostname="$(targetHostCmd cat /proc/sys/kernel/hostname)"
+        domainname="$(targetHostCmd cat /proc/sys/kernel/domainname)"
         if [[ -z $hostname ]]; then
             hostname=default
         fi
-        flakeAttr="nixosConfigurations.\"$hostname\""
+        if [[ -n $domainname ]]; then
+            fqdn="${hostname}.${domainname}"
+            flakeAttr="nixosConfigurations.\"$fqdn\""
+        else
+            flakeAttr="nixosConfigurations.\"$hostname\""
+        fi
     else
         flakeAttr="nixosConfigurations.\"$flakeAttr\""
     fi


### PR DESCRIPTION
## Description of changes

Since nixpkgs commit 993baa587c4b82e791686f6ce711bcd4ee8ef933, `networking.hostName` is not allowed to be a FQDN.

`networking.domain` instead can be used to set a dns domain name. This value is exposed via /proc/sys/kernel/domainname.

If a flake attribute is missing, and domain name is set, use the full 'hostname.domainname' to construct a flake attribute.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
