### PR TITLE
[24.05] Revert "[24.05] Revert "nixos/steam: add option fontPackages"", backport #315149

### DIFF
--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -100,6 +100,18 @@ in {
       '';
     };
 
+    fontPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = config.fonts.packages;
+      defaultText = lib.literalExpression "fonts.packages";
+      example = lib.literalExpression "with pkgs; [ source-han-sans ]";
+      description = ''
+        Font packages to use in Steam.
+
+        Defaults to system fonts, but could be overridden to use other fonts — useful for users who would like to customize CJK fonts used in Steam. According to the [upstream issue](https://github.com/ValveSoftware/steam-for-linux/issues/10422#issuecomment-1944396010), Steam only follows the per-user fontconfig configuration.
+      '';
+    };
+
     remotePlay.openFirewall = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -171,6 +183,8 @@ in {
         setuid = true;
       };
     };
+
+    programs.steam.extraPackages = cfg.fontPackages;
 
     programs.gamescope.enable = lib.mkDefault cfg.gamescopeSession.enable;
     services.displayManager.sessionPackages = lib.mkIf cfg.gamescopeSession.enable [ gamescopeSessionFile ];

--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -102,8 +102,9 @@ in {
 
     fontPackages = lib.mkOption {
       type = lib.types.listOf lib.types.package;
-      default = config.fonts.packages;
-      defaultText = lib.literalExpression "fonts.packages";
+      # `fonts.packages` is a list of paths now, filter out which are not packages
+      default = builtins.filter lib.types.package.check config.fonts.packages;
+      defaultText = lib.literalExpression "builtins.filter lib.types.package.check config.fonts.packages";
       example = lib.literalExpression "with pkgs; [ source-han-sans ]";
       description = ''
         Font packages to use in Steam.


### PR DESCRIPTION
Reverts NixOS/nixpkgs#315120
Backport #315149

In summary, add `programs.steam.fontPackages` option for 24.05 and fix the evaluation error in the previous backport. I would like to fix the CJK problem on 24.05.
The type should be stable this time.