### PR TITLE
thin-provisioning-tools: add symlinks for compatability

### DIFF
--- a/pkgs/tools/misc/thin-provisioning-tools/default.nix
+++ b/pkgs/tools/misc/thin-provisioning-tools/default.nix
@@ -25,6 +25,30 @@ rustPlatform.buildRustPackage rec {
     inherit (nixosTests.lvm2) lvm-thinpool-linux-latest;
   };
 
+  # required for config compatibility with configs done pre 0.9.0
+  # see https://github.com/NixOS/nixpkgs/issues/317018
+  postInstall = ''
+    ln -s $out/bin/pdata_tools $out/bin/cache_check
+    ln -s $out/bin/pdata_tools $out/bin/cache_dump
+    ln -s $out/bin/pdata_tools $out/bin/cache_metadata_size
+    ln -s $out/bin/pdata_tools $out/bin/cache_repair
+    ln -s $out/bin/pdata_tools $out/bin/cache_restore
+    ln -s $out/bin/pdata_tools $out/bin/cache_writeback
+    ln -s $out/bin/pdata_tools $out/bin/era_check
+    ln -s $out/bin/pdata_tools $out/bin/era_dump
+    ln -s $out/bin/pdata_tools $out/bin/era_invalidate
+    ln -s $out/bin/pdata_tools $out/bin/era_restore
+    ln -s $out/bin/pdata_tools $out/bin/thin_check
+    ln -s $out/bin/pdata_tools $out/bin/thin_delta
+    ln -s $out/bin/pdata_tools $out/bin/thin_dump
+    ln -s $out/bin/pdata_tools $out/bin/thin_ls
+    ln -s $out/bin/pdata_tools $out/bin/thin_metadata_size
+    ln -s $out/bin/pdata_tools $out/bin/thin_repair
+    ln -s $out/bin/pdata_tools $out/bin/thin_restore
+    ln -s $out/bin/pdata_tools $out/bin/thin_rmap
+    ln -s $out/bin/pdata_tools $out/bin/thin_trim
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/jthornber/thin-provisioning-tools/";
     description = "A suite of tools for manipulating the metadata of the dm-thin device-mapper target";


### PR DESCRIPTION
Previous version of thin-provisioning-tools  had a number of symlinks in the bin folder, after update to rust they are no longer there which breaks compatibility. This PR adds symlinks back.

https://github.com/NixOS/nixpkgs/issues/317018

## Description of changes

Manually link the binary in the postInstall phase

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
