### PR TITLE
python312Packages.matplotlib: 3.8.4 -> 3.9.0

### DIFF
--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchPypi,
-  writeText,
   buildPythonPackage,
   isPyPy,
   pythonOlder,
@@ -11,7 +10,7 @@
   certifi,
   pkg-config,
   pybind11,
-  setuptools,
+  meson-python,
   setuptools-scm,
 
   # native libraries
@@ -80,7 +79,7 @@ let
 in
 
 buildPythonPackage rec {
-  version = "3.8.4";
+  version = "3.9.0";
   pname = "matplotlib";
   pyproject = true;
 
@@ -88,7 +87,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-iqw5fV6ewViWDjHDgcX/xS3dUr2aR3F+KmlAOBZ9/+o=";
+    hash = "sha256-5tKepsGeNLMPt9iLcIH4aaAwFPZv4G1izHfVpuqI7Xo=";
   };
 
   env.XDG_RUNTIME_DIR = "/tmp";
@@ -100,21 +99,16 @@ buildPythonPackage rec {
   # With the following patch we just hard-code these paths into the install
   # script.
   postPatch =
-    let
-      tcl_tk_cache = ''"${tk}/lib", "${tcl}/lib", "${lib.strings.substring 0 3 tk.version}"'';
-    in
     ''
       substituteInPlace pyproject.toml \
         --replace-fail '"numpy>=2.0.0rc1,<2.3",' ""
-    ''
-    + lib.optionalString enableTk ''
-      sed -i '/self.tcl_tk_cache = None/s|None|${tcl_tk_cache}|' setupext.py
+      patchShebangs tools
     ''
     + lib.optionalString (stdenv.isLinux && interactive) ''
       # fix paths to libraries in dlopen calls (headless detection)
-      substituteInPlace src/_c_internal_utils.c \
-        --replace libX11.so.6 ${libX11}/lib/libX11.so.6 \
-        --replace libwayland-client.so.0 ${wayland}/lib/libwayland-client.so.0
+      substituteInPlace src/_c_internal_utils.cpp \
+        --replace-fail libX11.so.6 ${libX11}/lib/libX11.so.6 \
+        --replace-fail libwayland-client.so.0 ${wayland}/lib/libwayland-client.so.0
     '';
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals enableGtk3 [ gobject-introspection ];
@@ -144,7 +138,7 @@ buildPythonPackage rec {
     certifi
     numpy
     pybind11
-    setuptools
+    meson-python
     setuptools-scm
   ];
 
@@ -172,22 +166,23 @@ buildPythonPackage rec {
     ++ lib.optionals enableTk [ tkinter ];
 
   passthru.config = {
-    directories = {
-      basedirlist = ".";
-    };
-    libs = {
-      system_freetype = true;
-      system_qhull = true;
-      # LTO not working in darwin stdenv, see #19312
-      enable_lto = !stdenv.isDarwin;
-    };
+    # In previous version v3.8.4 we used this passthru.config to generate an
+    # INI build configuration file. Now upstream switched to meson, so we
+    # retain sort of compatibility with the attribute set we had in the past,
+    # and we generate the `mesonFlags` from this attribute set.
+    system-freetype = true;
+    system-qhull = true;
+    # Otherwise GNU's `ar` binary fails to put symbols from libagg into the
+    # matplotlib shared objects. See:
+    # -https://github.com/matplotlib/matplotlib/issues/28260#issuecomment-2146243663
+    # -https://github.com/matplotlib/matplotlib/issues/28357#issuecomment-2155350739
+    b_lto = false;
   };
+  mesonFlags = lib.mapAttrsToList lib.mesonBool passthru.config;
 
   passthru.tests = {
     inherit sage;
   };
-
-  env.MPLSETUPCFG = writeText "mplsetup.cfg" (lib.generators.toINI { } passthru.config);
 
   # Encountering a ModuleNotFoundError, as describved and investigated at:
   # https://github.com/NixOS/nixpkgs/issues/255262 . It could be that some of

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -12,10 +12,20 @@
   pybind11,
   meson-python,
   setuptools-scm,
+  pytestCheckHook,
+  python,
+  matplotlib,
+  fetchurl,
 
   # native libraries
   ffmpeg-headless,
   freetype,
+  # By default, almost all tests fail due to the fact we use our version of
+  # freetype. We still define use this argument to define the overriden
+  # derivation `matplotlib.passthru.tests.withoutOutdatedFreetype` - which
+  # builds matplotlib with the freetype version they default to, with which all
+  # tests should pass.
+  doCheck ? false,
   qhull,
 
   # propagates
@@ -182,13 +192,33 @@ buildPythonPackage rec {
 
   passthru.tests = {
     inherit sage;
+    withOutdatedFreetype = matplotlib.override {
+      doCheck = true;
+      freetype = freetype.overrideAttrs (_: {
+        src = fetchurl {
+          url = "https://download.savannah.gnu.org/releases/freetype/freetype-old/freetype-2.6.1.tar.gz";
+          sha256 = "sha256-Cjx9+9ptoej84pIy6OltmHq6u79x68jHVlnkEyw2cBQ=";
+        };
+        patches = [ ];
+      });
+    };
   };
 
-  # Encountering a ModuleNotFoundError, as describved and investigated at:
-  # https://github.com/NixOS/nixpkgs/issues/255262 . It could be that some of
-  # which may fail due to a freetype version that doesn't match the freetype
-  # version used by upstream.
-  doCheck = false;
+  pythonImportsCheck = [ "matplotlib" ];
+  inherit doCheck;
+  nativeCheckInputs = [ pytestCheckHook ];
+  preCheck = ''
+    # https://matplotlib.org/devdocs/devel/testing.html#obtain-the-reference-images
+    find lib -name baseline_images -printf '%P\n' | while read p; do
+      cp -r lib/"$p" $out/${python.sitePackages}/"$p"
+    done
+    # Tests will fail without these files as well
+    cp \
+      lib/matplotlib/tests/{mpltest.ttf,cmr10.pfb,Courier10PitchBT-Bold.pfb} \
+      $out/${python.sitePackages}/matplotlib/tests/
+    # https://github.com/NixOS/nixpkgs/issues/255262
+    cd $out
+  '';
 
   meta = with lib; {
     description = "Python plotting library, making publication quality plots";


### PR DESCRIPTION
Changelog: https://github.com/matplotlib/matplotlib/releases/tag/v3.9.0

## Description of changes

Currently still a draft, due to [this upstream issue (that apparently only we experience?)](https://discourse.matplotlib.org/t/trouble-setting-up-a-development-environment-and-running-tests-on-nixos/24471). Also intentionally I target `master` and not `staging`, so that I'll be able to use the CI more easily once this gets ready.

I'm still opening this, to let the maintainers know that I'm "on it", and to share the slightly non-trivial work needed to get this working.

As for the last commit that enables the tests, I'm fairly sure that at least we won't get circular import errors as described in https://github.com/NixOS/nixpkgs/issues/255262 , but perhaps many tests fail due to our freetype library different then upstream (and upstream compares the images bit by bit). So I'll see how CI runs the tests for all platforms and decide than (once upstream issue will be resolved).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
