### PR TITLE
open-webui: init at 0.2.4

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -767,6 +767,7 @@
   ./services/misc/octoprint.nix
   ./services/misc/ollama.nix
   ./services/misc/ombi.nix
+  ./services/misc/open-webui.nix
   ./services/misc/osrm.nix
   ./services/misc/owncast.nix
   ./services/misc/packagekit.nix

--- a/nixos/modules/services/misc/open-webui.nix
+++ b/nixos/modules/services/misc/open-webui.nix
@@ -1,0 +1,94 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) types;
+
+  cfg = config.services.open-webui;
+in
+{
+  options = {
+    services.open-webui = {
+      enable = lib.mkEnableOption "Enable open-webui, an interactive chat web app";
+      package = lib.mkPackageOption pkgs "open-webui" { };
+
+      stateDir = lib.mkOption {
+        type = types.path;
+        default = "/var/lib/open-webui";
+        description = "State directory of open-webui.";
+      };
+
+      host = lib.mkOption {
+        type = types.str;
+        default = "localhost";
+        description = "Host of open-webui";
+      };
+
+      port = lib.mkOption {
+        type = types.port;
+        default = 8080;
+        description = "Port of open-webui";
+      };
+
+      environment = lib.mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        example = ''
+          {
+            OLLAMA_API_BASE_URL = "http://localhost:11434";
+            # Disable authentication
+            WEBUI_AUTH = "False";
+          }
+        '';
+        description = "Extra environment variables for open-webui";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.open-webui = {
+      description = "User-friendly WebUI for LLMs (Formerly Ollama WebUI)";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      preStart = ''
+        mkdir -p ${cfg.stateDir}/static
+      '';
+
+      environment = {
+        STATIC_DIR = "${cfg.stateDir}/static";
+        DATA_DIR = "${cfg.stateDir}";
+      } // cfg.environment;
+
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} serve --host ${cfg.host} --port ${toString cfg.port}";
+        WorkingDirectory = cfg.stateDir;
+        StateDirectory = "open-webui";
+        RuntimeDirectory = "open-webui";
+        RuntimeDirectoryMode = "0755";
+        PrivateTmp = true;
+        DynamicUser = true;
+        DevicePolicy = "closed";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = false; # onnxruntime/capi/onnxruntime_pybind11_state.so: cannot enable executable stack as shared object requires: Permission Denied
+        PrivateUsers = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        ProcSubset = "all"; # Error in cpuinfo: failed to parse processor information from /proc/cpuinfo
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+        UMask = "0077";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ shivaraj-bh ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -691,6 +691,7 @@ in {
   outline = handleTest ./outline.nix {};
   image-contents = handleTest ./image-contents.nix {};
   openvscode-server = handleTest ./openvscode-server.nix {};
+  open-webui = runTest ./open-webui.nix;
   orangefs = handleTest ./orangefs.nix {};
   os-prober = handleTestOn ["x86_64-linux"] ./os-prober.nix {};
   osquery = handleTestOn ["x86_64-linux"] ./osquery.nix {};

--- a/nixos/tests/open-webui.nix
+++ b/nixos/tests/open-webui.nix
@@ -1,0 +1,33 @@
+{ lib, ... }:
+let
+  mainPort = "8080";
+in
+{
+  name = "open-webui";
+  meta = with lib.maintainers; {
+    maintainers = [ shivaraj-bh ];
+  };
+
+  nodes = {
+    machine =
+      { ... }:
+      {
+        services.open-webui = {
+          enable = true;
+          environment = {
+            # Requires network connection
+            RAG_EMBEDDING_MODEL = "";
+          };
+        };
+      };
+  };
+
+  testScript = ''
+    machine.start()
+
+    machine.wait_for_unit("open-webui.service")
+    machine.wait_for_open_port(${mainPort})
+
+    machine.succeed("curl http://127.0.0.1:${mainPort}")
+  '';
+}

--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -1,0 +1,142 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  python3,
+  nixosTests,
+}:
+let
+  pname = "open-webui";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "open-webui";
+    repo = "open-webui";
+    rev = "v${version}";
+    hash = "sha256-jWO0mo26C+QTIX5j3ucDk/no+vQnAh7Q6JwB3lLM83k=";
+  };
+
+  frontend = buildNpmPackage {
+    inherit pname version src;
+
+    npmDepsHash = "sha256-QIgYHZusuq2QD8p8MGsNVhCbz6fR+qP9UuU/kbBkadc=";
+
+    # Disabling `pyodide:fetch` as it downloads packages during `buildPhase`
+    # Until this is solved, running python packages from the browser will not work.
+    postPatch = ''
+      substituteInPlace package.json \
+        --replace-fail "npm run pyodide:fetch && vite build" "vite build" \
+    '';
+
+    env.CYPRESS_INSTALL_BINARY = "0"; # disallow cypress from downloading binaries in sandbox
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share
+      cp -a build $out/share/open-webui
+
+      runHook postInstall
+    '';
+  };
+in
+python3.pkgs.buildPythonApplication rec {
+  inherit pname version src;
+  pyproject = true;
+
+  # The custom hook tries to run `npm install` in `buildPhase`.
+  # We don't have to worry, as nodejs depedencies are managed by `frontend` drv.
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '[tool.hatch.build.hooks.custom]' "" \
+      --replace-fail ', build = "open_webui/frontend"' ""
+  '';
+
+  pythonRelaxDeps = true;
+
+  pythonRemoveDeps = [
+    # using `psycopg2` instead
+    "psycopg2-binary"
+    # using `opencv4`
+    "opencv-python-headless"
+    # package request: https://github.com/NixOS/nixpkgs/issues/317065
+    "rapidocr-onnxruntime"
+    # package request: https://github.com/NixOS/nixpkgs/issues/317066
+    "langfuse"
+    # package request: https://github.com/NixOS/nixpkgs/issues/317068
+    "langchain-chroma"
+  ];
+
+  dependencies = with python3.pkgs; [
+    beautifulsoup4
+    fastapi
+    uvicorn
+    python-multipart
+    flask
+    flask-cors
+    python-socketio
+    python-jose
+    passlib
+    requests
+    aiohttp
+    peewee
+    peewee-migrate
+    psycopg2
+    pymysql
+    bcrypt
+    litellm
+    boto3
+    argon2-cffi
+    apscheduler
+    google-generativeai
+    langchain
+    langchain-community
+    fake-useragent
+    chromadb
+    sentence-transformers
+    pypdf
+    docx2txt
+    python-pptx
+    unstructured
+    markdown
+    pypandoc
+    pandas
+    openpyxl
+    pyxlsb
+    xlrd
+    validators
+    opencv4
+    fpdf2
+    rank-bm25
+    faster-whisper
+    pyjwt
+    black
+    youtube-transcript-api
+    pytube
+  ];
+
+  build-system = with python3.pkgs; [
+    hatchling
+    pythonRelaxDepsHook
+  ];
+
+  pythonImportsCheck = [ "open_webui" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/open-webui \
+      --set FRONTEND_BUILD_DIR "${frontend}/share/open-webui"
+  '';
+
+  passthru.tests = {
+    inherit (nixosTests) open-webui;
+  };
+
+  meta = {
+    description = "Full-stack of open-webui. open-webui is a user-friendly WebUI for LLMs (Formerly Ollama WebUI)";
+    homepage = "https://github.com/open-webui/open-webui";
+    changelog = "https://github.com/open-webui/open-webui/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ shivaraj-bh ];
+    mainProgram = "open-webui";
+  };
+}


### PR DESCRIPTION
## Description of changes

Resolves #309567 

### open-webui package

```sh
mkdir -p ./{data,static}
DATA_DIR=$(pwd) STATIC_DIR=$(pwd)/static nix run github:shivaraj-bh/nixpkgs/open-webui#open-webui
```

### open-webui service

```nix
{
  services.open-webui.enable = true;
}
```

### open-webui service with ollama

```nix
{
  services.ollama.enable = true;
  services.open-webui = {
    enable = true;
    environment.OLLAMA_API_BASE_URL = "http://localhost:11434";
  };
}
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
—>



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
