### PR TITLE
metal-stack-metalctl: init at 0.16.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20539,6 +20539,12 @@
       fingerprint = "556A 403F B0A2 D423 F656  3424 8489 B911 F9ED 617B";
     }];
   };
+  tlinden = {
+    email = "git@daemon.de";
+    github = "tlinden";
+    githubId = 1322812;
+    name = "Tom von Dein";
+  };
   tljuniper = {
     email = "tljuniper1@gmail.com";
     github = "tljuniper";

--- a/pkgs/by-name/me/metal-stack-metalctl/package.nix
+++ b/pkgs/by-name/me/metal-stack-metalctl/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, makeWrapper
+, go-licenses
+, stdenv
+, glibc
+}:
+
+buildGoModule rec {
+  pname = "metal-stack-metalctl";
+
+  version = "0.16.2";
+
+  src = fetchFromGitHub {
+    owner = "metal-stack";
+    repo = "metalctl";
+    rev = "v${version}";
+    hash = "sha256-0Di9k00uziLZEvM3TxXuFPYojJNUye+v0cN3WMw7meM=";
+  };
+
+  vendorHash = "sha256-EmJZIMG+5/xV7Zf4qXDpOqkCWmBQjHai/MsAQfmTM4g=";
+
+  ldflags = let
+    gitversion = "tags/v0.16.2-0-gf9c3071";  # git describe --long --all
+    gitsha = "f9c3071b";                     # git rev-parse --short=8 HEAD
+    gittime = "2024-05-17T19:05:41+02:00";   # date --iso-8601=seconds
+  in [
+    "-X github.com/metal-stack/v.Version=${version}"
+    "-X github.com/metal-stack/v.Revision=${gitversion}"
+    "-X github.com/metal-stack/v.GitSHA1=${gitsha}"
+    "-X github.com/metal-stack/v.BuildDate=${gittime}"
+  ];
+
+  # unit tests fail because the build dir is no git repo during build anymore
+  # see: https://github.com/metal-stack/metalctl/issues/245. Also, the unit tests
+  # are being executed on each release anyway, see for example:
+  # https://github.com/metal-stack/metalctl/actions/runs/8999417227 for v0.16.2
+  doCheck = false;
+
+  meta = {
+    description = "Command-line client for metal-stack.io";
+    homepage = "https://github.com/metal-stack/metalctl";
+    license = lib.licenses.mit;
+    mainProgram = "metalctl";
+    maintainers = with lib.maintainers; [ tlinden ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds the package metalctl. This is the commandline interface for cloud services operated with https://metal-stack.io/.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
