### PR TITLE
itools: init at 1.1

### DIFF
--- a/pkgs/by-name/it/itools/package.nix
+++ b/pkgs/by-name/it/itools/package.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkgs
+, pkg-config
+, perl
+, libitl
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "itools";
+  version = "1.1";
+
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
+  buildInputs = [ libitl perl ];
+
+  outputs = [ "out" "man" ];
+
+  src = fetchFromGitHub {
+    owner = "arabeyes-org";
+    repo = "itools";
+    rev = finalAttrs.version;
+    hash = "sha256-DxTZaq2SlEmy9k7iAdjctpPkk+2rIaF+xEcfXj/ERWw=";
+  };
+
+  meta = {
+    description = "Islamic command-line tools for prayer times and hijri dates";
+    longDescription = ''
+      The itools package is a set of user friendly applications utilizing Arabeyes' ITL library.
+
+      The package addresses two main areas - hijri date and prayertime calculation. The package
+      is envisioned to mimick the development of the underlying ITL library and is meant to
+      always give the end-user a simple means to access its functions.
+    '';
+    homepage = "https://www.arabeyes.org/ITL";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ amyipdev ];
+  };
+})


### PR DESCRIPTION
## Description of changes

This patch adds itools, a set of four programs (ipraytime, idate, ical, ireminder) which provide command-line tools for common Islamic calculations. It uses libitl (#314794), which was merged to support this tool suite.

NOTE: itools building successfully is dependent on libitl being present in nixpkgs, which it currently is on nixpkgs-unstable but not yet on nixos-unstable. It builds successfully on my laptop (Fedora 40 w/ Nix) but does not on my NixOS desktop unless I manually override the channel into nixpkgs-unstable or directly point the package to a more up-to-date copy of nixpkgs.

Project homepage: https://github.com/arabeyes-org/itools

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) N/A
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) N/A
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) N/A
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages N/A
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) N/A
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) - `ical`, `idate`, `ipraytime`, `ireminder`
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
