### PR TITLE
Update Arcan and associated packages. Temporarily disable libunwind support added in new Arcan/Tracy versions.

### DIFF
--- a/pkgs/by-name/ar/arcan/package.nix
+++ b/pkgs/by-name/ar/arcan/package.nix
@@ -24,6 +24,7 @@
 , libjpeg
 , libusb1
 , libuvc
+, libunwind
 , libvlc
 , libvncserver
 , libxcb
@@ -57,12 +58,12 @@ let
   allSources = {
     letoram-arcan = {
       pname = "arcan";
-      version = "0.6.2.1-unstable-2023-11-18";
+      version = "0.6.3.0-unstable-2024-06-01";
       src = fetchFromGitHub {
         owner = "letoram";
         repo = "arcan";
-        rev = "0950ee236f96a555729498d0fdf91c16901037f5";
-        hash = "sha256-TxadRlidy4KRaQ4HunPO6ISJqm6JwnMRM8y6dX6vqJ4=";
+        rev = "1f9b22fad18f5b1fd4994699538458501dda2db7";
+        hash = "sha256-Foi8UF3kB5eOX89R/m2bx6yXGnwI/e+fREF/G4NrzPo=";
       };
     };
     letoram-openal-src = fetchFromGitHub {
@@ -74,20 +75,20 @@ let
     libuvc-src = fetchFromGitHub {
       owner = "libuvc";
       repo = "libuvc";
-      rev = "68d07a00e11d1944e27b7295ee69673239c00b4b";
-      hash = "sha256-IdV18mnPTDBODpS1BXl4ulkFyf1PU2ZmuVGNOIdQwzE=";
+      rev = "047920bcdfb1dac42424c90de5cc77dfc9fba04d";
+      hash = "sha256-Ds4N9ezdO44eBszushQVvK0SUVDwxGkUty386VGqbT0=";
     };
     luajit-src = fetchFromGitHub {
       owner = "LuaJIT";
       repo = "LuaJIT";
-      rev = "656ecbcf8f669feb94e0d0ec4b4f59190bcd2e48";
-      hash = "sha256-/gGQzHgYuWGqGjgpEl18Rbh3Sx2VP+zLlx4N9/hbYLc=";
+      rev = "4a22050df9e76a28ef904382e4b4c69578973cd5";
+      hash = "sha256-H9xWEh/g23xaoyQ8B5pxM76V+MFLTwQ+BgSFk04r4C0=";
     };
     tracy-src = fetchFromGitHub {
-      owner = "wolfpld";
+      owner = "letoram";
       repo = "tracy";
-      rev = "93537dff336e0796b01262e8271e4d63bf39f195";
-      hash = "sha256-FNB2zTbwk8hMNmhofz9GMts7dvH9phBRVIdgVjRcyQM=";
+      rev = "5b3513d9838317bfc0e72344b94aa4443943c2fd";
+      hash = "sha256-hUdYC4ziQ7V7T7k99MERp81F5mPHzFtPFrqReWsTjOQ=";
     };
   };
 in
@@ -122,6 +123,7 @@ stdenv.mkDerivation (finalAttrs: {
     libffi
     libjpeg
     libusb1
+    libunwind
     libuvc
     libvlc
     libvncserver
@@ -192,6 +194,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "STATIC_LIBUVC" useStaticLibuvc)
     (lib.cmakeBool "STATIC_SQLite3" useStaticSqlite)
     (lib.cmakeBool "ENABLE_TRACY" useTracy)
+    (lib.cmakeBool "TRACY_LIBUNWIND_BACKTRACE" false)
     "../src"
   ];
 

--- a/pkgs/by-name/ca/cat9/package.nix
+++ b/pkgs/by-name/ca/cat9/package.nix
@@ -5,13 +5,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "cat9";
-  version = "unstable-2023-11-06";
+  version = "unstable-2023-06-01";
 
   src = fetchFromGitHub {
     owner = "letoram";
     repo = "cat9";
-    rev = "a807776a85237ab0bdd0a712fb33c176fc295e30";
-    hash = "sha256-OlH8FgVBk76Qw+5mnsrryXOL9GbPJWlwUGtYlLuAPxQ=";
+    rev = "a34da77d186163b886049c7d85e812200b80d83d";
+    hash = "sha256-DEEbWyEi/Ba7bXWkjRQR4aG/uZSGz5lN5eaDy8TeWRA=";
   };
 
   dontConfigure = true;

--- a/pkgs/by-name/du/durden/package.nix
+++ b/pkgs/by-name/du/durden/package.nix
@@ -5,13 +5,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "durden";
-  version = "unstable-2023-10-23";
+  version = "unstable-2024-06-01";
 
   src = fetchFromGitHub {
     owner = "letoram";
     repo = "durden";
-    rev = "347dba6da011bbaa70c6edaf82a2d915f4057db3";
-    hash = "sha256-iNf7fOzz7mf1CXG5leCenkSTrdCc9/KL8VLw8gUIyKE=";
+    rev = "ea65224f268b590a9cc28bfb27e146e3c2b4e0d0";
+    hash = "sha256-1TS/57Ig9OCQEBQ0vj+YbWgOZh/YTR1yRfcWJkBnpLI=";
   };
 
   dontConfigure = true;

--- a/pkgs/by-name/xa/xarcan/package.nix
+++ b/pkgs/by-name/xa/xarcan/package.nix
@@ -39,13 +39,13 @@
 
 stdenv.mkDerivation (finalPackages: {
   pname = "xarcan";
-  version = "0-unstable-2024-05-11";
+  version = "0-unstable-2024-06-01";
 
   src = fetchFromGitHub {
     owner = "letoram";
     repo = "xarcan";
-    rev = "ecc4d0a6408dfeb19934e3bfd4c382b0862c03b4";
-    hash = "sha256-PmaoeemQpin5NN8I6JYOumP+PrzkyTYrqAyxxwBO9K0=";
+    rev = "ebb46609315d95fb286009310de11b03f7333022";
+    hash = "sha256-XXA5c/yV6QaPiz1LHWkb+Tm6Wmead8EndkSk3onvrcs=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

Updated arcan and related software to latest versions. Did not enable new libunwind backtraces for Tracy because I am having difficulty getting tracy/arcan to link to libunwind during the build.

https://github.com/letoram/arcan/blob/master/CHANGELOG.md

I don't have arcan working on bare metal yet, so I cannot assess whether there is any regression in bare metal support. I tested the console and durden appls briefly in SDL mode to confirm no obvious regressions there.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
