### PR TITLE
pkgs/top-level/make-tarball.nix: avoid hardlinks

### DIFF
--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -55,6 +55,8 @@ pkgs.releaseTools.sourceTarball {
     echo "file json-br $packages" >> $out/nix-support/hydra-build-products
   '';
 
+  # --hard-dereference: reproducibility for src if auto-optimise-store = true
+  #   Some context: https://github.com/NixOS/infra/issues/438
   distPhase = ''
     mkdir -p $out/tarballs
     XZ_OPT="-T0" tar \
@@ -71,6 +73,7 @@ pkgs.releaseTools.sourceTarball {
       --sort=name \
       --mtime="@$SOURCE_DATE_EPOCH" \
       --mode=ug+w \
+      --hard-dereference \
       $src $(pwd)/{.version-suffix,.git-revision}
   '';
 }


### PR DESCRIPTION
For context see https://github.com/NixOS/nix/issues/10395 and cross-linked discussions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux and checked that hardlinks were avoided (on a machine with `auto-optimize-store = true`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
