### PR TITLE
Revert "nix: 2.18 -> 2.22"

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -174,16 +174,6 @@ in lib.makeExtensible (self: ({
     version = "2.22.1";
     hash = "sha256-5Q1WkpTWH7fkVfYhHDc5r0A+Vc+K5xB1UhzrLzBCrB8=";
     self_attribute_name = "nix_2_22";
-    patches = [
-      (fetchpatch {
-        url = "https://github.com/NixOS/nix/commit/e5f509ef0b5c364544c904faa0bfda57dba03611.patch"; # fix for nix edit
-        sha256 = "sha256-E0QBD4h6MkGj5ye6Ba08MFR3drOOQu36t6xLXukm7a0=";
-      })
-      (fetchpatch {
-        url = "https://github.com/NixOS/nix/commit/bb1a4ea21a6af3c37c7d1c948e36678c96c3f499.patch"; # fix for nix edit
-        sha256 = "sha256-rgK+wus9qccVIKdhbKiDcvcngLvFk6SjjAnRQ6fAMno=";
-      })
-    ];
   };
 
   git = common rec {
@@ -217,7 +207,7 @@ in lib.makeExtensible (self: ({
     else
       nix;
 
-  stable = addFallbackPathsCheck self.nix_2_22;
+  stable = addFallbackPathsCheck self.nix_2_18;
 } // lib.optionalAttrs config.allowAliases (
   lib.listToAttrs (map (
     minor:


### PR DESCRIPTION
Reverts NixOS/nixpkgs#315262 cc @Mic92 @lovesegfault 

Looking into fixing the test failure https://hydra.nixos.org/build/261759976/nixlog/18 here

https://github.com/NixOS/nixpkgs/blob/d8a5a620da8e1cae5348ede15cd244705e02598c/nixos/tests/misc.nix#L75-L86

