### PR TITLE
intel-media-sdk: Search ONEVPLRT in /run/opengl-driver/lib

### DIFF
--- a/pkgs/development/libraries/intel-media-sdk/default.nix
+++ b/pkgs/development/libraries/intel-media-sdk/default.nix
@@ -13,6 +13,9 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Search oneVPL-intel-gpu in NixOS specific /run/opengl-driver/lib directory
+    # See https://github.com/NixOS/nixpkgs/pull/315425
+    ./nixos-search-onevplrt-in-run-opengl-driver-lib.patch
     # https://github.com/Intel-Media-SDK/MediaSDK/pull/3005
     (fetchpatch {
       name = "include-cstdint-explicitly.patch";

--- a/pkgs/development/libraries/intel-media-sdk/nixos-search-onevplrt-in-run-opengl-driver-lib.patch
+++ b/pkgs/development/libraries/intel-media-sdk/nixos-search-onevplrt-in-run-opengl-driver-lib.patch
@@ -1,0 +1,45 @@
+From aceb689ae69857def8a26a8d1ceb114ccfbb2569 Mon Sep 17 00:00:00 2001
+From: Philipp Jungkamp <p.jungkamp@gmx.net>
+Date: Tue, 28 May 2024 19:22:29 +0200
+Subject: [PATCH] NixOS: Search ONEVPLRT in /run/opengl-driver/lib
+
+---
+ api/mfx_dispatch/linux/mfxloader.cpp                            | 2 ++
+ .../suites/mfx_dispatch/linux/mfx_dispatch_test_cases_libs.cpp  | 1 +
+ 2 files changed, 3 insertions(+)
+
+diff --git a/api/mfx_dispatch/linux/mfxloader.cpp b/api/mfx_dispatch/linux/mfxloader.cpp
+index 39b6bff1..f76ed65d 100644
+--- a/api/mfx_dispatch/linux/mfxloader.cpp
++++ b/api/mfx_dispatch/linux/mfxloader.cpp
+@@ -193,6 +193,7 @@ mfxStatus LoaderCtx::Init(mfxInitParam& par)
+   if (selected_runtime && strcmp(selected_runtime, "ONEVPL") == 0) {
+     libs.emplace_back(ONEVPLRT);
+     libs.emplace_back(MFX_MODULES_DIR "/" ONEVPLRT);
++    libs.emplace_back("/run/opengl-driver/lib/" ONEVPLRT);
+   } else if ((selected_runtime && strcmp(selected_runtime, "MSDK") == 0) || (platform != MFX_HW_UNKNOWN)) {
+     if (MFX_IMPL_BASETYPE(par.Implementation) == MFX_IMPL_AUTO ||
+         MFX_IMPL_BASETYPE(par.Implementation) == MFX_IMPL_AUTO_ANY) {
+@@ -213,6 +214,7 @@ mfxStatus LoaderCtx::Init(mfxInitParam& par)
+   } else {
+     libs.emplace_back(ONEVPLRT);
+     libs.emplace_back(MFX_MODULES_DIR "/" ONEVPLRT);
++    libs.emplace_back("/run/opengl-driver/lib/" ONEVPLRT);
+   }
+ 
+   mfxStatus mfx_res = MFX_ERR_UNSUPPORTED;
+diff --git a/tests/unit/suites/mfx_dispatch/linux/mfx_dispatch_test_cases_libs.cpp b/tests/unit/suites/mfx_dispatch/linux/mfx_dispatch_test_cases_libs.cpp
+index dedee0b3..9657da4b 100644
+--- a/tests/unit/suites/mfx_dispatch/linux/mfx_dispatch_test_cases_libs.cpp
++++ b/tests/unit/suites/mfx_dispatch/linux/mfx_dispatch_test_cases_libs.cpp
+@@ -123,6 +123,7 @@ TEST_P(DispatcherLibsTestParametrized, ShouldEnumerateCorrectLibNames)
+     {
+         libs.emplace_back(ONEVPLRT);
+         libs.emplace_back(modules_dir + "/" + ONEVPLRT);
++        libs.emplace_back("/run/opengl-driver/lib/" + ONEVPLRT);
+     }
+ 
+     for (const std::string& lib : libs)
+-- 
+2.44.0
+


### PR DESCRIPTION
## Description of changes

This allows `intel-media-sdk` to dispatch to `onevpl-intel-gpu` if that was added to `hardware.opengl.extraPackages` on NixOS. This allows e.g. jellyfin and other ffmpeg consumers to use Intel Quick Sync Video on Alder Lake and newer graphics platforms.

This is the alternative approach to https://github.com/NixOS/nixpkgs/pull/315415 and enables QSV on Alder Lake (and newer) platforms for all `intel-media-sdk` users instead of only `jellyfin`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
