### PR TITLE
python3Packages.swh-*: init

### DIFF
--- a/pkgs/by-name/sw/swh/package.nix
+++ b/pkgs/by-name/sw/swh/package.nix
@@ -1,0 +1,24 @@
+{
+  python3Packages,
+  writeShellApplication,
+  withSwhPythonPackages ? [
+    python3Packages.swh-auth
+    python3Packages.swh-model
+    python3Packages.swh-scanner
+    python3Packages.swh-web-client
+  ],
+}:
+
+let
+  python3' = python3Packages.python.withPackages (ps: with ps; [ swh-core ] ++ withSwhPythonPackages);
+in
+writeShellApplication {
+  name = "swh";
+  text = ''
+    ${python3'}/bin/swh "$@"
+  '';
+  meta = {
+    inherit (python3Packages.swh-core.meta) license mainProgram platforms;
+    description = "Software Heritage command-line client";
+  };
+}

--- a/pkgs/development/python-modules/attrs-strict/default.nix
+++ b/pkgs/development/python-modules/attrs-strict/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  attrs,
+  setuptools,
+  setuptools-scm,
+}:
+
+buildPythonPackage rec {
+  pname = "attrs-strict";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "attrs_strict";
+    hash = "sha256-5wSGNiAUbF8qi2Ac1FdNFIkT2yb8Bjb5Qf5CEuQl6v4=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    attrs
+  ];
+
+  pythonImportsCheck = [ "attrs_strict" ];
+
+  # No tests in the pypi archive
+  doCheck = false;
+
+  meta = {
+    changelog = "https://github.com/bloomberg/attrs-strict/releases/tag/${version}";
+    description = "Python package which contains runtime validation for attrs data classes based on the types existing in the typing module";
+    homepage = "https://github.com/bloomberg/attrs-strict";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ drupol ];
+  };
+}

--- a/pkgs/development/python-modules/mirakuru/default.nix
+++ b/pkgs/development/python-modules/mirakuru/default.nix
@@ -51,11 +51,14 @@ buildPythonPackage rec {
   # > ps: vsz: requires entitlement
   # > ps: rss: requires entitlement
   # > ps: time: requires entitlement
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
-    "test_forgotten_stop"
-    "test_mirakuru_cleanup"
-    "test_daemons_killing"
-  ];
+  disabledTests =
+    [
+      "test_forgotten_stop"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      "test_mirakuru_cleanup"
+      "test_daemons_killing"
+    ];
 
   meta = with lib; {
     homepage = "https://pypi.org/project/mirakuru";

--- a/pkgs/development/python-modules/swh-auth/default.nix
+++ b/pkgs/development/python-modules/swh-auth/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitLab,
+  setuptools,
+  setuptools-scm,
+  click,
+  python-keycloak,
+  python-jose,
+  pyyaml,
+  swh-core,
+  aiocache,
+  httpx,
+  pytestCheckHook,
+  pytest-django,
+  pytest-mock,
+  djangorestframework,
+  starlette,
+}:
+
+buildPythonPackage rec {
+  pname = "swh-auth";
+  version = "0.10.0";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    domain = "gitlab.softwareheritage.org";
+    group = "swh";
+    owner = "devel";
+    repo = "swh-auth";
+    tag = "v${version}";
+    hash = "sha256-8ctd5D7zT66oVNZlvRIs8pN7Fe2BhTgC+S9p1HBDO9E=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    click
+    python-keycloak
+    python-jose
+    pyyaml
+    swh-core
+  ];
+
+  pythonImportsCheck = [ "swh.auth" ];
+
+  nativeCheckInputs = [
+    aiocache
+    djangorestframework
+    httpx
+    pytestCheckHook
+    pytest-django
+    pytest-mock
+    starlette
+  ];
+
+  meta = {
+    description = "Set of utility libraries related to user authentication in applications and services based on the use of Keycloak and OpenID Connect";
+    homepage = "https://gitlab.softwareheritage.org/swh/devel/swh-auth";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ drupol ];
+  };
+}

