### PR TITLE
github/labeler.yml: add dotnet label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,6 +16,17 @@
         - nixos/modules/services/x11/desktop-managers/cinnamon.nix
         - nixos/tests/cinnamon.nix
 
+"6.topic: dotnet":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/languages-frameworks/dotnet.section.md
+        - maintainers/scripts/update-dotnet-lockfiles.nix
+        - pkgs/build-support/dotnet/**/*
+        - pkgs/development/compilers/dotnet/**/*
+        - pkgs/test/dotnet/**/*
+        - pkgs/top-level/dotnet-packages.nix
+
 "6.topic: emacs":
   - any:
     - changed-files:


### PR DESCRIPTION
github/labeler.yml: add dotnet label

Auto-labels dotnet files with dotnet tag at GitHub.

Dotnet activity:
* PRs: https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+dotnet
* Issues: https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+dotnet+

CC @IvarWithoutBones @ratsclub @jonringer