### PR TITLE
csound-plugins: init at 1.0.2

### DIFF
--- a/pkgs/applications/audio/csound/default.nix
+++ b/pkgs/applications/audio/csound/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-O7s92N54+zIl07eIdK/puoSve/qJ3O01fTh0TP+VdZA=";
   };
 
-  cmakeFlags = [ "-DBUILD_CSOUND_AC=0" ] # fails to find Score.hpp
+  cmakeFlags = lib.optional stdenv.isAarch32 (lib.cmakeFeature "CMAKE_C_FLAGS" "-DPFFFT_SIMD_DISABLE")
     ++ lib.optional stdenv.isDarwin "-DCS_FRAMEWORK_DEST=${placeholder "out"}/lib"
     # Ignore gettext in CMAKE_PREFIX_PATH on cross to prevent find_program picking up the wrong gettext
     ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-DCMAKE_IGNORE_PATH=${lib.getBin gettext}/bin";

--- a/pkgs/applications/audio/csound/default.nix
+++ b/pkgs/applications/audio/csound/default.nix
@@ -9,12 +9,7 @@
 , libjack2 ? null
 , liblo ? null
 , ladspa-sdk ? null
-, fluidsynth ? null
-# , gmm ? null  # opcodes don't build with gmm 5.1
-, eigen ? null
 , curl ? null
