### PR TITLE
irust: init at 1.71.23

### DIFF
--- a/pkgs/by-name/ir/irust/package.nix
+++ b/pkgs/by-name/ir/irust/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  makeWrapper,
+  cargo,
+  rustfmt,
+  cargo-show-asm,
+  cargo-expand,
+  clang,
+  # Workaround to allow easily overriding runtime inputs
+  runtimeInputs ? [
+    cargo
+    rustfmt
+    cargo-show-asm
+    cargo-expand
+    clang
+  ],
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "irust";
+  version = "1.71.23";
+
+  src = fetchFromGitHub {
+    owner = "sigmaSd";
+    repo = "IRust";
+    rev = "irust@${version}";
+    hash = "sha256-+kl22m2Is8CdLlqGSFOglw4/fM1exayaMH05YSuTsbw=";
+  };
+
+  cargoHash = "sha256-4aQ1IOTcUAkgiQucUG8cg9pVShtlu2IJeqNCGO+6VYY=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postFixup = ''
+    wrapProgram $out/bin/irust \
+      --suffix PATH : ${lib.makeBinPath runtimeInputs}
+  '';
+
+  checkFlags = [
+    "--skip=repl"
+    "--skip=printer::tests"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "Cross Platform Rust Repl";
+    homepage = "https://github.com/sigmaSd/IRust";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lelgenio ];
+    mainProgram = "irust";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Github: https://github.com/sigmaSd/IRust

```
$ nix run -L -- .#irust
---------------------------------------Welcome to IRust---------------------------------------

In: :add bcrypt
 Adding dep [-]
    Updating crates.io index
      Adding bcrypt v0.15.1 to dependencies.
    Updating crates.io index

In: bcrypt::hash("test", 5)
Out: Ok("$2b$05$lrhhFn5CimgM8UAzY2W7muu3.ucCznWUHDy.mjYgqkcg0ZtGUs2gG")
```

The funky `runtimeInputs` is so that you can do something like this:

```
(irust.override {
    runtimeInputs = [ myRustToolchain ];
})
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
