### PR TITLE
lib, treewide: introduce `repoRevToName` and use it to cleanup most `fetch*` functions

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -433,6 +433,8 @@ let
         pathHasContext
         canCleanSource
         pathIsGitRepo
+        revOrTag
+        repoRevToName
         ;
       inherit (self.modules)
         evalModules

--- a/pkgs/build-support/fetchbitbucket/default.nix
+++ b/pkgs/build-support/fetchbitbucket/default.nix
@@ -1,11 +1,15 @@
-{ fetchzip, lib }:
+{
+  lib,
+  repoRevToNameMaybe,
+  fetchzip,
+}:
 
 lib.makeOverridable (
   {
     owner,
     repo,
     rev,
-    name ? "source",
+    name ? repoRevToNameMaybe repo rev "bitbucket",
     ... # For hash agility
   }@args:
   fetchzip (

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -5,29 +5,26 @@
   git-lfs,
   cacert,
 }:
+
 let
   urlToName =
     url: rev:
     let
-      inherit (lib) removeSuffix splitString last;
-      base = last (splitString ":" (baseNameOf (removeSuffix "/" url)));
-
-      matched = builtins.match "(.*)\\.git" base;
-
-      short = builtins.substring 0 7 rev;
-
-      appendShort = lib.optionalString ((builtins.match "[a-f0-9]*" rev) != null) "-${short}";
+      shortRev = lib.sources.shortRev rev;
+      appendShort = lib.optionalString ((builtins.match "[a-f0-9]*" rev) != null) "-${shortRev}";
     in
-    "${if matched == null then base else builtins.head matched}${appendShort}";
+    "${lib.sources.urlToName url}${appendShort}";
 in
+
 lib.makeOverridable (
   lib.fetchers.withNormalizedHash { } (
     # NOTE Please document parameter additions or changes in
-    #   doc/build-helpers/fetchers.chapter.md
+    #   ../../../doc/build-helpers/fetchers.chapter.md
     {
       url,
       tag ? null,
       rev ? null,
+      name ? urlToName url (lib.revOrTag rev tag),
       leaveDotGit ? deepClone || fetchTags,
       outputHash ? lib.fakeHash,
       outputHashAlgo ? null,
@@ -36,7 +33,6 @@ lib.makeOverridable (
       branchName ? null,
       sparseCheckout ? [ ],
       nonConeMode ? false,
-      name ? null,
       nativeBuildInputs ? [ ],
       # Shell code executed before the file has been fetched.  This, in
       # particular, can do things like set NIX_PREFETCH_GIT_CHECKOUT_HOOK to
@@ -108,7 +104,7 @@ lib.makeOverridable (
         "Please provide directories/patterns for sparse checkout as a list of strings. Passing a (multi-line) string is not supported any more."
     else
       stdenvNoCC.mkDerivation {
-        name = if name != null then name else urlToName url revWithTag;
+        inherit name;
 
         builder = ./builder.sh;
         fetcher = ./nix-prefetch-git;

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  repoRevToNameMaybe,
   fetchgit,
   fetchzip,
 }:
@@ -10,7 +11,7 @@ lib.makeOverridable (
     repo,
     tag ? null,
     rev ? null,
-    name ? "source",
+    name ? repoRevToNameMaybe repo (lib.revOrTag rev tag) "github",
     fetchSubmodules ? false,
     leaveDotGit ? null,
     deepClone ? false,

--- a/pkgs/build-support/fetchgitiles/default.nix
+++ b/pkgs/build-support/fetchgitiles/default.nix
@@ -1,11 +1,15 @@
-{ fetchzip, lib }:
+{
+  fetchzip,
+  repoRevToNameMaybe,
+  lib,
+}:
 
 lib.makeOverridable (
   {
     url,
     rev ? null,
     tag ? null,
-    name ? "source",
+    name ? repoRevToNameMaybe url (lib.revOrTag rev tag) "gitiles",
     ...
   }@args:
 

--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  repoRevToNameMaybe,
   fetchgit,
   fetchzip,
 }:
@@ -11,9 +12,9 @@ lib.makeOverridable (
     repo,
     rev ? null,
     tag ? null,
+    name ? repoRevToNameMaybe repo (lib.revOrTag rev tag) "gitlab",
     protocol ? "https",
     domain ? "gitlab.com",
-    name ? "source",
     group ? null,
     fetchSubmodules ? false,
     leaveDotGit ? false,

--- a/pkgs/build-support/fetchrepoorcz/default.nix
+++ b/pkgs/build-support/fetchrepoorcz/default.nix
@@ -1,10 +1,14 @@
-{ fetchzip }:
+{
+  lib,
+  repoRevToNameMaybe,
+  fetchzip,
+}:
 
 # gitweb example, snapshot support is optional in gitweb
 {
   repo,
   rev,
-  name ? "source",
+  name ? repoRevToNameMaybe repo rev "repoorcz",
   ... # For hash agility
 }@args:
 fetchzip (

--- a/pkgs/build-support/fetchsavannah/default.nix
+++ b/pkgs/build-support/fetchsavannah/default.nix
@@ -1,11 +1,15 @@
-{ fetchzip, lib }:
+{
+  lib,
+  repoRevToNameMaybe,
+  fetchzip,
+}:
 
 lib.makeOverridable (
   # cgit example, snapshot support is optional in cgit
   {
     repo,
     rev,
-    name ? "source",
+    name ? repoRevToNameMaybe repo rev "savannah",
     ... # For hash agility
   }@args:
   fetchzip (

--- a/pkgs/build-support/fetchsourcehut/default.nix
+++ b/pkgs/build-support/fetchsourcehut/default.nix
@@ -1,8 +1,9 @@
 {
+  lib,
+  repoRevToNameMaybe,
   fetchgit,
   fetchhg,
   fetchzip,
-  lib,
 }:
 
 let
@@ -18,9 +19,9 @@ makeOverridable (
     owner,
     repo,
     rev,
+    name ? repoRevToNameMaybe repo rev "sourcehut",
     domain ? "sr.ht",
     vc ? "git",
-    name ? "source",
     fetchSubmodules ? false,
     ... # For hash agility
   }@args:

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -7,6 +7,7 @@
 
 {
   lib,
+  repoRevToNameMaybe,
   fetchurl,
   withUnzip ? true,
   unzip,
@@ -14,9 +15,9 @@
 }:
 
 {
-  name ? "source",
   url ? "",
   urls ? [ ],
+  name ? repoRevToNameMaybe (if url != "" then url else builtins.head urls) null "unpacked",
   nativeBuildInputs ? [ ],
   postFetch ? "",
   extraPostFetch ? "",

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -574,6 +574,9 @@ with pkgs;
     stdenv = if stdenv.hostPlatform.isDarwin then llvmPackages_18.stdenv else stdenv;
   };
 
+  # this is used by most `fetch*` functions
+  repoRevToNameMaybe = lib.repoRevToName config.fetchedSourceNameDefault;
+
   fetchpatch =
     callPackage ../build-support/fetchpatch {
       # 0.3.4 would change hashes: https://github.com/NixOS/nixpkgs/issues/25154

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -150,8 +150,6 @@ let
     };
 
     cudaSupport = mkMassRebuild {
-      type = types.bool;
-      default = false;
       feature = "build packages with CUDA support by default";
     };
 
@@ -184,8 +182,6 @@ let
     };
 
     rocmSupport = mkMassRebuild {
-      type = types.bool;
-      default = false;
       feature = "build packages with ROCm support by default";
     };
 


### PR DESCRIPTION
This a first half of #49862. Basically, this is a noop cleanup that keeps all the `fetch*` names as they are now, while introducing the new `config.fetchedSourceNameDefault` option.

# Changes

This patch adds `lib.repoRevToName` function that generalizes away most of the code used for derivation name generation by `fetch*` functions (`fetchzip`, `fetchFromGitHub`, etc, except those which are delayed until latter commits for mass-rebuild reasons).

It's first argument controls how the resulting name will look (see below).

Since `lib` has no equivalent of Nixpkgs' `config`, this patch adds `config.fetchedSourceNameDefault` option to Nixpkgs and then re-exposes `lib.repoRevToName config.fetchedSourceNameDefault` expression as `pkgs.repoRevToNameMaybe` which is then used in `fetch*` derivations.

The result is that different values of `config.fetchedSourceNameDefault` now control how the `src` derivations produced by `fetch*` functions are to be named, e.g.:

- `fetchedSourceNameDefault = "source"` (the default):

        $ nix-instantiate -A fuse.src
        /nix/store/<hash>-source.drv

- `fetchedSourceNameDefault = "versioned"`:

        $ nix-instantiate -A fuse.src
        /nix/store/<hash>-libfuse-2.9.9-source.drv

- `fetchedSourceNameDefault = "full"`:

        $ nix-instantiate -A fuse.src
        /nix/store/<hash>-libfuse-2.9.9-github-source.drv

See documentation of `config.fetchedSourceNameDefault` for more info.