### PR TITLE
stdenv: Allow user to supply their bootstrapFiles set of tools

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -15,11 +15,12 @@
   overlays,
   crossOverlays ? [ ],
   # Allow passing in bootstrap files directly so we can test the stdenv bootstrap process when changing the bootstrap tools
-  bootstrapFiles ?
+  bootstrapFiles ? (config.replaceBootstrapFiles or lib.id) (
     if localSystem.isAarch64 then
       import ./bootstrap-files/aarch64-apple-darwin.nix
     else
-      import ./bootstrap-files/x86_64-apple-darwin.nix,
+      import ./bootstrap-files/x86_64-apple-darwin.nix
+  ),
 }:
 
 assert crossSystem == localSystem;

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -94,7 +94,7 @@
     or (throw "unsupported libc for the pure Linux stdenv");
   files = archLookupTable.${localSystem.system} or (if getCompatibleTools != null then getCompatibleTools
     else (throw "unsupported platform for the pure Linux stdenv"));
-  in files
+  in (config.replaceBootstrapFiles or lib.id) files
 }:
 
 assert crossSystem == localSystem;

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -134,6 +134,34 @@ let
       feature = "build packages with CUDA support by default";
     };
 
+    replaceBootstrapFiles = mkMassRebuild {
+      type = types.functionTo (types.attrsOf types.package);
+      default = lib.id;
+      defaultText = literalExpression "lib.id";
+      description = ''
+        Use the bootstrap files returned instead of the default bootstrap
+        files.
+        The default bootstrap files are passed as an argument.
+      '';
+      example = literalExpression ''
+        prevFiles:
+        let
+          replacements = {
+            "sha256-YQlr088HPoVWBU2jpPhpIMyOyoEDZYDw1y60SGGbUM0=" = import <nix/fetchurl.nix> {
+              url = "(custom glibc linux x86_64 bootstrap-tools.tar.xz)";
+              hash = "(...)";
+            };
+            "sha256-QrTEnQTBM1Y/qV9odq8irZkQSD9uOMbs2Q5NgCvKCNQ=" = import <nix/fetchurl.nix> {
+              url = "(custom glibc linux x86_64 busybox)";
+              hash = "(...)";
+              executable = true;
+            };
+          };
+        in
+        builtins.mapAttrs (name: prev: replacements.''${prev.outputHash} or prev) prevFiles
+      '';
+    };
+
     rocmSupport = mkMassRebuild {
       type = types.bool;
       default = false;


### PR DESCRIPTION
## Description of changes

This adds a config option `replaceBootstrapFiles`. It's a function that takes the normal bootstrap files and returns your custom bootstrap files.

Example nixpkgs/config.nix:

```nix
{
  replaceBootstrapFiles =
    prevFiles:
    let
      replacements = {
        "sha256-YQlr088HPoVWBU2jpPhpIMyOyoEDZYDw1y60SGGbUM0=" = import <nix/fetchurl.nix> {
          url = "(custom glibc linux x86_64 bootstrap-tools.tar.xz)";
          hash = "(...)";
        };
        "sha256-QrTEnQTBM1Y/qV9odq8irZkQSD9uOMbs2Q5NgCvKCNQ=" = import <nix/fetchurl.nix> {
          url = "(custom glibc linux x86_64 busybox)";
          hash = "(...)";
          executable = true;
        };
      };
    in
    builtins.mapAttrs (name: prev: replacements.${prev.outputHash} or prev) prevFiles;
}
```

fixes #272750

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
