### PR TITLE
nixos/systemd-tmpfiles: add systemd.user.tmpfiles.settings and systemd.user.tmpfiles.users.<name>.settings

### DIFF
--- a/nixos/lib/systemd-types.nix
+++ b/nixos/lib/systemd-types.nix
@@ -50,6 +50,7 @@ let
     nullOr
     path
     submodule
+    str
     ;
 in
 
@@ -117,4 +118,81 @@ in
       );
     };
   }));
+
+  tmpfilesSettings = attrsOf (attrsOf (attrsOf (submodule ({ name, config, ... }: {
+    options.type = mkOption {
+      type = str;
+      default = name;
+      example = "d";
+      description = ''
+        The type of operation to perform on the file.
+
+        The type consists of a single letter and optionally one or more
+        modifier characters.
+
+        Please see the upstream documentation for the available types and
+        more details:
+        <https://www.freedesktop.org/software/systemd/man/tmpfiles.d>
+      '';
+    };
+    options.mode = mkOption {
+      type = str;
+      default = "-";
+      example = "0755";
+      description = ''
+        The file access mode to use when creating this file or directory.
+      '';
+    };
+    options.user = mkOption {
+      type = str;
+      default = "-";
+      example = "root";
+      description = ''
+        The user of the file.
+
+        This may either be a numeric ID or a user/group name.
+
+        If omitted or when set to `"-"`, the user and group of the user who
+        invokes systemd-tmpfiles is used.
+      '';
+    };
+    options.group = mkOption {
+      type = str;
+      default = "-";
+      example = "root";
+      description = ''
+        The group of the file.
+
+        This may either be a numeric ID or a user/group name.
+
+        If omitted or when set to `"-"`, the user and group of the user who
+        invokes systemd-tmpfiles is used.
+      '';
+    };
+    options.age = mkOption {
+      type = str;
+      default = "-";
+      example = "10d";
+      description = ''
+        Delete a file when it reaches a certain age.
+
+        If a file or directory is older than the current time minus the age
+        field, it is deleted.
+
+        If set to `"-"` no automatic clean-up is done.
+      '';
+    };
+    options.argument = mkOption {
+      type = str;
+      default = "";
+      example = "";
+      description = ''
+        An argument whose meaning depends on the type of operation.
+
+        Please see the upstream documentation for the meaning of this
+        parameter in different situations:
+        <https://www.freedesktop.org/software/systemd/man/tmpfiles.d>
+      '';
+    };
+  }))));
 }

--- a/nixos/modules/system/boot/systemd/tmpfiles.nix
+++ b/nixos/modules/system/boot/systemd/tmpfiles.nix
@@ -1,6 +1,7 @@
 { config, lib, pkgs, utils, ... }:
 
 with lib;
+with utils;
 
 let
   cfg = config.systemd.tmpfiles;
@@ -38,82 +39,7 @@ in
         };
       };
       default = {};
-      type = types.attrsOf (types.attrsOf (types.attrsOf (types.submodule ({ name, config, ... }: {
-        options.type = mkOption {
-          type = types.str;
-          default = name;
-          example = "d";
-          description = ''
-            The type of operation to perform on the file.
-
-            The type consists of a single letter and optionally one or more
-            modifier characters.
-
-            Please see the upstream documentation for the available types and
-            more details:
-            <https://www.freedesktop.org/software/systemd/man/tmpfiles.d>
-          '';
-        };
-        options.mode = mkOption {
-          type = types.str;
-          default = "-";
-          example = "0755";
-          description = ''
-            The file access mode to use when creating this file or directory.
-          '';
-        };
-        options.user = mkOption {
-          type = types.str;
-          default = "-";
-          example = "root";
-          description = ''
-            The user of the file.
-
-            This may either be a numeric ID or a user/group name.
-
-            If omitted or when set to `"-"`, the user and group of the user who
-            invokes systemd-tmpfiles is used.
-          '';
-        };
-        options.group = mkOption {
-          type = types.str;
-          default = "-";
-          example = "root";
-          description = ''
-            The group of the file.
-
-            This may either be a numeric ID or a user/group name.
-
-            If omitted or when set to `"-"`, the user and group of the user who
-            invokes systemd-tmpfiles is used.
-          '';
-        };
-        options.age = mkOption {
-          type = types.str;
-          default = "-";
-          example = "10d";
-          description = ''
-            Delete a file when it reaches a certain age.
-
-            If a file or directory is older than the current time minus the age
-            field, it is deleted.
-
-            If set to `"-"` no automatic clean-up is done.
-          '';
-        };
-        options.argument = mkOption {
-          type = types.str;
-          default = "";
-          example = "";
-          description = ''
-            An argument whose meaning depends on the type of operation.
-
-            Please see the upstream documentation for the meaning of this
-            parameter in different situations:
-            <https://www.freedesktop.org/software/systemd/man/tmpfiles.d>
-          '';
-        };
-      }))));
+      type = systemdUtils.types.tmpfilesSettings;
     };
 
     systemd.tmpfiles.packages = mkOption {

--- a/nixos/modules/system/boot/systemd/user.nix
+++ b/nixos/modules/system/boot/systemd/user.nix
@@ -73,83 +73,6 @@ let
         '';
       }
     ) settings;
