### PR TITLE
epson_201601w: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1791,6 +1791,12 @@
     githubId = 10285250;
     name = "Artur E. Ruuge";
   };
+  asandikci = {
+    email = "git@aliberksandikci.com.tr";
+    github = "asandikci";
+    githubId = 94538585;
+    name = "Aliberk Sandıkçı";
+  };
   asbachb = {
     email = "asbachb-nixpkgs-5c2a@impl.it";
     matrix = "@asbachb:matrix.org";

--- a/pkgs/by-name/ep/epson_201601w/package.nix
+++ b/pkgs/by-name/ep/epson_201601w/package.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  rpmextract,
+  autoreconfHook,
+  file,
+  libjpeg,
+  cups,
+}:
+
+let
+  version = "1.0.1";
+  filterversion = "1.0.2";
+in
+stdenv.mkDerivation {
+
+  pname = "epson_201601w";
+  inherit version;
+
+  src = fetchurl {
+    # NOTE: Don't forget to update the webarchive link too!
+    urls = [
+      "https://download3.ebz.epson.net/dsc/f/03/00/15/66/51/1046e0a9f8d8ec892806a8d4921335cf6f5fd1ea/epson-inkjet-printer-201601w-${version}-1.src.rpm"
+      "https://web.archive.org/web/20240601191136/https://download3.ebz.epson.net/dsc/f/03/00/15/66/51/1046e0a9f8d8ec892806a8d4921335cf6f5fd1ea/epson-inkjet-printer-201601w-${version}-1.src.rpm"
+    ];
+    hash = "sha256-BI1y3U3EvVqqFfQ7YnQxiuIby6GJ5B0TCC2jQH1Uos0=";
+  };
+
+  nativeBuildInputs = [
+    rpmextract
+    autoreconfHook
+    file
+  ];
+
+  buildInputs = [
+    libjpeg
+    cups
+  ];
+
+  unpackPhase = ''
+    rpmextract $src
+    tar -zxf epson-inkjet-printer-201601w-${version}.tar.gz
+    tar -zxf epson-inkjet-printer-filter-${filterversion}.tar.gz
+    for ppd in epson-inkjet-printer-201601w-${version}/ppds/*; do
+      substituteInPlace $ppd --replace "/opt/epson-inkjet-printer-201601w" "$out"
+      substituteInPlace $ppd --replace "/cups/lib" "/lib/cups"
+    done
+    cd epson-inkjet-printer-filter-${filterversion}
+  '';
+
+  preConfigure = ''
+    chmod +x configure
+    export LDFLAGS="$LDFLAGS -Wl,--no-as-needed"
+  '';
+
+  postInstall = ''
+    cd ../epson-inkjet-printer-201601w-${version}
+    cp -a lib64 resource watermark $out
+    mkdir -p $out/share/cups/model/epson-inkjet-printer-201601w
+    cp -a ppds $out/share/cups/model/epson-inkjet-printer-201601w/
+    cp -a Manual.txt $out/doc/
+    cp -a README $out/doc/README.driver
+  '';
+
+  meta = {
+    homepage = "https://download.ebz.epson.net/dsc/du/02/DriverDownloadInfo.do?LG2=EN&CN2=&DSCMI=156651&DSCCHK=0ee68ffad69c21e7c0cedbbfe22494f7bb8e1eb7";
+    description = "Epson printer driver (L380/L382)";
+    longDescription = ''
+      This software is a filter program used with the Common UNIX Printing
+      System (CUPS) under Linux. It supplies high quality printing with
+      Seiko Epson Color Ink Jet Printers.
+
+      List of printers supported by this package:
+         Epson L380 Series
+         Epson L382 Series
+
+      To use the driver adjust your configuration.nix file:
+        services.printing = {
+          enable = true;
+          drivers = [ pkgs.epson_201601w ];
+        };
+
+      Note: Consider to use epson-201401w > L310 Driver if you have color/resolution issues
+    '';
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = with lib.licenses; [
+      lgpl21Only
+      epson
+    ];
+    maintainers = [ lib.maintainers.asandikci ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Added Epson 201601w driver that makes L380/L382 models usable
Resolves: #316342

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - I don't have enough RAM to test :(
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
  - I hope ...

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
