### PR TITLE
python312Packages.great-tables: init at 0.9.0

### DIFF
--- a/pkgs/development/python-modules/great-tables/default.nix
+++ b/pkgs/development/python-modules/great-tables/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  babel,
+  commonmark,
+  fetchFromGitHub,
+  htmltools,
+  importlib-metadata,
+  importlib-resources,
+  numpy,
+  pillow,
+  selenium,
+  setuptools,
+  setuptools-scm,
+  typing-extensions,
+}:
+
+buildPythonPackage rec {
+  pname = "great-tables";
+  version = "0.9.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "posit-dev";
+    repo = "great-tables";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-FLRuSqGKGKFbhj9t+iOm+E5oimkEzmmX3lqHYuJ6FU8=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    babel
+    commonmark
+    htmltools
+    importlib-metadata
+    importlib-resources
+    numpy
+    typing-extensions
+  ];
+
+  passthru.optional-dependencies = {
+    extra = [
+      pillow
+      selenium
+    ];
+  };
+
+  # need high version of polars
+  doCheck = false;
+
+  pythonImportsCheck = [ "great_tables" ];
+
+  meta = {
+    description = "Make awesome display tables using Python";
+    homepage = "https://github.com/posit-dev/great-tables";
+    changelog = "https://github.com/posit-dev/great-tables/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ moraxyc ];
+  };
+}

--- a/pkgs/development/python-modules/htmltools/default.nix
+++ b/pkgs/development/python-modules/htmltools/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  packaging,
+  typing-extensions,
+  pytestCheckHook,
+  syrupy,
+}:
+
+buildPythonPackage rec {
+  pname = "htmltools";
+  version = "0.5.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "posit-dev";
+    repo = "py-htmltools";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-H0M9dY8CNQAMEGEGHhPIWEYRmk4omCuVFgJUg8ef8Zw=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    packaging
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    syrupy
+  ];
+
+  pythonImportsCheck = [ "htmltools" ];
+
+  meta = {
+    description = "Tools for HTML generation and output";
+    homepage = "https://github.com/posit-dev/py-htmltools";
+    changelog = "https://github.com/posit-dev/py-htmltools/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ moraxyc ];
+  };
+}

--- a/pkgs/development/python-modules/plum-dispatch/default.nix
+++ b/pkgs/development/python-modules/plum-dispatch/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatch-vcs,
+  sybil,
+  numpy,
+  ipython,
+  hatchling,
+  beartype,
+  rich,
+  typing-extensions,
+  pytestCheckHook,
+  pytest-cov,
+}:
+
+buildPythonPackage rec {
+  pname = "plum-dispatch";
+  version = "2.4.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "beartype";
+    repo = "plum";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-q235pinc9B1YgA2/HUIldEwEO7uIgMg7lcd9Ogfd3LQ=";
+  };
+
+  build-system = [
+    hatch-vcs
+    hatchling
+  ];
+
+  dependencies = [
+    beartype
+    rich
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    sybil
+    numpy
+    ipython
+    pytestCheckHook
+    pytest-cov
+  ];
+
+  pythonImportsCheck = [ "plum" ];
+
+  meta = {
+    description = "Multiple dispatch in Python";
+    homepage = "https://github.com/beartype/plum";
+    changelog = "https://github.com/beartype/plum/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ moraxyc ];
+  };
+}

--- a/pkgs/development/python-modules/quartodoc/default.nix
+++ b/pkgs/development/python-modules/quartodoc/default.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  syrupy,
+  click,
+  griffe,
+  importlib-metadata,
+  importlib-resources,
+  plum-dispatch,
+  pydantic,
+  pyyaml,
+  sphobjinv,
+  tabulate,
+  typing-extensions,
+  watchdog,
+  pythonOlder,
+  pytestCheckHook,
+  fetchpatch2,
+}:
+
+buildPythonPackage rec {
+  pname = "quartodoc";
+  version = "0.7.2";
+  pyproject = true;
+
+  # requires when plum-dispatch > 2.00
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "machow";
+    repo = "quartodoc";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Cmn/eMnirdCT2zRgjzt/t5Cm9BWrbUjKavCj+auMY3w=";
+  };
+
+  patches = [
+    # fix: compatibility with griffe 0.39
+    # remove after next release
+    # see https://github.com/machow/quartodoc/commit/7b44cd229cabe90d34acf275e45e08054d0aea67
+    (fetchpatch2 {
+      name = "fix-griffe-0_39.patch";
+      url = "https://github.com/machow/quartodoc/commit/7b44cd229cabe90d34acf275e45e08054d0aea67.patch";
+      hash = "sha256-pxySsGVe9NQZOGX6S2qLZT7QAWkscEfkSMkXfFT6Ygo=";
+    })
+  ];
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    click
+    griffe
+    importlib-metadata
+    importlib-resources
+    plum-dispatch
+    pydantic
+    pyyaml
+    sphobjinv
+    tabulate
+    typing-extensions
+    watchdog
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    syrupy
+  ];
+
+  disabledTests = [
+    # failed when griffe >= 0.45.2
+    # see https://github.com/machow/quartodoc/issues/343
+    "test_func_resolve_alias"
+    "test_preview_warn_alias_no_load"
+  ];
+
+  pythonImportsCheck = [ "quartodoc" ];
+
+  meta = {
+    description = "Generate API documentation with quarto";
+    homepage = "https://github.com/machow/quartodoc";
+    license = lib.licenses.mit;
+    mainProgram = "quartodoc";
+    maintainers = with lib.maintainers; [ moraxyc ];
+  };
+}

