### PR TITLE
ytmdesktop: init at 2.0.5

### DIFF
--- a/pkgs/by-name/yt/ytmdesktop/package.nix
+++ b/pkgs/by-name/yt/ytmdesktop/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  asar,
+  binutils,
+  commandLineArgs ? "",
+  copyDesktopItems,
+  electron_30,
+  fetchurl,
+  makeDesktopItem,
+  makeWrapper,
+  nix-update-script,
+  stdenv,
+  zstd,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ytmdesktop";
+  version = "2.0.5";
+
+  desktopItem = makeDesktopItem {
+    desktopName = "Youtube Music Desktop App";
+    exec = "ytmdesktop";
+    icon = "ytmdesktop";
+    name = "ytmdesktop";
+    genericName = finalAttrs.meta.description;
+    mimeTypes = [ "x-scheme-handler/ytmd" ];
+    categories = [
+      "AudioVideo"
+      "Audio"
+    ];
+    startupNotify = true;
+  };
+
+  nativeBuildInputs = [
+    asar
+    copyDesktopItems
+    makeWrapper
+    zstd
+  ];
+
+  src = fetchurl {
+    url = "https://github.com/ytmdesktop/ytmdesktop/releases/download/v${finalAttrs.version}/youtube-music-desktop-app_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-0j8HVmkFyTk/Jpq9dfQXFxd2jnLwzfEiqCgRHuc5g9o=";
+  };
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    ar x $src data.tar.zst
+    tar xf data.tar.zst
+
+    runHook preUnpack
+  '';
+
+  postPatch = ''
+    pushd usr/lib/youtube-music-desktop-app
+
+    asar extract resources/app.asar patched-asar
+
+    # workaround for https://github.com/electron/electron/issues/31121
+    substituteInPlace patched-asar/.webpack/main/index.js \
+      --replace-fail "process.resourcesPath" "'$out/lib/resources'"
+
+    asar pack patched-asar resources/app.asar
+
+    popd
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{lib,share/pixmaps}
+
+    cp -r usr/lib/youtube-music-desktop-app/{locales,resources{,.pak}} $out/lib
+    cp usr/share/pixmaps/youtube-music-desktop-app.png $out/share/pixmaps/ytmdesktop.png
+
+    runHook postInstall
+  '';
+
+  fixupPhase = ''
+    runHook preFixup
+
+    makeWrapper ${lib.getExe electron_30} $out/bin/ytmdesktop \
+      --add-flags $out/lib/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --add-flags ${lib.escapeShellArg commandLineArgs}
+
+    runHook preFixup
+  '';
+
+  meta = {
+    changelog = "https://github.com/ytmdesktop/ytmdesktop/tag/v${finalAttrs.version}";
+    description = "A Desktop App for YouTube Music";
+    downloadPage = "https://github.com/ytmdesktop/ytmdesktop/releases";
+    homepage = "https://ytmdesktop.app/";
+    license = lib.licenses.gpl3Only;
+    mainProgram = finalAttrs.pname;
+    maintainers = [ lib.maintainers.cjshearer ];
+    inherit (electron_30.meta) platforms;
+    # While the files we extract from the .deb are cross-platform (javascript), the installation
+    # process for darwin is different, and I don't have a test device. PRs are welcome if you can
+    # add the correct installation steps. I would suggest looking at the following:
+    # https://www.electronjs.org/docs/latest/tutorial/application-distribution#manual-packaging
+    # https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/networking/instant-messengers/jitsi-meet-electron/default.nix
+    badPlatforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1405,7 +1405,6 @@ mapAliases ({
   yarn2nix-moretea-openssl_1_1 = throw "'yarn2nix-moretea-openssl_1_1' has been removed."; # Added 2023-02-04
   yi = throw "'yi' has been removed, as it was broken and unmaintained"; # added 2024-05-09
   yrd = throw "'yrd' has been removed, as it was broken and unmaintained"; # added 2024-05-27
-  ytmdesktop = throw "ytmdesktop was removed because upstream vanished"; # added 2024-03-24
   yubikey-manager4 = throw "yubikey-manager4 has been removed, since it is no longer required by yubikey-manager-qt. Please update to yubikey-manager."; # Added 2024-01-14
   yuzu-ea = throw "yuzu-ea has been removed from nixpkgs, as it has been taken down upstream"; # Added 2024-03-04
   yuzu-early-access = throw "yuzu-early-access has been removed from nixpkgs, as it has been taken down upstream"; # Added 2024-03-04


### PR DESCRIPTION
## Description of changes

Restores ytmdesktop, a desktop app for Youtube Music. It was previously [removed due to missing source](https://github.com/NixOS/nixpkgs/pull/298777). This also expands support to all electron platforms, with the exception of darwin, since I don't have a way to test that and the installation process is slightly different (see my comment above `meta.badPlatforms` for more info).

Note that `commandLineArgs` are passed from the derivation inputs, enabling a consumer to override it and set a default CLI flag. This is useful for setting values like `--password-store="gnome-libsecret"`, which is sometimes necessary to overcome [safeStorage detection outside of predefined desktop environments](https://github.com/electron/electron/issues/39789).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
