### PR TITLE
nixos/ydotool: Make group configurable

### DIFF
--- a/nixos/modules/programs/ydotool.nix
+++ b/nixos/modules/programs/ydotool.nix
@@ -14,22 +14,29 @@ in
 
   options.programs.ydotool = {
     enable = lib.mkEnableOption ''
-      ydotoold system service and install ydotool.
-      Add yourself to the 'ydotool' group to be able to use it.
+      ydotoold system service and {command}`ydotool` for members of
+      {option}`programs.ydotool.group`.
     '';
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "ydotool";
+      description = ''
+        Group which users must be in to use {command}`ydotool`.
+      '';
+    };
   };
 
   config = let
     runtimeDirectory = "ydotoold";
   in lib.mkIf cfg.enable {
-    users.groups.ydotool = { };
+    users.groups."${config.programs.ydotool.group}" = { };
 
     systemd.services.ydotoold = {
       description = "ydotoold - backend for ydotool";
       wantedBy = [ "multi-user.target" ];
       partOf = [ "multi-user.target" ];
       serviceConfig = {
-        Group = "ydotool";
+        Group = config.programs.ydotool.group;
         RuntimeDirectory = runtimeDirectory;
         RuntimeDirectoryMode = "0750";
         ExecStart = "${lib.getExe' pkgs.ydotool "ydotoold"} --socket-path=${config.environment.variables.YDOTOOL_SOCKET} --socket-perm=0660";

--- a/nixos/modules/programs/ydotool.nix
+++ b/nixos/modules/programs/ydotool.nix
@@ -19,7 +19,9 @@ in
     '';
   };
 
-  config = lib.mkIf cfg.enable {
+  config = let
+    runtimeDirectory = "ydotoold";
+  in lib.mkIf cfg.enable {
     users.groups.ydotool = { };
 
     systemd.services.ydotoold = {
@@ -28,9 +30,9 @@ in
       partOf = [ "multi-user.target" ];
       serviceConfig = {
         Group = "ydotool";
-        RuntimeDirectory = "ydotoold";
+        RuntimeDirectory = runtimeDirectory;
         RuntimeDirectoryMode = "0750";
-        ExecStart = "${lib.getExe' pkgs.ydotool "ydotoold"} --socket-path=/run/ydotoold/socket --socket-perm=0660";
+        ExecStart = "${lib.getExe' pkgs.ydotool "ydotoold"} --socket-path=${config.environment.variables.YDOTOOL_SOCKET} --socket-perm=0660";
 
         # hardening
 
@@ -76,7 +78,7 @@ in
     };
 
     environment.variables = {
-      YDOTOOL_SOCKET = "/run/ydotoold/socket";
+      YDOTOOL_SOCKET = "/run/${runtimeDirectory}/socket";
     };
     environment.systemPackages = with pkgs; [ ydotool ];
   };

--- a/nixos/tests/ydotool.nix
+++ b/nixos/tests/ydotool.nix
@@ -1,115 +1,141 @@
-import ./make-test-python.nix (
-  { pkgs, lib, ... }:
-  let
-    textInput = "This works.";
-    inputBoxText = "Enter input";
-    inputBox = pkgs.writeShellScript "zenity-input" ''
-      ${lib.getExe pkgs.gnome.zenity} --entry --text '${inputBoxText}:' > /tmp/output &
-    '';
-  in
-  {
-    name = "ydotool";
-
-    meta = {
-      maintainers = with lib.maintainers; [
-        OPNA2608
-        quantenzitrone
-      ];
-    };
-
-    nodes = {
-      headless =
-        { config, ... }:
-        {
-          imports = [ ./common/user-account.nix ];
-
-          users.users.alice.extraGroups = [ "ydotool" ];
-
-          programs.ydotool.enable = true;
-
-          services.getty.autologinUser = "alice";
-        };
-
-      x11 =
-        { config, ... }:
-        {
-          imports = [
-            ./common/user-account.nix
-            ./common/auto.nix
-            ./common/x11.nix
-          ];
-
-          users.users.alice.extraGroups = [ "ydotool" ];
-
-          programs.ydotool.enable = true;
-
-          test-support.displayManager.auto = {
-            enable = true;
-            user = "alice";
-          };
-
-          services.xserver.windowManager.dwm.enable = true;
-          services.displayManager.defaultSession = lib.mkForce "none+dwm";
-        };
-
-      wayland =
-        { config, ... }:
-        {
-          imports = [ ./common/user-account.nix ];
-
-          services.cage = {
-            enable = true;
-            user = "alice";
-          };
-
-          programs.ydotool.enable = true;
-
-          services.cage.program = inputBox;
-        };
-    };
+{
+  system ? builtins.currentSystem,
+  config ? { },
+  pkgs ? import ../.. { inherit system config; },
+  lib ? pkgs.lib,
+}:
+let
+  makeTest = import ./make-test-python.nix;
+  textInput = "This works.";
+  inputBoxText = "Enter input";
+  inputBox = pkgs.writeShellScript "zenity-input" ''
+    ${lib.getExe pkgs.gnome.zenity} --entry --text '${inputBoxText}:' > /tmp/output &
+  '';
+  asUser = ''
+    def as_user(cmd: str):
+        """
+        Return a shell command for running a shell command as a specific user.
+        """
+        return f"sudo -u alice -i {cmd}"
+  '';
+in
+{
+  headless = makeTest {
+    name = "headless";
 
     enableOCR = true;
 
-    testScript =
-      { nodes, ... }:
-      ''
-        def as_user(cmd: str):
-          """
-          Return a shell command for running a shell command as a specific user.
-          """
-          return f"sudo -u alice -i {cmd}"
+    nodes.machine = {
+      imports = [ ./common/user-account.nix ];
 
+      users.users.alice.extraGroups = [ "ydotool" ];
+
+      programs.ydotool.enable = true;
+
+      services.getty.autologinUser = "alice";
+    };
+
+    testScript =
+      asUser
+      + ''
         start_all()
 
-        # Headless
-        headless.wait_for_unit("multi-user.target")
-        headless.wait_for_text("alice")
-        headless.succeed(as_user("ydotool type 'echo ${textInput} > /tmp/output'")) # text input
-        headless.succeed(as_user("ydotool key 28:1 28:0")) # text input
-        headless.screenshot("headless_input")
-        headless.wait_for_file("/tmp/output")
-        headless.wait_until_succeeds("grep '${textInput}' /tmp/output") # text input
-
-        # X11
-        x11.wait_for_x()
-        x11.execute(as_user("${inputBox}"))
-        x11.wait_for_text("${inputBoxText}")
-        x11.succeed(as_user("ydotool type '${textInput}'")) # text input
-        x11.screenshot("x11_input")
-        x11.succeed(as_user("ydotool mousemove -a 400 110")) # mouse input
-        x11.succeed(as_user("ydotool click 0xC0")) # mouse input
-        x11.wait_for_file("/tmp/output")
-        x11.wait_until_succeeds("grep '${textInput}' /tmp/output") # text input
-
-        # Wayland
-        wayland.wait_for_unit("graphical.target")
-        wayland.wait_for_text("${inputBoxText}")
-        wayland.succeed("ydotool type '${textInput}'") # text input
-        wayland.screenshot("wayland_input")
-        wayland.succeed("ydotool mousemove -a 100 100") # mouse input
-        wayland.succeed("ydotool click 0xC0") # mouse input
-        wayland.wait_for_file("/tmp/output")
-        wayland.wait_until_succeeds("grep '${textInput}' /tmp/output") # text input
+        machine.wait_for_unit("multi-user.target")
+        machine.wait_for_text("alice")
+        machine.succeed(as_user("ydotool type 'echo ${textInput} > /tmp/output'")) # text input
+        machine.succeed(as_user("ydotool key 28:1 28:0")) # text input
+        machine.screenshot("headless_input")
+        machine.wait_for_file("/tmp/output")
+        machine.wait_until_succeeds("grep '${textInput}' /tmp/output") # text input
       '';
-  }
-)
+
+    meta.maintainers = with lib.maintainers; [
+      OPNA2608
+      quantenzitrone
+    ];
+  };
+
+  x11 = makeTest {
+    name = "x11";
+
+    enableOCR = true;
+
+    nodes.machine = {
+      imports = [
+        ./common/user-account.nix
+        ./common/auto.nix
+        ./common/x11.nix
+      ];
+
+      users.users.alice.extraGroups = [ "ydotool" ];
+
+      programs.ydotool.enable = true;
+
+      test-support.displayManager.auto = {
+        enable = true;
+        user = "alice";
+      };
+
+      services.xserver.windowManager.dwm.enable = true;
+      services.displayManager.defaultSession = lib.mkForce "none+dwm";
+    };
+
+    testScript =
+      asUser
+      + ''
+        start_all()
+
+        machine.wait_for_x()
+        machine.execute(as_user("${inputBox}"))
+        machine.wait_for_text("${inputBoxText}")
+        machine.succeed(as_user("ydotool type '${textInput}'")) # text input
+        machine.screenshot("x11_input")
+        machine.succeed(as_user("ydotool mousemove -a 400 110")) # mouse input
+        machine.succeed(as_user("ydotool click 0xC0")) # mouse input
+        machine.wait_for_file("/tmp/output")
+        machine.wait_until_succeeds("grep '${textInput}' /tmp/output") # text input
+      '';
+
+    meta.maintainers = with lib.maintainers; [
+      OPNA2608
+      quantenzitrone
+    ];
+  };
+
+  wayland = makeTest {
+    name = "wayland";
+
+    enableOCR = true;
+
+    nodes.machine = {
+      imports = [ ./common/user-account.nix ];
+
+      services.cage = {
+        enable = true;
+        user = "alice";
+      };
+
+      programs.ydotool.enable = true;
+
+      services.cage.program = inputBox;
+    };
+
+    testScript = ''
+      start_all()
+
+      machine.wait_for_unit("graphical.target")
+      machine.wait_for_text("${inputBoxText}")
+      machine.succeed("ydotool type '${textInput}'") # text input
+      machine.screenshot("wayland_input")
+      machine.succeed("ydotool mousemove -a 100 100") # mouse input
+      machine.succeed("ydotool click 0xC0") # mouse input
+      machine.wait_for_file("/tmp/output")
+      machine.wait_until_succeeds("grep '${textInput}' /tmp/output") # text input
+    '';
+
+    meta.maintainers = with lib.maintainers; [
+      OPNA2608
+      quantenzitrone
+    ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Allows users to refer to `config.programs.ydotool.group` rather than
hard-coding "ydotool".

Allows users to override the group name for whatever reason.

This closes #317013.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
