### PR TITLE
python311Packages.graph-tool: 2.65 -> 2.68

### DIFF
--- a/pkgs/development/python-modules/graph-tool/default.nix
+++ b/pkgs/development/python-modules/graph-tool/default.nix
@@ -5,13 +5,14 @@
   stdenv,
 
   autoreconfHook,
-  boost,
+  boost185,
   cairomm,
   cgal,
   expat,
   gmp,
   gobject-introspection,
   gtk3,
+  llvmPackages,
   matplotlib,
   mpfr,
   numpy,
@@ -23,32 +24,51 @@
   sparsehash,
 }:
 
+let
+  # graph-tool doesn't build against boost181 on Darwin
+  boost = boost185.override {
+    enablePython = true;
+    inherit python;
+  };
+in
 buildPythonPackage rec {
   pname = "graph-tool";
-  version = "2.65";
+  version = "2.68";
   format = "other";
 
   src = fetchurl {
     url = "https://downloads.skewed.de/graph-tool/graph-tool-${version}.tar.bz2";
-    hash = "sha256-ozpFv9rri2toG8BeNTqzoJdkwB06GdJ69XjtPkjUKZw=";
+    hash = "sha256-jB+/R6yZVhU0iohxYVNHdD205MauRxMoohbj4a2T+rw=";
   };
+
+  # Remove error messages about tput during build process without adding ncurses,
+  # and replace unavailable git commit hash and date.
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace-fail 'tput setaf $1' : \
+      --replace-fail 'tput sgr0' : \
+      --replace-fail \
+        "\"esyscmd(git show | head -n 1 | sed 's/commit //' |  grep -o -e '.\{8\}' | head -n 1 |tr -d '\n')\"" \
+        '["(nixpkgs-${version})"]' \
+      --replace-fail \
+        "\"esyscmd(git log -1 | head -n 3 | grep 'Date:' | sed s/'Date:   '// | tr -d '\n')\"" \
+        '["(unavailable)"]'
+  '';
 
   configureFlags = [
     "--with-python-module-path=$(out)/${python.sitePackages}"
     "--with-boost-libdir=${boost}/lib"
-    "--with-expat=${expat}"
     "--with-cgal=${cgal}"
-    "--enable-openmp"
   ];
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [
+  build-system = [
     autoreconfHook
     pkg-config
   ];
 
-  # https://git.skewed.de/count0/graph-tool/-/wikis/installation-instructions#manual-compilation
+  # https://graph-tool.skewed.de/installation.html#manual-compilation
   dependencies = [
     boost
     cairomm
@@ -64,13 +84,15 @@ buildPythonPackage rec {
     pygobject3
     scipy
     sparsehash
-  ];
+  ] ++ lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
 
-  meta = with lib; {
+  pythonImportsCheck = [ "graph_tool" ];
+
+  meta = {
     description = "Python module for manipulation and statistical analysis of graphs";
     homepage = "https://graph-tool.skewed.de";
-    license = licenses.lgpl3Plus;
-    broken = stdenv.isDarwin;
-    maintainers = with maintainers; [ ];
+    changelog = "https://git.skewed.de/count0/graph-tool/commits/release-${version}";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
## Description of changes

https://git.skewed.de/count0/graph-tool/-/compare/release-2.65...release-2.68

fix build on Darwin by using Boost 1.85

## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>python311Packages.graph-tool</li>
    <li>python312Packages.graph-tool</li>
  </ul>
</details>

## Result of `nixpkgs-review` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>python311Packages.graph-tool</li>
    <li>python312Packages.graph-tool</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc