### PR TITLE
nyxt: 3.11.6 -> 3.11.7

### DIFF
--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -277,14 +277,14 @@ let
     systems = [ "njson" "njson/cl-json" "njson/jzon"];
   };
 
-  nsymbols = build-asdf-system rec {
+  nsymbols = build-asdf-system {
     pname = "nsymbols";
-    version = "0.3.2";
+    version = "0.3.2-unstable-2024-03-25";
     src = pkgs.fetchFromGitHub {
       owner = "atlas-engineer";
       repo = "nsymbols";
-      rev = version;
-      sha256 = "sha256-psk29WEA7Hxgp29oUniBNvI+lyZfMkdpa5A7okc6kKs=";
+      rev = "9e94870b710a6216468de15b5ca2731e752df31a";
+      sha256 = "sha256-1jyh4craawFCosksD0MNlO4O4IxJKQHoxbDeoYALjW8=";
     };
     lispLibs = [ super.closer-mop ];
     systems = [ "nsymbols" "nsymbols/star" ];

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -368,6 +368,16 @@ let
     ];
   };
 
+  quri_20240328 = (super.quri.overrideAttrs (final: prev: {
+    version = "20240328-git";
+    src = pkgs.fetchFromGitHub {
+      owner = "fukamachi";
+      repo = "quri";
+      rev = "03ecaf3771561d713e58a9c5c22b4d95a7592527";
+      sha256 = "sha256-YqZFZvGVD2QRkD7wFyLEBHn+5mFVHfhxSkcv/nY1qbU=";
+    };
+  }));
+
   nyxt-gtk = build-asdf-system {
     pname = "nyxt";
     version = "3.11.6";
@@ -416,7 +426,6 @@ let
       unix-opts
       cluffer
       cl-cffi-gtk
-      quri
       sqlite
       # TODO: Remove these overrides after quicklisp updates past the June 2023 release
       (trivial-clipboard.overrideAttrs (final: prev: {
@@ -456,6 +465,7 @@ let
       iterate
       symbol-munger
     ]) ++ (with self; [
+      quri_20240328
       history-tree
       nhooks
       nkeymaps

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -238,15 +238,15 @@ let
     };
   };
 
-  prompter = build-asdf-system rec {
+  prompter = build-asdf-system {
     pname = "prompter";
-    version = "20240108-git";
+    version = "20240325-git";
 
     src = pkgs.fetchFromGitHub {
       owner = "atlas-engineer";
       repo = "prompter";
-      rev = "7890ed5d02e70aba01ceb964c6ee4f40776e7dc0";
-      hash = "sha256-rRKtpSKAqfzvnlC3NQ4840RrlbBUpI4V6uX6p5hRJWQ=";
+      rev = "1cc03a753f5823df778407288c55e2d941a3fd77";
+      hash = "sha256-9x2ESti8KZ21uQritzJ3NF3lbXG7kFL0w2rFu2quUHs=";
     };
 
     lispLibs = [

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -264,14 +264,14 @@ let
 
   };
 
-  njson = build-asdf-system rec {
+  njson = build-asdf-system {
     pname = "njson";
-    version = "1.2.2";
+    version = "1.2.2-unstable-2024-03-25";
     src = pkgs.fetchFromGitHub {
       owner = "atlas-engineer";
       repo = "njson";
-      rev = version;
-      sha256 = "sha256-kw5DD0GJp/TeCiYATBY8GL8UKqYS6Q4j0a0eQsdcZRc=";
+      rev = "3847bc749a6f6eb1103bc21f8ef3b4f6b301e822";
+      sha256 = "sha256-TgEo2xQCIlm5pHRnh2qAW5NZBfqAcxvvQ1w901pkbck=";
     };
     lispLibs = [ super.cl-json super.com_dot_inuoe_dot_jzon];
     systems = [ "njson" "njson/cl-json" "njson/jzon"];

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -336,14 +336,14 @@ let
     lispLibs = with self; [ bordeaux-threads closer-mop serapeum ];
   };
 
-  nkeymaps = build-asdf-system rec {
+  nkeymaps = build-asdf-system {
     pname = "nkeymaps";
-    version = "1.1.1";
+    version = "1.1.1-unstable-2024-03-25";
     src = pkgs.fetchFromGitHub {
       owner = "atlas-engineer";
       repo = "nkeymaps";
-      rev = version;
-      hash = "sha256-/t85Yh4EvnSyIM6xeDBLmfVz3wddmavInXzeYafNMJ0=";
+      rev = "e2a69a9c32fe701ac2ab8fd2385e2d57f849f26c";
+      hash = "sha256-WZ4EWKCX630xmG7WaV1I8pOln0QXhXpzWB11XkP00jo=";
     };
     lispLibs = with self; [ alexandria fset trivial-package-local-nicknames
                             str ];

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -291,14 +291,14 @@ let
 
   };
 
-  nclasses = build-asdf-system rec {
+  nclasses = build-asdf-system {
     pname = "nclasses";
-    version = "0.6.1";
+    version = "0.6.1-unstable-2024-03-25";
     src = pkgs.fetchFromGitHub {
       owner = "atlas-engineer";
       repo = "nclasses";
-      rev = version;
-      sha256 = "sha256-foXmaLxMYMFieB2Yd2iPsU4EX5kLXq7kyElqGZ47OgI=";
+      rev = "ad74d75c4eb0f0a626c618b0547709e6b04827ac";
+      sha256 = "sha256-Vh+Hm0C/YGz3MGvSbKLcOl+KQZ/7Dm/IG7twTNWhAPs=";
     };
     lispLibs = [ super.moptilities ];
   };

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -350,14 +350,14 @@ let
   };
 
 
-  history-tree = build-asdf-system rec {
+  history-tree = build-asdf-system {
     pname = "history-tree";
-    version = "0.1.2";
+    version = "0.1.2-unstable-2024-03-25";
     src = pkgs.fetchFromGitHub {
       owner = "atlas-engineer";
       repo = "history-tree";
-      rev = version;
-      hash = "sha256-wpVONvShNnvrPOlbNoX/t9sYiwxnIKnnJaJyALEyeNg=";
+      rev = "e26181adcca86be4cba39d0e8015a4e50f1eb105";
+      hash = "sha256-GNstsd3QohuwbVhd/gJp4O9OZaqKjx1/XDm3OyQn888=";
     };
     lispLibs = with self; [
       alexandria

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -303,18 +303,18 @@ let
     lispLibs = [ super.moptilities ];
   };
 
-  nfiles = build-asdf-system rec {
+  nfiles = build-asdf-system {
     pname = "nfiles";
-    version = "1.1.4";
+    version = "1.1.4-unstable-2024-03-25";
     src = pkgs.fetchFromGitHub {
       owner = "atlas-engineer";
       repo = "nfiles";
-      rev = version;
-      sha256 = "sha256-4rhpBErQgZHcwZRblxgiYaUmKalvllSbJjnRteDVH6k=";
+      rev = "a0c5514963c77e7bdf4b5f7ddda20fb1f158daa0";
+      sha256 = "sha256-hJbpOcEF+HmOwM8Uu8+2cW4Dky1vEiLwk6rON2LEzLw=";
     };
     lispLibs = [
       self.nclasses
-      super.quri
+      self.quri_20240328
       super.alexandria
       super.iolib
       super.serapeum

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -314,7 +314,7 @@ let
     };
     lispLibs = [
       self.nclasses
-      self.quri_20240328
+      self.quri
       super.alexandria
       super.iolib
       super.serapeum
@@ -368,153 +368,155 @@ let
     ];
   };
 
-  quri_20240328 = (super.quri.overrideAttrs (final: prev: {
-    version = "20240328-git";
-    src = pkgs.fetchFromGitHub {
-      owner = "fukamachi";
-      repo = "quri";
-      rev = "03ecaf3771561d713e58a9c5c22b4d95a7592527";
-      sha256 = "sha256-YqZFZvGVD2QRkD7wFyLEBHn+5mFVHfhxSkcv/nY1qbU=";
-    };
-  }));
 
-  nyxt-gtk = build-asdf-system {
-    pname = "nyxt";
-    version = "3.11.6";
+  nyxt-gtk = let
+    scope = self.overrideScope (self: super: {
+      quri = (super.quri.overrideAttrs (final: prev: {
+          version = "20240328-git";
+          src = pkgs.fetchFromGitHub {
+            owner = "fukamachi";
+            repo = "quri";
+            rev = "03ecaf3771561d713e58a9c5c22b4d95a7592527";
+            sha256 = "sha256-YqZFZvGVD2QRkD7wFyLEBHn+5mFVHfhxSkcv/nY1qbU=";
+          };
+        }));
+      nyxt-gtk = build-asdf-system {
+        pname = "nyxt";
+        version = "3.11.7";
 
-    lispLibs = (with super; [
-      alexandria
-      bordeaux-threads
-      calispel
-      cl-base64
-      cl-gopher
-      cl-html-diff
-      cl-json
-      cl-ppcre
-      cl-ppcre-unicode
-      cl-prevalence
-      cl-qrencode
-      cl-tld
-      closer-mop
-      dissect
-      moptilities
-      dexador
-      enchant
-      flexi-streams
-      idna
-      iolib
-      lass
-      local-time
-      lparallel
-      log4cl
-      montezuma
-      ndebug
-      osicat
-      parenscript
-      py-configparser
-      serapeum
-      str
-      phos
-      plump
-      clss
-      spinneret
-      trivia
-      trivial-features
-      trivial-garbage
-      trivial-package-local-nicknames
-      trivial-types
-      unix-opts
-      cluffer
-      cl-cffi-gtk
-      sqlite
-      # TODO: Remove these overrides after quicklisp updates past the June 2023 release
-      (trivial-clipboard.overrideAttrs (final: prev: {
+        lispLibs = (with self; [
+          alexandria
+          bordeaux-threads
+          calispel
+          cl-base64
+          cl-gopher
+          cl-html-diff
+          cl-json
+          cl-ppcre
+          cl-ppcre-unicode
+          cl-prevalence
+          cl-qrencode
+          cl-tld
+          closer-mop
+          dissect
+          moptilities
+          dexador
+          enchant
+          flexi-streams
+          idna
+          iolib
+          lass
+          local-time
+          lparallel
+          log4cl
+          montezuma
+          ndebug
+          osicat
+          parenscript
+          py-configparser
+          serapeum
+          str
+          phos
+          plump
+          clss
+          spinneret
+          trivia
+          trivial-features
+          trivial-garbage
+          trivial-package-local-nicknames
+          trivial-types
+          unix-opts
+          cluffer
+          cl-cffi-gtk
+          sqlite
+          # TODO: Remove these overrides after quicklisp updates past the June 2023 release
+          (trivial-clipboard.overrideAttrs (final: prev: {
+            src = pkgs.fetchFromGitHub {
+              owner = "snmsts";
+              repo = "trivial-clipboard";
+              rev = "50b3d3a25717ac78fb1f0517635c3cb1c31c7667";
+              sha256 = "sha256-QVLSkgVZ4r+XYIhor9UX4hVY8CvBE3M3mQdjwrcl8qk=";
+            };}))
+          (cl-gobject-introspection.overrideAttrs (final: prev: {
+            src = pkgs.fetchFromGitHub {
+              owner = "andy128k";
+              repo = "cl-gobject-introspection";
+              rev = "83beec4492948b52aae4d4152200de5d5c7ac3e9";
+              sha256 = "sha256-g/FwWE+Rzmzm5Y+irvd1AJodbp6kPHJIFOFDPhaRlXc=";
+            };}))
+          (cl-webkit2.overrideAttrs (final: prev: {
+            src = pkgs.fetchFromGitHub {
+              owner = "joachifm";
+              repo = "cl-webkit";
+              rev = "66fd0700111586425c9942da1694b856fb15cf41";
+              sha256 = "sha256-t/B9CvQTekEEsM/ZEp47Mn6NeZaTYFsTdRqclfX9BNg=";
+            };
+          }))
+          (slynk.overrideAttrs (final: prev: {
+            src = pkgs.fetchFromGitHub {
+              owner = "joaotavora";
+              repo = "sly";
+              rev = "9c43bf65b967e12cef1996f1af5f0671d8aecbf4";
+              hash = "sha256-YlHZ/7VwvHe2PBPRshN+Gr3WuGK9MpkOJprP6QXI3pY=";
+            };
+            systems = [ "slynk" "slynk/arglists" "slynk/fancy-inspector"
+                        "slynk/package-fu" "slynk/mrepl" "slynk/trace-dialog"
+                        "slynk/profiler" "slynk/stickers" "slynk/indentation"
+                        "slynk/retro" ];
+          }))
+          iterate
+          symbol-munger
+          misc-extensions
+          quri
+          history-tree
+          nhooks
+          nkeymaps
+          prompter
+          cl-colors2_0_5_4
+          njson
+          nsymbols
+          nclasses
+          nfiles
+          cl-containers
+          # remove this override after quicklisp one is updated.
+          (swank.overrideAttrs (final: prev: {
+            src = pkgs.fetchFromGitHub {
+              owner = "slime";
+              repo = "slime";
+              rev = "v2.29.1";
+              hash = "sha256-5hNB5XxbTER4HX3dn4umUGnw6UeiTQkczmggFz4uWoE=";
+            };
+            systems = [ "swank" "swank/exts" ];
+          }))
+        ]);
+
         src = pkgs.fetchFromGitHub {
-          owner = "snmsts";
-          repo = "trivial-clipboard";
-          rev = "f7b2c96fea00ca06a83f20b00b7b1971e76e03e7";
-          sha256 = "sha256-U6Y9BiM2P1t9P8fdX8WIRQPRWl2v2ZQuKdP1IUqvOAk=";
-        };}))
-      (cl-gobject-introspection.overrideAttrs (final: prev: {
-        src = pkgs.fetchFromGitHub {
-          owner = "andy128k";
-          repo = "cl-gobject-introspection";
-          rev = "83beec4492948b52aae4d4152200de5d5c7ac3e9";
-          sha256 = "sha256-g/FwWE+Rzmzm5Y+irvd1AJodbp6kPHJIFOFDPhaRlXc=";
-        };}))
-      (cl-webkit2.overrideAttrs (final: prev: {
-        src = pkgs.fetchFromGitHub {
-          owner = "joachifm";
-          repo = "cl-webkit";
-          rev = "66fd0700111586425c9942da1694b856fb15cf41";
-          sha256 = "sha256-t/B9CvQTekEEsM/ZEp47Mn6NeZaTYFsTdRqclfX9BNg=";
+          owner = "atlas-engineer";
+          repo = "nyxt";
+          rev = "3.11.7";
+          hash = "sha256-QhJ5uzhPJBVtfm7PbrtHcIrhx2YFKuRoWAIosoSeNGM=";
         };
-      }))
-      (slynk.overrideAttrs (final: prev: {
-        src = pkgs.fetchFromGitHub {
-          owner = "joaotavora";
-          repo = "sly";
-          rev = "9c43bf65b967e12cef1996f1af5f0671d8aecbf4";
-          hash = "sha256-YlHZ/7VwvHe2PBPRshN+Gr3WuGK9MpkOJprP6QXI3pY=";
-        };
-        systems = [ "slynk" "slynk/arglists" "slynk/fancy-inspector"
-                    "slynk/package-fu" "slynk/mrepl" "slynk/trace-dialog"
-                    "slynk/profiler" "slynk/stickers" "slynk/indentation"
-                    "slynk/retro" ];
-      }))
-      iterate
-      symbol-munger
-    ]) ++ (with self; [
-      quri_20240328
-      history-tree
-      nhooks
-      nkeymaps
-      prompter
-      cl-colors2_0_5_4
-      njson
-      nsymbols
-      nclasses
-      nfiles
-      cl-containers
-      # remove this override after quicklisp one is updated.
-      (swank.overrideAttrs (final: prev: {
-        src = pkgs.fetchFromGitHub {
-          owner = "slime";
-          repo = "slime";
-          rev = "v2.29.1";
-          hash = "sha256-5hNB5XxbTER4HX3dn4umUGnw6UeiTQkczmggFz4uWoE=";
-        };
-        systems = [ "swank" "swank/exts" ];
-      }))
-    ]);
 
-    src = pkgs.fetchFromGitHub {
-      owner = "atlas-engineer";
-      repo = "nyxt";
-      rev = "3.11.6";
-      hash = "sha256-o+4LnSNyhdz5YAjNQJuE2ERtt48PckjKfts9QVRw82A=";
-    };
+        nativeBuildInputs = [ pkgs.makeWrapper ];
 
-    nativeBuildInputs = [ pkgs.makeWrapper ];
+        buildInputs = [
+          # needed for GSETTINGS_SCHEMAS_PATH
+          pkgs.gsettings-desktop-schemas pkgs.glib pkgs.gtk3
 
-    buildInputs = [
-      # needed for GSETTINGS_SCHEMAS_PATH
-      pkgs.gsettings-desktop-schemas pkgs.glib pkgs.gtk3
+          # needed for XDG_ICON_DIRS
+          pkgs.gnome.adwaita-icon-theme
+        ];
 
-      # needed for XDG_ICON_DIRS
-      pkgs.gnome.adwaita-icon-theme
-    ];
+        # This patch removes the :build-operation component from the nyxt/gi-gtk-application system.
+        # This is done because if asdf:operate is used and the operation matches the system's :build-operation
+        # then output translations are ignored, causing the result of the operation to be placed where
+        # the .asd is located, which in this case is the nix store.
+        # see: https://gitlab.common-lisp.net/asdf/asdf/-/blob/master/doc/asdf.texinfo#L2582
+        patches = [ ./patches/nyxt-remove-build-operation.patch ];
 
-    # This patch removes the :build-operation component from the nyxt/gi-gtk-application system.
-    # This is done because if asdf:operate is used and the operation matches the system's :build-operation
-    # then output translations are ignored, causing the result of the operation to be placed where
-    # the .asd is located, which in this case is the nix store.
-    # see: https://gitlab.common-lisp.net/asdf/asdf/-/blob/master/doc/asdf.texinfo#L2582
-    patches = [ ./patches/nyxt-remove-build-operation.patch ];
+        NASDF_USE_LOGICAL_PATHS = true;
 
-    NASDF_USE_LOGICAL_PATHS = true;
-
-    buildScript = pkgs.writeText "build-nyxt.lisp" ''
+        buildScript = pkgs.writeText "build-nyxt.lisp" ''
       (load "${super.alexandria.asdfFasl}/asdf.${super.alexandria.faslExt}")
       (require :uiop)
       (let ((pwd (uiop:ensure-directory-pathname (uiop/os:getcwd))))
@@ -524,8 +526,8 @@ let
       (asdf:operate :program-op :nyxt/gi-gtk-application)
     '';
 
-    # TODO(kasper): use wrapGAppsHook3
-    installPhase = ''
+        # TODO(kasper): use wrapGAppsHook3
+        installPhase = ''
       mkdir -pv $out
       cp -r * $out
       rm -fv $out/nyxt
@@ -539,7 +541,8 @@ let
         --prefix GIO_EXTRA_MODULES ":" ${pkgs.dconf.lib}/lib/gio/modules/ \
         --prefix GIO_EXTRA_MODULES ":" ${pkgs.glib-networking}/lib/gio/modules/
     '';
-  };
+      };});
+    in scope.nyxt-gtk;
 
   nyxt = self.nyxt-gtk;
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Changelog: https://nyxt-browser.com/article/release-3.11.7.org

## Highlight
- ~~This pr may break some packages due to quri upgrade,  a widely used package.~~
- ~~quri cannot be updated in lisp module scope due to widely using. We also cannot update the one in nyxt simply. Because It is not only a dependency of nyxt, but also the ones in other nyxt deps, and all lispLibs are propagatedBuildInptus causing there are multilpe quri in the environment.~~
- To use the correct quri, I make a new scope for nyxt.
- The mesa on master is 24.0.7 ~~which is different from the one on  my machine (24.0.6). So I haven't test the nyxt update.~~


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
