### PR TITLE
jx: 2.1.155 -> 3.10.146

### DIFF
--- a/pkgs/applications/networking/cluster/jx/default.nix
+++ b/pkgs/applications/networking/cluster/jx/default.nix
@@ -1,49 +1,49 @@
-{ stdenv, buildGoModule, fetchFromGitHub, lib, installShellFiles }:
+{ stdenv, buildGoModule, fetchFromGitHub, lib, nix-update-script, go }:
 
 buildGoModule rec {
   pname = "jx";
-  version = "2.1.155";
+  version = "3.10.146";
 
   src = fetchFromGitHub {
     owner = "jenkins-x";
     repo = "jx";
     rev = "v${version}";
-    sha256 = "sha256-kwcmZSOA26XuSgNSHitGaMohalnLobabXf4z3ybSJtk=";
+    sha256 = "sha256-cbf/prSKHiu4I6w08j/HLD8c7Lrgt3eTC5QRVvuhS5w=";
   };
 
-  vendorHash = "sha256-ZtcCBXcJXX9ThzY6T0MhNfDDzRC9PYzRB1VyS4LLXLs=";
+  vendorHash = "sha256-AIaZVkWdNj1Vsrv2k4B5lLE0lOFuiTD7lwS/DikmC14=";
 
-  doCheck = false;
+  subPackages = [ "cmd" ];
 
-  subPackages = [ "cmd/jx" ];
-
-  nativeBuildInputs = [ installShellFiles ];
+  CGO_ENABLED = 0;
 
   ldflags = [
-    "-s -w"
-    "-X github.com/jenkins-x/jx/pkg/version.Version=${version}"
-    "-X github.com/jenkins-x/jx/pkg/version.Revision=${src.rev}"
-    "-X github.com/jenkins-x/jx/pkg/version.GitTreeState=clean"
+    "-s"
+    "-X github.com/jenkins-x/jx/pkg/cmd/version.Version=${version}"
+    "-X github.com/jenkins-x/jx/pkg/cmd/version.Revision=${src.rev}"
+    "-X github.com/jenkins-x/jx/pkg/cmd/version.GoVersion=${go.version}"
+    "-X github.com/jenkins-x/jx/pkg/cmd/version.GitTreeState=clean"
+    "-X github.com/jenkins-x/jx/pkg/cmd/version.BuildDate=''"
   ];
 
   postInstall = ''
-    for shell in bash zsh; do
-      $out/bin/jx completion $shell > jx.$shell
-      installShellCompletion jx.$shell
-    done
+    mv $out/bin/cmd $out/bin/jx
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     broken = stdenv.isDarwin;
     description = "Command line tool for installing and using Jenkins X";
     mainProgram = "jx";
     homepage = "https://jenkins-x.io";
+    changelog = "https://github.com/jenkins-x/jx/releases/tag/v${version}";
     longDescription = ''
       Jenkins X provides automated CI+CD for Kubernetes with Preview
-      Environments on Pull Requests using Jenkins, Knative Build, Prow,
-      Skaffold and Helm.
+      Environments on Pull Requests using using Cloud Native pipelines
+      from Tekton.
     '';
-    license = licenses.asl20 ;
+    license = licenses.asl20;
     maintainers = with maintainers; [ kalbasit ];
     platforms = platforms.linux ++ platforms.darwin;
   };


### PR DESCRIPTION
## Description of changes

I'm not using this package, just found it to be severely outdated when [scanning for Go vulnerabilities in nixpkgs](https://github.com/katexochen/govulncheck-nixpkgs). Package scored with a whopping 12 vulnerabilities, as it wasn't updated in more than 3 years:

https://pkg.go.dev/vuln/GO-2024-2748
https://pkg.go.dev/vuln/GO-2024-2687 (still present in latest release)
https://pkg.go.dev/vuln/GO-2024-2466
https://pkg.go.dev/vuln/GO-2024-2456
https://pkg.go.dev/vuln/GO-2023-2402
https://pkg.go.dev/vuln/GO-2023-1571
https://pkg.go.dev/vuln/GO-2022-0968
https://pkg.go.dev/vuln/GO-2022-0244
https://pkg.go.dev/vuln/GO-2022-0236
https://pkg.go.dev/vuln/GO-2021-0065
https://pkg.go.dev/vuln/GO-2021-0064
https://pkg.go.dev/vuln/GO-2020-0019

[Full report](https://gist.github.com/katexochen/3a27488426dd57a32462c738c753e233)

Not sure if all of these actually impact a user's security, as jx is a cli package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
