### PR TITLE
lomiri.lomiri-session: Unset QT_QPA_PLATFORMTHEME

### DIFF
--- a/pkgs/desktops/lomiri/data/lomiri-session/1001-Unset-QT_QPA_PLATFORMTHEME.patch
+++ b/pkgs/desktops/lomiri/data/lomiri-session/1001-Unset-QT_QPA_PLATFORMTHEME.patch
@@ -1,0 +1,33 @@
+From 30b5391c3f20180fe7427fe179ba26f846200d96 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Mon, 3 Jun 2024 20:50:03 +0200
+Subject: [PATCH] Unset QT_QPA_PLATFORMTHEME
+
+gtk3 value breaks Lomiri startup
+---
+ lomiri-session | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lomiri-session b/lomiri-session
+index 9d68249..b103840 100755
+--- a/lomiri-session
++++ b/lomiri-session
+@@ -47,6 +47,7 @@ fi
+ 
+ # Set some envs
+ export QT_QPA_PLATFORM=wayland
++export QT_QPA_PLATFORMTHEME=
+ export QT_IM_MODULE=maliit
+ export MALIIT_FORCE_DBUS_CONNECTION=1
+ export UITK_ICON_THEME=suru
+@@ -55,6 +56,7 @@ dbus-update-activation-environment --systemd MALIIT_FORCE_DBUS_CONNECTION=1
+ dbus-update-activation-environment --systemd QT_IM_MODULE=maliit
+ dbus-update-activation-environment --systemd GTK_IM_MODULE=maliit
+ dbus-update-activation-environment --systemd QT_QPA_PLATFORM=wayland
++dbus-update-activation-environment --systemd QT_QPA_PLATFORMTHEME=
+ dbus-update-activation-environment --systemd SDL_VIDEODRIVER=wayland
+ dbus-update-activation-environment --systemd QT_WAYLAND_DISABLE_WINDOWDECORATION=1
+ dbus-update-activation-environment --systemd QT_ACCESSIBILITY=1
+-- 
+2.44.1
+

--- a/pkgs/desktops/lomiri/data/lomiri-session/default.nix
+++ b/pkgs/desktops/lomiri/data/lomiri-session/default.nix
@@ -135,6 +135,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       excludes = [ "systemd/lomiri.service" ];
       hash = "sha256-BICb6ZwU/sUBzmM4udsOndIgw1A03I/UEG000YvMZ9Y=";
     })
+
+    ./1001-Unset-QT_QPA_PLATFORMTHEME.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Workaround startup failure when Pantheon module sets it to "gtk3" globally.

Related to https://github.com/NixOS/nixpkgs/issues/316991. Doesn't really *fix* the source of the issue, just addressing a symptom of it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
