### PR TITLE
lib.strings: add `trim`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -105,7 +105,7 @@ let
       hasInfix hasPrefix hasSuffix stringToCharacters stringAsChars escape
       escapeShellArg escapeShellArgs
       isStorePath isStringLike
-      isValidPosixName toShellVar toShellVars
+      isValidPosixName toShellVar toShellVars trim trimWith
       escapeRegex escapeURL escapeXML replaceChars lowerChars
       upperChars toLower toUpper addContextFrom splitString
       removePrefix removeSuffix versionOlder versionAtLeast

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -369,6 +369,72 @@ runTests {
     expected = "hellohellohellohellohello";
   };
 
+  # Test various strings are trimmed correctly
+  testTrimString = {
+    expr =
+    let
+      testValues = f: mapAttrs (_: f) {
+        empty = "";
+        cr = "\r";
+        lf = "\n";
+        tab = "\t";
+        spaces = "   ";
+        leading = "  Hello, world";
+        trailing = "Hello, world   ";
+        mixed = " Hello, world ";
+        mixed-tabs = " \t\tHello, world \t \t ";
+        multiline = "  Hello,\n  world!  ";
+        multiline-crlf = "  Hello,\r\n  world!  ";
+      };
+    in
+      {
+        leading = testValues (strings.trimWith { start = true; });
+        trailing = testValues (strings.trimWith { end = true; });
+        both = testValues strings.trim;
+      };
+    expected = {
+      leading = {
+        empty = "";
+        cr = "";
+        lf = "";
+        tab = "";
+        spaces = "";
+        leading = "Hello, world";
+        trailing = "Hello, world   ";
+        mixed = "Hello, world ";
+        mixed-tabs = "Hello, world \t \t ";
+        multiline = "Hello,\n  world!  ";
+        multiline-crlf = "Hello,\r\n  world!  ";
+      };
+      trailing = {
+        empty = "";
+        cr = "";
+        lf = "";
+        tab = "";
+        spaces = "";
+        leading = "  Hello, world";
+        trailing = "Hello, world";
+        mixed = " Hello, world";
+        mixed-tabs = " \t\tHello, world";
+        multiline = "  Hello,\n  world!";
+        multiline-crlf = "  Hello,\r\n  world!";
+      };
+      both = {
+        empty = "";
+        cr = "";
+        lf = "";
+        tab = "";
+        spaces = "";
+        leading = "Hello, world";
+        trailing = "Hello, world";
+        mixed = "Hello, world";
+        mixed-tabs = "Hello, world";
+        multiline = "Hello,\n  world!";
+        multiline-crlf = "Hello,\r\n  world!";
+      };
+    };
+  };
+
   testSplitStringsSimple = {
     expr = strings.splitString "." "a.b.c.d";
     expected = [ "a" "b" "c" "d" ];


### PR DESCRIPTION
`strings.trim` returns a copy of the string with all leading and trailing whitespace removed.

`strings.trimWith` does the same thing, but calling code can decide whether to trim the start and/or end of the string.

The obvious regex `[[:string:]]*(.*)[[:string:]]*` wouldn't work, because the `(.*)` is greedy and matches trailing whitespace. Since [ERE](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_04) doesn't support lazy/reluctant matches (`.*?`) introduced in perl-style regexes, we need to use a regex that fails to match blank/empty strings. This case is handled using `optionalString`.

## Description of changes

`trim` is a fairly core function included in most standard libraries. I've personally come across a couple scenarios where I would've liked to have been able to trim strings.

I've added a few basic tests.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Pinging recent contributors to lib.string: @infinisil @AndersonTorres @FireyFly @eclairevoyant @h7x4

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
