### PR TITLE
treewide: fix mkEnableOption usage

### DIFF
--- a/nixos/modules/misc/mandoc.nix
+++ b/nixos/modules/misc/mandoc.nix
@@ -96,12 +96,17 @@ in
                 {option}`documentation.man.mandoc.manPath` to an empty list (`[]`).
               '';
             };
-            output.fragment = lib.mkEnableOption ''
-              Omit the <!DOCTYPE> declaration and the <html>, <head>, and <body>
-              elements and only emit the subtree below the <body> element in HTML
-              output of {manpage}`mandoc(1)`. The style argument will be ignored.
-              This is useful when embedding manual content within existing documents.
-            '';
+            output.fragment = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              example = true;
+              description = ''
+                Whether to omit the <!DOCTYPE> declaration and the <html>, <head>, and <body>
+                elements and only emit the subtree below the <body> element in HTML
+                output of {manpage}`mandoc(1)`. The style argument will be ignored.
+                This is useful when embedding manual content within existing documents.
+              '';
+            };
             output.includes = lib.mkOption {
               type = with lib.types; nullOr str;
               default = null;
@@ -160,9 +165,9 @@ in
               '';
             };
             output.toc = lib.mkEnableOption ''
-              In HTML output of {manpage}`mandoc(1)`, If an input file contains
-              at least two non-standard sections, print a table of contents near
-              the beginning of the output.
+              printing a table of contents near the beginning of the HTML output
+              of {manpage}`mandoc(1)` if an input file contains at least two
+              non-standard sections
             '';
             output.width = lib.mkOption {
               type = with lib.types; nullOr int;

--- a/nixos/modules/programs/dublin-traceroute.nix
+++ b/nixos/modules/programs/dublin-traceroute.nix
@@ -8,9 +8,7 @@ in {
 
   options = {
     programs.dublin-traceroute = {
-      enable = lib.mkEnableOption ''
-      dublin-traceroute, add it to the global environment and configure a setcap wrapper for it.
-      '';
+      enable = lib.mkEnableOption "dublin-traceroute (including setcap wrapper)";
 
       package = lib.mkPackageOption pkgs "dublin-traceroute" { };
     };

--- a/nixos/modules/programs/joycond-cemuhook.nix
+++ b/nixos/modules/programs/joycond-cemuhook.nix
@@ -1,7 +1,7 @@
 { lib, pkgs, config, ... }:
 {
   options.programs.joycond-cemuhook = {
-    enable = lib.mkEnableOption "joycond-cemuhook, a program to enable support for cemuhook's UDP protocol for joycond devices.";
+    enable = lib.mkEnableOption "joycond-cemuhook, a program to enable support for cemuhook's UDP protocol for joycond devices";
   };
 
   config = lib.mkIf config.programs.joycond-cemuhook.enable {

--- a/nixos/modules/programs/mouse-actions.nix
+++ b/nixos/modules/programs/mouse-actions.nix
@@ -6,7 +6,7 @@ in
   {
     options.programs.mouse-actions = {
       enable = lib.mkEnableOption ''
-        mouse-actions udev rules. This is a prerequisite for using mouse-actions without being root.
+        mouse-actions udev rules. This is a prerequisite for using mouse-actions without being root
       '';
     };
     config = lib.mkIf cfg.enable {

--- a/nixos/modules/security/ca.nix
+++ b/nixos/modules/security/ca.nix
@@ -26,13 +26,13 @@ in
 
     security.pki.useCompatibleBundle = mkEnableOption ''usage of a compatibility bundle.
 
-      Such a bundle consist exclusively of `BEGIN CERTIFICATE` and no `BEGIN TRUSTED CERTIFICATE`,
-      which is a OpenSSL specific PEM format.
+      Such a bundle consists exclusively of `BEGIN CERTIFICATE` and no `BEGIN TRUSTED CERTIFICATE`,
+      which is an OpenSSL specific PEM format.
 
       It is known to be incompatible with certain software stacks.
 
       Nevertheless, enabling this will strip all additional trust rules provided by the
-      certificates themselves, this can have security consequences depending on your usecases.
+      certificates themselves. This can have security consequences depending on your usecases
     '';
 
     security.pki.certificateFiles = mkOption {

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -1055,7 +1055,7 @@ in
           the dp9ik pam module provided by tlsclient.
 
           If set, users can be authenticated against the 9front
-          authentication server given in {option}`security.pam.dp9ik.authserver`.
+          authentication server given in {option}`security.pam.dp9ik.authserver`
         '';
       control = mkOption {
         default = "sufficient";

--- a/nixos/modules/security/sudo-rs.nix
+++ b/nixos/modules/security/sudo-rs.nix
@@ -41,7 +41,7 @@ in
 
     enable = mkEnableOption ''
       a memory-safe implementation of the {command}`sudo` command,
-      which allows non-root users to execute commands as root.
+      which allows non-root users to execute commands as root
     '';
 
     package = mkPackageOption pkgs "sudo-rs" { };

--- a/nixos/modules/services/databases/memcached.nix
+++ b/nixos/modules/services/databases/memcached.nix
@@ -37,7 +37,7 @@ in
         description = "The port to bind to.";
       };
 
-      enableUnixSocket = mkEnableOption "Unix Domain Socket at /run/memcached/memcached.sock instead of listening on an IP address and port. The `listen` and `port` options are ignored.";
+      enableUnixSocket = mkEnableOption "Unix Domain Socket at /run/memcached/memcached.sock instead of listening on an IP address and port. The `listen` and `port` options are ignored";
 
       maxMemory = mkOption {
         type = types.ints.unsigned;

--- a/nixos/modules/services/matrix/mautrix-signal.nix
+++ b/nixos/modules/services/matrix/mautrix-signal.nix
@@ -52,7 +52,7 @@ let
 in
 {
   options.services.mautrix-signal = {
-    enable = lib.mkEnableOption "mautrix-signal, a Matrix-Signal puppeting bridge.";
+    enable = lib.mkEnableOption "mautrix-signal, a Matrix-Signal puppeting bridge";
 
     settings = lib.mkOption {
       apply = lib.recursiveUpdate defaultConfig;

--- a/nixos/modules/services/matrix/mautrix-whatsapp.nix
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.nix
@@ -47,7 +47,7 @@
 
 in {
   options.services.mautrix-whatsapp = {
-    enable = lib.mkEnableOption "mautrix-whatsapp, a puppeting/relaybot bridge between Matrix and WhatsApp.";
+    enable = lib.mkEnableOption "mautrix-whatsapp, a puppeting/relaybot bridge between Matrix and WhatsApp";
 
     settings = lib.mkOption {
       type = settingsFormat.type;

--- a/nixos/modules/services/misc/mqtt2influxdb.nix
+++ b/nixos/modules/services/misc/mqtt2influxdb.nix
@@ -124,7 +124,7 @@ let
 in {
   options = {
     services.mqtt2influxdb = {
-      enable = mkEnableOption "BigClown MQTT to InfluxDB bridge.";
+      enable = mkEnableOption "BigClown MQTT to InfluxDB bridge";
       package = mkPackageOption pkgs ["python3Packages" "mqtt2influxdb"] {};
       environmentFiles = mkOption {
         type = types.listOf types.path;

--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -225,7 +225,7 @@ in
       effectively never complete due to running into timeouts.
 
       This sets `OMP_NUM_THREADS` to `1` in order to mitigate the issue. See
-      https://github.com/NixOS/nixpkgs/issues/240591 for more information.
+      https://github.com/NixOS/nixpkgs/issues/240591 for more information
     '' // mkOption { default = true; };
   };
 

--- a/nixos/modules/services/misc/portunus.nix
+++ b/nixos/modules/services/misc/portunus.nix
@@ -70,7 +70,7 @@ in
 
         To activate dex, first a search user must be created in the Portunus web ui
         and then the password must to be set as the `DEX_SEARCH_USER_PASSWORD` environment variable
-        in the [](#opt-services.dex.environmentFile) setting.
+        in the [](#opt-services.dex.environmentFile) setting
       '';
 
       oidcClients = mkOption {

--- a/nixos/modules/services/misc/spice-autorandr.nix
+++ b/nixos/modules/services/misc/spice-autorandr.nix
@@ -6,7 +6,7 @@ in
 {
   options = {
     services.spice-autorandr = {
-      enable = lib.mkEnableOption "spice-autorandr service that will automatically resize display to match SPICE client window size.";
+      enable = lib.mkEnableOption "spice-autorandr service that will automatically resize display to match SPICE client window size";
       package = lib.mkPackageOption pkgs "spice-autorandr" { };
     };
   };

--- a/nixos/modules/services/monitoring/rustdesk-server.nix
+++ b/nixos/modules/services/monitoring/rustdesk-server.nix
@@ -4,7 +4,7 @@ let
   UDPPorts = [21116];
 in {
   options.services.rustdesk-server = with lib; with types; {
-    enable = mkEnableOption "RustDesk, a remote access and remote control software, allowing maintenance of computers and other devices.";
+    enable = mkEnableOption "RustDesk, a remote access and remote control software, allowing maintenance of computers and other devices";
 
     package = mkPackageOption pkgs "rustdesk-server" {};
 

--- a/nixos/modules/services/monitoring/thanos.nix
+++ b/nixos/modules/services/monitoring/thanos.nix
@@ -696,7 +696,7 @@ in {
     };
 
     store = paramsToOptions params.store // {
-      enable = mkEnableOption "the Thanos store node giving access to blocks in a bucket provider.";
+      enable = mkEnableOption "the Thanos store node giving access to blocks in a bucket provider";
       arguments = mkArgumentsOption "store";
     };
 

--- a/nixos/modules/services/monitoring/ups.nix
+++ b/nixos/modules/services/monitoring/ups.nix
@@ -385,8 +385,8 @@ in
 
     power.ups = {
       enable = mkEnableOption ''
-        Enables support for Power Devices, such as Uninterruptible Power
-        Supplies, Power Distribution Units and Solar Controllers.
+        support for Power Devices, such as Uninterruptible Power
+        Supplies, Power Distribution Units and Solar Controllers
       '';
 
       mode = mkOption {

--- a/nixos/modules/services/network-filesystems/openafs/server.nix
+++ b/nixos/modules/services/network-filesystems/openafs/server.nix
@@ -183,7 +183,7 @@ in {
 
           enableFabs = mkEnableOption ''
             FABS, the flexible AFS backup system. It stores volumes as dump files, relying on other
-            pre-existing backup solutions for handling them.
+            pre-existing backup solutions for handling them
           '';
 
           buserverArgs = mkOption {

--- a/nixos/modules/services/network-filesystems/samba-wsdd.nix
+++ b/nixos/modules/services/network-filesystems/samba-wsdd.nix
@@ -10,7 +10,7 @@ in {
     services.samba-wsdd = {
       enable = mkEnableOption ''
         Web Services Dynamic Discovery host daemon. This enables (Samba) hosts, like your local NAS device,
-        to be found by Web Service Discovery Clients like Windows.
+        to be found by Web Service Discovery Clients like Windows
       '';
       interface = mkOption {
         type = types.nullOr types.str;

--- a/nixos/modules/services/networking/gns3-server.nix
+++ b/nixos/modules/services/networking/gns3-server.nix
@@ -87,17 +87,17 @@ in {
       };
 
       dynamips = {
-        enable = lib.mkEnableOption ''Whether to enable Dynamips support.'';
+        enable = lib.mkEnableOption ''Dynamips support'';
         package = lib.mkPackageOptionMD pkgs "dynamips" { };
       };
 
       ubridge = {
-        enable = lib.mkEnableOption ''Whether to enable uBridge support.'';
+        enable = lib.mkEnableOption ''uBridge support'';
         package = lib.mkPackageOptionMD pkgs "ubridge" { };
       };
 
       vpcs = {
-        enable = lib.mkEnableOption ''Whether to enable VPCS support.'';
+        enable = lib.mkEnableOption ''VPCS support'';
         package = lib.mkPackageOptionMD pkgs "vpcs" { };
       };
     };

--- a/nixos/modules/services/networking/haproxy.nix
+++ b/nixos/modules/services/networking/haproxy.nix
@@ -17,7 +17,7 @@ with lib;
   options = {
     services.haproxy = {
 
-      enable = mkEnableOption "HAProxy, the reliable, high performance TCP/HTTP load balancer.";
+      enable = mkEnableOption "HAProxy, the reliable, high performance TCP/HTTP load balancer";
 
       package = mkPackageOption pkgs "haproxy" { };
 

--- a/nixos/modules/services/networking/hylafax/options.nix
+++ b/nixos/modules/services/networking/hylafax/options.nix
@@ -312,9 +312,9 @@ in
     };
 
     faxqclean.enable.spoolInit = mkEnableOption ''
-      Purge old files from the spooling area with
+      purging old files from the spooling area with
       {file}`faxqclean`
-      each time the spooling area is initialized.
+      each time the spooling area is initialized
     '';
     faxqclean.enable.frequency = mkOption {
       type = nullOr nonEmptyStr;

--- a/nixos/modules/services/networking/netbird/dashboard.nix
+++ b/nixos/modules/services/networking/netbird/dashboard.nix
@@ -39,7 +39,7 @@ in
 
     package = mkPackageOption pkgs "netbird-dashboard" { };
 
-    enableNginx = mkEnableOption "Nginx reverse-proxy to serve the dashboard.";
+    enableNginx = mkEnableOption "Nginx reverse-proxy to serve the dashboard";
 
     domain = mkOption {
       type = str;

--- a/nixos/modules/services/networking/netbird/management.nix
+++ b/nixos/modules/services/networking/netbird/management.nix
@@ -137,7 +137,7 @@ in
 
 {
   options.services.netbird.server.management = {
-    enable = mkEnableOption "Netbird Management Service.";
+    enable = mkEnableOption "Netbird Management Service";
 
     package = mkPackageOption pkgs "netbird" { };
 
@@ -335,7 +335,7 @@ in
       description = "Log level of the netbird services.";
     };
 
-    enableNginx = mkEnableOption "Nginx reverse-proxy for the netbird management service.";
+    enableNginx = mkEnableOption "Nginx reverse-proxy for the netbird management service";
   };
 
   config = mkIf cfg.enable {

--- a/nixos/modules/services/networking/netbird/server.nix
+++ b/nixos/modules/services/networking/netbird/server.nix
@@ -31,7 +31,7 @@ in
   options.services.netbird.server = {
     enable = mkEnableOption "Netbird Server stack, comprising the dashboard, management API and signal service";
 
-    enableNginx = mkEnableOption "Nginx reverse-proxy for the netbird server services.";
+    enableNginx = mkEnableOption "Nginx reverse-proxy for the netbird server services";
 
     domain = mkOption {
       type = str;

--- a/nixos/modules/services/networking/netbird/signal.nix
+++ b/nixos/modules/services/networking/netbird/signal.nix
@@ -28,7 +28,7 @@ in
 
     package = mkPackageOption pkgs "netbird" { };
 
-    enableNginx = mkEnableOption "Nginx reverse-proxy for the netbird signal service.";
+    enableNginx = mkEnableOption "Nginx reverse-proxy for the netbird signal service";
 
     domain = mkOption {
       type = str;

--- a/nixos/modules/services/networking/networkd-dispatcher.nix
+++ b/nixos/modules/services/networking/networkd-dispatcher.nix
@@ -14,7 +14,7 @@ in {
       enable = mkEnableOption ''
         Networkd-dispatcher service for systemd-networkd connection status
         change. See [https://gitlab.com/craftyguy/networkd-dispatcher](upstream instructions)
-        for usage.
+        for usage
       '';
 
       rules = mkOption {

--- a/nixos/modules/services/networking/nncp.nix
+++ b/nixos/modules/services/networking/nncp.nix
@@ -34,9 +34,7 @@ in {
           [](#opt-programs.nncp.settings)
         '';
         socketActivation = {
-          enable = mkEnableOption ''
-            Whether to run nncp-daemon persistently or socket-activated.
-          '';
+          enable = mkEnableOption "socket activation for nncp-daemon";
           listenStreams = mkOption {
             type = with types; listOf str;
             description = ''

--- a/nixos/modules/services/security/fail2ban.nix
+++ b/nixos/modules/services/security/fail2ban.nix
@@ -263,7 +263,7 @@ in
         '';
         type = with types; attrsOf (either lines (submodule ({ name, ... }: {
           options = {
-            enabled = mkEnableOption "this jail." // {
+            enabled = mkEnableOption "this jail" // {
               default = true;
               readOnly = name == "DEFAULT";
             };

--- a/nixos/modules/services/security/haveged.nix
+++ b/nixos/modules/services/security/haveged.nix
@@ -17,7 +17,7 @@ in
 
       enable = mkEnableOption ''
         haveged entropy daemon, which refills /dev/random when low.
-        NOTE: does nothing on kernels newer than 5.6.
+        NOTE: does nothing on kernels newer than 5.6
       '';
       # source for the note https://github.com/jirka-h/haveged/issues/57
 

--- a/nixos/modules/services/web-apps/audiobookshelf.nix
+++ b/nixos/modules/services/web-apps/audiobookshelf.nix
@@ -8,7 +8,7 @@ in
 {
   options = {
     services.audiobookshelf = {
-      enable = mkEnableOption "Audiobookshelf, self-hosted audiobook and podcast server.";
+      enable = mkEnableOption "Audiobookshelf, self-hosted audiobook and podcast server";
 
       package = mkPackageOption pkgs "audiobookshelf" { };
 

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -170,7 +170,7 @@ in
       '';
     };
 
-    caddy.enable = mkEnableOption "Whether to enable caddy reverse proxy to expose jitsi-meet";
+    caddy.enable = mkEnableOption "caddy reverse proxy to expose jitsi-meet";
 
     prosody.enable = mkOption {
       type = bool;

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -474,7 +474,7 @@ in {
             implementation into the virtual filesystem.
 
             Further details about this feature can be found in the
-            [upstream documentation](https://docs.nextcloud.com/server/22/admin_manual/configuration_files/primary_storage.html).
+            [upstream documentation](https://docs.nextcloud.com/server/22/admin_manual/configuration_files/primary_storage.html)
           '';
           bucket = mkOption {
             type = types.str;
@@ -576,7 +576,7 @@ in {
         This is used by the theming app and for generating previews of certain images (e.g. SVG and HEIF).
         You may want to disable it for increased security. In that case, previews will still be available
         for some images (e.g. JPEG and PNG).
-        See <https://github.com/nextcloud/server/issues/13099>.
+        See <https://github.com/nextcloud/server/issues/13099>
     '' // {
       default = true;
     };

--- a/nixos/modules/services/web-apps/pretix.nix
+++ b/nixos/modules/services/web-apps/pretix.nix
@@ -63,7 +63,7 @@ in
   };
 
   options.services.pretix = {
-    enable = mkEnableOption "Pretix, a ticket shop application for conferences, festivals, concerts, etc.";
+    enable = mkEnableOption "Pretix, a ticket shop application for conferences, festivals, concerts, etc";
 
     package = mkPackageOption pkgs "pretix" { };
 

--- a/nixos/modules/services/web-apps/silverbullet.nix
+++ b/nixos/modules/services/web-apps/silverbullet.nix
@@ -12,7 +12,7 @@ in
 {
   options = {
     services.silverbullet = {
-      enable = lib.mkEnableOption "Silverbullet, an open-source, self-hosted, offline-capable Personal Knowledge Management (PKM) web application.";
+      enable = lib.mkEnableOption "Silverbullet, an open-source, self-hosted, offline-capable Personal Knowledge Management (PKM) web application";
 
       package = lib.mkPackageOptionMD pkgs "silverbullet" { };
 

--- a/nixos/modules/services/web-apps/suwayomi-server.nix
+++ b/nixos/modules/services/web-apps/suwayomi-server.nix
@@ -9,7 +9,7 @@ in
 {
   options = {
     services.suwayomi-server = {
-      enable = mkEnableOption "Suwayomi, a free and open source manga reader server that runs extensions built for Tachiyomi.";
+      enable = mkEnableOption "Suwayomi, a free and open source manga reader server that runs extensions built for Tachiyomi";
 
       package = lib.mkPackageOptionMD pkgs "suwayomi-server" { };
 
@@ -72,7 +72,7 @@ in
               };
 
               basicAuthEnabled = mkEnableOption ''
-                Add basic access authentication to Suwayomi-Server.
+                basic access authentication for Suwayomi-Server.
                 Enabling this option is useful when hosting on a public network/the Internet
               '';
 

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -1086,9 +1086,9 @@ in
         '';
         description = "Declarative vhost config";
       };
-      validateConfigFile = lib.mkEnableOption ''
-        Validate configuration with pkgs.writeNginxConfig.
-      '' // { default = true; };
+      validateConfigFile = lib.mkEnableOption "validating configuration with pkgs.writeNginxConfig" // {
+        default = true;
+      };
     };
   };
 

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -57,12 +57,12 @@ in
   options.testing = {
 
     initrdBackdoor = lib.mkEnableOption ''
-      enable backdoor.service in initrd. Requires
+      backdoor.service in initrd. Requires
       boot.initrd.systemd.enable to be enabled. Boot will pause in
       stage 1 at initrd.target, and will listen for commands from the
       Machine python interface, just like stage 2 normally does. This
       enables commands to be sent to test and debug stage 1. Use
-      machine.switch_root() to leave stage 1 and proceed to stage 2.
+      machine.switch_root() to leave stage 1 and proceed to stage 2
     '';
 
   };

--- a/nixos/modules/virtualisation/incus.nix
+++ b/nixos/modules/virtualisation/incus.nix
@@ -149,7 +149,7 @@ in
 
         Users in the "incus-admin" group can interact with
         the daemon (e.g. to start or stop containers) using the
-        {command}`incus` command line tool, among others.
+        {command}`incus` command line tool, among others
       '';
 
       package = lib.mkPackageOption pkgs "incus-lts" { };

--- a/nixos/modules/virtualisation/multipass.nix
+++ b/nixos/modules/virtualisation/multipass.nix
@@ -10,9 +10,7 @@ in
 {
   options = {
     virtualisation.multipass = {
-      enable = lib.mkEnableOption ''
-        Multipass, a simple manager for virtualised Ubuntu instances.
-      '';
+      enable = lib.mkEnableOption "Multipass, a simple manager for virtualised Ubuntu instances";
 
       logLevel = lib.mkOption {
         type = lib.types.enum [ "error" "warning" "info" "debug" "trace" ];

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -900,7 +900,7 @@ in
     };
 
     virtualisation.tpm = {
-      enable = mkEnableOption "a TPM device in the virtual machine with a driver, using swtpm.";
+      enable = mkEnableOption "a TPM device in the virtual machine with a driver, using swtpm";
 
       package = mkPackageOption cfg.host.pkgs "swtpm" { };
 


### PR DESCRIPTION
## Description of changes

Same spirit as #316879.

I fixed all descriptions (that I could find) that:
* started with "enable" (or some variant)
* started with a capital letter for a non-proper noun
* started with an incompatible verb
* ended in a period

Obvious other grammatical issues were fixed as well.
Some items read better after fully rewording, so I did so in those cases.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
