### PR TITLE
sway-contrib.grimshot: 0-unstable-2024-01-20 -> 0-unstable-2024-03-19

### DIFF
--- a/pkgs/applications/misc/sway-contrib/default.nix
+++ b/pkgs/applications/misc/sway-contrib/default.nix
@@ -9,6 +9,7 @@
 , slurp
 , grim
 , jq
+, gnugrep
 , bash
 
 , python3Packages
@@ -57,6 +58,7 @@ grimshot = stdenvNoCC.mkDerivation {
         slurp
         grim
         jq
+        gnugrep
         ] }"
   '';
 

--- a/pkgs/applications/misc/sway-contrib/default.nix
+++ b/pkgs/applications/misc/sway-contrib/default.nix
@@ -16,12 +16,12 @@
 }:
 
 let
-  version = "0-unstable-2024-01-20";
+  version = "0-unstable-2024-03-19";
   src = fetchFromGitHub {
     owner = "OctopusET";
     repo = "sway-contrib";
-    rev = "b7825b218e677c65f6849be061b93bd5654991bf";
-    hash = "sha256-ZTfItJ77mrNSzXFVcj7OV/6zYBElBj+1LcLLHxBFypk=";
+    rev = "5d33a290e3cac3f0fed38ff950939da28e3ebfd7";
+    hash = "sha256-2qYxkXowSSzVcpsPO4JoUqaH/VUkOOWu1RKFXp1CXGs=";
   };
 
   meta = with lib; {

--- a/pkgs/applications/misc/sway-contrib/default.nix
+++ b/pkgs/applications/misc/sway-contrib/default.nix
@@ -47,6 +47,7 @@ grimshot = stdenvNoCC.mkDerivation {
   buildInputs = [ bash ];
   installPhase = ''
     installManPage grimshot.1
+    installShellCompletion --cmd grimshot grimshot-completion.bash
 
     install -Dm 0755 grimshot $out/bin/grimshot
     wrapProgram $out/bin/grimshot --set PATH \


### PR DESCRIPTION
## Description of changes
- Added gnugrep to wrapper (fixes https://github.com/NixOS/nixpkgs/issues/315172)
-  sway-contrib.grimshot: 0-unstable-2024-01-20 -> 0-unstable-2024-03-19 (one new commit which includes bash completion: https://github.com/OctopusET/sway-contrib/commit/5d33a290e3cac3f0fed38ff950939da28e3ebfd7)
- Added bash shell-completion

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
