### PR TITLE
ark-pixel-font: dependencies update and fix

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20271,6 +20271,12 @@
     githubId = 870673;
     name = "Takuo Yonezawa";
   };
+  TakWolf = {
+    email = "takwolf@foxmail.com";
+    github = "TakWolf";
+    githubId = 6064962;
+    name = "TakWolf";
+  };
   talkara = {
     email = "taito.horiuchi@relexsolutions.com";
     github = "talkara";

--- a/pkgs/development/python-modules/bdffont/default.nix
+++ b/pkgs/development/python-modules/bdffont/default.nix
@@ -2,42 +2,41 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pytestCheckHook,
   pythonOlder,
+  pytestCheckHook,
   nix-update-script,
-  hatch-vcs,
   hatchling,
-  brotli,
-  fonttools,
 }:
 
 buildPythonPackage rec {
   pname = "bdffont";
   version = "0.0.26";
+  pyproject = true;
 
-  disabled = pythonOlder "3.11";
+  disabled = pythonOlder "3.10";
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "bdffont";
+    inherit version;
     hash = "sha256-Q8IqwJmAYFicTX7RrVU9UvGZX+oaPb0RKlIFwArktXk=";
   };
 
-  format = "pyproject";
-
-  nativeBuildInputs = [
-    hatch-vcs
-    hatchling
-  ];
+  build-system = [ hatchling ];
 
   nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "bdffont" ];
 
   passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/TakWolf/bdffont";
-    description = "Library for manipulating .bdf format fonts";
+    description = "A library for manipulating Glyph Bitmap Distribution Format (BDF) Fonts";
     platforms = lib.platforms.all;
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ h7x4 ];
+    maintainers = with lib.maintainers; [
+      TakWolf
+      h7x4
+    ];
   };
 }

--- a/pkgs/development/python-modules/character-encoding-utils/default.nix
+++ b/pkgs/development/python-modules/character-encoding-utils/default.nix
@@ -2,10 +2,10 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  hatch-vcs,
-  hatchling,
-  pytestCheckHook,
   pythonOlder,
+  pytestCheckHook,
+  nix-update-script,
+  hatchling,
 }:
 
 buildPythonPackage rec {
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   version = "0.0.8";
   pyproject = true;
 
-  disabled = pythonOlder "3.11";
+  disabled = pythonOlder "3.10";
 
   src = fetchPypi {
     pname = "character_encoding_utils";
@@ -21,19 +21,22 @@ buildPythonPackage rec {
     hash = "sha256-UXX4L/x7fP37ZEFDCPc0KRNyx47xvwY0Jz+lfxzUulg=";
   };
 
-  build-system = [
-    hatch-vcs
-    hatchling
-  ];
+  build-system = [ hatchling ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "character_encoding_utils" ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
-    description = "Some character encoding utils";
     homepage = "https://github.com/TakWolf/character-encoding-utils";
+    description = "Some character encoding utils";
+    platforms = lib.platforms.all;
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ h7x4 ];
+    maintainers = with lib.maintainers; [
+      TakWolf
+      h7x4
+    ];
   };
 }

--- a/pkgs/development/python-modules/pcffont/default.nix
+++ b/pkgs/development/python-modules/pcffont/default.nix
@@ -1,11 +1,12 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-  hatchling,
-  bdffont,
+  fetchPypi,
+  pythonOlder,
   pytestCheckHook,
   nix-update-script,
