### PR TITLE
nixos/{hyprland, wayland-common}: disable wlr portal for hyprland, enable xdg autostart for all wayland compositors

### DIFF
--- a/nixos/modules/programs/wayland/hyprland.nix
+++ b/nixos/modules/programs/wayland/hyprland.nix
@@ -88,4 +88,6 @@ in
       "Nvidia patches are no longer needed"
     )
   ];
+
+  meta.maintainers = with lib.maintainers; [ fufexan ];
 }

--- a/nixos/modules/programs/wayland/hyprland.nix
+++ b/nixos/modules/programs/wayland/hyprland.nix
@@ -70,6 +70,7 @@ in
     (import ./wayland-session.nix {
       inherit lib pkgs;
       xwayland = cfg.xwayland.enable;
+      wlr-portal = false; # Hyprland has its own portal, wlr is not needed
     })
   ]);
 

--- a/nixos/modules/programs/wayland/hyprland.nix
+++ b/nixos/modules/programs/wayland/hyprland.nix
@@ -69,8 +69,8 @@ in
 
     (import ./wayland-session.nix {
       inherit lib pkgs;
-      xwayland = cfg.xwayland.enable;
-      wlr-portal = false; # Hyprland has its own portal, wlr is not needed
+      enableXWayland = cfg.xwayland.enable;
+      enableWlrPortal = false; # Hyprland has its own portal, wlr is not needed
     })
   ]);
 

--- a/nixos/modules/programs/wayland/river.nix
+++ b/nixos/modules/programs/wayland/river.nix
@@ -57,7 +57,7 @@ in
 
     (import ./wayland-session.nix {
       inherit lib pkgs;
-      xwayland = cfg.xwayland.enable;
+      enableXWayland = cfg.xwayland.enable;
     })
   ]);
 

--- a/nixos/modules/programs/wayland/sway.nix
+++ b/nixos/modules/programs/wayland/sway.nix
@@ -140,7 +140,7 @@ in
 
     (import ./wayland-session.nix {
       inherit lib pkgs;
-      xwayland = cfg.xwayland.enable;
+      enableXWayland = cfg.xwayland.enable;
     })
   ]);
 

--- a/nixos/modules/programs/wayland/wayland-session.nix
+++ b/nixos/modules/programs/wayland/wayland-session.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, xwayland ? true }:
+{
+  lib,
+  pkgs,
+  xwayland ? true,
+  wlr-portal ? true,
+}:
 
 {
   security = {
@@ -14,5 +19,5 @@
     xwayland.enable = lib.mkDefault xwayland;
   };
 
-  xdg.portal.wlr.enable = lib.mkDefault true;
+  xdg.portal.wlr.enable = wlr-portal;
 }

--- a/nixos/modules/programs/wayland/wayland-session.nix
+++ b/nixos/modules/programs/wayland/wayland-session.nix
@@ -20,4 +20,8 @@
   };
 
   xdg.portal.wlr.enable = wlr-portal;
+
+  # Window manager only sessions (unlike DEs) don't handle XDG
+  # autostart files, so force them to run the service
+  services.xserver.desktopManager.runXdgAutostartIfNone = lib.mkDefault true;
 }

--- a/nixos/modules/programs/wayland/wayland-session.nix
+++ b/nixos/modules/programs/wayland/wayland-session.nix
@@ -1,8 +1,8 @@
 {
   lib,
   pkgs,
-  xwayland ? true,
-  wlr-portal ? true,
+  enableXWayland ? true,
+  enableWlrPortal ? true,
 }:
 
 {
@@ -16,10 +16,10 @@
 
   programs = {
     dconf.enable = lib.mkDefault true;
-    xwayland.enable = lib.mkDefault xwayland;
+    xwayland.enable = lib.mkDefault enableXWayland;
   };
 
-  xdg.portal.wlr.enable = wlr-portal;
+  xdg.portal.wlr.enable = enableWlrPortal;
 
   # Window manager only sessions (unlike DEs) don't handle XDG
   # autostart files, so force them to run the service


### PR DESCRIPTION
## Description of changes

Hyprland has its own portal `xdg-desktop-portal-hyprland` and does not need the `wlr` portal.

As a follow up to #240989,

- Adds wlr-portal override of wayland-session module (enabled by default)
- Disable it for hyprland module

Additionally, enable xdg autostart service for Wayland Window compositors as unlike DEs, they do not handle it themselves. 

## Things done

- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

CC: @fufexan @SuperSandro2000

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
