### PR TITLE
Add "/run/opengl-driver" to jellyfin runtimeDeps

### DIFF
--- a/pkgs/servers/jellyfin/default.nix
+++ b/pkgs/servers/jellyfin/default.nix
@@ -29,6 +29,7 @@ buildDotnetModule rec {
   executables = [ "jellyfin" ];
   nugetDeps = ./nuget-deps.nix;
   runtimeDeps = [
+    "/run/opengl-driver"
     ffmpeg
     fontconfig
     freetype


### PR DESCRIPTION

## Description of changes

Add `"/run/opengl-driver"` to jellyfin server `runtimeDeps`.

This allows intel-media-sdk in the ffmpeg transcoding process spawned by jellyfin to find and load the
`libmfx-gen.so.1.2` from onevpl-intel-gpu if it's included in `hardware.opengl.extraPackages`.

## Workarounds

Adding an overlay with `jellyfin-ffmpeg.override { withVpl = true; withMfx = false}` should therefore not be required anymore.

If you're currently using an overlay like that you might want to try this overlay instead as builds considerably faster:
```nix
final: prev: {
  jellyfin = prev.jellyfin.overrideAttrs (finalAttrs: prevAttrs: {
    makeWrapperArgs = (prevAttrs.makeWrapperArgs or []) ++ ["--suffix LD_LIBRARY_PATH : /run/opengl-driver/lib"];
  });
}
```

## "Worse" approaches

- Adding `"/run/opengl-driver/lib"` to the ffmpeg `LD_LIBRARY_PATH` as a general hack was discarded: https://github.com/NixOS/nixpkgs/pull/264621#issuecomment-1963569055
- We could add an `LD_LIBRARY_PATH` only to `jellyfin-ffmpeg` but that's also a hack.

## A better approach?

This causes more rebuilds, so I opted to do the simple fix above for now.

We could add a patch to `intel-media-sdk` here: https://github.com/Intel-Media-SDK/MediaSDK/blob/7a72de33a15d6e7cdb842b12b901a003f7154f0a/api/mfx_dispatch/linux/mfxloader.cpp#L192-L216

This is an example patch that seems to work: [nixos-search-onevplrt-in-run-opengl-driver-lib.patch](https://github.com/NixOS/nixpkgs/files/15473862/nixos-search-onevplrt-in-run-opengl-driver-lib.patch.txt)

This would be the `intel-media-sdk` equivalent to https://github.com/NixOS/nixpkgs/pull/291559.

## Tags for interest

@RyanGibb 
@evanrichter
@Atemu 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
