### PR TITLE
onevpl-intel-gpu: Rename to vpl-gpu-rt

### DIFF
--- a/pkgs/by-name/vp/vpl-gpu-rt/package.nix
+++ b/pkgs/by-name/vp/vpl-gpu-rt/package.nix
@@ -8,14 +8,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "onevpl-intel-gpu";
+  pname = "vpl-gpu-rt";
   version = "24.2.2";
 
   outputs = [ "out" "dev" ];
 
   src = fetchFromGitHub {
-    owner = "oneapi-src";
-    repo = "oneVPL-intel-gpu";
+    owner = "intel";
+    repo = "vpl-gpu-rt";
     rev = "intel-onevpl-${version}";
     sha256 = "sha256-JtvRh4p4wPRnqFfE86tJW+yS9AKMoi3TPZO+LZ2Q7Mo=";
   };
@@ -26,8 +26,8 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "oneAPI Video Processing Library Intel GPU implementation";
-    homepage = "https://github.com/oneapi-src/oneVPL-intel-gpu";
-    changelog = "https://github.com/oneapi-src/oneVPL-intel-gpu/releases/tag/${src.rev}";
+    homepage = "https://github.com/intel/vpl-gpu-rt";
+    changelog = "https://github.com/intel/vpl-gpu-rt/releases/tag/${src.rev}";
     license = [ lib.licenses.mit ];
     platforms = lib.platforms.linux;
     # CMake adds x86 specific compiler flags in <source>/builder/FindGlobals.cmake

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -944,6 +944,7 @@ mapAliases ({
   octorpki = throw "octorpki has been removed, upstream says to use rpki-client instead"; # Added 2024-03-19
   ogre1_9 = throw "ogre1_9 has been removed, use ogre instead"; # Added 2023-03-22
   ogre1_10 = throw "ogre1_10 has been removed, use ogre instead"; # Added 2023-07-20
+  onevpl-intel-gpu = lib.warn "onevpl-intel-gpu has been renamed to vpl-gpu-rt" vpl-gpu-rt; # Added 2024-06-04
   opa = throw "opa has been removed from nixpkgs as upstream has abandoned the project"; # Added 2023-03-21
   opam_1_2 = throw "'opam_1_2' has been renamed to/replaced by 'opam'"; # Added 2023-03-08
   openafs_1_8 = openafs; # Added 2022-08-22


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Intel has merged the `oneapi-src` GitHub organization into the `intel` namespace. `oneVPL-intel-gpu` has been renamed to `vpl-gpu-rt` as part of this move. The repo at https://github.com/oneapi-src/oneVPL-intel-gpu now redirects to https://github.com/intel/vpl-gpu-rt.

I've updated the package `src` and `name` attributes and moved it from  `pkgs/by-name/on/onevpl-intel-gpu` to `pkgs/by-name/vp/vpl-gpu-rt`. I've also introduced a top-level alias with a warning for `onevpl-intel-gpu`.

There are no dependent packages. The wiki also does not document or refer to `onevpl-intel-gpu` (although it should probably).

Users of `onevpl-intel-gpu` will by notified by the warning on evaluation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
