### PR TITLE
nix: make boehmgc patch respect HAVE_PTHREAD_ATTR_GET_NP

### DIFF
--- a/pkgs/tools/package-management/nix/patches/boehmgc-coroutine-sp-fallback.patch
+++ b/pkgs/tools/package-management/nix/patches/boehmgc-coroutine-sp-fallback.patch
@@ -11,14 +11,23 @@ index 2b45489..0e6d8ef 100644
      GC_bool found_me = FALSE;
      size_t nthreads = 0;
      int i;
-@@ -868,6 +870,31 @@ GC_INNER void GC_push_all_stacks(void)
+@@ -868,6 +870,40 @@ GC_INNER void GC_push_all_stacks(void)
              hi = p->altstack + p->altstack_size;
  #         endif
            /* FIXME: Need to scan the normal stack too, but how ? */
 +        } else {
++          #ifdef HAVE_PTHREAD_ATTR_GET_NP
++          if (pthread_attr_init(&pattr) != 0) {
++            ABORT("GC_push_all_stacks: pthread_attr_init failed!");
++          }
++          if (pthread_attr_get_np(p->id, &pattr) != 0) {
++            ABORT("GC_push_all_stacks: pthread_attr_get_np failed!");
++          }
++          #else
 +          if (pthread_getattr_np(p->id, &pattr)) {
 +            ABORT("GC_push_all_stacks: pthread_getattr_np failed!");
 +          }
++          #endif
 +          if (pthread_attr_getstacksize(&pattr, &stack_limit)) {
 +            ABORT("GC_push_all_stacks: pthread_attr_getstacksize failed!");
 +          }


### PR DESCRIPTION
## Description of changes

This fixes the build on platforms where that attribute matters, like FreeBSD.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
