### PR TITLE
nu_plugin_polars: init at 0.94.1

### DIFF
--- a/pkgs/shells/nushell/plugins/default.nix
+++ b/pkgs/shells/nushell/plugins/default.nix
@@ -3,6 +3,7 @@
 lib.makeScope newScope (self: with self; {
   gstat = callPackage ./gstat.nix { inherit Security; };
   formats = callPackage ./formats.nix { inherit IOKit Foundation; };
+  polars = callPackage ./polars.nix { inherit IOKit Foundation; };
   query = callPackage ./query.nix { inherit IOKit CoreFoundation; };
   regex = throw "`nu_plugin_regex` is no longer compatible with the current Nushell release.";
   net = callPackage ./net.nix { inherit IOKit CoreFoundation; };

--- a/pkgs/shells/nushell/plugins/net.nix
+++ b/pkgs/shells/nushell/plugins/net.nix
@@ -1,10 +1,11 @@
-{ lib
-, rustPlatform
-, fetchFromGitHub
-, stdenv
-, IOKit
-, CoreFoundation
-, unstableGitUpdater
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenv,
+  IOKit,
+  CoreFoundation,
+  unstableGitUpdater,
 }:
 
 rustPlatform.buildRustPackage {
@@ -20,9 +21,7 @@ rustPlatform.buildRustPackage {
 
   cargoHash = "sha256-nBxcxADyvPgGrfkW8eBq/wmB2Slq+YGJV2IlxuuCgCg=";
 
-  nativeBuildInputs = [
-    rustPlatform.bindgenHook
-  ];
+  nativeBuildInputs = [ rustPlatform.bindgenHook ];
 
   buildInputs = lib.optionals stdenv.isDarwin [
     CoreFoundation
@@ -36,6 +35,6 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/fennewald/nu_plugin_net";
     license = licenses.mit;
     maintainers = with maintainers; [ happysalada ];
-    mainProgram = "nu-plugin-net";
+    mainProgram = "nu_plugin_net";
   };
 }

--- a/pkgs/shells/nushell/plugins/polars.nix
+++ b/pkgs/shells/nushell/plugins/polars.nix
@@ -1,0 +1,45 @@
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  openssl,
+  nushell,
+  pkg-config,
+  IOKit,
+  Foundation,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nushell_plugin_polars";
+  inherit (nushell) version src;
+
+  cargoHash = "sha256-GkVX12MEHFP4g183zUzOUn4MNeTEBEpB+D5s0OXa4nc=";
+
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
+  buildInputs =
+    [ openssl ]
+    ++ lib.optionals stdenv.isDarwin [
+      IOKit
+      Foundation
+    ];
+  cargoBuildFlags = [ "--package nu_plugin_polars" ];
+
+  checkPhase = ''
+    cargo test --manifest-path crates/nu_plugin_polars/Cargo.toml
+  '';
+
+  passthru.updateScript = nix-update-script {
+    # Skip the version check and only check the hash because we inherit version from nushell.
+    extraArgs = [ "--version=skip" ];
+  };
+
+  meta = with lib; {
+    description = "Nushell dataframe plugin commands based on polars.";
+    mainProgram = "nu_plugin_polars";
+    homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_polars";
+    license = licenses.mit;
+    maintainers = with maintainers; [ joaquintrinanes ];
+    platforms = with platforms; all;
+  };
+}


### PR DESCRIPTION
## Description of changes

This PR adds the [`polars` nushell plugin](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_polars).

Unfortunately, I wasn't able to build it without my computer crashing 🥲 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