--- a/pkgs/development/python-modules/swh-core/default.nix
+++ b/pkgs/development/python-modules/swh-core/default.nix
@@ -1,0 +1,127 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitLab,
+  backports-entry-points-selectable,
+  click,
+  deprecated,
+  python-magic,
+  pyyaml,
+  requests,
+  sentry-sdk_2,
+  tenacity,
+  setuptools,
+  setuptools-scm,
+  flask,
+  hypothesis,
+  iso8601,
+  lzip,
+  msgpack,
+  psycopg,
+  pylzma,
+  pytestCheckHook,
+  pytest-aiohttp,
+  pytest-mock,
+  pytest-postgresql,
+  pytz,
+  requests-mock,
+  types-deprecated,
+  types-psycopg2,
+  types-pytz,
+  types-pyyaml,
+  types-requests,
+  unzip,
+  pkgs, # Only for pkgs.zstd
+}:
+
+buildPythonPackage rec {
+  pname = "swh-core";
+  version = "4.0.0";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    domain = "gitlab.softwareheritage.org";
+    group = "swh";
+    owner = "devel";
+    repo = "swh-core";
+    tag = "v${version}";
+    hash = "sha256-kO4B25+oQrQ9sxmKJ5NMKTCCGztRaArFtD7QA8Bytts=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    backports-entry-points-selectable
+    click
+    deprecated
+    python-magic
+    pyyaml
+    requests
+    sentry-sdk_2
+    tenacity
+  ];
+
+  pythonImportsCheck = [ "swh.core" ];
+
+  __darwinAllowLocalNetworking = true;
+
+  nativeCheckInputs = [
+    flask
+    hypothesis
+    iso8601
+    lzip
+    msgpack
+    psycopg
+    pylzma
+    pytestCheckHook
+    pytest-aiohttp
+    pytest-mock
+    pytest-postgresql
+    pytz
+    requests-mock
+    types-deprecated
+    types-psycopg2
+    types-pytz
+    types-pyyaml
+    types-requests
+    unzip
+    pkgs.zstd
+  ];
+
+  disabledTests =
+    [
+      # ValueError: Unable to configure handler 'systemd'
+      "test_logging_configure_from_yaml"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
+      # FileExistsError: [Errno 17] File exists:
+      "test_uncompress_upper_archive_extension"
+      # AssertionError: |500 - 632.1152460000121| not within 100
+      "test_timed_coroutine"
+      "test_timed_start_stop_calls"
+      "test_timed"
+      "test_timed_no_metric"
+    ];
+
+  disabledTestPaths = [
+    # ModuleNotFoundError: No module named 'aiohttp_utils'
+    "swh/core/api/tests/test_async.py"
+    "swh/core/api/tests/test_rpc_server_asynchronous.py"
+    # ModuleNotFoundError: No module named 'systemd'
+    "swh/core/tests/test_logger.py"
+    # ModuleNotFoundError: No module named 'psycopg_pool'
+    "swh/core/db/tests"
+  ];
+
+  meta = {
+    description = "Low-level utilities and helpers used by almost all other modules in the stack";
+    homepage = "https://gitlab.softwareheritage.org/swh/devel/swh-core";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "swh";
+    maintainers = with lib.maintainers; [ drupol ];
+  };
+}

