### PR TITLE
pinentry: 1.2.1 -> 1.3.0

### DIFF
--- a/pkgs/tools/security/pinentry/default.nix
+++ b/pkgs/tools/security/pinentry/default.nix
@@ -1,23 +1,27 @@
-{ stdenv
-, lib
-, fetchurl
-, fetchpatch
-, pkg-config
-, autoreconfHook
-, wrapGAppsHook3
-, libgpg-error
-, libassuan
-, libsForQt5
-, ncurses
-, gtk2
-, gcr
-, withLibsecret ? true
-, libsecret
+{
+  stdenv,
+  lib,
+  fetchurl,
+  fetchpatch,
+  pkg-config,
+  autoreconfHook,
+  wrapGAppsHook3,
+  libgpg-error,
+  libassuan,
+  libsForQt5,
+  qt6,
+  ncurses,
+  gtk2,
+  gcr,
+  withLibsecret ? true,
+  libsecret,
 }:
 
 let
   flavorInfo = {
-    tty = { flag = "tty"; };
+    tty = {
+      flag = "tty";
+    };
     curses = {
       flag = "curses";
       buildInputs = [ ncurses ];
@@ -31,52 +35,70 @@ let
       buildInputs = [ gcr ];
       nativeBuildInputs = [ wrapGAppsHook3 ];
     };
-    qt = {
-      flag = "qt";
-      buildInputs = [ libsForQt5.qtbase ];
+    qt5 = {
+      flag = "qt5";
+      buildInputs = [
+        libsForQt5.qtbase
+        libsForQt5.kwayland
+        libsForQt5.qtx11extras
+      ];
       nativeBuildInputs = [ libsForQt5.wrapQtAppsHook ];
     };
-    emacs = { flag = "emacs"; };
+    qt = {
+      flag = "qt";
+      buildInputs = [
+        qt6.qtbase
+        qt6.qtwayland
+      ];
+      nativeBuildInputs = [ qt6.wrapQtAppsHook ];
+    };
+    emacs = {
+      flag = "emacs";
+    };
   };
 
-  buildPinentry = pinentryExtraPname: buildFlavors:
+  buildPinentry =
+    pinentryExtraPname: buildFlavors:
     let
-      enableFeaturePinentry = f:
-        lib.enableFeature (lib.elem f buildFlavors) ("pinentry-" + flavorInfo.${f}.flag);
+      enableFeaturePinentry =
+        f: lib.enableFeature (lib.elem f buildFlavors) ("pinentry-" + flavorInfo.${f}.flag);
 
       pinentryMkDerivation =
-        if (lib.elem "qt" buildFlavors)
-        then libsForQt5.mkDerivation
-        else stdenv.mkDerivation;
-
+        if (lib.elem "qt5" buildFlavors) then libsForQt5.mkDerivation else stdenv.mkDerivation;
     in
     pinentryMkDerivation rec {
       pname = "pinentry-${pinentryExtraPname}";
-      version = "1.2.1";
+      version = "1.3.0";
 
       src = fetchurl {
         url = "mirror://gnupg/pinentry/pinentry-${version}.tar.bz2";
-        hash = "sha256-RXoYXlqFI4+5RalV3GNSq5YtyLSHILYvyfpIx1QKQGc=";
+        hash = "sha256-mzzVIm51l/L97TmaO8ZZkjNRU2VZ6dsIJpgbyjFklN4=";
       };
 
-      nativeBuildInputs = [ pkg-config autoreconfHook ]
-        ++ lib.concatMap (f: flavorInfo.${f}.nativeBuildInputs or [ ]) buildFlavors;
+      nativeBuildInputs = [
+        pkg-config
+        autoreconfHook
+      ] ++ lib.concatMap (f: flavorInfo.${f}.nativeBuildInputs or [ ]) buildFlavors;
 
-      buildInputs = [ libgpg-error libassuan ]
+      buildInputs =
+        [
+          libgpg-error
+          libassuan
+        ]
         ++ lib.optional withLibsecret libsecret
         ++ lib.concatMap (f: flavorInfo.${f}.buildInputs or [ ]) buildFlavors;
 
       dontWrapGApps = true;
       dontWrapQtApps = true;
 
-      patches = [
-        ./autoconf-ar.patch
-      ] ++ lib.optionals (lib.elem "gtk2" buildFlavors) [
-        (fetchpatch {
-          url = "https://salsa.debian.org/debian/pinentry/raw/debian/1.1.0-1/debian/patches/0007-gtk2-When-X11-input-grabbing-fails-try-again-over-0..patch";
-          sha256 = "15r1axby3fdlzz9wg5zx7miv7gqx2jy4immaw4xmmw5skiifnhfd";
-        })
-      ];
+      patches =
+        [ ./autoconf-ar.patch ]
+        ++ lib.optionals (lib.elem "gtk2" buildFlavors) [
+          (fetchpatch {
+            url = "https://salsa.debian.org/debian/pinentry/raw/debian/1.1.0-1/debian/patches/0007-gtk2-When-X11-input-grabbing-fails-try-again-over-0..patch";
+            sha256 = "15r1axby3fdlzz9wg5zx7miv7gqx2jy4immaw4xmmw5skiifnhfd";
+          })
+        ];
 
       configureFlags = [
         "--with-libgpg-error-prefix=${libgpg-error.dev}"
@@ -87,35 +109,76 @@ let
       postInstall =
         lib.optionalString (lib.elem "gnome3" buildFlavors) ''
           wrapGApp $out/bin/pinentry-gnome3
-        '' + lib.optionalString (lib.elem "qt" buildFlavors) ''
+        ''
+        + lib.optionalString (lib.elem "qt5" buildFlavors) ''
+          wrapQtApp $out/bin/pinentry-qt5
+          ln -sf $out/bin/pinentry-qt5 $out/bin/pinentry-qt
+        ''
+        + lib.optionalString (lib.elem "qt" buildFlavors) ''
           wrapQtApp $out/bin/pinentry-qt
         '';
 
-      passthru = { flavors = buildFlavors; };
+      passthru = {
+        flavors = buildFlavors;
+      };
 
-      meta = with lib; {
+      meta = {
         homepage = "https://gnupg.org/software/pinentry/index.html";
         description = "GnuPG’s interface to passphrase input";
-        license = licenses.gpl2Plus;
+        license = lib.licenses.gpl2Plus;
         platforms =
-          if elem "gnome3" buildFlavors then platforms.linux else
-          if elem "qt" buildFlavors then (remove "aarch64-darwin" platforms.all) else
-          platforms.all;
+          if lib.elem "gnome3" buildFlavors then
+            lib.platforms.linux
+          else if (lib.elem "qt5" buildFlavors || lib.elem "qt" buildFlavors) then
+            (lib.remove "aarch64-darwin" lib.platforms.all)
+          else
+            lib.platforms.all;
         longDescription = ''
           Pinentry provides a console and (optional) GTK and Qt GUIs allowing users
           to enter a passphrase when `gpg` or `gpg2` is run and needs it.
         '';
-        maintainers = with maintainers; [ fpletz ];
+        maintainers = with lib.maintainers; [ fpletz ];
         mainProgram = "pinentry";
       };
     };
 in
 {
-  pinentry-curses = buildPinentry "curses" [ "curses" "tty" ];
-  pinentry-emacs = buildPinentry "emacs" [ "emacs" "curses" "tty" ];
-  pinentry-gnome3 = buildPinentry "gnome3" [ "gnome3" "curses" "tty" ];
-  pinentry-gtk2 = buildPinentry "gtk2" [ "gtk2" "curses" "tty" ];
-  pinentry-qt = buildPinentry "qt" [ "qt" "curses" "tty" ];
+  pinentry-curses = buildPinentry "curses" [
+    "curses"
+    "tty"
+  ];
+  pinentry-emacs = buildPinentry "emacs" [
+    "emacs"
+    "curses"
+    "tty"
+  ];
+  pinentry-gnome3 = buildPinentry "gnome3" [
+    "gnome3"
+    "curses"
+    "tty"
+  ];
+  pinentry-gtk2 = buildPinentry "gtk2" [
+    "gtk2"
+    "curses"
+    "tty"
+  ];
+  pinentry-qt5 = buildPinentry "qt5" [
+    "qt5"
+    "curses"
+    "tty"
+  ];
+  pinentry-qt = buildPinentry "qt" [
+    "qt"
+    "curses"
+    "tty"
+  ];
   pinentry-tty = buildPinentry "tty" [ "tty" ];
-  pinentry-all = buildPinentry "all" [ "curses" "tty" "gtk2" "gnome3" "qt" "emacs" ];
+  pinentry-all = buildPinentry "all" [
+    "curses"
+    "tty"
+    "gtk2"
+    "gnome3"
+    "qt"
+    "emacs"
+  ];
 }


### PR DESCRIPTION
## Description of changes

https://dev.gnupg.org/T7046

Adds support for qt6 in addition to qt5.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
