### PR TITLE
lisp-modules: Use OUTPUT-FILE arg to COMPILE-FILE instead of faslExt

### DIFF
--- a/doc/languages-frameworks/lisp.section.md
+++ b/doc/languages-frameworks/lisp.section.md
@@ -284,7 +284,6 @@ derivation.
 `wrapLisp` takes these arguments:
 
 - `pkg`: the Lisp package
-- `faslExt`: Implementation-specific extension for FASL files
 - `program`: The name of executable file in `${pkg}/bin/` (Default: `pkg.pname`)
 - `flags`: A list of flags to always pass to `program` (Default: `[]`)
 - `asdf`: The ASDF version to use (Default: `pkgs.asdf_3_3`)
@@ -295,7 +294,6 @@ This example wraps CLISP:
 ```nix
 wrapLisp {
   pkg = clisp;
-  faslExt = "fas";
   flags = ["-E" "UTF8"];
 }
 ```

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -505,7 +505,7 @@ let
     NASDF_USE_LOGICAL_PATHS = true;
 
     buildScript = pkgs.writeText "build-nyxt.lisp" ''
-      (load "${super.alexandria.asdfFasl}/asdf.${super.alexandria.faslExt}")
+      (load "${super.alexandria.asdfFasl}")
       (require :uiop)
       (let ((pwd (uiop:ensure-directory-pathname (uiop/os:getcwd))))
         (asdf:load-asd (uiop:merge-pathnames* "libraries/nasdf/nasdf.asd" pwd))
@@ -542,7 +542,7 @@ let
       hash = "sha256-zXj17ucgyFhv7P0qEr4cYSVRPGrL1KEIofXWN2trr/M=";
     };
     buildScript = pkgs.writeText "build-stumpwm.lisp" ''
-      (load "${super.stumpwm.asdfFasl}/asdf.${super.stumpwm.faslExt}")
+      (load "${super.stumpwm.asdfFasl}")
 
       (asdf:load-system 'stumpwm)
 
@@ -575,7 +575,7 @@ let
 
   clfswm = super.clfswm.overrideAttrs (o: rec {
     buildScript = pkgs.writeText "build-clfswm.lisp" ''
-      (load "${o.asdfFasl}/asdf.${o.faslExt}")
+      (load "${o.asdfFasl}")
       (asdf:load-system 'clfswm)
       (sb-ext:save-lisp-and-die
         "clfswm"
@@ -863,7 +863,7 @@ let
     ];
 
     buildScript = pkgs.writeText "build-qlot-cli" ''
-      (load "${self.qlot-cli.asdfFasl}/asdf.${self.qlot-cli.faslExt}")
+      (load "${self.qlot-cli.asdfFasl}")
       (asdf:load-system :qlot/command)
       (asdf:load-system :qlot/subcommands)
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25230,7 +25230,6 @@ with pkgs;
   # Armed Bear Common Lisp
   abcl = wrapLisp {
     pkg = callPackage ../development/compilers/abcl { };
-    faslExt = "abcl";
   };
 
   # Clozure Common Lisp
@@ -25238,19 +25237,16 @@ with pkgs;
     pkg = callPackage ../development/compilers/ccl {
       inherit (buildPackages.darwin) bootstrap_cmds;
     };
-    faslExt = "lx64fsl";
   };
 
   # Clasp Common Lisp
   clasp-common-lisp = wrapLisp {
     pkg = callPackage ../development/compilers/clasp { };
-    faslExt = "fasl";
   };
 
   # CLISP
   clisp = wrapLisp {
     pkg = callPackage ../development/interpreters/clisp { };
-    faslExt = "fas";
     flags = ["-E" "UTF-8"];
   };
 
@@ -25259,41 +25255,34 @@ with pkgs;
   # CMU Common Lisp
   cmucl_binary = wrapLispi686Linux {
     pkg = pkgsi686Linux.callPackage ../development/compilers/cmucl/binary.nix { };
-    faslExt = "sse2f";
     program = "lisp";
   };
 
   # Embeddable Common Lisp
   ecl = wrapLisp {
     pkg = callPackage ../development/compilers/ecl { };
-    faslExt = "fas";
   };
   ecl_16_1_2 = wrapLisp {
     pkg = callPackage ../development/compilers/ecl/16.1.2.nix { };
-    faslExt = "fas";
   };
 
   # GNU Common Lisp
   gcl = wrapLisp {
     pkg = callPackage ../development/compilers/gcl { };
-    faslExt = "o";
   };
 
   # ManKai Common Lisp
   mkcl = wrapLisp {
     pkg = callPackage ../development/compilers/mkcl {};
-    faslExt = "fas";
   };
 
   # Steel Bank Common Lisp
   sbcl_2_4_4 = wrapLisp {
     pkg = callPackage ../development/compilers/sbcl { version = "2.4.4"; };
-    faslExt = "fasl";
     flags = [ "--dynamic-space-size" "3000" ];
   };
   sbcl_2_4_5 = wrapLisp {
     pkg = callPackage ../development/compilers/sbcl { version = "2.4.5"; };
-    faslExt = "fasl";
     flags = [ "--dynamic-space-size" "3000" ];
   };
   sbcl = sbcl_2_4_5;


### PR DESCRIPTION
## Description of changes

The point of faslExt was to be able to load the pre-compiled ASDF. With :OUTPUT-FILE there's no need to know the extension because the full path can be specified.

It resolves the problem with Clozure where it uses different extensions depending on the CPU architecture, and so ccl.pkgs couldn't work on arm.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
