### PR TITLE
commitizen-go: init at 1.0.3

### DIFF
--- a/pkgs/by-name/co/commitizen-go/package.nix
+++ b/pkgs/by-name/co/commitizen-go/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "commitizen-go";
+  version = "1.0.3";
+
+  # we can't obtain the commit hash when using fetchFromGithub
+  commit_revision = "unspecified (nix build)";
+
+  src = fetchFromGitHub {
+    owner = "lintingzhen";
+    repo = "commitizen-go";
+    rev = "v${version}";
+    hash = "sha256-pAWdIQ3icXEv79s+sUVhQclsNcZg+PTZZ6I6JPo7pNg=";
+  };
+
+  vendorHash = "sha256-TbrgKE7P3c0gkqJPDkbchWTPkOuTaTAWd8wDcpffcCc=";
+
+  subPackages = [ "." ];
+
+  CGO_ENABLED = 0;
+
+  ldflags = [
+    "-X 'github.com/lintingzhen/commitizen-go/cmd.revision=${commit_revision}'"
+    "-X 'github.com/lintingzhen/commitizen-go/cmd.version=${version}'"
+  ];
+
+  meta = with lib; {
+    description = "Command line utility to standardize git commit messages, golang version";
+    homepage = "https://github.com/lintingzhen/commitizen-go";
+    license = licenses.mit;
+    maintainers = with maintainers; [ seanrmurphy ];
+    mainProgram = "commitizen-go";
+  };
+}


### PR DESCRIPTION
## Description of changes

Added commitizen-go package. This is a small package which supports conventional commit messages and does not require node.js.

https://github.com/lintingzhen/commitizen-go

It's definitely niche but has 23 forks and 229 stars - not sure if that's sufficient to be added here.

I've been using it for some years; it does not change v much as it has v clear and limited scope and the current implementation does all it needs to. Any required maintenance would prob arise from changes to go tooling or changes to nix build processes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
