### PR TITLE
hoppscotch-community-edition: init at 2024.3.3, add nixos module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -225,6 +225,8 @@
 
 - [Glances](https://github.com/nicolargo/glances), an open-source system cross-platform monitoring tool. Available as [services.glances](options.html#opt-services.glances).
 
+- [Hoppscotch](https://hoppscotch.com), an open source API development ecosystem; available as [services.hoppscotch](#opt-services.hoppscotch.enable).
+
 ## Backward Incompatibilities {#sec-release-24.11-incompatibilities}
 
 - Nixpkgs now requires Nix 2.3.17 or newer to allow for zstd compressed binary artifacts.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1820,6 +1820,7 @@
   ./services/web-servers/garage.nix
   ./services/web-servers/h2o/default.nix
   ./services/web-servers/hitch/default.nix
+  ./services/web-servers/hoppscotch/default.nix
   ./services/web-servers/jboss/default.nix
   ./services/web-servers/keter
   ./services/web-servers/lighttpd/cgit.nix

--- a/nixos/modules/services/web-servers/hoppscotch/default.nix
+++ b/nixos/modules/services/web-servers/hoppscotch/default.nix
@@ -1,0 +1,63 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    types
+    mkIf
+    ;
+  cfg = config.services.hoppscotch;
+in
+{
+  options.services.hoppscotch = {
+    enable = mkEnableOption "Hoppscotch Community Edition";
+
+    package = mkPackageOption pkgs "hoppscotch-community-edition" { };
+
+    createDatabaseLocally = mkOption {
+      description = ''
+        Whether a PostgreSQL database should be automatically created and
+        configured on the local host. If set to `false`, you need to provision
+        a database yourself and make sure to create the hstore extension in it.
+      '';
+      type = types.bool;
+      default = true;
+    };
+
+    environmentFile = mkOption {
+      description = ''
+        Environment file to be passed to the systemd service.
+        For an exhaustive list of accepted variables, refer to
+        <https://docs.hoppscotch.io/documentation/self-host/community-edition/install-and-build#configuring-the-environment>
+      '';
+      type = types.nullOr types.path;
+      default = null;
+      example = "/var/lib/secrets/hoppscotchSecrets";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    services.postgresql = mkIf cfg.createDatabaseLocally {
+      enable = true;
+
+      # FIXME: These should be configurable by the user.
+      # It also will conflict with DATABASE_URL otherwise.
+      ensureDatabases = [ "hoppscotch-community-edition" ];
+      ensureUsers = [
+        {
+          name = "hoppscotch-community-edition";
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+  };
+}

--- a/pkgs/by-name/ho/hoppscotch-community-edition/package.nix
+++ b/pkgs/by-name/ho/hoppscotch-community-edition/package.nix
@@ -1,0 +1,126 @@
+{
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  lib,
+  stdenvNoCC,
+
+  # build inputs
+  makeBinaryWrapper,
+  nodejs,
+  pnpm_10,
+  pnpmConfigHook,
+  prisma-engines,
+}:
+
+let
+  pnpm = pnpm_10;
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "hoppscotch-community-edition";
+  version = "2026.5.0";
+
+  src = fetchFromGitHub {
+    owner = "hoppscotch";
+    repo = "hoppscotch";
+    tag = finalAttrs.version;
+    hash = "sha256-54U0gLY7mnrio5b3jrB74Vvx2aq5ep5LBRdpa/2grTg=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-FnwJKOJaQNJVuEbxSOur+p9GzQx1HeK8UHCHoG6ZhPo=";
+  };
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    nodejs
+    pnpm
+    pnpmConfigHook
+  ];
+
+  env = {
+    # Prisma doesn't detect NixOS bindings by default
+    # See https://github.com/prisma/prisma/issues/22145
+    PRISMA_QUERY_ENGINE_LIBRARY = "${prisma-engines}/lib/libquery_engine.node";
+    PRISMA_QUERY_ENGINE_BINARY = lib.getExe' prisma-engines "query-engine";
+    PRISMA_SCHEMA_ENGINE_BINARY = lib.getExe' prisma-engines "schema-engine";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm --filter=@hoppscotch/common build
+    pnpm --filter=@hoppscotch/data build
+    pnpm --filter=@hoppscotch/js-sandbox build
+    pnpm --filter=@hoppscotch/cli build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib}
+    cp -r {packages,node_modules} $out/lib
+
+    # Backend build
+    # cd $out/lib/packages/hoppscotch-backend
+    # pnpm exec prisma generate
+    # pnpm run build
+    # pnpm --filter=hoppscotch-backend --prod deploy $out/dist/backend
+    # cd $out/dist/backend
+    # pnpm exec prisma generate
+
+    # Frontend build
+    # cd $out/lib/packages/hoppscotch-selfhost-web
+    # pnpm run generate
+
+    # SH Admin build
+    # cd $out/lib/packages/hoppscotch-sh-admin
+    # pnpm run build --outDir $out/dist/sh-admin-multiport-setup
+    # pnpm run build --outDir $out/dist/sh-admin-subpath-access --base /admin/
+
+    # Copy necessary files
+    # cp $out/lib/packages/hoppscotch-backend/backend.Caddyfile $out/etc/caddy/backend.Caddyfile
+    # cp $out/lib/packages/hoppscotch-backend/prod_run.mjs $out/dist/backend/
+    # cp $out/lib/packages/hoppscotch-selfhost-web/selfhost-web.Caddyfile $out/etc/caddy/selfhost-web.Caddyfile
+    # cp $out/lib/packages/hoppscotch-sh-admin/sh-admin-multiport-setup.Caddyfile $out/etc/caddy/sh-admin-multiport-setup.Caddyfile
+    # cp $out/lib/packages/hoppscotch-sh-admin/sh-admin-subpath-access.Caddyfile $out/etc/caddy/sh-admin-subpath-access.Caddyfile
+    # cp $out/lib/aio_run.mjs $out/
+    # cp $out/lib/aio-multiport-setup.Caddyfile $out/etc/caddy/aio-multiport-setup.Caddyfile
+    # cp $out/lib/aio-subpath-access.Caddyfile $out/etc/caddy/aio-subpath-access.Caddyfile
+
+    # cleanup
+    rm -r $out/lib/packages/hoppscotch-{cli,data,js-sandbox}/src
+    find $out/lib/packages/hoppscotch-{cli,data,js-sandbox} -name '*.ts' -delete
+
+    makeWrapper ${lib.getExe nodejs} $out/bin/hoppscotch \
+      --inherit-argv0 \
+      --add-flags $out/lib/packages/hoppscotch-cli/bin/hopp.js
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    install -D -m444 ${finalAttrs.src}/packages/hoppscotch-common/public/logo.svg $out/share/icons/hicolor/scalable/apps/hoppscotch.svg
+  '';
+
+  meta = {
+    changelog = "https://hoppscotch.com/changelog";
+    description = "Open source API development ecosystem";
+    longDescription = ''
+      Hoppscotch is a lightweight, web-based API development suite. It was built
+      from the ground up with ease of use and accessibility in mind providing
+      all the functionality needed for API developers with minimalist,
+      unobtrusive UI.
+    '';
+    homepage = "https://hoppscotch.com";
+    downloadPage = "https://hoppscotch.com/downloads";
+    license = lib.licenses.mit;
+    mainProgram = "hoppscotch";
+    maintainers = with lib.maintainers; [ getpsyched ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

Closes #261872

Pushing a boilerplate version of the package and its module here. I have been trying to package the self hosted version of Hoppscotch for a while now but never quite got anywhere. I've made a boilerplate here to gather comments from other maintainers to figure out the miscellaneous issues I've had packaging this.

### Packaging

#### From source

There are 2 major issues with this approach:
  1. No documentation on how to build/package from source.
  2. Upstream uses PNPM which lacks support in nixpkgs. (this should be fixed once #290715 is merged)

     EDIT: While that's been merged, it still lacks support for monorepos which also unfortunately blocks this PR. Track the issue here: #316908

#### Using Docker

Well, it's Docker. I don't think we should package it this way. Nevertheless, it's an option. Most of my attempts have been to build using Docker but due to the lack of suitable documentation on [`dockerTools`](https://nixos.org/manual/nixpkgs/unstable/#sec-pkgs-dockerTools) and an inherent skill issue, I haven't been able to package it using Docker.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
