### PR TITLE
aporia: init at 0-unstable-2024-06-01

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -579,6 +579,7 @@
   ./services/display-managers/greetd.nix
   ./services/display-managers/sddm.nix
   ./services/display-managers/ly.nix
+  ./services/display-managers/aporia.nix
   ./services/editors/emacs.nix
   ./services/editors/haste.nix
   ./services/editors/infinoted.nix

--- a/nixos/modules/services/display-managers/aporia.nix
+++ b/nixos/modules/services/display-managers/aporia.nix
@@ -1,7 +1,13 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   cfg = config.services.displayManager.aporia;
-in {
+in
+{
   options = {
     services.displayManager.aporia = {
       enable = lib.mkEnableOption "aporia as the display manager";
@@ -53,29 +59,34 @@ in {
     };
 
     environment = lib.mkMerge [
-      (let
-       session-prefix = config.services.displayManager.sessionData.desktops;
-      in {
-        etc."aporia/config".text = (lib.optionalString (cfg.settings.ascii.text != null) ''
-        # Ascii is the name of the ascii file to use
-        ascii = ${cfg.settings.ascii.name}
-        '') + ''
-        # The size of the box in the top left.
-        # Warning: values lower than 35 will not display properly.
-        box_width = ${builtins.toString cfg.settings.box-width}
+      (
+        let
+          session-prefix = config.services.displayManager.sessionData.desktops;
+        in
+        {
+          etc."aporia/config".text =
+            (lib.optionalString (cfg.settings.ascii.text != null) ''
+              # Ascii is the name of the ascii file to use
+              ascii = ${cfg.settings.ascii.name}
+            '')
+            + ''
+              # The size of the box in the top left.
+              # Warning: values lower than 35 will not display properly.
+              box_width = ${builtins.toString cfg.settings.box-width}
 
-        # The shutdown and reboot commands to use
-        shutdown_command = ${cfg.settings.commands.shutdown}
-        reboot_command = ${cfg.settings.commands.reboot}
+              # The shutdown and reboot commands to use
+              shutdown_command = ${cfg.settings.commands.shutdown}
+              reboot_command = ${cfg.settings.commands.reboot}
 
-        # The paths to search for desktop files
-        xsessions_path = "${session-prefix}/share/xsessions
-        wayland_sessions_path = ${session-prefix}/share/wayland-sessions
-        '';
+              # The paths to search for desktop files
+              xsessions_path = "${session-prefix}/share/xsessions
+              wayland_sessions_path = ${session-prefix}/share/wayland-sessions
+            '';
 
-        pathsToLink = [ "/share/aporia" ];
-        systemPackages = [ cfg.package ];
-      })
+          pathsToLink = [ "/share/aporia" ];
+          systemPackages = [ cfg.package ];
+        }
+      )
       (lib.mkIf (cfg.settings.ascii.text != null) {
         etc."aporia/${cfg.settings.ascii.name}.ascii".text = cfg.settings.ascii.text;
       })
@@ -89,7 +100,7 @@ in {
         execCmd = "exec /run/current-system/sw/bin/aporia";
       };
 
-     xserver = lib.mkIf config.services.xserver.enable {
+      xserver = lib.mkIf config.services.xserver.enable {
         tty = null;
         display = null;
       };

--- a/nixos/modules/services/display-managers/aporia.nix
+++ b/nixos/modules/services/display-managers/aporia.nix
@@ -1,0 +1,115 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.displayManager.aporia;
+in {
+  options = {
+    services.displayManager.aporia = {
+      enable = lib.mkEnableOption "aporia as the display manager";
+
+      package = lib.mkPackageOption pkgs [ "aporia" ] { };
+
+      settings = {
+        ascii = {
+          name = lib.mkOption {
+            description = "Ascii art filename";
+            type = lib.types.str;
+            default = "default";
+          };
+
+          text = lib.mkOption {
+            description = "filepath to the ascii art to display in background";
+            type = lib.types.nullOr lib.types.lines;
+            default = null;
+          };
+        };
+
+        box-width = lib.mkOption {
+          description = "size of the box in the top left";
+          type = lib.types.ints.positive;
+          default = 50;
+        };
+
+        commands = {
+          reboot = lib.mkOption {
+            description = "reboot commands to use";
+            type = lib.types.str;
+            default = "/run/current-system/systemd/bin/systemctl reboot";
+          };
+
+          shutdown = lib.mkOption {
+            description = "shutdown commands to use";
+            type = lib.types.str;
+            default = "/run/current-system/systemd/bin/systemctl poweroff";
+          };
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    security.pam.services.aporia = {
+      startSession = true;
+      unixAuth = true;
+    };
+
+    environment = lib.mkMerge [
+      (let
+       session-prefix = config.services.displayManager.sessionData.desktops;
+      in {
+        etc."aporia/config".text = (lib.optionalString (cfg.settings.ascii.text != null) ''
+        # Ascii is the name of the ascii file to use
+        ascii = ${cfg.settings.ascii.name}
+        '') + ''
+        # The size of the box in the top left.
+        # Warning: values lower than 35 will not display properly.
+        box_width = ${builtins.toString cfg.settings.box-width}
+
+        # The shutdown and reboot commands to use
+        shutdown_command = ${cfg.settings.commands.shutdown}
+        reboot_command = ${cfg.settings.commands.reboot}
+
+        # The paths to search for desktop files
+        xsessions_path = "${session-prefix}/share/xsessions
+        wayland_sessions_path = ${session-prefix}/share/wayland-sessions
+        '';
+
+        pathsToLink = [ "/share/aporia" ];
+        systemPackages = [ cfg.package ];
+      })
+      (lib.mkIf (cfg.settings.ascii.text != null) {
+        etc."aporia/${cfg.settings.ascii.name}.ascii".text = cfg.settings.ascii.text;
+      })
+    ];
+
+    services = {
+      dbus.packages = [ cfg.package ];
+
+      displayManager = {
+        enable = true;
+        execCmd = "exec /run/current-system/sw/bin/aporia";
+      };
+
+     xserver = lib.mkIf config.services.xserver.enable {
+        tty = null;
+        display = null;
+      };
+    };
+
+    systemd.services.display-manager = {
+      after = [
+        "systemd-user-sessions.service"
+        "plymouth-quit-wait.service"
+      ];
+
+      conflicts = [ "getty@tty1.service" ];
+
+      serviceConfig = {
+        Type = "idle";
+        StandardInput = "tty";
+        TTYPath = "/dev/tty1";
+        TTYReset = "yes";
+        TTYVHangup = "yes";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/display-managers/default.nix
+++ b/nixos/modules/services/display-managers/default.nix
@@ -257,7 +257,12 @@ in
         dmConf = config.services.xserver.displayManager;
         noDmUsed =
           !(
-            dmConf.gdm.enable || cfg.sddm.enable || dmConf.xpra.enable || dmConf.lightdm.enable || cfg.ly.enable || cfg.aporia.enable
+            dmConf.gdm.enable
+            || cfg.sddm.enable
+            || dmConf.xpra.enable
+            || dmConf.lightdm.enable
+            || cfg.ly.enable
+            || cfg.aporia.enable
           );
       in
       lib.mkIf noDmUsed (lib.mkDefault false);

--- a/nixos/modules/services/display-managers/default.nix
+++ b/nixos/modules/services/display-managers/default.nix
@@ -257,7 +257,7 @@ in
         dmConf = config.services.xserver.displayManager;
         noDmUsed =
           !(
-            dmConf.gdm.enable || cfg.sddm.enable || dmConf.xpra.enable || dmConf.lightdm.enable || cfg.ly.enable
+            dmConf.gdm.enable || cfg.sddm.enable || dmConf.xpra.enable || dmConf.lightdm.enable || cfg.ly.enable || cfg.aporia.enable
           );
       in
       lib.mkIf noDmUsed (lib.mkDefault false);

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -647,6 +647,7 @@ in
       let dmConf = cfg.displayManager;
           default = !(dmConf.gdm.enable
                     || config.services.displayManager.sddm.enable
+                    || config.services.displayManager.aporia.enable
                     || dmConf.xpra.enable
                     || dmConf.sx.enable
                     || dmConf.startx.enable

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -177,6 +177,7 @@ in {
   anuko-time-tracker = runTest ./anuko-time-tracker.nix;
   apcupsd = runTest ./apcupsd.nix;
   apfs = runTest ./apfs.nix;
+  aporia = import ./aporia { inherit runTestOn; };
   appliance-repart-image = runTest ./appliance-repart-image.nix;
   appliance-repart-image-verity-store = runTest ./appliance-repart-image-verity-store.nix;
   apparmor = runTest ./apparmor;

--- a/nixos/tests/aporia/default.nix
+++ b/nixos/tests/aporia/default.nix
@@ -1,0 +1,5 @@
+{ runTestOn }:
+{
+  x11 = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./x11.nix;
+  wayland = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./wayland.nix;
+}

--- a/nixos/tests/aporia/wayland.nix
+++ b/nixos/tests/aporia/wayland.nix
@@ -1,0 +1,43 @@
+{ ... }:
+{
+  name = "aporia-wayland";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ ../common/user-account.nix ];
+
+      environment.etc."aporia/qtile.wayland" = {
+        text = "qtile start -b wayland";
+        mode = "755";
+      };
+
+      services = {
+        displayManager.aporia.enable = true;
+
+        seatd.enable = true;
+        xserver.windowManager.qtile.enable = true;
+      };
+
+      users.users.alice.extraGroups = [ "seat" ];
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      user = nodes.machine.users.users.alice;
+    in
+    ''
+      start_all()
+      machine.wait_until_tty_matches("1", "password:")
+      machine.sleep(1)
+      machine.screenshot("tty")
+      machine.send_key("ret")
+      machine.send_chars("alice")
+      machine.send_key("ret")
+      machine.send_chars("${user.password}")
+      machine.send_key("ret")
+      machine.sleep(5) # wayland do not support wait_for_window
+      machine.screenshot("qtile")
+    '';
+}

--- a/nixos/tests/aporia/x11.nix
+++ b/nixos/tests/aporia/x11.nix
@@ -1,0 +1,70 @@
+{ ... }:
+{
+  name = "aporia-x11";
+
+  nodes.machine =
+    { pkgs, ... }:
+    let
+      default-ascii-art = pkgs.fetchurl {
+        url = "https://raw.githubusercontent.com/Lunarmagpie/aporia/main/examples/luna.ascii";
+        hash = "sha256-9niyJnW48SBnM5jumpVvSBJy0kVvTgE4K45fIWZZ3VA=";
+      };
+    in
+    {
+      imports = [ ../common/user-account.nix ];
+
+      environment.etc."aporia/qtile.x11" = {
+        text = "qtile start";
+        mode = "755";
+      };
+
+      users.users.alice.extraGroups = [ "seat" ];
+
+      services = {
+        displayManager = {
+          aporia = {
+            enable = true;
+            settings.ascii = {
+              name = "luna";
+              text = (builtins.readFile default-ascii-art);
+            };
+          };
+          defaultSession = "none+qtile";
+        };
+
+        seatd.enable = true;
+        xserver = {
+          enable = true;
+          windowManager.qtile.enable = true;
+        };
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      user = nodes.machine.users.users.alice;
+    in
+    ''
+      start_all()
+
+      with subtest("ensure aporia starts"):
+          machine.wait_until_tty_matches("1", "password:")
+          machine.sleep(1)
+          machine.screenshot("tty")
+
+      with subtest("ensure we can login"):
+          machine.send_key("ret")
+          machine.send_chars("alice")
+          machine.send_key("ret")
+          machine.send_chars("${user.password}")
+          machine.send_key("ret")
+
+      with subtest("ensure x starts"):
+          # machine.wait_for_x()
+          # machine.wait_for_file("/home/alice/.Xauthority")
+          # machine.succeed("xauth merge ~alice/.Xauthority")
+          for i in range(50):
+            machine.screenshot(f"qtile-{i}")
+    '';
+}

--- a/pkgs/by-name/ap/aporia/package.nix
+++ b/pkgs/by-name/ap/aporia/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchpatch2,
+  linux-pam,
+  bash,
+  util-linux,
+  makeWrapper,
+  xorg,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "aporia";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Lunarmagpie";
+    repo = "aporia";
+    tag = finalAttrs.version;
+    hash = "sha256-n6xqcn1ZZNlV5hthZQSg5yJCOFaeVuuLFo/U+E0TihA=";
+  };
+
+  vendorHash = "sha256-OG14/f707RRNZqDtGPPnphP9kXP4abGaBfNvlPsC0pk=";
+
+  prePatch = ''
+    patchShebangs .;
+
+    substituteInPlace constants/constants.go \
+      --replace-fail "/etc/aporia/.scripts" "${placeholder "out"}/scripts" \
+      --replace-fail "/etc/pam.d" "${placeholder "out"}/etc/pam.d" \
+      --replace-fail "/bin/bash" "${lib.getExe bash}"
+
+    substituteInPlace extra/startx.sh \
+      --replace-fail "/usr/bin/mcookie" "${util-linux}/bin/mcookie" \
+      --replace-fail "/usr/bin/X" "${xorg.xorgserver}/bin/X"
+  '';
+
+  patches = [
+    # fix build error
+    (fetchpatch2 {
+      url = "https://github.com/zunda-arrow/aporia/commit/76444c7ec6db0ed774e9b70bf30580d06b4c179b.patch?full_index=1";
+      hash = "sha256-J827TDodF26PBpNog7/ztfsCY/nUJMbHWU7tPrD+IdY=";
+    })
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ linux-pam ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    install -Dm 755 $GOPATH/bin/aporia $out/bin/aporia
+    install -Dm 755 extra/xsetup.sh $out/scripts/xsetup.sh
+    install -Dm 755 extra/startx.sh $out/scripts/startx.sh
+    wrapProgram $out/scripts/startx.sh \
+      --prefix PATH : ${lib.makeBinPath [ xorg.xinit ]}
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "Login manager that displays ascii art";
+    license = lib.licenses.wtfpl;
+    homepage = "https://github.com/Lunarmagpie/aporia";
+    maintainers = with lib.maintainers; [ sigmanificient ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Add the package for [aporia](https://github.com/Lunarmagpie/aporia), along with nix options to enable it.
I am quite new to nix options, and this work has been based on the [ly module update pr](https://github.com/NixOS/nixpkgs/pull/297434).

**Currently, I cant make Icewm to successfully start, looking for help**

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
