### PR TITLE
basedpyright: 1.12.4 -> 1.12.5

### DIFF
--- a/pkgs/by-name/ba/basedpyright/package.nix
+++ b/pkgs/by-name/ba/basedpyright/package.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  nix-update-script,
   buildNpmPackage,
   fetchFromGitHub,
   runCommand,
@@ -8,13 +7,13 @@
 }:
 
 let
-  version = "1.12.4";
+  version = "1.12.5";
 
   src = fetchFromGitHub {
     owner = "detachhead";
     repo = "basedpyright";
     rev = "v${version}";
-    hash = "sha256-ZcFCK6KKX10w5KgsUQIDMMBIzU+8pw0t9/pn1tzCnMg=";
+    hash = "sha256-fiaIkZoW0eOzVLOv9vhEk32kgKorNSG1vtNw0bIOtNU=";
   };
 
   patchedPackageJSON = runCommand "package.json" { } ''
@@ -44,7 +43,7 @@ let
     pname = "pyright-internal";
     inherit version src;
     sourceRoot = "${src.name}/packages/pyright-internal";
-    npmDepsHash = "sha256-90IGWvXvUpvIQdpukm8njwcNj7La6rWwoENh4kiBayI=";
+    npmDepsHash = "sha256-bdlcGrYLnX318+MByYIzjnchl9n4+EcZKCZJgSMKyHo=";
     dontNpmBuild = true;
     # FIXME: Remove this flag when TypeScript 5.5 is released
     npmFlags = [ "--legacy-peer-deps" ];
@@ -60,7 +59,7 @@ buildNpmPackage rec {
   inherit version src;
 
   sourceRoot = "${src.name}/packages/pyright";
-  npmDepsHash = "sha256-HI3ehtJ29kFSv0XyrXcp5JGs9HGYb9ub2oOSQ6uEn8Q=";
+  npmDepsHash = "sha256-JDGNpyOBK3EwbHIHp4Zoo376MqU5u97Zj46vtuWY488=";
 
   postPatch = ''
     chmod +w ../../
@@ -76,7 +75,7 @@ buildNpmPackage rec {
 
   dontNpmBuild = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = ./update.sh;
 
   meta = {
     changelog = "https://github.com/detachhead/basedpyright/releases/tag/${version}";

--- a/pkgs/by-name/ba/basedpyright/update.sh
+++ b/pkgs/by-name/ba/basedpyright/update.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused common-updater-scripts jq prefetch-npm-deps
+set -euo pipefail
+
+version=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} -v -s https://api.github.com/repos/detachhead/basedpyright/releases/latest | jq -r '.tag_name | sub("^v"; "")')
+
+update-source-version basedpyright "$version"
+
+root="$(dirname "$(readlink -f "$0")")"
+FILE_PATH="$root/package.nix"
+REPO_URL_PREFIX="https://github.com/detachhead/basedpyright/raw"
+TEMP_DIR=$(mktemp -d)
+
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+# Function to download `package-lock.json` for a given source path and update hash
+update_hash() {
+    local source_root_path="$1"
+    local existing_hash="$2"
+
+    # Formulate download URL
+    local download_url="${REPO_URL_PREFIX}/v${version}${source_root_path}/package-lock.json"
+
+    # Download package-lock.json to temporary directory
+    curl -fsSL -v -o "${TEMP_DIR}/package-lock.json" "$download_url"
+
+    # Calculate the new hash
+    local new_hash
+    new_hash=$(prefetch-npm-deps "${TEMP_DIR}/package-lock.json")
+
+    # Update npmDepsHash in the original file
+    sed -i "s|$existing_hash|${new_hash}|" "$FILE_PATH"
+}
+
+while IFS= read -r source_root_line; do
+    [[ "$source_root_line" =~ sourceRoot ]] || continue
+    source_root_path=$(echo "$source_root_line" | sed -e 's/^.*"${src.name}\(.*\)";.*$/\1/')
+
+    # Extract the current npmDepsHash for this sourceRoot
+    existing_hash=$(grep -A1 "$source_root_line" "$FILE_PATH" | grep 'npmDepsHash' | sed -e 's/^.*npmDepsHash = "\(.*\)";$/\1/')
+
+    # Call the function to download and update the hash
+    update_hash "$source_root_path" "$existing_hash"
+done < "$FILE_PATH"


### PR DESCRIPTION
## Description of changes

Diff:
https://github.com/detachhead/basedpyright/compare/v1.12.4...v1.12.5

Changelog:
https://github.com/detachhead/basedpyright/releases/tag/v1.12.5

Other actions:
Import and use pyright's `update.sh` to update this package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
