### PR TITLE
xfce.xfmpc: init at 0.3.1-2024-05-29

### DIFF
--- a/pkgs/by-name/li/libmpd/package.nix
+++ b/pkgs/by-name/li/libmpd/package.nix
@@ -41,5 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ doronbehar ];
     platforms = platforms.all;
+    # Getting DARWIN_NULL related errors
+    broken = stdenv.isDarwin;
   };
 })

--- a/pkgs/by-name/li/libmpd/package.nix
+++ b/pkgs/by-name/li/libmpd/package.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, doxygen
+, glib
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libmpd";
+  version = "11.8.17";
+  outputs = [
+    "out"
+    "dev"
+    "devdoc"
+  ];
+
+  src = fetchurl {
+    url = "https://www.musicpd.org/download/libmpd/${finalAttrs.version}/libmpd-${finalAttrs.version}.tar.gz";
+    hash = "sha256-/iAyaw0QZB9xxGc/rmN7+SIqluFxL3HxcPyi/DS/eoM=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    doxygen
+  ];
+  buildInputs = [
+    glib
+  ];
+
+  postInstall = ''
+    make doc
+    mkdir -p $devdoc/share/devhelp/libmpd
+    cp -r doc/html $devdoc/share/devhelp/libmpd/doxygen
+  '';
+
+  meta = with lib; {
+    description = "Higher level access to MPD functions";
+    homepage = "https://www.musicpd.org/download/libmpd/";
+    changelog = "https://www.musicpd.org/download/libmpd/${finalAttrs.version}/README";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ doronbehar ];
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/desktops/xfce/applications/xfmpc/default.nix
+++ b/pkgs/desktops/xfce/applications/xfmpc/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, mkXfceDerivation
+, vala
+, libxfce4util
+, libxfce4ui
+, gtk3
+, glib
+, libmpd
+}:
+
+mkXfceDerivation rec {
+  category = "apps";
+  pname = "xfmpc";
+  # Last release is too old
+  version = "0.3.1-2024-05-29";
+  rev = "cf40dffec6e9b80abb1f1aa6d7dceef4790173dc";
+  sha256 = "sha256-moCWSLGBJuWM4/lRJi6D3w38iJeCntLo3Vl/eVfu7lw=";
+
+  nativeBuildInputs = [
+    vala
+    libxfce4util
+    # Needed both here and in buildInputs for cross compilation to work
+    libxfce4ui
+  ];
+  buildInputs = [
+    gtk3
+    glib
+    libxfce4ui
+    libmpd
+  ];
+
+  meta = with lib; {
+    description = "MPD client written in GTK";
+    homepage = "https://docs.xfce.org/apps/xfmpc/start";
+    changelog = "https://gitlab.xfce.org/apps/xfmpc/-/blob/${rev}/NEWS";
+    maintainers = with maintainers; [ doronbehar ] ++ teams.xfce.members;
+    mainProgram = "xfmpc";
+  };
+}

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -80,6 +80,8 @@ makeScopeWithSplicing' {
 
       ristretto = callPackage ./applications/ristretto { };
 
+      xfmpc = callPackage ./applications/xfmpc { };
+
       xfce4-taskmanager = callPackage ./applications/xfce4-taskmanager { };
 
       xfce4-dict = callPackage ./applications/xfce4-dict { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
