### PR TITLE
openmodelica.omcompiler: fix build

### DIFF
--- a/pkgs/applications/science/misc/openmodelica/omcompiler/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/omcompiler/default.nix
@@ -44,6 +44,11 @@ mkOpenModelicaDerivation ({
         $(find ./OMCompiler -name 'Makefile*')
   '';
 
+  env.CFLAGS = toString [
+    "-Wno-error=dynamic-exception-spec"
+    "-Wno-error=implicit-function-declaration"
+  ];
+
   preFixup = ''
     for entry in $(find $out -name libipopt.so); do
       patchelf --shrink-rpath --allowed-rpath-prefixes "$NIX_STORE" "$entry"

--- a/pkgs/applications/science/misc/openmodelica/omsimulator/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/omsimulator/default.nix
@@ -5,6 +5,7 @@
 , libxml2
 , openmodelica
 , mkOpenModelicaDerivation
+, fetchpatch
 }:
 
 mkOpenModelicaDerivation rec {
@@ -12,9 +13,22 @@ mkOpenModelicaDerivation rec {
   omdir = "OMSimulator";
   omdeps = [ openmodelica.omcompiler ];
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/OpenModelica/OMSimulator/commit/5ef06e251d639a0224adc205cdbfa1f99bf9a956.patch";
+      stripLen = 1;
+      extraPrefix = "OMSimulator/";
+      hash = "sha256-hLsS6TNEjddm2o2Optnf8n6hh14up9bWJBoztNmisH0=";
+    })
+  ];
+
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ readline libxml2 boost ];
+
+  env.CFLAGS = toString [
+    "-Wno-error=implicit-function-declaration"
+  ];
 
   meta = with lib; {
     description = "The OpenModelica FMI & SSP-based co-simulation environment";


### PR DESCRIPTION
## Description of changes

https://hydra.nixos.org/job/nixpkgs/trunk/openmodelica.omcompiler.aarch64-linux

Failing since 23.11.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
