### PR TITLE
plymouth-proxzima-theme: init at 0-unstable-2023-01-30

### DIFF
--- a/pkgs/by-name/pl/plymouth-proxzima-theme/package.nix
+++ b/pkgs/by-name/pl/plymouth-proxzima-theme/package.nix
@@ -1,0 +1,39 @@
+{
+  stdenvNoCC,
+  fetchFromGitHub,
+  lib,
+  unstableGitUpdater,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "plymouth-proxzima-theme";
+  version = "0-unstable-2023-01-30";
+
+  src = fetchFromGitHub {
+    owner = "PROxZIMA";
+    repo = "proxzima-plymouth";
+    rev = "b6e335a631e057942700de5c523198a5b8061d9c";
+    hash = "sha256-f4CtXKsZPc/gZMVD+MJrHMrMw7TTFUndhUT4YLpfORU=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/plymouth/themes/proxzima
+    cp proxzima/* $out/share/plymouth/themes/proxzima
+    substituteInPlace $out/share/plymouth/themes/proxzima/proxzima.plymouth \
+      --replace-fail "/usr/" "$out/"
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "A techno Plymouth theme with crazy animation";
+    homepage = "https://github.com/PROxZIMA/proxzima-plymouth";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ johnrtitor ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Homepage:- https://github.com/PROxZIMA/proxzima-plymouth

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
