### PR TITLE
sdr-j-fm: init at 3.16-unstable-2023-12-07

### DIFF
--- a/pkgs/applications/radio/sdr-j-fm/default.nix
+++ b/pkgs/applications/radio/sdr-j-fm/default.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  wrapQtAppsHook,
+  pkg-config,
+  qtbase,
+  qwt,
+  fftwFloat,
+  libsamplerate,
+  portaudio,
+  libusb1,
+  libsndfile,
+  featuresOverride ? { },
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sdr-j-fm";
+  # The stable release doen't include the commit the came after 3.16 which
+  # added support for cmake options instead of using cmake set() commands. See
+  # also: https://github.com/JvanKatwijk/sdr-j-fm/pull/25
+  version = "3.16-unstable-2023-12-07";
+
+  src = fetchFromGitHub {
+    owner = "JvanKatwijk";
+    repo = "sdr-j-fm";
+    rev = "8e3a67f8fbf72dd6968cbeb2e3d7d513fd107c71";
+    hash = "sha256-l9WqfhDp2V01lhleYZqRpmyL1Ww+tJj10bjkMMlvyA0=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    qtbase
+    qwt
+    fftwFloat
+    libsamplerate
+    portaudio
+    libusb1
+    libsndfile
+  ];
+  cmakeFlags = lib.mapAttrsToList lib.cmakeBool finalAttrs.passthru.features;
+
+  passthru = {
+    features = {
+      # All of these features don't require an external depencies, althought it
+      # may be implied - upstraem bundles everything they need in their repo.
+      AIRSPY =     true;
+      SDRPLAY =    true;
+      SDRPLAY_V3 = true;
+      HACKRF =     true;
+      PLUTO =      true;
+      # Some more cmake flags are mentioned in upstream's CMakeLists.txt file
+      # but they don't actually make a difference.
+    } // featuresOverride;
+  };
+
+  postInstall = ''
+    # Weird default of upstream
+    mv $out/linux-bin $out/bin
+  '';
+
+  meta = with lib; {
+    description = "SDR based FM radio receiver software";
+    homepage = "https://github.com/JvanKatwijk/sdr-j-fm";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ doronbehar ];
+    # Upstream doesn't find libusb1 on Darwin. Upstream probably doesn't
+    # support it officially.
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24258,6 +24258,8 @@ with pkgs;
 
   sdrplay = callPackage ../applications/radio/sdrplay { };
 
+  sdr-j-fm = libsForQt5.callPackage ../applications/radio/sdr-j-fm { };
+
   sdrpp = callPackage ../applications/radio/sdrpp {
     inherit (darwin.apple_sdk.frameworks) AppKit;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
