### PR TITLE
windows11-fonts: init at 10.0.26100.1742-3, windows10-fonts: init at 10.0.19045.2006-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23768,6 +23768,13 @@
     githubId = 1437166;
     name = "Xia Bin";
   };
+  sobte = {
+    matrix = "@sobte:matrix.org";
+    email = "nixos@sobte.me";
+    github = "Sobte";
+    githubId = 22280111;
+    name = "Sobte";
+  };
   sochotnicky = {
     email = "stanislav+github@ochotnicky.com";
     github = "sochotnicky";

--- a/pkgs/by-name/wi/windows10-fonts/languages.nix
+++ b/pkgs/by-name/wi/windows10-fonts/languages.nix
@@ -1,0 +1,164 @@
+{
+  default = [
+    "arial.ttf"
+    "arialbd.ttf"
+    "ariali.ttf"
+    "arialbi.ttf" # Arial
+    "ariblk.ttf" # Arial Black
+    "bahnschrift.ttf" # Bahnschrift
+    "calibri.ttf"
+    "calibrib.ttf"
+    "calibrii.ttf"
+    "calibriz.ttf" # Calibri
+    "calibril.ttf"
+    "calibrili.ttf" # Calibri Light
+    "cambria.ttc"
+    "cambriab.ttf"
+    "cambriai.ttf"
+    "cambriaz.ttf" # Cambria
+    "Candara.ttf"
+    "Candarab.ttf"
+    "Candarai.ttf"
+    "Candaraz.ttf" # Candara
+    "Candaral.ttf"
+    "Candarali.ttf" # Candara Light
+    "comic.ttf"
+    "comicbd.ttf"
+    "comici.ttf"
+    "comicz.ttf" # Comic Sans MS
+    "consola.ttf"
+    "consolab.ttf"
+    "consolai.ttf"
+    "consolaz.ttf" # Consolas
+    "constan.ttf"
+    "constanb.ttf"
+    "constani.ttf"
+    "constanz.ttf" # Constantia
+    "corbel.ttf"
+    "corbelb.ttf"
+    "corbeli.ttf"
+    "corbelz.ttf" # Corbel
+    "corbell.ttf"
+    "corbelli.ttf" # Corbel Light
+    "cour.ttf"
+    "courbd.ttf"
+    "couri.ttf"
+    "courbi.ttf" # Courier New
+    "framd.ttf"
+    "framdit.ttf" # Franklin Gothic Medium
+    "Gabriola.ttf" # Gabriola
+    "georgia.ttf"
+    "georgiab.ttf"
+    "georgiai.ttf"
+    "georgiaz.ttf" # Georgia
+    "impact.ttf" # Impact
+    "Inkfree.ttf" # Ink Free
+    "l_10646.ttf" # Lucida Sans Unicode
+    "lucon.ttf" # Lucida Console
+    "marlett.ttf" # Marlett
+    "micross.ttf" # Microsoft Sans Serifc
+    "pala.ttf"
+    "palab.ttf"
+    "palai.ttf"
+    "palabi.ttf" # Palatino Linotype
+    "segmdl2.ttf" # Segoe MDL2 Assets
+    "segoepr.ttf"
+    "segoeprb.ttf" # Segoe Print
+    "segoesc.ttf"
+    "segoescb.ttf" # Segoe Script
+    "segoeui.ttf"
+    "segoeuib.ttf"
+    "segoeuii.ttf"
+    "segoeuiz.ttf" # Segoe UI
+    "segoeuil.ttf"
+    "seguili.ttf" # Segoe UI Light
+    "segoeuisl.ttf"
+    "seguisli.ttf" # Segoe UI Semilight
+    "seguibl.ttf"
+    "seguibli.ttf" # Segoe UI Black
+    "seguiemj.ttf" # Segoe UI Emoji
+    "seguihis.ttf" # Segoe UI Historic
+    "seguisb.ttf"
+    "seguisbi.ttf" # Segoe UI Semibold
+    "seguisym.ttf" # Segoe UI Symbol
+    "sylfaen.ttf" # Sylfaen
+    "symbol.ttf" # Symbol
+    "tahoma.ttf"
+    "tahomabd.ttf" # Tahoma
+    "times.ttf"
+    "timesbd.ttf"
+    "timesi.ttf"
+    "timesbi.ttf" # Times New Roman
+    "trebuc.ttf"
+    "trebucbd.ttf"
+    "trebucit.ttf"
+    "trebucbi.ttf" # Trebuchet MS
+    "verdana.ttf"
+    "verdanab.ttf"
+    "verdanai.ttf"
+    "verdanaz.ttf" # Verdana
+    "webdings.ttf" # Webdings
+    "wingding.ttf" # Wingdings
+  ];
+
+  japanese = [
+    "msgothic.ttc" # MS Gothic
+    "YuGothR.ttc"
+    "YuGothB.ttc" # Yu Gothic
+    "YuGothM.ttc" # Yu Gothic Medium
+    "YuGothL.ttc" # Yu Gothic Light
+  ];
+
+  korean = [
+    "malgun.ttf"
+    "malgunbd.ttf" # Malgun Gothic
+    "malgunsl.ttf" # Malgun Gothic Semilight
+  ];
+
+  sea = [
+    "javatext.ttf" # Javanese Text
+    "himalaya.ttf" # Microsoft Himalaya
+    "ntailu.ttf"
+    "ntailub.ttf" # Microsoft New Tai Lue
+    "phagspa.ttf"
+    "phagspab.ttf" # Microsoft PhagsPa
+    "taile.ttf"
+    "taileb.ttf" # Microsoft Tai Le
+    "msyi.ttf" # Microsoft Yi Baiti
+    "monbaiti.ttf" # Mongolian Baiti
+    "mmrtext.ttf"
+    "mmrtextb.ttf" # Myanmar Text
+    "Nirmala.ttf"
+    "NirmalaB.ttf" # Nirmala UI
+    "NirmalaS.ttf" # Nirmala UI Semilight
+  ];
+
+  thai = [
+    "LeelawUI.ttf"
+    "LeelaUIb.ttf" # Leelawadee UI
+    "LeelUIsl.ttf" # Leelawadee UI Semilight
+  ];
+
+  zh_cn = [
+    "simsun.ttc" # NSimSun
+    "simsunb.ttf" # SimSun-ExtB
+    "msyh.ttc"
+    "msyhbd.ttc" # Microsoft YaHei
+    "msyhl.ttc" # Microsoft YaHei Light
+  ];
+
+  zh_tw = [
+    "msjh.ttc"
+    "msjhbd.ttc" # Microsoft JhengHei
+    "msjhl.ttc" # Microsoft JhengHei Light
+    "mingliub.ttc" # MingLiU_HKSCS-ExtB
+  ];
+
+  other = [
+    "ebrima.ttf"
+    "ebrimabd.ttf" # Ebrima
+    "gadugi.ttf"
+    "gadugib.ttf" # Gadugi
+    "mvboli.ttf" # MV Boli
+  ];
+}

--- a/pkgs/by-name/wi/windows10-fonts/package.nix
+++ b/pkgs/by-name/wi/windows10-fonts/package.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchurl,
+  windows11-fonts,
+}:
+(windows11-fonts.override {
+  languages = import ./languages.nix;
+  os = "Microsoft Windows 10";
+}).overrideAttrs
+  (
+    _: prev: {
+      pname = "windows10-fonts";
+      version = "10.0.19045.2006-1";
+      src = fetchurl {
+        url = "https://software-static.download.prss.microsoft.com/dbazure/988969d5-f34g-4e03-ac9d-1f9786c66750/19045.2006.220908-0225.22h2_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso";
+        hash = "sha256-bqeKy1+ojCwJdfZ2zEbKWTtDUYPIFbinxWHlbOkaajk=";
+        # Don't ever cache this
+        meta.license = lib.licenses.unfree;
+      };
+    }
+  )

