### PR TITLE
poezio: 0.13.1 -> 0.14; add missing dependencies

### DIFF
--- a/pkgs/applications/networking/instant-messengers/poezio/default.nix
+++ b/pkgs/applications/networking/instant-messengers/poezio/default.nix
@@ -1,27 +1,26 @@
 { lib
-, fetchFromGitLab
+, fetchFromGitea
 , pkg-config
 , python3
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "poezio";
-  version = "0.13.1";
-  format = "setuptools";
+  version = "0.14";
+  pyproject = true;
 
-  src = fetchFromGitLab {
-    domain = "lab.louiz.org";
-    owner = pname;
-    repo = pname;
-    rev = "refs/tags/v${version}";
-    sha256 = "sha256-3pUegEfhQxEv/7Htw6b2BN1lXtDockyANmi1xW4wPhA=";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "poezio";
+    repo = "poezio";
+    rev = "v${version}";
+    hash = "sha256-sk+8r+a0CcoB0RidqnE7hJUgt/xvN/MCJMkxiquvdJc=";
   };
 
-  nativeBuildInputs = [
-    pkg-config
-  ];
+  nativeBuildInputs = [ pkg-config ];
+  build-system = [ python3.pkgs.setuptools ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3.pkgs; [
     aiodns
     cffi
     mpd2
@@ -30,6 +29,7 @@ python3.pkgs.buildPythonApplication rec {
     pyasn1-modules
     pycares
     pyinotify
+    setuptools
     slixmpp
     typing-extensions
   ];
@@ -42,10 +42,15 @@ python3.pkgs.buildPythonApplication rec {
     "poezio"
   ];
 
+  # remove poezio directory to prevent pytest import confusion
+  preCheck = ''
+    rm -r poezio
+  '';
+
   meta = with lib; {
     description = "Free console XMPP client";
     homepage = "https://poez.io";
-    changelog = "https://lab.louiz.org/poezio/poezio/-/blob/v${version}/CHANGELOG";
+    changelog = "https://codeberg.org/poezio/poezio/src/tag/v${version}/CHANGELOG";
     license = licenses.zlib;
     maintainers = with maintainers; [ lsix ];
   };


### PR DESCRIPTION
*needs backport release-24.05 tag*
## Description of changes

closes https://github.com/NixOS/nixpkgs/issues/316531

- https://codeberg.org/poezio/poezio/src/tag/v0.14/CHANGELOG
- project migrated to https://codeberg.org/poezio/poezio.git
- add dependencies listed in https://codeberg.org/poezio/poezio/src/commit/61076a2c35c33a21110743c3e65c9212227d0598/setup.py#L168-L171 which fixes https://github.com/NixOS/nixpkgs/issues/316531



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
