### PR TITLE
tests-stdenv-gcc-stageCompare: cleanup

### DIFF
--- a/pkgs/test/stdenv/gcc-stageCompare.nix
+++ b/pkgs/test/stdenv/gcc-stageCompare.nix
@@ -8,25 +8,45 @@
 # must remember to do the check.
 #
 
-{ stdenv
-, pkgs
-, lib
+{ lib
+, stdenv
+, runCommand
+, overrideCC
+, wrapCCWith
 }:
 
-assert stdenv.cc.isGNU;
-with pkgs;
-# rebuild gcc using the "final" stdenv
-let gcc-stageCompare = (gcc-unwrapped.override {
-      reproducibleBuild = true;
-      profiledCompiler = false;
-      stdenv = overrideCC stdenv (wrapCCWith {
-        cc = stdenv.cc;
-      });
-    }).overrideAttrs(_: {
-      NIX_OUTPATH_USED_AS_RANDOM_SEED = stdenv.cc.cc.out;
+let
+  inherit (stdenv.cc) cc;
+in
+
+assert cc.isGNU;
+
+# Rebuild gcc using the "final" stdenv.
+let
+  rebuiltCC = (cc.override {
+    reproducibleBuild = true;
+    profiledCompiler = false;
+    stdenv = overrideCC stdenv (wrapCCWith {
+      inherit cc;
     });
-in (runCommand "gcc-stageCompare" {} ''
-  diff -sr ${pkgs.gcc-unwrapped.checksum}/checksums ${gcc-stageCompare.checksum}/checksums && touch $out
-'').overrideAttrs (a: {
-  meta = (a.meta or { }) // { platforms = lib.platforms.linux; };
-})
+  }).overrideAttrs (_: {
+    # TODO: do we really have to set random seed? This likely won’t work with
+    # content-addressed derivations, and also GCC expects random seed to be
+    # different for each file (but that is an issue with stdenv in general).
+    # https://gcc.gnu.org/onlinedocs/gcc-14.1.0/gcc/Developer-Options.html#index-frandom-seed
+    # >The string should be different for every file you compile.
+    NIX_OUTPATH_USED_AS_RANDOM_SEED = cc.out;
+  });
+
+  cmdArgs = {
+    checksumBefore = cc.checksum;
+    checksumAfter = rebuiltCC.checksum;
+    meta.platforms = lib.platforms.linux;
+  };
+in
+runCommand "gcc-stageCompare" cmdArgs ''
+  diff --report-identical-files --recursive -- \
+    "$checksumBefore"/checksums \
+    "$checksumAfter"/checksums
+  touch $out
+''


### PR DESCRIPTION
## Description of changes

Minor cleanup of the `tests-stdenv-gcc-stageCompare`. Note that the test itself is currently silently broken, see https://github.com/NixOS/nixpkgs/pull/314920#issuecomment-2138797149. _This PR does not fix that._

**Parent PR:**
- #314920

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
