### PR TITLE
erlang: limited upkeep

### DIFF
--- a/pkgs/development/interpreters/lfe/2.1.nix
+++ b/pkgs/development/interpreters/lfe/2.1.nix
@@ -1,7 +1,7 @@
 { mkDerivation }:
 
 mkDerivation {
-  version = "2.1.3";
-  hash = "sha256-HUOVBzUaU0ixIfPPctwR2TPijxJjcFY3dJ8Z7Ot2bpE=";
-  maximumOTPVersion = "26";
+  version = "2.1.4";
+  hash = "sha256-mDavRI2it0SrSR0iBItm2MfjI+F/zCy38YSd2KpE0Hs=";
+  maximumOTPVersion = "27";
 }

--- a/pkgs/servers/amqp/rabbitmq-server/default.nix
+++ b/pkgs/servers/amqp/rabbitmq-server/default.nix
@@ -38,12 +38,12 @@ in
 
 stdenv.mkDerivation rec {
   pname = "rabbitmq-server";
-  version = "3.12.13";
+  version = "3.13.3";
 
   # when updating, consider bumping elixir version in all-packages.nix
   src = fetchurl {
     url = "https://github.com/rabbitmq/rabbitmq-server/releases/download/v${version}/${pname}-${version}.tar.xz";
-    hash = "sha256-UjUkiS8ay66DDzeW9EXOJPQVHHxC1sXT8mCn+KVXSQ4=";
+    hash = "sha256-CPnoPK3tBKKmIo8IioUCUWkw6+sdvzRaAngseRZ8eUM=";
   };
 
   nativeBuildInputs = [ unzip xmlto docbook_xml_dtd_45 docbook_xsl zip rsync python3 ];
@@ -85,12 +85,12 @@ stdenv.mkDerivation rec {
     vm-test = nixosTests.rabbitmq;
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://www.rabbitmq.com/";
     description = "An implementation of the AMQP messaging protocol";
     changelog = "https://github.com/rabbitmq/rabbitmq-server/releases/tag/v${version}";
-    license = licenses.mpl20;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ turion ];
+    license = lib.licenses.mpl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ turion ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17180,7 +17180,6 @@ with pkgs;
 
   inherit (beam.interpreters)
     erlang erlang_27 erlang_26 erlang_25 erlang_24
-    erlang_odbc erlang_javac erlang_odbc_javac
     elixir elixir_1_16 elixir_1_15 elixir_1_14 elixir_1_13 elixir_1_12 elixir_1_11 elixir_1_10
     elixir-ls;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26432,7 +26432,7 @@ with pkgs;
 
   rabbitmq-server = callPackage ../servers/amqp/rabbitmq-server {
     inherit (darwin.apple_sdk.frameworks) AppKit Carbon Cocoa;
-    elixir = elixir_1_14;
+    erlang = erlang_26;
   };
 
   radicale2 = callPackage ../servers/radicale/2.x.nix { };

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -72,7 +72,7 @@ in
   # appropriate Erlang/OTP version.
   packages = {
     erlang = self.packages.${self.latestVersion};
-
+    erlang_27 = self.packagesWith self.interpreters.erlang_27;
     erlang_26 = self.packagesWith self.interpreters.erlang_26;
     erlang_25 = self.packagesWith self.interpreters.erlang_25;
     erlang_24 = self.packagesWith self.interpreters.erlang_24;

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -23,9 +23,6 @@ in
   interpreters = {
 
     erlang = self.interpreters.${self.latestVersion};
-    erlang_odbc = self.interpreters."${self.latestVersion}_odbc";
-    erlang_javac = self.interpreters."${self.latestVersion}_javac";
-    erlang_odbc_javac = self.interpreters."${self.latestVersion}_odbc_javac";
 
     # Standard Erlang versions, using the generic builder.
 
@@ -44,24 +41,12 @@ in
       autoconf = buildPackages.autoconf269;
       inherit wxSupport systemdSupport;
     };
-    erlang_26_odbc = self.interpreters.erlang_26.override { odbcSupport = true; };
-    erlang_26_javac = self.interpreters.erlang_26.override { javacSupport = true; };
-    erlang_26_odbc_javac = self.interpreters.erlang_26.override {
-      javacSupport = true;
-      odbcSupport = true;
-    };
 
     erlang_25 = self.beamLib.callErlang ../development/interpreters/erlang/25.nix {
       wxGTK = wxGTK32;
       parallelBuild = true;
       autoconf = buildPackages.autoconf269;
       inherit wxSupport systemdSupport;
-    };
-    erlang_25_odbc = self.interpreters.erlang_25.override { odbcSupport = true; };
-    erlang_25_javac = self.interpreters.erlang_25.override { javacSupport = true; };
-    erlang_25_odbc_javac = self.interpreters.erlang_25.override {
-      javacSupport = true;
-      odbcSupport = true;
     };
 
     erlang_24 = self.beamLib.callErlang ../development/interpreters/erlang/24.nix {
@@ -70,12 +55,6 @@ in
       parallelBuild = true;
       autoconf = buildPackages.autoconf269;
       inherit wxSupport systemdSupport;
-    };
-    erlang_24_odbc = self.interpreters.erlang_24.override { odbcSupport = true; };
-    erlang_24_javac = self.interpreters.erlang_24.override { javacSupport = true; };
-    erlang_24_odbc_javac = self.interpreters.erlang_24.override {
-      javacSupport = true;
-      odbcSupport = true;
     };
 
     # Other Beam languages. These are built with `beam.interpreters.erlang`. To


### PR DESCRIPTION
erlang: limited upkeep

Fixes #290871

I've reduced the scope of this PR to:

* rabbitmq-server: 3.12.13 -> 3.13.3
* lfe: 2.1.3 -> 2.1.4
* erlang_27: fix missing reference
* erlang_{24,25,26}_{odbc,javac,odbc_javac}: remove

<!--
Pending test & fix of downstream:
- elixir_16, elixir_15 [ok]
- elixir_10-elixir_14 [fails]
- rebar3
- lfe [ok]
- rabbitmq-server [ok]
- akkoma [failing]
- livebook
- gleam 
- plausible
- mobilizon
- pleroma
- What else?

* Pending: Add warnings for dropped versions. Fix invalid warnings.
-->
