### PR TITLE
iina: 1.3.4 -> 1.3.5; iina: add maintainer donteatoreo; iina: use finalAttrs pattern; iina: sort meta alphabetically; iina: remove `with lib;` from meta; iina: refactor stdenv -> stdenvNoCC; iina: format with nixfmt-rfc-style

### DIFF
--- a/pkgs/by-name/ii/iina/package.nix
+++ b/pkgs/by-name/ii/iina/package.nix
@@ -27,12 +27,12 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
-    homepage = "https://iina.io/";
     description = "The modern media player for macOS";
-    platforms = platforms.darwin;
+    homepage = "https://iina.io/";
     license = licenses.gpl3;
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    mainProgram = "iina";
     maintainers = with maintainers; [ arkivm donteatoreo stepbrobd ];
+    mainProgram = "iina";
+    platforms = platforms.darwin;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };
 })

--- a/pkgs/by-name/ii/iina/package.nix
+++ b/pkgs/by-name/ii/iina/package.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "iina";
-  version = "1.3.4";
+  version = "1.3.5";
 
   src = fetchurl {
     url = "https://github.com/iina/iina/releases/download/v${version}/IINA.v${version}.dmg";
-    hash = "sha256-feUPWtSi/Vsnv1mjGyBgB0wFMxx6r6UzrUratlAo14w=";
+    hash = "sha256-O4uRmfQaGMKqizDlgk0MnazMHVkXaDLqZQ9TP8vcajg=";
   };
 
   nativeBuildInputs = [ undmg ];

--- a/pkgs/by-name/ii/iina/package.nix
+++ b/pkgs/by-name/ii/iina/package.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     mainProgram = "iina";
-    maintainers = with maintainers; [ arkivm stepbrobd ];
+    maintainers = with maintainers; [ arkivm donteatoreo stepbrobd ];
   };
 }

--- a/pkgs/by-name/ii/iina/package.nix
+++ b/pkgs/by-name/ii/iina/package.nix
@@ -26,13 +26,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "The modern media player for macOS";
     homepage = "https://iina.io/";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ arkivm donteatoreo stepbrobd ];
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ arkivm donteatoreo stepbrobd ];
     mainProgram = "iina";
-    platforms = platforms.darwin;
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 })

--- a/pkgs/by-name/ii/iina/package.nix
+++ b/pkgs/by-name/ii/iina/package.nix
@@ -1,11 +1,11 @@
 { lib
 , fetchurl
-, stdenv
+, stdenvNoCC
 , undmg
 , nix-update-script
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "iina";
   version = "1.3.5";
 

--- a/pkgs/by-name/ii/iina/package.nix
+++ b/pkgs/by-name/ii/iina/package.nix
@@ -1,8 +1,9 @@
-{ lib
-, fetchurl
-, stdenvNoCC
-, undmg
-, nix-update-script
+{
+  lib,
+  fetchurl,
+  stdenvNoCC,
+  undmg,
+  nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -30,7 +31,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "The modern media player for macOS";
     homepage = "https://iina.io/";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ arkivm donteatoreo stepbrobd ];
+    maintainers = with lib.maintainers; [
+      arkivm
+      donteatoreo
+      stepbrobd
+    ];
     mainProgram = "iina";
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/ii/iina/package.nix
+++ b/pkgs/by-name/ii/iina/package.nix
@@ -5,12 +5,12 @@
 , nix-update-script
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "iina";
   version = "1.3.5";
 
   src = fetchurl {
-    url = "https://github.com/iina/iina/releases/download/v${version}/IINA.v${version}.dmg";
+    url = "https://github.com/iina/iina/releases/download/v${finalAttrs.version}/IINA.v${finalAttrs.version}.dmg";
     hash = "sha256-O4uRmfQaGMKqizDlgk0MnazMHVkXaDLqZQ9TP8vcajg=";
   };
 
@@ -35,4 +35,4 @@ stdenv.mkDerivation rec {
     mainProgram = "iina";
     maintainers = with maintainers; [ arkivm donteatoreo stepbrobd ];
   };
-}
+})


### PR DESCRIPTION
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
