### PR TITLE
asfa: init at 0.10.0

### DIFF
--- a/pkgs/by-name/as/asfa/package.nix
+++ b/pkgs/by-name/as/asfa/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenv,
+  darwin,
+  help2man,
+  openssl,
+  pkg-config,
+  installShellFiles,
+}:
+let
+  version = "0.10.0";
+  src = fetchFromGitHub {
+    owner = "obreitwi";
+    repo = "asfa";
+    rev = "v${version}";
+    hash = "sha256-MnhnwtZmPFhOuiqNiaxJnPu88JOdlpvyVy0YGphblBc=";
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "asfa";
+  inherit version src;
+
+  cargoHash = "sha256-/bRBP/NzcNOXl/nANeOYouUAo3NNbtbV9fxIJrNajYQ=";
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  buildInputs = [
+    openssl
+  ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.SystemConfiguration ];
+
+  nativeBuildInputs = [
+    help2man
+    installShellFiles
+    pkg-config
+  ];
+
+  # checks disabled because tests need to be run against (docker-based) ephemeral ssh-server
+  doCheck = false;
+
+  postInstall = ''
+    mkdir -p "man/man1"
+    help2man -o "man/man1/asfa.1" "$out/bin/asfa"
+
+    # Generate info about all subcommands except for 'help' (which leads to error)
+    "$out/bin/asfa" --help | awk 'enabled && $1 != "help" { print $1 } /^SUBCOMMANDS:$/ { enabled=1 }' \
+        | while read -r cmd; do
+        help2man \
+            "--version-string=${version}" \
+            -o "man/man1/asfa-$cmd.1" \
+            "$out/bin/asfa $cmd"
+    done
+
+    installManPage man/man1/*.1
+  '';
+
+  meta = {
+    description = "Avoid sending file attachments by uploading them via SSH to a remote site and sharing a publicly-accessible URL with non-guessable (hash-based) prefix instead";
+    homepage = "https://github.com/obreitwi/asfa";
+    changelog = "https://github.com/obreitwi/asfa/blob/${src.rev}/CHANGELOG.md";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ obreitwi ];
+    mainProgram = "asfa";
+  };
+}


### PR DESCRIPTION
## Description of changes

* add new package: [asfa](https://crates.io/crates/asfa) at latest version

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`), also [working my personal setup](f06e5d3592d8e7d061067acf61613832ef2750b9)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
