### PR TITLE
PCBox: init at r14275.86b6d80

### DIFF
--- a/pkgs/applications/emulators/pcbox/default.nix
+++ b/pkgs/applications/emulators/pcbox/default.nix
@@ -1,0 +1,114 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  makeWrapper,
+  freetype,
+  SDL2,
+  glib,
+  pcre2,
+  openal,
+  rtmidi,
+  fluidsynth,
+  jack2,
+  alsa-lib,
+  qt5,
+  libvncserver,
+  discord-gamesdk,
+  libpcap,
+  libslirp,
+
+  enableDynarec ? with stdenv.hostPlatform; isx86 || isAarch,
+  enableNewDynarec ? enableDynarec && stdenv.hostPlatform.isAarch,
+  enableVncRenderer ? false,
+  unfreeEnableDiscord ? false,
+  unfreeEnableRoms ? false,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "PCBox";
+  version = "r14275.86b6d80";
+
+  src = fetchFromGitHub {
+    owner = "PCBox";
+    repo = "PCBox";
+    rev = "86b6d807a720daebc8fbaeac34d8c06dabf51dd2";
+    hash = "sha256-g5ZvcDGwccHV99BTmSjLTPT/eMyxSM6vOlqggODJXbM=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    makeWrapper
+    qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    freetype
+    fluidsynth
+    SDL2
+    glib
+    openal
+    rtmidi
+    pcre2
+    jack2
+    libpcap
+    libslirp
+    qt5.qtbase
+    qt5.qttools
+  ] ++ lib.optional stdenv.isLinux alsa-lib ++ lib.optional enableVncRenderer libvncserver;
+
+  cmakeFlags =
+    lib.optional stdenv.isDarwin "-DCMAKE_MACOSX_BUNDLE=OFF"
+    ++ lib.optional enableNewDynarec "-DNEW_DYNAREC=ON"
+    ++ lib.optional enableVncRenderer "-DVNC=ON"
+    ++ lib.optional (!enableDynarec) "-DDYNAREC=OFF"
+    ++ lib.optional (!unfreeEnableDiscord) "-DDISCORD=OFF";
+
+  postInstall =
+    lib.optionalString stdenv.isLinux ''
+      install -Dm644 $src/src/unix/assets/net.86box.86Box.desktop $out/share/applications/net.pcbox.PCBox.desktop
+      sed -i 's#Name=86Box#Name=PCBox#g' $out/share/applications/net.pcbox.PCBox.desktop
+      sed -i 's#Exec=86Box#Exec=PCBox -P .local/share/PCBox#g' $out/share/applications/net.pcbox.PCBox.desktop
+
+      for size in 48 64 72 96 128 192 256 512; do
+        install -Dm644 -t $out/share/icons/hicolor/"$size"x"$size"/apps \
+          $src/src/unix/assets/"$size"x"$size"/net.86box.86Box.png
+      done;
+    ''
+    + lib.optionalString unfreeEnableRoms ''
+      mkdir -p $out/share/PCBox
+      ln -s ${finalAttrs.passthru.roms} $out/share/PCBox/roms
+    '';
+
+  passthru = {
+    roms = fetchFromGitHub {
+      owner = "PCBox";
+      repo = "roms";
+      rev = "d2f9f57838f86e104d021b8acdb06aa8ce0fc222";
+      hash = "sha256-3plxCWNdmH2Q+oqTEpRzxBug1uUQNEAtEpR9fhko5N4=";
+    };
+  };
+
+  # Some libraries are loaded dynamically, but QLibrary doesn't seem to search
+  # the runpath, so use a wrapper instead.
+  preFixup =
+    let
+      libPath = lib.makeLibraryPath ([ libpcap ] ++ lib.optional unfreeEnableDiscord discord-gamesdk);
+      libPathVar = if stdenv.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
+    in
+    ''
+      makeWrapperArgs+=(--prefix ${libPathVar} : "${libPath}")
+    '';
+
+  meta = with lib; {
+    description = "Emulator of x86-based machines forked from 86Box.";
+    mainProgram = "PCBox";
+    homepage = "https://pcbox-emu.xyz/";
+    license = with licenses; [ gpl2Only ] ++ optional (unfreeEnableDiscord || unfreeEnableRoms) unfree;
+    maintainers = [ maintainers.syboxez ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2715,6 +2715,13 @@ with pkgs;
 
   packwiz = callPackage ../tools/games/minecraft/packwiz { };
 
+  PCBox = callPackage ../applications/emulators/pcbox { };
+
+  PCBox-with-roms = PCBox.override {
+    unfreeEnableRoms = true;
+    unfreeEnableDiscord = true;
+  };
+
   pcem = callPackage ../applications/emulators/pcem { };
 
   pcsx2 = qt6Packages.callPackage ../applications/emulators/pcsx2 { };


### PR DESCRIPTION
CC: @jchv @fuel-pcbox 

## Description of changes
This is mostly a copypasta of `pkgs/applications/emulators/86box`, changed to support the PCBox fork (which uses a rolling release model, hence the `revision.hash` style of versioning)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
