### PR TITLE
networkmanager: 1.46.0 → 1.48.0

### DIFF
--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -60,11 +60,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "networkmanager";
-  version = "1.46.0";
+  version = "1.48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/${lib.versions.majorMinor version}/NetworkManager-${version}.tar.xz";
-    hash = "sha256-ciZJ4lNiaTszQ3FHOAKnKbDsnuKDN1CWkF+GiAjnQGg=";
+    hash = "sha256-/IC5Qt444ylGjm/B37QKrWp40C3fa47DH5rMZGC4cj8=";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];

--- a/pkgs/tools/networking/networkmanager/fix-paths.patch
+++ b/pkgs/tools/networking/networkmanager/fix-paths.patch
@@ -11,10 +11,10 @@ index 148acade5c..6395fbfbe5 100644
  
  LABEL="nm_drivers_end"
 diff --git a/src/core/devices/nm-device.c b/src/core/devices/nm-device.c
-index a9e8c08508..875d6cc2cd 100644
+index f3441508ab..7cde8d7d39 100644
 --- a/src/core/devices/nm-device.c
 +++ b/src/core/devices/nm-device.c
-@@ -14645,14 +14645,14 @@ nm_device_start_ip_check(NMDevice *self)
+@@ -14839,14 +14839,14 @@ nm_device_start_ip_check(NMDevice *self)
              gw = nm_l3_config_data_get_best_default_route(l3cd, AF_INET);
              if (gw) {
                  nm_inet4_ntop(NMP_OBJECT_CAST_IP4_ROUTE(gw)->gateway, buf);
@@ -32,22 +32,22 @@ index a9e8c08508..875d6cc2cd 100644
              }
          }
 diff --git a/src/libnm-client-impl/meson.build b/src/libnm-client-impl/meson.build
-index 79ac95598a..83f7ab1373 100644
+index 3dd2338a82..de75cc040b 100644
 --- a/src/libnm-client-impl/meson.build
 +++ b/src/libnm-client-impl/meson.build
