### PR TITLE
vmware-workstation: 17.5.1 -> 17.5.2

### DIFF
--- a/pkgs/applications/virtualization/vmware-workstation/default.nix
+++ b/pkgs/applications/virtualization/vmware-workstation/default.nix
@@ -1,14 +1,15 @@
 { stdenv
 , buildFHSEnv
 , fetchurl
+, fetchzip
 , lib
 , zlib
 , gdbm
-, bzip2
 , libxslt
 , libxml2
 , libuuid
 , readline
+, readline70
 , xz
 , cups
 , glibc
@@ -25,22 +26,50 @@
 , python3
 , autoPatchelfHook
 , makeWrapper
-, sqlite
-, enableInstaller ? false
-, enableMacOSGuests ? false, fetchFromGitHub, gnutar, unzip
+, symlinkJoin
+, enableInstaller ? false, bzip2, sqlite
+, enableMacOSGuests ? false, fetchFromGitHub, unzip
+, enableGuestTools ? true,
 }:
 
 let
+  # base - versions
+  version = "17.5.2";
+  build = "23775571";
+  baseUrl = "https://softwareupdate.vmware.com/cds/vmw-desktop/ws/${version}/${build}/linux";
+
+  # tools - versions
+  toolsVersion = "12.4.0";
+  toolsBuild = "23259341";
+
   # macOS - versions
-  fusionVersion = "13.5.1";
-  fusionBuild = "23298085";
+  fusionVersion = "13.5.2";
+  fusionBuild = "23775688";
   unlockerVersion = "3.0.5";
 
