### PR TITLE
electrum: 4.5.4 -> 4.5.5

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , fetchurl
 , fetchFromGitHub
-, fetchpatch
 , wrapQtAppsHook
 , python3
 , zbar
@@ -14,7 +13,7 @@
 }:
 
 let
-  version = "4.5.4";
+  version = "4.5.5";
 
   python = python3.override {
     self = python;
@@ -47,7 +46,7 @@ let
     owner = "spesmilo";
     repo = "electrum";
     rev = version;
-    sha256 = "sha256-fDu2PlEQOF7ftlS6dYw15S2XiAx+D/bng4zC9ELj6uk=";
+    sha256 = "sha256-CbhI/q+zjk9odxuvdzpogi046FqkedJooiQwS+WAkJ8=";
 
     postFetch = ''
       mv $out ./all
@@ -63,7 +62,7 @@ python.pkgs.buildPythonApplication {
 
   src = fetchurl {
     url = "https://download.electrum.org/${version}/Electrum-${version}.tar.gz";
-    sha256 = "sha256-lDuwXhOjcbCx8x/oIoigrklDwCbhn1trf5lDf/X/1Qc=";
+    sha256 = "1jiagz9avkbd158pcip7p4wz0pdsxi94ndvg5p8afvshb32aqwav";
   };
 
   postUnpack = ''
@@ -99,7 +98,7 @@ python.pkgs.buildPythonApplication {
     keepkey
     trezor
     bitbox02
-    cbor
+    cbor2
     pyserial
   ] ++ lib.optionals enableQt [
     pyqt5
@@ -110,30 +109,7 @@ python.pkgs.buildPythonApplication {
     pyqt6
   ];
 
-  patches = [
-    # aiorpcx 0.23.1 compatibility
-    # Note: this patches `/run_electrum`.
-    # In the source repo, `/electrum/electrum`
-    # is a symlink to `../run_electrum`,
-    # so that path would also be affected by the patch.
-    # However, in the distribution tarball used here,
-    # `/electrum/electrum` is simply an exact copy of
-    # `/run_electrum` and is thereby *not* affected.
-    # So we have to manually copy the patched `/run_electrum`
-    # over `/electrum/electrum` after the patching (see below).
-    # XXX remove the copy command in `postPatch`
-    # as soon as the patch itself is removed!
-    (fetchpatch {
-      url = "https://github.com/spesmilo/electrum/commit/5f95d919dfa9868eaf82889903b94faa8c6443e0.patch";
-      hash = "sha256-cEkduLsL6A8qPhXS2KPQWzVtkQPYQhHSbuwQ2SnanHw=";
-    })
-  ];
-
   postPatch = ''
-    # copy the patched `/run_electrum` over `/electrum/electrum`
-    # so the aiorpcx compatibility patch is used
-    cp run_electrum electrum/electrum
-
     # make compatible with protobuf4 by easing dependencies ...
     substituteInPlace ./contrib/requirements/requirements.txt \
       --replace "protobuf>=3.20,<4" "protobuf>=3.20"


### PR DESCRIPTION
## Description of changes
4.5.4 -> 4.5.5
https://github.com/spesmilo/electrum/blob/master/RELEASE-NOTES

As part of the update
- No longer need patch for aiorpcx (removed).
- Replaced `cbor` hardware requirement with `cbor2` (otherwise electrum complains)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
