### PR TITLE
python312Packages.av: 11.0.0 -> 12.3.0, refactor, adopt

### DIFF
--- a/pkgs/development/python-modules/av/allow-skipping-network-tests.patch
+++ b/pkgs/development/python-modules/av/allow-skipping-network-tests.patch
@@ -1,0 +1,24 @@
+diff --git a/av/datasets.py b/av/datasets.py
+index 5954a9c..a239ba0 100644
+--- a/av/datasets.py
++++ b/av/datasets.py
+@@ -105,6 +105,9 @@ def fate(name: str) -> str:
+     See the `FFmpeg Automated Test Environment <https://www.ffmpeg.org/fate.html>`_
+ 
+     """
++    if(os.environ.get("SKIP_NETWORK_TESTS") == "1"):
++        import pytest
++        pytest.skip("Test uses network", allow_module_level=True)
+     return cached_download(
+         "http://fate.ffmpeg.org/fate-suite/" + name,
+         os.path.join("fate-suite", name.replace("/", os.path.sep)),
+@@ -117,6 +120,9 @@ def curated(name: str) -> str:
+     Data is handled by :func:`cached_download`.
+ 
+     """
++    if(os.environ.get("SKIP_NETWORK_TESTS") == "1"):
++        import pytest
++        pytest.skip("Test uses network", allow_module_level=True)
+     return cached_download(
+         "https://pyav.org/datasets/" + name,
+         os.path.join("pyav-curated", name.replace("/", os.path.sep)),

--- a/pkgs/development/python-modules/av/default.nix
+++ b/pkgs/development/python-modules/av/default.nix
@@ -1,11 +1,9 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   cython,
   fetchFromGitHub,
-  fetchpatch,
-  ffmpeg_5-headless,
+  ffmpeg-headless,
   numpy,
   pillow,
   pkg-config,
@@ -16,37 +14,36 @@
 
 buildPythonPackage rec {
   pname = "av";
-  version = "11.0.0";
+  version = "12.3.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
-    owner = "mikeboers";
+    owner = "PyAV-Org";
     repo = "PyAV";
     rev = "refs/tags/v${version}";
-    hash = "sha256-pCKP+4ZmZCJcG7/Qy9H6aS4svQdgaRA9S1QVNWFYhSQ=";
+    hash = "sha256-ezeYv55UzNnnYDjrMz5YS5g2pV6U/Fxx3e2bCoPP3eI=";
   };
 
   patches = [
-    # merged upstream PR: https://github.com/PyAV-Org/PyAV/pull/1387
-    (fetchpatch {
-      name = "use-pkg-config-env-var-fix-cross.patch";
-      url = "https://github.com/PyAV-Org/PyAV/commit/ba7a2c9f716af506838d399e6ed27ed6d64d2435.patch";
-      sha256 = "sha256-oH+g8sVoVCQe6DimRN38VT2GdziriwHYRAhldNxz9/E=";
-    })
+    # call pytest.skip() in certain functions using the network when SKIP_NETWORK_TESTS is set
+    ./allow-skipping-network-tests.patch
   ];
 
-  nativeBuildInputs = [
+  env.SKIP_NETWORK_TESTS = "1";
+
+  build-system = [
     cython
-    pkg-config
     setuptools
   ];
 
-  buildInputs = [ ffmpeg_5-headless ];
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ ffmpeg-headless ];
 
   preCheck = ''
-    # ensure we import the built version
+    # ensure we import the built package from $out
     rm -r av
   '';
 
@@ -56,72 +53,21 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTests =
-    [
-      # urlopen fails during DNS resolution
-      "test_writing_to_custom_io"
-      "test_decode_close_then_use"
-      # Tests that want to download FATE data, https://github.com/PyAV-Org/PyAV/issues/955
-      "test_vobsub"
-      "test_transcode"
-      "test_stream_tuples"
-      "test_stream_seek"
-      "test_stream_probing"
-      "test_seek_start"
-      "test_seek_middle"
-      "test_seek_int64"
-      "test_seek_float"
-      "test_seek_end"
-      "test_roundtrip"
-      "test_reading_from_write_readonl"
-      "test_reading_from_pipe_readonly"
-      "test_reading_from_file"
-      "test_reading_from_buffer"
-      "test_reading_from_buffer_no_see"
-      "test_parse"
-      "test_movtext"
-      "test_encoding_xvid"
-      "test_encoding_tiff"
-      "test_encoding_png"
-      "test_encoding_pcm_s24le"
-      "test_encoding_mpeg4"
-      "test_encoding_mpeg1video"
-      "test_encoding_mp2"
-      "test_encoding_mjpeg"
-      "test_encoding_h264"
-      "test_encoding_dvvideo"
-      "test_encoding_dnxhd"
-      "test_encoding_aac"
-      "test_decoded_video_frame_count"
-      "test_decoded_time_base"
-      "test_decoded_motion_vectors"
-      "test_decode_half"
-      "test_decode_audio_sample_count"
-      "test_data"
-      "test_container_probing"
-      "test_codec_tag"
-      "test_selection"
-    ]
-    ++ lib.optionals (stdenv.isDarwin) [
-      # Segmentation Faults
-      "test_encoding_with_pts"
-      "test_bayer_write"
-    ];
-
-  disabledTestPaths = [
-    # urlopen fails during DNS resolution
-    "tests/test_doctests.py"
-    "tests/test_timeout.py"
+  disabledTests = [
+    # Error: Invalid data found when processing input: 'custom_io_output.mpd'
+    # Probably has to do something with the fact that this is using the @run_in_sandbox decorator
+    "test_writing_to_custom_io_dash"
   ];
 
   pythonImportsCheck = [
     "av"
+    "av._core"
     "av.audio"
+    "av.bitstream"
     "av.buffer"
     "av.bytesource"
     "av.codec"
     "av.container"
-    "av._core"
     "av.datasets"
     "av.descriptor"
     "av.dictionary"
@@ -134,18 +80,19 @@ buildPythonPackage rec {
     "av.option"
     "av.packet"
     "av.plane"
+    "av.sidedata"
     "av.stream"
     "av.subtitles"
     "av.utils"
     "av.video"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Pythonic bindings for FFmpeg/Libav";
     mainProgram = "pyav";
-    homepage = "https://github.com/mikeboers/PyAV/";
-    changelog = "https://github.com/PyAV-Org/PyAV/blob/v${version}/CHANGELOG.rst";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ ];
+    homepage = "https://github.com/PyAV-Org/PyAV/";
+    changelog = "https://github.com/PyAV-Org/PyAV/blob/${src.rev}/CHANGELOG.rst";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ tomasajt ];
   };
 }


### PR DESCRIPTION
## Description of changes

This PR bumps the version of the `av` python package.

It also adds a patch that facilitates skipping tests that require the network to fetch test files.

I also added myself to the maintainer list, since it was empty.

Other changes:
- update the owner of the repo (it was transferred)
- use `build-system` for build-time python deps
- reorder some items

---
Question: should this go into staging? The build time is not short.



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
