### PR TITLE
clang: don't set machine flags for overridden target

### DIFF
--- a/pkgs/applications/blockchains/polkadot/default.nix
+++ b/pkgs/applications/blockchains/polkadot/default.nix
@@ -93,8 +93,5 @@ rustPlatform.buildRustPackage rec {
     maintainers = with maintainers; [ akru andresilva FlorianFranzen RaghavSood ];
     # See Iso::from_arch in src/isa/mod.rs in cranelift-codegen-meta.
     platforms = intersectLists platforms.unix (platforms.aarch64 ++ platforms.s390x ++ platforms.riscv64 ++ platforms.x86);
-    # See comment about wasm32-unknown-unknown in rustc.nix.
-    broken = lib.any (a: lib.hasAttr a stdenv.hostPlatform.gcc) [ "cpu" "float-abi" "fpu" ] ||
-      !stdenv.hostPlatform.gcc.thumb or true;
   };
 }

--- a/pkgs/applications/misc/pagefind/default.nix
+++ b/pkgs/applications/misc/pagefind/default.nix
@@ -8,7 +8,6 @@
 , gzip
 , nodejs
 , rustc
-, stdenv
 , wasm-bindgen-cli
 , wasm-pack
 }:
@@ -121,9 +120,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ pbsds ];
     platforms = platforms.unix;
-    # See comment about wasm32-unknown-unknown in rustc.nix.
-    broken = lib.any (a: lib.hasAttr a stdenv.hostPlatform.gcc) [ "cpu" "float-abi" "fpu" ] ||
-      !stdenv.hostPlatform.gcc.thumb or true;
     mainProgram = "pagefind";
   };
 }

--- a/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh
+++ b/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh
@@ -7,5 +7,5 @@ for p in "${params[@]}"; do
 done
 
 if $needsTarget; then
-    extraBefore+=(-target @defaultTarget@ @march@)
+    extraBefore+=(-target @defaultTarget@ @machineFlags@)
 fi

--- a/pkgs/by-name/re/rerun/package.nix
+++ b/pkgs/by-name/re/rerun/package.nix
@@ -126,8 +126,5 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with maintainers; [ SomeoneSerge ];
     mainProgram = "rerun";
-    # See comment about wasm32-unknown-unknown in rustc.nix.
-    broken = lib.any (a: lib.hasAttr a stdenv.hostPlatform.gcc) [ "cpu" "float-abi" "fpu" ] ||
-      !stdenv.hostPlatform.gcc.thumb or true;
   };
 }

--- a/pkgs/by-name/su/surrealist/package.nix
+++ b/pkgs/by-name/su/surrealist/package.nix
@@ -166,8 +166,5 @@ in stdenv.mkDerivation (finalAttrs: {
     mainProgram = "surrealist";
     maintainers = with maintainers; [ frankp ];
     platforms = platforms.linux;
-    # See comment about wasm32-unknown-unknown in rustc.nix.
-    broken = lib.any (a: lib.hasAttr a stdenv.hostPlatform.gcc) [ "cpu" "float-abi" "fpu" ] ||
-      !stdenv.hostPlatform.gcc.thumb or true;
   };
 })

--- a/pkgs/by-name/te/tetrio-desktop/tetrio-plus.nix
+++ b/pkgs/by-name/te/tetrio-desktop/tetrio-plus.nix
@@ -78,9 +78,6 @@ let
       license = lib.licenses.mit;
       maintainers = with lib.maintainers; [ huantian wackbyte ];
       platforms = lib.platforms.linux;
