### PR TITLE
nixos/networkmanager: split modemmanager into a separate module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -28,6 +28,8 @@
 
 - [MaryTTS](https://github.com/marytts/marytts), an open-source, multilingual text-to-speech synthesis system written in pure Java. Available as [services.marytts](options.html#opt-services.marytts).
 
+- [networking.modemmanager](options.html#opt-networking.modemmanager) has been split out of [networking.networkmanager](options.html#opt-networking.networkmanager). NetworkManager still enables ModemManager by default, but options exist now to run NetworkManager without ModemManager.
+
 - [Conduwuit](https://conduwuit.puppyirl.gay/), a federated chat server implementing the Matrix protocol, forked from Conduit. Available as [services.conduwuit](#opt-services.conduwuit.enable).
 
 - [Traccar](https://www.traccar.org/), a modern GPS Tracking Platform. Available as [services.traccar](#opt-services.traccar.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1135,6 +1135,7 @@
   ./services/networking/miredo.nix
   ./services/networking/mjpg-streamer.nix
   ./services/networking/mmsd.nix
+  ./services/networking/modemmanager.nix
   ./services/networking/monero.nix
   ./services/networking/morty.nix
   ./services/networking/mosquitto.nix

--- a/nixos/modules/services/networking/modemmanager.nix
+++ b/nixos/modules/services/networking/modemmanager.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   cfg = config.networking.modemmanager;
 in
@@ -19,6 +24,8 @@ in
           connectivity (e.g. GPS).
         '';
       };
+
+      package = mkPackageOption pkgs "modemmanager" { };
 
       fccUnlockScripts = mkOption {
         type = types.listOf (
@@ -82,9 +89,9 @@ in
       });
     '';
 
-    environment.systemPackages = [ pkgs.modemmanager ];
-    systemd.packages = [ pkgs.modemmanager ];
-    services.dbus.packages = [ pkgs.modemmanager ];
-    services.udev.packages = [ pkgs.modemmanager ];
+    environment.systemPackages = [ cfg.package ];
+    systemd.packages = [ cfg.package ];
+    services.dbus.packages = [ cfg.package ];
+    services.udev.packages = [ cfg.package ];
   };
 }

--- a/nixos/modules/services/networking/modemmanager.nix
+++ b/nixos/modules/services/networking/modemmanager.nix
@@ -1,0 +1,90 @@
+{ config, lib, ... }:
+let
+  cfg = config.networking.modemmanager;
+in
+{
+  meta = {
+    maintainers = lib.teams.freedesktop.members;
+  };
+
+  options = with lib; {
+    networking.modemmanager = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to use ModemManager to manage modem devices.
+          This is usually used by some higher layer manager such as NetworkManager
+          but can be used standalone especially if using a modem for non-IP
+          connectivity (e.g. GPS).
+        '';
+      };
+
+      fccUnlockScripts = mkOption {
+        type = types.listOf (
+          types.submodule {
+            options = {
+              id = mkOption {
+                type = types.str;
+                description = "vid:pid of either the PCI or USB vendor and product ID";
+              };
+              path = mkOption {
+                type = types.path;
+                description = "Path to the unlock script";
+              };
+            };
+          }
+        );
+        default = [ ];
+        example = literalExpression ''[{ id = "03f0:4e1d"; path = "''${pkgs.modemmanager}/share/ModemManager/fcc-unlock.available.d/03f0:4e1d"; }]'';
+        description = ''
+          List of FCC unlock scripts to enable on the system, behaving as described in
+          https://modemmanager.org/docs/modemmanager/fcc-unlock/#integration-with-third-party-fcc-unlock-tools.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.etc = builtins.listToAttrs (
+      map (
+        e:
+        lib.nameValuePair "ModemManager/fcc-unlock.d/${e.id}" {
+          source = e.path;
+        }
+      ) cfg.fccUnlockScripts
+    );
+
+    systemd.services.ModemManager = {
+      aliases = [ "dbus-org.freedesktop.ModemManager1.service" ];
+      path = lib.optionals (cfg.fccUnlockScripts != [ ]) [
+        pkgs.libqmi
+        pkgs.libmbim
+      ];
+    };
+
+    /*
+      [modem-manager]
+      Identity=unix-group:networkmanager
+      Action=org.freedesktop.ModemManager*
+      ResultAny=yes
+      ResultInactive=no
+      ResultActive=yes
+    */
+    security.polkit.enable = true;
+    security.polkit.extraConfig = ''
+      polkit.addRule(function(action, subject) {
+        if (
+          subject.isInGroup("networkmanager")
+          && action.id.indexOf("org.freedesktop.ModemManager") == 0
+          )
+            { return polkit.Result.YES; }
+      });
+    '';
+
+    environment.systemPackages = [ pkgs.modemmanager ];
+    systemd.packages = [ pkgs.modemmanager ];
+    services.dbus.packages = [ pkgs.modemmanager ];
+    services.udev.packages = [ pkgs.modemmanager ];
+  };
+}

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -129,7 +129,7 @@ let
 
   packages =
     [
-      pkgs.networkmanager
+      cfg.package
     ]
     ++ cfg.plugins
     ++ lib.optionals (!delegateWireless && !enableIwd) [
@@ -160,6 +160,8 @@ in
           to change network settings to this group.
         '';
       };