-  # macOS - ISOs
-  darwinIsoSrc = fetchurl {
-    url = "https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/${fusionVersion}/${fusionBuild}/universal/core/com.vmware.fusion.zip.tar";
-    sha256 = "sha256-bn6hoicby2YVj1pZTBzBhabNhKefzVQTm5vIrdTO2K4=";
+  guestToolsSrc =
+  let
+    fetchComponent = (system: hash: fetchzip {
+      inherit hash;
+      url = "${baseUrl}/packages/vmware-tools-${system}-${toolsVersion}-${toolsBuild}.x86_64.component.tar";
+      stripRoot = false;
+    } + "/vmware-tools-${system}-${toolsVersion}-${toolsBuild}.x86_64.component");
+  in lib.mapAttrsToList fetchComponent {
+      linux = "sha256-vT08mR6cCXZjiQgb9jy+MaqYzS0hFbNUM7xGAHIJ8Ao=";
+      linuxPreGlibc25 = "sha256-BodN1lxuhxyLlxIQSlVhGKItJ10VPlti/sEyxcRF2SA=";
+      netware = "sha256-o/S4wAYLR782Fn20fTQ871+rzsa1twnAxb9laV16XIk=";
+      solaris = "sha256-3LdFoI4TD5zxlohDGR3DRGbF6jwDZAoSMEpHWU4vSGU=";
+      winPre2k = "sha256-+QcvWfY3aCDxUwAfSuj7Wf9sxIO+ztWBrRolMim8Dfw=";
+      winPreVista = "sha256-3NgO/GdRFTpKNo45TMet0msjzxduuoF4nVLtnOUTHUA=";
+      windows = "sha256-2F7UPjNvtibmWAJxpB8IOnol12aMOGMy+403WeCTXw8=";
   };
+
+  # macOS - ISOs
+  darwinIsoSrc = fetchzip {
+    url = "https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/${fusionVersion}/${fusionBuild}/universal/core/com.vmware.fusion.zip.tar";
+    sha256 = "sha256-DDLRWAVRI3ZeXV5bUXWwput9mEC1qsJUsjojI0CJYMI=";
+    stripRoot = false;
+  } + "/com.vmware.fusion.zip";
 
   # macOS - Unlocker
   unlockerSrc = fetchFromGitHub {
@@ -68,11 +97,18 @@ let
     name = "vmware-unpack-env";
     targetPkgs = pkgs: [ zlib ];
   };
+
+  readline70_compat63 = symlinkJoin {
+    name = "readline70_compat63";
+    paths = [ readline70 ];
+    postBuild = ''
+      ln -s $out/lib/libreadline.so $out/lib/libreadline.so.6
+    '';
+  };
 in
 stdenv.mkDerivation rec {
   pname = "vmware-workstation";
-  version = "17.5.1";
-  build = "23298084";
+  inherit version build;
 
   buildInputs = [
     libxslt
@@ -96,21 +132,24 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ python3 vmware-unpack-env autoPatchelfHook makeWrapper ]
-    ++ lib.optionals enableInstaller [ sqlite bzip2 ]
-    ++ lib.optionals enableMacOSGuests [ gnutar unzip ];
+    ++ lib.optionals enableInstaller [ bzip2 sqlite readline70_compat63 ]
+    ++ lib.optionals enableMacOSGuests [ unzip ];
 
-  src = fetchurl {
-    url = "https://download3.vmware.com/software/WKST-${builtins.replaceStrings ["."] [""] version}-LX/VMware-Workstation-Full-${version}-${build}.x86_64.bundle";
-    sha256 = "sha256-qmC3zvKoes77z3x6UkLHsJ17kQrL1a/rxe9mF+UMdJY=";
-  };
+  src = fetchzip {
+    url = "${baseUrl}/core/VMware-Workstation-${version}-${build}.x86_64.bundle.tar";
+    sha256 = "sha256-5PZZpXN/V687TXjqeTm8MEays4/QTf02jVfdpi9C7GI=";
+    stripRoot = false;
+  } + "/VMware-Workstation-${version}-${build}.x86_64.bundle";
 
-  unpackPhase = ''
-    ${vmware-unpack-env}/bin/vmware-unpack-env -c "sh ${src} --extract unpacked"
+  unpackPhase = let
+    guestTools = lib.optionalString enableGuestTools (lib.concatMapStringsSep " " (src: "--install-component ${src}") guestToolsSrc);
+  in
+  ''
+    ${vmware-unpack-env}/bin/vmware-unpack-env -c "sh ${src} ${guestTools} --extract unpacked"
 
     ${lib.optionalString enableMacOSGuests ''
       mkdir -p fusion/
-      tar -xvpf "${darwinIsoSrc}" -C fusion/
-      unzip "fusion/com.vmware.fusion.zip" \
+      unzip "${darwinIsoSrc}" \
         "payload/VMware Fusion.app/Contents/Library/isoimages/x86_x64/darwin.iso" \
         "payload/VMware Fusion.app/Contents/Library/isoimages/x86_x64/darwinPre15.iso" \
         -d fusion/
@@ -173,7 +212,7 @@ stdenv.mkDerivation rec {
         component_version=$(cat unpacked/$component/manifest.xml | grep -oPm1 "(?<=<version>)[^<]+")
         component_core_id=$([ "$component" == "vmware-installer" ] && echo "-1" || echo "1")
         type=$([ "$component" == "vmware-workstation" ] && echo "0" || echo "1")
-        sqlite3 "$database_filename" "INSERT INTO components(name,version,buildNumber,component_core_id,longName,description,type) VALUES(\"$component\",\"$component_version\",\"${build}\",$component_core_id,\"$component\",\"$component\",$type);"
+        sqlite3 "$database_filename" "INSERT INTO components(name,version,buildNumber,component_core_id,longName,description,type) VALUES('$component','$component_version',${build},$component_core_id,'$component','$component',$type);"
         mkdir -p $out/etc/vmware-installer/components/$component
         cp -r $folder/* $out/etc/vmware-installer/components/$component
       done
@@ -255,9 +294,10 @@ stdenv.mkDerivation rec {
     unpacked="unpacked/vmware-network-editor"
     cp -r $unpacked/lib $out/lib/vmware/
 
-    ## VMware Tools
-    echo "Installing VMware Tools"
     mkdir -p $out/lib/vmware/isoimages/
+
+    ${lib.optionalString enableGuestTools ''
+    echo "Installing VMware Tools"
     cp unpacked/vmware-tools-linux/linux.iso \
        unpacked/vmware-tools-linuxPreGlibc25/linuxPreGlibc25.iso \
        unpacked/vmware-tools-netware/netware.iso \
@@ -266,6 +306,7 @@ stdenv.mkDerivation rec {
        unpacked/vmware-tools-winPreVista/winPreVista.iso \
        unpacked/vmware-tools-windows/windows.iso \
        $out/lib/vmware/isoimages/
+    ''}
 
     ${lib.optionalString enableMacOSGuests ''
       echo "Installing VMWare Tools for MacOS"


### PR DESCRIPTION
## Description of changes

This PR should close #310121

This derivation now uses https://softwareupdate.vmware.com as source, as of changes to distribution stated in [this blog](https://blogs.vmware.com/workstation/2024/05/vmware-workstation-pro-now-available-free-for-personal-use.html) 

Those changes by Broadcom causes derivation to become a little more complex by now needing to download all the components separately.
Many thanks to @kulczwoj for providing overlay that this PR was based on. 

Change in software itself are minor for now.

Also fixes SQLite INSERT INTO syntax.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
