### PR TITLE
cc-wrapper: fix -Bprefix to not confuse lib/libc++.so and bin/c++

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-flags.sh
+++ b/pkgs/build-support/cc-wrapper/add-flags.sh
@@ -29,8 +29,8 @@ done
 
 # Arocc does not support "-B"
 if [[ -z "@isArocc@" ]]; then
-    # `-B@out@/bin' forces cc to use ld-wrapper.sh when calling ld.
-    NIX_CFLAGS_COMPILE_@suffixSalt@="-B@out@/bin/ $NIX_CFLAGS_COMPILE_@suffixSalt@"
+    # `-B@bintools@/bin' forces cc to use ld-wrapper.sh when calling ld.
+    NIX_CFLAGS_COMPILE_@suffixSalt@="-B@bintools@/bin/ $NIX_CFLAGS_COMPILE_@suffixSalt@"
 fi
 
 # Export and assign separately in order that a failing $(..) will fail


### PR DESCRIPTION
Before this commit, `pkgs/build-support/cc-wrapper/add-flags.sh` was using `-B@out@/bin` instead of `-B@bintools@/bin` to force `cc` to use `ld-wrapper.sh` when calling `ld`. That was confusing `cc` when asked to print the location of a library precisely named `c++` because `-B` prefixes are also used by `cc` to find libraries, see https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html#index-B

Indeed, instead of having [`cc --print-file-name c++`](https://gcc.gnu.org/onlinedocs/gcc/Developer-Options.html#index-print-file-name) failing to find a `c++` library and just returning the given `c++` string to let a linker resolve it thereafter, it was finding that `@out@/bin/c++` executable, mistaking it for a library and returning its absolute path, forcing the linker to load an executable as a library.

Users should likely ask for `libc++.so` instead of `c++`, but that's not what's done,
For instance this confusion was breaking with GHC on Darwin:
https://gitlab.haskell.org/ghc/ghc/-/issues/23138#note_567034
It's not clear to me why only the Darwin port of GHC was affected since this `-B` was also injected in the Linux toolchain.
And I don't have a Darwin host to test whether this fix is enough to solve the GHC bug mentioned.
But the result of `cc --print-file-name c++` is clearly wrong to motivate this fix:

Before this commit:

```console
$ nix run -f . stdenv.cc -- --print-file-name c++
/nix/store/9bv7dcvmfcjnmg5mnqwqlq2wxfn8d7yi-gcc-wrapper-13.2.0/bin/c++
```

After this commit:

```console
$ nix run -f . stdenv.cc -- --print-file-name c++
c++
```


## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
