### PR TITLE
(rPackages.buildRPackage): bypass requireX on darwin (macOS) platforms

### DIFF
--- a/pkgs/development/r-modules/generic-builder.nix
+++ b/pkgs/development/r-modules/generic-builder.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation ({
   buildInputs = buildInputs ++ [R gettext] ++
-                lib.optionals requireX [util-linux xvfb-run] ++
+                lib.optionals (requireX && stdenv.isLinux) [util-linux xvfb-run] ++
                 lib.optionals stdenv.isDarwin [Cocoa Foundation gfortran libiconv];
 
   env.NIX_CFLAGS_COMPILE =


### PR DESCRIPTION
Dear @jbedo,

> Note: `buildRPackage` do not have a `meta` attribute so no maintainer is specified, as you (@jbedo) are the only person mention as a maintainer for some R-packages, and you have already reviewed a PR related to `generic-builder.nix`, I took the liberty of tagging you. If you are not the person in charge, I would be pleased if you please redirect me to someone else.

Recently a colleague of mine, who uses MacOS, tried to `nix develop` a flake specifying some R packages. This was unsuccessful because one of the dependency is a R-package listed in [`packagesRequiringX`](https://github.com/NixOS/nixpkgs/blob/5f6ccfaad57dd58f34581441fdea481bc508265a/pkgs/development/r-modules/default.nix#L747).

Indeed, when `requireX` is true, `xvfb-run` is added to the `buildInputs` however this cannot work on darwin platforms because [`xvfb-run` is only available for linux](https://github.com/NixOS/nixpkgs/blob/5f6ccfaad57dd58f34581441fdea481bc508265a/pkgs/tools/misc/xvfb-run/default.nix#L60) (`platforms = platforms.linux;`)

This PR will add `util-linux` and `xvfb-run` to `buildInputs` if `requireX` is true **and if the platform is Linux**.

I don't really know if `requireX` is:
1. A requirement of those R-packages themselves (so eventually they can not be installed on MacOS, or Windows) 
2. Or if it is a requirement for building those R-packages **on a Linux platforms**.

My guess is that some packages are concerned with the second option (but it is only a guess, I don't have any evidence of that).  So this PR can fix the build of those packages concerned by the "option 2".

Best regards,
@juliendiot42 

## Description of changes

The actual change is rather small:

```diff
  buildInputs = buildInputs ++ [R gettext] ++
-               lib.optionals requireX [util-linux xvfb-run] ++
+               lib.optionals (requireX && stdenv.isLinux) [util-linux xvfb-run] ++
                lib.optionals stdenv.isDarwin [Cocoa Foundation gfortran libiconv];
```
EDIT: ~~However, this change is obfuscated by "alejandra" auto-formater. Since the reformat follows more [the requested code conventions](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#code-conventions) I kept it, but I can also modify only as presented above if you prefer.~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)

Since all the R-packages depends on `buildRPackage` to be built, I didn't test all of them. I tested to build with one package (`pkgs.rPackages.ade4TkGUI`, as it is the first one in the list not marked as broken) and the build was successful, but I am on NixOS, not Darwin. Sadly, I don't know how to emulate a Darwin platform to test by my self (any recommendation for doing that would be appreciated). I was counting on the CI to test that more properly, if possible.


- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