+
+      package = mkPackageOption pkgs "networkmanager" { };
 
       connectionConfig = mkOption {
         type =
@@ -643,7 +645,7 @@ in
           ${pkgs.envsubst}/bin/envsubst -i ${ini.generate (lib.escapeShellArg profile.n) profile.v} > ${path (lib.escapeShellArg profile.n)}
         '') (lib.mapAttrsToList (n: v: { inherit n v; }) cfg.ensureProfiles.profiles)
         + ''
-          ${pkgs.networkmanager}/bin/nmcli connection reload
+          ${cfg.package}/bin/nmcli connection reload
         '';
       serviceConfig = {
         EnvironmentFile = cfg.ensureProfiles.environmentFiles;

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 with lib;
 
@@ -15,14 +20,10 @@ let
       plugins = "keyfile";
       inherit (cfg) dhcp dns;
       # If resolvconf is disabled that means that resolv.conf is managed by some other module.
-      rc-manager =
-        if config.networking.resolvconf.enable then "resolvconf"
-        else "unmanaged";
+      rc-manager = if config.networking.resolvconf.enable then "resolvconf" else "unmanaged";
     };
     keyfile = {
-      unmanaged-devices =
-      if cfg.unmanaged == [ ] then null
-      else lib.concatStringsSep ";" cfg.unmanaged;
+      unmanaged-devices = if cfg.unmanaged == [ ] then null else lib.concatStringsSep ";" cfg.unmanaged;
     };
     logging = {
       audit = config.security.audit.enable;
@@ -30,8 +31,8 @@ let
     };
     connection = cfg.connectionConfig;
     device = {
-        "wifi.scan-rand-mac-address" = cfg.wifi.scanRandMacAddress;
-        "wifi.backend" = cfg.wifi.backend;
+      "wifi.scan-rand-mac-address" = cfg.wifi.scanRandMacAddress;
+      "wifi.backend" = cfg.wifi.backend;
     };
   } cfg.settings;
   configFile = ini.generate "NetworkManager.conf" configAttrs;
@@ -54,13 +55,18 @@ let
     });
   '';
 
-  ns = xs: pkgs.writeText "nameservers" (
-    concatStrings (map (s: "nameserver ${s}\n") xs)
-  );
+  ns = xs: pkgs.writeText "nameservers" (concatStrings (map (s: "nameserver ${s}\n") xs));
 
   overrideNameserversScript = pkgs.writeScript "02overridedns" ''
     #!/bin/sh
-    PATH=${with pkgs; makeBinPath [ gnused gnugrep coreutils ]}
+    PATH=${
+      with pkgs;
+      makeBinPath [
+        gnused
+        gnugrep
+        coreutils
+      ]
+    }
     tmp=$(mktemp)
     sed '/nameserver /d' /etc/resolv.conf > $tmp
     grep 'nameserver ' /etc/resolv.conf | \
@@ -76,7 +82,15 @@ let
   };
 
   macAddressOptWifi = mkOption {
-    type = types.either types.str (types.enum [ "permanent" "preserve" "random" "stable" "stable-ssid" ]);
+    type = types.either types.str (
+      types.enum [
+        "permanent"
+        "preserve"
+        "random"
+        "stable"
+        "stable-ssid"
+      ]
+    );
     default = "preserve";
     example = "00:11:22:33:44:55";
     description = ''
@@ -92,7 +106,14 @@ let
   };
 
   macAddressOptEth = mkOption {
-    type = types.either types.str (types.enum [ "permanent" "preserve" "random" "stable" ]);
+    type = types.either types.str (
+      types.enum [
+        "permanent"
+        "preserve"
+        "random"
+        "stable"
+      ]
+    );
     default = "preserve";
     example = "00:11:22:33:44:55";
     description = ''
@@ -106,13 +127,14 @@ let
     '';
   };
 