--- a/pkgs/development/python-modules/shiny/default.nix
+++ b/pkgs/development/python-modules/shiny/default.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  buildPythonPackage,
+  appdirs,
+  asgiref,
+  click,
+  coverage,
+  fetchFromGitHub,
+  htmltools,
+  linkify-it-py,
+  markdown-it-py,
+  mdit-py-plugins,
+  packaging,
+  pandas,
+  playwright,
+  pytest-asyncio,
+  pytest-cov,
+  pytest-playwright,
+  pytest-rerunfailures,
+  pytest-timeout,
+  pytest-xdist,
+  pytestCheckHook,
+  python-multipart,
+  questionary,
+  setuptools,
+  starlette,
+  typing-extensions,
+  uvicorn,
+  watchfiles,
+  websockets,
+}:
+
+buildPythonPackage rec {
+  pname = "shiny";
+  version = "0.10.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "posit-dev";
+    repo = "py-shiny";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-s1j9bMAapO0iRXsuNxiwlNaVv2EoWcl9U7WnHwQe9n8=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  dependencies = [
+    appdirs
+    asgiref
+    click
+    htmltools
+    linkify-it-py
+    markdown-it-py
+    mdit-py-plugins
+    packaging
+    python-multipart
+    questionary
+    starlette
+    typing-extensions
+    uvicorn
+    watchfiles
+    websockets
+  ];
+
+  nativeCheckInputs = [
+    coverage
+    pandas
+    playwright
+    pytest-asyncio
+    pytest-cov
+    pytest-playwright
+    pytest-rerunfailures
+    pytest-timeout
+    pytest-xdist
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "shiny" ];
+
+  meta = {
+    description = "Shiny for Python";
+    homepage = "https://github.com/posit-dev/py-shiny";
+    changelog = "https://github.com/posit-dev/py-shiny/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "shiny";
+    maintainers = with lib.maintainers; [ moraxyc ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-removed-in/default.nix
+++ b/pkgs/development/python-modules/sphinx-removed-in/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+  sphinx,
+  defusedxml,
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-removed-in";
+  version = "0.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "MrSenko";
+    repo = "sphinx-removed-in";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-ygcKDWf7DDoOjTEio633/9O8RdKZo9CkU3yJPKWsVu8=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    sphinx
+    defusedxml
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "sphinx_removed_in" ];
+
+  meta = {
+    description = "versionremoved and removed-in directives for Sphinx";
+    homepage = "https://github.com/MrSenko/sphinx-removed-in";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ moraxyc ];
+  };
+}

--- a/pkgs/development/python-modules/sphobjinv/default.nix
+++ b/pkgs/development/python-modules/sphobjinv/default.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  buildPythonPackage,
+  attrs,
+  certifi,
+  codecov,
+  coverage,
+  dictdiffer,
+  fetchFromGitHub,
+  jsonschema,
+  md-toc,
+  pytest-check,
+  pytest-cov,
+  pytest-timeout,
+  pytestCheckHook,
+  setuptools,
+  sphinx,
+  sphinx-issues,
+  sphinx-removed-in,
+  sphinx-rtd-theme,
+  sphinxcontrib-programoutput,
+  stdio-mgr,
+}:
+
+buildPythonPackage rec {
+  pname = "sphobjinv";
+  version = "2.3.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bskinn";
+    repo = "sphobjinv";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-gz28WMVTL4mLeGJJdJAkByyeCONMf+VNLPZef7TrFg8=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    attrs
+    certifi
+    jsonschema
+  ];
+
+  nativeCheckInputs = [
+    codecov
+    coverage
+    dictdiffer
+    md-toc
+    pytest-check
+    pytest-cov
+    pytest-timeout
+    pytestCheckHook
+    sphinx
+    sphinx-issues
+    sphinx-removed-in
+    sphinx-rtd-theme
+    sphinxcontrib-programoutput
+    stdio-mgr
+  ];
+
+  preCheck = ''
+    export PATH=$out/bin:$PATH
+  '';
+
+  pythonImportsCheck = [ "sphobjinv" ];
+
+  meta = {
+    description = "Toolkit for manipulation and inspection of Sphinx objects.inv files";
+    homepage = "https://github.com/bskinn/sphobjinv";
+    changelog = "https://github.com/bskinn/sphobjinv/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "sphobjinv";
+    maintainers = with lib.maintainers; [ moraxyc ];
+  };
+}

