### PR TITLE
python312Packages.import-expression: 1.1.5 -> 2.0.0; python312Packages.jishaku: 2.5.2 -> 2.5.1-unstable-2024-05-29

### DIFF
--- a/pkgs/development/python-modules/import-expression/default.nix
+++ b/pkgs/development/python-modules/import-expression/default.nix
@@ -4,29 +4,26 @@
   fetchPypi,
   fetchpatch,
   pytestCheckHook,
-  astunparse,
   setuptools,
+  typing-extensions,
 }:
 buildPythonPackage rec {
   pname = "import-expression";
-  version = "1.1.5";
+  version = "2.0.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit version;
     pname = "import_expression";
-    hash = "sha256-mVlYj8/I3LFEoHJRds/vbCjH2x/C1oNiUCXmh1FtQME=";
+    hash = "sha256-Biw7dIOPKbDcqYJSCyeqC/seREcVihSZuaKNFfgjTew=";
   };
 
   build-system = [ setuptools ];
-  dependencies = [ astunparse ];
+  dependencies = [ typing-extensions ];
   nativeCheckInputs = [ pytestCheckHook ];
   pytestFlagsArray = [ "tests.py" ];
 
-  pythonImportsCheck = [
-    "import_expression"
-    "import_expression._codec"
-  ];
+  pythonImportsCheck = [ "import_expression" ];
 
   meta = {
     description = "Transpiles a superset of python to allow easy inline imports";

--- a/pkgs/development/python-modules/jishaku/default.nix
+++ b/pkgs/development/python-modules/jishaku/default.nix
@@ -3,7 +3,6 @@
   bash,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   setuptools,
   discordpy,
   click,
@@ -13,26 +12,20 @@
   pytestCheckHook,
   pytest-asyncio,
   youtube-dl,
+  unstableGitUpdater,
 }:
+
 buildPythonPackage rec {
   pname = "jishaku";
-  version = "2.5.2";
+  version = "2.5.1-unstable-2024-05-29";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Gorialis";
-    repo = pname;
-    rev = "refs/tags/${version}";
-    hash = "sha256-BWnuk6h80cKwRECyTuRvnYnTC78219oraeTNoqWDd1c=";
+    repo = "jishaku";
+    rev = "f68f4395cc58fca247b86967b52b35d95f2b7cd3";
+    hash = "sha256-1FBQNUC+qXBHWcY/7h2Rvw1anTD5BTYY/yAm+QnBlaQ=";
   };
-
-  patches = [
-    (fetchpatch {
-      # add entrypoint for install script
-      url = "https://github.com/Gorialis/jishaku/commit/b96cd55a1c2fd154c548f08019ccd6f7be9c7f90.patch";
-      hash = "sha256-laPoupwCC1Zthib8G+c1BXqTwZK0Z6up1DKVkhFicJ0=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace jishaku/shell.py \
@@ -60,6 +53,8 @@ buildPythonPackage rec {
     "jishaku.repl"
     "jishaku.features"
   ];
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "A debugging and testing cog for discord.py bots";


### PR DESCRIPTION
## Description of changes

- **python312Packages.import-expression: 1.1.5 -> 2.0.0**
- **python312Packages.jishaku: 2.5.2 -> 2.5.1-unstable-2024-05-29** - this is **not** a downgrade, upstream just managed their tags weirdly.

Alternative to #315235

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
