### PR TITLE
ki: fix beartype error and format with nixfmt

### DIFF
--- a/pkgs/by-name/ki/ki/fix-beartype-error.patch
+++ b/pkgs/by-name/ki/ki/fix-beartype-error.patch
@@ -1,0 +1,38 @@
+From bd765844b40f88547a2afe90d0e09bf74ff0bd61 Mon Sep 17 00:00:00 2001
+From: eljamm <fedi.jamoussi@protonmail.ch>
+Date: Fri, 31 May 2024 16:48:06 +0100
+Subject: [PATCH] Fix beartype Frozenset error
+
+The `copy_note_media` function wrongly returns a `Frozenset` instead of
+a `Set`, which raises an error for the newest beartype version (v0.18.5)
+---
+ ki/__init__.py | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/ki/__init__.py b/ki/__init__.py
+index 3f29c1a..cc65fae 100644
+--- a/ki/__init__.py
++++ b/ki/__init__.py
+@@ -752,9 +752,7 @@ def media_filenames_in_field(col: Collection, s: str) -> Iterable[str]:
+ 
+ @curried
+ @beartype
+-def copy_note_media(
+-    col: Collection, src: Dir, tgt: Dir, row: NoteDBRow
+-) -> FrozenSet[File]:
++def copy_note_media(col: Collection, src: Dir, tgt: Dir, row: NoteDBRow) -> Set[File]:
+     """
+     Copy a single note's media files and return the copies as a set. We do this
+     by first filtering for only 'rootfiles', i.e. excluding media files in
+@@ -769,7 +767,7 @@ def copy_note_media(
+     rootfiles = filter(lambda f: f == os.path.basename(f), files)
+     medias: Iterable[File] = filter(F.isfile, map(lambda f: F.chk(src / f), rootfiles))
+     srcdsts = map(lambda file: (file, F.chk(tgt / file.name)), medias)
+-    return frozenset(starmap(F.copyfile, srcdsts))
++    return set(starmap(F.copyfile, srcdsts))
+ 
+ 
+ @curried
+-- 
+2.44.1
+

--- a/pkgs/by-name/ki/ki/package.nix
+++ b/pkgs/by-name/ki/ki/package.nix
@@ -1,8 +1,9 @@
-{ lib
-, fetchFromGitHub
-, python3Packages
-, cmake
-, anki
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  cmake,
+  anki,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -21,24 +22,25 @@ python3Packages.buildPythonApplication rec {
   };
 
   patches = [
-    ./update-to-newer-anki-versions.patch
+    ./fix-beartype-error.patch
     ./replace-deprecated-distutils-with-setuptools.patch
+    ./update-to-newer-anki-versions.patch
   ];
 
   nativeBuildInputs = [ cmake ];
 
-  propagatedBuildInputs = with python3Packages; [
-    beartype
-    click
-    colorama
-    git-filter-repo
-    gitpython
-    lark
-    tqdm
-    whatthepatch
-  ] ++ [
-    anki
-  ];
+  propagatedBuildInputs =
+    [ anki ]
+    ++ (with python3Packages; [
+      beartype
+      click
+      colorama
+      git-filter-repo
+      gitpython
+      lark
+      tqdm
+      whatthepatch
+    ]);
 
   nativeCheckInputs = with python3Packages; [
     bitstring


### PR DESCRIPTION
## Description of changes
The `copy_note_media` function wrongly returns a `Frozenset` instead of a `Set`, which raises an error for the newest beartype version (v0.18.5)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
