### PR TITLE
dewduct: init at 0.2.3

### DIFF
--- a/pkgs/by-name/de/dewduct/package.nix
+++ b/pkgs/by-name/de/dewduct/package.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  cargo,
+  copyDesktopItems,
+  fetchFromGitHub,
+  glib,
+  gtk4,
+  libadwaita,
+  makeDesktopItem,
+  mpv,
+  openssl,
+  pkg-config,
+  rustc,
+  rustPlatform,
+  stdenv,
+  wrapGAppsHook4,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dewduct";
+  version = "v0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "DaKnig";
+    repo = "DewDuct";
+    rev = finalAttrs.version;
+    hash = "sha256-XNHq5tuogJkdTGq37/mCZVXzrmjE1tKLa3rGOpg6T3Y=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    src = finalAttrs.src;
+    name = "dewduct-${finalAttrs.version}";
+    hash = "sha256-w760JgvCgVXjoZEg44oMP8gjybb858ERJhPYHFUU9H4=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    cargo
+    pkg-config
+    rustPlatform.cargoSetupHook
+    rustc
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    libadwaita
+    mpv
+    openssl
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "${mpv}/bin"
+    )
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 target/release/dewduct $out/bin/dewduct
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "dewduct";
+      exec = "dewduct";
+      type = "Application";
+      desktopName = "DewDuct";
+      comment = finalAttrs.meta.description;
+      categories = [
+        "AudioVideo"
+        "GNOME"
+        "GTK"
+        "Player"
+        "Video"
+      ];
+      keywords = [
+        "YouTube"
+      ];
+    })
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/DaKnig/DewDuct/releases/tag/${finalAttrs.version}";
+    description = "YouTube client for desktop and mobile Linux";
+    homepage = "https://github.com/DaKnig/DewDuct";
+    license = licenses.gpl3Plus;
+    mainProgram = "dewduct";
+    maintainers = with maintainers; [ michaelgrahamevans ];
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [DewDuct](https://github.com/DaKnig/DewDuct/), a GTK YouTube client inspired by NewPipe. As seen in [This Week in GNOME #150](https://thisweek.gnome.org/posts/2024/05/twig-150/).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
