### PR TITLE
meson: add patch to find boost via pkg-config

### DIFF
--- a/pkgs/applications/audio/pulseeffects-legacy/default.nix
+++ b/pkgs/applications/audio/pulseeffects-legacy/default.nix
@@ -99,11 +99,6 @@ in stdenv.mkDerivation rec {
     )
   '';
 
-  # Meson is no longer able to pick up Boost automatically.
-  # https://github.com/NixOS/nixpkgs/issues/86131
-  BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
-  BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
-
   meta = with lib; {
     description = "Limiter, compressor, reverberation, equalizer and auto volume effects for Pulseaudio applications";
     mainProgram = "pulseeffects";

--- a/pkgs/applications/misc/tuxclocker/default.nix
+++ b/pkgs/applications/misc/tuxclocker/default.nix
@@ -27,10 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-QLKLqTCpVMWxlDINa8Bo1vgCDcjwovoaXUs/PdMnxv0=";
   };
 
-  # Meson doesn't find boost without these
-  BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
-  BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
-
   nativeBuildInputs = [
     git
     makeWrapper

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -13,6 +13,7 @@
 , python3
 , substituteAll
 , zlib
+, fetchpatch
 }:
 
 let
@@ -70,6 +71,16 @@ python3.pkgs.buildPythonApplication rec {
 
     # This edge case is explicitly part of meson but is wrong for nix
     ./007-freebsd-pkgconfig-path.patch
+
+    # Find boost via pkg-config
+    # https://github.com/NixOS/nixpkgs/issues/86131
+    # Already merged upstream PR: https://github.com/mesonbuild/meson/pull/13272
+    # FIXME: Will be in meson 1.5.0
+    (fetchpatch {
+      name = "find-boost-pkg-config.patch";
+      url = "https://github.com/mesonbuild/meson/commit/c21b886ba8a60cce7fa56e4be40bd7547129fb00.patch";
+      hash = "sha256-uSilNuSx9yd1cxs0XVLcLw4MOXEd2uIe2g+wk+SBqeU=";
+    })
   ];
 
   buildInputs = lib.optionals (python3.pythonOlder "3.9") [

--- a/pkgs/by-name/tu/tuxclocker-nvidia-plugin/package.nix
+++ b/pkgs/by-name/tu/tuxclocker-nvidia-plugin/package.nix
@@ -11,7 +11,7 @@
 stdenv.mkDerivation {
   pname = "tuxclocker-nvidia-plugin";
 
-  inherit (tuxclocker-plugins) src version meta BOOST_INCLUDEDIR BOOST_LIBRARYDIR nativeBuildInputs;
+  inherit (tuxclocker-plugins) src version meta nativeBuildInputs;
 
   buildInputs = [
     boost

--- a/pkgs/by-name/tu/tuxclocker-plugins/package.nix
+++ b/pkgs/by-name/tu/tuxclocker-plugins/package.nix
@@ -13,7 +13,7 @@
 }:
 
 stdenv.mkDerivation {
-  inherit (tuxclocker) src version meta BOOST_INCLUDEDIR BOOST_LIBRARYDIR;
+  inherit (tuxclocker) src version meta;
 
   pname = "tuxclocker-plugins";
 

--- a/pkgs/development/interpreters/emilua/default.nix
+++ b/pkgs/development/interpreters/emilua/default.nix
@@ -71,13 +71,6 @@ stdenv.mkDerivation rec {
 
   dontUseCmakeConfigure = true;
 
-  # Meson is no longer able to pick up Boost automatically.
-  # https://github.com/NixOS/nixpkgs/issues/86131
-  env = {
-    BOOST_INCLUDEDIR = "${lib.getDev boost182}/include";
-    BOOST_LIBRARYDIR = "${lib.getLib boost182}/lib";
-  };
-
   mesonFlags = [
     (lib.mesonBool "enable_file_io" true)
     (lib.mesonBool "enable_io_uring" true)

--- a/pkgs/development/libraries/cairomm/1.16.nix
+++ b/pkgs/development/libraries/cairomm/1.16.nix
@@ -44,11 +44,6 @@ stdenv.mkDerivation rec {
     "-Dbuild-tests=true"
   ];
 
-  # Meson is no longer able to pick up Boost automatically.
-  # https://github.com/NixOS/nixpkgs/issues/86131
-  BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
-  BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
-
   # Tests fail on Darwin, possibly because of sandboxing.
   doCheck = !stdenv.isDarwin;
 

--- a/pkgs/development/libraries/cairomm/default.nix
+++ b/pkgs/development/libraries/cairomm/default.nix
@@ -44,11 +44,6 @@ stdenv.mkDerivation rec {
     "-Dbuild-tests=true"
   ];
 
-  # Meson is no longer able to pick up Boost automatically.
-  # https://github.com/NixOS/nixpkgs/issues/86131
-  BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
-  BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
-
   doCheck = !stdenv.isDarwin;
 
   meta = with lib; {

--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -203,13 +203,6 @@ stdenv.mkDerivation {
       (lib.mesonOption "sandbox-shell" "${busybox-sandbox-shell}/bin/busybox")
     ];
 
-  # Needed for Meson to find Boost.
-  # https://github.com/NixOS/nixpkgs/issues/86131.
-  env = {
-    BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
-    BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
-  };
-
   postInstall =
     ''
       mkdir -p $doc/nix-support


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/86131

https://github.com/mesonbuild/meson/pull/13272

TODO remove all the meson(cmake uses the vars too) `BOOST_{INCLUDE,LIBRARY}DIR`

Tested with

```diff
diff --git a/pkgs/tools/package-management/lix/common.nix b/pkgs/tools/package-management/lix/common.nix
index fe77830d56f1..f25b16af3309 100644
--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -21,6 +21,7 @@ assert (hash == null) -> (src != null);
   bash,
   bison,
   boehmgc,
+  fetchpatch,
   boost,
   brotli,
   busybox-sandbox-shell,
@@ -110,7 +111,16 @@ let
         bison
         flex
         jq
-        meson
+        (meson.overrideAttrs (previousAttrs: {
+          patches = previousAttrs.patches ++ [
+            # upstream PR: https://github.com/mesonbuild/meson/pull/13272
+            (fetchpatch {
+              name = "find-boost-pkg-config.patch";
+              url = "https://github.com/mesonbuild/meson/commit/f0eda0346b2b936e4ef795f3a82733d6711b18fb.patch";
+              sha256 = "sha256-uSilNuSx9yd1cxs0XVLcLw4MOXEd2uIe2g+wk+SBqeU=";
+            })
+          ];
+        }))
         ninja
         cmake
         python3
@@ -201,13 +211,6 @@ let
         (lib.mesonOption "sandbox-shell" "${busybox-sandbox-shell}/bin/busybox")
       ];
 
-    # Needed for Meson to find Boost.
-    # https://github.com/NixOS/nixpkgs/issues/86131.
-    env = {
-      BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
-      BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
-    };
-
     postInstall =
       ''
         mkdir -p $doc/nix-support
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
