### PR TITLE
easyaudiosync: init at 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12804,6 +12804,12 @@
     githubId = 952712;
     name = "Matt Christ";
   };
+  matteopacini = {
+    email = "m@matteopacini.me";
+    github = "matteo-pacini";
+    githubId = 3139724;
+    name = "Matteo Pacini";
+  };
   matthewbauer = {
     email = "mjbauer95@gmail.com";
     github = "matthewbauer";

--- a/pkgs/applications/audio/easyaudiosync/0001-fix-project-name.patch
+++ b/pkgs/applications/audio/easyaudiosync/0001-fix-project-name.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7065538..b2716e1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,7 +4,7 @@ if (VCPKG)
+   include("${CMAKE_SOURCE_DIR}/cmake/vcpkg.cmake")
+ endif ()
+ 
+-project("Easy Audio Sync"
++project("easyaudiosync"
+   VERSION 1.1.1
+   DESCRIPTION "Audio library syncing and conversion utility"
+   HOMEPAGE_URL "https://github.com/complexlogic/EasyAudioSync"

--- a/pkgs/applications/audio/easyaudiosync/0002-fix-qt67-deprecated-methods.patch
+++ b/pkgs/applications/audio/easyaudiosync/0002-fix-qt67-deprecated-methods.patch
@@ -1,0 +1,21 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index e7befae..8689f13 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -43,11 +43,14 @@ configure_file("${PROJECT_SOURCE_DIR}/translations/languages.hpp.in" "${PROJECT_
+ 
+ # Make lupdate target for Qt 6
+ if (${QT_VERSION} VERSION_GREATER_EQUAL "6")
+-  qt_add_lupdate(${EXECUTABLE_NAME}
++  qt_add_lupdate(
+     TS_FILES ${TS_FILES} "${PROJECT_SOURCE_DIR}/translations/source.ts"
++    SOURCE_TARGETS ${EXECUTABLE_NAME}
+   )
+ endif ()
+-qt_add_translation(QM_FILES "${TS_FILES}")
++qt_add_translations(
++  ${EXECUTABLE_NAME} 
++)
+ foreach (FILE ${QM_FILES})
+   get_filename_component(BASENAME ${FILE} NAME)
+   string(APPEND TRANSLATION_FILES "    <file>${BASENAME}</file>\n")

--- a/pkgs/applications/audio/easyaudiosync/0003-fix-darwin-app.patch
+++ b/pkgs/applications/audio/easyaudiosync/0003-fix-darwin-app.patch
@@ -1,0 +1,35 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index e7befae..e7dc255 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -86,7 +86,6 @@ if (UNIX)
+     )
+   endif ()
+   if (APPLE)
+-    if (DMG)
+       set_target_properties(${EXECUTABLE_NAME} PROPERTIES 
+                             MACOSX_BUNDLE ON
+                             MACOSX_BUNDLE_EXECUTABLE_NAME "${EXECUTABLE_NAME}"
+@@ -94,21 +93,12 @@ if (UNIX)
+                             MACOSX_BUNDLE_ICON_FILE "${EXECUTABLE_NAME}.icns"
+                             MACOSX_BUNDLE_GUI_IDENTIFIER "${RDNS_NAME}"
+                             MACOSX_BUNDLE_LONG_VERSION_STRING "${PROJECT_VERSION}"
+-                            MACOSX_BUNDLE_BUNDLE_NAME "${PROJECT_NAME}"
++                            MACOSX_BUNDLE_BUNDLE_NAME "Easy Audio Sync"
+                             MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_VERSION}"
+                             MACOSX_BUNDLE_BUNDLE_VERSION "${PROJECT_VERSION}"
+                             MACOSX_BUNDLE_COPYRIGHT "Public Domain"
+ 
+       )
+-      install(CODE "include(BundleUtilities)\nfixup_bundle(\"${PROJECT_BINARY_DIR}/${EXECUTABLE_NAME}.app\" \"\" \"\")")
+-      add_custom_target(my_install COMMAND ${CMAKE_COMMAND} --build . --target install WORKING_DIRECTORY "${PROJECT_BINARY_DIR}")
+-      add_custom_target(dmg
+-        COMMAND mv "${EXECUTABLE_NAME}.app" "${PROJECT_NAME}.app" # fixup_bundle won't accept app names with spaces so need to manually rename
+-        COMMAND "${MACDEPLOYQT}" "${PROJECT_NAME}.app" -dmg
+-        COMMAND mv "${PROJECT_NAME}.dmg" "${EXECUTABLE_NAME}-${PROJECT_VERSION}-${CMAKE_OSX_ARCHITECTURES}.dmg"
+-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}")
+-      add_dependencies(dmg my_install)
+-    endif ()
+   else ()
+     install(TARGETS ${EXECUTABLE_NAME} DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+     set (DATA_DIR "${CMAKE_INSTALL_PREFIX}/share")

--- a/pkgs/applications/audio/easyaudiosync/0004-force-qt6.patch
+++ b/pkgs/applications/audio/easyaudiosync/0004-force-qt6.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7065538..1946574 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -19,14 +19,8 @@ set(EXECUTABLE_OUTPUT_PATH "${PROJECT_BINARY_DIR}")
+ set(VS_STARTUP_PROJECT ${EXECUTABLE_NAME})
+ 
+ # Configure options
+-if (WIN32 OR APPLE)
+-  set(QT_VERSION "6")
+-else ()
+-  set(QT_VERSION "5" CACHE STRING "Qt major version to use (5 or 6).")
+-  if (NOT (QT_VERSION STREQUAL "5" OR QT_VERSION STREQUAL "6"))
+-    message(FATAL_ERROR "Unsupported Qt version '${QT_VERSION}'. Only 5 and 6 are supported")
+-  endif ()
+-endif ()
++set(QT_VERSION "6")
++
+ if (APPLE)
+   option(DMG "Make deployable DMG" OFF)
+ endif ()

--- a/pkgs/applications/audio/easyaudiosync/default.nix
+++ b/pkgs/applications/audio/easyaudiosync/default.nix
@@ -1,0 +1,98 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, cmake
+, qtbase
+, qttools
+, spdlog
+, ffmpeg
+, taglib
+, wrapQtAppsHook
+, makeDesktopItem
+, copyDesktopItems
+}:
+
+stdenv.mkDerivation rec {
+  pname = "easyaudiosync";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "complexlogic";
+    repo = "EasyAudioSync";
+    rev = "v${version}";
+    hash = "sha256-w98tj9BuixPhuDgwn74EYY0gvKH6kbfQmtg030RWRU0=";
+  };
+
+  patches = [
+    ./0001-fix-project-name.patch
+    ./0002-fix-qt67-deprecated-methods.patch
+    ./0003-fix-darwin-app.patch
+    ./0004-force-qt6.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapQtAppsHook
+  ] ++ lib.optional stdenv.isLinux copyDesktopItems;
+
+  buildInputs = [
+    qtbase
+    qttools
+    ffmpeg
+    spdlog
+    taglib
+  ];
+
+  installPhase =
+    ''
+      runHook preInstall
+    '' + lib.optionalString stdenv.isDarwin ''
+      mkdir -p $out/Applications
+      mv "easyaudiosync.app" "Easy Audio Sync.app"
+      cp -r "Easy Audio Sync.app" $out/Applications
+    '' + lib.optionalString stdenv.isLinux ''
+      install -Dm755 easyaudiosync $out/bin/easyaudiosync
+
+      for RES in 48 64 128 256; do
+        install -Dm755 "$src/assets/icons/easyaudiosync''${RES}.png" "$out/share/icons/hicolor/''${RES}x''${RES}/apps/easyaudiosync.png"
+      done
+
+      install -Dm755 "$src/assets/icons/easyaudiosync.svg" "$out/share/icons/hicolor/scalable/apps/easyaudiosync.svg"
+    '' + ''
+      runHook postInstall
+    '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "easyaudiosync";
+      exec = "easyaudiosync";
+      icon = "easyaudiosync";
+      desktopName = "Easy Audio Sync";
+      categories = [
+        "Qt"
+        "Audio"
+        "AudioVideo"
+      ];
+      comment = "Audio library syncing and conversion utility";
+    })
+  ];
+
+  meta = with lib; {
+    description = "Audio library syncing and conversion utility";
+    longDescription = ''
+      Easy Audio Sync is an audio library syncing and conversion utility.
+      The intended use is syncing an audio library with many lossless files to a mobile device
+      with limited storage.
+
+      The program's design is inspired by the rsync utility. It supports folder-based
+      source to destination syncing, with added audio transcoding capability, and is
+      GUI-based instead of CLI-based.
+    '';
+    homepage = "https://github.com/complexlogic/EasyAudioSync";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ matteopacini ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5029,6 +5029,8 @@ with pkgs;
 
   easyabc = callPackage ../applications/audio/easyabc { };
 
+  easyaudiosync = qt6Packages.callPackage ../applications/audio/easyaudiosync {};
+
   easycrypt = callPackage ../applications/science/logic/easycrypt {
     why3 = pkgs.why3.override { ideSupport = false; };
   };


### PR DESCRIPTION
## Description of changes

Added new package "Easy Audio Sync".

[Easy Audio Sync](https://github.com/complexlogic/EasyAudioSync) is an audio library syncing and conversion utility. The intended use is syncing an audio library with many lossless files to a mobile device with limited storage.

This fixes #314834.

Tested on Darwin (aarch64) and Linux (aarch64).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
