### PR TITLE
libgit2: 1.7.2 -> 1.8.1; python312Packages.pygit2: 1.14.1 -> 1.15.0

### DIFF
--- a/pkgs/development/libraries/libgit2-glib/default.nix
+++ b/pkgs/development/libraries/libgit2-glib/default.nix
@@ -13,6 +13,7 @@
 , libgit2
 , glib
 , python3
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -25,6 +26,15 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "EzHa2oOPTh9ZGyZFnUQSajJd52LcPNJhU6Ma+9/hgZA=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "support-libgit2-1.8.patch";
+      # https://gitlab.gnome.org/GNOME/libgit2-glib/-/merge_requests/40
+      url = "https://gitlab.gnome.org/GNOME/libgit2-glib/-/commit/a76fdf96c3af9ce9d21a3985c4be8a1aa6eea661.patch";
+      hash = "sha256-ysU8pAixyftensfEC9bE0RUFMPMei0jYT26WKN5uOFE=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson

--- a/pkgs/development/libraries/libgit2/default.nix
+++ b/pkgs/development/libraries/libgit2/default.nix
@@ -8,7 +8,6 @@
 , libssh2
 , openssl
 , pcre
-, http-parser
 , libiconv
 , Security
 , staticBuild ? stdenv.hostPlatform.isStatic
@@ -16,11 +15,14 @@
 , libgit2-glib
 , python3Packages
 , gitstatus
+, llhttp
+, withGssapi ? false
+, krb5
 }:
 
 stdenv.mkDerivation rec {
   pname = "libgit2";
-  version = "1.7.2";
+  version = "1.8.1";
   # also check the following packages for updates: python3Packages.pygit2 and libgit2-glib
 
   outputs = ["lib" "dev" "out"];
@@ -29,12 +31,13 @@ stdenv.mkDerivation rec {
     owner = "libgit2";
     repo = "libgit2";
     rev = "v${version}";
-    hash = "sha256-fVPY/byE2/rxmv/bUykcAbmUFMlF3UZogVuTzjOXJUU=";
+    hash = "sha256-J2rCxTecyLbbDdsyBWn9w7r3pbKRMkI9E7RvRgAqBdY=";
   };
 
   cmakeFlags = [
     "-DUSE_HTTP_PARSER=system"
     "-DUSE_SSH=ON"
+    (lib.cmakeBool "USE_GSSAPI" withGssapi)
     "-DBUILD_SHARED_LIBS=${if staticBuild then "OFF" else "ON"}"
   ] ++ lib.optionals stdenv.hostPlatform.isWindows [
     "-DDLLTOOL=${stdenv.cc.bintools.targetPrefix}dlltool"
@@ -44,7 +47,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake python3 pkg-config ];
 
-  buildInputs = [ zlib libssh2 openssl pcre http-parser ]
+  buildInputs = [ zlib libssh2 openssl pcre llhttp ]
+    ++ lib.optional withGssapi krb5
     ++ lib.optional stdenv.isDarwin Security;
 
   propagatedBuildInputs = lib.optional (!stdenv.isLinux) libiconv;

--- a/pkgs/development/libraries/libgit2/default.nix
+++ b/pkgs/development/libraries/libgit2/default.nix
@@ -20,7 +20,7 @@
 , krb5
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libgit2";
   version = "1.8.1";
   # also check the following packages for updates: python3Packages.pygit2 and libgit2-glib
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "libgit2";
     repo = "libgit2";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-J2rCxTecyLbbDdsyBWn9w7r3pbKRMkI9E7RvRgAqBdY=";
   };
 
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     )
   '';
 
-  passthru.tests = {
+  passthru.tests = lib.mapAttrs (_: v: v.override { libgit2 = finalAttrs.finalPackage; }) {
     inherit libgit2-glib;
     inherit (python3Packages) pygit2;
     inherit gitstatus;
@@ -84,4 +84,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ SuperSandro2000 ];
   };
-}
+})

--- a/pkgs/development/python-modules/pygit2/default.nix
+++ b/pkgs/development/python-modules/pygit2/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "pygit2";
-  version = "1.14.1";
+  version = "1.15.0";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-7FlYVxuCpjUXhcpkXlOUwxrkXuxThLL6nE4F3eNZetY=";
+    hash = "sha256-pjVSX/x0EoZp3i9jRgqUydVgljSkh1wKr85RD97sF6w=";
   };
 
   preConfigure = lib.optionalString stdenv.isDarwin ''


### PR DESCRIPTION
## Description of changes

- 1.7.2 -> 1.8.1
  - This also replaces the dependency on the abandoned `http-parser` with `llhttp`.
- fix incorrect recursive structure in tests (tracking issue: #312345)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
