### PR TITLE
fedimint: init at 0.3.2-rc.0

### DIFF
--- a/pkgs/by-name/fe/fedimint/package.nix
+++ b/pkgs/by-name/fe/fedimint/package.nix
@@ -1,0 +1,91 @@
+{ lib
+, fetchFromGitHub
+, openssl
+, pkg-config
+, protobuf
+, rustPlatform
+, buildPackages
+, git
+, stdenv
+, libiconv
+, clang
+, libclang
+, Security
+, SystemConfiguration
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "fedimint";
+  version = "0.3.2-rc.0";
+
+  src = fetchFromGitHub {
+    owner = "fedimint";
+    repo = "fedimint";
+    rev = "v${version}";
+    hash = "sha256-eOGmx/freDQLxZ48nP9Y2kA84F6sdig6qfZwnJfOB3g=";
+  };
+
+  cargoHash = "sha256-2ctrZLvovgMpxZPFtmblZ/NGyxievE6FmzC4BBGuw6g=";
+
+  nativeBuildInputs = [
+    protobuf
+    pkg-config
+    clang
+    libclang.lib
+  ];
+
+  buildInputs = [
+    openssl
+  ] ++ lib.optionals stdenv.isDarwin [
+    Security
+    libiconv
+    Security
+    SystemConfiguration
+  ];
+
+  outputs = [ "out" "fedimintCli" "fedimint" "gateway" "gatewayCli" "devimint" ];
+
+  postInstall = ''
+    mkdir -p $fedimint/bin $fedimintCli/bin $gateway/bin $gatewayCli/bin $devimint/bin
+
+    # delete fuzzing targets and other binaries no one cares about
+    binsToKeep=(fedimint-cli fedimint-dbtool recoverytool fedimintd gatewayd gateway-cli gateway-cln-extension devimint)
+    keepPattern=$(printf "|%s" "''${binsToKeep[@]}")
+    keepPattern=''${keepPattern:1}
+    find "$out/bin" -maxdepth 1 -type f | grep -Ev "(''${keepPattern})" | xargs rm -f
+
+    # fix the upstream name
+    mv $out/bin/recoverytool $out/bin/fedimint-recoverytool
+
+
+    cp -a $releaseDir/fedimint-cli  $fedimintCli/bin/
+    cp -a $releaseDir/fedimint-dbtool  $fedimintCli/bin/
+    cp -a $releaseDir/recoverytool  $fedimintCli/bin/fedimint-recoverytool
+
+    cp -a $releaseDir/fedimintd  $fedimint/bin/
+
+    cp -a $releaseDir/gateway-cli $gatewayCli/bin/
+
+    cp -a $releaseDir/gatewayd $gateway/bin/
+    cp -a $releaseDir/gateway-cln-extension $gateway/bin/
+
+    cp -a $releaseDir/devimint $devimint/bin/
+  '';
+
+  PROTOC = "${buildPackages.protobuf}/bin/protoc";
+  PROTOC_INCLUDE = "${protobuf}/include";
+  OPENSSL_DIR = openssl.dev;
+  LIBCLANG_PATH = "${libclang.lib}/lib";
+
+  FEDIMINT_BUILD_FORCE_GIT_HASH = "0000000000000000000000000000000000000000";
+
+  # currently broken, will require some upstream fixes
+  doCheck = false;
+
+  meta = {
+    description = "Federated E-Cash Mint";
+    homepage = "https://github.com/fedimint/fedimint";
+    license = [ lib.licenses.mit ];
+    maintainers = with lib.maintainers; [ dpc ];
+    mainProgram = "fedimint-cli";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5169,6 +5169,10 @@ with pkgs;
 
   fdroidserver = python3Packages.callPackage ../development/tools/fdroidserver { };
 
+  fedimint = callPackage ../by-name/fe/fedimint/package.nix {
+    inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
+  };
+
   fetch-scm = callPackage ../tools/misc/fetch-scm { };
 
   fiano = callPackage ../tools/misc/fiano { };


### PR DESCRIPTION
## Description of changes

Add Fedimint package.

[Fedimint](https://fedimint.org/) is a module based system for building federated applications. It is designed to be a trust-minimized, censorship-resistant, and private alternative to centralized applications.

Fedimint is sizeable Rust project (>90k lines of Rust), in a big workspace that shares most dependencies. Build creates multiple binaries, intended to run on a different systems (cli, daemon, LN gateway with cli and daemon, etc.), so to avoid rebuilding the project multiple times, I went with the multiple outputs route.

I'm one of the main contributors to Fedimint and maintain our Nix Flake based CI system, etc. so I'm planning to maintain this package. Once this is accepted, I'd like to follow up with NixOS modules that are already part of our flake.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
