### PR TITLE
wireplumber: add `enableSystemd` option

### DIFF
--- a/pkgs/development/libraries/pipewire/wireplumber.nix
+++ b/pkgs/development/libraries/pipewire/wireplumber.nix
@@ -20,6 +20,7 @@
 # options
 , enableDocs ? true
 , enableGI ? true
+, enableSystemd ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -54,9 +55,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glib
-    systemd
     lua5_4
     pipewire
+  ] ++ lib.optionals enableSystemd [
+    systemd
   ];
 
   mesonFlags = [
@@ -64,8 +66,10 @@ stdenv.mkDerivation rec {
     (lib.mesonEnable "elogind" false)
     (lib.mesonEnable "doc" enableDocs)
     (lib.mesonEnable "introspection" enableGI)
-    (lib.mesonBool "systemd-system-service" true)
+    (lib.mesonEnable "systemd" enableSystemd)
+    (lib.mesonBool "systemd-system-service" enableSystemd)
     (lib.mesonOption "systemd-system-unit-dir" "${placeholder "out"}/lib/systemd/system")
+    (lib.mesonBool "systemd-user-service" enableSystemd)
     (lib.mesonOption "sysconfdir" "/etc")
   ];
 


### PR DESCRIPTION
## Description of changes

setting this `false` causes the `libwireplumber-module-logind.so` module to not be built or shipped. audio devices which are ordinarily provided by logind (e.g. those under /dev/snd/) are no longer visible unless the user adds themselves to the `audio` group.

best combined with `pipewire.override { inherit enableSystemd; }`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux  (and `pkgsCross.aarch64-multiplatform`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] ~~Tested, as applicable:~~ the pipewire tests (e.g. `nixosTests.installed-tests.pipewire`) do not use wireplumber
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
