### PR TITLE
postgresql: add wolfgangwalther as maintainer

### DIFF
--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -252,7 +252,7 @@ let
       description = "A powerful, open source object-relational database system";
       license     = licenses.postgresql;
       changelog   = "https://www.postgresql.org/docs/release/${finalAttrs.version}/";
-      maintainers = with maintainers; [ thoughtpolice danbst globin ivan ma27 ];
+      maintainers = with maintainers; [ thoughtpolice danbst globin ivan ma27 wolfgangwalther ];
       pkgConfigModules = [ "libecpg" "libecpg_compat" "libpgtypes" "libpq" ];
       platforms   = platforms.unix;
 


### PR DESCRIPTION
I have worked quite a bit on the postgresql package in the last couple of months and will continue to do so. It only makes sense to put me down as a maintainer there.

Along the way I noticed that @Ma27 was the only maintainer to respond to my PRs.

@thoughtpolice @danbst @globin @ivan are you still interested in the package / want to be listed as maintainers? Or should we remove you to reduce your notification-load?