### PR TITLE
Create jupyterlab execute time

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21147,6 +21147,12 @@
     githubId = 245573;
     name = "Dmitry Kalinkin";
   };
+  vglfr = {
+    email = "vf.velt@gmail.com";
+    github = "vglfr";
+    githubId = 20283252;
+    name = "vglfr";
+  };
   vgskye = {
     name = "Skye Green";
     email = "me@skye.vg";

--- a/pkgs/development/python-modules/jupyterlab-execute-time/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-execute-time/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, jupyterlab
+, jupyter-packaging
+}:
+
+buildPythonPackage rec {
+  pname = "jupyterlab-execute-time";
+  version = "3.1.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "jupyterlab_execute_time";
+    inherit version;
+    hash = "sha256-DiyGsoNXXh+ieMfpSrA6A/5c0ftNV9Ygs9Tl2/VEdbk=";
+  };
+
+  # jupyterlab is required to build from source but we use the pre-build package
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace '"jupyterlab~=4.0.0"' ""
+  '';
+
+  nativeBuildInputs = [
+    jupyterlab
+    jupyter-packaging
+  ];
+
+  # has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "jupyterlab_execute_time" ];
+
+  meta = with lib; {
+    description = "A JupyterLab extension for displaying cell timings";
+    homepage = "https://github.com/deshaw/jupyterlab-execute-time";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ vglfr ];
+  };
+}

--- a/pkgs/development/python-modules/jupyterlab-execute-time/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-execute-time/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
       --replace '"jupyterlab~=4.0.0"' ""
   '';
 
-  nativeBuildInputs = [
+  dependencies = [
     jupyterlab
     jupyter-packaging
   ];
@@ -32,10 +32,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "jupyterlab_execute_time" ];
 
-  meta = with lib; {
-    description = "A JupyterLab extension for displaying cell timings";
+  meta = {
+    description = "JupyterLab extension for displaying cell timings";
     homepage = "https://github.com/deshaw/jupyterlab-execute-time";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ vglfr ];
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.vglfr ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6242,6 +6242,8 @@ self: super: with self; {
 
   jupyterlab = callPackage ../development/python-modules/jupyterlab { };
 
+  jupyterlab-execute-time = callPackage ../development/python-modules/jupyterlab-execute-time { };
+
   jupyterlab-git = callPackage ../development/python-modules/jupyterlab-git { };
 
   jupyterlab-pygments = callPackage ../development/python-modules/jupyterlab-pygments { };


### PR DESCRIPTION
## Description of changes

Jupyterlab extension to display cell execution time https://github.com/deshaw/jupyterlab-execute-time.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).