### PR TITLE
v8: mark vulnerable, move dependents to `nodejs.libv8`

### DIFF
--- a/pkgs/applications/networking/misc/zammad/default.nix
+++ b/pkgs/applications/networking/misc/zammad/default.nix
@@ -17,7 +17,6 @@
 , nodejs
 , yarn
 , yarn2nix-moretea
-, v8
 , cacert
 , redis
 }:
@@ -83,7 +82,7 @@ let
       };
       mini_racer = attrs: {
         buildFlags = [
-          "--with-v8-dir=\"${v8}\""
+          "--with-v8-dir=\"${nodejs.libv8}\""
         ];
         dontBuild = false;
         postPatch = ''

--- a/pkgs/development/libraries/v8/default.nix
+++ b/pkgs/development/libraries/v8/default.nix
@@ -190,5 +190,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ proglodyte matthewbauer ];
     platforms = platforms.unix;
     license = licenses.bsd3;
+    knownVulnerabilities = [ "Severely outdated with multiple publicly known vulnerabilities" ];
   };
 }

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -483,7 +483,7 @@ let
     units = [ pkgs.udunits ];
     unigd = [ pkgs.pkg-config ];
     vdiffr = [ pkgs.libpng.dev ];
-    V8 = [ pkgs.v8 ];
+    V8 = [ pkgs.nodejs.libv8 ];
     XBRL = with pkgs; [ zlib libxml2.dev ];
     XLConnect = [ pkgs.jdk ];
     xml2 = [ pkgs.libxml2.dev ] ++ lib.optionals stdenv.isDarwin [ pkgs.perl ];
