### PR TITLE
icu: enable updateAutotoolsGnuConfigScriptsHook

### DIFF
--- a/pkgs/development/libraries/icu/default.nix
+++ b/pkgs/development/libraries/icu/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, lib, fetchurl, fetchpatch, fixDarwinDylibNames, testers, buildPackages }:
+{ stdenv, lib, fetchurl, fetchpatch, fixDarwinDylibNames, testers, buildPackages, updateAutotoolsGnuConfigScriptsHook }:
 
 let
   make-icu = (import ./make-icu.nix) {
-    inherit stdenv lib buildPackages fetchurl fixDarwinDylibNames testers;
+    inherit stdenv lib buildPackages fetchurl fixDarwinDylibNames testers updateAutotoolsGnuConfigScriptsHook;
   };
 in
 {

--- a/pkgs/development/libraries/icu/make-icu.nix
+++ b/pkgs/development/libraries/icu/make-icu.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPackages, fetchurl, fixDarwinDylibNames, testers }:
+{ stdenv, lib, buildPackages, fetchurl, fixDarwinDylibNames, testers, updateAutotoolsGnuConfigScriptsHook }:
 
 { version, hash, patches ? [], patchFlags ? [], withStatic ? stdenv.hostPlatform.isStatic }:
 
@@ -64,9 +64,11 @@ let
     outputs = [ "out" "dev" ] ++ lib.optional withStatic "static";
     outputBin = "dev";
 
-    # FIXME: This fixes dylib references in the dylibs themselves, but
-    # not in the programs in $out/bin.
-    nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
+    nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ] ++
+      # FIXME: This fixes dylib references in the dylibs themselves, but
+      # not in the programs in $out/bin.
+      lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
+
 
     # remove dependency on bootstrap-tools in early stdenv build
     postInstall = lib.optionalString withStatic ''


### PR DESCRIPTION
## Description of changes

Continuation of https://github.com/NixOS/nixpkgs/pull/313496

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
