### PR TITLE
lomiri.lomiri-filemanager-app: init at 1.0.4

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -22,6 +22,7 @@ in {
         libusermetrics
         lomiri
         lomiri-download-manager
+        lomiri-filemanager-app
         lomiri-schemas # exposes some required dbus interfaces
         lomiri-session # wrappers to properly launch the session
         lomiri-sounds

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -516,6 +516,7 @@ in {
   lxd-image-server = handleTest ./lxd-image-server.nix {};
   #logstash = handleTest ./logstash.nix {};
   lomiri = handleTest ./lomiri.nix {};
+  lomiri-filemanager-app = runTest ./lomiri-filemanager-app.nix;
   lomiri-system-settings = handleTest ./lomiri-system-settings.nix {};
   lorri = handleTest ./lorri/default.nix {};
   maddy = discoverTests (import ./maddy { inherit handleTest; });

--- a/nixos/tests/lomiri-filemanager-app.nix
+++ b/nixos/tests/lomiri-filemanager-app.nix
@@ -1,0 +1,48 @@
+{ pkgs, lib, ... }:
+{
+  name = "lomiri-filemanager-app-standalone";
+  meta.maintainers = lib.teams.lomiri.members;
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      imports = [ ./common/x11.nix ];
+
+      services.xserver.enable = true;
+
+      environment = {
+        systemPackages = with pkgs.lomiri; [
+          suru-icon-theme
+          lomiri-filemanager-app
+        ];
+        variables = {
+          UITK_ICON_THEME = "suru";
+        };
+      };
+
+      i18n.supportedLocales = [ "all" ];
+
+      fonts.packages = with pkgs; [
+        # Intended font & helps with OCR
+        ubuntu_font_family
+      ];
+    };
+
+  enableOCR = true;
+
+  testScript = ''
+    machine.wait_for_x()
+
+    with subtest("lomiri filemanager launches"):
+        machine.execute("lomiri-filemanager-app >&2 &")
+        machine.wait_for_text(r"(filemanager.ubports|alice|items|directories|files|folder)")
+        machine.screenshot("lomiri-filemanager_open")
+
+    machine.succeed("pkill -f lomiri-filemanager-app")
+
+    with subtest("lomiri filemanager localisation works"):
+        machine.execute("env LANG=de_DE.UTF-8 lomiri-filemanager-app >&2 &")
+        machine.wait_for_text(r"(Elemente|Verzeichnisse|Dateien|Ordner)")
+        machine.screenshot("lomiri-filemanager_localised")
+  '';
+}

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -268,7 +268,7 @@ in {
         machine.screenshot("settings_content-hub_peers")
 
         # Select Morph as content source
-        mouse_click(300, 100)
+        mouse_click(370, 100)
 
         # Expect Morph to be brought into the foreground, with its Downloads page open
         machine.wait_for_text("No downloads")

--- a/pkgs/desktops/lomiri/applications/lomiri-filemanager-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-filemanager-app/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitLab,
   fetchpatch,
   gitUpdater,
+  nixosTests,
   biometryd,
   cmake,
   content-hub,
@@ -125,6 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    tests.vm = nixosTests.lomiri-filemanager-app;
     updateScript = gitUpdater { rev-prefix = "v"; };
   };
 

--- a/pkgs/desktops/lomiri/applications/lomiri-filemanager-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-filemanager-app/default.nix
@@ -1,0 +1,140 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchpatch,
+  gitUpdater,
+  biometryd,
+  cmake,
+  content-hub,
+  gettext,
+  lomiri-thumbnailer,
+  lomiri-ui-extras,
+  lomiri-ui-toolkit,
+  pkg-config,
+  python3,
+  qtbase,
+  qtdeclarative,
+  samba,
+  wrapQtAppsHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-filemanager-app";
+  version = "1.0.4";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/apps/lomiri-filemanager-app";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-vjGCTfXoqul1S7KUJXG6JwgZOc2etXWsdKbyQ/V3abA=";
+  };
+
+  patches = [
+    # This sets the *wrong* domain, but at least it sets *some* domain.
+    # Remove when version > 1.0.4
+    (fetchpatch {
+      name = "0001-lomiri-filemanager-app-Set-a-gettext-domain.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-filemanager-app/-/commit/b310434d2c25a3b446d3d975f3755eb473a833e8.patch";
+      hash = "sha256-gzFFzZCIxedMGW4fp6sonnHj/HmwqdqU5fvGhXUsSOI=";
+    })
+
+    # Set the *correct* domain.
+    # Remove when version > 1.0.4
+    (fetchpatch {
+      name = "0002-lomiri-filemanager-app-Fix-gettext-domain.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-filemanager-app/-/commit/2bb19aeef2baba8d12df1e4976becc08d7cf341d.patch";
+      hash = "sha256-wreOMMvBjf316N/XJv3VfI5f5N/VFiEraeadtgRStjA=";
+    })
+
+    # Bind domain to locale dir
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-filemanager-app/-/merge_requests/112 merged & in release
+    (fetchpatch {
+      name = "0003-lomiri-filemanager-app-Call-i18n.bindtextdomain.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-filemanager-app/-/commit/ac0ab681c52c691d464cf94707b013b39675ad2d.patch";
+      hash = "sha256-mwpcHwMT2FcNC6KIZNuSWU/bA8XP8rEQKHn7t5m6npM=";
+    })
+
+    # Stop using deprecated qt5_use_modules
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-filemanager-app/-/merge_requests/113 merged & in release
+    (fetchpatch {
+      name = "0004-lomiri-filemanager-app-Stop-using-qt5_use_modules.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-filemanager-app/-/commit/c2bfe927b16e660bf4730371b1e61e442e034780.patch";
+      hash = "sha256-wPOZP2FOaacEGj4SMS5Q/TO+/L11Qz7NTux4kA86Bcs=";
+    })
+
+    # Use pkg-config for smbclient flags
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-filemanager-app/-/merge_requests/115 merged & in release
+    (fetchpatch {
+      name = "0005-lomiri-filemanager-app-Get-smbclient-flags-via-pkg-config.patch";
+      url = "https://gitlab.com/ubports/development/apps/lomiri-filemanager-app/-/commit/aa791da5999719724e0b0592765e8fa2962305c6.patch";
+      hash = "sha256-fFAYKBR28ym/n7fhP9O6VE2owarLxK8cN9QeExHFbtU=";
+    })
+  ];
+
+  postPatch = ''
+    # Use correct QML install path, don't pull in autopilot test code (we can't run that system)
+    # Remove absolute paths from desktop file, https://github.com/NixOS/nixpkgs/issues/308324
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'qmake -query QT_INSTALL_QML' 'echo ${placeholder "out"}/${qtbase.qtQmlPrefix}' \
+      --replace-fail 'add_subdirectory(tests)' '#add_subdirectory(tests)' \
+      --replace-fail 'ICON ''${CMAKE_INSTALL_PREFIX}/''${DATA_DIR}/''${ICON_FILE}' 'ICON lomiri-filemanager-app' \
+      --replace-fail 'SPLASH ''${CMAKE_INSTALL_PREFIX}/''${DATA_DIR}/''${SPLASH_FILE}' 'SPLASH lomiri-app-launch/splash/lomiri-filemanager-app.svg'
+
+    # In case this ever gets run, at least point it to a correct-ish path
+    substituteInPlace tests/autopilot/CMakeLists.txt \
+      --replace-fail 'python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"' 'echo "${placeholder "out"}/${python3.sitePackages}/lomiri_filemanager_app"'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase
+    qtdeclarative
+    samba
+
+    # QML
+    biometryd
+    content-hub
+    lomiri-thumbnailer
+    lomiri-ui-extras
+    lomiri-ui-toolkit
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "INSTALL_TESTS" false)
+    (lib.cmakeBool "CLICK_MODE" false)
+  ];
+
+  # No tests we can actually run (just autopilot)
+  doCheck = false;
+
+  postInstall = ''
+    # Some misc files don't get installed to the correct paths for us
+    mkdir -p $out/share/{content-hub/peers,icons/hicolor/scalable/apps,lomiri-app-launch/splash}
+    ln -s $out/share/lomiri-filemanager-app/content-hub.json $out/share/content-hub/peers/lomiri-filemanager-app
+    ln -s $out/share/lomiri-filemanager-app/filemanager.svg $out/share/icons/hicolor/scalable/apps/lomiri-filemanager-app.svg
+    ln -s $out/share/lomiri-filemanager-app/splash.svg $out/share/lomiri-app-launch/splash/lomiri-filemanager-app.svg
+  '';
+
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
+
+  meta = {
+    description = "File Manager application for Ubuntu Touch devices";
+    homepage = "https://gitlab.com/ubports/development/apps/lomiri-filemanager-app";
+    changelog = "https://gitlab.com/ubports/development/apps/lomiri-filemanager-app/-/blob/v${finalAttrs.version}/ChangeLog";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "lomiri-filemanager-app";
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -9,6 +9,7 @@ let
   in {
     #### Core Apps
     lomiri = callPackage ./applications/lomiri { };
+    lomiri-filemanager-app = callPackage ./applications/lomiri-filemanager-app { };
     lomiri-system-settings-unwrapped = callPackage ./applications/lomiri-system-settings { };
     lomiri-system-settings-security-privacy = callPackage ./applications/lomiri-system-settings/plugins/lomiri-system-settings-security-privacy.nix { };
     lomiri-system-settings = callPackage ./applications/lomiri-system-settings/wrapper.nix { };


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[Lomiri Filemanager App](https://gitlab.com/ubports/development/apps/lomiri-filemanager-app). Self-explanatory.
![Bildschirmfoto_2024-05-31_21-56-40](https://github.com/NixOS/nixpkgs/assets/23431373/5d0c1545-cc44-4aa7-9f1c-5413ec91f74c)

It's also one of the most flexible ways of sending files for content-hub transfers, so it's very much desired for a usable desktop experience.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