--- a/pkgs/by-name/wi/windows11-fonts/languages.nix
+++ b/pkgs/by-name/wi/windows11-fonts/languages.nix
@@ -1,0 +1,166 @@
+{
+  default = [
+    "arial.ttf"
+    "arialbd.ttf"
+    "ariali.ttf"
+    "arialbi.ttf" # Arial
+    "ariblk.ttf" # Arial Black
+    "bahnschrift.ttf" # Bahnschrift
+    "calibri.ttf"
+    "calibrib.ttf"
+    "calibrii.ttf"
+    "calibriz.ttf" # Calibri
+    "calibril.ttf"
+    "calibrili.ttf" # Calibri Light
+    "cambria.ttc"
+    "cambriab.ttf"
+    "cambriai.ttf"
+    "cambriaz.ttf" # Cambria
+    "Candara.ttf"
+    "Candarab.ttf"
+    "Candarai.ttf"
+    "Candaraz.ttf" # Candara
+    "Candaral.ttf"
+    "Candarali.ttf" # Candara Light
+    "comic.ttf"
+    "comicbd.ttf"
+    "comici.ttf"
+    "comicz.ttf" # Comic Sans MS
+    "consola.ttf"
+    "consolab.ttf"
+    "consolai.ttf"
+    "consolaz.ttf" # Consolas
+    "constan.ttf"
+    "constanb.ttf"
+    "constani.ttf"
+    "constanz.ttf" # Constantia
+    "corbel.ttf"
+    "corbelb.ttf"
+    "corbeli.ttf"
+    "corbelz.ttf" # Corbel
+    "corbell.ttf"
+    "corbelli.ttf" # Corbel Light
+    "cour.ttf"
+    "courbd.ttf"
+    "couri.ttf"
+    "courbi.ttf" # Courier New
+    "framd.ttf"
+    "framdit.ttf" # Franklin Gothic Medium
+    "Gabriola.ttf" # Gabriola
+    "georgia.ttf"
+    "georgiab.ttf"
+    "georgiai.ttf"
+    "georgiaz.ttf" # Georgia
+    "impact.ttf" # Impact
+    "Inkfree.ttf" # Ink Free
+    "l_10646.ttf" # Lucida Sans Unicode
+    "lucon.ttf" # Lucida Console
+    "marlett.ttf" # Marlett
+    "micross.ttf" # Microsoft Sans Serifc
+    "pala.ttf"
+    "palab.ttf"
+    "palai.ttf"
+    "palabi.ttf" # Palatino Linotype
+    "segmdl2.ttf" # Segoe MDL2 Assets
+    "SegoeIcons.ttf" # Segoe Fluent Icons
+    "segoepr.ttf"
+    "segoeprb.ttf" # Segoe Print
+    "segoesc.ttf"
+    "segoescb.ttf" # Segoe Script
+    "segoeui.ttf"
+    "segoeuib.ttf"
+    "segoeuii.ttf"
+    "segoeuiz.ttf" # Segoe UI
+    "segoeuil.ttf"
+    "seguili.ttf" # Segoe UI Light
+    "segoeuisl.ttf"
+    "seguisli.ttf" # Segoe UI Semilight
+    "seguibl.ttf"
+    "seguibli.ttf" # Segoe UI Black
+    "seguiemj.ttf" # Segoe UI Emoji
+    "seguihis.ttf" # Segoe UI Historic
+    "seguisb.ttf"
+    "seguisbi.ttf" # Segoe UI Semibold
+    "seguisym.ttf" # Segoe UI Symbol
+    "SegUIVar.ttf" # Segoe UI Variable
+    "SitkaVF.ttf"
+    "SitkaVF-Italic.ttf" # Sitka
+    "sylfaen.ttf" # Sylfaen
+    "symbol.ttf" # Symbol
+    "tahoma.ttf"
+    "tahomabd.ttf" # Tahoma
+    "times.ttf"
+    "timesbd.ttf"
+    "timesi.ttf"
+    "timesbi.ttf" # Times New Roman
+    "trebuc.ttf"
+    "trebucbd.ttf"
+    "trebucit.ttf"
+    "trebucbi.ttf" # Trebuchet MS
+    "verdana.ttf"
+    "verdanab.ttf"
+    "verdanai.ttf"
+    "verdanaz.ttf" # Verdana
+    "webdings.ttf" # Webdings
+    "wingding.ttf" # Wingdings
+  ];
+
+  japanese = [
+    "msgothic.ttc" # MS Gothic
+    "YuGothR.ttc"
+    "YuGothB.ttc" # Yu Gothic
+    "YuGothM.ttc" # Yu Gothic Medium
+    "YuGothL.ttc" # Yu Gothic Light
+  ];
+
+  korean = [
+    "malgun.ttf"
+    "malgunbd.ttf" # Malgun Gothic
+    "malgunsl.ttf" # Malgun Gothic Semilight
+  ];
+
+  sea = [
+    "javatext.ttf" # Javanese Text
+    "himalaya.ttf" # Microsoft Himalaya
+    "ntailu.ttf"
+    "ntailub.ttf" # Microsoft New Tai Lue
+    "phagspa.ttf"
+    "phagspab.ttf" # Microsoft PhagsPa
+    "taile.ttf"
+    "taileb.ttf" # Microsoft Tai Le
+    "msyi.ttf" # Microsoft Yi Baiti
+    "monbaiti.ttf" # Mongolian Baiti
+    "mmrtext.ttf"
+    "mmrtextb.ttf" # Myanmar Text
+    "Nirmala.ttc" # Nirmala UI
+  ];
+
+  thai = [
+    "LeelawUI.ttf"
+    "LeelaUIb.ttf" # Leelawadee UI
+    "LeelUIsl.ttf" # Leelawadee UI Semilight
+  ];
+
+  zh_cn = [
+    "simsun.ttc" # NSimSun
+    "simsunb.ttf" # SimSun-ExtB
+    "msyh.ttc"
+    "msyhbd.ttc" # Microsoft YaHei
+    "msyhl.ttc" # Microsoft YaHei Light
+  ];
+
+  zh_tw = [
+    "msjh.ttc"
+    "msjhbd.ttc" # Microsoft JhengHei
+    "msjhl.ttc" # Microsoft JhengHei Light
+    "mingliub.ttc" # MingLiU_HKSCS-ExtB
+  ];
+
+  other = [
+    "ebrima.ttf"
+    "ebrimabd.ttf" # Ebrima
+    "gadugi.ttf"
+    "gadugib.ttf" # Gadugi
+    "mvboli.ttf" # MV Boli
+  ];
+}

