### PR TITLE
protege: init at 5.6.4

### DIFF
--- a/pkgs/by-name/pr/protege/enforce-plugin-versions.patch
+++ b/pkgs/by-name/pr/protege/enforce-plugin-versions.patch
@@ -1,0 +1,43 @@
+diff --git a/pom.xml b/pom.xml
+index 839bed04..4cb5f392 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -358,6 +358,30 @@
+ 						<release>11</release>
+ 					</configuration>
+ 				</plugin>
++
++                                <plugin>
++					<groupId>org.apache.maven.plugins</groupId>
++					<artifactId>maven-install-plugin</artifactId>
++					<version>3.1.1</version>
++                                </plugin>
++
++                                <plugin>
++					<groupId>org.apache.maven.plugins</groupId>
++					<artifactId>maven-site-plugin</artifactId>
++					<version>3.12.1</version>
++                                </plugin>
++
++                                <plugin>
++					<groupId>org.apache.maven.plugins</groupId>
++					<artifactId>maven-deploy-plugin</artifactId>
++					<version>3.1.1</version>
++                                </plugin>
++
++                                <plugin>
++					<groupId>org.apache.maven.plugins</groupId>
++					<artifactId>maven-jar-plugin</artifactId>
++					<version>3.3.0</version>
++                                </plugin>
+ 							
+ 				<plugin>
+ 					<groupId>org.apache.maven.plugins</groupId>
+@@ -476,6 +494,7 @@
+ 								<requireMavenVersion>
+ 									<version>3.6.3</version>
+ 								</requireMavenVersion>
++                                                                <requirePluginVersions/>
+ 							</rules>
+ 						</configuration>
+ 					</execution>

--- a/pkgs/by-name/pr/protege/package.nix
+++ b/pkgs/by-name/pr/protege/package.nix
@@ -1,0 +1,93 @@
+{ lib
+, fetchFromGitHub
+, copyDesktopItems
+, iconConvTools
+, makeDesktopItem
+, makeWrapper
+, jdk11
+, maven
+}:
+
+let
+  mvn = maven.override { jdk = jdk11; };
+in
+mvn.buildMavenPackage rec {
+  pname = "protege";
+  version = "5.6.4";
+
+  src = fetchFromGitHub {
+    owner = "protegeproject";
+    repo = "protege";
+    rev = version;
+    hash = "sha256-Q3MHa7nCeF31n7JPltcemFBc/sJwGA9Ev0ymjQhY/U0=";
+  };
+
+  mvnHash = "sha256-kemP2gDv1CYuaoK0fwzBxdLTusarPasf2jCDQj/HPYE=";
+
+  patches = [
+    # Pin built-in Maven plugins to avoid checksum variations on Maven updates
+    ./enforce-plugin-versions.patch
+    # Avoid building platform-dependent builds which embed their own JREs
+    ./platform-independent-only.patch
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    iconConvTools
+    jdk11
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/protege
+
+    # Copy the application directory whole into the output, as it is used by the
+    # launcher script as a reference point to look for default configuration
+    mv protege-desktop/target/protege-${version}-platform-independent/Protege-${version} $out/Protege
+
+    # Place a wrapper for the launcher script into a default /bin location
+    makeWrapper $out/Protege/run.sh $out/bin/protege \
+      --set JAVA_HOME ${jdk11.home}
+
+    # Link all jars from within the standard /share/protege directory
+    ln -s -t $out/share/protege $out/Protege/bundles/*
+
+    # Generate and copy icons to where they can be found
+    icoFileToHiColorTheme $out/Protege/app/Protege.ico protege $out
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = "Protege Desktop";
+      genericName = "Ontology Editor";
+      icon = "protege";
+      comment = meta.description;
+      categories = [ "Development" ];
+      exec = "protege";
+    })
+  ];
+
+  meta = {
+    homepage = "https://protege.stanford.edu/";
+    downloadPage = "https://protege.stanford.edu/software.php#desktop-protege";
+    description = "A free and open-source OWL 2 ontology editor";
+    longDescription = ''
+      Protégé Desktop is a feature rich ontology editing environment with full
+      support for the OWL 2 Web Ontology Language, and direct in-memory
+      connections to description logic reasoners.
+    '';
+    maintainers = with lib.maintainers; [ nessdoor ];
+    license = with lib.licenses; [ bsd2 ];
+    # TODO Protege is able to run on Darwin as well, but I (@nessdoor) had no
+    #      way of testing it nor any experience in packaging Darwin apps, so I
+    #      will leave the task to someone who has the right tools and knowledge.
+    platforms = lib.platforms.unix;
+    mainProgram = "protege";
+    sourceProvenance = with lib.sourceTypes; [ fromSource binaryBytecode ];
+  };
+}

--- a/pkgs/by-name/pr/protege/platform-independent-only.patch
+++ b/pkgs/by-name/pr/protege/platform-independent-only.patch
@@ -1,0 +1,24 @@
+diff --git a/protege-desktop/pom.xml b/protege-desktop/pom.xml
+index 2f599708..60059308 100644
+--- a/protege-desktop/pom.xml
++++ b/protege-desktop/pom.xml
+@@ -110,9 +110,6 @@
+ 							</archiverConfig>
+ 							<descriptors>
+ 								<descriptor>src/main/assembly/protege-platform-independent.xml</descriptor>
+-								<descriptor>src/main/assembly/protege-os-x.xml</descriptor>
+-								<descriptor>src/main/assembly/protege-win.xml</descriptor>
+-								<descriptor>src/main/assembly/protege-linux.xml</descriptor>
+ 							</descriptors>
+ 						</configuration>
+ 					</execution>
+@@ -165,9 +162,6 @@
+ 									</archiverConfig>
+ 									<descriptors>
+ 										<descriptor>src/main/assembly/protege-platform-independent.xml</descriptor>
+-										<descriptor>src/main/assembly/protege-os-x.xml</descriptor>
+-										<descriptor>src/main/assembly/protege-win.xml</descriptor>
+-										<descriptor>src/main/assembly/protege-linux.xml</descriptor>
+ 									</descriptors>
+ 								</configuration>
+ 							</execution>


### PR DESCRIPTION
## Description of changes
The current `protege-distribution` package is derived directly from the upstream release archives, which include a number of pre-installed third-party plugins.

This PR introduces the "vanilla" Protégé build with no added plugins. More importantly, it is a source-based build, contrary to the current "distribution" build, and is better engineered overall.

This Protégé build is platform-independent and the derivation has been structured to support both Linux and Darwin, but, due to the lack of a Darwin machine at hand, I could not come up with a working installation for Darwin systems. Input from knowledgeable people is welcome and solicited.

I will try to refactor the old `protege-distribution` derivation into a source-based build as soon as technically possible, and maybe integrate it into the new derivation as a special case (maybe as a `protegeFull` package?).

Thanks go to @doronbehar for pointing me to `maven.buildMavenPackage` as a way to properly build Maven projects.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
