### PR TITLE
nixos-rebuild: Document all supported builder flags in manpage

### DIFF
--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
@@ -18,7 +18,6 @@
 .Op Fl -no-build-nix
 .Op Fl -fast
 .Op Fl -rollback
-.Op Fl -builders Ar builder-spec
 .br
 .Op Fl -flake Ar flake-uri
 .Op Fl -no-flake
@@ -31,14 +30,26 @@
 .Op Fl -target-host Va host
 .Op Fl -use-remote-sudo
 .br
-.Op Fl -show-trace
-.Op Fl I Va NIX_PATH
 .Op Fl -verbose | v
-.Op Fl -accept-flake-config
-.Op Fl -impure
+.Op Fl -quiet
+.Op Fl -log-format Ar format
+.Op Fl -no-build-output | Q
 .Op Fl -max-jobs | j Va number
-.Op Fl -keep-failed | K
+.Op Fl -cores Va number
 .Op Fl -keep-going | k
+.Op Fl -keep-failed | K
+.Op Fl -fallback
+.Op Fl I Va NIX_PATH
+.Op Fl -option Ar name value
+.Op Fl -repair
+.Op Fl -builders Va builder-spec
+.Op Fl -accept-flake-config
+.Op Fl -print-build-logs | L
+.Op Fl -show-trace
+.Op Fl -refresh
+.Op Fl -impure
+.Op Fl -offline
+.Op Fl -no-net
 .
 .
 .
@@ -390,18 +401,34 @@ even if the current NixOS systems uses flakes.
 .Pp
 In addition,
 .Nm
-accepts various Nix-related flags, including
+accepts following builder flags:
+.Fl -verbose Ns ,
+.Fl v Ns ,
+.Fl -quiet Ns ,
+.Fl -log-format Ns ,
+.Fl -no-build-output Ns ,
+.Fl Q Ns ,
 .Fl -max-jobs Ns ,
 .Fl j Ns ,
-.Fl I Ns ,
-.Fl -accept-flake-config Ns ,
-.Fl -show-trace Ns ,
-.Fl -keep-failed Ns ,
+.Fl -cores Ns ,
 .Fl -keep-going Ns ,
+.Fl k Ns ,
+.Fl -keep-failed Ns ,
+.Fl K Ns ,
+.Fl -fallback Ns ,
+.Fl I Ns ,
+.Fl -option Ns
+.Fl -repair Ns ,
+.Fl -builders Ns ,
+.Fl -accept-flake-config Ns ,
+.Fl -print-build-logs Ns ,
+.Fl L Ns ,
+.Fl -show-trace Ns ,
+.Fl -refresh Ns ,
 .Fl -impure Ns ,
-.Fl -verbose Ns , and
-.Fl v Ns
-\&. See the Nix manual for details.
+.Fl -offline Ns , and
+.Fl -no-net Ns
+\&. See the Nix manual or nix-build manpage for details.
 .
 .
 .

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
@@ -21,7 +21,13 @@
 .br
 .Op Fl -flake Ar flake-uri
 .Op Fl -no-flake
-.Op Fl -override-input Ar input-name flake-uri
+.Op Fl -recreate-lock-file
+.Op Fl -no-update-lock-file
+.Op Fl -no-write-lock-file
+.Op Fl -no-registries
+.Op Fl -commit-lock-file
+.Op Fl -update-input Ar input-path
+.Op Fl -override-input Ar input-path flake-url
 .br
 .Op Fl -profile-name | p Ar name
 .Op Fl -specialisation | c Ar name
@@ -401,7 +407,23 @@ even if the current NixOS systems uses flakes.
 .Pp
 In addition,
 .Nm
-accepts following builder flags:
+accepts following options from nix commands that the tool calls:
+.
+.Pp
+flake-related options:
+.Bd -offset indent
+.Fl -recreate-lock-file Ns ,
+.Fl -no-update-lock-file Ns ,
+.Fl -no-write-lock-file Ns ,
+.Fl -no-registries Ns ,
+.Fl -commit-lock-file Ns ,
+.Fl -update-input Ar input-path Ns ,
+.Fl -override-input Ar input-path flake-url Ns
+.Ed
+.
+.Pp
+Builder options:
+.Bd -offset indent
 .Fl -verbose Ns ,
 .Fl v Ns ,
 .Fl -quiet Ns ,
@@ -426,9 +448,16 @@ accepts following builder flags:
 .Fl -show-trace Ns ,
 .Fl -refresh Ns ,
 .Fl -impure Ns ,
-.Fl -offline Ns , and
+.Fl -offline Ns ,
 .Fl -no-net Ns
-\&. See the Nix manual or nix-build manpage for details.
+.Ed
+.
+.Pp
+See the Nix manual,
+.Ic nix flake lock --help
+or
+.Ic nix-build --help
+for details.
 .
 .
 .


### PR DESCRIPTION
## Description of changes

Not all nix-build arguments that nixos-rebuild allowed to use were documented in the manpage
this commit rectifies that.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