-@@ -191,7 +191,6 @@ if enable_introspection
+@@ -190,7 +190,6 @@ if enable_introspection
        input: [gen_infos_cmd, libnm_gir[0]] + libnm_core_settings_sources,
        output: 'nm-property-infos-' + name + '.xml',
        command: [
--        python.path(),
+-        python_path,
          gen_infos_cmd,
          name,
          '@OUTPUT@',
-@@ -207,7 +206,6 @@ if enable_introspection
+@@ -206,7 +205,6 @@ if enable_introspection
          'env',
          'GI_TYPELIB_PATH=' + gi_typelib_path,
          'LD_LIBRARY_PATH=' + ld_library_path,
--        python.path(),
+-        python_path,
          gen_gir_cmd,
          '--lib-path', meson.current_build_dir(),
          '--gir', libnm_gir[0],
@@ -89,14 +89,14 @@ index cbe76f5f1c..8515f94994 100644
      oc_argv[oc_argc++] = path;
      oc_argv[oc_argc++] = "--authenticate";
 diff --git a/src/libnmc-setting/meson.build b/src/libnmc-setting/meson.build
-index 7fb460dc33..790a2b75fc 100644
+index 4d5079dfb3..5a15447fde 100644
 --- a/src/libnmc-setting/meson.build
 +++ b/src/libnmc-setting/meson.build
 @@ -9,7 +9,6 @@ if enable_docs
      input: [merge_cmd, nm_settings_docs_xml_gir['nmcli'], nm_property_infos_xml['nmcli']],
      output: 'settings-docs-input.xml',
      command: [
--      python.path(),
+-      python_path,
        merge_cmd,
        '@OUTPUT@',
        nm_property_infos_xml['nmcli'],
@@ -104,19 +104,19 @@ index 7fb460dc33..790a2b75fc 100644
      input: [gen_cmd, settings_docs_input_xml],
      output: 'settings-docs.h',
      command: [
--      python.path(),
+-      python_path,
        gen_cmd,
        '--output', '@OUTPUT@',
        '--xml', settings_docs_input_xml
 diff --git a/src/tests/client/meson.build b/src/tests/client/meson.build
-index 8c36e40559..cfb6649a21 100644
+index 5686a1c174..cfb6649a21 100644
 --- a/src/tests/client/meson.build
 +++ b/src/tests/client/meson.build
 @@ -6,7 +6,6 @@ test(
    args: [
      build_root,
      source_root,
--    python.path(),
+-    python_path,
      '--',
      'TestNmcli',
    ],
@@ -124,7 +124,7 @@ index 8c36e40559..cfb6649a21 100644
      args: [
        build_root,
        source_root,
--      python.path(),
+-      python_path,
        '--',
        'TestNmCloudSetup',
      ],

--- a/pkgs/tools/networking/networkmanager/iodine/default.nix
+++ b/pkgs/tools/networking/networkmanager/iodine/default.nix
@@ -12,32 +12,26 @@
   gtk3,
   withGnome ? true,
   unstableGitUpdater,
-  fetchpatch,
   libnma,
   glib,
 }:
 
 stdenv.mkDerivation {
   pname = "NetworkManager-iodine${lib.optionalString withGnome "-gnome"}";
-  version = "unstable-2019-11-05";
+  version = "1.2.0-unstable-2024-05-12";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = "network-manager-iodine";
-    rev = "2ef0abf089b00a0546f214dde0d45e63f2990b79";
-    sha256 = "1ps26fr9b1yyafj7lrzf2kmaxb0ipl0mhagch5kzrjdsc5xkajz7";
+    rev = "8ec0a35e12047ccf256b3951897c701661ddb8af";
+    sha256 = "cNjznry8wi1UmE5khf0JCEYjs9nDU/u8lFLte53MLTM=";
   };
 
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
       inherit iodine;
-    })
-    # Don't use etc/dbus-1/system.d
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/network-manager-iodine/merge_requests/2.patch";
-      sha256 = "108pkf0mddj32s46k7jkmpwcaq2ylci4dqpp7wck3zm9q2jffff2";
     })
   ];
 
@@ -60,7 +54,6 @@ stdenv.mkDerivation {
     ];
 
   configureFlags = [
-    "--without-libnm-glib"
     "--with-gnome=${if withGnome then "yes" else "no"}"
     "--localstatedir=/" # needed for the management socket under /run/NetworkManager
     "--enable-absolute-paths"
@@ -69,11 +62,6 @@ stdenv.mkDerivation {
   preConfigure = ''
     intltoolize
   '';
-
-  env = {
-    # glib-2.62 deprecations
-    NIX_CFLAGS_COMPILE = "-DGLIB_DISABLE_DEPRECATION_WARNINGS";
-  };
 
   passthru = {
     updateScript = unstableGitUpdater {

--- a/pkgs/tools/networking/networkmanager/iodine/default.nix
+++ b/pkgs/tools/networking/networkmanager/iodine/default.nix
@@ -11,7 +11,7 @@
   libsecret,
   gtk3,
   withGnome ? true,
-  gnome,
+  unstableGitUpdater,
   fetchpatch,
   libnma,
   glib,
@@ -76,9 +76,8 @@ stdenv.mkDerivation {
   };
 
   passthru = {
-    updateScript = gnome.updateScript {
-      packageName = "NetworkManager-iodine";
-      attrPath = "networkmanager-iodine";
+    updateScript = unstableGitUpdater {
+      tagPrefix = "v";
     };
 
     networkManagerPlugin = "VPN/nm-iodine-service.name";


### PR DESCRIPTION
## Description of changes

https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/1.48.0/NEWS?ref_type=tags
https://gitlab.gnome.org/GNOME/NetworkManager/-/compare/1.46.0...1.48.0

Fixes: https://github.com/NixOS/nixpkgs/pull/227788
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
