### PR TITLE
nixos/ssh: use upstream's default cryptographic algorithms

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -19,6 +19,9 @@
 - `openssh` and `openssh_hpn` are now compiled without Kerberos 5 / GSSAPI support in an effort to reduce the attack surface of the components for the majority of users. Users needing this support can
   use the new `opensshWithKerberos` and `openssh_hpnWithKerberos` flavors (e.g. `programs.ssh.package = pkgs.openssh_gssapi`).
 
+- The `openssh` module now uses upstream's default cryptographic algorithms, in an effort to reduce
+  required maintenance.
+
 - `nvimpager` was updated to version 0.13.0, which changes the order of user and
   nvimpager settings: user commands in `-c` and `--cmd` now override the
   respective default settings because they are executed later.

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -417,36 +417,13 @@ in
             };
             KexAlgorithms = mkOption {
               type = types.nullOr (types.listOf types.str);
-              default = [
-                "sntrup761x25519-sha512@openssh.com"
-                "curve25519-sha256"
-                "curve25519-sha256@libssh.org"
-                "diffie-hellman-group-exchange-sha256"
-              ];
-              description = ''
-                Allowed key exchange algorithms
-
-                Uses the lower bound recommended in both
-                <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
-                and
-                <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
-              '';
+              default = null;
+              description = "Allowed key exchange algorithms. `null` uses upstream's default.";
             };
             Macs = mkOption {
               type = types.nullOr (types.listOf types.str);
-              default = [
-                "hmac-sha2-512-etm@openssh.com"
-                "hmac-sha2-256-etm@openssh.com"
-                "umac-128-etm@openssh.com"
-              ];
-              description = ''
-                Allowed MACs
-
-                Defaults to recommended settings from both
-                <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
-                and
-                <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
-              '';
+              default = null;
+              description = "Allowed MACs. `null` uses upstream's default.";
             };
             StrictModes = mkOption {
               type = types.nullOr (types.bool);
@@ -457,22 +434,8 @@ in
             };
             Ciphers = mkOption {
               type = types.nullOr (types.listOf types.str);
-              default = [
-                "chacha20-poly1305@openssh.com"
-                "aes256-gcm@openssh.com"
-                "aes128-gcm@openssh.com"
-                "aes256-ctr"
-                "aes192-ctr"
-                "aes128-ctr"
-              ];
-              description = ''
-                Allowed ciphers
-
-                Defaults to recommended settings from both
-                <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
-                and
-                <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
-              '';
+              default = null;
+              description = "Allowed ciphers. `null` uses upstream's default.";
             };
             AllowUsers = mkOption {
               type = with types; nullOr (listOf str);

--- a/nixos/modules/system/boot/initrd-ssh.nix
+++ b/nixos/modules/system/boot/initrd-ssh.nix
@@ -150,9 +150,13 @@ in
         HostKey ${initrdKeyPath path}
       '')}
 
-      KexAlgorithms ${concatStringsSep "," sshdCfg.settings.KexAlgorithms}
-      Ciphers ${concatStringsSep "," sshdCfg.settings.Ciphers}
-      MACs ${concatStringsSep "," sshdCfg.settings.Macs}
+      '' + lib.optionalString (sshdCfg.settings.KexAlgorithms != null) ''
+        KexAlgorithms ${concatStringsSep "," sshdCfg.settings.KexAlgorithms}
+      '' + lib.optionalString (sshdCfg.settings.Ciphers != null) ''
+        Ciphers ${concatStringsSep "," sshdCfg.settings.Ciphers}
+      '' + lib.optionalString (sshdCfg.settings.Macs != null) ''
+        MACs ${concatStringsSep "," sshdCfg.settings.Macs}
+      '' + ''
 
       LogLevel ${sshdCfg.settings.LogLevel}
 

--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -119,14 +119,6 @@ in {
           hostKeys = [
             { type = "ed25519"; path = "/etc/ssh/ssh_host_ed25519_key"; }
           ];
-          settings = {
-            # Must not specify the OpenSSL provided algorithms.
-            Ciphers = [ "chacha20-poly1305@openssh.com" ];
-            KexAlgorithms = [
-              "curve25519-sha256"
-              "curve25519-sha256@libssh.org"
-            ];
-          };
         };
         users.users.root.openssh.authorizedKeys.keys = [
           snakeOilEd25519PublicKey

--- a/nixos/tests/ssh-audit.nix
+++ b/nixos/tests/ssh-audit.nix
@@ -13,7 +13,21 @@ import ./make-test-python.nix (
         networking.firewall.allowedTCPPorts = [
           sshAuditPort
         ];
-        services.openssh.enable = true;
+        services.openssh = {
+          enable = true;
+          settings = {
+            # An arbitrary minimum that passes ssh-audit.
+            KexAlgorithms = [
+              "curve25519-sha256"
+            ];
+            Ciphers = [
+              "chacha20-poly1305@openssh.com"
+            ];
+            Macs = [
+              "hmac-sha2-512-etm@openssh.com"
+            ];
+          };
+        };
         users.users."${sshUsername}" = {
           isNormalUser = true;
           openssh.authorizedKeys.keys = [


### PR DESCRIPTION
## Motivation

Hardening SSH algorithms, which typically means dropping all-but-the-strongest is of questionable value, given SSH's downgrade protection[0]. We pay in compatibility, and maintenance.

Further, as noted in
https://github.com/NixOS/nixpkgs/pull/172393/files#r871727289 , both the guidelines that we follow have not been updated in years.

The costs of having/maintaining these defaults:

1. The burden of having a larger module that deviates from upstream. We've slowly been reducing the upstream diff, to reduce maintenance burden.
2. Difficult for users to opt-out of these defaults. For example, when using a "no OpenSSL" build of OpenSSH, having these defaults means having to manually overriding NixOS's defaults. Upstream's defaults, meanwhile, gracefully only use available algorithms, if OpenSSL is not linked.
    * For users seeking to reduce attack surfaces that are fortunate enough to only have modern clients, they could choose to use `pkgs.opensshPackages.openssh.override { linkOpenssl = false; }`, which only supports chacha20-poly1305 and curve25519-sha256. This has the added benefit of removing openssl from the memory of sshd.
3. https://github.com/NixOS/nixpkgs/pull/231165 unexpectedly broke many clients.
4. The time in discussing/reviewing these defaults.
5. Anecdotally, a friend trying NixOS for the first time with a ssh_config supporting only ecdh-* key exchanges was unable to SSH in after install.

There's a certain level of enjoyment that comes from researching and selecting a favourite suite of ciphers, but as a distro, it's not our core competancy, and best left for upstream who are active in advances/attacks/compatibility.

0. https://eprint.iacr.org/2016/072.pdf

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
