### PR TITLE
yazi: fix plugins and flavors config

### DIFF
--- a/pkgs/by-name/ya/yazi/package.nix
+++ b/pkgs/by-name/ya/yazi/package.nix
@@ -58,14 +58,14 @@ let
 
     mkdir $out/plugins
     ${lib.optionalString (plugins != { }) ''
-        ${lib.concatMapStringsSep
+        ${lib.concatStringsSep
         "\n"
         (lib.mapAttrsToList (name: value: "ln -s ${value} $out/plugins/${name}") plugins)}
     ''}
 
     mkdir $out/flavors
     ${lib.optionalString (flavors != { }) ''
-        ${lib.concatMapStringsSep
+        ${lib.concatStringsSep
         "\n"
         (lib.mapAttrsToList (name: value: "ln -s ${value} $out/flavors/${name}") flavors)}
     ''}


### PR DESCRIPTION
Tried to install yazi with plugins, failed, discovered a typo of ```concatMapStringsSep``` instead of ```concatStringsSep``` in the package that makes build fail when plugins or flavors options are not default empty sets