### PR TITLE
mark: 9.1.4 -> 9.12.0

### DIFF
--- a/pkgs/tools/text/mark/default.nix
+++ b/pkgs/tools/text/mark/default.nix
@@ -2,18 +2,28 @@
 
 buildGoModule rec {
   pname = "mark";
-  version = "9.1.4";
+  version = "9.12.0";
 
   src = fetchFromGitHub {
     owner  = "kovetskiy";
     repo   = "mark";
     rev    = version;
-    sha256 = "sha256-nAgEegtRT4c2wJzVOY41JgM/JVW5xQjRnhXUzjwqxLY=";
+    sha256 = "sha256-GbtwC361BI02mI1xzwdH9iqTIrY5ItiAKfZ7C3uk5ms=";
   };
 
-  vendorHash = "sha256-2rEwZffM+RK0baz8m+fXN2NGYskv4zO67cWC4rx+hfI=";
+  vendorHash = "sha256-3OTHHhRgY9N6l6GXN6HCbmPAgpXyfyJ/3KAZWLltz24=";
 
   ldflags = [ "-s" "-w" "-X main.version=${version}" ];
+
+  checkFlags =
+    let
+      skippedTests = [
+        # Expects to be able to launch google-chrome
+        "TestExtractMermaidImage"
+      ];
+    in [
+      "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$"
+    ];
 
   meta = with lib; {
     description = "A tool for syncing your markdown documentation with Atlassian Confluence pages";


### PR DESCRIPTION
## Description of changes

This change bumps `mark` from `9.1.4`, to `9.12.0`. This is jumping _several_ versions.

Full changelog: https://github.com/kovetskiy/mark/compare/9.2.0...9.12.0

Version-specific changelogs:

- **9.12.0**: https://github.com/kovetskiy/mark/releases/tag/9.12.0
- **9.11.1**: https://github.com/kovetskiy/mark/releases/tag/9.11.1
- **9.11.0**: https://github.com/kovetskiy/mark/releases/tag/9.11.0
- **9.10.1**: https://github.com/kovetskiy/mark/releases/tag/9.10.1
- **9.10.0**: https://github.com/kovetskiy/mark/releases/tag/9.10.0
- **9.9.0**: https://github.com/kovetskiy/mark/releases/tag/9.9.0
- **9.8.0**: https://github.com/kovetskiy/mark/releases/tag/9.8.0
- **9.7.1**: https://github.com/kovetskiy/mark/releases/tag/9.7.1
- **9.7.0**: https://github.com/kovetskiy/mark/releases/tag/9.7.0
- **9.6.2**: https://github.com/kovetskiy/mark/releases/tag/9.6.2
- **9.6.1**: https://github.com/kovetskiy/mark/releases/tag/9.6.1
- **9.6.0**: https://github.com/kovetskiy/mark/releases/tag/9.6.0
- **9.5.2**: https://github.com/kovetskiy/mark/releases/tag/9.5.2
- **9.5.1**: https://github.com/kovetskiy/mark/releases/tag/9.5.1
- **9.5.0**: https://github.com/kovetskiy/mark/releases/tag/9.5.0
- **9.4.0**: https://github.com/kovetskiy/mark/releases/tag/9.4.0
- **9.3.1**: https://github.com/kovetskiy/mark/releases/tag/9.3.1
- **9.3.0**: https://github.com/kovetskiy/mark/releases/tag/9.3.0
- **9.2.1**: https://github.com/kovetskiy/mark/releases/tag/9.2.1
- **9.2.0**: https://github.com/kovetskiy/mark/releases/tag/9.2.0
- _end of changes since 9.1.4_

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## Notes

* The tests failed for me because they depend on `google-chrome`, which I do not have installed, and had no interest in running. I'm going to naively assume that they pass, because they do in the upstream source and the tool works. These [seem to have entered upstream's tree in `9.2.0`](https://github.com/kovetskiy/mark/commit/d9d560eda0bf05af41302b52e411c9922487514c), the first version after the currently committed version in nixpkgs. Should I include `google-chrome` as a build dependency, or patch out those tests?

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
