### PR TITLE
nixos/davfs2: Remove deprecated extraConfig

### DIFF
--- a/nixos/modules/services/network-filesystems/davfs2.nix
+++ b/nixos/modules/services/network-filesystems/davfs2.nix
@@ -20,14 +20,10 @@ let
     else toString value;
 
   configFile = pkgs.writeText "davfs2.conf" (
-    if (cfg.settings != { }) then
-      (toINIWithGlobalSection {
-        mkSectionName = escapeString;
-        mkKeyValue = k: v: "${k} ${formatValue v}";
-      } cfg.settings)
-    else
-      cfg.extraConfig
-  );
+    toINIWithGlobalSection {
+      mkSectionName = escapeString;
+      mkKeyValue = k: v: "${k} ${formatValue v}";
+    } cfg.settings);
 in
 {
 
@@ -51,29 +47,6 @@ in
         member of this group in order to mount a davfs2 file system. Value must
         be given as name, not as numerical id.
       '';
-    };
-
-    extraConfig = mkOption {
-      type = lines;
-      default = "";
-      example = ''
-        proxy foo.bar:8080
-        use_locks 0
-
-        [/media/dav]
-        use_locks 1
-
-        [/home/otto/mywebspace]
-        gui_optimize 1
-      '';
-      description = ''
-        Extra lines appended to the configuration of davfs2.
-        See {manpage}`davfs2.conf(5)` for available settings.
-
-        **Note**: Please pass structured settings via
-        {option}`settings` instead, this option
-        will get deprecated in the future.
-      ''  ;
     };
 
     settings = mkOption {
@@ -108,21 +81,6 @@ in
   };
 
   config = mkIf cfg.enable {
-
-    assertions = [
-      {
-        assertion = cfg.extraConfig != "" -> cfg.settings == { };
-        message = ''
-          services.davfs2.extraConfig and services.davfs2.settings cannot be used together.
-          Please prefer using services.davfs2.settings.
-        '';
-      }
-    ];
-
-    warnings = optional (cfg.extraConfig != "") ''
-      services.davfs2.extraConfig will be deprecated in future releases;
-      please use services.davfs2.settings instead.
-    '';
 
     environment.systemPackages = [ pkgs.davfs2 ];
     environment.etc."davfs2/davfs2.conf".source = configFile;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
