### PR TITLE
llvmPackages.libcxx: remove option for external libcxx

### DIFF
--- a/pkgs/development/compilers/llvm/common/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/common/libcxx/default.nix
@@ -8,31 +8,17 @@
 , runCommand
 , substitute
 , cmake
-, lndir
 , ninja
 , python3
 , fixDarwinDylibNames
 , version
-, cxxabi ? null
-, libcxxrt
 , libunwind
 , enableShared ? !stdenv.hostPlatform.isStatic
 }:
 
-# note: our setup using libcxxabi instead of libcxxrt on FreeBSD diverges from
-# normal FreeBSD. This may cause issues with binary patching down the line.
-# If this becomes an issue, try adding as symlink libcxxrt.so -> libc++abi.so
-
-# external cxxabi is not supported on Darwin as the build will not link libcxx
-# properly and not re-export the cxxabi symbols into libcxx
-# https://github.com/NixOS/nixpkgs/issues/166205
-# https://github.com/NixOS/nixpkgs/issues/269548
-assert cxxabi == null || !stdenv.hostPlatform.isDarwin;
 let
   basename = "libcxx";
   pname = basename;
-  cxxabiName = "lib${if cxxabi == null then "cxxabi" else cxxabi.libName}";
-  runtimes = [ "libcxx" ] ++ lib.optional (cxxabi == null) "libcxxabi";
 
   # Note: useLLVM is likely false for Darwin but true under pkgsLLVM
   useLLVM = stdenv.hostPlatform.useLLVM or false;
@@ -40,19 +26,15 @@ let
   src' = if monorepoSrc != null then
     runCommand "${pname}-src-${version}" {} (''
       mkdir -p "$out/llvm"
-    '' + (lib.optionalString (lib.versionAtLeast release_version "14") ''
-      cp -r ${monorepoSrc}/cmake "$out"
-    '') + ''
       cp -r ${monorepoSrc}/libcxx "$out"
       cp -r ${monorepoSrc}/llvm/cmake "$out/llvm"
       cp -r ${monorepoSrc}/llvm/utils "$out/llvm"
-    '' + (lib.optionalString (lib.versionAtLeast release_version "14") ''
-      cp -r ${monorepoSrc}/third-party "$out"
-    '') + ''
       cp -r ${monorepoSrc}/runtimes "$out"
-    '' + (lib.optionalString (cxxabi == null) ''
       cp -r ${monorepoSrc}/libcxxabi "$out"
-    '')) else src;
+    '' + lib.optionalString (lib.versionAtLeast release_version "14") ''
+      cp -r ${monorepoSrc}/third-party "$out"
+      cp -r ${monorepoSrc}/cmake "$out"
+    '') else src;
 
   cxxabiCMakeFlags = lib.optionals (lib.versionAtLeast release_version "18") [
     "-DLIBCXXABI_USE_LLVM_UNWINDER=OFF"
@@ -70,15 +52,13 @@ let
   ];
 
   cxxCMakeFlags = [
-    "-DLIBCXX_CXX_ABI=${cxxabiName}"
-  ] ++ lib.optionals (cxxabi == null && lib.versionAtLeast release_version "16") [
+    "-DLIBCXX_CXX_ABI=libcxxabi"
+  ] ++ lib.optionals (lib.versionAtLeast release_version "16") [
     # Note: llvm < 16 doesn't support this flag (or it's broken); handled in postInstall instead.
     # Include libc++abi symbols within libc++.a for static linking libc++;
     # dynamic linking includes them through libc++.so being a linker script
     # which includes both shared objects.
     "-DLIBCXX_STATICALLY_LINK_ABI_IN_STATIC_LIBRARY=ON"
-  ] ++ lib.optionals (cxxabi != null) [
-    "-DLIBCXX_CXX_ABI_INCLUDE_PATHS=${lib.getDev cxxabi}/include"
   ] ++ lib.optionals (stdenv.hostPlatform.isMusl || stdenv.hostPlatform.isWasi) [
     "-DLIBCXX_HAS_MUSL_LIBC=1"
   ] ++ lib.optionals (lib.versionAtLeast release_version "18" && !useLLVM && stdenv.hostPlatform.libc == "glibc" && !stdenv.hostPlatform.isStatic) [
@@ -96,7 +76,7 @@ let
   ];
 
   cmakeFlags = [
-    "-DLLVM_ENABLE_RUNTIMES=${lib.concatStringsSep ";" runtimes}"
+    "-DLLVM_ENABLE_RUNTIMES=libcxx;libcxxabi"
   ] ++ lib.optionals (useLLVM && !stdenv.hostPlatform.isWasm) [
     # libcxxabi's CMake looks as though it treats -nostdlib++ as implying -nostdlib,
     # but that does not appear to be the case for example when building
@@ -108,7 +88,7 @@ let
     "-DCMAKE_CXX_COMPILER_WORKS=ON"
     "-DUNIX=ON" # Required otherwise libc++ fails to detect the correct linker
   ] ++ cxxCMakeFlags
