### PR TITLE
nixos/tests/postgresql: add tls client cert test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -754,6 +754,7 @@ in {
   postgresql = handleTest ./postgresql.nix {};
   postgresql-jit = handleTest ./postgresql-jit.nix {};
   postgresql-wal-receiver = handleTest ./postgresql-wal-receiver.nix {};
+  postgresql-tls-client-cert = handleTest ./postgresql-tls-client-cert.nix {};
   powerdns = handleTest ./powerdns.nix {};
   powerdns-admin = handleTest ./powerdns-admin.nix {};
   power-profiles-daemon = handleTest ./power-profiles-daemon.nix {};

--- a/nixos/tests/postgresql-tls-client-cert.nix
+++ b/nixos/tests/postgresql-tls-client-cert.nix
@@ -1,0 +1,141 @@
+{ system ? builtins.currentSystem
+, config ? { }
+, pkgs ? import ../.. { inherit system config; }
+, package ? null
+}:
+
+with import ../lib/testing-python.nix { inherit system pkgs; };
+
+let
+  lib = pkgs.lib;
+
+  # Makes a test for a PostgreSQL package, given by name and looked up from `pkgs`.
+  makeTestAttribute = name:
+    {
+      inherit name;
+      value = makePostgresqlTlsClientCertTest pkgs."${name}";
+    };
+
+  makePostgresqlTlsClientCertTest = pkg:
+    let
+      runWithOpenSSL = file: cmd: pkgs.runCommand file
+        {
+          buildInputs = [ pkgs.openssl ];
+        }
+        cmd;
+      caKey = runWithOpenSSL "ca.key" "openssl ecparam -name prime256v1 -genkey -noout -out $out";
+      caCert = runWithOpenSSL
+        "ca.crt"
+        ''
+          openssl req -new -x509 -sha256 -key ${caKey} -out $out -subj "/CN=test.example" -days 36500
+        '';
+      serverKey =
+        runWithOpenSSL "server.key" "openssl ecparam -name prime256v1 -genkey -noout -out $out";
+      serverKeyPath = "/var/lib/postgresql";
+      serverCert =
+        runWithOpenSSL "server.crt" ''
+          openssl req -new -sha256 -key ${serverKey} -out server.csr -subj "/CN=db.test.example"
+          openssl x509 -req -in server.csr -CA ${caCert} -CAkey ${caKey} \
+            -CAcreateserial -out $out -days 36500 -sha256
+        '';
+      clientKey =
+        runWithOpenSSL "client.key" "openssl ecparam -name prime256v1 -genkey -noout -out $out";
+      clientCert =
+        runWithOpenSSL "client.crt" ''
+          openssl req -new -sha256 -key ${clientKey} -out client.csr -subj "/CN=test"
+          openssl x509 -req -in client.csr -CA ${caCert} -CAkey ${caKey} \
+            -CAcreateserial -out $out -days 36500 -sha256
+        '';
+      clientKeyPath = "/root";
+
+    in
+    makeTest {
+      name = "postgresql-tls-client-cert-${pkg.name}";
+      meta.maintainers = with lib.maintainers; [ erictapen ];
+
+      nodes.server = { ... }: {
+        system.activationScripts = {
+          keyPlacement.text = ''
+            mkdir -p '${serverKeyPath}'
+            cp '${serverKey}' '${serverKeyPath}/server.key'
+            chown postgres:postgres '${serverKeyPath}/server.key'
+            chmod 600 '${serverKeyPath}/server.key'
+          '';
+        };
+        services.postgresql = {
+          package = pkg;
+          enable = true;
+          enableTCPIP = true;
+          ensureUsers = [
+            {
+              name = "test";
+              ensureDBOwnership = true;
+            }
+          ];
+          ensureDatabases = [ "test" ];
+          settings = {
+            ssl = "on";
+            ssl_ca_file = toString caCert;
+            ssl_cert_file = toString serverCert;
+            ssl_key_file = "${serverKeyPath}/server.key";
+          };
+          authentication = ''
+            hostssl test test ::/0 cert clientcert=verify-full
+          '';
+        };
+        networking = {
+          interfaces.eth1 = {
+            ipv6.addresses = [
+              { address = "fc00::1"; prefixLength = 120; }
+            ];
+          };
+          firewall.allowedTCPPorts = [ 5432 ];
+        };
+      };
+
+      nodes.client = { ... }: {
+        system.activationScripts = {
+          keyPlacement.text = ''
+            mkdir -p '${clientKeyPath}'
+            cp '${clientKey}' '${clientKeyPath}/client.key'
+            chown root:root '${clientKeyPath}/client.key'
+            chmod 600 '${clientKeyPath}/client.key'
+          '';
+        };
+        environment = {
+          variables = {
+            PGHOST = "db.test.example";
+            PGPORT = "5432";
+            PGDATABASE = "test";
+            PGUSER = "test";
+            PGSSLMODE = "verify-full";
+            PGSSLCERT = clientCert;
+            PGSSLKEY = "${clientKeyPath}/client.key";
+            PGSSLROOTCERT = caCert;
+          };
+          systemPackages = [ pkg ];
+        };
+        networking = {
+          interfaces.eth1 = {
+            ipv6.addresses = [
+              { address = "fc00::2"; prefixLength = 120; }
+            ];
+          };
+          hosts = { "fc00::1" = [ "db.test.example" ]; };
+        };
+      };
+
+      testScript = ''
+        server.wait_for_unit("multi-user.target")
+        client.wait_for_unit("multi-user.target")
+        client.succeed("psql -c \"SELECT 1;\"")
+      '';
+    };
+
+in
+if package == null then
+# all-tests.nix: Maps the generic function over all attributes of PostgreSQL packages
+  builtins.listToAttrs (map makeTestAttribute (builtins.attrNames (import ../../pkgs/servers/sql/postgresql pkgs)))
+else
+# Called directly from <package>.tests
+  makePostgresqlTlsClientCertTest package


### PR DESCRIPTION
## Description of changes

I wrote this to test a bug I thought I found, but it turned out the mistake was on my side.

Would the maintainers of PostgreSQL be interested in this? It takes 24s on my machine and tests wether a client can connect to a running server using TLS client certificates for authentication and encryption. I would maintain this in the future if it should break.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
