### PR TITLE
Let-float various fromJSON calls to avoid repeated JSON reading/parsing

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -23,6 +23,11 @@ formats commits for you.
 
 */
 
+let
+  # Read ./recipes-archive-melpa.json in an outer let to make sure we only do this once.
+  defaultArchive = builtins.fromJSON (builtins.readFile ./recipes-archive-melpa.json);
+in
+
 { lib, pkgs }: variant: self:
 let
   dontConfigure = pkg:
@@ -57,7 +62,7 @@ let
     if pkg != null then dontConfigure (externalSrc pkg pkgs.rtags)
     else null;
 
-  generateMelpa = lib.makeOverridable ({ archiveJson ? ./recipes-archive-melpa.json
+  generateMelpa = lib.makeOverridable ({ archiveJson ? defaultArchive
                                        }:
     let
       inherit (import ./libgenerated.nix lib self) melpaDerivation;
@@ -66,7 +71,7 @@ let
           (s: s != null)
           (map
             (melpaDerivation variant)
-            (lib.importJSON archiveJson)
+            (if builtins.isList archiveJson then archiveJson else lib.importJSON archiveJson)
           )
         )
       );

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -1,3 +1,10 @@
+let
+  # `ides.json` is handwritten and contains information that doesn't change across updates, like maintainers and other metadata
+  # `versions.json` contains everything generated/needed by the update script version numbers, build numbers and tarball hashes
+  ideInfo = builtins.fromJSON (builtins.readFile ./bin/ides.json);
+  versions = builtins.fromJSON (builtins.readFile ./bin/versions.json);
+in
+
 { lib
 , stdenv
 , callPackage
@@ -30,10 +37,6 @@
 let
   inherit (stdenv.hostPlatform) system;
 
-  # `ides.json` is handwritten and contains information that doesn't change across updates, like maintainers and other metadata
-  # `versions.json` contains everything generated/needed by the update script version numbers, build numbers and tarball hashes
-  ideInfo = lib.importJSON ./bin/ides.json;
-  versions = lib.importJSON ./bin/versions.json;
   products = versions.${system} or (throw "Unsupported system: ${system}");
 
   package = if stdenv.isDarwin then ./bin/darwin.nix else ./bin/linux.nix;

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk11-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk11-darwin.nix
@@ -1,7 +1,7 @@
 { lib }:
 
 let
-  sources = lib.importJSON ./sources.json;
+  sources = import ./sources.nix;
 in
 {
   jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk11.mac.jdk.hotspot; };

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk11-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk11-linux.nix
@@ -2,7 +2,7 @@
 
 let
   variant = if stdenv.hostPlatform.isMusl then "alpine_linux" else "linux";
-  sources = lib.importJSON ./sources.json;
+  sources = import ./sources.nix;
 in
 {
   jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk11.${variant}.jdk.hotspot; };

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk13-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk13-darwin.nix
@@ -1,7 +1,7 @@
 { lib }:
 
 let
-  sources = lib.importJSON ./sources.json;
+  sources = import ./sources.nix;
 in
 {
   jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk13.mac.jdk.hotspot; knownVulnerabilities = ["Support ended"]; };

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk13-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk13-linux.nix
@@ -2,7 +2,7 @@
 
 let
   variant = if stdenv.hostPlatform.isMusl then "alpine_linux" else "linux";
-  sources = lib.importJSON ./sources.json;
+  sources = import ./sources.nix;
 in
 {
   jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk13.${variant}.jdk.hotspot; knownVulnerabilities = ["Support ended"]; };

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk14-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk14-darwin.nix
@@ -1,7 +1,7 @@
 { lib }:
 
 let
-  sources = lib.importJSON ./sources.json;
+  sources = import ./sources.nix;
 in
 {
   jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk14.mac.jdk.hotspot; knownVulnerabilities = ["Support ended"]; };

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk14-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk14-linux.nix
@@ -2,7 +2,7 @@
 
 let
   variant = if stdenv.hostPlatform.isMusl then "alpine_linux" else "linux";
-  sources = lib.importJSON ./sources.json;
+  sources = import ./sources.nix;
 in
 {
   jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk14.${variant}.jdk.hotspot; knownVulnerabilities = ["Support ended"]; };

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk15-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk15-darwin.nix
@@ -1,7 +1,7 @@
 { lib }:
 
 let
-  sources = lib.importJSON ./sources.json;
+  sources = import ./sources.nix;
 in
 {
   jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jdk.hotspot; knownVulnerabilities = [ "Support ended" ]; };

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk15-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk15-linux.nix
@@ -2,7 +2,7 @@
 
 let
   variant = if stdenv.hostPlatform.isMusl then "alpine_linux" else "linux";
-  sources = lib.importJSON ./sources.json;
+  sources = import ./sources.nix;
 in
 {
   jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jdk.hotspot; knownVulnerabilities = [ "Support ended" ]; };

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk16-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk16-darwin.nix
@@ -1,7 +1,7 @@
 { lib }:
 
 let
-  sources = lib.importJSON ./sources.json;
+  sources = import ./sources.nix;
 in
 {
   jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jdk.hotspot; knownVulnerabilities = [ "Support ended" ]; };

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk16-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk16-linux.nix
@@ -2,7 +2,7 @@
 
 let
   variant = if stdenv.hostPlatform.isMusl then "alpine_linux" else "linux";
-  sources = lib.importJSON ./sources.json;
+  sources = import ./sources.nix;
 in
 {
   jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jdk.hotspot; knownVulnerabilities = [ "Support ended" ]; };

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk17-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk17-darwin.nix
@@ -1,7 +1,7 @@
 { lib }:
 
 let
-  sources = lib.importJSON ./sources.json;
+  sources = import ./sources.nix;
 in
 {
   jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk17.mac.jdk.hotspot; };

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk17-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk17-linux.nix
@@ -2,7 +2,7 @@
 
 let
   variant = if stdenv.hostPlatform.isMusl then "alpine_linux" else "linux";
-  sources = lib.importJSON ./sources.json;
+  sources = import ./sources.nix;
 in
 {
   jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk17.${variant}.jdk.hotspot; };

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk8-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk8-darwin.nix
@@ -1,7 +1,7 @@
 { lib }:
 
 let
-  sources = lib.importJSON ./sources.json;
+  sources = import ./sources.nix;
 in
 {
   jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk8.mac.jdk.hotspot; };

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk8-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk8-linux.nix
@@ -2,7 +2,7 @@
 
 let
   variant = if stdenv.hostPlatform.isMusl then "alpine_linux" else "linux";
-  sources = lib.importJSON ./sources.json;
+  sources = import ./sources.nix;
 in
 {
   jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk8.${variant}.jdk.hotspot; };

--- a/pkgs/development/compilers/adoptopenjdk-bin/sources.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/sources.nix
@@ -1,0 +1,1 @@
+builtins.fromJSON (builtins.readFile ./sources.json)

--- a/pkgs/development/tools/electron/binary/default.nix
+++ b/pkgs/development/tools/electron/binary/default.nix
@@ -1,8 +1,11 @@
+let
+  infoJson = builtins.fromJSON (builtins.readFile ./info.json);
+in
+
 { lib, callPackage }:
 
 let
   mkElectron = callPackage ./generic.nix { };
-  infoJson = builtins.fromJSON (builtins.readFile ./info.json);
 in
 lib.mapAttrs' (majorVersion: info:
   lib.nameValuePair

--- a/pkgs/games/papermc/default.nix
+++ b/pkgs/games/papermc/default.nix
@@ -1,6 +1,8 @@
+let
+  versions = builtins.fromJSON (builtins.readFile ./versions.json);
+in
 { callPackage, lib, ... }:
 let
-  versions = lib.importJSON ./versions.json;
   latestVersion = lib.last (builtins.sort lib.versionOlder (builtins.attrNames versions));
   escapeVersion = builtins.replaceStrings [ "." ] [ "_" ];
   packages = lib.mapAttrs'

--- a/pkgs/misc/translatelocally-models/default.nix
+++ b/pkgs/misc/translatelocally-models/default.nix
@@ -1,7 +1,10 @@
+let
+  modelSpecs = (builtins.fromJSON (builtins.readFile ./models.json));
+in
+
 { lib, stdenvNoCC, fetchurl }:
 
 let
-  modelSpecs = (builtins.fromJSON (builtins.readFile ./models.json));
   withCodeAsKey = f: { code, ... }@attrs: lib.nameValuePair code (f attrs);
   mkModelPackage = { name, code, version, url, checksum }:
     stdenvNoCC.mkDerivation {

--- a/pkgs/os-specific/linux/kernel/mainline.nix
+++ b/pkgs/os-specific/linux/kernel/mainline.nix
@@ -1,7 +1,10 @@
+let
+  allKernels = builtins.fromJSON (builtins.readFile ./kernels-org.json);
+in
+
 { branch, lib, fetchurl, fetchzip, buildLinux, ... } @ args:
 
 let
-  allKernels = builtins.fromJSON (builtins.readFile ./kernels-org.json);
   thisKernel = allKernels.${branch};
   inherit (thisKernel) version;
 


### PR DESCRIPTION
## Description of changes

Some of these were read/parsed dozens of times in a `nix search` invocation, and in particular the MELPA recipes archive (3 MiB) was read 4 times.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
