### PR TITLE
boxfs: add missing includes to fix clang build

### DIFF
--- a/pkgs/tools/filesystems/boxfs/default.nix
+++ b/pkgs/tools/filesystems/boxfs/default.nix
@@ -32,7 +32,10 @@ in stdenv.mkDerivation {
     cp -a --no-preserve=mode ${libapp} libapp
     cp -a --no-preserve=mode ${libjson} libjson
   '';
-  patches = [ ./work-around-API-borkage.patch ];
+  patches = [
+    ./work-around-API-borkage.patch
+    ./libapp-include-ctype.diff
+  ];
 
   buildInputs = [ curl fuse libxml2 ];
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/tools/filesystems/boxfs/libapp-include-ctype.diff
+++ b/pkgs/tools/filesystems/boxfs/libapp-include-ctype.diff
@@ -1,0 +1,11 @@
+diff --git a/libapp/libapp/app.c b/libapp/libapp/app.c
+index 0188795..f9f1cfa 100644
+--- a/libapp/libapp/app.c
++++ b/libapp/libapp/app.c
+@@ -1,5 +1,6 @@
+ #include "app.h"
+ 
++#include <ctype.h>
+ #include <stdlib.h>
+ #include <string.h>
+ #include <libgen.h>

--- a/pkgs/tools/filesystems/boxfs/work-around-API-borkage.patch
+++ b/pkgs/tools/filesystems/boxfs/work-around-API-borkage.patch
@@ -1,8 +1,16 @@
 diff --git a/boxapi.c b/boxapi.c
-index 4964273..1a32e0d 100644
+index 4964273..e4b7404 100644
 --- a/boxapi.c
 +++ b/boxapi.c
-@@ -38,8 +38,8 @@
+@@ -29,6 +29,7 @@
+ #include <curl/curl.h>
+ 
+ #include <libxml/hash.h>
++#include <libxml/parser.h>
+ 
+ #include <libapp/app.h>
+ /* Building blocks for OpenBox api endpoints
+@@ -38,8 +39,8 @@
  //    AUTH
  #define API_KEY_VAL "f9ss11y2w0hg5r04jsidxlhk4pil28cf"
  #define API_SECRET  "r3ZHAIhsOL2FoHjgERI9xf74W5skIM0w"


### PR DESCRIPTION
*needs backport release-24.05 tag*
## Description of changes

add ctype.h and libxml/parser.h to fix clang build

https://hydra.nixos.org/build/260126224/nixlog/1/tail
ZHF: https://github.com/NixOS/nixpkgs/issues/309482

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
