### PR TITLE
ell: 0.65 -> 0.66, iwd: 2.17 -> 2.18

### DIFF
--- a/pkgs/os-specific/linux/ell/default.nix
+++ b/pkgs/os-specific/linux/ell/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , fetchgit
+, fetchpatch
 , autoreconfHook
 , pkg-config
 , dbus
@@ -9,15 +10,26 @@
 
 stdenv.mkDerivation rec {
   pname = "ell";
-  version = "0.65";
+  version = "0.66";
 
   outputs = [ "out" "dev" ];
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/libs/ell/ell.git";
     rev = version;
-    hash = "sha256-q0C9KfWHxdmrG7xcbb8zpFL4ro+BJb7BL2tyKdFIhew=";
+    hash = "sha256-FqJbAE2P6rKKUMwcDShCKNDQu4RRifEGrbE7F4gSpm0=";
   };
+
+  patches = [
+    # Without the revert TCP dbus tests fail to bind the port and fail.
+    # Seemingly a known dbus bug: https://gitlab.freedesktop.org/dbus/dbus/-/issues/28
+    (fetchpatch {
+      name = "revert-tcp-tests.patch";
+      url = "https://git.kernel.org/pub/scm/libs/ell/ell.git/patch/?id=7863e06b18b9cce56392b65928e927297108337d";
+      hash = "sha256-8+M1k0hGE64CHmK1T5/zW8+Q76pIjl5SMaYktRqpudg=";
+      revert = true;
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -13,12 +13,12 @@
 
 stdenv.mkDerivation rec {
   pname = "iwd";
-  version = "2.17";
+  version = "2.18";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/network/wireless/iwd.git";
     rev = version;
-    hash = "sha256-o/Q8vUtB4Yiz1x+/6+8LUKUQNtiAmwcdh++/tTUN4mM=";
+    hash = "sha256-icPYxbCkfgv3v/FIVnrwKoHuLh9Sx2fcpQPO3kXJe4A=";
   };
 
   outputs = [ "out" "man" "doc" ]


### PR DESCRIPTION
## Description of changes

iwd: 2.17 -> 2.18
Changes: https://git.kernel.org/pub/scm/network/wireless/iwd.git/tree/ChangeLog?h=2.18

ell: 0.65 -> 0.66
Changes: https://git.kernel.org/pub/scm/libs/ell/ell.git/tree/ChangeLog?h=0.66

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
