### PR TITLE
julia.withPackages: be able to test different julia attrs

### DIFF
--- a/pkgs/development/julia-modules/tests/julia-top-n/julia-top-n.cabal
+++ b/pkgs/development/julia-modules/tests/julia-top-n/julia-top-n.cabal
@@ -27,6 +27,7 @@ executable julia-top-n-exe
     , filepath
     , optparse-applicative
     , sandwich
+    , string-interpolate
     , text
     , unliftio
     , vector

--- a/pkgs/development/julia-modules/tests/julia-top-n/package.yaml
+++ b/pkgs/development/julia-modules/tests/julia-top-n/package.yaml
@@ -11,6 +11,7 @@ dependencies:
 - filepath
 - optparse-applicative
 - sandwich
+- string-interpolate
 - text
 - unliftio
 - vector


### PR DESCRIPTION
## Description of changes

I've just noticed that Julia 1.10 has a number of package build failures that Julia 1.9 doesn't have. This PR adds a "--julia-attr" flag to the test infrastructure, so it's easy to test different Julia versions like this:

```shell
nixpkgs/pkgs/development/julia-modules/tests> ./run_tests.sh --julia-attr julia_110
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
