### PR TITLE
goodvibes: 0.7.9 -> 0.8.0

### DIFF
--- a/pkgs/applications/audio/goodvibes/default.nix
+++ b/pkgs/applications/audio/goodvibes/default.nix
@@ -1,13 +1,14 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, fetchpatch
 , meson
 , ninja
 , pkg-config
 , glib
 , glib-networking
 , gtk3
-, libsoup
+, libsoup_3
 , keybinder3
 , gst_all_1
 , wrapGAppsHook3
@@ -17,14 +18,21 @@
 
 stdenv.mkDerivation rec {
   pname = "goodvibes";
-  version = "0.7.9";
+  version = "0.8.0";
 
   src = fetchFromGitLab {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-yXrCE3nsdZP4JHKVslzQafjZ380zC8sZv5TJf8dJqJw=";
+    hash = "sha256-KflLEc6BFA3pBY9HukEm5NluGi2igFNP6joOMdmZ0Ds=";
   };
+  patches = [
+    # Fixes a compilation error
+    (fetchpatch {
+      url = "https://gitlab.com/goodvibes/goodvibes/-/commit/e332f831b91ee068a1a58846d7607b30ab010116.patch";
+      hash = "sha256-PzbTltbD0xWJAytCGg1TAwBLrICP+9QZbCbG1QQ8Qmw=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson
@@ -40,7 +48,7 @@ stdenv.mkDerivation rec {
     # for libsoup TLS support
     glib-networking
     gtk3
-    libsoup
+    libsoup_3
     keybinder3
   ] ++ (with gst_all_1; [
     gstreamer


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
