### PR TITLE
cudaPackages: fix cuda alias warning

### DIFF
--- a/pkgs/development/cuda-modules/aliases.nix
+++ b/pkgs/development/cuda-modules/aliases.nix
@@ -13,6 +13,6 @@ in
     mkRenamed "autoAddDriverRunpath" "pkgs.autoAddDriverRunpath"
       final.pkgs.autoAddDriverRunpath; # Added 2024-03-30
   autoAddOpenGLRunpathHook =
-    mkRenamed "autoAddOpenGLRunpathHook" "pkgs.autoAddDriverRunpath"
+    mkRenamed "autoAddOpenGLRunpathHook" "pkgs.autoAddDriverRunpathHook"
       final.pkgs.autoAddDriverRunpath; # Added 2024-03-30
 }

--- a/pkgs/development/cuda-modules/cuda/extension.nix
+++ b/pkgs/development/cuda-modules/cuda/extension.nix
@@ -53,6 +53,10 @@ let
       redistribRelease = redistribManifest.${pname};
       featureRelease = featureManifest.${pname};
       drv =
+        let
+          # get `autoAddDriverRunpath` from pkgs instead of cudaPackages' alias to avoid warning
+          inherit (callPackage ({ pkgs }: pkgs) { }) autoAddDriverRunpath;
+        in
         (callPackage ../generic-builders/manifest.nix {
           # We pass the whole release to the builder because it has logic to handle
           # the case we're trying to build on an unsupported platform.
@@ -61,6 +65,7 @@ let
             redistName
             redistribRelease
             featureRelease
+            autoAddDriverRunpath
             ;
         }).overrideAttrs
           (prevAttrs: {


### PR DESCRIPTION
## Description of changes

When build cuda packages, this is always an annoying warning, this PR fix that.

```bash
$ NIXPKGS_ALLOW_UNFREE=1 nix build --impure .#cudaPackages.cuda_cccl
trace: warning: cudaPackages.autoAddDriverRunpath is deprecated, use pkgs.autoAddDriverRunpath instead
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
