### PR TITLE
gcc: provide a $libgcc/$target/lib -> $libgcc/lib symlink

### DIFF
--- a/pkgs/development/compilers/gcc/common/libgcc.nix
+++ b/pkgs/development/compilers/gcc/common/libgcc.nix
@@ -84,21 +84,20 @@ in
       rm -f $out/lib/libgcc_s.so*
     ''
 
-    # TODO(amjoseph): remove the `libgcc_s.so` symlinks below and replace them
-    # with a `-L${gccForLibs.libgcc}/lib` in cc-wrapper's
-    # `$out/nix-support/cc-flags`.  See also:
-    # - https://github.com/NixOS/nixpkgs/pull/209870#discussion_r1130614895
-    # - https://github.com/NixOS/nixpkgs/pull/209870#discussion_r1130635982
-    # - https://github.com/NixOS/nixpkgs/commit/404155c6acfa59456aebe6156b22fe385e7dec6f
-    #
     # move `libgcc_s.so` into its own output, `$libgcc`
+    # We maintain $libgcc/lib/$target/ structure to make sure target
+    # strip runs over libgcc_s.so and remove debug references to headers:
+    #   https://github.com/NixOS/nixpkgs/issues/316114
     + lib.optionalString enableLibGccOutput (''
       # move libgcc from lib to its own output (libgcc)
-      mkdir -p $libgcc/lib
-      mv    $lib/${targetPlatformSlash}lib/libgcc_s.so      $libgcc/lib/
-      mv    $lib/${targetPlatformSlash}lib/libgcc_s.so.${libgcc_s-version-major}    $libgcc/lib/
-      ln -s $libgcc/lib/libgcc_s.so   $lib/${targetPlatformSlash}lib/
-      ln -s $libgcc/lib/libgcc_s.so.${libgcc_s-version-major} $lib/${targetPlatformSlash}lib/
+      mkdir -p $libgcc/${targetPlatformSlash}lib
+      mv    $lib/${targetPlatformSlash}lib/libgcc_s.so      $libgcc/${targetPlatformSlash}lib/
+      mv    $lib/${targetPlatformSlash}lib/libgcc_s.so.${libgcc_s-version-major}    $libgcc/${targetPlatformSlash}lib/
+      ln -s $libgcc/${targetPlatformSlash}lib/libgcc_s.so   $lib/${targetPlatformSlash}lib/
+      ln -s $libgcc/${targetPlatformSlash}lib/libgcc_s.so.${libgcc_s-version-major} $lib/${targetPlatformSlash}lib/
+    ''
+    + lib.optionalString (targetPlatformSlash != "") ''
+      ln -s ${targetPlatformSlash}lib $libgcc/lib
     ''
     #
     # Nixpkgs ordinarily turns dynamic linking into pseudo-static linking:


### PR DESCRIPTION
The primary reason for the layout change is for `gcc.libgcc` to match closer `gcc.lib` layout. That way we allow `$STRIP_FOR_TARGET` to strip `libgcc_s.so.1` file moved to $libgcc output. Otherwise `$STRIP` (for host) fails to do it and leaves debug strings like references to headers in it and bloats HOST closure with BUILD inputs.

The change shrinks `aarch64-multiplatform-musl.coreutils` closure from 50MB down to 10MB:

Before:

    $ nix path-info -rsSh $(nix-build -A pkgs.pkgsCross.aarch64-multiplatform-musl.coreutils) |& unnix
    /<<NIX>>/xgcc-13.2.0-libgcc                              155.8K  155.8K
    /<<NIX>>/musl-aarch64-unknown-linux-musl-1.2.3             3.8M    3.8M
    /<<NIX>>/libunistring-1.1                                  1.7M    1.7M
    /<<NIX>>/libidn2-2.3.7                                   352.7K    2.1M
    /<<NIX>>/glibc-2.39-52                                    28.7M   31.0M
    /<<NIX>>/bash-5.2p26                                       1.5M   32.5M
    /<<NIX>>/musl-aarch64-unknown-linux-musl-1.2.3-bin        69.4K    3.8M
    /<<NIX>>/linux-headers-6.7                                 6.2M    6.2M
    /<<NIX>>/musl-aarch64-unknown-linux-musl-1.2.3-dev       550.2K   43.1M
    /<<NIX>>/aarch64-unknown-linux-musl-gcc-13.2.0-libgcc    579.7K   43.6M
    /<<NIX>>/aarch64-unknown-linux-musl-gcc-13.2.0-lib         3.8M   47.4M
    /<<NIX>>/gmp-with-cxx-aarch64-unknown-linux-musl-6.3.0   653.4K   48.1M
    /<<NIX>>/attr-aarch64-unknown-linux-musl-2.5.2            73.8K    3.8M
    /<<NIX>>/acl-aarch64-unknown-linux-musl-2.3.2            156.4K    4.0M
    /<<NIX>>/coreutils-aarch64-unknown-linux-musl-9.5          1.6M   49.9M

After:

    $ nix path-info -rsSh $(nix-build -A pkgs.pkgsCross.aarch64-multiplatform-musl.coreutils) |& unnix
    /<<NIX>>/musl-aarch64-unknown-linux-musl-1.2.3             3.8M    3.8M
    /<<NIX>>/aarch64-unknown-linux-musl-gcc-13.2.0-libgcc    147.9K  147.9K
    /<<NIX>>/aarch64-unknown-linux-musl-gcc-13.2.0-lib         3.8M    7.7M
    /<<NIX>>/gmp-with-cxx-aarch64-unknown-linux-musl-6.3.0   653.4K    8.4M
    /<<NIX>>/attr-aarch64-unknown-linux-musl-2.5.2            73.8K    3.8M
    /<<NIX>>/acl-aarch64-unknown-linux-musl-2.3.2            156.4K    4.0M
    /<<NIX>>/coreutils-aarch64-unknown-linux-musl-9.5          1.6M   10.1M

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