+  hatchling,
+  bdffont,
 }:
 
 buildPythonPackage rec {
@@ -13,11 +14,12 @@ buildPythonPackage rec {
   version = "0.0.14";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "TakWolf";
-    repo = "pcffont";
-    rev = "refs/tags/${version}";
-    hash = "sha256-UIRhUlsRd3ICdLAjUasQ1NX5NofSKCEqa8cf1c1voGM=";
+  disabled = pythonOlder "3.10";
+
+  src = fetchPypi {
+    pname = "pcffont";
+    inherit version;
+    hash = "sha256-S3mK4tY7zNGRX8K81QJVvaYpIaTDLx5zn4vKbhrK9VM=";
   };
 
   build-system = [ hatchling ];
@@ -31,9 +33,13 @@ buildPythonPackage rec {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "Library for manipulating Portable Compiled Format (PCF) fonts";
     homepage = "https://github.com/TakWolf/pcffont";
+    description = "A library for manipulating Portable Compiled Format (PCF) Fonts";
+    platforms = lib.platforms.all;
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [
+      TakWolf
+      h7x4
+    ];
   };
 }

--- a/pkgs/development/python-modules/pixel-font-builder/default.nix
+++ b/pkgs/development/python-modules/pixel-font-builder/default.nix
@@ -2,17 +2,15 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pytestCheckHook,
   pythonOlder,
+  pytestCheckHook,
   nix-update-script,
-  hatch-vcs,
   hatchling,
-  bdffont,
-  brotli,
   fonttools,
-  pypng,
+  brotli,
+  bdffont,
   pcffont,
-  pythonRelaxDepsHook,
+  pypng,
 }:
 
 buildPythonPackage rec {
@@ -28,26 +26,19 @@ buildPythonPackage rec {
     hash = "sha256-66mGZ7q64z+tTJSSveD7UCkTq7YXgsHTM25MqUSLfvM=";
   };
 
-  pythonRelaxDeps = [ "fonttools" ];
+  build-system = [ hatchling ];
 
-  nativeBuildInputs = [ pythonRelaxDepsHook ];
-
-  build-system = [
-    hatch-vcs
-    hatchling
-  ];
-
-  nativeCheckInputs = [
-    pytestCheckHook
+  dependencies = [
+    fonttools
+    brotli
+    bdffont
+    pcffont
     pypng
   ];
 
-  dependencies = [
-    bdffont
-    brotli
-    fonttools
-    pcffont
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pixel_font_builder" ];
 
   passthru.updateScript = nix-update-script { };
 
@@ -56,6 +47,9 @@ buildPythonPackage rec {
     description = "Library that helps create pixel style fonts";
     platforms = lib.platforms.all;
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ h7x4 ];
+    maintainers = with lib.maintainers; [
+      TakWolf
+      h7x4
+    ];
   };
 }

--- a/pkgs/development/python-modules/unidata-blocks/default.nix
+++ b/pkgs/development/python-modules/unidata-blocks/default.nix
@@ -2,10 +2,9 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pytestCheckHook,
   pythonOlder,
+  pytestCheckHook,
   nix-update-script,
-  hatch-vcs,
   hatchling,
   langcodes,
 }:
@@ -13,8 +12,9 @@
 buildPythonPackage rec {
   pname = "unidata-blocks";
   version = "0.0.10";
+  pyproject = true;
 
-  disabled = pythonOlder "3.11";
+  disabled = pythonOlder "3.10";
 
   src = fetchPypi {
     pname = "unidata_blocks";
@@ -22,16 +22,15 @@ buildPythonPackage rec {
     hash = "sha256-wwiOjfIAx6AZtK98uuPQ0jwblq+CdnMQp+JkQWh+RgM=";
   };
 
-  format = "pyproject";
+  build-system = [ hatchling ];
 
-  nativeBuildInputs = [
-    hatch-vcs
-    hatchling
+  dependencies = [
+    langcodes
   ];
 
-  propagatedBuildInputs = [ langcodes ];
-
   nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "unidata_blocks" ];
 
   passthru.updateScript = nix-update-script { };
 
@@ -40,6 +39,9 @@ buildPythonPackage rec {
     description = "Library that helps query unicode blocks by Blocks.txt";
     platforms = lib.platforms.all;
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ h7x4 ];
+    maintainers = with lib.maintainers; [
+      TakWolf
+      h7x4
+    ];
   };
 }


### PR DESCRIPTION
## Description of changes

I am the original maintainer of these python packages. 
They are dependencies of https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/ar/ark-pixel-font
The config of these packages seems to have some issues, and I have tried to fix them.
But I am not a user of NixOS, I'm not sure if I do the right thing.
These packages require testing and review.

Related to https://github.com/TakWolf/ark-pixel-font/issues/35

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