--- a/pkgs/by-name/wi/windows11-fonts/package.nix
+++ b/pkgs/by-name/wi/windows11-fonts/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  p7zip,
+
+  languages ? import ./languages.nix,
+  os ? "Microsoft Windows 11",
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "windows11-fonts";
+  version = "10.0.26100.1742-3";
+
+  src = fetchurl {
+    url = "https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26100.1742.240906-0331.ge_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso";
+    hash = "sha256-dVqQ1D6CanS54ZMqNHiLiY4CgnJDm3d+VZPe6NU2Iq4=";
+    # Don't ever cache this
+    meta.license = lib.licenses.unfree;
+  };
+
+  sources = lib.mapAttrs (
+    name: lib.concatMapStringsSep " " (font: "Windows/Fonts/${font}")
+  ) languages;
+  outputs = [ "out" ] ++ builtins.attrNames finalAttrs.sources;
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ p7zip ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    7z x $src
+    7z x -aoa sources/install.wim Windows/{Fonts/"*".{ttf,ttc},System32/Licenses/neutral/"*"/"*"/license.rtf}
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype
+
+    for outputName in ''${!outputs[@]} ; do
+      install -Dm644 Windows/System32/Licenses/neutral/*/*/license.rtf -t ''${!outputName}/share/licenses
+
+      if [[ $outputName != "out" ]]; then
+        install -Dm644 ''${sources[$outputName]} -t ''${!outputName}/share/fonts/truetype
+        ln -s ''${!outputName}/share/fonts/truetype/*.{ttf,ttc} $out/share/fonts/truetype
+      fi
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Some TrueType fonts from ${os} (Arial, Bahnschrift, Calibri, ...)";
+    homepage = "https://learn.microsoft.com/typography/";
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ sobte ];
+
+    # Set a non-zero priority to allow easy overriding of the
+    # fontconfig configuration files.
+    priority = 5;
+  };
+})


### PR DESCRIPTION
## Description of changes
I want to add windows fonts, just like [vista-fonts](https://github.com/NixOS/nixpkgs/blob/master/pkgs/data/fonts/vista-fonts/default.nix) and [ttf-ms-win11-auto](https://aur.archlinux.org/packages/ttf-ms-win11-auto)

Sorry, I accidentally rebase. I'm really sorry. I didn't mean to do that. https://github.com/NixOS/nixpkgs/pull/313500

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
