### PR TITLE
openjdk: enable Clang-based builds of jdk{11,17,19,20,21,22}

### DIFF
--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -74,9 +74,19 @@ let
       "--with-lcms=system"
       "--with-stdc++lib=dynamic"
       "--disable-warnings-as-errors"
-    ] ++ lib.optional stdenv.isx86_64 "--with-jvm-features=zgc"
-      ++ lib.optional headless "--enable-headless-only"
-      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+    ]
+    # Cannot be built by recent versions of Clang, as far as I can tell (see
+    # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=260319). Known to
+    # compile with LLVM 12.
+    ++ lib.optionals stdenv.cc.isClang [
+      "--with-toolchain-type=clang"
+      # Explicitly tell Clang to compile C++ files as C++, see
+      # https://github.com/NixOS/nixpkgs/issues/150655#issuecomment-1935304859
+      "--with-extra-cxxflags=-xc++"
+    ]
+    ++ lib.optional stdenv.isx86_64 "--with-jvm-features=zgc"
+    ++ lib.optional headless "--enable-headless-only"
+    ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
 
     separateDebugInfo = true;
 

--- a/pkgs/development/compilers/openjdk/17.nix
+++ b/pkgs/development/compilers/openjdk/17.nix
@@ -98,8 +98,15 @@ let
       "--with-zlib=system"
       "--with-lcms=system"
       "--with-stdc++lib=dynamic"
-    ] ++ lib.optional headless "--enable-headless-only"
-      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+    ]
+    ++ lib.optionals stdenv.cc.isClang [
+      "--with-toolchain-type=clang"
+      # Explicitly tell Clang to compile C++ files as C++, see
+      # https://github.com/NixOS/nixpkgs/issues/150655#issuecomment-1935304859
+      "--with-extra-cxxflags=-xc++"
+    ]
+    ++ lib.optional headless "--enable-headless-only"
+    ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
 
     separateDebugInfo = true;
 

--- a/pkgs/development/compilers/openjdk/19.nix
+++ b/pkgs/development/compilers/openjdk/19.nix
@@ -100,8 +100,15 @@ let
       "--with-zlib=system"
       "--with-lcms=system"
       "--with-stdc++lib=dynamic"
-    ] ++ lib.optional headless "--enable-headless-only"
-      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+    ]
+    ++ lib.optionals stdenv.cc.isClang [
+      "--with-toolchain-type=clang"
+      # Explicitly tell Clang to compile C++ files as C++, see
+      # https://github.com/NixOS/nixpkgs/issues/150655#issuecomment-1935304859
+      "--with-extra-cxxflags=-xc++"
+    ]
+    ++ lib.optional headless "--enable-headless-only"
+    ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
 
     separateDebugInfo = true;
 

--- a/pkgs/development/compilers/openjdk/20.nix
+++ b/pkgs/development/compilers/openjdk/20.nix
@@ -98,8 +98,15 @@ let
       "--with-zlib=system"
       "--with-lcms=system"
       "--with-stdc++lib=dynamic"
-    ] ++ lib.optional headless "--enable-headless-only"
-      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+    ]
+    ++ lib.optionals stdenv.cc.isClang [
+      "--with-toolchain-type=clang"
+      # Explicitly tell Clang to compile C++ files as C++, see
+      # https://github.com/NixOS/nixpkgs/issues/150655#issuecomment-1935304859
+      "--with-extra-cxxflags=-xc++"
+    ]
+    ++ lib.optional headless "--enable-headless-only"
+    ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
 
     separateDebugInfo = true;
 

--- a/pkgs/development/compilers/openjdk/21.nix
+++ b/pkgs/development/compilers/openjdk/21.nix
@@ -91,9 +91,16 @@ let
       "--with-zlib=system"
       "--with-lcms=system"
       "--with-stdc++lib=dynamic"
-    ] ++ lib.optional stdenv.isx86_64 "--with-jvm-features=zgc"
-      ++ lib.optional headless "--enable-headless-only"
-      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+    ]
+    ++ lib.optionals stdenv.cc.isClang [
+      "--with-toolchain-type=clang"
+      # Explicitly tell Clang to compile C++ files as C++, see
+      # https://github.com/NixOS/nixpkgs/issues/150655#issuecomment-1935304859
+      "--with-extra-cxxflags=-xc++"
+    ]
+    ++ lib.optional stdenv.isx86_64 "--with-jvm-features=zgc"
+    ++ lib.optional headless "--enable-headless-only"
+    ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
 
     separateDebugInfo = true;
 

--- a/pkgs/development/compilers/openjdk/22.nix
+++ b/pkgs/development/compilers/openjdk/22.nix
@@ -160,6 +160,12 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-lcms=system"
     "--with-stdc++lib=dynamic"
   ]
+  ++ lib.optionals stdenv.cc.isClang [
+    "--with-toolchain-type=clang"
+    # Explicitly tell Clang to compile C++ files as C++, see
+    # https://github.com/NixOS/nixpkgs/issues/150655#issuecomment-1935304859
+    "--with-extra-cxxflags=-xc++"
+  ]
   ++ lib.optional headless "--enable-headless-only"
   ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
 


### PR DESCRIPTION
## Description of changes
Make it possible to compile the latest 4 releases of OpenJDK and all LTS versions (minus OpenJDK 8, see below) using Clang/LLVM. This should reduce friction for the compilation of OpenJDK binaries on Darwin systems.

Part of the concerted improvement efforts outlined in #313216.
Contributes to the closure of #313213.

### Caveats
While all most recent versions of OpenJDK compile beautifully with Clang, older versions tend to croak:
- OpenJDK 11 can be built by LLVM 12, but segfaults with more recent versions (the FreeBSD folks [encountered the same problem](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=260319), and I don't understand if they eventually managed to make it work with newer compilers);
- the venerable OpenJDK 8 is written in pre-C++11, and I couldn't manage to convince the Clang stdenv to accept its ancient code (inputs from more knowledgeable people are welcome).

In addition, I _really_ wanted to enable the automatic test suite to detect any regressions w.r.t. the GCC builds (the _tier 1_ test battery, to be precise), but Google Test did not cooperate (see #313213 for more details), making 6 tests fail due to the test libraries not being found. Suggestions are welcome.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
