### PR TITLE
haskellPackages: build with RTS -A64M options

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -235,7 +235,7 @@ let
   ] ++ optional (allPkgconfigDepends != [])
     "--with-pkg-config=${pkg-config.targetPrefix}pkg-config";
 
-  parallelBuildingFlags = "-j$NIX_BUILD_CORES" + optionalString stdenv.isLinux " +RTS -A64M -RTS";
+  makeGhcOptions = opts: lib.concatStringsSep " " (map (opt: "--ghc-option=${opt}") opts);
 
   crossCabalFlagsString =
     lib.optionalString isCross (" " + lib.concatStringsSep " " crossCabalFlags);
@@ -256,8 +256,8 @@ let
     "--package-db=$packageConfDir"
     (optionalString (enableSharedExecutables && stdenv.isLinux) "--ghc-option=-optl=-Wl,-rpath=$out/${ghcLibdir}/${pname}-${version}")
     (optionalString (enableSharedExecutables && stdenv.isDarwin) "--ghc-option=-optl=-Wl,-headerpad_max_install_names")
-    (optionalString enableParallelBuilding "--ghc-options=${parallelBuildingFlags}")
-    (optionalString useCpphs "--with-cpphs=${cpphs}/bin/cpphs --ghc-options=-cpp --ghc-options=-pgmP${cpphs}/bin/cpphs --ghc-options=-optP--cpp")
+    (optionalString enableParallelBuilding (makeGhcOptions [ "-j$NIX_BUILD_CORES" "+RTS" "-A64M" "-RTS" ]))
+    (optionalString useCpphs ("--with-cpphs=${cpphs}/bin/cpphs " + (makeGhcOptions [ "-cpp"  "-pgmP${cpphs}/bin/cpphs" "-optP--cpp" ])))
     (enableFeature enableLibraryProfiling "library-profiling")
     (optionalString (enableExecutableProfiling || enableLibraryProfiling) "--profiling-detail=${profilingDetail}")
     (enableFeature enableExecutableProfiling "profiling")
@@ -280,16 +280,14 @@ let
   ) ++ optionals enableSeparateBinOutput [
     "--bindir=${binDir}"
   ] ++ optionals (doHaddockInterfaces && isLibrary) [
-    "--ghc-options=-haddock"
+    "--ghc-option=-haddock"
   ];
 
   postPhases = optional doInstallIntermediates "installIntermediatesPhase";
 
   setupCompileFlags = [
     (optionalString (!coreSetup) "-package-db=$setupPackageConfDir")
-    (optionalString enableParallelBuilding parallelBuildingFlags)
     "-threaded"       # https://github.com/haskell/cabal/issues/2398
-    "-rtsopts"        # allow us to pass RTS flags to the generated Setup executable
   ];
 
   isHaskellPkg = x: x ? isHaskellLibrary;


### PR DESCRIPTION
While working on #317181 I realized that the `+RTS -A64M -RTS` options in `parallelBuildingFlags` were never passed to GHC, because the arguments are not passed quoted. This means those arguments are actually passed to `Setup.hs`. This can be verified by removing `-rtsopts` from `setupCompileFlags` - after this change the configure command will throw an error, because it doesn't understand the `+RTS ...` argument anymore. Once you pass it properly, the error is gone again and GHC receives the arguments.

Passing the RTS flags to `Setup.hs`  (i.e. cabal) - makes little to zero sense. The same is true for the entire `parallelBuildingFlags` being passed to `setupCompileFlags`: If there was any custom `Setup.hs` script in any package anywhere that benefits from heavy parallelization like this... there would be something wrong with that script! ;)

Those flags were introduced in #86948. The related twitch live stream uses the build of git-annex as a measurement. I get the following numbers when building `git-annex` with `doCheck = false;`:

- current master: 1:40 wall clock / 340s user
- without -A64M: 1:40 wall clock / 340s user
- with this fix: 1:13 wall clock / 280s user

This 27% improvement is essentially the result from that live stream mentioned above. Let's use that, shall we?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux: `haskell.lib.overrideCabal haskellPackages.git-annex { doCheck = false; }`
[...]
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
