### PR TITLE
doc: swap ANDROID_HOME and ANDROID_SDK_ROOT in android section

### DIFF
--- a/doc/languages-frameworks/android.section.md
+++ b/doc/languages-frameworks/android.section.md
@@ -249,11 +249,11 @@ In addition to prebuilt APKs, you can also bind the APK parameter to a
 
 ## Notes on environment variables in Android projects {#notes-on-environment-variables-in-android-projects}
 
-* `ANDROID_SDK_ROOT` should point to the Android SDK. In your Nix expressions, this should be
-  `${androidComposition.androidsdk}/libexec/android-sdk`. Note that `ANDROID_HOME` is deprecated,
+* `ANDROID_HOME` should point to the Android SDK. In your Nix expressions, this should be
+  `${androidComposition.androidsdk}/libexec/android-sdk`. Note that `ANDROID_SDK_ROOT` is deprecated,
   but if you rely on tools that need it, you can export it too.
 * `ANDROID_NDK_ROOT` should point to the Android NDK, if you're doing NDK development.
-  In your Nix expressions, this should be `${ANDROID_SDK_ROOT}/ndk-bundle`.
+  In your Nix expressions, this should be `${ANDROID_HOME}/ndk-bundle`.
 
 If you are running the Android Gradle plugin, you need to export GRADLE_OPTS to override aapt2
 to point to the aapt2 binary in the Nix store as well, or use a FHS environment so the packaged
@@ -267,11 +267,11 @@ let
   androidComposition = <...>;
 in
 pkgs.mkShell rec {
-  ANDROID_SDK_ROOT = "${androidComposition.androidsdk}/libexec/android-sdk";
-  ANDROID_NDK_ROOT = "${ANDROID_SDK_ROOT}/ndk-bundle";
+  ANDROID_HOME = "${androidComposition.androidsdk}/libexec/android-sdk";
+  ANDROID_NDK_ROOT = "${ANDROID_HOME}/ndk-bundle";
 
   # Use the same buildToolsVersion here
-  GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${ANDROID_SDK_ROOT}/build-tools/${buildToolsVersion}/aapt2";
+  GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${ANDROID_HOME}/build-tools/${buildToolsVersion}/aapt2";
 }
 ```
 
@@ -287,18 +287,18 @@ let
   androidComposition = <...>;
 in
 pkgs.mkShell rec {
-  ANDROID_SDK_ROOT = "${androidComposition.androidsdk}/libexec/android-sdk";
-  ANDROID_NDK_ROOT = "${ANDROID_SDK_ROOT}/ndk-bundle";
+  ANDROID_HOME = "${androidComposition.androidsdk}/libexec/android-sdk";
+  ANDROID_NDK_ROOT = "${ANDROID_HOME}/ndk-bundle";
 
   # Use the same cmakeVersion here
   shellHook = ''
-    export PATH="$(echo "$ANDROID_SDK_ROOT/cmake/${cmakeVersion}".*/bin):$PATH"
+    export PATH="$(echo "$ANDROID_HOME/cmake/${cmakeVersion}".*/bin):$PATH"
   '';
 }
 ```
 
-Note that running Android Studio with ANDROID_SDK_ROOT set will automatically write a
-`local.properties` file with `sdk.dir` set to $ANDROID_SDK_ROOT if one does not already
+Note that running Android Studio with ANDROID_HOME set will automatically write a
+`local.properties` file with `sdk.dir` set to $ANDROID_HOME if one does not already
 exist. If you are using the NDK as well, you may have to add `ndk.dir` to this file.
 
 An example shell.nix that does all this for you is provided in examples/shell.nix.


### PR DESCRIPTION
## Description of changes

Current description ([source](https://nixos.org/manual/nixpkgs/unstable/#notes-on-environment-variables-in-android-projects)):

> ANDROID_SDK_ROOT should point to the Android SDK. In your Nix expressions, this should be ${androidComposition.androidsdk}/libexec/android-sdk. Note that ANDROID_HOME is deprecated, but if you rely on tools that need it, you can export it too.

But official android documentation describes a completely opposite state about using ANDROID_HOME and ANDROID_SDK_ROOT ([source](https://developer.android.com/tools/variables#envar))
> ANDROID_HOME 	Sets the path to the SDK installation directory. Once set, the value does not typically change and can be shared by multiple users on the same machine. **ANDROID_SDK_ROOT, which also points to the SDK installation directory, is deprecated**. If you continue to use it, Android Studio and the Android Gradle plugin will check that the old and new variables are consistent. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
