### PR TITLE
ccache: 4.9.1 -> 4.10

### DIFF
--- a/pkgs/by-name/cc/ccache/package.nix
+++ b/pkgs/by-name/cc/ccache/package.nix
@@ -1,20 +1,21 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, substituteAll
-, binutils
-, asciidoctor
-, cmake
-, doctest
-, fmt
-, hiredis
-, perl
-, zstd
-, bashInteractive
-, xcodebuild
-, xxHash
-, makeWrapper
-, nix-update-script
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  substituteAll,
+  binutils,
+  asciidoctor,
+  cmake,
+  perl,
+  fmt,
+  hiredis,
+  xxHash,
+  zstd,
+  bashInteractive,
+  doctest,
+  xcodebuild,
+  makeWrapper,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -28,7 +29,10 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-0T9iJXnDX8LffhB/5hsfBNyZQ211f0lL/7dvTrjmiE0=";
   };
 
-  outputs = [ "out" "man" ];
+  outputs = [
+    "out"
+    "man"
+  ];
 
   patches = [
     # When building for Darwin, test/run uses dwarfdump, whereas on
@@ -44,12 +48,24 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   strictDeps = true;
-  nativeBuildInputs = [ asciidoctor cmake perl ];
-  buildInputs = [ fmt hiredis xxHash zstd ];
+
+  nativeBuildInputs = [
+    asciidoctor
+    cmake
+    perl
+  ];
+
+  buildInputs = [
+    fmt
+    hiredis
+    xxHash
+    zstd
+  ];
 
   cmakeFlags = lib.optional (!finalAttrs.finalPackage.doCheck) "-DENABLE_TESTING=OFF";
 
   doCheck = true;
+
   nativeCheckInputs = [
     # test/run requires the compgen function which is available in
     # bashInteractive, but not bash.
@@ -62,14 +78,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkPhase =
     let
-      badTests = [
-        "test.trim_dir" # flaky on hydra (possibly filesystem-specific?)
-      ] ++ lib.optionals stdenv.isDarwin [
-        "test.basedir"
-        "test.fileclone" # flaky on hydra (possibly filesystem-specific?)
-        "test.multi_arch"
-        "test.nocpp2"
-      ];
+      badTests =
+        [
+          "test.trim_dir" # flaky on hydra (possibly filesystem-specific?)
+        ]
+        ++ lib.optionals stdenv.isDarwin [
+          "test.basedir"
+          "test.fileclone" # flaky on hydra (possibly filesystem-specific?)
+          "test.multi_arch"
+          "test.nocpp2"
+        ];
     in
     ''
       runHook preCheck
@@ -81,53 +99,59 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     # A derivation that provides gcc and g++ commands, but that
     # will end up calling ccache for the given cacheDir
-    links = { unwrappedCC, extraConfig }: stdenv.mkDerivation {
-      pname = "ccache-links";
-      inherit (finalAttrs) version;
-      passthru = {
-        isClang = unwrappedCC.isClang or false;
-        isGNU = unwrappedCC.isGNU or false;
-        isCcache = true;
+    links =
+      { unwrappedCC, extraConfig }:
+      stdenv.mkDerivation {
+        pname = "ccache-links";
+        inherit (finalAttrs) version;
+        passthru = {
+          isClang = unwrappedCC.isClang or false;
+          isGNU = unwrappedCC.isGNU or false;
+          isCcache = true;
+        };
+        inherit (unwrappedCC) lib;
+        nativeBuildInputs = [ makeWrapper ];
+        # Unwrapped clang does not have a targetPrefix because it is multi-target
+        # target is decided with argv0.
+        buildCommand =
+          let
+            targetPrefix =
+              if unwrappedCC.isClang or false then
+                ""
+              else
+                (lib.optionalString (
+                  unwrappedCC ? targetConfig && unwrappedCC.targetConfig != null && unwrappedCC.targetConfig != ""
+                ) "${unwrappedCC.targetConfig}-");
+          in
+          ''
+            mkdir -p $out/bin
+
+            wrap() {
+              local cname="${targetPrefix}$1"
+              if [ -x "${unwrappedCC}/bin/$cname" ]; then
+                makeWrapper ${finalAttrs.finalPackage}/bin/ccache $out/bin/$cname \
+                  --run ${lib.escapeShellArg extraConfig} \
+                  --add-flags ${unwrappedCC}/bin/$cname
+              fi
+            }
+
+            wrap cc
+            wrap c++
+            wrap gcc
+            wrap g++
+            wrap clang
+            wrap clang++
+
+            for executable in $(ls ${unwrappedCC}/bin); do
+              if [ ! -x "$out/bin/$executable" ]; then
+                ln -s ${unwrappedCC}/bin/$executable $out/bin/$executable
+              fi
+            done
+            for file in $(ls ${unwrappedCC} | grep -vw bin); do
+              ln -s ${unwrappedCC}/$file $out/$file
+            done
+          '';
       };
-      inherit (unwrappedCC) lib;
-      nativeBuildInputs = [ makeWrapper ];
-      # Unwrapped clang does not have a targetPrefix because it is multi-target
-      # target is decided with argv0.
-      buildCommand = let
-        targetPrefix = if unwrappedCC.isClang or false
-          then
-            ""
-          else
-            (lib.optionalString (unwrappedCC ? targetConfig && unwrappedCC.targetConfig != null && unwrappedCC.targetConfig != "") "${unwrappedCC.targetConfig}-");
-      in ''
-        mkdir -p $out/bin
-
-        wrap() {
-          local cname="${targetPrefix}$1"
-          if [ -x "${unwrappedCC}/bin/$cname" ]; then
-            makeWrapper ${finalAttrs.finalPackage}/bin/ccache $out/bin/$cname \
-              --run ${lib.escapeShellArg extraConfig} \
-              --add-flags ${unwrappedCC}/bin/$cname
-          fi
-        }
-
-        wrap cc
-        wrap c++
-        wrap gcc
-        wrap g++
-        wrap clang
-        wrap clang++
-
-        for executable in $(ls ${unwrappedCC}/bin); do
-          if [ ! -x "$out/bin/$executable" ]; then
-            ln -s ${unwrappedCC}/bin/$executable $out/bin/$executable
-          fi
-        done
-        for file in $(ls ${unwrappedCC} | grep -vw bin); do
-          ln -s ${unwrappedCC}/$file $out/$file
-        done
-      '';
-    };
 
     updateScript = nix-update-script { };
   };
@@ -141,7 +165,10 @@ stdenv.mkDerivation (finalAttrs: {
     }";
     license = licenses.gpl3Plus;
     mainProgram = "ccache";
-    maintainers = with maintainers; [ kira-bruneau r-burns ];
+    maintainers = with maintainers; [
+      kira-bruneau
+      r-burns
+    ];
     platforms = platforms.unix;
   };
 })


### PR DESCRIPTION
## Description of changes
Updates `ccache` from version `4.9.1` to version `4.10`. The `package.nix` was formatted with `nixfmt-rfc-style`. Dependencies now necessary to compile `ccache` added: `doctest`, `fmt`, `hiredis`, `xxHash`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
