### PR TITLE
python311Packages.nireports: init at 23.2.1

### DIFF
--- a/pkgs/development/python-modules/nireports/default.nix
+++ b/pkgs/development/python-modules/nireports/default.nix
@@ -1,0 +1,97 @@
+{ lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  hatch-vcs,
+  hatchling,
+  nipreps-versions,
+  importlib-resources,
+  matplotlib,
+  nibabel,
+  nilearn,
+  nipype,
+  numpy,
+  pandas,
+  pybids,
+  pyyaml,
+  seaborn,
+  svgutils,
+  templateflow,
+  pytestCheckHook,
+  pytest-xdist,
+}:
+
+buildPythonPackage rec {
+  pname = "nireports";
+  version = "23.2.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "nipreps";
+    repo = "nireports";
+    rev = version;
+    hash = "sha256-kr6nWsCA4GcPLEYV/IPm0N3VRz+Mho209/iNVd+59Ik=";
+  };
+
+  build-system = [
+    hatch-vcs
+    hatchling
+    nipreps-versions
+  ];
+
+  dependencies = [
+    matplotlib
+    nibabel
+    nilearn
+    nipype
+    numpy
+    pandas
+    pybids
+    pyyaml
+    seaborn
+    svgutils
+    templateflow
+  ] ++ lib.optionals (pythonOlder "3.12") [
+    importlib-resources
+  ];
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeCheckInputs = [
+    matplotlib
+    pytestCheckHook
+    pytest-xdist
+  ];
+
+  pytestFlagsArray = [ "nireports" ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  disabledTests = [
+    # try to download data:
+    "test_cifti_surfaces_plot"
+    "test_mriqc_plot_mosaic"
+    # fails when run under pytest-xdist
+    "test_reportlets.py"
+  ];
+
+  pythonImportsCheck = [
+    "nireports"
+    "nireports.assembler"
+    "nireports.interfaces"
+    "nireports.reportlets"
+    "nireports.tools"
+  ];
+
+  meta = with lib; {
+    description = "The NiPreps Reporting and Visualization system - report templates and 'reportlets'";
+    homepage = "https://nireports.readthedocs.io";
+    changelog = "https://github.com/nipreps/nireports/blob/${src.rev}/CHANGES.rst";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8834,6 +8834,8 @@ self: super: with self; {
     inherit (pkgs) which;
   };
 
+  nireports = callPackage ../development/python-modules/nireports { };
+
   nitime = callPackage ../development/python-modules/nitime { };
 
   nitpick = callPackage ../applications/version-management/nitpick { };


### PR DESCRIPTION
## Description of changes

Add `python311Packages.nireports`, a package for generating reports on medical image processing pipelines.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
