### PR TITLE
musescore: 4.3.0 -> 4.3.1

### DIFF
--- a/nixos/tests/musescore.nix
+++ b/nixos/tests/musescore.nix
@@ -43,13 +43,10 @@ in
     )
 
     # Start MuseScore window
-    machine.execute("DISPLAY=:0.0 mscore >&2 &")
+    machine.execute("env XDG_RUNTIME_DIR=$PWD DISPLAY=:0.0 mscore >&2 &")
 
     # Wait until MuseScore has launched
-    machine.wait_for_window("MuseScore 4")
-
-    # Wait until the window has completely initialised
-    machine.wait_for_text("MuseScore 4")
+    machine.wait_for_window("MuseScore Studio")
 
     machine.screenshot("MuseScore0")
 
@@ -75,29 +72,22 @@ in
     machine.screenshot("MuseScore2")
 
     # Go to the export dialogue and create a PDF
-    machine.send_key("alt-f")
-    machine.sleep(1)
-    machine.send_key("e")
+    machine.send_key("ctrl-p")
 
-    # Wait until the export dialogue appears.
-    machine.wait_for_text("Export")
-
-    machine.screenshot("MuseScore3")
-
-    machine.send_key("shift-tab")
-    machine.sleep(1)
-    machine.send_key("ret")
-    machine.sleep(1)
-    machine.send_key("ret")
+    # Wait until the Print dialogue appears.
+    machine.wait_for_window("Print")
 
     machine.screenshot("MuseScore4")
-
-    # Wait until PDF is exported
-    machine.wait_for_file('"/root/Documents/MuseScore4/Scores/Untitled score.pdf"')
-
-    # Check that it contains the title of the score
-    machine.succeed('pdfgrep "Untitled score" "/root/Documents/MuseScore4/Scores/Untitled score.pdf"')
+    machine.send_key("alt-p")
+    machine.sleep(1)
 
     machine.screenshot("MuseScore5")
+
+    # Wait until PDF is exported
+    machine.wait_for_file('"/root/Untitled score.pdf"')
+
+    ## Check that it contains the title of the score
+    machine.succeed('pdfgrep "Untitled score" "/root/Untitled score.pdf"')
+    machine.copy_from_vm("/root/Untitled score.pdf")
   '';
 })

--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -20,6 +20,9 @@
 , qtdeclarative
 , qtgraphicaleffects
 , flac
+, libopusenc
+, libopus
+, tinyxml-2
 , qtquickcontrols
 , qtquickcontrols2
 , qtscript
@@ -47,13 +50,13 @@ let
   } else portaudio;
 in stdenv'.mkDerivation (finalAttrs: {
   pname = "musescore";
-  version = "4.3.0";
+  version = "4.3.1";
 
   src = fetchFromGitHub {
     owner = "musescore";
     repo = "MuseScore";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-X3zvrIf5DOC5PWcnuw0aClm++IWUED1ZzAyjnp7Mo+g=";
+    sha256 = "sha256-EqPofl2l+UBkmuzym4bL0EyFx+SOxVy0EXtxbw9Sqiw=";
   };
 
   cmakeFlags = [
@@ -62,8 +65,12 @@ in stdenv'.mkDerivation (finalAttrs: {
     # not useful on NixOS, see:
     # https://github.com/musescore/MuseScore/issues/15571
     "-DMUE_BUILD_CRASHPAD_CLIENT=OFF"
-    # Use our freetype
+    # Use our versions of system libraries
     "-DMUE_COMPILE_USE_SYSTEM_FREETYPE=ON"
+    "-DMUE_COMPILE_USE_SYSTEM_TINYXML=ON"
+    # Implies also -DMUE_COMPILE_USE_SYSTEM_OPUS=ON
+    "-DMUE_COMPILE_USE_SYSTEM_OPUSENC=ON"
+    "-DMUE_COMPILE_USE_SYSTEM_FLAC=ON"
     # From some reason, in $src/build/cmake/SetupBuildEnvironment.cmake,
     # upstream defaults to compiling to x86_64 only, unless this cmake flag is
     # set
@@ -102,6 +109,9 @@ in stdenv'.mkDerivation (finalAttrs: {
     portaudio'
     portmidi
     flac
+    libopusenc
+    libopus
+    tinyxml-2
     qtbase
     qtdeclarative
     qtgraphicaleffects


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
