### PR TITLE
rtl_fm_streamer: init at unstable-2021-06-08

### DIFF
--- a/pkgs/by-name/rt/rtl_fm_streamer/package.nix
+++ b/pkgs/by-name/rt/rtl_fm_streamer/package.nix
@@ -45,5 +45,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/AlbrechtL/rtl_fm_streamer";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ doronbehar ];
+    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 })

--- a/pkgs/by-name/rt/rtl_fm_streamer/package.nix
+++ b/pkgs/by-name/rt/rtl_fm_streamer/package.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libusb1
+, libev
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rtl_fm_streamer";
+  version = "unstable-2021-06-08";
+
+  src = fetchFromGitHub {
+    owner = "AlbrechtL";
+    repo = "rtl_fm_streamer";
+    rev = "ceb2bf06883f986ed01aa57c84989ba35b6b9a27";
+    sha256 = "sha256-9M7GS6AC7HEJge04vl7V6ZdtwWvbMu/Rhaf9fwQa9WA=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace '/etc/udev/rules.d' "$out/etc/udev/rules.d"
+
+    substituteInPlace rtl-sdr.rules \
+      --replace 'MODE:="0666"' 'ENV{ID_SOFTWARE_RADIO}="1", MODE="0660", GROUP="plugdev"'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libusb1
+    libev
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "INSTALL_UDEV_RULES" stdenv.isLinux)
+  ];
+
+  meta = {
+    description = "Turns your Realtek RTL2832 based DVB dongle into a FM radio stereo receiver";
+    homepage = "https://github.com/AlbrechtL/rtl_fm_streamer";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ doronbehar ];
+  };
+})


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
