### PR TITLE
python311Packages.loguru: speed-up tests phase

### DIFF
--- a/pkgs/development/python-modules/loguru/default.nix
+++ b/pkgs/development/python-modules/loguru/default.nix
@@ -7,6 +7,7 @@
   freezegun,
   pytestCheckHook,
   pythonOlder,
+  pytest-xdist
 }:
 
 buildPythonPackage rec {
@@ -25,6 +26,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-xdist # massive speedup, not tested by upstream
     colorama
     freezegun
   ];
@@ -38,6 +40,8 @@ buildPythonPackage rec {
       # fails on some machine configurations
       # AssertionError: assert '' != ''
       "test_file_buffering"
+      # Slow test
+      "test_time_rotation"
     ]
     ++ lib.optionals stdenv.isDarwin [
       "test_rotation_and_retention"


### PR DESCRIPTION
## Description of changes

Speed-up test by a factor of `6`:
- use `pytest-xdist` (`59s` -> `22s`)
- remove slow rotation test (`22s` -> `8s`) (will revert if unwanted)

This isn't a life-changing change, but it's still a nice to have improvement.

> `before`
```
============================= test session starts ==============================
platform linux -- Python 3.11.9, pytest-8.1.1, pluggy-1.4.0
rootdir: /build/source
configfile: tox.ini
testpaths: tests
collected 1496 items

tests/test_activation.py ..............................                  [  2%]
tests/test_add_option_backtrace.py .                                     [  2%]
[...]
tests/test_standard_handler.py ................                          [ 99%]
tests/test_threading.py .....                                            [100%]

====================== 1465 passed, 31 skipped in 59.65s =======================
```

> `after`
```
============================= test session starts ==============================
platform linux -- Python 3.11.9, pytest-8.1.1, pluggy-1.4.0
rootdir: /build/source
configfile: tox.ini
testpaths: tests
plugins: xdist-3.5.0
16 workers [1424 items]  m
........................................................................ [  4%]
........................................................................ [ 10%]
[...]
........................................................................ [ 96%]
......................ss..............................                   [100%]
======================= 1398 passed, 26 skipped in 8.83s =======================
```



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
