### PR TITLE
emacsPackage.el-easydraw: 1.1.0 → 20240529.1009

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/default.nix
@@ -7,17 +7,17 @@
 }:
 
 let
-  rev = "de68851724072c6695e675f090b33a8abec040c9";
+  rev = "13c9fa22155066acfb5a2e444fe76245738e7fb7";
 in
 melpaBuild {
   pname = "edraw";
-  version = "1.1.0";
+  version = "20240529.1009";
 
   src = fetchFromGitHub {
     owner = "misohena";
     repo = "el-easydraw";
     inherit rev;
-    hash = "sha256-l9i+HCRKnKiDqID+bfAOPE7LpVBZp1AOPkceX8KbDXM=";
+    hash = "sha256-h2auwVIWjrOBPHPCuLdJv5y3FpoV4V+MEOPf4xprfYg=";
   };
 
   commit = rev;

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/default.nix
@@ -2,7 +2,7 @@
 , melpaBuild
 , fetchFromGitHub
 , writeText
-, unstableGitUpdater
+, writeScript
 , gzip
 }:
 
@@ -33,7 +33,19 @@ melpaBuild {
        "msg"))
   '';
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = writeScript "update.sh" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p common-updater-scripts coreutils git gnused
+    set -eu -o pipefail
+    tmpdir="$(mktemp -d)"
+    git clone --depth=1 https://github.com/misohena/el-easydraw.git "$tmpdir"
+    pushd "$tmpdir"
+    commit=$(git show -s --pretty='format:%H')
+    # Based on: https://github.com/melpa/melpa/blob/2d8716906a0c9e18d6c979d8450bf1d15dd785eb/package-build/package-build.el#L523-L533
+    version=$(TZ=UTC git show -s --pretty='format:%cd' --date='format-local:%Y%m%d.%H%M' | sed 's|\.0*|.|')
+    popd
+    update-source-version emacsPackages.el-easydraw $version --rev="$commit"
+  '';
 
   meta = {
     homepage = "https://github.com/misohena/el-easydraw";


### PR DESCRIPTION
## Description of changes
Resolves #316574.

Updates package to latest commit, and fixes the update script.
- [Latest tag](https://github.com/misohena/el-easydraw/releases/tag/v1.2.0)
- [Changes from previous tag to current tag](https://github.com/misohena/el-easydraw/compare/v1.1.0...v1.2.0)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
