### PR TITLE
joypixels: fix sourceProvenance

### DIFF
--- a/pkgs/data/fonts/joypixels/default.nix
+++ b/pkgs/data/fonts/joypixels/default.nix
@@ -108,6 +108,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ toonn jtojnar ];
     # Not quite accurate since it's a font, not a program, but clearly
     # indicates we're not actually building it from source.
-    sourceProvenance = sourceTypes.binaryNativeCode;
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
   };
 }


### PR DESCRIPTION
## Description of changes

https://github.com/NixOS/nixpkgs/pull/305975 introduced a usage of `sourceProvenance` with a type that the infra does not recognise (see comment at https://github.com/NixOS/nixpkgs/pull/305975#issuecomment-2143375374 for stack trace).

`nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` fails with the same error after this PR, but I have successfully run `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD --branch fix-joypixels --remote https://github.com/Smaug123/nixpkgs"` to check a different branch, which I believe means this PR fixes the problem.

```
error: value is a set while a list was expected

       at /Users/patrick/.cache/nixpkgs-review/rev-f16922fb3d4cb807e8a9dc6423ab51c13ace4592-1/nixpkgs/pkgs/stdenv/generic/check-meta.nix:135:30:

          134|
          135|   isNonSource = sourceTypes: any (t: !t.isSource) sourceTypes;
             |                              ^
          136|

       … while evaluating 'isNonSource'

       at /Users/patrick/.cache/nixpkgs-review/rev-f16922fb3d4cb807e8a9dc6423ab51c13ace4592-1/nixpkgs/pkgs/stdenv/generic/check-meta.nix:135:17:

          134|
          135|   isNonSource = sourceTypes: any (t: !t.isSource) sourceTypes;
             |                 ^
          136|

       … from call site

       at /Users/patrick/.cache/nixpkgs-review/rev-f16922fb3d4cb807e8a9dc6423ab51c13ace4592-1/nixpkgs/pkgs/stdenv/generic/check-meta.nix:139:5:

          138|     (attrs ? meta.sourceProvenance) &&
          139|     isNonSource attrs.meta.sourceProvenance;
             |     ^
          140|

       … while evaluating 'hasNonSourceProvenance'
```

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
