### PR TITLE
python311Packages.tf2onnx: mark as broken

### DIFF
--- a/pkgs/development/python-modules/tf2onnx/default.nix
+++ b/pkgs/development/python-modules/tf2onnx/default.nix
@@ -79,5 +79,10 @@ buildPythonPackage rec {
     homepage = "https://github.com/onnx/tensorflow-onnx";
     license = licenses.asl20;
     maintainers = with maintainers; [ happysalada ];
+    # Duplicated `protobuf` in the derivation:
+    # - version 4.24.4 (from onnx), the default version of protobuf in nixpkgs
+    # - version 4.21.12 (from tensorflow), pinned as such because tensorflow is outdated and does
+    #   not support more recent versions of protobuf
+    broken = true;
   };
 }


### PR DESCRIPTION
## Description of changes

Broken because `tensorflow` is too old and does not support recent versions of `protobuf`.
```
Running phase: pythonCatchConflictsPhase
Found duplicated packages in closure for dependency 'protobuf': 
  protobuf 4.24.4 (/nix/store/8g2k3idj2f4kbvra98clakdlcvsy6f2y-python3.11-protobuf-4.24.4)
    dependency chain:
      this derivation: /nix/store/r9fq9spwzn87ad0k4npbw487q2zbgryx-python3.11-tf2onnx-1.16.1
      ...depending on: /nix/store/73g093ny57lfgnrbx6lmvphj8y7j5826-python3.11-onnx-1.15.0
      ...depending on: /nix/store/8g2k3idj2f4kbvra98clakdlcvsy6f2y-python3.11-protobuf-4.24.4
  protobuf 4.21.12 (/nix/store/2lk63v57qnqp8n3ydvx0ja61ij2bxv35-python3.11-protobuf-4.21.12)
    dependency chain:
      this derivation: /nix/store/r9fq9spwzn87ad0k4npbw487q2zbgryx-python3.11-tf2onnx-1.16.1
      ...depending on: /nix/store/kngclwr5xpl63vwccpj05drfg60nfh5b-python3.11-tensorflow-2.13.0
      ...depending on: /nix/store/2lk63v57qnqp8n3ydvx0ja61ij2bxv35-python3.11-protobuf-4.21.12
```

cc @happysalada 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
