### PR TITLE
qtile: install proper session .desktop files for both xorg and wayland

### DIFF
--- a/nixos/tests/qtile.nix
+++ b/nixos/tests/qtile.nix
@@ -10,7 +10,7 @@ import ./make-test-python.nix ({ lib, ...} : {
     test-support.displayManager.auto.user = "alice";
 
     services.xserver.windowManager.qtile.enable = true;
-    services.displayManager.defaultSession = lib.mkForce "none+qtile";
+    services.displayManager.defaultSession = lib.mkForce "qtile";
 
     environment.systemPackages = [ pkgs.kitty ];
   };

--- a/pkgs/development/python-modules/qtile/default.nix
+++ b/pkgs/development/python-modules/qtile/default.nix
@@ -30,6 +30,7 @@
   xcffib,
   xkbcommon,
   nixosTests,
+  extraPackages ? [ ],
 }:
 
 buildPythonPackage rec {
@@ -66,7 +67,7 @@ buildPythonPackage rec {
     pkg-config
   ];
 
-  dependencies = [
+  dependencies = extraPackages ++ [
     (cairocffi.override { withXcffib = true; })
     dbus-next
     iwlib
@@ -96,6 +97,11 @@ buildPythonPackage rec {
     tests.qtile = nixosTests.qtile;
     providedSessions = [ "qtile" ];
   };
+
+  postInstall = ''
+    install resources/qtile.desktop -Dt $out/share/xsessions
+    install resources/qtile-wayland.desktop -Dt $out/share/wayland-sessions
+  '';
 
   meta = with lib; {
     homepage = "http://www.qtile.org/";

--- a/pkgs/development/python-modules/qtile/wrapper.nix
+++ b/pkgs/development/python-modules/qtile/wrapper.nix
@@ -1,8 +1,0 @@
-{ python3 }:
-
-(python3.withPackages (_: [ python3.pkgs.qtile ])).overrideAttrs (_: {
-  # restore some qtile attrs, beautify name
-  inherit (python3.pkgs.qtile) pname version meta;
-  name = with python3.pkgs.qtile; "${pname}-${version}";
-  passthru.unwrapped = python3.pkgs.qtile;
-})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35092,8 +35092,6 @@ with pkgs;
 
   qpdfview = libsForQt5.callPackage ../applications/office/qpdfview { };
 
-  qtile = callPackage ../development/python-modules/qtile/wrapper.nix { };
-
   vimgolf = callPackage ../games/vimgolf { };
 
   vimpc = callPackage ../applications/audio/vimpc { };


### PR DESCRIPTION
## Description of changes
This PR modifies the qtile package to install the provided session desktop files for login managers.
That in turn allows us to add the package to `services.displayManager.sessionPackages` when the NixOS module is enabled.
After that, both the Xorg and Wayland sessions will be available from login (display) managers, instead of just one session that's hard coded to a specific backend (via the now removed option `backend`).

Additionally, this fixes the `services.xserver.windowManager.qtile.finalPackage` assignment to use the qtile package instead of building a whole new env.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