@@ -1407,12 +1407,15 @@ let
     V8 = old.V8.overrideAttrs (attrs: {
       postPatch = ''
         substituteInPlace configure \
-          --replace " -lv8_libplatform" ""
+          --replace-fail " -lv8_libplatform" ""
+        # Bypass the test checking if pointer compression is needed
+        substituteInPlace configure \
+          --replace-fail "./pctest1" "true"
       '';
 
       preConfigure = ''
-        export INCLUDE_DIR=${pkgs.v8}/include
-        export LIB_DIR=${pkgs.v8}/lib
+        export INCLUDE_DIR=${pkgs.nodejs.libv8}/include
+        export LIB_DIR=${pkgs.nodejs.libv8}/lib
         patchShebangs configure
       '';
 

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -18,7 +18,7 @@
 # (to make gems behave if necessary).
 
 { lib, fetchurl, writeScript, ruby, libkrb5, libxml2, libxslt, python2, stdenv, which
-, libiconv, postgresql, v8, clang, sqlite, zlib, imagemagick, lasem
+, libiconv, postgresql, nodejs, clang, sqlite, zlib, imagemagick, lasem
 , pkg-config , ncurses, xapian, gpgme, util-linux, tzdata, icu, libffi
 , cmake, libssh2, openssl, openssl_1_1, libmysqlclient, git, perl, pcre, pcre2, gecode_3, curl
 , libsodium, snappy, libossp_uuid, lxc, libpcap, xorg, gtk2, gtk3, buildRubyGem
@@ -476,7 +476,7 @@ in
   # otherwise the gem will fail to link to the libv8 binary.
   # see: https://github.com/cowboyd/libv8/pull/161
   libv8 = attrs: {
-    buildInputs = [ which v8 python2 ];
+    buildInputs = [ which nodejs.libv8 python2 ];
     buildFlags = [ "--with-system-v8=true" ];
     dontBuild = false;
     # The gem includes broken symlinks which are ignored during unpacking, but
@@ -496,7 +496,7 @@ in
   };
 
   execjs = attrs: {
-    propagatedBuildInputs = [ v8 ];
+    propagatedBuildInputs = [ nodejs.libv8 ];
   };
 
   libxml-ruby = attrs: {

--- a/pkgs/servers/sql/postgresql/ext/plv8/0001-build-Allow-using-V8-from-system.patch
+++ b/pkgs/servers/sql/postgresql/ext/plv8/0001-build-Allow-using-V8-from-system.patch
@@ -1,47 +1,44 @@
 diff --git a/Makefile b/Makefile
-index 38879cc..6e78eeb 100644
+index a705c11..08b952b 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -20,6 +20,7 @@ OBJS = $(SRCS:.cc=.o)
+@@ -13,11 +13,14 @@ OBJS = $(SRCS:.cc=.o)
  MODULE_big = plv8-$(PLV8_VERSION)
  EXTENSION = plv8
  PLV8_DATA = plv8.control plv8--$(PLV8_VERSION).sql
 +USE_SYSTEM_V8 = 0
  
- 
- # Platform detection
-@@ -41,6 +42,7 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
- PG_VERSION_NUM := $(shell cat `$(PG_CONFIG) --includedir-server`/pg_config*.h \
- 		   | perl -ne 'print $$1 and exit if /PG_VERSION_NUM\s+(\d+)/')
+ ifeq ($(OS),Windows_NT)
+ 	# noop for now
+ else
++	ifeq ($(USE_SYSTEM_V8),0)
+ 	SHLIB_LINK += -Ldeps/v8-cmake/build
++	endif
+ 	UNAME_S := $(shell uname -s)
+ 	ifeq ($(UNAME_S),Darwin)
+ 		CCFLAGS += -stdlib=libc++
+@@ -34,6 +37,7 @@ ifeq ($(NUMPROC),0)
+ 	NUMPROC = 1
+ endif
  
 +ifeq ($(USE_SYSTEM_V8),0)
- AUTOV8_DIR = build/v8
- AUTOV8_OUT = build/v8/out.gn/obj
- AUTOV8_STATIC_LIBS = -lv8_libplatform -lv8_libbase
-@@ -66,6 +68,7 @@ v8:
- 	make -f Makefiles/Makefile.macos v8
- endif
- endif
+ SHLIB_LINK += -Ldeps/v8-cmake/build
+ 
+ all: v8 $(OBJS)
+@@ -46,11 +50,16 @@ deps/v8-cmake/build/libv8_libbase.a:
+ 	@cd deps/v8-cmake && mkdir -p build && cd build && cmake -Denable-fPIC=ON -DCMAKE_BUILD_TYPE=Release ../ && make -j $(NUMPROC)
+ 
+ v8: deps/v8-cmake/build/libv8_libbase.a
++else
++all: $(OBJS)
 +endif
  
  # enable direct jsonb conversion by default
  CCFLAGS += -DJSONB_DIRECT_CONVERSION
-@@ -83,6 +86,7 @@ ifdef BIGINT_GRACEFUL
- endif
- 
  
 +ifeq ($(USE_SYSTEM_V8),0)
- # We're gonna build static link.  Rip it out after include Makefile
- SHLIB_LINK := $(filter-out -lv8, $(SHLIB_LINK))
- 
-@@ -101,6 +105,7 @@ else
- 		SHLIB_LINK += -lrt -std=c++14 
- 	endif
- endif
+ CCFLAGS += -Ideps/v8-cmake/v8/include -std=c++17
 +endif
  
- DATA = $(PLV8_DATA)
- ifndef DISABLE_DIALECT
--- 
-2.37.3
-
+ ifdef EXECUTION_TIMEOUT
+ 	CCFLAGS += -DEXECUTION_TIMEOUT

--- a/pkgs/servers/sql/postgresql/ext/plv8/default.nix
+++ b/pkgs/servers/sql/postgresql/ext/plv8/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, v8
+, nodejs_20
 , perl
 , postgresql
 , jitSupport
@@ -11,15 +11,17 @@
 , gnugrep
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+let
+  libv8 = nodejs_20.libv8;
+in stdenv.mkDerivation (finalAttrs: {
   pname = "plv8";
-  version = "3.1.10";
+  version = "3.2.2";
 
   src = fetchFromGitHub {
     owner = "plv8";
     repo = "plv8";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-g1A/XPC0dX2360Gzvmo9/FSQnM6Wt2K4eR0pH0p9fz4=";
+    hash = "sha256-azO33v22EF+/sTNmwswxyDR0PhrvWfTENuLu6JgSGJ0=";
   };
 
   patches = [
@@ -33,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    v8
+    libv8
     postgresql
   ];
 
@@ -43,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Nixpkgs build a v8 monolith instead of separate v8_libplatform.
     "USE_SYSTEM_V8=1"
     "SHLIB_LINK=-lv8"
-    "V8_OUTDIR=${v8}/lib"
+    "V8_OUTDIR=${libv8}/lib"
   ];
 
   installFlags = [
@@ -56,9 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs ./generate_upgrade.sh
-    # https://github.com/plv8/plv8/pull/506
-    substituteInPlace generate_upgrade.sh \
-      --replace " 2.3.10 " " 2.3.10 2.3.11 2.3.12 2.3.13 2.3.14 2.3.15 "
   '';
 
   postInstall = ''


### PR DESCRIPTION
## Description of changes

nixpkgs `v8` package is basically unmaintained (no upgrade in 3 years) and it appears we can move all the dependents to `nodejs.liblv8`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Result of `nixpkgs-review pr 315851` run on aarch64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>10 packages marked as broken and skipped:</summary>
  <ul>
    <li>postgresql12JitPackages.plv8</li>
    <li>postgresql13JitPackages.plv8</li>
    <li>postgresql14JitPackages.plv8</li>
    <li>postgresql15JitPackages.plv8</li>
    <li>postgresql16JitPackages.plv8</li>
    <li>postgresqlJitPackages.plv8</li>
    <li>rubyPackages.libv8</li>
    <li>rubyPackages_3_1.libv8</li>
    <li>rubyPackages_3_2.libv8</li>
    <li>rubyPackages_3_3.libv8</li>
  </ul>
</details>
<details>
  <summary>31 packages built:</summary>
  <ul>
    <li>discourse</li>
    <li>discourseAllPlugins</li>
    <li>gitlab</li>
    <li>gitlab-ee</li>
    <li>gollum</li>
    <li>jasp-desktop</li>
    <li>mailcatcher</li>
    <li>postgresql12Packages.plv8</li>
    <li>postgresql13Packages.plv8</li>
    <li>postgresql14Packages.plv8</li>
    <li>postgresqlPackages.plv8 (postgresql15Packages.plv8)</li>
    <li>postgresql16Packages.plv8</li>
    <li>rubyPackages.coffee-script (rubyPackages_3_1.coffee-script)</li>
    <li>rubyPackages.execjs (rubyPackages_3_1.execjs)</li>
    <li>rubyPackages.github-pages (rubyPackages_3_1.github-pages)</li>
    <li>rubyPackages.jekyll-coffeescript (rubyPackages_3_1.jekyll-coffeescript)</li>
    <li>rubyPackages.jekyll-webmention_io (rubyPackages_3_1.jekyll-webmention_io)</li>
    <li>rubyPackages.uglifier (rubyPackages_3_1.uglifier)</li>
    <li>rubyPackages_3_2.coffee-script</li>
    <li>rubyPackages_3_2.execjs</li>
    <li>rubyPackages_3_2.github-pages</li>
    <li>rubyPackages_3_2.jekyll-coffeescript</li>
    <li>rubyPackages_3_2.jekyll-webmention_io</li>
    <li>rubyPackages_3_2.uglifier</li>
    <li>rubyPackages_3_3.coffee-script</li>
    <li>rubyPackages_3_3.execjs</li>
    <li>rubyPackages_3_3.github-pages</li>
    <li>rubyPackages_3_3.jekyll-coffeescript</li>
    <li>rubyPackages_3_3.jekyll-webmention_io</li>
    <li>rubyPackages_3_3.uglifier</li>
    <li>zammad</li>
  </ul>
</details>
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
