### PR TITLE
nanopb: Fix self-inclusive src

### DIFF
--- a/pkgs/development/libraries/nanopb/test-message-with-annotations/default.nix
+++ b/pkgs/development/libraries/nanopb/test-message-with-annotations/default.nix
@@ -1,9 +1,12 @@
-{ stdenv, protobuf, nanopb }:
+{ lib, stdenv, protobuf, nanopb }:
 
 stdenv.mkDerivation {
   name = "nanopb-test-message-with-annotations";
   meta.timeout = 60;
-  src = ./.;
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [ ./withannotations.proto ];
+  };
 
   # protoc requires any .proto file to be compiled to reside within it's
   # proto_path. By default the current directory is automatically added to the

--- a/pkgs/development/libraries/nanopb/test-message-with-options/default.nix
+++ b/pkgs/development/libraries/nanopb/test-message-with-options/default.nix
@@ -1,9 +1,15 @@
-{ stdenv, protobuf, nanopb }:
+{ lib, stdenv, protobuf, nanopb }:
 
 stdenv.mkDerivation {
   name = "nanopb-test-message-with-options";
   meta.timeout = 60;
-  src = ./.;
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [
+      ./withoptions.proto
+      ./withoptions.options
+    ];
+  };
 
   # protoc requires any .proto file to be compiled to reside within it's
   # proto_path. By default the current directory is automatically added to the

--- a/pkgs/development/libraries/nanopb/test-simple-proto2/default.nix
+++ b/pkgs/development/libraries/nanopb/test-simple-proto2/default.nix
@@ -1,9 +1,12 @@
-{ stdenv, protobuf, nanopb }:
+{ lib, stdenv, protobuf, nanopb }:
 
 stdenv.mkDerivation {
   name = "nanopb-test-simple-proto2";
   meta.timeout = 60;
-  src = ./.;
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [ ./simple.proto ];
+  };
 
   # protoc requires any .proto file to be compiled to reside within it's
   # proto_path. By default the current directory is automatically added to the

--- a/pkgs/development/libraries/nanopb/test-simple-proto3/default.nix
+++ b/pkgs/development/libraries/nanopb/test-simple-proto3/default.nix
@@ -1,10 +1,12 @@
-{ stdenv, protobuf, nanopb }:
+{ lib, stdenv, protobuf, nanopb }:
 
 stdenv.mkDerivation {
   name = "nanopb-test-simple-proto3";
   meta.timeout = 60;
-  src = ./.;
-
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [ ./simple.proto ];
+  };
   # protoc requires any .proto file to be compiled to reside within it's
   # proto_path. By default the current directory is automatically added to the
   # proto_path. I tried using --proto_path ${./.} ${./simple.proto} and it did


### PR DESCRIPTION
## Description of changes
Fixes issue described in #301014
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
