### PR TITLE
LPCNet: init at 0.5

### DIFF
--- a/pkgs/by-name/lp/LPCNet/package.nix
+++ b/pkgs/by-name/lp/LPCNet/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  cmake,
+  codec2,
+  # for tests
+  octave,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "LPCNet";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "drowe67";
+    repo = "LPCNet";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-tHZLKXmuM86A6OpfS3CRRjhFbqj1Q/w1w56msdgLHb0=";
+  };
+  passthru = {
+    # Prebuilt neural network model that is needed during the build - can be overrwritten
+    nnmodel = fetchurl {
+      url = "http://rowetel.com/downloads/deep/lpcnet_191005_v1.0.tgz";
+      hash = "sha256-UJRAkkdR/dh/+qVoPuPd3ZN69cgzuRBMzOZdUWFJJsg=";
+    };
+  };
+  preConfigure = ''
+    mkdir build
+    cp \
+      ${finalAttrs.finalPackage.passthru.nnmodel} \
+      build/${finalAttrs.finalPackage.passthru.nnmodel.name}
+  '';
+
+  prePatch = ''
+    patchShebangs *.sh unittest/*.sh
+  '';
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ codec2 ];
+  nativeCheckInputs = [ octave ];
+
+  doCheck = true;
+  preCheck = ''
+    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}/build/source/build/src"
+  '';
+
+  meta = with lib; {
+    description = "Experimental Neural Net speech coding for FreeDV";
+    homepage = "https://github.com/drowe67/LPCNet";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ doronbehar ];
+    platforms = platforms.all;
+  };
+})


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
