### PR TITLE
glslviewer: 1.6.8 -> 3.2.4

### DIFF
--- a/pkgs/development/tools/glslviewer/default.nix
+++ b/pkgs/development/tools/glslviewer/default.nix
@@ -1,60 +1,54 @@
-{ lib, stdenv, fetchFromGitHub, glfw, pkg-config, libXrandr, libXdamage
-, libXext, libXrender, libXinerama, libXcursor, libXxf86vm, libXi
-, libX11, libGLU, python3Packages, ensureNewerSourcesForZipFilesHook
-, Cocoa
+{
+  stdenv,
+  cmake,
+  ninja,
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  libX11,
+  libXrandr,
+  libXinerama,
+  libXcursor,
+  libXi,
+  libXext,
+  libGLU,
+  ffmpeg,
+  ncurses,
+  Cocoa,
 }:
-
 stdenv.mkDerivation rec {
   pname = "glslviewer";
-  version = "1.6.8";
-
+  version = "3.2.4";
   src = fetchFromGitHub {
     owner = "patriciogonzalezvivo";
     repo = "glslViewer";
+    fetchSubmodules = true;
     rev = version;
-    sha256 = "0v7x93b61ama0gmzlx1zc56jgi7bvzsfvbkfl82xzwf2h5g1zni7";
+    sha256 = "sha256-Ve3wmX5+kABCu8IRe4ySrwsBJm47g1zvMqDbqrpQl88=";
   };
-
-  postPatch = ''
-    sed '1i#include <cstring>' -i src/tools/text.cpp # gcc12
-    sed '8i#include <cstdint>' -i src/io/fs.cpp # gcc13
-  '';
-
-  nativeBuildInputs = [ pkg-config ensureNewerSourcesForZipFilesHook python3Packages.six ];
-  buildInputs = [
-    glfw libGLU glfw libXrandr libXdamage
-    libXext libXrender libXinerama libXcursor libXxf86vm
-    libXi libX11
-  ] ++ (with python3Packages; [ python setuptools wrapPython ])
+  nativeBuildInputs = [cmake ninja pkg-config];
+  buildInputs =
+    [
+      libX11
+      libXrandr
+      libXinerama
+      libXcursor
+      libXi
+      libXext
+      libGLU
+      ncurses
+      ffmpeg
+    ]
     ++ lib.optional stdenv.isDarwin Cocoa;
-  pythonPath = with python3Packages; [ pyyaml requests ];
-
-  # Makefile has /usr/local/bin hard-coded for 'make install'
-  preConfigure = ''
-    substituteInPlace Makefile \
-        --replace '/usr/local' "$out" \
-        --replace '/usr/bin/clang++' 'clang++'
-    substituteInPlace Makefile \
-        --replace 'python setup.py install' "python setup.py install --prefix=$out"
-    2to3 -w bin/*
-  '';
-
-  preInstall = ''
-    mkdir -p $out/bin $(toPythonPath "$out")
-    export PYTHONPATH=$PYTHONPATH:$(toPythonPath "$out")
-  '';
-
-  postInstall = ''
-    wrapPythonPrograms
-  '';
 
   meta = with lib; {
     description = "Live GLSL coding renderer";
     homepage = "https://patriciogonzalezvivo.com/2015/glslViewer/";
     license = licenses.bsd3;
-    platforms = platforms.linux ++ platforms.darwin;
-    maintainers = [ maintainers.hodapp ];
+    maintainers = [maintainers.hodapp];
+    platforms = platforms.unix;
+    mainProgram = "glslViewer";
     # never built on aarch64-darwin since first introduction in nixpkgs
-    broken = stdenv.isDarwin && stdenv.isAarch64;
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
## Description of changes

Some changes are documented in 
https://github.com/patriciogonzalezvivo/glslViewer/blob/main/changelog

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
