### PR TITLE
pwalarmd: init at 0.1.0

### DIFF
--- a/pkgs/by-name/pw/pwalarmd/package.nix
+++ b/pkgs/by-name/pw/pwalarmd/package.nix
@@ -1,0 +1,37 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, alsa-lib
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pwalarmd";
+  version = "0.1.0";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ alsa-lib ];
+
+  src = fetchFromGitHub {
+    owner = "amyipdev";
+    repo = "pwalarmd";
+    rev = "v${version}";
+    hash = "sha256-xoC1PtDQjkvoWb9x8A43ITo6xyYOv9hxH2pxiZBBvKI=";
+  };
+
+  cargoHash = "sha256-cRAFnmgvzWLFAjB7H1rU4FdxMwm0J6d76kdFPoXpPMw=";
+
+  meta = {
+    description = "Background CLI-based alarm system for *nix";
+    longDescription = ''
+      pwalarmd is a command-line (daemon-based) alarm system.
+      It has extensive configuration and personalization, PulseAudio
+      and PipeWire support, and supports live configuration changes.
+    '';
+    mainProgram = "pwalarmd";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.all;
+    badPlatforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ amyipdev ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This patch adds pwalarmd, a daemon which provides alarm clock services with custom notification support and live command-line configuration editing (achieved through pwalarmctl, which will be requested for addition separately).

This patch does not add a service file, as pwalarmd is meant to be run in user mode. Home-Manager support will be added separately later for running pwalarmd under systemd/with declarative configuration.

Homepage: https://github.com/amyipdev/pwalarmd

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin N/A
  - [ ] aarch64-darwin N/A
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) N/A
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking N/A
  - [ ] (Module updates) Added a release notes entry if the change is significant N/A
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module N/A
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
