### PR TITLE
antimatter-dimensions: init at 0-unstable-2024-05-11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1189,6 +1189,11 @@
     githubId = 858965;
     name = "Andrew Morsillo";
   };
+  amozeo = {
+    email = "wroclaw223@outlook.com";
+    githubId = 37040543;
+    name = "Wroclaw";
+  };
   amyipdev = {
     email = "amy@amyip.net";
     github = "amyipdev";

--- a/pkgs/by-name/an/antimatter-dimensions/app.js
+++ b/pkgs/by-name/an/antimatter-dimensions/app.js
@@ -1,0 +1,14 @@
+const { app, BrowserWindow } = require('electron');
+
+app.setName(process.env.ELECTRON_APP_NAME || 'Antimatter Dimensions');
+
+app.whenReady().then(() => {
+  const mainWindow = new BrowserWindow({
+    autoHideMenuBar: true,
+  });
+  mainWindow.loadFile('index.html');
+});
+
+app.on('window-all-closed', () => {
+  app.quit();
+});

--- a/pkgs/by-name/an/antimatter-dimensions/package.nix
+++ b/pkgs/by-name/an/antimatter-dimensions/package.nix
@@ -1,0 +1,82 @@
+{ buildNpmPackage
+, copyDesktopItems
+, electron
+, fetchFromGitHub
+, lib
+, makeDesktopItem
+, unstableGitUpdater
+, writeScriptBin
+, electronAppName ? "Antimatter Dimensions"
+}:
+
+let
+  # build doesn't provide app.js, only index.html as entry point.
+  # app.js is used to change the directory where data is stored
+  # instead of default Electron. This workaround will be removed
+  # when this file will be available in upstream repository.
+  dummyElectronApp = ./app.js;
+in
+buildNpmPackage rec {
+  pname = "antimatter-dimensions";
+  version = "0-unstable-2024-05-11";
+  src = fetchFromGitHub {
+    owner = "IvarK";
+    repo = "AntimatterDimensionsSourceCode";
+    rev = "b3a254af60207a03d04473bb81726e921f5b2c61";
+    hash = "sha256-+G9mNilt5Ewja5P+Bt312EcCJknMu7FOMn5b4FseAyQ=";
+  };
+  nativeBuildInputs = [
+    copyDesktopItems
+    # build script calls git to get git hash, message and author
+    # since fetchFromGitHub doesn't provide this information
+    # and in order to keep determinism (#8567), create a dummy git
+    (writeScriptBin "git" ''
+      echo "unknown"
+    '')
+  ];
+
+  npmDepsHash = "sha256-aG+oysgitQvdFM0QyzJ3DBxsanBHYI+UPJPhj6bf00Q=";
+  npmFlags = [ "--legacy-peer-deps" ];
+  npmBuildScript = "build:release";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/antimatter-dimensions
+    cp -Tr dist $out/share/antimatter-dimensions
+    mkdir -p $out/share/icons/hicolor/256x256/apps
+    ln -rs $out/share/antimatter-dimensions/icon.png $out/share/icons/hicolor/256x256/apps/antimatter-dimensions.png
+    cp ${dummyElectronApp} $out/share/antimatter-dimensions/app.js
+
+    makeWrapper ${lib.getExe electron} $out/bin/antimatter-dimensions \
+      --add-flags $out/share/antimatter-dimensions/app.js \
+      --set ELECTRON_APP_NAME "${electronAppName}"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "antimatter-dimensions";
+      exec = "antimatter-dimensions";
+      icon = "antimatter-dimensions";
+      desktopName = electronAppName;
+      comment = meta.description;
+      categories = [ "Game" ];
+      terminal = false;
+    })
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    homepage = "https://github.com/IvarK/AntimatterDimensionsSourceCode";
+    description = "Idle incremental game with multiple prestige layers.";
+    license = lib.licenses.mit;
+    mainProgram = "antimatter-dimensions";
+    maintainers = with lib.maintainers; [ amozeo ];
+    inherit (electron.meta) platforms;
+  };
+}


### PR DESCRIPTION
## About package

Antimatter Dimensions is an idle incremental game with many prestige layers, and can take up to year to complete it.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