-      # See comment about wasm32-unknown-unknown in rustc.nix.
-      broken = lib.any (a: lib.hasAttr a stdenv.hostPlatform.gcc) [ "cpu" "float-abi" "fpu" ] ||
-        !stdenv.hostPlatform.gcc.thumb or true;
     };
   };
 

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -106,9 +106,7 @@ in stdenv.mkDerivation (finalAttrs: {
       stdenv.targetPlatform.rust.rustcTargetSpec
 
     # Other targets that don't need any extra dependencies to build.
-    # Temporarily broken if some global compiler flags are set:
-    # https://github.com/NixOS/nixpkgs/pull/317273
-    ] ++ optionals (!fastCross && !lib.any (a: lib.hasAttr a stdenv.hostPlatform.gcc) [ "cpu" "float-abi" "fpu" ] && stdenv.hostPlatform.gcc.thumb or true) [
+    ] ++ optionals (!fastCross) [
       "wasm32-unknown-unknown"
 
     # (build!=target): When cross-building a compiler we need to add

--- a/pkgs/development/compilers/swift/wrapper/wrapper.sh
+++ b/pkgs/development/compilers/swift/wrapper/wrapper.sh
@@ -252,7 +252,7 @@ for ((i=0; i < ${#extraBefore[@]}; i++));do
         # TODO: Assumes macOS.
         extraBefore[i]="${extraBefore[i]/-apple-darwin/-apple-macosx${MACOSX_DEPLOYMENT_TARGET:-11.0}}"
         ;;
-    -march=*)
+    -march=*|-mcpu=*|-mfloat-abi=*|-mfpu=*|-mmode=*|-mthumb|-marm|-mtune=*)
         [[ i -gt 0 && ${extraBefore[i-1]} == -Xcc ]] && continue
         extraBefore=(
             "${extraBefore[@]:0:i}"

--- a/pkgs/servers/ldap/lldap/default.nix
+++ b/pkgs/servers/ldap/lldap/default.nix
@@ -5,7 +5,6 @@
 , nixosTests
 , rustPlatform
 , rustc
-, stdenv
 , wasm-bindgen-cli
 , wasm-pack
 , which
@@ -85,9 +84,6 @@ in rustPlatform.buildRustPackage (commonDerivationAttrs // {
     changelog = "https://github.com/lldap/lldap/blob/v${lldap.version}/CHANGELOG.md";
     license = licenses.gpl3Only;
     platforms = platforms.linux;
-    # See comment about wasm32-unknown-unknown in rustc.nix.
-    broken = lib.any (a: lib.hasAttr a stdenv.hostPlatform.gcc) [ "cpu" "float-abi" "fpu" ] ||
-      !stdenv.hostPlatform.gcc.thumb or true;
     maintainers = with maintainers; [ bendlas ];
     mainProgram = "lldap";
   };

--- a/pkgs/servers/teleport/generic.nix
+++ b/pkgs/servers/teleport/generic.nix
@@ -180,9 +180,6 @@ buildGoModule rec {
     platforms = platforms.unix;
     # go-libfido2 is broken on platforms with less than 64-bit because it defines an array
     # which occupies more than 31 bits of address space.
-    broken = stdenv.hostPlatform.parsed.cpu.bits < 64 ||
-      # See comment about wasm32-unknown-unknown in rustc.nix.
-      lib.any (a: lib.hasAttr a stdenv.hostPlatform.gcc) [ "cpu" "float-abi" "fpu" ] ||
-      !stdenv.hostPlatform.gcc.thumb or true;
+    broken = stdenv.hostPlatform.parsed.cpu.bits < 64;
   };
 }


### PR DESCRIPTION
## Description of changes

We already did this for -march in 12b0e8ac74f8 ("clang: don't set -march for overridden target"), but it should have been done for all machine flags, for the same reason.

Example bug this fixes:

	nix-shell -E '
	  with import ./. {
	    crossSystem = {
	      system = "powerpc64le-linux";
	      gcc.cpu = "power10";
	    };
	  };
	  clangStdenv.mkDerivation { name = "test"; }
	' --run '$CC -target wasm32-unknown-unknown -c /dev/null'

Which previously failed with:

      clang: error: unsupported option '-mcpu=' for target 'wasm32-unknown-unknown'

@vcunat could you please test whether this fixes rustc on aarch64-darwin, as reported in https://github.com/NixOS/nixpkgs/pull/309580#issuecomment-2143327104?  If it does, we can make a temporary fix on staging-next.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
