### PR TITLE
frink: 2023-12-02 -> 2024-05-09

### DIFF
--- a/pkgs/development/tools/frink/default.nix
+++ b/pkgs/development/tools/frink/default.nix
@@ -1,46 +1,50 @@
-{ fetchurl
-, frink
-, jdk
-, lib
-, rlwrap
-, stdenv
-, testers
+{
+  fetchurl,
+  frink,
+  jdk,
+  lib,
+  rlwrap,
+  stdenv,
+  testers,
 }:
 stdenv.mkDerivation rec {
   pname = "frink";
-  version = "2023-12-02";
+  version = "2024-05-09";
 
   src = fetchurl {
     # Upstream does not provide versioned download links
-    url = "https://web.archive.org/web/20231210094124/https://frinklang.org/frinkjar/frink.jar";
-    sha256 = "sha256-oURRTrgyVMPD4cOdM6g0bDpZ0KMlVsLqa0nzC1UvqIs=";
+    url = "https://web.archive.org/web/20240605193919/https://frinklang.org/frinkjar/frink-tng.jar";
+    sha256 = "sha256-ceV1p9wsXprcNLhol79evswVZ1SpH5IzfSbl8st4cmU=";
   };
 
   dontUnpack = true;
 
   nativeBuildInputs = [ jdk ];
 
-  buildInputs = [ jdk rlwrap ];
+  buildInputs = [
+    jdk
+    rlwrap
+  ];
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/bin $out/lib
 
-    cp ${src} $out/lib/frink.jar
+    cp ${src} $out/lib/frink-tng.jar
 
     # Generate rlwrap helper files.
     # See https://frinklang.org/fsp/colorize.fsp?f=listUnits.frink
     # and https://frinklang.org/fsp/colorize.fsp?f=listFunctions.frink
-    java -classpath "$out/lib/frink.jar" frink.gui.FrinkStarter -e 'joinln[lexicalSort[units[]]]' > $out/lib/unitnames.txt
-    java -classpath "$out/lib/frink.jar" frink.gui.FrinkStarter -e 'joinln[map[{|f|
+    java -classpath "$out/lib/frink-tng.jar" frink.gui.FrinkStarter -e 'joinln[lexicalSort[units[]]]' > $out/lib/unitnames.txt
+    java -classpath "$out/lib/frink-tng.jar" frink.gui.FrinkStarter -e 'joinln[map[{|f|
         f =~ %s/\s+//g
         return "$f$"
       }, lexicalSort[functions[]]]]' > $out/lib/functionnames.txt
 
     cat > "$out/bin/frink" << EOF
     #!${stdenv.shell}
-    exec ${rlwrap}/bin/rlwrap -f $out/lib/unitnames.txt -b '$' -f $out/lib/functionnames.txt ${jdk}/bin/java -classpath "$out/lib/frink.jar" frink.gui.FrinkStarter "\$@"
+    exec ${rlwrap}/bin/rlwrap -f $out/lib/unitnames.txt -b '$' -f $out/lib/functionnames.txt ${jdk}/bin/java -classpath "$out/lib/frink-tng.jar" frink.gui.FrinkStarter "\$@"
     EOF
 
     chmod a+x "$out/bin/frink"


### PR DESCRIPTION
## Description of changes

Switches to Frink: The Next Generation

https://frinklang.org/whatsnew.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
