### PR TITLE
rke2: update and release packages by official release channels

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/README.md
+++ b/pkgs/applications/networking/cluster/rke2/README.md
@@ -1,0 +1,25 @@
+# RKE2 Version
+
+RKE2, Kubernetes, and other clustered software has the property of not being able to update atomically. Most software in nixpkgs, like for example bash, can be updated as part of a `nixos-rebuild switch` without having to worry about the old and the new bash interacting in some way.
+
+> [!NOTE]
+> Upgrade the server nodes first, one at a time. Once all servers have been upgraded, you may then upgrade agent nodes.
+
+## Release Channels
+
+RKE2 has there own release channels, which are: `stable`, `latest` and `testing`.
+
+The `stable` channel is the default channel and is recommended for production use. The `latest` channel is the latest stable release. The `testing` channel is the latest release, including pre-releases.
+
+| Channel   | Description                                                                                                                                                                                    |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stable`  | **(Default)** Stable is recommended for production environments. These releases have been through a period of community hardening, and are compatible with the most recent release of Rancher. |
+| `latest`  | Latest is recommended for trying out the latest features. These releases have not yet been through a period of community hardening, and may not be compatible with Rancher.                    |
+| `testing` | The most recent release, including pre-releases.                                                                                                                                               |
+
+Learn more about the [RKE2 release channels](https://docs.rke2.io/upgrade/manual_upgrade).
+
+For an exhaustive and up-to-date list of channels, you can visit the [rke2 channel service API](https://update.rke2.io/v1-release/channels). For more technical details on how channels work, you can see the [channelserver project](https://github.com/rancher/channelserver).
+
+> [!TIP]
+> When attempting to upgrade to a new version of RKE2, the [Kubernetes version skew policy](https://kubernetes.io/docs/setup/release/version-skew-policy) applies. Ensure that your plan does not skip intermediate minor versions when upgrading. Nothing in the upgrade process will protect against unsupported changes to the Kubernetes version.

--- a/pkgs/applications/networking/cluster/rke2/builder.nix
+++ b/pkgs/applications/networking/cluster/rke2/builder.nix
@@ -1,0 +1,99 @@
+lib: { rke2Version, rke2RepoSha256, rke2VendorHash, updateScript
+
+, rke2Commit, k8sImageTag, etcdVersion, pauseVersion, ccmVersion, dockerizedVersion, ... }:
+
+{ lib, stdenv, buildGoModule, go, fetchgit, makeWrapper
+
+# Runtime dependencies
+, procps, coreutils, util-linux, ethtool, socat, iptables, bridge-utils, iproute2, kmod, lvm2
+
+# Testing dependencies
+, nixosTests, testers, rke2
+}:
+
+buildGoModule rec {
+  pname = "rke2";
+  version = rke2Version;
+
+  src = fetchgit {
+    url = "https://github.com/rancher/rke2.git";
+    rev = "v${version}";
+    sha256 = rke2RepoSha256;
+  };
+
+  vendorHash = rke2VendorHash;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # Important utilities used by the kubelet.
+  # See: https://github.com/kubernetes/kubernetes/issues/26093#issuecomment-237202494
+  # Notice the list in that issue is stale, but as a redundancy reservation.
+  buildInputs = [
+    procps # pidof pkill
+    coreutils # uname touch env nice du
+    util-linux # lsblk fsck mkfs nsenter mount umount
+    ethtool # ethtool
+    socat # socat
+    iptables # iptables iptables-restore iptables-save
+    bridge-utils # brctl
+    iproute2 # ip tc
+    kmod # modprobe
+    lvm2 # dmsetup
+  ];
+
+  # See: https://github.com/rancher/rke2/blob/e7f87c6dd56fdd76a7dab58900aeea8946b2c008/scripts/build-binary#L27-L38
+  ldflags = [
+    "-w"
+    "-X github.com/k3s-io/k3s/pkg/version.GitCommit=${lib.substring 0 6 rke2Commit}"
+    "-X github.com/k3s-io/k3s/pkg/version.Program=${pname}"
+    "-X github.com/k3s-io/k3s/pkg/version.Version=v${version}"
+    "-X github.com/k3s-io/k3s/pkg/version.UpstreamGolang=go${go.version}"
+    "-X github.com/rancher/rke2/pkg/images.DefaultRegistry=docker.io"
+    "-X github.com/rancher/rke2/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:${etcdVersion}-build20240418"
+    "-X github.com/rancher/rke2/pkg/images.DefaultKubernetesImage=rancher/hardened-kubernetes:${k8sImageTag}"
+    "-X github.com/rancher/rke2/pkg/images.DefaultPauseImage=rancher/mirrored-pause:${pauseVersion}"
+    "-X github.com/rancher/rke2/pkg/images.DefaultRuntimeImage=rancher/rke2-runtime:${dockerizedVersion}"
+    "-X github.com/rancher/rke2/pkg/images.DefaultCloudControllerManagerImage=rancher/rke2-cloud-provider:${ccmVersion}"
+  ];
+
+  tags = [
+    "no_cri_dockerd"
+    "no_embedded_executor"
+    "no_stage"
+    "sqlite_omit_load_extension"
+    "selinux"
+    "netgo"
+    "osusergo"
+  ];
+
+  subPackages = [ "." ];
+
+  installPhase = ''
+    install -D $GOPATH/bin/rke2 $out/bin/rke2
+    wrapProgram $out/bin/rke2 \
+      --prefix PATH : ${lib.makeBinPath buildInputs}
+  '';
+
+  doCheck = false;
+
+  passthru.updateScript = updateScript;
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = rke2;
+      version = "v${version}";
+    };
+  } // lib.optionalAttrs stdenv.isLinux {
+    inherit (nixosTests) rke2;
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/rancher/rke2";
+    description = "RKE2, also known as RKE Government, is Rancher's next-generation Kubernetes distribution.";
+    changelog = "https://github.com/rancher/rke2/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ zimbatm zygot ];
+    mainProgram = "rke2";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/cluster/rke2/default.nix
+++ b/pkgs/applications/networking/cluster/rke2/default.nix
@@ -1,79 +1,19 @@
-{ lib, stdenv, buildGoModule, fetchFromGitHub, makeWrapper, nix-update-script
+{ lib, callPackage, ... }@args:
 
-# Runtime dependencies
-, procps, coreutils, util-linux, ethtool, socat, iptables, bridge-utils, iproute2, kmod, lvm2
+let
+  common = opts: callPackage (import ./builder.nix lib opts);
+  extraArgs = builtins.removeAttrs args [ "callPackage" ];
+in
+{
+  rke2_stable = common ((import ./stable/versions.nix) // {
+    updateScript = [ ./update-script.sh "stable" ];
+  }) extraArgs;
 
-# Testing dependencies
-, nixosTests, testers, rke2
-}:
+  rke2_latest = common ((import ./latest/versions.nix) // {
+    updateScript = [ ./update-script.sh "latest" ];
+  }) extraArgs;
 
-buildGoModule rec {
-  pname = "rke2";
-  version = "1.29.0+rke2r1";
-
-  src = fetchFromGitHub {
-    owner = "rancher";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-E59GUcbnbvsGZYn87RGNrGTVUsydKsjL+C5h15q74p0=";
-  };
-
-  vendorHash = "sha256-Og0CqxNnhRN6PdggneGK05uprZ2D7lux/snXcArIm8Q=";
-
-  postPatch = ''
-    # Patch the build scripts so they work in the Nix build environment.
-    patchShebangs ./scripts
-
-    # Disable the static build as it breaks.
-    sed -e 's/STATIC_FLAGS=.*/STATIC_FLAGS=/g' -i scripts/build-binary
-  '';
-
-  nativeBuildInputs = [ makeWrapper ];
-
-  # Important utilities used by the kubelet.
-  # See: https://github.com/kubernetes/kubernetes/issues/26093#issuecomment-237202494
-  # Notice the list in that issue is stale, but as a redundancy reservation.
-  buildInputs = [
-    procps # pidof pkill
-    coreutils # uname touch env nice du
-    util-linux # lsblk fsck mkfs nsenter mount umount
-    ethtool # ethtool
-    socat # socat
-    iptables # iptables iptables-restore iptables-save
-    bridge-utils # brctl
-    iproute2 # ip tc
-    kmod # modprobe
-    lvm2 # dmsetup
-  ];
-
-  buildPhase = ''
-    DRONE_TAG="v${version}" ./scripts/build-binary
-  '';
-
-  installPhase = ''
-    install -D ./bin/rke2 $out/bin/rke2
-    wrapProgram $out/bin/rke2 \
-      --prefix PATH : ${lib.makeBinPath buildInputs}
-  '';
-
-  passthru.updateScript = nix-update-script { };
-
-  passthru.tests = {
-    version = testers.testVersion {
-      package = rke2;
-      version = "v${version}";
-    };
-  } // lib.optionalAttrs stdenv.isLinux {
-    inherit (nixosTests) rke2;
-  };
-
-  meta = with lib; {
-    homepage = "https://github.com/rancher/rke2";
-    description = "RKE2, also known as RKE Government, is Rancher's next-generation Kubernetes distribution.";
-    changelog = "https://github.com/rancher/rke2/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ zimbatm zygot ];
-    mainProgram = "rke2";
-    platforms = platforms.linux;
-  };
+  rke2_testing = common ((import ./testing/versions.nix) // {
+    updateScript = [ ./update-script.sh "testing" ];
+  }) extraArgs;
 }

--- a/pkgs/applications/networking/cluster/rke2/latest/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/latest/versions.nix
@@ -1,0 +1,14 @@
+{
+  rke2Version = "1.30.1+rke2r1";
+  rke2RepoSha256 = "0jrvvpj9fnlbykyr06w1f92ay708xzaizg8dhg1z4bsq1cdgs33k";
+  rke2Commit = "e7f87c6dd56fdd76a7dab58900aeea8946b2c008";
+  rke2VendorHash = "sha256-QqV8mSbqa8A5zABHQoVB2jht/eYCoqTZ/WoAqIl9oZY=";
+  k8sVersion = "v1.30.1";
+  k8sImageTag = "v1.30.1-rke2r1-build20240515";
+  etcdVersion = "v3.5.9-k3s1";
+  pauseVersion = "3.6";
+  ccmVersion = "v1.29.3-build20240412";
+  dockerizedVersion = "v1.30.1-rke2r1";
+  golangVersion = "go1.22.2";
+  eol = "2025-06-28";
+}

--- a/pkgs/applications/networking/cluster/rke2/stable/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/stable/versions.nix
@@ -1,0 +1,14 @@
+{
+  rke2Version = "1.28.10+rke2r1";
+  rke2RepoSha256 = "1pbanikvrl6rqrplrpvjc9ym8qq1yrs621gwy99shp0prfw5zvsx";
+  rke2Commit = "b0d0d687d98f4fa015e7b30aaf2807b50edcc5d7";
+  rke2VendorHash = "sha256-iidkTSrrHyW5ZEouzHAWUwCC9nplGz1v/E9bM2lMPeM=";
+  k8sVersion = "v1.28.10";
+  k8sImageTag = "v1.28.10-rke2r1-build20240514";
+  etcdVersion = "v3.5.9-k3s1";
+  pauseVersion = "3.6";
+  ccmVersion = "v1.29.3-build20240412";
+  dockerizedVersion = "v1.28.10-rke2r1";
+  golangVersion = "go1.21.9";
+  eol = "2024-10-28";
+}

--- a/pkgs/applications/networking/cluster/rke2/testing/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/testing/versions.nix
@@ -1,0 +1,14 @@
+{
+  rke2Version = "1.30.1-rc3+rke2r1";
+  rke2RepoSha256 = "0jrvvpj9fnlbykyr06w1f92ay708xzaizg8dhg1z4bsq1cdgs33k";
+  rke2Commit = "e7f87c6dd56fdd76a7dab58900aeea8946b2c008";
+  rke2VendorHash = "sha256-QqV8mSbqa8A5zABHQoVB2jht/eYCoqTZ/WoAqIl9oZY=";
+  k8sVersion = "v1.30.1";
+  k8sImageTag = "v1.30.1-rke2r1-build20240515";
+  etcdVersion = "v3.5.9-k3s1";
+  pauseVersion = "3.6";
+  ccmVersion = "v1.29.3-build20240412";
+  dockerizedVersion = "v1.30.1-rc3-rke2r1";
+  golangVersion = "go1.22.2";
+  eol = "2025-06-28";
+}

--- a/pkgs/applications/networking/cluster/rke2/update-script.sh
+++ b/pkgs/applications/networking/cluster/rke2/update-script.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl git gnugrep gnused yq-go nix-prefetch
+
+set -x -eu -o pipefail
+
+CHANNEL_NAME="${1:?Must provide a release channel, like 'stable', as the only argument}"
+
+mkdir --parents --verbose ./${CHANNEL_NAME}
+
+LATEST_TAG_NAME=$(curl --silent --fail https://update.rke2.io/v1-release/channels | \
+    yq eval ".data[] | select(.id == \"${CHANNEL_NAME}\").latest" - | \
+    sort -rV | grep --extended-regexp "^v[0-9]+\.[0-9]+\.[0-9]+" | head -n1)
+
+RKE2_VERSION=$(echo ${LATEST_TAG_NAME} | sed 's/^v//')
+
+RKE2_REPO_SHA256=$(nix-prefetch-url --quiet --unpack \
+        https://github.com/rancher/rke2/archive/refs/tags/${LATEST_TAG_NAME}.tar.gz)
+
+RKE2_COMMIT=$(curl --silent --fail ${GITHUB_TOKEN:+-u ":${GITHUB_TOKEN}"} \
+        https://api.github.com/repos/rancher/rke2/git/refs/tags | \
+    yq eval ".[] | select(.ref == \"refs/tags/${LATEST_TAG_NAME}\").object.sha" -)
+
+VERSIONS_SCRIPT=$(mktemp --suffix ".${RKE2_COMMIT:0:6}.sh")
+trap "rm --force ${VERSIONS_SCRIPT}" EXIT
+
+curl --silent --fail --output ${VERSIONS_SCRIPT} \
+        https://raw.githubusercontent.com/rancher/rke2/${RKE2_COMMIT}/scripts/version.sh
+
+set +eu
+DRONE_TAG=${LATEST_TAG_NAME} source ${VERSIONS_SCRIPT}
+set -eu
+
+KUBERNETES_CYCLES=$(echo ${KUBERNETES_VERSION} | grep -Eo "[0-9]+\.[0-9]+")
+KUBERNETES_EOL=$(curl --silent --fail \
+        https://endoflife.date/api/kubernetes/${KUBERNETES_CYCLES}.json | \
+    yq eval ".eol" -)
+
+FAKE_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+cat > ./${CHANNEL_NAME}/versions.nix << EOF
+{
+  rke2Version = "${RKE2_VERSION}";
+  rke2RepoSha256 = "${RKE2_REPO_SHA256}";
+  rke2Commit = "${RKE2_COMMIT}";
+  rke2VendorHash = "${FAKE_HASH}";
+  k8sVersion = "${KUBERNETES_VERSION}";
+  k8sImageTag = "${KUBERNETES_IMAGE_TAG}";
+  etcdVersion = "${ETCD_VERSION}";
+  pauseVersion = "${PAUSE_VERSION}";
+  ccmVersion = "${CCM_VERSION}";
+  dockerizedVersion = "${DOCKERIZED_VERSION}";
+  golangVersion = "${VERSION_GOLANG}";
+  eol = "${KUBERNETES_EOL}";
+}
+EOF
+
+NIXPKGS_ROOT=$(git rev-parse --show-toplevel)
+
+set +e
+RKE2_VENDOR_HASH=$(nix-prefetch -I nixpkgs=${NIXPKGS_ROOT} \
+        "{ sha256 }: (import ${NIXPKGS_ROOT}/. {}).rke2_${CHANNEL_NAME}.goModules.overrideAttrs (_: { vendorHash = sha256; })")
+set -e
+
+if [ -n "${RKE2_VENDOR_HASH:-}" ]; then
+    sed -i "s#${FAKE_HASH}#${RKE2_VENDOR_HASH}#g" ./${CHANNEL_NAME}/versions.nix
+else
+    echo "Update failed. 'RKE2_VENDOR_HASH' is empty."
+    exit 1
+fi
+
+# Implement commit
+# See: https://nixos.org/manual/nixpkgs/stable/#var-passthru-updateScript-commit
+OLD_VERSION=$(nix-instantiate --eval -E \
+        "with import ${NIXPKGS_ROOT}/. {}; rke2.version or (builtins.parseDrvName rke2.name).version" | \
+    tr -d '"')
+
+cat << EOF
+[{
+  "attrPath": "rke2_${CHANNEL_NAME}",
+  "oldVersion": "${OLD_VERSION}",
+  "newVersion": "${RKE2_VERSION}",
+  "files": [
+    "${PWD}/${CHANNEL_NAME}/versions.nix"
+  ]
+}]
+EOF

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34115,7 +34115,15 @@ with pkgs;
 
   rke = callPackage ../applications/networking/cluster/rke { };
 
-  rke2 = callPackage ../applications/networking/cluster/rke2 { };
+  inherit (callPackage ../applications/networking/cluster/rke2 {
+    buildGoModule = buildGo121Module;
+    go = go_1_21;
+  }) rke2_stable;
+  inherit (callPackage ../applications/networking/cluster/rke2 {
+    buildGoModule = buildGo122Module;
+    go = go_1_22;
+  }) rke2_latest rke2_testing;
+  rke2 = rke2_stable;
 
   rocketchat-desktop = callPackage ../applications/networking/instant-messengers/rocketchat-desktop { };
 


### PR DESCRIPTION
## Description of changes

This PR allows RKE2 to use the update script to obtain version information from RKE2's official [Release Channels](https://update.rke2.io/v1-release/channels).

Release Channels include: `stable`, `latest`, `testing`, and ~version number (e.g. `v1.30`)~.

The `stable` channel is the default channel and is recommended for production use. The `latest` channel is the latest stable release. The `testing` channel is the latest release, including pre-releases. ~The version number channel is the latest release for a specific `major.minor` version~.

| Channel                         | Description                                                                                                                                                                                           |
| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `stable`                        | **(Default)** Stable is recommended for production environments. These releases have been through a period of community hardening, and are compatible with the most recent release of Rancher.        |
| `latest`                        | Latest is recommended for trying out the latest features. These releases have not yet been through a period of community hardening, and may not be compatible with Rancher.                           |
| `testing`                       | The most recent release, including pre-releases.                                                                                                                                                      |
| ~Version number (e.g. `v1.30`)~ | ~There is a release channel tied to each Kubernetes minor version, including versions that are end-of-life. These channels will select the latest patch available, not necessarily a stable release.~ |

Learn more about the [RKE2 release channels](https://docs.rke2.io/upgrade/manual_upgrade).

At the same time, I rewrote the entire build script. **Use NixLang to write the build scripts instead of the scripts instead of patching the scripts provided by the RKE2 project.**

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
