### PR TITLE
python311Packages.skops: init at 0.9.0

### DIFF
--- a/pkgs/development/python-modules/skops/default.nix
+++ b/pkgs/development/python-modules/skops/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  setuptools,
+  pytestCheckHook,
+  pytest-cov-stub,
+  huggingface-hub,
+  matplotlib,
+  pandas,
+  scikit-learn,
+  streamlit,
+  tabulate,
+}:
+
+buildPythonPackage rec {
+  pname = "skops";
+  version = "0.10";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "skops-dev";
+    repo = "skops";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-2uX5sGVdTnZEbl0VXI8E7h1pQYQVbpQeUKUchCZpgg4=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    huggingface-hub
+    scikit-learn
+    tabulate
+  ];
+
+  nativeCheckInputs = [
+    matplotlib
+    pandas
+    pytestCheckHook
+    pytest-cov-stub
+    streamlit
+  ];
+  pytestFlagsArray = [ "skops" ];
+  disabledTestPaths = [
+    # try to download data from Huggingface Hub:
+    "skops/hub_utils/tests"
+    "skops/card/tests"
+    # minor output formatting issue
+    "skops/card/_model_card.py"
+  ];
+
+  pythonImportsCheck = [ "skops" ];
+
+  meta = {
+    description = "Library for saving/loading, sharing, and deploying scikit-learn based models";
+    mainProgram = "skops";
+    homepage = "https://skops.readthedocs.io/en/stable";
+    changelog = "https://github.com/skops-dev/skops/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14514,6 +14514,8 @@ self: super: with self; {
 
   skodaconnect = callPackage ../development/python-modules/skodaconnect { };
 
+  skops = callPackage ../development/python-modules/skops { };
+
   skorch = callPackage ../development/python-modules/skorch { };
 
   skrl = callPackage ../development/python-modules/skrl { };


### PR DESCRIPTION
## Description of changes

Add `skops`, a Python package for safe reading/writing, deploying, and sharing sklearn-based models.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
