### PR TITLE
release: disallow aliases

### DIFF
--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -27,13 +27,6 @@ let
     then removeAttrs alias [ "recurseForDerivations" ]
     else alias;
 
-  # Disabling distribution prevents top-level aliases for non-recursed package
-  # sets from building on Hydra.
-  removeDistribute = alias: with lib;
-    if isDerivation alias then
-      dontDistribute alias
-    else alias;
-
   # Make sure that we are not shadowing something from all-packages.nix.
   checkInPkgs = n: alias:
     if builtins.hasAttr n super
@@ -43,9 +36,8 @@ let
   mapAliases = aliases:
     lib.mapAttrs
       (n: alias:
-        removeDistribute
-          (removeRecurseForDerivations
-            (checkInPkgs n alias)))
+        removeRecurseForDerivations
+          (checkInPkgs n alias))
       aliases;
 in
 

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -17,7 +17,13 @@
 , # Strip most of attributes when evaluating to spare memory usage
   scrubJobs ? true
 , # Attributes passed to nixpkgs. Don't build packages marked as unfree.
-  nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
+  nixpkgsArgs ? {
+    config = {
+      allowAliases = false;
+      allowUnfree = false;
+      inHydra = true;
+    };
+  }
 }:
 
 let

--- a/pkgs/top-level/release-cuda.nix
+++ b/pkgs/top-level/release-cuda.nix
@@ -15,7 +15,13 @@
     "x86_64-linux"
   ]
 , # Attributes passed to nixpkgs.
-  nixpkgsArgs ? { config = { allowUnfree = true; inHydra = true; }; }
+  nixpkgsArgs ? {
+    config = {
+      allowAliases = false;
+      allowUnfree = true;
+      inHydra = true;
+    };
+  }
 }:
 
 let

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -2,7 +2,13 @@
 , packageSet ? (import ../..)
 , scrubJobs ? true
 , # Attributes passed to nixpkgs. Don't build packages marked as unfree.
-  nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
+  nixpkgsArgs ? {
+    config = {
+      allowAliases = false;
+      allowUnfree = false;
+      inHydra = true;
+    };
+  }
 }:
 
 let

--- a/pkgs/top-level/release-python.nix
+++ b/pkgs/top-level/release-python.nix
@@ -10,6 +10,7 @@
   ]
 , # Attributes passed to nixpkgs. Don't build packages marked as unfree.
   nixpkgsArgs ? { config = {
+    allowAliases = false;
     allowUnfree = false;
     inHydra = true;
     permittedInsecurePackages = [

--- a/pkgs/top-level/release-small.nix
+++ b/pkgs/top-level/release-small.nix
@@ -4,7 +4,13 @@
 { nixpkgs ? { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
 , supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
 , # Attributes passed to nixpkgs. Don't build packages marked as unfree.
-  nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
+  nixpkgsArgs ? {
+    config = {
+      allowAliases = false;
+      allowUnfree = false;
+      inHydra = true;
+    };
+  }
 }:
 
 let

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -26,6 +26,7 @@
 , scrubJobs ? true
   # Attributes passed to nixpkgs. Don't build packages marked as unfree.
 , nixpkgsArgs ? { config = {
+    allowAliases = false;
     allowUnfree = false;
     inHydra = true;
     permittedInsecurePackages = [


### PR DESCRIPTION
## Description of changes

Having multiple attributes point to the same derivation [makes debugging harder](https://discourse.nixos.org/t/rant-finding-errors-in-module-configs-after-incompatible-upgrades-is-dreadful/46375/3) because you often cannot just grep the canonical attribute name. It is even annoying when multiple aliases are chained.

Having Hydra build aliases is [recognized as redundant](https://github.com/NixOS/nixpkgs/commit/2d0a7c4eeecd22f26eb37f6077a0397c32250375) so let’s do the same with their evaluation.

This commit will make Hydra ignore aliases when evaluating.

A nice benefit of this is that it will allow us to warn users when an attribute is renamed, to assist them with early migration. Since tracing messages during evaluation are not allowed because of Hydra, we can currently only choose between having a silent alias and throwing.

This was last attempted in 2018 but ended up being [reverted](https://github.com/NixOS/nixpkgs/commit/8c025c67d5a151055ef63d2b0d94921604ff0f62) because of widespread use of aliases that was not caught by CI. CI has since been [improved](https://github.com/NixOS/ofborg/pull/645).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
