### PR TITLE
nixos/gnome-keyring: rewrite module and fix unlocking on GDM session login

### DIFF
--- a/nixos/modules/services/desktops/gnome/gnome-keyring.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-keyring.nix
@@ -43,6 +43,9 @@ in
         gdm-password.enableGnomeKeyring = true;
         gdm-autologin.enableGnomeKeyring = true;
       })
+      (lib.mkIf (config.services.xserver.displayManager.gdm.enable && config.services.fprintd.enable) {
+        gdm-fingerprint.enableGnomeKeyring = true;
+      })
     ];
 
     security.wrappers.gnome-keyring-daemon = {

--- a/nixos/modules/services/desktops/gnome/gnome-keyring.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-keyring.nix
@@ -1,41 +1,37 @@
 # GNOME Keyring daemon.
 
-{ config, pkgs, lib, ... }:
-
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.gnome.gnome-keyring;
+in
 {
 
   meta = {
     maintainers = lib.teams.gnome.members;
   };
 
-  ###### interface
-
   options = {
-
     services.gnome.gnome-keyring = {
-
-      enable = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Whether to enable GNOME Keyring daemon, a service designed to
-          take care of the user's security credentials,
-          such as user names and passwords.
-        '';
-      };
-
+      enable = lib.mkEnableOption ''
+        GNOME Keyring daemon, a service designed to
+        take care of the user's security credentials,
+        such as user names and passwords
+      '';
     };
-
   };
 
-
-  ###### implementation
-
-  config = lib.mkIf config.services.gnome.gnome-keyring.enable {
-
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = [ pkgs.gnome.gnome-keyring ];
 
-    services.dbus.packages = [ pkgs.gnome.gnome-keyring pkgs.gcr ];
+    services.dbus.packages = [
+      pkgs.gnome.gnome-keyring
+      pkgs.gcr
+    ];
 
     xdg.portal.extraPortals = [ pkgs.gnome.gnome-keyring ];
 
@@ -47,7 +43,5 @@
       capabilities = "cap_ipc_lock=ep";
       source = "${pkgs.gnome.gnome-keyring}/bin/gnome-keyring-daemon";
     };
-
   };
-
 }

--- a/nixos/modules/services/desktops/gnome/gnome-keyring.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-keyring.nix
@@ -35,7 +35,15 @@ in
 
     xdg.portal.extraPortals = [ pkgs.gnome.gnome-keyring ];
 
-    security.pam.services.login.enableGnomeKeyring = true;
+    security.pam.services = lib.mkMerge [
+      {
+        login.enableGnomeKeyring = true;
+      }
+      (lib.mkIf config.services.xserver.displayManager.gdm.enable {
+        gdm-password.enableGnomeKeyring = true;
+        gdm-autologin.enableGnomeKeyring = true;
+      })
+    ];
 
     security.wrappers.gnome-keyring-daemon = {
       owner = "root";


### PR DESCRIPTION
## Description of changes

This PR rewrites the `nixos/gnome/gnome-keyring` module.

GDM uses gdm-password as the PAM service name for both logins and unlocks.
So unlock gnome-keyring as part of `gdm-password`.
Without this, keyrings may not be unlocked properly for GDM 45+.

## Things done

- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

@NixOS/gnome

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
