### PR TITLE
python3Packages.tpm2-pytss: bring fix for tpm2-tss 4.1

### DIFF
--- a/pkgs/development/python-modules/tpm2-pytss/default.nix
+++ b/pkgs/development/python-modules/tpm2-pytss/default.nix
@@ -40,10 +40,9 @@ buildPythonPackage rec {
     [
       # Fix hardcoded `fapi-config.json` configuration path
       ./fapi-config.patch
-      (fetchurl {
-        url = "https://github.com/tpm2-software/tpm2-pytss/pull/571/commits/b02fdc8e259fe977c1065389c042be69e2985bdf.patch";
-        hash = "sha256-+jZFv+s9p52JxtUcNeJx7ayzKDVtPoQSSGgyZqPDuEc=";
-      })
+      # Backport for https://github.com/tpm2-software/tpm2-pytss/pull/576
+      # This is likely to be dropped with the next major release (>= 2.3)
+      ./pr576-backport.patch
     ]
     ++ lib.optionals isCross [
       # pytss will regenerate files from headers of tpm2-tss.

--- a/pkgs/development/python-modules/tpm2-pytss/pr576-backport.patch
+++ b/pkgs/development/python-modules/tpm2-pytss/pr576-backport.patch
@@ -1,0 +1,117 @@
+Backport for https://github.com/tpm2-software/tpm2-pytss/pull/576 on 2.2.1
+
+diff --git a/scripts/prepare_headers.py b/scripts/prepare_headers.py
+index 6ca9b64..a7529b3 100644
+--- a/scripts/prepare_headers.py
++++ b/scripts/prepare_headers.py
+@@ -32,6 +32,7 @@ def remove_common_guards(s):
+ 
+     # Restructure #defines with ...
+     s = re.sub("(#define [A-Za-z0-9_]+) +\(\(.*?\) \(.*?\)\)", "\g<1>...", s)
++    s = re.sub("(#define [A-Za-z0-9_]+) +\(\(\(.*?\) .*\)", "\g<1>...", s)
+     s = re.sub("(#define [A-Za-z0-9_]+) +\(\(.*?\).*?\) ", "\g<1>...", s)
+     s = re.sub(
+         "(#define [A-Za-z0-9_]+) .*\n.*?.*\)\)", "\g<1>...", s, flags=re.MULTILINE
+diff --git a/src/tpm2_pytss/internal/crypto.py b/src/tpm2_pytss/internal/crypto.py
+index 42030c5..f9d8c34 100644
+--- a/src/tpm2_pytss/internal/crypto.py
++++ b/src/tpm2_pytss/internal/crypto.py
+@@ -25,6 +25,7 @@ from cryptography.hazmat.backends import default_backend
+ from cryptography.exceptions import UnsupportedAlgorithm, InvalidSignature
+ from typing import Tuple, Type, Any
+ import secrets
++import inspect
+ import sys
+ 
+ _curvetable = (
+diff --git a/test/test_encoding.py b/test/test_encoding.py
+index 1f58562..8cf4b51 100644
+--- a/test/test_encoding.py
++++ b/test/test_encoding.py
+@@ -1406,7 +1406,7 @@ class ToolsTest(TSS2_BaseTest):
+     def test_tools_decode_tpm2b_name(self):
+         if not self.has_tools:
+             self.skipTest("tools not in path")
+-        key = ec.generate_private_key(ec.SECP256R1).public_key()
++        key = ec.generate_private_key(ec.SECP256R1()).public_key()
+         kb = key.public_bytes(
+             serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+         )
+diff --git a/test/test_fapi.py b/test/test_fapi.py
+index f702fc9..6b77c66 100644
+--- a/test/test_fapi.py
++++ b/test/test_fapi.py
+@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives.asymmetric.padding import PSS
+ 
+ from tpm2_pytss import *
+ 
+-from tpm2_pytss.internal.utils import is_bug_fixed, _lib_version_atleast
++from tpm2_pytss.internal.utils import is_bug_fixed
+ 
+ from .TSS2_BaseTest import TpmSimulator
+ from tpm2_pytss.TSS2_Exception import TSS2_Exception
+@@ -614,8 +614,7 @@ class Common:
+         self.fapi.sign(key_path, b"\x22" * 32)
+ 
+     @pytest.mark.skipif(
+-        _lib_version_atleast("tss2-fapi", "4.0.1-170")
+-        or not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
++        not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
+         reason="tpm2-tss bug, see #2084",
+     )
+     def test_write_authorize_nv(self, esys):
+@@ -662,8 +661,7 @@ class Common:
+             self.fapi.quote(path=key_path, pcrs=[7, 9])
+ 
+     @pytest.mark.skipif(
+-        _lib_version_atleast("tss2-fapi", "4.0.1-170")
+-        or not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
++        not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
+         reason="tpm2-tss bug, see #2084",
+     )
+     def test_authorize_policy(self, sign_key):
+@@ -728,9 +726,7 @@ class Common:
+             self.fapi.quote(path=key_path, pcrs=[7, 9])
+ 
+     @pytest.mark.skipif(
+-        _lib_version_atleast("tss2-fapi", "4.0.1-170")
+-        or not is_bug_fixed(fixed_in="3.2"),
+-        reason="tpm2-tss bug, see #2080",
++        not is_bug_fixed(fixed_in="3.2"), reason="tpm2-tss bug, see #2080"
+     )
+     def test_policy_signed(self, cryptography_key):
+         # create external signing key used by the signing authority external to the TPM
+@@ -792,10 +788,6 @@ class Common:
+         with pytest.raises(TSS2_Exception):
+             self.fapi.sign(path=key_path, digest=b"\x11" * 32)
+ 
+-    @pytest.mark.skipif(
+-        _lib_version_atleast("tss2-fapi", "4.0.1-170"),
+-        reason="issue on master branch.",
+-    )
+     def test_policy_branched(self):
+         pcr_index = 15
+         pcr_data = b"ABCDEF"
+@@ -913,8 +905,7 @@ class Common:
+         self.fapi.delete(path=nv_path)
+ 
+     @pytest.mark.skipif(
+-        _lib_version_atleast("tss2-fapi", "4.0.1-170")
+-        or not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
++        not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
+         reason="tpm2-tss bug, see #2089",
+     )
+     def test_policy_action(self):
+diff --git a/test/test_policy.py b/test/test_policy.py
+index f18aa8a..5f56e21 100644
+--- a/test/test_policy.py
++++ b/test/test_policy.py
+@@ -47,7 +47,7 @@ class TestPolicy(TSS2_EsapiTest):
+         super().setUp()
+         self._has_secp192r1 = True
+         try:
+-            ec.generate_private_key(ec.SECP192R1)
++            ec.generate_private_key(ec.SECP192R1())
+         except Exception:
+             self._has_secp192r1 = False
+ 


### PR DESCRIPTION
## Description of changes
When tpm2-tss got released, it changed its header format in a way that broke tpm2-pytss.
This derivation was previously pulling an unmerged PR. This PR has now been superseded (and merged). This pulls the new version of the code.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
