### PR TITLE
neovim-node-client: init at 5.3.0

### DIFF
--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -3,7 +3,7 @@
 , ruby
 , nodejs
 , writeText
-, nodePackages
+, neovim-node-client
 , python3
 , callPackage
 , neovimUtils
@@ -173,7 +173,7 @@ let
         ln -s ${finalAttrs.rubyEnv}/bin/neovim-ruby-host $out/bin/nvim-ruby
       ''
       + lib.optionalString finalAttrs.withNodeJs ''
-        ln -s ${nodePackages.neovim}/bin/neovim-node-host $out/bin/nvim-node
+        ln -s ${neovim-node-client}/bin/neovim-node-host $out/bin/nvim-node
       ''
       + lib.optionalString finalAttrs.withPerl ''
         ln -s ${perlEnv}/bin/perl $out/bin/nvim-perl

--- a/pkgs/by-name/ne/neovim-node-client/package.nix
+++ b/pkgs/by-name/ne/neovim-node-client/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchNpmDeps,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "node-client";
+  version = "5.3.0";
+
+  src = fetchFromGitHub {
+    owner = "neovim";
+    repo = "node-client";
+    rev = "02a5fdef8e3ec2812d295981db38dbccf82e0728";
+    hash = "sha256-0vPw2hCGUDepSpF1gp/lI71EgwGsCSnw7ePP7ElHsTQ=";
+  };
+
+  npmDeps = fetchNpmDeps {
+    inherit src;
+    hash = "sha256-VYoJAi1RzVf5ObjuGmnuiA/1WYBWC+qYPdfWF98+oGw=";
+  };
+  npmWorkspace = "packages/neovim";
+
+  postInstall = ''
+    mkdir -p $out/bin
+    # Overwrite the unwanted wrapper created by buildNpmPackage
+    ln -sf $out/lib/node_modules/neovim/bin/cli.js $out/bin/neovim-node-host
+  '';
+
+  meta = {
+    mainProgram = "node-client";
+    description = "Nvim msgpack API client and remote plugin provider";
+    homepage = "https://github.com/neovim/node-client";
+    changelog = "https://github.com/neovim/node-client/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fidgetingbits ];
+  };
+}

--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -136,6 +136,7 @@ mapAliases {
   inherit (pkgs) mermaid-cli; # added 2023-10-01
   musescore-downloader = pkgs.dl-librescore; # added 2023-08-19
   inherit (pkgs) near-cli; # added 2023-09-09
+  neovim = pkgs.neovim-node-client; # added 2024-11-13
   node-inspector = throw "node-inspector was removed because it was broken"; # added 2023-08-21
   inherit (pkgs) node-gyp; # added 2024-08-13
   inherit (pkgs) node-pre-gyp; # added 2024-08-05

--- a/pkgs/development/node-packages/main-programs.nix
+++ b/pkgs/development/node-packages/main-programs.nix
@@ -36,7 +36,6 @@
   less = "lessc";
   localtunnel = "lt";
   lua-fmt = "luafmt";
-  neovim = "neovim-node-host";
   parsoid = "parse.js";
   poor-mans-t-sql-formatter-cli = "sqlformat";
   postcss-cli = "postcss";

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -137,7 +137,6 @@
 , "meat"
 , "mocha"
 , "multi-file-swagger"
-, "neovim"
 , "nijs"
 , "node-gyp-build"
 , "node2nix"


### PR DESCRIPTION
This moves the neovim node-client out of nodePackages into it's own standalone package that uses `buildNpmPackage`. 

## Description of changes

EDIT: The follow two paragraphs are already solved. See comment thread.

Note that when moving to `buildNpmPackage` I ran into an issue where node-client wouldn't built, which I described here https://github.com/neovim/node-client/pull/365. That PR has been merged into node-client, but the node-client maintainer was concerned that this might be an issue with `buildNpmPackage` or with the way I packaged it, so it would be good if someone more familiar with node packaging could clarify.

Previous version of node-client is in `nodePackages` (currently 5.0.1), so the neovim package will have to get updated to reference this package for updates. Pinging @manveru @rvolosatovs for comment about that, and if you have any issue with the way I setup this package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
