### PR TITLE
python-matter-server: 5.8.0 -> 6.0.1

### DIFF
--- a/pkgs/development/python-modules/python-matter-server/default.nix
+++ b/pkgs/development/python-modules/python-matter-server/default.nix
@@ -34,13 +34,13 @@
 let
   paaCerts = stdenvNoCC.mkDerivation rec {
     pname = "matter-server-paa-certificates";
-    version = "1.2.0.1";
+    version = "1.3.0.0";
 
     src = fetchFromGitHub {
       owner = "project-chip";
       repo = "connectedhomeip";
       rev = "refs/tags/v${version}";
-      hash = "sha256-p3P0n5oKRasYz386K2bhN3QVfN6oFndFIUWLEUWB0ss=";
+      hash = "sha256-5MI6r0KhSTzolesTQ8YWeoko64jFu4jHfO5KOOKpV0A=";
     };
 
     installPhase = ''
@@ -56,7 +56,7 @@ in
 
 buildPythonPackage rec {
   pname = "python-matter-server";
-  version = "5.10.0";
+  version = "6.0.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.10";
@@ -65,7 +65,7 @@ buildPythonPackage rec {
     owner = "home-assistant-libs";
     repo = "python-matter-server";
     rev = "refs/tags/${version}";
-    hash = "sha256-rfpGclSgCBTxlTgVqgNz3ixoldB9M+6mLmogkNDDdWs=";
+    hash = "sha256-Ou2bNEDsN8yIslkf4Rf4UrMrcMxTBND/hBtEU1nM8a0=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/python-matter-server/link-paa-root-certs.patch
+++ b/pkgs/development/python-modules/python-matter-server/link-paa-root-certs.patch
@@ -1,3 +1,13 @@
+From f45cf9898f2e5a3a4c2b73a9ed84c4a037a85a1e Mon Sep 17 00:00:00 2001
+From: Matt Leon <ml@mattleon.com>
+Date: Sat, 1 Jun 2024 23:28:41 -0400
+Subject: [PATCH] Symlink PAA root certificates to nix store
+
+---
+ matter_server/server/const.py                    | 2 ++
+ matter_server/server/helpers/paa_certificates.py | 6 ++++++
+ 2 files changed, 8 insertions(+)
+
 diff --git a/matter_server/server/const.py b/matter_server/server/const.py
 index 8cca3cf..43f02f5 100644
 --- a/matter_server/server/const.py
@@ -12,19 +22,19 @@ index 8cca3cf..43f02f5 100644
      .parent.resolve()
      .parent.resolve()
 diff --git a/matter_server/server/helpers/paa_certificates.py b/matter_server/server/helpers/paa_certificates.py
-index e530838..fdd6025 100644
+index de60c78..185e54c 100644
 --- a/matter_server/server/helpers/paa_certificates.py
 +++ b/matter_server/server/helpers/paa_certificates.py
-@@ -64,6 +64,8 @@ async def fetch_dcl_certificates(
-     fetch_production_certificates: bool = True,
+@@ -105,6 +105,8 @@ async def fetch_dcl_certificates(
+     base_url: str,
  ) -> int:
      """Fetch DCL PAA Certificates."""
 +    return 0
 +
-     LOGGER.info("Fetching the latest PAA root certificates from DCL.")
      fetch_count: int = 0
-     base_urls = set()
-@@ -124,6 +126,8 @@ async def fetch_dcl_certificates(
+ 
+     try:
+@@ -151,6 +153,8 @@ async def fetch_dcl_certificates(
  
  async def fetch_git_certificates(paa_root_cert_dir: Path) -> int:
      """Fetch Git PAA Certificates."""
@@ -33,12 +43,15 @@ index e530838..fdd6025 100644
      fetch_count = 0
      LOGGER.info("Fetching the latest PAA root certificates from Git.")
  
-@@ -159,6 +163,8 @@ async def fetch_certificates(
+@@ -185,6 +189,8 @@ async def fetch_certificates(
      fetch_production_certificates: bool = True,
  ) -> int:
      """Fetch PAA Certificates."""
 +    return 0
 +
      loop = asyncio.get_running_loop()
+     paa_root_cert_dir_version = paa_root_cert_dir / ".version"
  
-     if not paa_root_cert_dir.is_dir():
+-- 
+2.44.1
+


### PR DESCRIPTION
## Description of changes

Release notes:

* python-matter-server
  * https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.0.0
  * https://github.com/home-assistant-libs/python-matter-server/releases/tag/6.0.1
* Matter SDK
  * https://github.com/project-chip/connectedhomeip/compare/v1.2.0.1...v1.3.0.0
* chip-wheels
  * https://github.com/home-assistant-libs/chip-wheels/releases/tag/2024.4.0
  * https://github.com/home-assistant-libs/chip-wheels/releases/tag/2024.4.1
  * https://github.com/home-assistant-libs/chip-wheels/releases/tag/2024.5.0
  * https://github.com/home-assistant-libs/chip-wheels/releases/tag/2024.5.1
  * https://github.com/home-assistant-libs/chip-wheels/releases/tag/2024.5.2

## Things done

I did not add anything to the release notes, since the changes are relatively minor afaict. No config changes needed.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
