### PR TITLE
cli.nix: improve documentation, including arguments

### DIFF
--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -7,8 +7,6 @@ rec {
     This helps protect against malformed command lines and also to reduce
     boilerplate related to command-line construction for simple use cases.
 
-    `toGNUCommandLine` returns a list of nix strings.
-
     `toGNUCommandLineShell` returns an escaped shell string.
 
 
@@ -16,16 +14,85 @@ rec {
 
     `options`
 
-    : 1\. Function argument
+    : How to format the arguments, see `toGNUCommandLine`
 
     `attrs`
 
-    : 2\. Function argument
+    : The attributes to transform into arguments.
 
 
     # Examples
     :::{.example}
     ## `lib.cli.toGNUCommandLineShell` usage example
+
+    ```nix
+    cli.toGNUCommandLineShell {} {
+      data = builtins.toJSON { id = 0; };
+      X = "PUT";
+      retry = 3;
+      retry-delay = null;
+      url = [ "https://example.com/foo" "https://example.com/bar" ];
+      silent = false;
+      verbose = true;
+    }
+    => "'-X' 'PUT' '--data' '{\"id\":0}' '--retry' '3' '--url' 'https://example.com/foo' '--url' 'https://example.com/bar' '--verbose'";
+    ```
+
+    :::
+  */
+  toGNUCommandLineShell =
+    options: attrs: lib.escapeShellArgs (toGNUCommandLine options attrs);
+
+  /**
+    Automatically convert an attribute set to a list of command-line options.
+
+    `toGNUCommandLine` returns a list of string arguments.
+
+
+    # Inputs
+
+    `options`
+
+    : How to format the arguments, see below.
+
+    `attrs`
+
+    : The attributes to transform into arguments.
+
+    # Options
+
+    `mkOptionName`
+
+    : How to string-format the option name;
+    By default one character is a short option (`-`), more than one characters a long option (`--`).
+
+    `mkBool`
+
+    : How to format a boolean value to a command list;
+    By default it’s a flag option (only the option name if true, left out completely if false).
+
+    `mkList`
+
+    : How to format a list value to a command list;
+    By default the option name is repeated for each value and `mkOption` is applied to the values themselves.
+
+
+    `mkOption`
+
+    : How to format any remaining value to a command list;
+    On the toplevel, booleans and lists are handled by `mkBool` and `mkList`, though they can still appear as values of a list.
+    By default, everything is printed verbatim and complex types are forbidden (lists, attrsets, functions). `null` values are omitted.
+
+    `optionValueSeparator`
+
+    : How to separate an option from its flag;
+    By default, there is no separator, so option `-c` and value `5` would become ["-c" "5"].
+    This is useful if the command requires equals, for example, `-c=5`.
+
+
+    # Examples
+    :::{.example}
+    ## `lib.cli.toGNUCommandLine` usage example
 
     ```nix
     cli.toGNUCommandLine {} {
@@ -45,48 +112,20 @@ rec {
       "--url" "https://example.com/bar"
       "--verbose"
     ]
-
-    cli.toGNUCommandLineShell {} {
-      data = builtins.toJSON { id = 0; };
-      X = "PUT";
-      retry = 3;
-      retry-delay = null;
-      url = [ "https://example.com/foo" "https://example.com/bar" ];
-      silent = false;
-      verbose = true;
-    }
-    => "'-X' 'PUT' '--data' '{\"id\":0}' '--retry' '3' '--url' 'https://example.com/foo' '--url' 'https://example.com/bar' '--verbose'";
     ```
 
     :::
   */
-  toGNUCommandLineShell =
-    options: attrs: lib.escapeShellArgs (toGNUCommandLine options attrs);
-
   toGNUCommandLine = {
-    # how to string-format the option name;
-    # by default one character is a short option (`-`),
-    # more than one characters a long option (`--`).
     mkOptionName ?
       k: if builtins.stringLength k == 1
           then "-${k}"
           else "--${k}",
 
-    # how to format a boolean value to a command list;
-    # by default it’s a flag option
-    # (only the option name if true, left out completely if false).
     mkBool ? k: v: lib.optional v (mkOptionName k),
 
-    # how to format a list value to a command list;
-    # by default the option name is repeated for each value
-    # and `mkOption` is applied to the values themselves.
     mkList ? k: v: lib.concatMap (mkOption k) v,
 
-    # how to format any remaining value to a command list;
-    # on the toplevel, booleans and lists are handled by `mkBool` and `mkList`,
-    # though they can still appear as values of a list.
-    # By default, everything is printed verbatim and complex types
-    # are forbidden (lists, attrsets, functions). `null` values are omitted.
     mkOption ?
       k: v: if v == null
             then []
@@ -95,10 +134,6 @@ rec {
             else
               [ "${mkOptionName k}${optionValueSeparator}${lib.generators.mkValueStringDefault {} v}" ],
 
-    # how to separate an option from its flag;
-    # by default, there is no separator, so option `-c` and value `5`
-    # would become ["-c" "5"].
-    # This is useful if the command requires equals, for example, `-c=5`.
     optionValueSeparator ? null
     }:
     options:


### PR DESCRIPTION
## Description of changes

Following on from #309517 / #308500 / #264893, this improves the documentation around `cli.nix`

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