--- a/pkgs/development/python-modules/swh-model/default.nix
+++ b/pkgs/development/python-modules/swh-model/default.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitLab,
+  setuptools,
+  setuptools-scm,
+  attrs,
+  attrs-strict,
+  dateutils,
+  deprecated,
+  hypothesis,
+  iso8601,
+  typing-extensions,
+  click,
+  dulwich,
+  aiohttp,
+  pytestCheckHook,
+  pytz,
+  types-click,
+  types-python-dateutil,
+  types-pytz,
+  types-deprecated,
+
+}:
+
+buildPythonPackage rec {
+  pname = "swh-model";
+  version = "7.1.0";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    domain = "gitlab.softwareheritage.org";
+    group = "swh";
+    owner = "devel";
+    repo = "swh-model";
+    tag = "v${version}";
+    hash = "sha256-I0DaSipE5TVFqAdGkNo4e66l1x4A26EYk0F4tKMy33k=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    attrs
+    attrs-strict
+    click
+    dulwich
+    dateutils
+    deprecated
+    hypothesis
+    iso8601
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "swh.model" ];
+
+  nativeCheckInputs = [
+    aiohttp
+    click
+    pytestCheckHook
+    pytz
+    types-click
+    types-python-dateutil
+    types-pytz
+    types-deprecated
+  ];
+
+  pytestFlagsArray = lib.optionals (stdenv.hostPlatform.isDarwin) [
+    # OSError: [Errno 92] Illegal byte sequence
+    "--deselect swh/model/tests/test_cli.py::TestIdentify::test_exclude"
+    "--deselect swh/model/tests/test_from_disk.py::DirectoryToObjects::test_exclude"
+    "--deselect swh/model/tests/test_from_disk.py::DirectoryToObjects::test_exclude_trailing"
+  ];
+
+  meta = {
+    description = "Implementation of the Data model of the Software Heritage project, used to archive source code artifacts";
+    homepage = "https://gitlab.softwareheritage.org/swh/devel/swh-model";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ drupol ];
+  };
+}

--- a/pkgs/development/python-modules/swh-scanner/default.nix
+++ b/pkgs/development/python-modules/swh-scanner/default.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitLab,
+  setuptools,
+  setuptools-scm,
+  requests,
+  ndjson,
+  flask,
+  importlib-metadata,
+  swh-core,
+  swh-model,
+  swh-auth,
+  swh-web-client,
+  beautifulsoup4,
+  pytestCheckHook,
+  pytest-flask,
+  pytest-mock,
+  types-beautifulsoup4,
+  types-pyyaml,
+  types-requests,
+}:
+
+buildPythonPackage rec {
+  pname = "swh-scanner";
+  version = "0.8.3";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    domain = "gitlab.softwareheritage.org";
+    group = "swh";
+    owner = "devel";
+    repo = "swh-scanner";
+    tag = "v${version}";
+    hash = "sha256-baUUuYFapBD7iuDaDP8CSR9f4glVZcS5qBpZddVf7z8=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    requests
+    ndjson
+    flask
+    importlib-metadata
+    swh-core
+    swh-model
+    swh-auth
+    swh-web-client
+  ];
+
+  pythonImportsCheck = [ "swh.scanner" ];
+
+  nativeCheckInputs = [
+    beautifulsoup4
+    pytestCheckHook
+    pytest-flask
+    pytest-mock
+    swh-core
+    swh-model
+    types-beautifulsoup4
+    types-pyyaml
+    types-requests
+  ];
+
+  disabledTests = [
+    # AttributeError: 'called_once' is not a valid assertion. Use a spec for the mock if 'called_once' is meant to be an attribute.
+    "test_scan_api_url_option_success"
+  ];
+
+  disabledTestPaths = [
+    # pytestRemoveBytecodePhase fails with: "error (ignored): error: opening directory "/tmp/nix-build-python3.12-swh-scanner-0.8.3.drv-5/build/pytest-of-nixbld/pytest-0/test_randomdir_policy_info_cal0/big-directory/dir/dir/dir/ ......"
+    "swh/scanner/tests/test_policy.py"
+  ];
+
+  meta = {
+    description = "Implementation of the Data model of the Software Heritage project, used to archive source code artifacts";
+    homepage = "https://gitlab.softwareheritage.org/swh/devel/swh-model";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ drupol ];
+  };
+}

