### PR TITLE
lomiri.lomiri: Try to consider services.xserver.xkb.layout

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -36,6 +36,10 @@ in {
         suru-icon-theme
         # telephony-service # currently broken: https://github.com/NixOS/nixpkgs/pull/314043
       ]);
+      variables = {
+        # To override the keyboard layouts in Lomiri
+        NIXOS_XKB_LAYOUTS = config.services.xserver.xkb.layout;
+      };
     };
 
     hardware.pulseaudio.enable = lib.mkDefault true;

--- a/pkgs/desktops/lomiri/applications/lomiri/9902-lomiri-Check-NIXOS_XKB_LAYOUTS.patch
+++ b/pkgs/desktops/lomiri/applications/lomiri/9902-lomiri-Check-NIXOS_XKB_LAYOUTS.patch
@@ -1,0 +1,29 @@
+From 640cab41986fac83742af39dd19877041a2ab8dc Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Sat, 1 Jun 2024 00:22:27 +0200
+Subject: [PATCH] Check NIXOS_XKB_LAYOUTS for layouts before falling back to
+ "us"
+
+---
+ plugins/AccountsService/AccountsService.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/plugins/AccountsService/AccountsService.cpp b/plugins/AccountsService/AccountsService.cpp
+index bcf18246c..f4a7dfaa1 100644
+--- a/plugins/AccountsService/AccountsService.cpp
++++ b/plugins/AccountsService/AccountsService.cpp
+@@ -295,6 +295,11 @@ QStringList AccountsService::keymaps() const
+         return simplifiedMaps;
+     }
+ 
++    char* fallbackNixosLayouts = getenv("NIXOS_XKB_LAYOUTS");
++    if (fallbackNixosLayouts != NULL && fallbackNixosLayouts[0] != '\0') {
++        return QString(fallbackNixosLayouts).split(QLatin1Char(','), Qt::SkipEmptyParts);
++    }
++
+     return {QStringLiteral("us")};
+ }
+ 
+-- 
+2.42.0
+

--- a/pkgs/desktops/lomiri/applications/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri/default.nix
@@ -117,6 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
 
     ./9901-lomiri-Disable-Wizard.patch
+    ./9902-lomiri-Check-NIXOS_XKB_LAYOUTS.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Propagate the configuration setting through an envvar, check the envvar in the compositor. Needed because querying AccountsSettings for this information fails, due to Ubuntu-only "InputSources" interface. So you're stuck on US layout without this hack.

---

Tested by setting `services.xserver.xkb.layout = "de";` in the VM test, logging in, spawning a terminal and pressing the `z` and `ß` keys on my keyboard.

I assume the current behaviour would bother ppl quite abit, so would like to backport.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
