### PR TITLE
supercell-wx: init at 0.4.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2458,6 +2458,11 @@
     githubId = 206242;
     name = "Andreas Wiese";
   };
+  aware70 = {
+    name = "aware70";
+    github = "aware70";
+    githubId = 7832566;
+  };
   awwpotato = {
     email = "awwpotato@voidq.com";
     github = "awwpotato";

--- a/pkgs/by-name/su/supercell-wx/package.nix
+++ b/pkgs/by-name/su/supercell-wx/package.nix
@@ -1,0 +1,167 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  aws-sdk-cpp,
+  bzip2,
+  cmake,
+  ninja,
+  zlib,
+  openssl,
+  curl,
+  glew,
+  geos,
+  boost,
+  spdlog,
+  stb,
+  libcpr,
+  libpng,
+  libSM,
+  geographiclib,
+  howard-hinnant-date,
+  re2,
+  gtest,
+  glm,
+  qt6,
+  tbb_2021_11,
+  tracy,
+  substituteAll,
+  python3,
+}:
+let
+  gtestSkip = [
+    # Skip tests requiring network access
+    "AwsLevel*DataProvider.FindKeyNow"
+    "AwsLevel*DataProvider.FindKeyFixed"
+    "AwsLevel*DataProvider.LoadObjectByKey"
+    "AwsLevel*DataProvider.Refresh"
+    "AwsLevel*DataProvider.GetAvailableProducts"
+    "AwsLevel*DataProvider.GetTimePointsByDate"
+    "AwsLevel*DataProvider.Prune"
+    "UpdateManagerTest.CheckForUpdates"
+    "WarningsProvider*\"https"
+
+    # These tests are failing (seemingly can't overwrite a file created by earlier test).
+    "SettingsManager/DefaultSettingsTest*"
+    "SettingsManager/BadSettingsTest*"
+    "MarkerModelTest.*"
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "supercell-wx";
+  version = "0.4.8";
+  src = fetchFromGitHub {
+    owner = "dpaulat";
+    repo = "supercell-wx";
+    rev = "refs/tags/v${finalAttrs.version}-release";
+    sha256 = "sha256-gKR5Mfzw5B4f4/dWintlbDHX3q+d1RmFE+MNp5uSSuc=";
+    fetchSubmodules = true;
+  };
+
+  meta = {
+    homepage = "https://supercell-wx.rtfd.io";
+    downloadPage = "https://github.com/dpaulat/supercell-wx/releases";
+    description = "Live visualization of NEXRAD weather data and alerts";
+    longDescription = ''
+      Supercell Wx is a free, open source application to visualize live and
+      archive NEXRAD Level 2 and Level 3 data, and severe weather alerts.
+      It displays continuously updating weather data on top of a responsive
+      map, providing the capability to monitor weather events using
+      reflectivity, velocity, and other products.
+    '';
+    license = lib.licenses.mit;
+    mainProgram = "supercell-wx";
+    platforms = [
+      "x86_64-linux"
+      #     "aarch64-linux"
+    ];
+    maintainers = with lib.maintainers; [ aware70 ];
+  };
+
+  env.CXXFLAGS = "-Wno-error=restrict -Wno-error=maybe-uninitialized -Wno-error=deprecated-declarations -Wno-error=stringop-overflow";
+  env.GTEST_FILTER = "-${lib.concatStringsSep ":" gtestSkip}";
+
+  doCheck = true;
+
+  # These tests aren't built by 'all', but ctest still tries to run them.
+  cmakeFlags = [
+    "-DCMAKE_CTEST_ARGUMENTS=-E;'test_mln_core|test_mln_widgets'"
+    "-DSTB_INCLUDE_DIR=${stb}/include/stb"
+    "-DFETCHCONTENT_SOURCE_DIR_TRACY=${tracy.src}"
+  ];
+
+  patches = [
+    # These are for Nix compatibility {{{
+    ./patches/use-find-package.patch # Replace some vendored dependencies with Nix provided versions
+    (substituteAll {
+      # Skip tagging build with git version, and substitute it with the src revision (still uses current year timestamp)
+      src = ./patches/skip-git-versioning.patch;
+      rev = finalAttrs.src.rev;
+    })
+    # Prevents using some Qt scripts that seemed to break the install step. Fixes missing link to some targets.
+    ./patches/fix-cmake-install.patch
+    # }}}
+
+    # These may be or already are submitted upstream {{{
+    ./patches/explicit-link-aws-crt.patch # fix missing symbols from aws-crt-cpp
+    # }}}
+  ];
+
+  # This also may be submitted upstream to maplibre-native-qt, which is currently vendored
+  postPatch = ''
+    substituteInPlace external/maplibre-native-qt/src/core/CMakeLists.txt \
+      --replace-fail "CMAKE_SOURCE_DIR" "PROJECT_SOURCE_DIR"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    zlib
+    openssl
+    qt6.qtbase
+    qt6.qttools
+    qt6.qtmultimedia
+    qt6.qtpositioning
+    qt6.qtimageformats
+    aws-sdk-cpp
+    howard-hinnant-date
+    boost
+    tbb_2021_11
+    glew
+    geos
+    spdlog
+    stb
+    libcpr
+    libpng
+    libSM
+    re2
+    openssl
+    # FIXME: split outputs aren't working with find_package. Possibly related to nixpkgs/issues/144170 ?
+    (geographiclib.overrideAttrs {
+      outputs = [ "out" ];
+    })
+    gtest
+    glm
+    bzip2
+    (python3.withPackages (ps: [
+      ps.geopandas
+    ]))
+  ];
+
+  # Currently crashes on wayland; must force X11
+  qtWrapperArgs = [
+    "--set QT_QPA_PLATFORM xcb"
+  ];
+
+  # Install .desktop file and icons
+  postInstall = ''
+    install -m0644 -D "$src/scwx-qt/res/linux/supercell-wx.desktop" "$out/share/applications/supercell-wx.desktop"
+    install -m0644 -D "$src/scwx-qt/res/icons/scwx-256.png"  "$out/share/icons/hicolor/256x256/apps/supercell-wx.png"
+    install -m0644 -D "$src/scwx-qt/res/icons/scwx-64.png"  "$out/share/icons/hicolor/64x64/apps/supercell-wx.png"
+  '';
+})

