### PR TITLE
pkgs/test: fix silent failures when using runTests

### DIFF
--- a/pkgs/test/systemd/nixos/default.nix
+++ b/pkgs/test/systemd/nixos/default.nix
@@ -1,37 +1,42 @@
 { pkgs, lib, stdenv, ... }:
 
-lib.runTests {
-  # Merging two non-list definitions must still result in an error
-  # about a conflicting definition.
-  test-unitOption-merging-non-lists-conflict =
-    let nixos = pkgs.nixos {
-        system.stateVersion = lib.trivial.release;
-        systemd.services.systemd-test-nixos = {
-          serviceConfig = lib.mkMerge [
-            { StateDirectory = "foo"; }
-            { StateDirectory = "bar"; }
-          ];
+let
+  failures = lib.runTests {
+    # Merging two non-list definitions must still result in an error
+    # about a conflicting definition.
+    test-unitOption-merging-non-lists-conflict =
+      let nixos = pkgs.nixos {
+          system.stateVersion = lib.trivial.release;
+          systemd.services.systemd-test-nixos = {
+            serviceConfig = lib.mkMerge [
+              { StateDirectory = "foo"; }
+              { StateDirectory = "bar"; }
+            ];
+          };
         };
-      };
-    in {
-    expr = (builtins.tryEval (nixos.config.systemd.services.systemd-test-nixos.serviceConfig.StateDirectory)).success;
-    expected = false;
-  };
+      in {
+      expr = (builtins.tryEval (nixos.config.systemd.services.systemd-test-nixos.serviceConfig.StateDirectory)).success;
+      expected = false;
+    };
 
-  # Merging must lift non-list definitions to a list
-  # if at least one of them is a list.
-  test-unitOption-merging-list-non-list-append =
-    let nixos = pkgs.nixos {
-        system.stateVersion = lib.trivial.release;
-        systemd.services.systemd-test-nixos = {
-          serviceConfig = lib.mkMerge [
-            { StateDirectory = "foo"; }
-            { StateDirectory = ["bar"]; }
-          ];
+    # Merging must lift non-list definitions to a list
+    # if at least one of them is a list.
+    test-unitOption-merging-list-non-list-append =
+      let nixos = pkgs.nixos {
+          system.stateVersion = lib.trivial.release;
+          systemd.services.systemd-test-nixos = {
+            serviceConfig = lib.mkMerge [
+              { StateDirectory = "foo"; }
+              { StateDirectory = ["bar"]; }
+            ];
+          };
         };
-      };
-    in {
-    expr = nixos.config.systemd.services.systemd-test-nixos.serviceConfig.StateDirectory;
-    expected = [ "foo" "bar" ];
+      in {
+      expr = nixos.config.systemd.services.systemd-test-nixos.serviceConfig.StateDirectory;
+      expected = [ "foo" "bar" ];
+    };
   };
-}
+in
+
+lib.optional (failures != [])
+  (throw "The following systemd unit tests failed: ${lib.generators.toPretty {} failures}")


### PR DESCRIPTION
## Description of changes

In https://github.com/NixOS/nixpkgs/pull/290946 I blindly copied `pkgs/test/kernel.nix`'s use of `lib.runTests`, but it was not used correctly because no build error would be reported in case of a failing test:

For example, introducing a failure with:
```diff                                                                                                                  
diff --git a/pkgs/test/kernel.nix b/pkgs/test/kernel.nix
index e345d9fa207e..abb62276ecf6 100644                                                                                                                
--- a/pkgs/test/kernel.nix
+++ b/pkgs/test/kernel.nix
@@ -37,7 +37,7 @@ let                                                                                                                                  
   failures = runTests {                                                                                                                               
     testEasy = {                                                                                                                                      
       expr = (getConfig { NIXOS_FAKE_USB_DEBUG = yes;}).NIXOS_FAKE_USB_DEBUG;                                                                         
-      expected = { tristate = "y"; optional = false; freeform = null; };                                                                              
+      expected = { tristate = "N"; optional = false; freeform = null; };                                                                              
     };
 
     # mandatory flag should win over optional
```

would not lead to a build failure, only to a list of non-derivations:
```console
$ nix -L build -f . tests.kernel-config
$ echo $?
0
$ nix -L eval -f . tests.kernel-config
[ { expected = { freeform = null; optional = false; tristate = "N"; }; name = "testEasy"; result = { freeform = null; optional = false; tristate = "y"; }; } ]
```

With this PR introducing `throw` as in `lib/path/tests/unit.nix`, failures are reported as expected:
```console
$ nix -L build -f . tests.kernel-config
error:
       … while calling the 'throw' builtin                                                                                                             

         at /home/julm/src/nix/nixpkgs/worktree/fix-pkgs-test-runTests/pkgs/test/kernel.nix:73:4:                                                 

           72| lib.optional (failures != [])                                                                                                           
           73|   (throw "The following kernel unit tests failed: ${lib.generators.toPretty {} failures}")                                              
             |    ^                                                                                                                                    
           74|

       error: The following kernel unit tests failed: [
         {
           expected = {
             freeform = null;                                                                                                                          
             optional = false;
             tristate = "N";
           };                                                                                                                                          
           name = "testEasy";                                                                                                                          
           result = {                                                                                                                                  
             freeform = null;                                                                                                                          
             optional = false;                                                                                                                         
             tristate = "y";
           };
         }
       ]
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
The diff is big due to a mandatory increased indentation, but this change is just to examine the result of `runTests` and `throw` any failure.

- [X] Fix `tests.kernel-config`
- [X] Fix `tests.systemd.nixos`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
