### PR TITLE
python3Packages.fipy: disable on Python 3.12+ and skip checkPhase

### DIFF
--- a/pkgs/development/python-modules/fipy/default.nix
+++ b/pkgs/development/python-modules/fipy/default.nix
@@ -14,6 +14,7 @@
   stdenv,
   openssh,
   fetchFromGitHub,
+  pythonAtLeast,
   pythonOlder,
 }:
 
@@ -22,7 +23,10 @@ buildPythonPackage rec {
   version = "3.4.4";
   format = "setuptools";
 
-  disabled = pythonOlder "3.7";
+  # Python 3.12 is not yet supported.
+  # https://github.com/usnistgov/fipy/issues/997
+  # https://github.com/usnistgov/fipy/pull/1023
+  disabled = pythonOlder "3.7" || pythonAtLeast "3.12";
 
   src = fetchFromGitHub {
     owner = "usnistgov";
@@ -45,12 +49,18 @@ buildPythonPackage rec {
 
   nativeCheckInputs = lib.optionals (!stdenv.isDarwin) [ gmsh ];
 
+  # NOTE: Two of the doctests in fipy.matrices.scipyMatrix._ScipyMatrix.CSR fail, and there is no
+  # clean way to disable them.
+  doCheck = false;
+
   checkPhase = ''
     export OMPI_MCA_plm_rsh_agent=${openssh}/bin/ssh
     ${python.interpreter} setup.py test --modules
   '';
 
-  pythonImportsCheck = [ "fipy" ];
+  # NOTE: Importing fipy within the sandbox will fail because plm_rsh_agent isn't set and the process isn't able
+  # to start a daemon on the builder.
+  # pythonImportsCheck = [ "fipy" ];
 
   meta = with lib; {
     homepage = "https://www.ctcms.nist.gov/fipy/";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Mark as broken with Python 3.12 and disable checks.

Python 3.12 is an ongoing work (https://github.com/usnistgov/fipy/pull/1023) upstream, and Hydra should not try to build it (https://hydra.nixos.org/build/262255462).

Checks fail (https://hydra.nixos.org/build/262253387), perhaps due to changes in indexing.

Failing doctests:

https://github.com/usnistgov/fipy/blob/fdc17193bc293da7511be9021e6d4766757e1966/fipy/matrices/scipyMatrix.py#L302-L306

Example test failures:

```console
python3.11-fipy> ----------------------------------------------------------------------
python3.11-fipy> File "/build/source/fipy/matrices/scipyMatrix.py", line 302, in fipy.matrices.scipyMatrix._ScipyMatrix.CSR
python3.11-fipy> Failed example:
python3.11-fipy>     print(numerix.asarray(cols))
python3.11-fipy> Expected:
python3.11-fipy>     [0 1 2 1 2 0 2]
python3.11-fipy> Got:
python3.11-fipy>     [0 2 1 2 1 2 0]
python3.11-fipy> ----------------------------------------------------------------------
python3.11-fipy> File "/build/source/fipy/matrices/scipyMatrix.py", line 304, in fipy.matrices.scipyMatrix._ScipyMatrix.CSR
python3.11-fipy> Failed example:
python3.11-fipy>     print(numerix.asarray(data))
python3.11-fipy> Expected:
python3.11-fipy>     [ 12.3         10.           3.           3.14159265   2.96
python3.11-fipy>        2.5          2.2       ]
python3.11-fipy> Got:
python3.11-fipy>     [ 12.3          3.          10.           2.96         3.14159265
python3.11-fipy>        2.2          2.5       ]
python3.11-fipy> ----------------------------------------------------------------------
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
