### PR TITLE
rewind-ai: init at 1.5284-15284.1-dcd0176-20240504

### DIFF
--- a/pkgs/by-name/re/rewind-ai/package.nix
+++ b/pkgs/by-name/re/rewind-ai/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  writeShellApplication,
+  curl,
+  gawk,
+  xmlstarlet,
+  common-updater-scripts,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "rewind-ai";
+  # Example version with explanation
+  # 1.5284 (Base version)
+  # 15284.1 (build number)
+  # dcd0176 (commit hash)
+  # 20240504 (pub date)
+  version = "1.5284-15284.1-dcd0176-20240504";
+
+  src = fetchzip {
+    url =
+      let
+        buildNumber = lib.elemAt (lib.splitString "-" finalAttrs.version) 1;
+        commitHash = lib.elemAt (lib.splitString "-" finalAttrs.version) 2;
+      in
+      "https://updates.rewind.ai/builds/main/b${buildNumber}-main-${commitHash}.zip";
+    hash = "sha256-Y7iAYHH/msZoXFzAZHJb6YoDz5fwMPHJx1kg7TqP5Gw=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications/Rewind.app"
+    cp -R . "$out/Applications/Rewind.app"
+
+    runHook postInstall
+  '';
+
+  # Example response to use when modifing the script: https://pastebin.com/raw/90qU3n6H
+  # There is a real harsh limit on update checks, so DO NOT send any unnecessary update checks
+  # Wait at least 3 days since the last pub_date (you will find the date at the end of the version number)
+  # Example: 20240504 would be 2024/05/04, and that would mean that we want to check no earlier than on 2024/05/07 for any updates
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "${finalAttrs.pname}-update-script";
+    runtimeInputs = [
+      curl
+      gawk
+      xmlstarlet
+      common-updater-scripts
+    ];
+    text = ''
+      xml_get () {
+        echo "$update_xml" | xmlstarlet sel -t -v "$1"
+      }
+
+      update_url="https://updates.rewind.ai/appcasts/main.xml"
+
+      update_xml=$(curl -s "$update_url")
+
+      version_base=$(xml_get "/rss/channel/item/sparkle:shortVersionString")
+      url=$(xml_get "/rss/channel/item/enclosure/@url")
+      pub_date=$(xml_get "/rss/channel/item/pubDate")
+      commit_id=$(echo "$url" | awk -F '-|\\.' '{ print $(NF - 1) }')
+      build_number=$(xml_get "/rss/channel/item/sparkle:version")
+      formatted_pub_date=$(date -d "$pub_date" +"%Y%m%d")
+
+      full_version="''${version_base}-''${build_number}-''${commit_id}-''${formatted_pub_date}"
+      update-source-version "rewind-ai" "$full_version" --version-key=version --file=./pkgs/by-name/re/rewind-ai/package.nix --print-changes
+    '';
+  });
+
+  meta = {
+    changelog = "https://www.rewind.ai/changelog";
+    description = "Rewind is a personalized AI powered by everything you've seen, said, or heard";
+    homepage = "https://www.rewind.ai/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ donteatoreo ];
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc