### PR TITLE
cpptrace: init at 0.6.2

### DIFF
--- a/pkgs/by-name/cp/cpptrace/findpackage-integration.nix
+++ b/pkgs/by-name/cp/cpptrace/findpackage-integration.nix
@@ -1,0 +1,39 @@
+{
+  stdenv,
+  lib,
+  cmake,
+  cpptrace,
+  src,
+  checkOutput,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  name = "cpptrace-findpackage-integration-test";
+
+  inherit src;
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ cpptrace ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install main $out/bin
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = lib.strings.concatLines (
+    [ "$out/bin/main" ]
+    # Check that the backtrace contains the path to the executable.
+    ++ lib.optionals (checkOutput) [
+      ''
+        if [[ !(`$out/bin/main 2>&1` =~ "${finalAttrs.name}") ]]; then
+          echo "ERROR: $out/bin/main does not output '${finalAttrs.name}'"
+          exit 1
+        fi
+      ''
+    ]
+  );
+})

--- a/pkgs/by-name/cp/cpptrace/package.nix
+++ b/pkgs/by-name/cp/cpptrace/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  libdwarf,
+  gtest,
+  callPackage,
+  zstd,
+  static ? stdenv.hostPlatform.isStatic,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cpptrace";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "jeremy-rifkin";
+    repo = "cpptrace";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-zjPxPtq+OQ104sJoeBD3jpMV9gV57FSHEJS4W6SF8GM=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [ libdwarf ];
+  propagatedBuildInputs = [ zstd ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "CPPTRACE_USE_EXTERNAL_LIBDWARF" true)
+    (lib.cmakeBool "CPPTRACE_FIND_LIBDWARF_WITH_PKGCONFIG" true)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!static))
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "CPPTRACE_USE_EXTERNAL_GTEST" true)
+  ];
+
+  checkInputs = [ gtest ];
+
+  # Unit tests are flaky and hard to get right.
+  doCheck = false;
+
+  passthru.tests = {
+    findpackage-integration = callPackage ./findpackage-integration.nix {
+      src = "${finalAttrs.src}/test/findpackage-integration";
+      checkOutput = finalAttrs.finalPackage.doCheck;
+    };
+  };
+
+  meta = {
+    changelog = "https://github.com/jeremy-rifkin/cpptrace/releases/tag/v${finalAttrs.version}";
+    description = "Simple, portable, and self-contained stacktrace library for C++11 and newer";
+    homepage = "https://github.com/jeremy-rifkin/cpptrace";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ xokdvium ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

[Homepage](https://github.com/jeremy-rifkin/cpptrace) and Conan [recipe](https://github.com/conan-io/conan-center-index/blob/a5c52a107e77f3f7a860d72a8a41d768f8fcedb2/recipes/cpptrace/all/conanfile.py)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
