### PR TITLE
python311Packages.curvefitgui: init at 0-unstable-2021-08-25

### DIFF
--- a/pkgs/development/python-modules/curvefitgui/default.nix
+++ b/pkgs/development/python-modules/curvefitgui/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pythonAtLeast,
+  numpy,
+  scipy,
+  pyqt5,
+  matplotlib,
+}:
+
+buildPythonPackage {
+  pname = "curvefitgui";
+  version = "0-unstable-2021-08-25";
+  pyproject = true;
+  # For some reason, importing the main module makes the whole python
+  # interpreter crash! This needs further investigation, possibly the problem
+  # is with one of the dependencies.. See upstream report:
+  # https://github.com/moosepy/curvefitgui/issues/2
+  disabled = pythonAtLeast "3.12";
+
+  src = fetchFromGitHub {
+    owner = "moosepy";
+    repo = "curvefitgui";
+    rev = "5f1e7f3b95cd77d10bd8183c9a501e47ff94fad7";
+    hash = "sha256-oK0ROKxh/91OrHhuufG6pvc2EMBeMP8R5O+ED2thyW8=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    pyqt5
+    matplotlib
+  ];
+
+  pythonImportsCheck = [ "curvefitgui" ];
+
+  meta = {
+    description = "Graphical interface to the non-linear curvefit function scipy.optimise.curve_fit";
+    homepage = "https://github.com/moosepy/curvefitgui";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2650,6 +2650,8 @@ self: super: with self; {
 
   curve25519-donna = callPackage ../development/python-modules/curve25519-donna { };
 
+  curvefitgui = callPackage ../development/python-modules/curvefitgui { };
+
   cvelib = callPackage ../development/python-modules/cvelib { };
 
   cvss = callPackage ../development/python-modules/cvss { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
