### PR TITLE
punes-qt6: Fetch patch to fix Qt 6.7.1 compat

### DIFF
--- a/pkgs/applications/emulators/punes/default.nix
+++ b/pkgs/applications/emulators/punes/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , gitUpdater
 , cmake
 , pkg-config
@@ -26,6 +27,16 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-TIXjYkInWV3yVnvXrdHcmeWYeps5TcvkG2Xjg4roIds=";
   };
+
+  patches = [
+    # Fix FTBFS with Qt 6.7.1
+    # Remove when https://github.com/punesemu/puNES/pull/403 merged & in release
+    (fetchpatch {
+      name = "0001-punes-Fix-compatibility-with-Qt-6.7.1.patch";
+      url = "https://github.com/punesemu/puNES/commit/78c72d2dfcd570e7463a78da10904cebae6127f5.patch";
+      hash = "sha256-xRalKIOb1qWgqJsFLcm7uUOblEfHDYbkukmcr4/+4Qc=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
## Description of changes

Fixes:
```
[ 89%] Building CXX object src/CMakeFiles/punes.dir/gui/dlgStdPad.cpp.o
In file included from /nix/store/ikqvl8jq0d7vlp25d9zlbh44m4hljahc-qtbase-6.7.1/include/QtCore/qiodevice.h:10,
                 from /nix/store/ikqvl8jq0d7vlp25d9zlbh44m4hljahc-qtbase-6.7.1/include/QtCore/qbuffer.h:7,
                 from /nix/store/ikqvl8jq0d7vlp25d9zlbh44m4hljahc-qtbase-6.7.1/include/QtCore/QBuffer:1,
                 from /build/source/src/gui/dlgStdPad.cpp:19:
/nix/store/ikqvl8jq0d7vlp25d9zlbh44m4hljahc-qtbase-6.7.1/include/QtCore/qobject.h: In instantiation of 'T QObject::findChild(QAnyStringView, Qt::FindChildOptions) const [with T = pixmapButton*; Qt::FindChildOptions = QFlags<Qt::FindChildOption>]':
/build/source/src/gui/dlgStdPad.cpp:99:35:   required from here
/nix/store/ikqvl8jq0d7vlp25d9zlbh44m4hljahc-qtbase-6.7.1/include/QtCore/qobject.h:151:62: error: static assertion failed: No Q_OBJECT in the class passed to QObject::findChild
  151 |         static_assert(QtPrivate::HasQ_OBJECT_Macro<ObjType>::Value,
      |                                                              ^~~~~
/nix/store/ikqvl8jq0d7vlp25d9zlbh44m4hljahc-qtbase-6.7.1/include/QtCore/qobject.h:151:62: note: 'QtPrivate::HasQ_OBJECT_Macro<pixmapButton>::Value' evaluates to false
make[2]: *** [src/CMakeFiles/punes.dir/build.make:7505: src/CMakeFiles/punes.dir/gui/dlgStdPad.cpp.o] Error 1
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
