### PR TITLE
python311Packages.opentelemetry: fix version

### DIFF
--- a/pkgs/development/python-modules/opentelemetry-exporter-prometheus/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-prometheus/default.nix
@@ -4,6 +4,7 @@
   pythonOlder,
   hatchling,
   opentelemetry-api,
+  opentelemetry-instrumentation,
   opentelemetry-sdk,
   opentelemetry-test-utils,
   prometheus-client,
@@ -13,7 +14,9 @@
 buildPythonPackage {
   inherit (opentelemetry-api) src;
   pname = "opentelemetry-exporter-prometheus";
-  version = "0.44b0";
+  # This package is in the same repository as `opentelemetry-api`,
+  # but its version is synchronized with `opentelemetry-instrumentation` in another repository.
+  version = opentelemetry-instrumentation.version;
   pyproject = true;
 
   disabled = pythonOlder "3.8";

--- a/pkgs/development/python-modules/opentelemetry-semantic-conventions/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-semantic-conventions/default.nix
@@ -4,13 +4,16 @@
   pythonOlder,
   hatchling,
   opentelemetry-api,
+  opentelemetry-instrumentation,
   pytestCheckHook,
 }:
 
 buildPythonPackage {
   inherit (opentelemetry-api) src;
   pname = "opentelemetry-semantic-conventions";
-  version = "0.44b0";
+  # This package is in the same repository as `opentelemetry-api`,
+  # but its version is synchronized with `opentelemetry-instrumentation` in another repository.
+  version = opentelemetry-instrumentation.version;
   pyproject = true;
 
   disabled = pythonOlder "3.8";

--- a/pkgs/development/python-modules/opentelemetry-test-utils/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-test-utils/default.nix
@@ -5,13 +5,16 @@
   asgiref,
   hatchling,
   opentelemetry-api,
+  opentelemetry-instrumentation,
   opentelemetry-sdk,
 }:
 
 buildPythonPackage {
   inherit (opentelemetry-api) src;
   pname = "opentelemetry-test-utils";
-  version = "0.44b0";
+  # This package is in the same repository as `opentelemetry-api`,
+  # but its version is synchronized with `opentelemetry-instrumentation` in another repository.
+  version = opentelemetry-instrumentation.version;
   pyproject = true;
 
   disabled = pythonOlder "3.8";


### PR DESCRIPTION
These packages are in the same repository as `opentelemetry-api`, but
their versions are synchronized with `opentelemetry-instrumentation` in
another repository.

## Description of changes

This is a follow-up PR for https://github.com/NixOS/nixpkgs/pull/305470 .

I don't know why, but only `opentelemetry-exporter-prometheus`, `opentelemetry-semantic-conventions`, and  `opentelemetry-test-utils` have the same versioning as `opentelemetry-instrumentation`.

https://github.com/open-telemetry/opentelemetry-python/blob/v1.24.0/tests/opentelemetry-test-utils/src/opentelemetry/test/version.py

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
