### PR TITLE
emacs: clean some manualPackages

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/color-theme-solarized/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/color-theme-solarized/default.nix
@@ -6,7 +6,7 @@
 
 trivialBuild {
   pname = "color-theme-solarized";
-  version = "0.pre+unstable=2017-10-24";
+  version = "0-unstable-2017-10-24";
 
   src = fetchFromGitHub {
     owner = "sellout";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/copilot/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/copilot/default.nix
@@ -8,7 +8,7 @@
 }:
 trivialBuild {
   pname = "copilot";
-  version = "unstable-2023-12-26";
+  version = "0-unstable-2023-12-26";
   src = fetchFromGitHub {
     owner = "zerolfx";
     repo = "copilot.el";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/evil-markdown/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/evil-markdown/default.nix
@@ -8,7 +8,7 @@
 
 trivialBuild rec {
   pname = "evil-markdown";
-  version = "0.pre+unstable=2021-07-21";
+  version = "0-unstable-2021-07-21";
 
   src = fetchFromGitHub {
     owner = "Somelauw";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/font-lock-plus/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/font-lock-plus/default.nix
@@ -5,7 +5,7 @@
 
 trivialBuild {
   pname = "font-lock-plus";
-  version = "208+unstable=2018-01-01";
+  version = "208-unstable-2018-01-01";
 
   src = fetchFromGitHub {
     owner = "emacsmirror";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/git-undo/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/git-undo/default.nix
@@ -6,7 +6,7 @@
 
 trivialBuild {
   pname = "git-undo";
-  version = "0.pre+unstable=2019-12-21";
+  version = "0-unstable-2019-12-21";
 
   src = fetchFromGitHub {
     owner = "jwiegley";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/helm-words/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/helm-words/default.nix
@@ -8,7 +8,7 @@
 
 trivialBuild rec {
   pname = "helm-words";
-  version = "0.pre+unstable=2019-03-12";
+  version = "0-unstable-2019-03-12";
 
   src = fetchFromGitHub {
     owner = "emacsmirror";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/isearch-plus/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/isearch-plus/default.nix
@@ -6,7 +6,7 @@
 
 trivialBuild {
   pname = "isearch-plus";
-  version = "3434+unstable=2021-08-23";
+  version = "3434-unstable-2021-08-23";
 
   src = fetchFromGitHub {
     owner = "emacsmirror";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/isearch-prop/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/isearch-prop/default.nix
@@ -6,7 +6,7 @@
 
 trivialBuild {
   pname = "isearch-prop";
-  version = "0.pre+unstable=2019-05-01";
+  version = "0-unstable-2019-05-01";
 
   src = fetchFromGitHub {
     owner = "emacsmirror";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/lspce/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/lspce/default.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  version = "unstable-2024-02-03";
+  version = "1.0.0-unstable-2024-02-03";
 
   src = fetchFromGitHub {
     owner = "zbelial";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/rect-mark/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/rect-mark/default.nix
@@ -15,8 +15,6 @@ trivialBuild rec {
     hash = "sha256-/8T1VTYkKUxlNWXuuS54S5jpl4UxJBbgSuWc17a/VyM=";
   };
 
-  buildInputs = [ emacs ];
-
   meta = with lib; {
     homepage = "http://emacswiki.org/emacs/RectangleMark";
     description = "Mark a rectangle of text with highlighting";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/sunrise-commander/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/sunrise-commander/default.nix
@@ -6,7 +6,7 @@
 
 trivialBuild {
   pname = "sunrise-commander";
-  version = "unstable=2021-09-27";
+  version = "0-unstable-2021-09-27";
 
   src = fetchFromGitHub {
     owner = "sunrise-commander";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/voicemacs/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/voicemacs/default.nix
@@ -17,7 +17,7 @@
 
 trivialBuild {
   pname = "voicemacs";
-  version = "unstable-2022-02-16";
+  version = "0-unstable-2022-02-16";
 
   src = fetchFromGitHub {
     owner = "jcaw";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/yes-no/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/yes-no/default.nix
@@ -2,7 +2,7 @@
 
 trivialBuild {
   pname = "yes-no";
-  version = "2017-10-01";
+  version = "0-unstable-2017-10-01";
 
   src = fetchurl {
     url = "https://raw.githubusercontent.com/emacsmirror/emacswiki.org/143bcaeb679a8fa8a548e92a5a9d5c2baff50d9c/yes-no.el";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/youtube-dl/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/youtube-dl/default.nix
@@ -6,7 +6,7 @@
 
 trivialBuild {
   pname = "youtube-dl";
-  version = "0.pre+unstable=2018-10-12";
+  version = "1.0-unstable-2018-10-12";
 
   src = fetchFromGitHub {
     owner = "skeeto";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/youtube-dl/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/youtube-dl/default.nix
@@ -15,8 +15,6 @@ trivialBuild {
     sha256 = "sha256-Etl95rcoRACDPjcTPQqYK2L+w8OZbOrTrRT0JadMdH4=";
   };
 
-  buildInputs = [ emacs ];
-
   meta = with lib; {
     description = "Emacs youtube-dl download manager";
     homepage = "https://github.com/skeeto/youtube-dl-emacs";


### PR DESCRIPTION
## Description of changes

When people add their first manual package, they may [use existing ones as examples](https://github.com/NixOS/nixpkgs/pull/313309#issuecomment-2123850292).  So I did some trivial cleaning for manual packages.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
