### PR TITLE
[23.11] nginxMainline: 1.25.4 -> 1.25.5, nginxQuic: apply patches for CVE-2024-32760, CVE-2024-31079, CVE-2024-35200 and CVE-2024-34161

### DIFF
--- a/pkgs/servers/http/nginx/mainline.nix
+++ b/pkgs/servers/http/nginx/mainline.nix
@@ -1,6 +1,6 @@
 { callPackage, ... }@args:
 
 callPackage ./generic.nix args {
-  version = "1.25.4";
-  hash = "sha256-dgcpkBrLqlF5luaB7m6iWQMpheN8J2i+74DfOod97tk=";
+  version = "1.25.5";
+  hash = "sha256-L+IpT4r0FE5+hC6uqIQYKoTueXDhEEa6mBlEAJArvsA=";
 }

--- a/pkgs/servers/http/nginx/quic.nix
+++ b/pkgs/servers/http/nginx/quic.nix
@@ -1,5 +1,6 @@
 { callPackage
 , nginxMainline
+, fetchpatch
 , ...
 } @ args:
 
@@ -10,5 +11,38 @@ callPackage ./generic.nix args {
 
   configureFlags = [
     "--with-http_v3_module"
+  ];
+
+  extraPatches = [
+    (fetchpatch {
+      name = "CVE-2024-32760_CVE-2024-31079_CVE-2024-35200_CVE-2024-34161_1.patch";
+      url = "https://hg.nginx.org/nginx/raw-rev/04bc350b2919";
+      hash = "sha256-zIt5epu1vox8z9oONuHF+eYLrECxVZPMOjI2rp6yBTQ=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-32760_CVE-2024-31079_CVE-2024-35200_CVE-2024-34161_2.patch";
+      url = "https://hg.nginx.org/nginx/raw-rev/08f8e9c33a08";
+      hash = "sha256-w324E98LgRDaMF9RKQdUCmntMv2vxdBTPDLk+Y2Gb9Y=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-32760_CVE-2024-31079_CVE-2024-35200_CVE-2024-34161_3.patch";
+      url = "https://hg.nginx.org/nginx/raw-rev/ed593e26c79a";
+      hash = "sha256-yrBKfsGlI93ln1jlvBCY5PspPED40mOH80xWH7WjXOE=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-32760_CVE-2024-31079_CVE-2024-35200_CVE-2024-34161_4.patch";
+      url = "https://hg.nginx.org/nginx/raw-rev/e4e9d7003b31";
+      hash = "sha256-FVEWP4bUaWAx5aKoAvn2qFWZ6aWb9PhAJeUV25wXMrw=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-32760_CVE-2024-31079_CVE-2024-35200_CVE-2024-34161_5.patch";
+      url = "https://hg.nginx.org/nginx/raw-rev/b32b516f36b1";
+      hash = "sha256-rZj0f7YXlO2hLJ/NSANHmxoawlfyFJ9z3vfu35kt7XQ=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-32760_CVE-2024-31079_CVE-2024-35200_CVE-2024-34161_6.patch";
+      url = "https://hg.nginx.org/nginx/raw-rev/5b3f409d55f0";
+      hash = "sha256-bURuSZyajMst2k/qIvE9XUVhEhOZ7vwlmL2zpCWyc48=";
+    })
   ];
 }


### PR DESCRIPTION
## Description of changes

Bumped `nginxMainline` to 1.25.5 and used the security patches from the 1.26 branch.

```
Changes with nginx 1.25.5                                        16 Apr 2024

    *) Feature: virtual servers in the stream module.

    *) Feature: the ngx_stream_pass_module.

    *) Feature: the "deferred", "accept_filter", and "setfib" parameters of
       the "listen" directive in the stream module.

    *) Feature: cache line size detection for some architectures.
       Thanks to Piotr Sikora.

    *) Feature: support for Homebrew on Apple Silicon.
       Thanks to Piotr Sikora.

    *) Bugfix: Windows cross-compilation bugfixes and improvements.
       Thanks to Piotr Sikora.

    *) Bugfix: unexpected connection closure while using 0-RTT in QUIC.
       Thanks to Vladimir Khomutov.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Result of `nixpkgs-review pr 316119` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>nginxMainline</li>
    <li>nginxMainline.doc</li>
    <li>nginxQuic</li>
    <li>nginxQuic.doc</li>
  </ul>
</details>

Result of `nixpkgs-review pr 316119` run on aarch64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>nginxMainline</li>
    <li>nginxMainline.doc</li>
    <li>nginxQuic</li>
    <li>nginxQuic.doc</li>
  </ul>
</details>
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
