### PR TITLE
homer: init at 24.04.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8532,6 +8532,12 @@
     github = "the-furry-hubofeverything";
     githubId = 53921912;
   };
+  huetremy = {
+    name = "Rémy Huet";
+    email = "remy.huet@utc.fr";
+    github = "huetremy";
+    githubId = 32484913;
+  };
   hufman = {
     email = "hufman@gmail.com";
     github = "hufman";

--- a/pkgs/by-name/ho/homer/package.nix
+++ b/pkgs/by-name/ho/homer/package.nix
@@ -1,0 +1,46 @@
+{ stdenvNoCC, lib, buildNpmPackage, fetchFromGitHub, nodejs, pnpm_8 }:
+stdenvNoCC.mkDerivation rec {
+  pname = "homer";
+  version = "24.04.1";
+
+  src = fetchFromGitHub {
+    owner = "bastienwirtz";
+    repo = "homer";
+    rev = "v${version}";
+    hash = "sha256-QGBOvP2EAs9tEziksWRT6Pw5dl76MpzSlNFoCjWExgk=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm_8.configHook
+  ];
+
+  pnpmDeps = pnpm_8.fetchDeps {
+    inherit pname version src;
+    hash = "sha256-Qfvp7Zpd+/nv8ILmeXi79QfV94an9BxH6Xwk/epT26M=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cp -R ./dist/* $out/lib/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A full static html/js dashboard, based on a simple yaml configuration file";
+    license = licenses.asl20;
+    maintainers = [ maintainers.huetremy ];
+    homepage = "https://github.com/bastienwirtz/homer";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add homer, a simple dashboard application. This package contains the built static site to be served (eg by nginx).
I added a `package-lock.json` as homer uses `pnpm` and it seems that it is not possible to use this yet #231513 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
