### PR TITLE
Revert "python3Packages.xapp: 2.4.1 -> 21" and "python3Packages.xapp: 21 -> 22"

### DIFF
--- a/pkgs/development/python-modules/xapp/default.nix
+++ b/pkgs/development/python-modules/xapp/default.nix
@@ -55,7 +55,10 @@ buildPythonPackage rec {
   doCheck = false;
   pythonImportsCheck = [ "xapp" ];
 
-  passthru.updateScript = gitUpdater { ignoredVersions = "^master.*"; };
+  passthru = {
+    updateScript = gitUpdater { ignoredVersions = "^master.*"; };
+    skipBulkUpdate = true; # This should be bumped as part of Cinnamon update.
+  };
 
   meta = with lib; {
     homepage = "https://github.com/linuxmint/python-xapp";

--- a/pkgs/development/python-modules/xapp/default.nix
+++ b/pkgs/development/python-modules/xapp/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "xapp";
-  version = "21";
+  version = "2.4.1";
 
   format = "other";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "python-xapp";
-    rev = "refs/tags/master.mint${version}";
+    rev = version;
     hash = "sha256-Kvhp+biZ+KK9FYma/8cUEaQCHPKMLjOO909kbyMLQ3o=";
   };
 

--- a/pkgs/development/python-modules/xapp/default.nix
+++ b/pkgs/development/python-modules/xapp/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "xapp";
-  version = "22";
+  version = "21";
 
   format = "other";
 
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "linuxmint";
     repo = "python-xapp";
     rev = "refs/tags/master.mint${version}";
-    hash = "sha256-2Gx85y0ARu6EfDYAT9ZL154RH0R1HY78tm3rceODnZU=";
+    hash = "sha256-Kvhp+biZ+KK9FYma/8cUEaQCHPKMLjOO909kbyMLQ3o=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

The master.* tags are not stable tags and can be re-tagged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

