### PR TITLE
zsa-udev-rules: enable udev rules for keyboards with old firmware

### DIFF
--- a/pkgs/os-specific/linux/zsa-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/zsa-udev-rules/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/lib/udev/rules.d
     cp dist/linux64/50-oryx.rules $out/lib/udev/rules.d/
+    cp dist/linux64/50-oryx-legacy.rules $out/lib/udev/rules.d/
     cp dist/linux64/50-wally.rules $out/lib/udev/rules.d/
   '';
 


### PR DESCRIPTION
## Description of changes

Some ZSA keyboards come with older firmware, which requires a different set of udev rules. I've just received mine and tried to install zsa-udev-rules in hopes that it would work with Chrome-based firmware flasher. But it didn't work.

I digged a little bit and found out that zsa-udev-rules only installs a subset of the udev rules that are present in the upstream repository. This is because for most people as soon as you flash your keyboard once, it gets updated to firmware version 21+ for which the new rules work. I guess the original author has already flashed their keyboard when they were working on the contribution of the udev rules.

But if your keyboard is new, it is likely that it has the older version of firmware, because the manufacturer doesn't update their existing inventory.

With this diff I'm adding "50-oryx-legacy.rules" file to fix the problem. It shouldn't make any difference for other users, as it won't match anything with new firmware.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