--- a/pkgs/by-name/su/supercell-wx/patches/explicit-link-aws-crt.patch
+++ b/pkgs/by-name/su/supercell-wx/patches/explicit-link-aws-crt.patch
@@ -1,0 +1,12 @@
+diff --git a/wxdata/wxdata.cmake b/wxdata/wxdata.cmake
+index 47ada181..a1beea15 100644
+--- a/wxdata/wxdata.cmake
++++ b/wxdata/wxdata.cmake
+@@ -280,6 +280,7 @@ endif()
+ 
+ target_link_libraries(wxdata PUBLIC aws-cpp-sdk-core
+                                     aws-cpp-sdk-s3
++                                    aws-crt-cpp
+                                     cpr::cpr
+                                     LibXml2::LibXml2
+                                     re2::re2

--- a/pkgs/by-name/su/supercell-wx/patches/fix-cmake-install.patch
+++ b/pkgs/by-name/su/supercell-wx/patches/fix-cmake-install.patch
@@ -1,0 +1,53 @@
+diff --git a/scwx-qt/scwx-qt.cmake b/scwx-qt/scwx-qt.cmake
+index cda6c7f..32d807a 100644
+--- a/scwx-qt/scwx-qt.cmake
++++ b/scwx-qt/scwx-qt.cmake
+@@ -601,6 +601,7 @@ target_link_libraries(scwx-qt PUBLIC Qt${QT_VERSION_MAJOR}::Widgets
+                                      Boost::json
+                                      Boost::timer
+                                      QMapLibre::Core
++                                     QMapLibre::Widgets
+                                      $<$<CXX_COMPILER_ID:MSVC>:opengl32>
+                                      Fontconfig::Fontconfig
+                                      GeographicLib::GeographicLib
+@@ -615,40 +616,13 @@ target_link_libraries(scwx-qt PUBLIC Qt${QT_VERSION_MAJOR}::Widgets
+ target_link_libraries(supercell-wx PRIVATE scwx-qt
+                                            wxdata)
+ 
+-# Set DT_RUNPATH for Linux targets
+-set_target_properties(MLNQtCore    PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib") # QMapLibre::Core
+-set_target_properties(supercell-wx PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
+-
+ install(TARGETS supercell-wx
+-                MLNQtCore # QMapLibre::Core
+-        RUNTIME_DEPENDENCIES
+-          PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-" "qt6"
+-          POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
+-                               "^(/usr)?/lib/.*\\.so(\\..*)?"
+         RUNTIME
+           COMPONENT supercell-wx
+         LIBRARY
+           COMPONENT supercell-wx
+           OPTIONAL)
+ 
+-# NO_TRANSLATIONS is needed for Qt 6.5.0 (will be fixed in 6.5.1)
+-# https://bugreports.qt.io/browse/QTBUG-112204
+-qt_generate_deploy_app_script(TARGET MLNQtCore # QMapLibre::Core
+-                              OUTPUT_SCRIPT deploy_script_qmaplibre_core
+-                              NO_TRANSLATIONS
+-                              NO_UNSUPPORTED_PLATFORM_ERROR)
+-
+-qt_generate_deploy_app_script(TARGET supercell-wx
+-                              OUTPUT_SCRIPT deploy_script_scwx
+-                              NO_TRANSLATIONS
+-                              NO_UNSUPPORTED_PLATFORM_ERROR)
+-
+-install(SCRIPT ${deploy_script_qmaplibre_core}
+-        COMPONENT supercell-wx)
+-
+-install(SCRIPT ${deploy_script_scwx}
+-        COMPONENT supercell-wx)
+-
+ if (MSVC)
+     set(CPACK_PACKAGE_NAME                "Supercell Wx")
+     set(CPACK_PACKAGE_VENDOR              "Dan Paulat")

--- a/pkgs/by-name/su/supercell-wx/patches/skip-git-versioning.patch
+++ b/pkgs/by-name/su/supercell-wx/patches/skip-git-versioning.patch
@@ -1,0 +1,50 @@
+diff --git a/scwx-qt/tools/generate_versions.py b/scwx-qt/tools/generate_versions.py
+index c6c94020..3fcdcf08 100644
+--- a/scwx-qt/tools/generate_versions.py
++++ b/scwx-qt/tools/generate_versions.py
+@@ -1,6 +1,5 @@
+ import argparse
+ import datetime
+-import git
+ import json
+ import os
+ import pathlib
+@@ -110,27 +109,22 @@ def ParseArguments():
+                         required = True)
+     return parser.parse_args()
+ 
++def GetYearFromLicense(license_file: pathlib.Path):
++    import re
++    for line in license_file.read_text().splitlines():
++        m = re.search(r'^\s*Copyright \(c\) 2021-(\d{4,})', line)
++        if m is not None:
++            return int(m.group(1))
++    raise RuntimeError(f"Could not find copyright year in {license_file}")
++
+ def CollectVersionInfo(args):
+     print("Collecting version info")
+ 
+     versionInfo = VersionInfo()
+-
+-    repo = git.Repo(args.gitRepo_, search_parent_directories = True)
+-
+-    commitString = str(repo.head.commit)[:10]
+-
+-    if not repo.is_dirty(submodules = False):
+-        copyrightYear = datetime.datetime.fromtimestamp(repo.head.commit.committed_date).year
+-    else:
+-        commitString  = commitString + "+dirty"
+-        copyrightYear = datetime.date.today().year
+-
+-    resourceDir = str(args.gitRepo_).replace("\\", "\\\\")
+-
+     versionInfo.buildNumber_   = args.buildNumber_
+-    versionInfo.commitString_  = commitString
+-    versionInfo.copyrightYear_ = copyrightYear
+-    versionInfo.resourceDir_   = resourceDir
++    versionInfo.commitString_  = "@rev@"
++    versionInfo.copyrightYear_ = GetYearFromLicense(args.gitRepo_ / 'LICENSE.txt')
++    versionInfo.resourceDir_   = str(args.gitRepo_).replace("\\", "\\\\")
+     versionInfo.versionString_ = args.version_
+ 
+     versionInfo.Calculate()

--- a/pkgs/by-name/su/supercell-wx/patches/use-find-package.patch
+++ b/pkgs/by-name/su/supercell-wx/patches/use-find-package.patch
@@ -1,0 +1,67 @@
+diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
+index 2137ae62..041cb87d 100644
+--- a/external/CMakeLists.txt
++++ b/external/CMakeLists.txt
+@@ -14,7 +14,7 @@ set_property(DIRECTORY
+              units.cmake
+              qt6ct.cmake)
+ 
+-include(aws-sdk-cpp.cmake)
++find_package(AWSSDK CONFIG REQUIRED)
+ include(date.cmake)
+ include(hsluv-c.cmake)
+ include(imgui.cmake)
+diff --git a/external/stb.cmake b/external/stb.cmake
+index 570af425..f9817226 100644
+--- a/external/stb.cmake
++++ b/external/stb.cmake
+@@ -1,4 +1,3 @@
+ cmake_minimum_required(VERSION 3.24)
+ set(PROJECT_NAME scwx-stb)
+
+-set(STB_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/stb PARENT_SCOPE)
++# Nix: set STB_INCLUDE_DIR in cmake flags
+diff --git a/scwx-qt/scwx-qt.cmake b/scwx-qt/scwx-qt.cmake
+index 09ea6fe3..c20a2cb6 100644
+--- a/scwx-qt/scwx-qt.cmake
++++ b/scwx-qt/scwx-qt.cmake
+@@ -11,14 +11,15 @@ set(CMAKE_AUTORCC ON)
+ set(CMAKE_CXX_STANDARD 20)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ 
+-find_package(Boost)
++find_package(Boost REQUIRED COMPONENTS json timer)
+ find_package(Fontconfig)
+-find_package(geographiclib)
++find_package(GeographicLib)
+ find_package(geos)
+ find_package(GLEW)
+ find_package(glm)
+ find_package(Python COMPONENTS Interpreter)
+ find_package(SQLite3)
++find_package(PNG)
+ 
+ find_package(QT NAMES Qt6
+              COMPONENTS Gui
+@@ -699,6 +700,7 @@ target_link_libraries(scwx-qt PUBLIC Qt${QT_VERSION_MAJOR}::Widgets
+                                      imgui
+                                      qt6ct-common
+                                      SQLite::SQLite3
++                                     PNG::PNG
+                                      wxdata)
+ 
+ target_link_libraries(supercell-wx PRIVATE scwx-qt
+diff --git a/wxdata/wxdata.cmake b/wxdata/wxdata.cmake
+index 94b0e3a7..a36c2c81 100644
+--- a/wxdata/wxdata.cmake
++++ b/wxdata/wxdata.cmake
+@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.24)
+ 
+ project(scwx-data)
+ 
+-find_package(Boost)
++find_package(Boost REQUIRED COMPONENTS iostreams)
++find_package(BZip2)
+ find_package(cpr)
+ find_package(LibXml2)
+ find_package(OpenSSL)


### PR DESCRIPTION
## Description of changes
Adds [Supercell Wx](https://supercell-wx.readthedocs.io/en/stable/#) at version 0.4.8.

Supercell Wx is a free, open source application to visualize live and archive NEXRAD Level 2 and Level 3 data, and severe weather alerts. It displays continuously updating weather data on top of a responsive map, providing the capability to monitor weather events using reflectivity, velocity, and other products. Extended functionality, including weather reports and lightning data can be added using placefiles.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
