### PR TITLE
xqilla,dbxml: fix clang and darwin builds

### DIFF
--- a/pkgs/development/libraries/dbxml/default.nix
+++ b/pkgs/development/libraries/dbxml/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
     "--with-berkeleydb=${db62.out}"
     "--with-xerces=${xercesc}"
     "--with-xqilla=${xqilla}"
+    # code uses register storage specifier
+    "CXXFLAGS=-std=c++14"
   ];
 
   preConfigure = ''

--- a/pkgs/development/tools/xqilla/default.nix
+++ b/pkgs/development/tools/xqilla/default.nix
@@ -17,7 +17,11 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  configureFlags = [ "--with-xerces=${xercesc}" ];
+  configureFlags = [
+    "--with-xerces=${xercesc}"
+    # code uses register storage specifier
+    "CXXFLAGS=-std=c++14"
+  ];
 
   meta = with lib; {
     description = "An XQuery and XPath 2 library and command line utility written in C++, implemented on top of the Xerces-C library";

--- a/pkgs/development/tools/xqilla/default.nix
+++ b/pkgs/development/tools/xqilla/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, xercesc }:
+{ lib, stdenv, fetchurl, fetchpatch, darwin, xercesc }:
 
 stdenv.mkDerivation rec {
   pname = "xqilla";
@@ -22,6 +22,13 @@ stdenv.mkDerivation rec {
     # code uses register storage specifier
     "CXXFLAGS=-std=c++14"
   ];
+
+  buildInputs = [
+    xercesc
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin (with darwin.apple_sdk.frameworks; [
+    CoreServices
+    SystemConfiguration
+  ]);
 
   meta = with lib; {
     description = "An XQuery and XPath 2 library and command line utility written in C++, implemented on top of the Xerces-C library";


### PR DESCRIPTION
*needs backport release-24.05 tag*

## Description of changes

use std=c++14 due to use of register storage specifier

add missing darwin frameworks

https://hydra.nixos.org/build/259654261
ZHF: https://github.com/NixOS/nixpkgs/issues/309482



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux w/ clang
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