-    ++ lib.optionals (cxxabi == null) cxxabiCMakeFlags;
+    ++ cxxabiCMakeFlags;
 
 in
 
@@ -124,33 +104,22 @@ stdenv.mkDerivation (rec {
   '';
 
   nativeBuildInputs = [ cmake ninja python3 ]
-    ++ lib.optional stdenv.isDarwin fixDarwinDylibNames
-    ++ lib.optional (cxxabi != null) lndir;
+    ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  buildInputs = [ cxxabi ]
-    ++ lib.optionals (useLLVM && !stdenv.hostPlatform.isWasm) [ libunwind ];
+  buildInputs = lib.optionals (useLLVM && !stdenv.hostPlatform.isWasm) [ libunwind ];
 
-  # libc++.so is a linker script which expands to multiple libraries,
-  # libc++.so.1 and libc++abi.so or the external cxxabi. ld-wrapper doesn't
-  # support linker scripts so the external cxxabi needs to be symlinked in
-  postInstall = lib.optionalString (cxxabi != null) ''
-    lndir ${lib.getDev cxxabi}/include $dev/include/c++/v1
-    lndir ${lib.getLib cxxabi}/lib $out/lib
-    libcxxabi=$out/lib/lib${cxxabi.libName}.a
-  ''
-  # LIBCXX_STATICALLY_LINK_ABI_IN_STATIC_LIBRARY=ON doesn't work for LLVM < 16 or
-  # external cxxabi libraries so merge libc++abi.a into libc++.a ourselves.
-
+  # LIBCXX_STATICALLY_LINK_ABI_IN_STATIC_LIBRARY=ON doesn't work for LLVM < 16 so
+  # merge libc++abi.a into libc++.a ourselves.
+  #
   # GNU binutils emits objects in LIFO order in MRI scripts so after the merge
   # the objects are in reversed order so a second MRI script is required so the
   # objects in the archive are listed in proper order (libc++.a, libc++abi.a)
-  + lib.optionalString (cxxabi != null || lib.versionOlder release_version "16") ''
-    libcxxabi=''${libcxxabi-$out/lib/libc++abi.a}
-    if [[ -f $out/lib/libc++.a && -e $libcxxabi ]]; then
+  postInstall = lib.optionalString (lib.versionOlder release_version "16") ''
+    if [[ -f $out/lib/libc++.a && -f $out/lib/libc++abi.a ]]; then
       $AR -M <<MRI
         create $out/lib/libc++.a
         addlib $out/lib/libc++.a
-        addlib $libcxxabi
+        addlib $out/lib/libc++abi.a
         save
         end
     MRI


### PR DESCRIPTION
## Description of changes

This patch was suggested by a, uh, now-deleted user at https://github.com/NixOS/nixpkgs/pull/311777#discussion_r1605547523

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