-  packages = [
-    pkgs.networkmanager
-  ]
-  ++ cfg.plugins
-  ++ lib.optionals (!delegateWireless && !enableIwd) [
-    pkgs.wpa_supplicant
-  ];
+  packages =
+    [
+      pkgs.networkmanager
+    ]
+    ++ cfg.plugins
+    ++ lib.optionals (!delegateWireless && !enableIwd) [
+      pkgs.wpa_supplicant
+    ];
 
 in
 {
@@ -140,11 +162,15 @@ in
       };
 
       connectionConfig = mkOption {
-        type = with types; attrsOf (nullOr (oneOf [
-          bool
-          int
-          str
-        ]));
+        type =
+          with types;
+          attrsOf (
+            nullOr (oneOf [
+              bool
+              int
+              str
+            ])
+          );
         default = { };
         description = ''
           Configuration for the [connection] section of NetworkManager.conf.
@@ -160,7 +186,7 @@ in
 
       settings = mkOption {
         type = ini.type;
-        default = {};
+        default = { };
         description = ''
           Configuration added to the generated NetworkManager.conf, note that you can overwrite settings with this.
           Refer to
@@ -196,9 +222,7 @@ in
               check =
                 p:
                 lib.assertMsg
-                  (types.package.check p
-                    && p ? networkManagerPlugin
-                    && lib.isString p.networkManagerPlugin)
+                  (types.package.check p && p ? networkManagerPlugin && lib.isString p.networkManagerPlugin)
                   ''
                     Package ‘${p.name}’, is not a NetworkManager plug-in.
                     Those need to have a ‘networkManagerPlugin’ attribute.
@@ -214,7 +238,10 @@ in
       };
 
       dhcp = mkOption {
-        type = types.enum [ "dhcpcd" "internal" ];
+        type = types.enum [
+          "dhcpcd"
+          "internal"
+        ];
         default = "internal";
         description = ''
           Which program (or internal library) should be used for DHCP.
@@ -222,7 +249,14 @@ in
       };
 
       logLevel = mkOption {
-        type = types.enum [ "OFF" "ERR" "WARN" "INFO" "DEBUG" "TRACE" ];
+        type = types.enum [
+          "OFF"
+          "ERR"
+          "WARN"
+          "INFO"
+          "DEBUG"
+          "TRACE"
+        ];
         default = "WARN";
         description = ''
           Set the default logging verbosity level.
@@ -253,7 +287,10 @@ in
         macAddress = macAddressOptWifi;
 
         backend = mkOption {
-          type = types.enum [ "wpa_supplicant" "iwd" ];
+          type = types.enum [
+            "wpa_supplicant"
+            "iwd"
+          ];
           default = "wpa_supplicant";
           description = ''
             Specify the Wi-Fi backend used for the device.
@@ -280,7 +317,12 @@ in
       };
 
       dns = mkOption {
-        type = types.enum [ "default" "dnsmasq" "systemd-resolved" "none" ];
+        type = types.enum [
+          "default"
+          "dnsmasq"
+          "systemd-resolved"
+          "none"
+        ];
         default = "default";
         description = ''
           Set the DNS (`resolv.conf`) processing mode.
@@ -295,27 +337,29 @@ in
       };
 
       dispatcherScripts = mkOption {
-        type = types.listOf (types.submodule {
-          options = {
-            source = mkOption {
-              type = types.path;
-              description = ''
-                Path to the hook script.
-              '';
-            };
+        type = types.listOf (
+          types.submodule {
+            options = {
+              source = mkOption {
+                type = types.path;
+                description = ''
+                  Path to the hook script.
+                '';
+              };
 
-            type = mkOption {
-              type = types.enum (attrNames dispatcherTypesSubdirMap);
-              default = "basic";
-              description = ''
-                Dispatcher hook type. Look up the hooks described at
-                [https://developer.gnome.org/NetworkManager/stable/NetworkManager.html](https://developer.gnome.org/NetworkManager/stable/NetworkManager.html)
-                and choose the type depending on the output folder.
-                You should then filter the event type (e.g., "up"/"down") from within your script.
-              '';
+              type = mkOption {
+                type = types.enum (attrNames dispatcherTypesSubdirMap);
+                default = "basic";
+                description = ''
+                  Dispatcher hook type. Look up the hooks described at
+                  [https://developer.gnome.org/NetworkManager/stable/NetworkManager.html](https://developer.gnome.org/NetworkManager/stable/NetworkManager.html)
+                  and choose the type depending on the output folder.
+                  You should then filter the event type (e.g., "up"/"down") from within your script.
+                '';
+              };
             };
-          };
-        });
+          }
+        );
         default = [ ];
         example = literalExpression ''
           [ {
@@ -350,66 +394,68 @@ in
       };
 
       ensureProfiles = {
-        profiles = with lib.types; mkOption {
-          type = attrsOf (submodule {
-            freeformType = ini.type;
+        profiles =
+          with lib.types;
+          mkOption {
+            type = attrsOf (submodule {
+              freeformType = ini.type;
 
-            options = {
-              connection = {
-                id = lib.mkOption {
-                  type = str;
-                  description = "This is the name that will be displayed by NetworkManager and GUIs.";
+              options = {
+                connection = {
+                  id = lib.mkOption {
+                    type = str;
+                    description = "This is the name that will be displayed by NetworkManager and GUIs.";
+                  };
+                  type = lib.mkOption {
+                    type = str;
+                    description = "The connection type defines the connection kind, like vpn, wireguard, gsm, wifi and more.";
+                    example = "vpn";
+                  };
                 };
-                type = lib.mkOption {
-                  type = str;
-                  description = "The connection type defines the connection kind, like vpn, wireguard, gsm, wifi and more.";
-                  example = "vpn";
+              };
+            });
+            apply = (lib.filterAttrsRecursive (n: v: v != { }));
+            default = { };
+            example = {
+              home-wifi = {
+                connection = {
+                  id = "home-wifi";
+                  type = "wifi";
+                  permissions = "";
+                };
+                wifi = {
+                  mac-address-blacklist = "";
+                  mode = "infrastructure";
+                  ssid = "Home Wi-Fi";
+                };
+                wifi-security = {
+                  auth-alg = "open";
+                  key-mgmt = "wpa-psk";
+                  psk = "$HOME_WIFI_PASSWORD";
+                };
+                ipv4 = {
+                  dns-search = "";
+                  method = "auto";
+                };
+                ipv6 = {
+                  addr-gen-mode = "stable-privacy";
+                  dns-search = "";
+                  method = "auto";
                 };
               };
             };
-          });
-          apply = (lib.filterAttrsRecursive (n: v: v != { }));
-          default = { };
-          example = {
-            home-wifi = {
-              connection = {
-                id = "home-wifi";
-                type = "wifi";
-                permissions = "";
-              };
-              wifi = {
-                mac-address-blacklist = "";
-                mode = "infrastructure";
-                ssid = "Home Wi-Fi";
-              };
-              wifi-security = {
-                auth-alg = "open";
-                key-mgmt = "wpa-psk";
-                psk = "$HOME_WIFI_PASSWORD";
-              };
-              ipv4 = {
-                dns-search = "";
-                method = "auto";
-              };
-              ipv6 = {
-                addr-gen-mode = "stable-privacy";
-                dns-search = "";
-                method = "auto";
-              };
-            };
+            description = ''
+              Declaratively define NetworkManager profiles. You can find information about the generated file format [here](https://networkmanager.dev/docs/api/latest/nm-settings-keyfile.html) and [here](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/assembly_networkmanager-connection-profiles-in-keyfile-format_configuring-and-managing-networking).
+              You current profiles which are most likely stored in `/etc/NetworkManager/system-connections` and there is [a tool](https://github.com/janik-haag/nm2nix) to convert them to the needed nix code.
+              If you add a new ad-hoc connection via a GUI or nmtui or anything similar it should just work together with the declarative ones.
+              And if you edit a declarative profile NetworkManager will move it to the persistent storage and treat it like a ad-hoc one,
+              but there will be two profiles as soon as the systemd unit from this option runs again which can be confusing since NetworkManager tools will start displaying two profiles with the same name and probably a bit different settings depending on what you edited.
+              A profile won't be deleted even if it's removed from the config until the system reboots because that's when NetworkManager clears it's temp directory.
+              If `networking.resolvconf.enable` is true, attributes affecting the name resolution (such as `ignore-auto-dns`) may not end up changing `/etc/resolv.conf` as expected when other name services (for example `networking.dhcpcd`) are enabled. Run `resolvconf -l` in the terminal to see what each service produces.
+            '';
           };
-          description = ''
-            Declaratively define NetworkManager profiles. You can find information about the generated file format [here](https://networkmanager.dev/docs/api/latest/nm-settings-keyfile.html) and [here](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/assembly_networkmanager-connection-profiles-in-keyfile-format_configuring-and-managing-networking).
-            You current profiles which are most likely stored in `/etc/NetworkManager/system-connections` and there is [a tool](https://github.com/janik-haag/nm2nix) to convert them to the needed nix code.
-            If you add a new ad-hoc connection via a GUI or nmtui or anything similar it should just work together with the declarative ones.
-            And if you edit a declarative profile NetworkManager will move it to the persistent storage and treat it like a ad-hoc one,
-            but there will be two profiles as soon as the systemd unit from this option runs again which can be confusing since NetworkManager tools will start displaying two profiles with the same name and probably a bit different settings depending on what you edited.
-            A profile won't be deleted even if it's removed from the config until the system reboots because that's when NetworkManager clears it's temp directory.
-            If `networking.resolvconf.enable` is true, attributes affecting the name resolution (such as `ignore-auto-dns`) may not end up changing `/etc/resolv.conf` as expected when other name services (for example `networking.dhcpcd`) are enabled. Run `resolvconf -l` in the terminal to see what each service produces.
-          '';
-        };
         environmentFiles = mkOption {
-          default = [];
+          default = [ ];
           type = types.listOf types.path;
           example = [ "/run/secrets/network-manager.env" ];
           description = ''
@@ -444,8 +490,7 @@ in
       +    settings.main.no-auto-default = "*";
          };
       ```
-    ''
-    )
+    '')
     (mkRemovedOptionModule [ "networking" "networkmanager" "enableFccUnlock" ] ''
       This option was removed, because using bundled FCC unlock scripts is risky,
       might conflict with vendor-provided unlock scripts, and should
@@ -470,7 +515,6 @@ in
     )
   ];
 
-
   ###### implementation
 
   config = mkIf cfg.enable {
@@ -487,31 +531,38 @@ in
 
     hardware.wirelessRegulatoryDatabase = true;
 
-    environment.etc = {
-      "NetworkManager/NetworkManager.conf".source = configFile;
-
-      # The networkmanager-l2tp plugin expects /etc/ipsec.secrets to include /etc/ipsec.d/ipsec.nm-l2tp.secrets;
-      # see https://github.com/NixOS/nixpkgs/issues/64965
-      "ipsec.secrets".text = ''
-        include ipsec.d/ipsec.nm-l2tp.secrets
-      '';
-    }
-    // builtins.listToAttrs (map
-      (pkg: nameValuePair "NetworkManager/${pkg.networkManagerPlugin}" {
-        source = "${pkg}/lib/NetworkManager/${pkg.networkManagerPlugin}";
-      })
-      cfg.plugins)
-    // optionalAttrs (cfg.appendNameservers != [ ] || cfg.insertNameservers != [ ])
+    environment.etc =
       {
+        "NetworkManager/NetworkManager.conf".source = configFile;
+
+        # The networkmanager-l2tp plugin expects /etc/ipsec.secrets to include /etc/ipsec.d/ipsec.nm-l2tp.secrets;
+        # see https://github.com/NixOS/nixpkgs/issues/64965
+        "ipsec.secrets".text = ''
+          include ipsec.d/ipsec.nm-l2tp.secrets
+        '';
+      }
+      // builtins.listToAttrs (
+        map (
+          pkg:
+          nameValuePair "NetworkManager/${pkg.networkManagerPlugin}" {
+            source = "${pkg}/lib/NetworkManager/${pkg.networkManagerPlugin}";
+          }
+        ) cfg.plugins
+      )
+      // optionalAttrs (cfg.appendNameservers != [ ] || cfg.insertNameservers != [ ]) {
         "NetworkManager/dispatcher.d/02overridedns".source = overrideNameserversScript;
       }
-    // listToAttrs (lib.imap1
-      (i: s:
-        {
-          name = "NetworkManager/dispatcher.d/${dispatcherTypesSubdirMap.${s.type}}03userscript${lib.fixedWidthNumber 4 i}";
-          value = { mode = "0544"; inherit (s) source; };
-        })
-      cfg.dispatcherScripts);
+      // listToAttrs (
+        lib.imap1 (i: s: {
+          name = "NetworkManager/dispatcher.d/${
+            dispatcherTypesSubdirMap.${s.type}
+          }03userscript${lib.fixedWidthNumber 4 i}";
+          value = {
+            mode = "0544";
+            inherit (s) source;
+          };
+        }) cfg.dispatcherScripts
+      );
 
     environment.systemPackages = packages;
 
@@ -562,10 +613,17 @@ in
 
     systemd.services.NetworkManager-dispatcher = {
       wantedBy = [ "network.target" ];
-      restartTriggers = [ configFile overrideNameserversScript ];
+      restartTriggers = [
+        configFile
+        overrideNameserversScript
+      ];
 
       # useful binaries for user-specified hooks
-      path = [ pkgs.iproute2 pkgs.util-linux pkgs.coreutils ];
+      path = [
+        pkgs.iproute2
+        pkgs.util-linux
+        pkgs.coreutils
+      ];
       aliases = [ "dbus-org.freedesktop.nm-dispatcher.service" ];
     };
 
@@ -574,17 +632,19 @@ in
       wantedBy = [ "multi-user.target" ];
       before = [ "network-online.target" ];
       after = [ "NetworkManager.service" ];
-      script = let
-        path = id: "/run/NetworkManager/system-connections/${id}.nmconnection";
-      in ''
-        mkdir -p /run/NetworkManager/system-connections
-      '' + lib.concatMapStringsSep "\n"
-        (profile: ''
+      script =
+        let
+          path = id: "/run/NetworkManager/system-connections/${id}.nmconnection";
+        in
+        ''
+          mkdir -p /run/NetworkManager/system-connections
+        ''
+        + lib.concatMapStringsSep "\n" (profile: ''
           ${pkgs.envsubst}/bin/envsubst -i ${ini.generate (lib.escapeShellArg profile.n) profile.v} > ${path (lib.escapeShellArg profile.n)}
         '') (lib.mapAttrsToList (n: v: { inherit n v; }) cfg.ensureProfiles.profiles)
-      + ''
-        ${pkgs.networkmanager}/bin/nmcli connection reload
-      '';
+        + ''
+          ${pkgs.networkmanager}/bin/nmcli connection reload
+        '';
       serviceConfig = {
         EnvironmentFile = cfg.ensureProfiles.environmentFiles;
         UMask = "0177";
@@ -625,9 +685,12 @@ in
           "ethernet.cloned-mac-address" = cfg.ethernet.macAddress;
           "wifi.cloned-mac-address" = cfg.wifi.macAddress;
           "wifi.powersave" =
-            if cfg.wifi.powersave == null then null
-            else if cfg.wifi.powersave then 3
-            else 2;
+            if cfg.wifi.powersave == null then
+              null
+            else if cfg.wifi.powersave then
+              3
+            else
+              2;
         };
       }
     ];
@@ -637,7 +700,8 @@ in
     security.polkit.enable = true;
     security.polkit.extraConfig = polkitConf;
 
-    services.dbus.packages = packages
+    services.dbus.packages =
+      packages
       ++ optional cfg.enableStrongSwan pkgs.strongswanNM
       ++ optional (cfg.dns == "dnsmasq") pkgs.dnsmasq;
 


### PR DESCRIPTION
## Description of changes

this does not change any default behavior: it's just refactoring for easier development and use.

- separate modemmanager bits into `modemmanager.nix`.
- give the two modules their own `enable` option, with networkmanager enabling modemmanager by default.
  neither one of these is _dependent_ on the other -- they're just commonly used together. now our nixos modules reflect that.
- give each module its own `package` option.
  networkmanager and modemmanager somehow end up as inputs to a lot of other packages, so now we can iterate the service-specific parts without mass-rebuilding (for example, the possibility to run NetworkManager as its own user instead of root may require patching the actual package).
- introduce a `networking.networkmanager.enableDefaultPlugins` option, default true, to give an easier way to deploy without the plugins. several of the plugins are costly to build (requiring e.g. `webkitgtk` for captive portals) or don't even build for all platforms (especially cross-platform builds).
  
## Things done

- [x] deployed to a x86_64 ethernet-only box, an x86_64 ethernet + wifi box, an x86_64 wifi-only box, and an aarch64 wifi + cellular modem box.
- Built on platform(s)
  - [x] x86_64-linux  (and `pkgsCross.aarch64-multiplatform`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
