### PR TITLE
prometheus-deluge-exporter: init at 2.4.0-unstable-2024-06-02

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -29,6 +29,7 @@ let
     "blackbox"
     "buildkite-agent"
     "collectd"
+    "deluge"
     "dmarc"
     "dnsmasq"
     "dnssec"
@@ -413,6 +414,14 @@ in
         Please ensure you have either `services.prometheus.exporters.idrac.configuration'
           or `services.prometheus.exporters.idrac.configurationPath' set!
       '';
+    } {
+      assertion = cfg.deluge.enable -> (
+        (cfg.deluge.delugePassword == null) != (cfg.deluge.delugePasswordFile == null)
+      );
+      message = ''
+        Please ensure you have either `services.prometheus.exporters.deluge.delugePassword'
+          or `services.prometheus.exporters.deluge.delugePasswordFile' set!
+      '';
     } ] ++ (flip map (attrNames exporterOpts) (exporter: {
       assertion = cfg.${exporter}.firewallFilter != null -> cfg.${exporter}.openFirewall;
       message = ''
@@ -446,6 +455,13 @@ in
     hardware.rtl-sdr.enable = mkDefault true;
   })] ++ [(mkIf config.services.postfix.enable {
     services.prometheus.exporters.postfix.group = mkDefault config.services.postfix.setgidGroup;
+  })] ++ [(mkIf config.services.prometheus.exporters.deluge.enable {
+    system.activationScripts = {
+      deluge-exported.text = ''
+      mkdir -p /etc/deluge-exporter
+      echo "DELUGE_PASSWORD=$(cat ${config.services.prometheus.exporters.deluge.delugePasswordFile})" > /etc/deluge-exporter/password
+      '';
+    };
   })] ++ (mapAttrsToList (name: conf:
     mkExporterConf {
       inherit name;

--- a/nixos/modules/services/monitoring/prometheus/exporters/deluge.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/deluge.nix
@@ -1,0 +1,85 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.prometheus.exporters.deluge;
+  inherit (lib) mkOption types concatStringsSep;
+in
+{
+  port = 9354;
+
+  extraOpts = {
+    delugeHost = mkOption {
+      type = types.str;
+      default = "localhost";
+      description = ''
+        Hostname where deluge server is running.
+      '';
+    };
+
+    delugePort = mkOption {
+      type = types.port;
+      default = 58846;
+      description = ''
+        Port where deluge server is listening.
+      '';
+    };
+
+    delugeUser = mkOption {
+      type = types.str;
+      default = "localclient";
+      description = ''
+        User to connect to deluge server.
+      '';
+    };
+
+    delugePassword = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Password to connect to deluge server.
+
+        This stores the password unencrypted in the nix store and is thus considered unsafe. Prefer
+        using the delugePasswordFile option.
+      '';
+    };
+
+    delugePasswordFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        File containing the password to connect to deluge server.
+      '';
+    };
+
+    exportPerTorrentMetrics = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enable per-torrent metrics.
+
+        This may significantly increase the number of time series depending on the number of
+        torrents in your Deluge instance.
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = ''
+        ${pkgs.prometheus-deluge-exporter}/bin/deluge-exporter
+      '';
+      Environment = [
+        "LISTEN_PORT=${toString cfg.port}"
+        "LISTEN_ADDRESS=${toString cfg.listenAddress}"
+
+        "DELUGE_HOST=${cfg.delugeHost}"
+        "DELUGE_USER=${cfg.delugeUser}"
+        "DELUGE_PORT=${toString cfg.delugePort}"
+      ] ++ lib.optionals (cfg.delugePassword != null) [
+        "DELUGE_PASSWORD=${cfg.delugePassword}"
+      ] ++ lib.optionals cfg.exportPerTorrentMetrics [
+        "PER_TORRENT_METRICS=1"
+      ];
+      EnvironmentFile = lib.optionalString (cfg.delugePasswordFile != null) "/etc/deluge-exporter/password";
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -209,6 +209,34 @@ let
         '';
     };
 
+    deluge = {
+      exporterConfig = {
+        enable = true;
+        port = 1234;
+        listenAddress = "127.0.0.1";
+
+        delugeUser = "user";
+        delugePort = 2345;
+        delugePasswordFile = pkgs.writeText "password" "weak_password";
+      };
+      metricProvider = {
+        services.deluge.enable = true;
+        services.deluge.declarative = true;
+        services.deluge.config.daemon_port = 2345;
+        services.deluge.authFile = pkgs.writeText "authFile" ''
+        localclient:abcdef:10
+        user:weak_password:10
+        '';
+      };
+      exporterTest = ''
+        wait_for_unit("deluged.service")
+        wait_for_open_port(2345)
+        wait_for_unit("prometheus-deluge-exporter.service")
+        wait_for_open_port(1234)
+        succeed("curl -sSf http://localhost:1234 | grep 'deluge_torrents'")
+      '';
+    };
+
     dnsmasq = {
       exporterConfig = {
         enable = true;

--- a/pkgs/by-name/pr/prometheus-deluge-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-deluge-exporter/package.nix
@@ -1,0 +1,35 @@
+{ lib
+, python3
+, fetchFromGitHub
+, nixosTests
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "deluge-exporter";
+  version = "2.4.0-unstable-2024-06-02";
+
+  src = fetchFromGitHub {
+    owner = "ibizaman";
+    repo = "deluge_exporter";
+    rev = "8d446c8cba4a324aa052e66c115121b23adc970f";
+    hash = "sha256-1brLWx6IEGffcvHPCkz10k9GCNQIXXJ9PYZuEzlKHTA=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    deluge-client
+    loguru
+    prometheus-client
+  ];
+
+  pythonImportsCheck = [
+    "deluge_exporter"
+  ];
+
+  meta = with lib; {
+    description = "Prometheus exporter for Deluge";
+    homepage = "https://github.com/ibizaman/deluge_exporter";
+    license = licenses.isc;
+    maintainers = with maintainers; [ ibizaman ];
+    mainProgram = "deluge-exporter";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/tobbez/deluge_exporter

Prometheus exporter for the Deluge BitTorrent client

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Ran:

```
nix-build -A prometheus-deluge-exporter
DELUGE_HOST=baryum DELUGE_PORT=58846 DELUGE_USER=localclient DELUGE_PASSWORD=<redacted> ./result/bin/deluge-exporter
curl localhost:9354
```
and saw metrics.

Also, ran the tests which succeeded:

```
nix-build -A nixosTests.prometheus-exporters.deluge
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
