### PR TITLE
nixVersions.stable: reference nixos-smoketets test 

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -112,7 +112,7 @@ in rec {
         (onFullSupported "nixos.tests.latestKernel.login")
         (onFullSupported "nixos.tests.lightdm")
         (onFullSupported "nixos.tests.login")
-        (onFullSupported "nixos.tests.misc.default")
+        (onFullSupported "nixos.tests.nixos-smoketests.default")
         (onFullSupported "nixos.tests.mutableUsers")
         (onFullSupported "nixos.tests.nat.firewall")
         (onFullSupported "nixos.tests.nat.standalone")

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -41,7 +41,7 @@ in rec {
         firewall
         ipv6
         login
-        misc
+        nixos-smoketests
         nat
         nfs4
         openssh
@@ -124,7 +124,7 @@ in rec {
         "nixos.tests.firewall"
         "nixos.tests.ipv6"
         "nixos.tests.login"
-        "nixos.tests.misc.default"
+        "nixos.tests.nixos-smoketests.default"
         "nixos.tests.nat.firewall"
         "nixos.tests.nat.standalone"
         "nixos.tests.nfs4.simple"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -556,7 +556,6 @@ in {
   miniflux = handleTest ./miniflux.nix {};
   minio = handleTest ./minio.nix {};
   miriway = handleTest ./miriway.nix {};
-  misc = handleTest ./misc.nix {};
   mjolnir = handleTest ./matrix/mjolnir.nix {};
   mobilizon = handleTest ./mobilizon.nix {};
   mod_perl = handleTest ./mod_perl.nix {};
@@ -605,6 +604,7 @@ in {
   nebula = handleTest ./nebula.nix {};
   netbird = handleTest ./netbird.nix {};
   nimdow = handleTest ./nimdow.nix {};
+  nixos-smoketests = handleTest ./nixos-smoketests.nix {};
   neo4j = handleTest ./neo4j.nix {};
   netdata = handleTest ./netdata.nix {};
   networking.scripted = handleTest ./networking/networkd-and-scripted.nix { networkd = false; };

--- a/nixos/tests/nixos-smoketests.nix
+++ b/nixos/tests/nixos-smoketests.nix
@@ -20,7 +20,7 @@ let
   let
     foo = pkgs.writeText "foo" "Hello World";
   in {
-    name = "misc";
+    name = "nixos-smoketests";
     meta.maintainers = with lib.maintainers; [ raitobezarius ];
 
     nodes.machine =

--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -260,7 +260,7 @@ let
     passthru = {
       inherit aws-sdk-cpp boehmgc;
       tests = {
-        misc = nixosTests.misc.lix.passthru.override { nixPackage = self; };
+        nixos-smoketests = nixosTests.nixos-smoketests.lix.passthru.override { nixPackage = self; };
       };
     };
 

--- a/pkgs/tools/package-management/nix/common.nix
+++ b/pkgs/tools/package-management/nix/common.nix
@@ -62,6 +62,7 @@ in
 , mdbook
 , mdbook-linkcheck
 , nlohmann_json
+, nixosTests
 , openssl
 , perl
 , pkg-config
@@ -251,6 +252,9 @@ self = stdenv.mkDerivation {
 
     tests = {
       nixi686 = pkgsi686Linux.nixVersions.${self_attribute_name};
+      # Basic nixos smoke test that needs to pass when upgrading nix.
+      # Note that this test does only test the nixVersions.stable attribute.
+      nixos-smoketests = nixosTests.nixos-smoketests;
     };
   };
 


### PR DESCRIPTION
According to the previous nix maintainer, this test is critical for nix upgrades.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
