### PR TITLE
mepo: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/applications/misc/mepo/default.nix
+++ b/pkgs/applications/misc/mepo/default.nix
@@ -17,23 +17,23 @@
 , util-linux
 , xwininfo
 , zenity
-, zig_0_11
+, zig_0_12
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mepo";
-  version = "1.2.0";
+  version = "1.2.1";
 
   src = fetchFromSourcehut {
     owner = "~mil";
     repo = "mepo";
     rev = finalAttrs.version;
-    hash = "sha256-sxN7yTnk3KDAkP/d3miKa2bEgB3AUaf9/M9ajJyRt3g=";
+    hash = "sha256-Ii5E9TgUxzlVIdkKS/6RtasOETeclMm1yoU86gs4hB8=";
   };
 
   nativeBuildInputs = [
     pkg-config
-    zig_0_11.hook
+    zig_0_12.hook
     makeWrapper
   ];
 
@@ -56,10 +56,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   postFixup = ''
     substituteInPlace $out/bin/mepo_ui_menu_user_pin_updater.sh \
-      --replace /usr/libexec/geoclue-2.0 ${geoclue2-with-demo-agent}/libexec/geoclue-2.0
+      --replace-fail /usr/libexec/geoclue-2.0 ${geoclue2-with-demo-agent}/libexec/geoclue-2.0
     substituteInPlace $out/bin/mepo_ui_central_menu.sh \
-      --replace "grep mepo_" "grep '^\.mepo_\|^mepo_'" \
-      --replace " ls " " ls -a " #circumvent wrapping for script detection
+      --replace-fail "grep mepo_" "grep '^\.mepo_\|^mepo_'" \
+      --replace-fail " ls " " ls -a " #circumvent wrapping for script detection
     for program in $out/bin/* ; do
       wrapProgram $program \
         --suffix PATH : $out/bin:${lib.makeBinPath ([


### PR DESCRIPTION
## Description of changes

[Mepo 1.2.1 simply ports to Zig 0.12.](https://git.sr.ht/~mil/mepo/refs/1.2.1)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).