### PR TITLE
darkman: 1.5.4 -> 2.0.1

### DIFF
--- a/pkgs/applications/misc/darkman/default.nix
+++ b/pkgs/applications/misc/darkman/default.nix
@@ -1,28 +1,37 @@
-{ lib, fetchFromGitLab, buildGoModule, scdoc, nix-update-script }:
+{ lib
+, fetchFromGitLab
+, buildGoModule
+, scdoc
+, nix-update-script
+}:
 
 buildGoModule rec {
   pname = "darkman";
-  version = "1.5.4";
+  version = "2.0.1";
 
   src = fetchFromGitLab {
     owner = "WhyNotHugo";
     repo = "darkman";
     rev = "v${version}";
-    sha256 = "sha256-6SNXVe6EfVwcXH9O6BxNw+v4/uhKhCtVS3XE2GTc2Sc=";
+    sha256 = "sha256-FaEpVy/0PqY5Bmw00hMyFZb9wcwYwEuCKMatYN8Xk3o=";
   };
 
-  vendorHash = "sha256-xEPmNnaDwFU4l2G4cMvtNeQ9KneF5g9ViQSFrDkrafY=";
-
-  nativeBuildInputs = [ scdoc ];
+  patches = [
+    ./go-mod.patch
+    ./makefile.patch
+  ];
 
   postPatch = ''
     substituteInPlace darkman.service \
-      --replace "/usr/bin/darkman" "$out/bin/darkman"
+      --replace-fail /usr/bin/darkman $out/bin/darkman
     substituteInPlace contrib/dbus/nl.whynothugo.darkman.service \
-      --replace "/usr/bin/darkman" "$out/bin/darkman"
+      --replace-fail /usr/bin/darkman $out/bin/darkman
     substituteInPlace contrib/dbus/org.freedesktop.impl.portal.desktop.darkman.service \
-      --replace "/usr/bin/darkman" "$out/bin/darkman"
+      --replace-fail /usr/bin/darkman $out/bin/darkman
   '';
+
+  vendorHash = "sha256-3lILSVm7mtquCdR7+cDMuDpHihG+gDJTcQa1cM2o7ZU=";
+  nativeBuildInputs = [ scdoc ];
 
   buildPhase = ''
     runHook preBuild
@@ -32,6 +41,7 @@ buildGoModule rec {
 
   installPhase = ''
     runHook preInstall
+    install -Dm755 darkman -t $out/bin
     make PREFIX=$out install
     runHook postInstall
   '';

--- a/pkgs/applications/misc/darkman/go-mod.patch
+++ b/pkgs/applications/misc/darkman/go-mod.patch
@@ -1,0 +1,28 @@
+diff --git a/go.mod b/go.mod
+index 2d396a4..c4fea4b 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,14 +1,19 @@
+ module gitlab.com/WhyNotHugo/darkman
+ 
+-go 1.16
++go 1.18
+ 
+ require (
+ 	github.com/adrg/xdg v0.3.3
+ 	github.com/godbus/dbus/v5 v5.0.4
+-	github.com/kr/pretty v0.2.0 // indirect
+ 	github.com/rxwycdh/rxhash v0.0.0-20230131062142-10b7a38b400d
+ 	github.com/sj14/astral v0.1.2
+-	github.com/spf13/cobra v1.7.0 // indirect
+-	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
++	github.com/spf13/cobra v1.7.0
+ 	gopkg.in/yaml.v3 v3.0.1
+ )
++
++require (
++	github.com/inconshreveable/mousetrap v1.1.0 // indirect
++	github.com/kr/pretty v0.2.0 // indirect
++	github.com/spf13/pflag v1.0.5 // indirect
++	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
++)

--- a/pkgs/applications/misc/darkman/makefile.patch
+++ b/pkgs/applications/misc/darkman/makefile.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+index 9048e45..0fb1f5a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -26,7 +26,6 @@ site/index.html: darkman.1
+ 	mandoc -T html -O style=man-style.css < darkman.1 > site/index.html
+ 
+ install: build
+-	@install -Dm755 darkman 	${DESTDIR}${PREFIX}/bin/darkman
+ 	@install -Dm644 darkman.service	${DESTDIR}${PREFIX}/lib/systemd/user/darkman.service
+ 	@install -Dm644 darkman.1	${DESTDIR}${PREFIX}/share/man/man1/darkman.1
+ 	@install -Dm644 LICENCE 	${DESTDIR}${PREFIX}/share/licenses/darkman/LICENCE


### PR DESCRIPTION
Closes #317206

[Changelog](https://gitlab.com/WhyNotHugo/darkman/-/blob/main/CHANGELOG.md)

## 2.0.0

- **BREAKING** Exit with an error if the configuration file has unknown fields.
- **BREAKING** Geoclue integration is now disabled by default. To retain the
  previous behaviour, explicitly enable it in the configuration file.
- **BREAKING** Go version 1.18 is now required to build.
- **BREAKING** The deprecated `darkmanctl` alias is gone. Use `darkman` instead.
- Don't print usage output if an error occurs. Only show it if the provided
  arguments are invalid. This was a bug, and made reading error output extremely
  unintuitive.
- Miscellaneous improvements to example scripts.
- Various documentation improvements, including docs for `portals.conf`.
- Dropped hardening rules for the systemd service. This doesn't realistically
  add much security but interferes with several common configurations.
- Switch back from `flaggy` to `cobra`. The latter has fixed the issues that we
  had in the past, and can also generate shell completions.
- Shell completions are now included for `bash`, `fish` and `zsh`.
- Add a `check` command to verify if a configuration file is valid.
- Add a `--ready-fd` flag to `darkman run`. This prints `\n` to a given file
  descriptor once the service has reached its ready state. This enables service
  managers to ascertain when darkman is ready to receive connections. At this
  point, it is safe to start dependant services.
- Add a custom xdg-desktop-portal setting to determine if darkman is being used
  to retrieve settings.
- Darkman will exit with an error if configured to use geoclue and connecting to
  geoclue falis.

## 2.0.1

- Fix initial location not being applied properly.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
