### PR TITLE
python3Packages.clustershell: remove blocking test

### DIFF
--- a/pkgs/development/python-modules/clustershell/default.nix
+++ b/pkgs/development/python-modules/clustershell/default.nix
@@ -69,10 +69,9 @@ buildPythonPackage rec {
     rm tests/TaskDistantPdshMixin.py
     rm tests/TaskDistantPdshTest.py
     rm tests/TaskRLimitsTest.py
+    rm tests/TreeGatewayTest.py
 
     nosetests -v \
-      -e test_channel_ctl_shell_remote1 \
-      -e test_channel_ctl_shell_remote2 \
       -e test_fromall_grouplist \
       -e test_rank_placeholder \
       -e test_engine_on_the_fly_launch \
@@ -92,9 +91,6 @@ buildPythonPackage rec {
       -e testClushConfigSetRlimit  \
       -e testTimerInvalidateInHandler \
       -e testTimerSetNextFireInHandler \
-      -e test_channel_ctl_shell_mlocal1 \
-      -e test_channel_ctl_shell_mlocal2 \
-      -e test_channel_ctl_shell_mlocal3 \
       -e test_node_placeholder \
     tests/*.py
   '';


### PR DESCRIPTION
## Description of changes

remove tests/TreeGatewayTest.py because it does not return.

Apparently

    def wait(self):
        """wait for task/thread termination"""
        # can be blocked indefinitely if StreamWorker doesn't complete
        self.task.join()

does apply in nix sandbox.

fixes #315146

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
