### PR TITLE
nixos/ssh: introduce enableRecommendedAlgorithms

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -334,7 +334,15 @@ in
         '';
       };
 
-
+      enableRecommendedAlgorithms = mkEnableOption "recommended cryptographic algorithms" // {
+        default = true;
+        description = ''
+            Uses the lower bound recommended in both
+            <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
+            and
+            <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
+        '';
+      };
 
       settings = mkOption {
         description = "Configuration for `sshd_config(5)`.";
@@ -417,36 +425,22 @@ in
             };
             KexAlgorithms = mkOption {
               type = types.nullOr (types.listOf types.str);
-              default = [
+              default = if cfg.enableRecommendedAlgorithms then [
                 "sntrup761x25519-sha512@openssh.com"
                 "curve25519-sha256"
                 "curve25519-sha256@libssh.org"
                 "diffie-hellman-group-exchange-sha256"
-              ];
-              description = ''
-                Allowed key exchange algorithms
-
-                Uses the lower bound recommended in both
-                <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
-                and
-                <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
-              '';
+              ] else null;
+              description = "Allowed key exchange algorithms";
             };
             Macs = mkOption {
               type = types.nullOr (types.listOf types.str);
-              default = [
+              default = if cfg.enableRecommendedAlgorithms then [
                 "hmac-sha2-512-etm@openssh.com"
                 "hmac-sha2-256-etm@openssh.com"
                 "umac-128-etm@openssh.com"
-              ];
-              description = ''
-                Allowed MACs
-
-                Defaults to recommended settings from both
-                <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
-                and
-                <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
-              '';
+              ] else null;
+              description = "Allowed MACs";
             };
             StrictModes = mkOption {
               type = types.nullOr (types.bool);
@@ -457,22 +451,15 @@ in
             };
             Ciphers = mkOption {
               type = types.nullOr (types.listOf types.str);
-              default = [
+              default = if cfg.enableRecommendedAlgorithms then [
                 "chacha20-poly1305@openssh.com"
                 "aes256-gcm@openssh.com"
                 "aes128-gcm@openssh.com"
                 "aes256-ctr"
                 "aes192-ctr"
                 "aes128-ctr"
-              ];
-              description = ''
-                Allowed ciphers
-
-                Defaults to recommended settings from both
-                <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
-                and
-                <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
-              '';
+              ] else null;
+              description = "Allowed ciphers";
             };
             AllowUsers = mkOption {
               type = with types; nullOr (listOf str);

--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -113,20 +113,15 @@ in {
       {
         services.openssh = {
           enable = true;
+          # Rely on upstream's alg selection: it knows to not use OpenSSL algorithms
+          # when not linked with OpenSSL.
+          enableRecommendedAlgorithms = false;
           package = pkgs.opensshPackages.openssh.override {
             linkOpenssl = false;
           };
           hostKeys = [
             { type = "ed25519"; path = "/etc/ssh/ssh_host_ed25519_key"; }
           ];
-          settings = {
-            # Must not specify the OpenSSL provided algorithms.
-            Ciphers = [ "chacha20-poly1305@openssh.com" ];
-            KexAlgorithms = [
-              "curve25519-sha256"
-              "curve25519-sha256@libssh.org"
-            ];
-          };
         };
         users.users.root.openssh.authorizedKeys.keys = [
           snakeOilEd25519PublicKey


### PR DESCRIPTION
Prior to this commit, the default behaviour of services.openssh is to set the cryptographic algorithms to those recommended by Mozilla and a blog post.

This option allows users to easily opt-opt ouf of this recommendation and instead use upstream's defaults.

I'm also open to just dropping any overriding of upstream's defaults. In future I'll be exploring switching this default to false.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
