### PR TITLE
markuplinkchecker: init at 0.17.0

### DIFF
--- a/pkgs/by-name/ma/markuplinkchecker/package.nix
+++ b/pkgs/by-name/ma/markuplinkchecker/package.nix
@@ -1,0 +1,38 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, openssl
+, perl
+, stdenv
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "markuplinkchecker";
+  version = "0.17.0";
+
+  src = fetchFromGitHub {
+    owner = "becheran";
+    repo = "mlc";
+    rev = "v${version}";
+    hash = "sha256-vRsL3t/uauAWMCXgJXQ5ICgNtLpa8Dzq/gyjFlKgfqw=";
+  };
+
+  cargoHash = "sha256-nlHNhO9g4Oa878Tl6/Qe1yQeZR6c/fEzY4LilVpMSk0=";
+
+  nativeBuildInputs = [ perl ];
+
+  buildInputs = [ openssl ];
+
+  doCheck = false; # because it requires an internet connection
+
+  meta = {
+    description = "Check for broken links in markup files";
+    homepage = "https://github.com/becheran/mlc";
+    changelog = "https://github.com/becheran/mlc/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    mainProgram = "mlc";
+    maintainers = with lib.maintainers; [ anas ];
+    platforms = with lib.platforms; unix ++ windows;
+    broken = stdenv.isDarwin; # needing some apple_sdk packages
+  };
+}


### PR DESCRIPTION
## Description of changes

Add [markuplinkchecker (mlc)](https://github.com/becheran/mlc) which is a lintier (checker) for links in markup files 
`html` and `markdown` to prevent broken links in your markup docs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
