### PR TITLE
catppuccin-whiskers: init at 2.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14363,6 +14363,12 @@
     githubId = 1009523;
     name = "Ashijit Pramanik";
   };
+  Name = {
+    name = "Name";
+    email = "lasagna@garfunkles.space";
+    github = "namescode";
+    githubId = 86119896;
+  };
   name-snrl = {
     github = "name-snrl";
     githubId = 72071763;

--- a/pkgs/by-name/ca/catppuccin-whiskers/package.nix
+++ b/pkgs/by-name/ca/catppuccin-whiskers/package.nix
@@ -1,0 +1,23 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+let version = "2.4.0";
+in rustPlatform.buildRustPackage {
+  pname = "catppuccin-whiskers";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "catppuccin";
+    repo = "whiskers";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-rbPr5eSs99nS70J785SWO7tVBdiX/S7XUNHuo3aOQU4=";
+  };
+
+  cargoHash = "sha256-T7dreELSHfJizfbJEvvgkOmkMwlOETZVUdLwRFJOJEo=";
+
+  meta = {
+    homepage = "https://github.com/catppuccin/whiskers";
+    description = "A templating tool to simplify the creation of Catppuccin ports";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Name ];
+    mainProgram = "whiskers";
+  };
+}


### PR DESCRIPTION
## Description of changes

Setup a `package.nix` for [whiskers](https://github.com/catppuccin/toolbox/tree/main/whiskers) and register myself as its maintainer.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