--- a/pkgs/development/python-modules/stdio-mgr/default.nix
+++ b/pkgs/development/python-modules/stdio-mgr/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  attrs,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "stdio-mgr";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bskinn";
+    repo = "stdio-mgr";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-LLp4AmUfuYUX/gHK7Qwge1ib3DBsmxdhFybIo9M5ZnU=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ attrs ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [
+    # README test failed
+    "README.rst"
+  ];
+
+  pythonImportsCheck = [ "stdio_mgr" ];
+
+  meta = {
+    description = "Context manager for mocking/wrapping stdin/stdout/stderr";
+    homepage = "https://www.github.com/bskinn/stdio-mgr";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ moraxyc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10245,6 +10245,8 @@ self: super: with self; {
 
   plugwise = callPackage ../development/python-modules/plugwise { };
 
+  plum-dispatch = callPackage ../development/python-modules/plum-dispatch { };
+
   plum-py = callPackage ../development/python-modules/plum-py { };
 
   plumbum = callPackage ../development/python-modules/plumbum { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14450,6 +14450,8 @@ self: super: with self; {
 
   sphinx-mdinclude = callPackage ../development/python-modules/sphinx-mdinclude { };
 
+  sphinx-removed-in = callPackage ../development/python-modules/sphinx-removed-in { };
+
   sphinx-rtd-dark-mode = callPackage ../development/python-modules/sphinx-rtd-dark-mode { };
 
   sphinx-rtd-theme = callPackage ../development/python-modules/sphinx-rtd-theme { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13914,6 +13914,8 @@ self: super: with self; {
 
   shimmy = callPackage ../development/python-modules/shimmy { };
 
+  shiny = callPackage ../development/python-modules/shiny { };
+
   shippai = callPackage ../development/python-modules/shippai { };
 
   shiv = callPackage ../development/python-modules/shiv { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5151,6 +5151,8 @@ self: super: with self; {
 
   greatfet = callPackage ../development/python-modules/greatfet { };
 
+  great-tables = callPackage ../development/python-modules/great-tables { };
+
   greeclimate = callPackage ../development/python-modules/greeclimate { };
 
   green = callPackage ../development/python-modules/green { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5509,6 +5509,8 @@ self: super: with self; {
 
   htmlmin = callPackage ../development/python-modules/htmlmin { };
 
+  htmltools = callPackage ../development/python-modules/htmltools { };
+
   html-sanitizer = callPackage ../development/python-modules/html-sanitizer { };
 
   html-tag-names = callPackage ../development/python-modules/html-tag-names { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12997,6 +12997,8 @@ self: super: with self; {
 
   quart = callPackage ../development/python-modules/quart { };
 
+  quartodoc = callPackage ../development/python-modules/quartodoc { };
+
   quart-cors = callPackage ../development/python-modules/quart-cors { };
 
   quaternion = callPackage ../development/python-modules/quaternion { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14306,6 +14306,8 @@ self: super: with self; {
 
   sphfile = callPackage ../development/python-modules/sphfile { };
 
+  sphobjinv = callPackage ../development/python-modules/sphobjinv { };
+
   spiderpy = callPackage ../development/python-modules/spiderpy { };
 
   spinners = callPackage ../development/python-modules/spinners { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14608,6 +14608,8 @@ self: super: with self; {
 
   stdiomask = callPackage ../development/python-modules/stdiomask { };
 
+  stdio-mgr = callPackage ../development/python-modules/stdio-mgr { };
+
   stdlib-list = callPackage ../development/python-modules/stdlib-list { };
 
   stdlibs = callPackage ../development/python-modules/stdlibs { };


### PR DESCRIPTION
## Description of changes

- **python312Packages.stdio-mgr: init at 1.0.1**
- **python312Packages.sphinx-removed-in: init at 0.2.2**
- **python312Packages.sphobjinv: init at 2.3.1.1**
- **python312Packages.shiny: init at 0.10.2**
- **python312Packages.plum-dispatch: init at 2.4.1**
- **python312Packages.quartodoc: init at 0.7.2**
- **python312Packages.htmltools: init at 0.5.2**
- **python312Packages.great-tables: init at 0.9.0**

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
