### PR TITLE
rustc: Add support for FreeBSD

### DIFF
--- a/pkgs/development/compilers/rust/1_78.nix
+++ b/pkgs/development/compilers/rust/1_78.nix
@@ -49,6 +49,7 @@ import ./default.nix {
     aarch64-apple-darwin = "415bb2bc198feb0f2d8329e33c57d0890bbd57977d1ae48b17f6c7e1f632eaa7";
     powerpc64le-unknown-linux-gnu = "79582acb339bd2d79fef095b977049049ffa04616011f1af1793fb8e98194b19";
     riscv64gc-unknown-linux-gnu = "300fe4861e2d1f6e4c4f5e36ae7997beca8a979343a7f661237ab78a37a54648";
+    x86_64-unknown-freebsd = "72f49040fc2ed4492cddfaef3b4a9cb28d008f9f5ce5cac50802a5fca910f58c";
   };
 
   selectRustPackage = pkgs: pkgs.rust_1_78;

--- a/pkgs/development/compilers/rust/binary.nix
+++ b/pkgs/development/compilers/rust/binary.nix
@@ -35,7 +35,8 @@ rec {
 
     nativeBuildInputs = lib.optional (!stdenv.isDarwin) autoPatchelfHook;
     buildInputs = [ bash ]
-      ++ lib.optionals (!stdenv.isDarwin) [ gcc.cc.lib zlib ]
+      ++ lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) gcc.cc.lib
+      ++ lib.optional (!stdenv.isDarwin) zlib
       ++ lib.optional stdenv.isDarwin Security;
 
     postPatch = ''
@@ -81,7 +82,7 @@ rec {
     nativeBuildInputs = [ makeWrapper ]
       ++ lib.optional (!stdenv.isDarwin) autoPatchelfHook;
     buildInputs = [ bash ]
-      ++ lib.optional (!stdenv.isDarwin) gcc.cc.lib
+      ++ lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) gcc.cc.lib
       ++ lib.optional stdenv.isDarwin Security;
 
     postPatch = ''

--- a/pkgs/development/compilers/rust/print-hashes.sh
+++ b/pkgs/development/compilers/rust/print-hashes.sh
@@ -19,6 +19,7 @@ PLATFORMS=(
   aarch64-apple-darwin
   powerpc64le-unknown-linux-gnu
   riscv64gc-unknown-linux-gnu
+  x86_64-unknown-freebsd
 )
 BASEURL=https://static.rust-lang.org/dist
 VERSION=${1:-}


### PR DESCRIPTION
## Description of changes

Add x86_64-unknown-freebsd to the list of rust platforms and adjust the requisite inputs. It works!

This has some prerequisites if you actually want to test it out:

- https://github.com/NixOS/nixpkgs/pull/316253
- https://github.com/NixOS/nixpkgs/pull/316249
- https://github.com/NixOS/nixpkgs/pull/315176
- https://github.com/NixOS/nixpkgs/pull/311795 if you're trying to build on native FreeBSD instead of cross

This targets staging because https://github.com/NixOS/nixpkgs/pull/309580 doesn't seem to have made it to master yet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
