### PR TITLE
tabiew: init at 0.3.4

### DIFF
--- a/pkgs/by-name/ta/tabiew/package.nix
+++ b/pkgs/by-name/ta/tabiew/package.nix
@@ -1,0 +1,41 @@
+{ lib, fetchFromGitHub, rustPlatform, stdenv, installShellFiles }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "tabiew";
+  version = "0.3.4";
+
+  src = fetchFromGitHub {
+    owner = "shshemi";
+    repo = "tabiew";
+    rev = "v${version}";
+    hash = "sha256-sJQlvJxVXHgkE4RUtlM3BNL1rZKvQa7C5wlPHjFSuus=";
+  };
+
+  cargoHash = "sha256-QpeCGeId6pPYSGQvcI06zFC013RLcv7ryZlEn3F9dAI=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  outputs = [ "out" "man" ];
+
+  postInstall = ''
+    installManPage target/manual/tabiew.1
+
+    installShellCompletion \
+      --bash target/completion/tw.bash \
+      --zsh target/completion/_tw \
+      --fish target/completion/tw.fish
+  '';
+
+  doCheck = false; # there are no tests
+
+  meta = {
+    description =
+      "Lightweight, terminal-based application to view and query delimiter separated value formatted documents, such as CSV and TSV files";
+    homepage = "https://github.com/shshemi/tabiew";
+    changelog = "https://github.com/shshemi/tabiew/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    mainProgram = "tw";
+    maintainers = with lib.maintainers; [ anas ];
+    platforms = with lib.platforms; unix ++ windows;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add [tabiew (tw)](https://github.com/shshemi/tabiew) package, which is a lightweight, terminal-based application to view and query delimiter-separated value formatted documents, such as CSV and TSV files.

### Try it
```sh
nix run github:anas-contribs/nixpkgs/by-name/tabiew#tabiew
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
