### PR TITLE
plymouth-vortex-ubuntu-theme: init at 0-unstable-2024-05-05

### DIFF
--- a/pkgs/by-name/pl/plymouth-vortex-ubuntu-theme/package.nix
+++ b/pkgs/by-name/pl/plymouth-vortex-ubuntu-theme/package.nix
@@ -1,0 +1,43 @@
+{
+  stdenvNoCC,
+  fetchFromGitHub,
+  lib,
+  unstableGitUpdater,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "plymouth-vortex-ubuntu-theme";
+  version = "0-unstable-2024-05-05";
+
+  src = fetchFromGitHub {
+    owner = "emanuele-scarsella";
+    repo = "vortex-ubuntu-plymouth-theme";
+    rev = "331a201918a3b026dd200659403c1cf779c718f0";
+    hash = "sha256-RSWfuKCdsuFA2e5kb0OXnxW+QV7b2iHVvZEKVHoLgMw=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/plymouth/themes/vortex-ubuntu
+    cp vortex-ubuntu/* $out/share/plymouth/themes/vortex-ubuntu
+    substituteInPlace $out/share/plymouth/themes/vortex-ubuntu/vortex-ubuntu.plymouth \
+      --replace-fail "/usr/" "$out/"
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Animated Plymouth boot theme with rotating Ubuntu logo";
+    longDescription = ''
+      Animated Plymouth theme with the Ubuntu logo and a futuristic and elegant look.
+      Disk encryption password prompt is supported.
+    '';
+    homepage = "https://github.com/emanuele-scarsella/vortex-ubuntu-plymouth-theme";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ johnrtitor ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Homepage:- https://github.com/emanuele-scarsella/vortex-ubuntu-plymouth-theme

Yeah I know its not Ubuntu but the animation looks good enough for me to package this :)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
