### PR TITLE
coan: fix compile error in configure.ac

### DIFF
--- a/pkgs/development/tools/analysis/coan/default.nix
+++ b/pkgs/development/tools/analysis/coan/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, perl }:
+{ lib, stdenv, fetchurl, autoreconfHook, perl }:
 
 stdenv.mkDerivation rec {
   version = "6.0.1";
@@ -9,9 +9,14 @@ stdenv.mkDerivation rec {
     sha256 = "1d041j0nd1hc0562lbj269dydjm4rbzagdgzdnmwdxr98544yw44";
   };
 
-  nativeBuildInputs = [ perl ];
+  patches = [
+    # fix compile error in configure.ac
+    ./fix-big-endian-config-check.diff
+  ];
 
-  CXXFLAGS = "-std=c++11";
+  nativeBuildInputs = [ autoreconfHook perl ];
+
+  configureFlags = [ "CXXFLAGS=-std=c++11" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/tools/analysis/coan/fix-big-endian-config-check.diff
+++ b/pkgs/development/tools/analysis/coan/fix-big-endian-config-check.diff
@@ -1,0 +1,22 @@
+diff --git a/configure.ac b/configure.ac
+index 23ba6f0..13e6647 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -4,7 +4,7 @@ AC_PREREQ(2.59)
+ AM_INIT_AUTOMAKE(1.13 no-define)
+ AC_CHECK_HEADERS(strings.h)
+ AC_MSG_CHECKING(for big-endian host)
+-AC_TRY_RUN([main () {
++AC_TRY_RUN([int main () {
+   /* Are we little or big endian?  From Harbison&amp;Steele.  */
+   union
+   {
+@@ -12,7 +12,7 @@ AC_TRY_RUN([main () {
+     char c[sizeof (long)];
+   } u;
+   u.l = 1;
+-  exit (u.c[sizeof (long) - 1] == 1);
++  return u.c[sizeof (long) - 1] == 1;
+ }], BIG_ENDIAN=no, BIG_ENDIAN=yes)
+ AC_MSG_RESULT([$BIG_ENDIAN])
+ AM_CONDITIONAL([IS_BIG_ENDIAN],[test "$BIG_ENDIAN" = "yes"])


### PR DESCRIPTION
*needs backport release-24.05 tag*
## Description of changes

fix the big-endian compile error (implicit return type) when built with clang

https://hydra.nixos.org/build/260166605/nixlog/1/tail
ZHF: https://github.com/NixOS/nixpkgs/issues/309482

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
