### PR TITLE
artalk: add completion scripts

### DIFF
--- a/pkgs/by-name/ar/artalk/package.nix
+++ b/pkgs/by-name/ar/artalk/package.nix
@@ -61,6 +61,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "Self-hosted comment system";
     homepage = "https://github.com/ArtalkJS/Artalk";
+    changelog = "https://github.com/ArtalkJS/Artalk/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ moraxyc ];
     mainProgram = "artalk";

--- a/pkgs/by-name/ar/artalk/package.nix
+++ b/pkgs/by-name/ar/artalk/package.nix
@@ -31,9 +31,16 @@ buildGoModule rec {
     "-X github.com/ArtalkJS/Artalk/internal/config.Version=${version}"
     "-X github.com/ArtalkJS/Artalk/internal/config.CommitHash=${version}"
   ];
+
   preBuild = ''
     tar -xzf ${web}
     cp -r ./artalk_ui/* ./public
+  '';
+
+  postInstall = ''
+    # work around case insensitive file systems
+    mv $out/bin/Artalk $out/bin/artalk.tmp
+    mv $out/bin/artalk.tmp $out/bin/artalk
   '';
 
   passthru.tests = {
@@ -45,6 +52,6 @@ buildGoModule rec {
     homepage = "https://github.com/ArtalkJS/Artalk";
     license = licenses.mit;
     maintainers = with maintainers; [ moraxyc ];
-    mainProgram = "Artalk";
+    mainProgram = "artalk";
   };
 }

--- a/pkgs/by-name/ar/artalk/package.nix
+++ b/pkgs/by-name/ar/artalk/package.nix
@@ -58,12 +58,12 @@ buildGoModule rec {
     version = testers.testVersion { package = artalk; };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Self-hosted comment system";
     homepage = "https://github.com/ArtalkJS/Artalk";
     changelog = "https://github.com/ArtalkJS/Artalk/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ moraxyc ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ moraxyc ];
     mainProgram = "artalk";
   };
 }

--- a/pkgs/by-name/ar/artalk/package.nix
+++ b/pkgs/by-name/ar/artalk/package.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "ArtalkJS";
     repo = "artalk";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-fOuZiFomXGvRUXkpEM3BpJyMOtSm6/RHd0a7dPOsoT4=";
   };
   web = fetchurl {


### PR DESCRIPTION
## Description of changes

- **artalk: rename mainProgram**
- **artalk: add completion scripts**

Since the program name in the generated completion scripts is `artalk`, I believe `mainProgram` should be this one.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
