### PR TITLE
ejson2env: add tests

### DIFF
--- a/pkgs/tools/admin/ejson2env/default.nix
+++ b/pkgs/tools/admin/ejson2env/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, nix-update-script }:
+{ lib, buildGoModule, fetchFromGitHub, nix-update-script, testers, callPackage, ejson2env }:
 
 buildGoModule rec {
   pname = "ejson2env";
@@ -19,7 +19,13 @@ buildGoModule rec {
     "-X main.version=${version}"
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      version = testers.testVersion { package = ejson2env; };
+      decryption = callPackage ./test-decryption.nix {};
+    };
+  };
 
   meta = with lib; {
     description = "Decrypt EJSON secrets and export them as environment variables";

--- a/pkgs/tools/admin/ejson2env/test-decryption.nix
+++ b/pkgs/tools/admin/ejson2env/test-decryption.nix
@@ -1,0 +1,19 @@
+{ ejson2env, runCommand }:
+runCommand "check-ejson2env.sh" {
+  nativeBuildInputs = [ ejson2env ];
+} ''
+  cat > $TMP/abc.ejson <<EOF
+    {
+      "_public_key": "349a0e027725db0693cf0505344c5104807d38fb398cd4597029dccc8d0d8711",
+      "environment": {
+        "foo": "EJ[1:7oqIDkyXLro12rcrg7/psjK5Qcfuw5FRquvfBaRUBic=:OTtncVl0wT4U6UWdxoaCGBRnM2WzGnV3:1FiIgHYT5U6MjFN8IUU83T1fzQ==]"
+      }
+    }
+EOF
+  response="$(echo "ff34961809e9d7a0ae20b9d09e5d8630c8d4924cef19cdb5385916b9be019954" | ejson2env --key-from-stdin $TMP/abc.ejson)"
+  if [[ "$response" != "export foo=bar" ]]; then
+    echo "test file not decrypted correctly"
+    exit 1
+  fi
+  touch $out
+''


### PR DESCRIPTION
## Description of changes

Test the basic functionality and the version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
