### PR TITLE
nixos/ibus: improve error message for non-engine packages

### DIFF
--- a/nixos/modules/i18n/input-method/ibus.nix
+++ b/nixos/modules/i18n/input-method/ibus.nix
@@ -5,8 +5,9 @@ with lib;
 let
   cfg = config.i18n.inputMethod.ibus;
   ibusPackage = pkgs.ibus-with-plugins.override { plugins = cfg.engines; };
-  ibusEngine = types.package // {
+  ibusEngine = lib.types.mkOptionType {
     name  = "ibus-engine";
+    inherit (lib.types.package) descriptionClass merge;
     check = x: (lib.types.package.check x) && (attrByPath ["meta" "isIbusEngine"] false x);
   };
 


### PR DESCRIPTION
when setting the option i18n.inputMethod.ibus.engines to a non-engine, like this:
```
    i18n.inputMethod.ibus.engines = [ pkgs.sl ];
```

the error message would be quite misleading:
```
error: A definition for option `nodes.machine.i18n.inputMethod.ibus.engines."[definition 1-entry 1]"' is not of type `package'. Definition values:
- In `makeTest parameters': <derivation sl-5.05>
```
sl is rejected and yet it *is* a package.

This change improves the error message to this:
```
error: A definition for option `nodes.machine.i18n.inputMethod.ibus.engines."[definition 1-entry 1]"' is not of type `ibus-engine'. Definition values:
- In `makeTest parameters': <derivation sl-5.05>
```

cc @ttuegel @yanateras ibus maintainers