-, tcltk ? null
-, fltk ? null
 }:
 
 stdenv.mkDerivation rec {
@@ -36,14 +31,13 @@ stdenv.mkDerivation rec {
     ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-DCMAKE_IGNORE_PATH=${lib.getBin gettext}/bin";
 
   nativeBuildInputs = [ cmake flex bison gettext ];
-  buildInputs = [ libsndfile libsamplerate boost ]
+  buildInputs = [ libsndfile libsamplerate boost curl ]
     ++ lib.optionals stdenv.isDarwin [
       Accelerate AudioUnit CoreAudio CoreMIDI portaudio
-    ] ++ lib.optionals stdenv.isLinux (builtins.filter (optional: optional != null) [
+    ] ++ lib.optionals stdenv.isLinux [
       alsa-lib libpulseaudio libjack2
-      liblo ladspa-sdk fluidsynth eigen
-      curl tcltk fltk
-    ]);
+      liblo ladspa-sdk
+    ];
 
   postInstall = lib.optional stdenv.isDarwin ''
     mkdir -p $out/Library/Frameworks

--- a/pkgs/by-name/cs/csound-plugins/package.nix
+++ b/pkgs/by-name/cs/csound-plugins/package.nix
@@ -1,0 +1,133 @@
+{ lib, stdenv, fetchFromGitHub, cmake, gettext, runCommand
+, csound
+, eigen
+, faust2
+, fltk
+, fluidsynth
+, gmm
+, hdf5
+, lame
+, libjack2
+, libpng
+, libwebsockets
+, openssl
+, python3
+, wiiuse
+
+# Flags to enable/disable building of opcodes
+, enableChua ? !stdenv.hostPlatform.isAarch32
+, enableFaust ? !stdenv.hostPlatform.isAarch
+, enableFluid ? true
+, enableHdf5 ? !stdenv.hostPlatform.isAarch
+, enableImage ? true
+, enableJack ? stdenv.isLinux
+, enableLinearAlgebra ? !stdenv.hostPlatform.isAarch32
+, enableMp3out ? true
+, enablePython ? stdenv.buildPlatform.canExecute stdenv.hostPlatform
+, enableWebsocket ? true
+, enableFltk ? stdenv.isLinux
+, enableWiimote ? true
+}:
+
+assert enableChua -> eigen != null;
+assert enableFaust -> faust2 != null;
+assert enableFluid -> fluidsynth != null;
+assert enableHdf5 -> hdf5 != null;
+assert enableImage -> libpng != null;
+assert enableJack -> libjack2 != null;
+assert enableLinearAlgebra -> gmm != null;
+assert enableMp3out -> lame != null;
+assert enablePython -> python3 != null;
+assert enableWebsocket -> (libwebsockets != null && openssl != null);
+assert enableFltk -> fltk != null;
+assert enableWiimote -> wiiuse != null;
+
+let
+  inherit (lib) cmakeBool concatLists optional optionals optionalAttrs;
+
+in stdenv.mkDerivation (finalAttrs: {
+  pname = "csound-plugins";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "csound";
+    repo = "plugins";
+    rev = finalAttrs.version;
+    hash = "sha256-bbcL+5WIFUb0Tps5jeMTOhnDRA3cm52B/yY/W6s9nA0=";
+  };
+
+  cmakeFlags = [
+    (cmakeBool "BUILD_ABLETON_LINK_OPCODES"   false)
+    (cmakeBool "BUILD_CUDA_OPCODES"           false)
+    (cmakeBool "BUILD_CHUA_OPCODES"           enableChua)
+    (cmakeBool "BUILD_FAUST_OPCODES"          enableFaust)
+    (cmakeBool "BUILD_FLUID_OPCODES"          enableFluid)
+    (cmakeBool "BUILD_HDF5_OPCODES"           enableHdf5)
+    (cmakeBool "BUILD_IMAGE_OPCODES"          enableImage)
+    (cmakeBool "BUILD_JACK_OPCODES"           enableJack)
+    (cmakeBool "BUILD_LINEAR_ALGEBRA_OPCODES" enableLinearAlgebra)
+    (cmakeBool "BUILD_MP3OUT_OPCODE"          enableMp3out)
+    (cmakeBool "BUILD_OPENCL_OPCODES"         false)
+    (cmakeBool "BUILD_P5GLOVE_OPCODES"        false)
+    (cmakeBool "BUILD_PYTHON_OPCODES"         enablePython)
+    (cmakeBool "BUILD_STK_OPCODES"            false)
+    (cmakeBool "BUILD_WEBSOCKET_OPCODE"       enableWebsocket)
+    (cmakeBool "USE_FLTK"                     enableFltk)
+    (cmakeBool "BUILD_WIIMOTE_OPCODES"        enableWiimote)
+  ];
+
+  nativeBuildInputs = [ cmake gettext ] ++ optional enablePython python3;
+  buildInputs = concatLists [
+    [ csound ]
+    (optional enableChua eigen)
+    (optional enableFaust faust2)
+    (optional enableFluid fluidsynth)
+    (optional enableHdf5 hdf5)
+    (optional enableImage libpng)
+    (optional enableJack libjack2)
+    (optional enableLinearAlgebra gmm)
+    (optional enableMp3out lame)
+    (optionals enableWebsocket [ libwebsockets openssl ])
+    (optional enableFltk fltk)
+    (optional enableWiimote wiiuse)
+  ];
+
+  passthru.tests = optionalAttrs (stdenv.buildPlatform.canExecute stdenv.hostPlatform) {
+    opcodes = runCommand "${finalAttrs.pname}-opcodes-test" {
+      plugins = finalAttrs.finalPackage;
+      nativeBuildInputs = [ csound ];
+      assertOpcodes = concatLists [
+        (optional enableChua "chuap")
+        (optional enableFaust "faustgen")
+        (optional enableFluid "fluidInfo")
+        (optional enableHdf5 "hdf5write")
+        (optional enableImage "imageload")
+        (optionals enableJack [ "JackoInit" "jacktransport" ])
+        (optional enableLinearAlgebra "la_i_vr_create")
+        (optional enableMp3out "mp3out")
+        (optional enablePython "pyinit")
+        (optional enableWebsocket "websocket")
+        (optionals enableFltk [ "FLpanel" "FLvkeybd" ])
+        (optional enableWiimote "wiiconnect")
+      ];
+    } ''
+      export OPCODE6DIR=$plugins/lib/csound/plugins-6.0
+      export OPCODE6DIR64=$plugins/lib/csound/plugins64-6.0
+
+      csound -z >& opcodes || true
+
+      for opcode in $assertOpcodes; do
+        echo "Checking for $opcode opcode"
+        grep -F "$opcode" opcodes >> $out
+      done
+    '';
+  };
+
+  meta = with lib; {
+    description = "Additional opcodes for Csound";
+    homepage = "https://csound.com/";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ marcweber rvl ];
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Some features which were previously built in to Csound have been moved to an [external plugins repository](https://github.com/csound/plugins).

Examples of removed functionality includes the Jacko opcodes, FLTK, and the virtual MIDI keyboard.

This patch allows the lost opcodes to be used again.

## Things done

- [x] Built on platform(s): `x86_64-linux`, `x86_64-linux.pkgsCross.aarch64-multiplatform`, `x86_64-linux.pkgsCross.raspberryPi`
- [x] Tested: has a package test to check for plugin opcodes
- [x] Tested basic functionality of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
