### PR TITLE
shoreline: init at 0-unstable-2021-08-21

### DIFF
--- a/pkgs/by-name/sh/shoreline/package.nix
+++ b/pkgs/by-name/sh/shoreline/package.nix
@@ -1,0 +1,49 @@
+{
+  stdenv,
+  lib,
+  pkg-config,
+  imagemagick,
+  fetchFromGitHub,
+  SDL2,
+  numactl,
+  libvncserver,
+  freetype,
+  unstableGitUpdater,
+}:
+stdenv.mkDerivation {
+  pname = "shoreline";
+  version = "0-unstable-2021-08-24";
+
+  src = fetchFromGitHub {
+    owner = "TobleMiner";
+    repo = "shoreline";
+    rev = "05a2bbfb4559090727c51673e1fb47d20eac5672";
+    hash = "sha256-fWzk1gM8vmqkM9hwl6Jnut2AAMQQ91hAYu41xgoI1Jk=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    SDL2
+    numactl
+    libvncserver
+    freetype
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -m755 -D shoreline $out/bin/shoreline
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
+
+  meta = {
+    description = "Very fast (200+ Gbit/s) pixelflut server written in C with full IPv6 support";
+    homepage = "https://github.com/TobleMiner/shoreline";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ zebreus ];
+    platforms = lib.platforms.linux;
+    mainProgram = "shoreline";
+  };
+}


### PR DESCRIPTION
## Description of changes

[shoreline](https://github.com/TobleMiner/shoreline) is a high performance pixelflut server.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
