### PR TITLE
ruff: only generate completions if program can be executed

### DIFF
--- a/pkgs/development/tools/ruff/default.nix
+++ b/pkgs/development/tools/ruff/default.nix
@@ -64,7 +64,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=semantic::types::infer::tests::resolve_visible_def"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd ruff \
       --bash <($out/bin/ruff generate-shell-completion bash) \
       --fish <($out/bin/ruff generate-shell-completion fish) \


### PR DESCRIPTION
## Description of changes

Getting ahead of https://github.com/NixOS/nixpkgs/pull/289517 for cross builds.

Fixes

```
$ nix build .#pkgsCross.aarch64-multiplatform.ruff -L
[...]
ruff-aarch64-unknown-linux-gnu> /nix/store/l30525lnvzaiwqihqzspgrljmvjfx9j6-stdenv-linux/setup: line 114: /nix/store/4ws8s0ri2si18djfz9pps62pj208mihf-ruff-aarch64-unknown-linux-gnu-0.4.7/bin/ruff: cannot execute binary file: Exec format error
ruff-aarch64-unknown-linux-gnu> /nix/store/l30525lnvzaiwqihqzspgrljmvjfx9j6-stdenv-linux/setup: line 114: /nix/store/4ws8s0ri2si18djfz9pps62pj208mihf-ruff-aarch64-unknown-linux-gnu-0.4.7/bin/ruff: cannot execute binary file: Exec format error
ruff-aarch64-unknown-linux-gnu> /nix/store/l30525lnvzaiwqihqzspgrljmvjfx9j6-stdenv-linux/setup: line 114: /nix/store/4ws8s0ri2si18djfz9pps62pj208mihf-ruff-aarch64-unknown-linux-gnu-0.4.7/bin/ruff: cannot execute binary file: Exec format error
```

which will cause errors.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
