### PR TITLE
python312Packages.prometheus-fastapi-instrumentator: init at 7.0.0

### DIFF
--- a/pkgs/development/python-modules/prometheus-fastapi-instrumentator/default.nix
+++ b/pkgs/development/python-modules/prometheus-fastapi-instrumentator/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, devtools
+, fastapi
+, httpx
+, poetry-core
+, prometheus-client
+, requests
+, starlette
+}:
+
+buildPythonPackage rec {
+  pname = "prometheus-fastapi-instrumentator";
+  version = "7.0.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "trallnag";
+    repo = "prometheus-fastapi-instrumentator";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-yvKdhQdbY0+jEc8TEHNNgtdnqE0abnd4MN/JZFQwQ2E=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    prometheus-client
+    starlette
+  ];
+
+  nativeCheckInputs = [
+    devtools
+    fastapi
+    httpx
+    pytestCheckHook
+    requests
+  ];
+
+  pythonImportsCheck = [ "prometheus_fastapi_instrumentator" ];
+
+  meta = {
+    description = "Instrument FastAPI with Prometheus metrics";
+    homepage = "https://github.com/trallnag/prometheus-fastapi-instrumentator";
+    changelog = "https://github.com/trallnag/prometheus-fastapi-instrumentator/blob/${src.rev}/CHANGELOG.md";
+    license = with lib.licenses; [ isc bsd3 ];
+    maintainers = with lib.maintainers; [ bcdarwin ];
+    platforms = lib.platforms.linux;  # numerous test failures on Darwin
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10400,6 +10400,8 @@ self: super: with self; {
 
   prometheus-client = callPackage ../development/python-modules/prometheus-client { };
 
+  prometheus-fastapi-instrumentator = callPackage ../development/python-modules/prometheus-fastapi-instrumentator { };
+
   prometheus-flask-exporter = callPackage ../development/python-modules/prometheus-flask-exporter { };
 
   prometrix = callPackage ../development/python-modules/prometrix { };


### PR DESCRIPTION
## Description of changes

Add [Prometheus FastAPI instrumentator](https://github.com/trallnag/prometheus-fastapi-instrumentator).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
