### PR TITLE
briar-desktop: 0.6.0 -> 0.6.1

### DIFF
--- a/pkgs/by-name/br/briar-desktop/package.nix
+++ b/pkgs/by-name/br/briar-desktop/package.nix
@@ -8,6 +8,7 @@
 , p7zip
 , bash
 , writeScript
+, libGL
 }:
 let
 
@@ -39,7 +40,7 @@ stdenv.mkDerivation rec {
     makeWrapper ${openjdk}/bin/java $out/bin/briar-desktop \
       --add-flags "-jar $out/lib/briar-desktop.jar" \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [
-        libnotify
+        libnotify libGL
       ]}"
   '';
 

--- a/pkgs/by-name/br/briar-desktop/package.nix
+++ b/pkgs/by-name/br/briar-desktop/package.nix
@@ -19,11 +19,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "briar-desktop";
-  version = "0.6.0-beta";
+  version = "0.6.1-beta";
 
   src = fetchurl {
     url = "https://desktop.briarproject.org/jars/linux/${version}/briar-desktop-linux-${version}.jar";
-    hash = "sha256-ITlg2THQwP91nVxHhLfXPBtC4e3EU9V7D/15XqWC7FE=";
+    hash = "sha256-Np5yf9z+jtmQ8x0OgB7y6mpR/Rdb6ogd17fFRY7h/bM=";
   };
 
   dontUnpack = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6463,8 +6463,6 @@ with pkgs;
 
   boofuzz= callPackage ../tools/security/boofuzz { };
 
-  briar-desktop = callPackage ../applications/networking/instant-messengers/briar-desktop { };
-
   bsdbuild = callPackage ../development/tools/misc/bsdbuild { };
 
   bsdiff = callPackage ../tools/compression/bsdiff { };


### PR DESCRIPTION
## Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/316116

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
