### PR TITLE
ladybird: 0-unstable-2024-05-26 -> 0-unstable-2024-06-04

### DIFF
--- a/nixos/tests/ladybird.nix
+++ b/nixos/tests/ladybird.nix
@@ -10,9 +10,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     ];
 
     services.xserver.enable = true;
-    environment.systemPackages = [
-      pkgs.ladybird
-    ];
+    programs.ladybird.enable = true;
   };
 
   enableOCR = true;

--- a/pkgs/applications/networking/browsers/ladybird/default.nix
+++ b/pkgs/applications/networking/browsers/ladybird/default.nix
@@ -50,13 +50,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ladybird";
-  version = "0-unstable-2024-05-26";
+  version = "0-unstable-2024-06-04";
 
   src = fetchFromGitHub {
-    owner = "SerenityOS";
-    repo = "serenity";
-    rev = "1a9d8e8fbe360f2d3b376ca0e13c507bd2cc6e8b";
-    hash = "sha256-+g/1F/v8nTVbvtSrtyvQbeYacjTlfRpg+Htu0lRlkcU=";
+    owner = "LadybirdWebBrowser";
+    repo = "ladybird";
+    rev = "c6e9f0e7b5b050ddbb5d735ca9c65458add9b4a5";
+    hash = "sha256-+NDrd0kO9bqXFcCEJFmNwNu5jmf+wT+uUVlmbmCYLw4=";
   };
 
   patches = [
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    sed -i '/iconutil/d' CMakeLists.txt
+    sed -i '/iconutil/d' Ladybird/CMakeLists.txt
 
     # Don't set absolute paths in RPATH
     substituteInPlace Meta/CMake/lagom_install_options.cmake \
@@ -73,16 +73,14 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   preConfigure = ''
-    cd Ladybird
-
     # Setup caches for LibLocale, LibUnicode, LibTimezone, LibTLS and LibGfx
     # Note that the versions of the input data packages must match the
     # expected version in the package's CMake.
 
     # Check that the versions match
-    grep -F 'set(CLDR_VERSION "${cldr_version}")' ../Meta/CMake/locale_data.cmake || (echo cldr_version mismatch && exit 1)
-    grep -F 'set(TZDB_VERSION "${tzdata.version}")' ../Meta/CMake/time_zone_data.cmake || (echo tzdata.version mismatch && exit 1)
-    grep -F 'set(CACERT_VERSION "${cacert_version}")' ../Meta/CMake/ca_certificates_data.cmake || (echo cacert_version mismatch && exit 1)
+    grep -F 'set(CLDR_VERSION "${cldr_version}")' Meta/CMake/locale_data.cmake || (echo cldr_version mismatch && exit 1)
+    grep -F 'set(TZDB_VERSION "${tzdata.version}")' Meta/CMake/time_zone_data.cmake || (echo tzdata.version mismatch && exit 1)
+    grep -F 'set(CACERT_VERSION "${cacert_version}")' Meta/CMake/ca_certificates_data.cmake || (echo cacert_version mismatch && exit 1)
 
     mkdir -p build/Caches
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Source for new repo location:
https://awesomekling.substack.com/p/forking-ladybird-and-stepping-down-serenityos

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
