### PR TITLE
Add multiple GPIO related packages by @joan2937

### DIFF
--- a/pkgs/by-name/lg/lgpio/package.nix
+++ b/pkgs/by-name/lg/lgpio/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  swig,
+  # If we build the python packages, these two not null
+  buildPythonPackage ? null,
+  lgpioWithoutPython ? null,
+  # When building a python Packages, this specifies the python subproject
+  pyProject ? "",
+}:
+
+let
+  mkDerivation = if pyProject == "" then stdenv.mkDerivation else buildPythonPackage;
+  preConfigure =
+    if pyProject != "" then
+      ''
+        cd ${pyProject}
+      ''
+    else
+      '''';
+  # Emulate ldconfig when building the C API
+  postConfigure =
+    if pyProject == "" then
+      ''
+        substituteInPlace Makefile \
+          --replace ldconfig 'echo ldconfig'
+      ''
+    else
+      '''';
+  preBuild =
+    if pyProject == "PY_LGPIO" then
+      ''
+        swig -python lgpio.i
+      ''
+    else
+      '''';
+in
+mkDerivation rec {
+  pname = "lgpio";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "joan2937";
+    repo = "lg";
+    rev = "v${version}";
+    hash = "sha256-92lLV+EMuJj4Ul89KIFHkpPxVMr/VvKGEocYSW2tFiE=";
+  };
+  nativeBuildInputs = lib.optionals (pyProject == "PY_LGPIO") [ swig ];
+  buildInputs = [ lgpioWithoutPython ];
+  inherit preConfigure postConfigure preBuild;
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = with lib; {
+    description = "Linux C libraries and Python modules for manipulating GPIO";
+    homepage = "https://github.com/joan2937/lg";
+    license = with licenses; [ unlicense ];
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/by-name/pi/pigpio/package.nix
+++ b/pkgs/by-name/pi/pigpio/package.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, buildPythonPackage ? null
+}:
+
+let
+  mkDerivation = if builtins.isNull buildPythonPackage then
+    stdenv.mkDerivation
+  else
+    buildPythonPackage
+  ;
+in mkDerivation rec {
+  pname = "pigpio";
+  version = "79";
+
+  src = fetchFromGitHub {
+    owner = "joan2937";
+    repo = "pigpio";
+    rev = "v${version}";
+    hash = "sha256-Z+SwUlBbtWtnbjTe0IghR3gIKS43ZziN0amYtmXy7HE=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = with lib; {
+    description = "Pigpio is a C library for the Raspberry which allows control of the General Purpose Input Outputs (GPIO";
+    homepage = "https://github.com/joan2937/pigpio";
+    license = with licenses; [ unlicense ];
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/by-name/pi/piscope/package.nix
+++ b/pkgs/by-name/pi/piscope/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  wrapGAppsHook3,
+  gtk3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "piscope";
+  version = "0.8";
+
+  src = fetchFromGitHub {
+    owner = "joan2937";
+    repo = "piscope";
+    # Version is embedded in source code, no tag or github release available
+    rev = "V${finalAttrs.version}";
+    hash = "sha256-VDrx/RLSpMhyD64PmdeWVacb9LleHakcy7D6zFxeyhw=";
+  };
+  # Fix FHS paths
+  postConfigure = ''
+    substituteInPlace piscope.c \
+      --replace /usr/share/piscope $out/share/piscope
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook3
+  ];
+  buildInputs = [
+    gtk3
+  ];
+  # Upstream's Makefile assumes FHS
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m 0755 piscope       $out/bin/piscope
+    install -D -m 0644 piscope.glade $out/share/piscope/piscope.glade
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "http://abyz.me.uk/rpi/pigpio/piscope.html";
+    description = "A logic analyser (digital waveform viewer) for the Raspberry";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+})

--- a/pkgs/by-name/pi/piscope/package.nix
+++ b/pkgs/by-name/pi/piscope/package.nix
@@ -28,9 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     wrapGAppsHook3
   ];
-  buildInputs = [
-    gtk3
-  ];
+  buildInputs = [ gtk3 ];
   # Upstream's Makefile assumes FHS
   installPhase = ''
     runHook preInstall

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6596,6 +6596,11 @@ self: super: with self; {
     lgpioWithoutPython = pkgs.lgpio;
   });
 
+  rgpio = toPythonModule (pkgs.lgpio.override {
+    inherit buildPythonPackage;
+    pyProject = "PY_RGPIO";
+  });
+
   libagent = callPackage ../development/python-modules/libagent { };
 
   pa-ringbuffer = callPackage ../development/python-modules/pa-ringbuffer { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6590,6 +6590,12 @@ self: super: with self; {
     inherit python;
   });
 
+  lgpio = toPythonModule (pkgs.lgpio.override {
+    inherit buildPythonPackage;
+    pyProject = "PY_LGPIO";
+    lgpioWithoutPython = pkgs.lgpio;
+  });
+
   libagent = callPackage ../development/python-modules/libagent { };
 
   pa-ringbuffer = callPackage ../development/python-modules/pa-ringbuffer { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9757,6 +9757,10 @@ self: super: with self; {
 
   pypemicro = callPackage ../development/python-modules/pypemicro { };
 
+  pigpio = toPythonModule (pkgs.pigpio.override {
+    inherit buildPythonPackage;
+  });
+
   pymeshlab = toPythonModule (pkgs.libsForQt5.callPackage ../applications/graphics/pymeshlab { });
 
   pyprecice = callPackage ../development/python-modules/pyprecice { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
