### PR TITLE
dyalog: 19.0.48958 -> 19.0.49960, also apply patchelf to dyalog.rt

### DIFF
--- a/pkgs/by-name/dy/dyalog/package.nix
+++ b/pkgs/by-name/dy/dyalog/package.nix
@@ -51,14 +51,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "dyalog";
-  version = "19.0.48958";
+  version = "19.0.49960";
   shortVersion = lib.versions.majorMinor finalAttrs.version;
 
   src =
     assert !acceptLicense -> throw licenseDisclaimer;
     fetchurl {
       url = "https://download.dyalog.com/download.php?file=${finalAttrs.shortVersion}/linux_64_${finalAttrs.version}_unicode.x86_64.deb";
-      hash = "sha256-+L9XI7Knt91sG/0E3GFSeqjD9Zs+1n72MDfvsXnr77M=";
+      hash = "sha256-WeIrwF6msiQGS6ltYWn6TN+v+aXK1cbJ1e11B6f0+2A=";
     };
 
   outputs = [ "out" ] ++ lib.optional enableDocs "doc";

--- a/pkgs/by-name/dy/dyalog/package.nix
+++ b/pkgs/by-name/dy/dyalog/package.nix
@@ -143,8 +143,11 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # Register some undeclared runtime dependencies to be patched in by autoPatchelfHook
+  # Note: dyalog.rt is used internally to run child APL processes in
   preFixup = ''
-    patchelf ${dyalogHome}/dyalog --add-needed libncurses.so
+    for exec in "dyalog" "dyalog.rt"; do
+        patchelf ${dyalogHome}/$exec --add-needed libncurses.so
+    done
   ''
   + lib.optionalString htmlRendererSupport ''
     patchelf ${dyalogHome}/libcef.so --add-needed libudev.so --add-needed libGL.so


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/316439

This PR bumps the version of the `dyalog` package. This is needed since Dyalog remvoed the previous version's files and since this is marked as unfree, it didn't get cached.

The original PR only addressed this:
Using the `isolate` workspace will create some internal `dyalog.rt` processes, but those weren't able to `dlopen` `libncurses.so` because I only `patchelf`-ed the main `dyalog` binary, causing it to crash.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
