### PR TITLE
session-desktop: file desktop exec path

### DIFF
--- a/pkgs/applications/networking/instant-messengers/session-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/session-desktop/default.nix
@@ -33,7 +33,7 @@ stdenvNoCC.mkDerivation {
       name = "Session";
       desktopName = "Session";
       comment = "Onion routing based messenger";
-      exec = "${appimage}/bin/session-desktop-${version}";
+      exec = "session-desktop";
       icon = "${appimage-contents}/session-desktop.png";
       terminal = false;
       type = "Application";


### PR DESCRIPTION
## Description of changes
Session messenger installs and runs from the terminal but the desktop file for Gnome etc. was broken since it referred to a file that did not exist.