### PR TITLE
lomiri.{lomiri-app-launch,content-hub}: Fix issues with peer spawning & data transfer

### DIFF
--- a/pkgs/desktops/lomiri/development/lomiri-app-launch/2001-Inject-current-system-PATH.patch
+++ b/pkgs/desktops/lomiri/development/lomiri-app-launch/2001-Inject-current-system-PATH.patch
@@ -1,0 +1,59 @@
+From e4fe87427f24aa9b506c15c0f73f298e8909aabe Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Fri, 31 May 2024 21:31:46 +0200
+Subject: [PATCH] Inject current-system PATH
+
+---
+ liblomiri-app-launch/jobs-systemd.cpp | 16 ++++++++++++++++
+ liblomiri-app-launch/jobs-systemd.h   |  1 +
+ 2 files changed, 17 insertions(+)
+
+diff --git a/liblomiri-app-launch/jobs-systemd.cpp b/liblomiri-app-launch/jobs-systemd.cpp
+index e9be801..246bea8 100644
+--- a/liblomiri-app-launch/jobs-systemd.cpp
++++ b/liblomiri-app-launch/jobs-systemd.cpp
+@@ -574,6 +574,20 @@ void SystemD::copyEnvByPrefix(const std::string& prefix, std::list<std::pair<std
+     }
+ }
+ 
++/* We don't have a normal PATH, so we need to inject our special one as a fallback & propagate it */
++void SystemD::setupNixosPath(std::list<std::pair<std::string, std::string>>& env)
++{
++        std::string newPath { "/run/current-system/sw/bin" };
++        char* oldPath = getenv("PATH");
++        if (oldPath != NULL && oldPath[0] != '\0')
++        {
++            newPath.insert(0, 1, ':');
++            newPath.insert(0, oldPath);
++        }
++        setenv("PATH", newPath.c_str(), true);
++        copyEnv("PATH", env);
++}
++
+ std::shared_ptr<Application::Instance> SystemD::launch(
+     const AppID& appId,
+     const std::string& job,
+@@ -625,6 +639,8 @@ std::shared_ptr<Application::Instance> SystemD::launch(
+ 
+         copyEnv("DISPLAY", env);
+ 
++        setupNixosPath(env);
++
+         for (const auto& prefix : {"DBUS_", "MIR_", "LOMIRI_APP_LAUNCH_"})
+         {
+             copyEnvByPrefix(prefix, env);
+diff --git a/liblomiri-app-launch/jobs-systemd.h b/liblomiri-app-launch/jobs-systemd.h
+index fe35932..19bf44e 100644
+--- a/liblomiri-app-launch/jobs-systemd.h
++++ b/liblomiri-app-launch/jobs-systemd.h
+@@ -136,6 +136,7 @@ private:
+     static void copyEnv(const std::string& envname, std::list<std::pair<std::string, std::string>>& env);
+     static void copyEnvByPrefix(const std::string& prefix, std::list<std::pair<std::string, std::string>>& env);
+     static int envSize(std::list<std::pair<std::string, std::string>>& env);
++    static void setupNixosPath(std::list<std::pair<std::string, std::string>>& env);
+ 
+     static std::vector<std::string> parseExec(std::list<std::pair<std::string, std::string>>& env);
+     static void application_start_cb(GObject* obj, GAsyncResult* res, gpointer user_data);
+-- 
+2.42.0
+

--- a/pkgs/desktops/lomiri/development/lomiri-app-launch/default.nix
+++ b/pkgs/desktops/lomiri/development/lomiri-app-launch/default.nix
@@ -48,10 +48,10 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
-    # Remove when https://gitlab.com/ubports/development/core/lomiri-app-launch/-/merge_requests/57 merged & in release
+    # Remove when version > 0.1.9
     (fetchpatch {
       name = "0001-lomiri-app-launch-Fix-typelib-gir-dependency.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-app-launch/-/commit/0419b2592284f43ee5e76060948ea3d5f1c991fd.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-app-launch/-/commit/8466e77914e73801499df224fcd4a53c4a0eab25.patch";
       hash = "sha256-11pEhFi39Cvqb9Hg47kT8+5hq+bz6WmySqaIdwt1MVk=";
     })
 
@@ -64,10 +64,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     # used pkg_get_variable, cannot replace prefix
     substituteInPlace data/CMakeLists.txt \
-      --replace 'pkg_get_variable(SYSTEMD_USER_UNIT_DIR systemd systemduserunitdir)' 'set(SYSTEMD_USER_UNIT_DIR "''${CMAKE_INSTALL_PREFIX}/lib/systemd/user")'
+      --replace-fail 'pkg_get_variable(SYSTEMD_USER_UNIT_DIR systemd systemduserunitdir)' 'pkg_get_variable(SYSTEMD_USER_UNIT_DIR systemd systemduserunitdir DEFINE_VARIABLES prefix=''${CMAKE_INSTALL_PREFIX})'
 
     substituteInPlace tests/jobs-systemd.cpp \
-      --replace '^(/usr)?' '^(/nix/store/\\w+-bash-.+)?'
+      --replace-fail '^(/usr)?' '^(/nix/store/\\w+-bash-.+)?'
   '';
 
   strictDeps = true;
@@ -139,13 +139,13 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "System and associated utilities to launch applications in a standard and confined way";
     homepage = "https://gitlab.com/ubports/development/core/lomiri-app-launch";
     changelog = "https://gitlab.com/ubports/development/core/lomiri-app-launch/-/blob/${finalAttrs.version}/ChangeLog";
-    license = licenses.gpl3Only;
-    maintainers = teams.lomiri.members;
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Only;
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.linux;
     pkgConfigModules = [
       "lomiri-app-launch-0"
     ];

--- a/pkgs/desktops/lomiri/development/lomiri-app-launch/default.nix
+++ b/pkgs/desktops/lomiri/development/lomiri-app-launch/default.nix
@@ -54,6 +54,9 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://gitlab.com/ubports/development/core/lomiri-app-launch/-/commit/0419b2592284f43ee5e76060948ea3d5f1c991fd.patch";
       hash = "sha256-11pEhFi39Cvqb9Hg47kT8+5hq+bz6WmySqaIdwt1MVk=";
     })
+
+    # Use /run/current-system/sw/bin fallback for desktop file Exec= lookups, propagate to launched applications
+    ./2001-Inject-current-system-PATH.patch
   ];
 
   postPatch = ''