-
-  tmpfilesSettingsType = types.attrsOf (types.attrsOf (types.attrsOf (types.submodule ({ name, config, ... }: {
-    options.type = mkOption {
-      type = types.str;
-      default = name;
-      example = "d";
-      description = ''
-        The type of operation to perform on the file.
-
-        The type consists of a single letter and optionally one or more
-        modifier characters.
-
-        Please see the upstream documentation for the available types and
-        more details:
-        <https://www.freedesktop.org/software/systemd/man/tmpfiles.d>
-      '';
-    };
-    options.mode = mkOption {
-      type = types.str;
-      default = "-";
-      example = "0755";
-      description = ''
-        The file access mode to use when creating this file or directory.
-      '';
-    };
-    options.user = mkOption {
-      type = types.str;
-      default = "-";
-      example = "root";
-      description = ''
-        The user of the file.
-
-        This may either be a numeric ID or a user/group name.
-
-        If omitted or when set to `"-"`, the user and group of the user who
-        invokes systemd-tmpfiles is used.
-      '';
-    };
-    options.group = mkOption {
-      type = types.str;
-      default = "-";
-      example = "root";
-      description = ''
-        The group of the file.
-
-        This may either be a numeric ID or a user/group name.
-
-        If omitted or when set to `"-"`, the user and group of the user who
-        invokes systemd-tmpfiles is used.
-      '';
-    };
-    options.age = mkOption {
-      type = types.str;
-      default = "-";
-      example = "10d";
-      description = ''
-        Delete a file when it reaches a certain age.
-
-        If a file or directory is older than the current time minus the age
-        field, it is deleted.
-
-        If set to `"-"` no automatic clean-up is done.
-      '';
-    };
-    options.argument = mkOption {
-      type = types.str;
-      default = "";
-      example = "";
-      description = ''
-        An argument whose meaning depends on the type of operation.
-
-        Please see the upstream documentation for the meaning of this
-        parameter in different situations:
-        <https://www.freedesktop.org/software/systemd/man/tmpfiles.d>
-      '';
-    };
-  }))));
 in
 {
   options = {
@@ -235,7 +158,7 @@ in
             };
           };
         };
-        type = tmpfilesSettingsType;
+        type = systemdUtils.types.tmpfilesSettings;
       };
 
       users = mkOption {
@@ -275,7 +198,7 @@ in
                   };
                 };
               };
-              type = tmpfilesSettingsType;
+              type = systemdUtils.types.tmpfilesSettings;
             };
           };
         });

--- a/nixos/tests/systemd-user-tmpfiles-rules.nix
+++ b/nixos/tests/systemd-user-tmpfiles-rules.nix
@@ -15,9 +15,19 @@ import ./make-test-python.nix ({ lib, ... }: {
       rules = [
         "d %h/user_tmpfiles_created"
       ];
+      settings = {
+        "10-test" = {
+          "%h/user_tmpfiles_settings".d = {};
+        };
+      };
       users.alice.rules = [
         "d %h/only_alice"
       ];
+      users.alice.settings = {
+        "10-test" = {
+          "%h/only_alice_settings".d = {};
+        };
+      };
     };
   };
 
@@ -26,10 +36,14 @@ import ./make-test-python.nix ({ lib, ... }: {
 
     machine.wait_until_succeeds("systemctl --user --machine=alice@ is-active systemd-tmpfiles-setup.service")
     machine.succeed("[ -d ~alice/user_tmpfiles_created ]")
+    machine.succeed("[ -d ~alice/user_tmpfiles_settings ]")
     machine.succeed("[ -d ~alice/only_alice ]")
+    machine.succeed("[ -d ~alice/only_alice_settings ]")
 
     machine.wait_until_succeeds("systemctl --user --machine=bob@ is-active systemd-tmpfiles-setup.service")
     machine.succeed("[ -d ~bob/user_tmpfiles_created ]")
+    machine.succeed("[ -d ~bob/user_tmpfiles_settings ]")
     machine.succeed("[ ! -e ~bob/only_alice ]")
+    machine.succeed("[ ! -e ~bob/only_alice_settings ]")
   '';
 })


### PR DESCRIPTION
## Description of changes
Add the settings attribute to systemd.user.tmpfiles and systemd.user.tmpfiles.user.<name>
This is to match systemd.tmpfiles and uses the same implementation with minor changes.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
