### PR TITLE
pkgsLinux: set crossSystem instead of localSystem

### DIFF
--- a/pkgs/development/tools/build-managers/icmake/default.nix
+++ b/pkgs/development/tools/build-managers/icmake/default.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec {
     homepage = "https://fbb-git.gitlab.io/icmake/";
     license = licenses.gpl3;
     maintainers = with maintainers; [ pSub ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/tools/misc/yodl/default.nix
+++ b/pkgs/development/tools/misc/yodl/default.nix
@@ -22,7 +22,9 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     patchShebangs ./build
     patchShebangs scripts/
-    substituteInPlace INSTALL.im --replace /usr $out
+    substituteInPlace INSTALL.im \
+      --replace-fail /usr "$out" \
+      --replace-fail 'COMPILER = "gcc";' "COMPILER = \"$CC\";"
     substituteInPlace macros/rawmacros/startdoc.pl --replace /usr/bin/perl ${perl}/bin/perl
     substituteInPlace scripts/yodl2whatever.in --replace getopt ${util-linux}/bin/getopt
   '';
@@ -47,6 +49,6 @@ stdenv.mkDerivation rec {
     homepage = "https://fbb-git.gitlab.io/yodl/";
     license = licenses.gpl3;
     maintainers = with maintainers; [ pSub ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -7,8 +7,8 @@
 
   # `ps` with systemd support is able to properly report different
   # attributes like unit name, so we want to have it on linux.
-, withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd
-, systemd
+, withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs
+, systemdLibs
 
   # procps is mostly Linux-only. Most commands require a running Linux
   # system (or very similar like that found in Cygwin). The one
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ ncurses ]
-    ++ lib.optional withSystemd systemd;
+    ++ lib.optional withSystemd systemdLibs;
   nativeBuildInputs = [ pkg-config ];
 
   makeFlags = [ "usrbin_execdir=$(out)/bin" ]

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -249,7 +249,7 @@ let
       if stdenv.hostPlatform.isLinux
       then self
       else nixpkgsFun {
-        localSystem = lib.systems.elaborate "${stdenv.hostPlatform.parsed.cpu.name}-linux";
+        crossSystem = lib.systems.elaborate "${stdenv.hostPlatform.parsed.cpu.name}-linux";
       };
 
     # Extend the package set with zero or more overlays. This preserves


### PR DESCRIPTION
## Description of changes

As the doc implies, we should be using crossSystem to build *for* the Linux platform. Using localSystem just happens to occasionally hit cached builds. See also https://github.com/NixOS/nixpkgs/pull/316659#issuecomment-2149539101 and https://github.com/NixOS/nixpkgs/runs/25855763929

See also #282401, #294725

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