--- a/pkgs/development/python-modules/swh-web-client/default.nix
+++ b/pkgs/development/python-modules/swh-web-client/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitLab,
+  setuptools,
+  setuptools-scm,
+  click,
+  dateutils,
+  requests,
+  swh-auth,
+  swh-core,
+  swh-model,
+  pytestCheckHook,
+  pytest-mock,
+  requests-mock,
+  types-python-dateutil,
+  types-pyyaml,
+  types-requests,
+}:
+
+buildPythonPackage rec {
+  pname = "swh-web-client";
+  version = "0.9.0";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    domain = "gitlab.softwareheritage.org";
+    group = "swh";
+    owner = "devel";
+    repo = "swh-web-client";
+    tag = "v${version}";
+    hash = "sha256-/h3TaEwo2+B89KFpIKi9LH0tlGplsv3y18pC0TKM0jA=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    click
+    dateutils
+    requests
+    swh-auth
+    swh-core
+    swh-model
+  ];
+
+  pythonImportsCheck = [ "swh.web.client" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-mock
+    requests-mock
+    types-python-dateutil
+    types-pyyaml
+    types-requests
+  ];
+
+  meta = {
+    description = "Client for Software Heritage Web applications, via their APIs";
+    homepage = "https://gitlab.softwareheritage.org/swh/devel/swh-web-client";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ drupol ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17349,6 +17349,8 @@ self: super: with self; {
 
   swagger-ui-bundle = callPackage ../development/python-modules/swagger-ui-bundle { };
 
+  swh-core = callPackage ../development/python-modules/swh-core { };
+
   swh-model = callPackage ../development/python-modules/swh-model { };
 
   swift = callPackage ../development/python-modules/swift { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17349,6 +17349,8 @@ self: super: with self; {
 
   swagger-ui-bundle = callPackage ../development/python-modules/swagger-ui-bundle { };
 
+  swh-model = callPackage ../development/python-modules/swh-model { };
+
   swift = callPackage ../development/python-modules/swift { };
 
   swifter = callPackage ../development/python-modules/swifter { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1053,6 +1053,8 @@ self: super: with self; {
 
   attrs = callPackage ../development/python-modules/attrs { };
 
+  attrs-strict = callPackage ../development/python-modules/attrs-strict { };
+
   aubio = callPackage ../development/python-modules/aubio { };
 
   audible = callPackage ../development/python-modules/audible { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17355,6 +17355,8 @@ self: super: with self; {
 
   swh-model = callPackage ../development/python-modules/swh-model { };
 
+  swh-scanner = callPackage ../development/python-modules/swh-scanner { };
+
   swh-web-client = callPackage ../development/python-modules/swh-web-client { };
 
   swift = callPackage ../development/python-modules/swift { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17349,6 +17349,8 @@ self: super: with self; {
 
   swagger-ui-bundle = callPackage ../development/python-modules/swagger-ui-bundle { };
 
+  swh-auth = callPackage ../development/python-modules/swh-auth { };
+
   swh-core = callPackage ../development/python-modules/swh-core { };
 
   swh-model = callPackage ../development/python-modules/swh-model { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17355,6 +17355,8 @@ self: super: with self; {
 
   swh-model = callPackage ../development/python-modules/swh-model { };
 
+  swh-web-client = callPackage ../development/python-modules/swh-web-client { };
+
   swift = callPackage ../development/python-modules/swift { };
 
   swifter = callPackage ../development/python-modules/swifter { };


### PR DESCRIPTION
This PR:

- Package some `swh-*` python modules: https://gitlab.softwareheritage.org/swh/devel/
- Package `attrs-strict`, required by `swh-model`: https://pypi.org/project/attrs-strict/

Status: all good !

![image](https://github.com/user-attachments/assets/a7c048b7-bae4-4117-b163-8c44781d3c6d)

Quickly test with: nix shell --impure --expr 'let pkgs = import (builtins.getFlake "github:drupol/nixpkgs/init/swh-model") { }; in pkgs.python3.withPackages (ps: with ps; [ swh-core swh-scanner ])'

Ping @zacchiro for review

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
