### PR TITLE
syslinux: use nixpkgs' gnu-efi

### DIFF
--- a/pkgs/os-specific/linux/syslinux/default.nix
+++ b/pkgs/os-specific/linux/syslinux/default.nix
@@ -68,12 +68,12 @@ stdenv.mkDerivation {
   ];
 
   postPatch = ''
-    substituteInPlace Makefile --replace /bin/pwd $(type -P pwd)
-    substituteInPlace utils/ppmtolss16 --replace /usr/bin/perl $(type -P perl)
+    substituteInPlace Makefile --replace-fail /bin/pwd $(type -P pwd)
+    substituteInPlace utils/ppmtolss16 --replace-fail /usr/bin/perl $(type -P perl)
 
     # fix tests
     substituteInPlace tests/unittest/include/unittest/unittest.h \
-      --replace /usr/include/ ""
+      --replace-fail /usr/include/ ""
 
     # Hack to get `gcc -m32' to work without having 32-bit Glibc headers.
     mkdir gnu-efi/inc/ia32/gnu
@@ -126,7 +126,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    homepage = "http://www.syslinux.org/";
+    homepage = "https://www.syslinux.org/";
     description = "A lightweight bootloader";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.samueldr ];

--- a/pkgs/os-specific/linux/syslinux/import-efisetjmp.patch
+++ b/pkgs/os-specific/linux/syslinux/import-efisetjmp.patch
@@ -1,0 +1,22 @@
+From 68defee52f4eba82eefaeea17f21c7498448dd6b Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Mon, 3 Jun 2024 16:16:25 -0400
+Subject: [PATCH] efi/efi.h: Add efisetjmp.h
+
+See https://github.com/ncroxon/gnu-efi/commit/486ba3c3bdd147b7d98159b9e650be60bce0f027
+---
+ efi/efi.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/efi/efi.h b/efi/efi.h
+index c266532f3..e4497574b 100644
+--- a/efi/efi.h
++++ b/efi/efi.h
+@@ -23,6 +23,7 @@
+ #include <efi.h>
+ #include <efilib.h>
+ #include <efistdarg.h>
++#include <efisetjmp.h>
+ 
+ /* Delay for 100 ms */
+ #define EFI_NOMAP_PRINT_DELAY	100


### PR DESCRIPTION
## Description of changes

This is a refresh of #317030 that keeps things at the same commit of syslinux instead of moving to the latest master, as the latest master made `nixosTests.boot.biosCdrom` fail.

Closes #317158

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
