### PR TITLE
nixos/tests/qtile: test extraPackages and qtile-extras

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -827,7 +827,7 @@ in {
   qgis = handleTest ./qgis.nix { qgisPackage = pkgs.qgis; };
   qgis-ltr = handleTest ./qgis.nix { qgisPackage = pkgs.qgis-ltr; };
   qownnotes = handleTest ./qownnotes.nix {};
-  qtile = handleTestOn ["x86_64-linux" "aarch64-linux"] ./qtile.nix {};
+  qtile = handleTestOn ["x86_64-linux" "aarch64-linux"] ./qtile/default.nix {};
   quake3 = handleTest ./quake3.nix {};
   quicktun = handleTest ./quicktun.nix {};
   quickwit = handleTest ./quickwit.nix {};

--- a/nixos/tests/qtile/add-widget.patch
+++ b/nixos/tests/qtile/add-widget.patch
@@ -1,0 +1,19 @@
+--- a/config.py	2024-05-31 14:49:23.852287845 +0200
++++ b/config.py	2024-05-31 14:51:00.935182266 +0200
+@@ -29,6 +29,8 @@
+ from libqtile.lazy import lazy
+ from libqtile.utils import guess_terminal
+ 
++from qtile_extras import widget
++
+ mod = "mod4"
+ terminal = guess_terminal()
+ 
+@@ -162,6 +164,7 @@
+                 # NB Systray is incompatible with Wayland, consider using StatusNotifier instead
+                 # widget.StatusNotifier(),
+                 widget.Systray(),
++                widget.AnalogueClock(),
+                 widget.Clock(format="%Y-%m-%d %a %I:%M %p"),
+                 widget.QuickExit(),
+             ],

--- a/nixos/tests/qtile/config.nix
+++ b/nixos/tests/qtile/config.nix
@@ -1,0 +1,24 @@
+{ stdenvNoCC, fetchurl }:
+stdenvNoCC.mkDerivation {
+  name = "qtile-config";
+  version = "0.0.1";
+
+  src = fetchurl {
+    url = "https://raw.githubusercontent.com/qtile/qtile/v0.28.1/libqtile/resources/default_config.py";
+    hash = "sha256-Y5W277CWVNSi4BdgEW/f7Px/MMjnN9W9TDqdOncVwPc=";
+  };
+
+  prePatch = ''
+    cp $src config.py
+  '';
+
+  patches = [ ./add-widget.patch ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out
+    cp config.py $out/config.py
+  '';
+}

--- a/nixos/tests/qtile/default.nix
+++ b/nixos/tests/qtile/default.nix
@@ -1,15 +1,26 @@
-import ./make-test-python.nix ({ lib, ...} : {
+import ../make-test-python.nix ({ lib, ...} : {
   name = "qtile";
 
   meta = {
     maintainers = with lib.maintainers; [ sigmanificient ];
   };
 
-  nodes.machine = { pkgs, lib, ... }: {
-    imports = [ ./common/x11.nix ./common/user-account.nix ];
+  nodes.machine = { pkgs, lib, ... }: let
+    # We create a custom Qtile configuration file that adds a widget from
+    # qtile-extras to the bar. This ensure that the qtile-extras package
+    # also works, and that extraPackages behave as expected.
+
+    config-deriv = pkgs.callPackage ./config.nix { };
+  in {
+    imports = [ ../common/x11.nix ../common/user-account.nix ];
     test-support.displayManager.auto.user = "alice";
 
-    services.xserver.windowManager.qtile.enable = true;
+    services.xserver.windowManager.qtile = {
+      enable = true;
+      configFile = "${config-deriv}/config.py";
+      extraPackages = ps: [ ps.qtile-extras ];
+    };
+
     services.displayManager.defaultSession = lib.mkForce "qtile";
 
     environment.systemPackages = [ pkgs.kitty ];


### PR DESCRIPTION
## Description of changes

Update to nixos-vm tests to feature `extraPackages` option and `qtile-extras`.
It's based on the WIP tests I mentioned in #299843.

- move `qtile.nix` -> `qtile/default.nix`, reflect in `all-tests.nix`
- add the default config with a small patch featuring a small patch file to add the analogue clock from `qtile-extras` in the bar:

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