--- a/pkgs/desktops/lomiri/services/content-hub/default.nix
+++ b/pkgs/desktops/lomiri/services/content-hub/default.nix
@@ -80,6 +80,13 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://gitlab.com/ubports/development/core/content-hub/-/commit/6e30f4f10ef90e817ca01d32959b6c782de48955.patch";
       hash = "sha256-TAbYn265RpHpulaRVaHy9XqNF+qoDE7YQIfFMPfqEhw=";
     })
+
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-content-hub/-/merge_requests/40 merged & in release
+    (fetchpatch {
+      name = "0006-content-hub-Fix-AppArmor-less-transfer.patch";
+      url = "https://gitlab.com/ubports/development/core/content-hub/-/commit/b58e5c8babf00ad7c402555c96254ce0165adb9e.patch";
+      hash = "sha256-a7x/0NiUBmmFlq96jkHyLCL0f5NIFh5JR/H+FQ/2GqI=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/desktops/lomiri/services/content-hub/default.nix
+++ b/pkgs/desktops/lomiri/services/content-hub/default.nix
@@ -47,11 +47,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
-    # Remove when https://gitlab.com/ubports/development/core/content-hub/-/merge_requests/33 merged & in release
+    # Remove when version > 1.1.1
     (fetchpatch {
       name = "0001-content-hub-Migrate-to-GetConnectionCredentials.patch";
-      url = "https://gitlab.com/ubports/development/core/content-hub/-/commit/9c0eae42d856b4b6e24fa609ade0e674c7a84cfe.patch";
-      hash = "sha256-IWoCQKSCCk26n7133oG0Ht+iEjavn/IiOVUM+tCLX2U=";
+      url = "https://gitlab.com/ubports/development/core/content-hub/-/commit/9ec9df32f77383eec7994d8e3e6961531bc8464d.patch";
+      hash = "sha256-14dZosMTMa1FDGEMuil0r1Hz6vn+L9XC83NMAqC7Ol8=";
     })
 
     # Remove when https://gitlab.com/ubports/development/core/content-hub/-/merge_requests/34 merged & in release
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-T+6T9lXne6AhDFv9d7L8JNwdl8f0wjDmvSoNVPkHza4=";
     })
 
-    # Remove when https://gitlab.com/ubports/development/core/content-hub/-/merge_requests/35 merged & in release
+    # Remove when version > 1.1.1
     # fetchpatch2 due to renames, https://github.com/NixOS/nixpkgs/issues/32084
     (fetchpatch2 {
       name = "0003-content-hub-Add-more-better-GNUInstallDirs-variables-usage.patch";
@@ -69,16 +69,11 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-kYN0eLwMyM/9yK+zboyEsoPKZMZ4SCXodVYsvkQr2F8=";
     })
 
-    # Remove when https://gitlab.com/ubports/development/core/content-hub/-/merge_requests/37 merged & in release
+    # Remove when version > 1.1.1
     (fetchpatch {
-      name = "0004-content-hub-Fix-generation-of-transfer_files.patch";
-      url = "https://gitlab.com/ubports/development/core/content-hub/-/commit/7ab3a4421356f83515f0deffb5f97a5b38601c13.patch";
-      hash = "sha256-MJZm3ny5t0/GX0bd5hGQbPM2k7M4KUvKqce/0cYYgvM=";
-    })
-    (fetchpatch {
-      name = "0005-content-hub-Fix-generation-of-moc_test_harness.patch";
-      url = "https://gitlab.com/ubports/development/core/content-hub/-/commit/6e30f4f10ef90e817ca01d32959b6c782de48955.patch";
-      hash = "sha256-TAbYn265RpHpulaRVaHy9XqNF+qoDE7YQIfFMPfqEhw=";
+      name = "0004-content-hub-Fix-generation-of-transfer_files-and-moc_test_harness.patch";
+      url = "https://gitlab.com/ubports/development/core/content-hub/-/commit/68899c75e77e1f34176b8a550d52794413e5070f.patch";
+      hash = "sha256-HAxePnzY/cL2c+o+Aw2N1pdr8rsbHGmRsH2EQkrBcHg=";
     })
 
     # Remove when https://gitlab.com/ubports/development/core/lomiri-content-hub/-/merge_requests/40 merged & in release
@@ -182,7 +177,7 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Content sharing/picking service";
     longDescription = ''
       content-hub is a mediation service to let applications share content between them,
@@ -190,10 +185,10 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://gitlab.com/ubports/development/core/content-hub";
     changelog = "https://gitlab.com/ubports/development/core/content-hub/-/blob/${finalAttrs.version}/ChangeLog";
-    license = with licenses; [ gpl3Only lgpl3Only ];
+    license = with lib.licenses; [ gpl3Only lgpl3Only ];
     mainProgram = "content-hub-service";
-    maintainers = teams.lomiri.members;
-    platforms = platforms.linux;
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.linux;
     pkgConfigModules = [
       "libcontent-hub"
       "libcontent-hub-glib"


### PR DESCRIPTION
## Description of changes

See individual commits for thorough-ish explanations.

Without this, content-hub data exchanges are kinda broken.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
