### PR TITLE
dediprog-sf100: init at 1.14.20.x

### DIFF
--- a/pkgs/by-name/de/dediprog-sf100/package.nix
+++ b/pkgs/by-name/de/dediprog-sf100/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  pkgs,
+  stdenv,
+  fetchFromGitHub,
+  libusb1,
+  pkg-config,
+}:
+
+let
+  dediprogVersion = "1.14.20.x";
+  dediprogHash = "sha256-hQvBZIwaWEC41vj2flaekIUP9Fwtj/JPi3XwRxfUbD0=";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dediprog-sf100-linux";
+  version = finalAttrs.dediprogVersion;
+
+  inherit dediprogVersion dediprogHash;
+
+  src = fetchFromGitHub {
+    owner = "DediProgSW";
+    repo = "SF100Linux";
+    rev = "V${finalAttrs.dediprogVersion}";
+    hash = finalAttrs.dediprogHash;
+  };
+
+  buildInputs = [ libusb1 ];
+  nativeBuildInputs = [ pkg-config ];
+
+  udevRules = pkgs.writeText "dediprog.rules" ''
+    ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="dada", MODE="660", GROUP="plugdev"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm0755 ./dpcmd -t $out/bin
+    install -Dm0644 ./ChipInfoDb.dedicfg -t $out/share/DediProg
+    install -Dm0644 ${finalAttrs.udevRules} -D $out/lib/udev/rules.d/60-dediprog.rules
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/DediProgSW/SF100Linux";
+    description = "Linux software for DediProg SF100/SF600 programmers";
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ thillux ];
+  };
+})


### PR DESCRIPTION
DediProg produces SPI-based flash chip programmers which are rather common in the hardware/embedded space.

Add support for their linux-based programming driver.

See: https://github.com/DediProgSW/SF100Linux

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
