### PR TITLE
nixos/emacs: add alternateEditor option

### DIFF
--- a/nixos/modules/services/editors/emacs.nix
+++ b/nixos/modules/services/editors/emacs.nix
@@ -9,9 +9,9 @@ let
   editorScript = pkgs.writeScriptBin "emacseditor" ''
     #!${pkgs.runtimeShell}
     if [ -z "$1" ]; then
-      exec ${cfg.package}/bin/emacsclient --create-frame --alternate-editor ${cfg.package}/bin/emacs
+      exec ${cfg.package}/bin/emacsclient --create-frame
     else
-      exec ${cfg.package}/bin/emacsclient --alternate-editor ${cfg.package}/bin/emacs "$@"
+      exec ${cfg.package}/bin/emacsclient "$@"
     fi
   '';
 
@@ -55,6 +55,20 @@ in
       '';
     };
 
+    alternateEditor = mkOption {
+      type = types.str;
+      default = "emacs";
+      example = "vi";
+      description = ''
+        If the Emacs server is not running, the shell command in this
+        environment variable runs instead. If set to the empty string, Emacs
+        starts in daemon mode, and the client tries to connect to it. Will be
+        overridden by the `--alternate-editor` option, if present.
+
+        Here it defaults to a non-daemon instance of Emacs.
+      '';
+    };
+
     startWithGraphical = mkOption {
       type = types.bool;
       default = config.services.xserver.enable;
@@ -85,7 +99,10 @@ in
 
     environment.systemPackages = [ cfg.package editorScript ];
 
-    environment.variables.EDITOR = mkIf cfg.defaultEditor (mkOverride 900 "emacseditor");
+    environment.variables = {
+      EDITOR = mkIf cfg.defaultEditor (mkOverride 900 "emacseditor");
+      ALTERNATE_EDITOR = cfg.alternateEditor;
+    };
   };
 
   meta.doc = ./emacs.md;


### PR DESCRIPTION
## Description of changes

1. ~~Originally, this weird `emacseditor` script created a GUI client, when no arguments were provided, or a TUI one, when there was at least one arg (like `$EDITOR /tmp/crontab-2183912`). Not so convenient, when you're expecting the consistent behaviour. My proposition: replace this script and `EDITOR`'s value with `emacsclient -ca '${alternativeEditor}'`, so that, if `cfg.package` is set to a GUI-capable edition of Emacs, the command always started a graphical window.~~
2. ~~`cfg.alternativeEditor` is described in the patch itself.~~

This PR replaces `--alternate-editor` flag in the script with an envvar and also makes its value configurable.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
