### PR TITLE
texlivePackages: fix symlimk creation condition

### DIFF
--- a/doc/languages-frameworks/texlive.section.md
+++ b/doc/languages-frameworks/texlive.section.md
@@ -83,12 +83,13 @@ Release 23.11 ships with a new interface that will eventually replace `texlive.c
   ```nix
   stdenvNoCC.mkDerivation rec {
     src = texlive.pkgs.iwona;
+    dontUnpack = true;
 
     inherit (src) pname version;
 
     installPhase = ''
       runHook preInstall
-      install -Dm644 fonts/opentype/nowacki/iwona/*.otf -t $out/share/fonts/opentype
+      install -Dm644 $src/fonts/opentype/nowacki/iwona/*.otf -t $out/share/fonts/opentype
       runHook postInstall
     '';
   }

--- a/pkgs/data/fonts/iwona/default.nix
+++ b/pkgs/data/fonts/iwona/default.nix
@@ -4,11 +4,12 @@ stdenvNoCC.mkDerivation rec {
   inherit (src) pname version;
 
   src = texlive.pkgs.iwona;
+  dontUnpack = true;
 
   installPhase = ''
     runHook preInstall
 
-    install -Dm644 fonts/opentype/nowacki/iwona/*.otf -t $out/share/fonts/opentype
+    install -Dm644 $src/fonts/opentype/nowacki/iwona/*.otf -t $out/share/fonts/opentype
 
     runHook postInstall
   '';

--- a/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
@@ -233,7 +233,7 @@ let
     # if the container is missing (that is, outputs == [ ]), create a file, to prevent passing the package to .withPackages
     ''
       for outputName in ''${!outputs[@]} ; do
-        if [[ -z ''${outputDrvs[$outputName]} ]] ; then
+        if [[ -n ''${outputDrvs[$outputName]} ]] ; then
           ln -s "''${outputDrvs[$outputName]}" "''${outputs[$outputName]}"
         else
           touch "''${outputs[$outputName]}"


### PR DESCRIPTION
## Description of changes

Use -n to check that string is not empty, -z checks the opposite.

Seems to be a regression introduced in #311134

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
