### PR TITLE
python312Packages.google-cloud-spanner: 3.45.0 -> 3.47.0

### DIFF
--- a/pkgs/development/python-modules/google-cloud-spanner/default.nix
+++ b/pkgs/development/python-modules/google-cloud-spanner/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   deprecated,
-  fetchPypi,
+  fetchFromGitHub,
   google-api-core,
   google-cloud-core,
   google-cloud-testutils,
@@ -21,14 +21,16 @@
 
 buildPythonPackage rec {
   pname = "google-cloud-spanner";
-  version = "3.45.0";
+  version = "3.47.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-MKtW6krGqnQ3hCmPgh4N5lRAGTe0DGDMegpUUoSpG0M=";
+  src = fetchFromGitHub {
+    owner = "googleapis";
+    repo = "python-spanner";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-eq4tXwXHDdGUyZfPtU/l5cpzYB6AMdqZtj03+2yK8Wk=";
   };
 
   build-system = [ setuptools ];
@@ -60,6 +62,13 @@ buildPythonPackage rec {
     rm -r google
   '';
 
+  disabledTests = [
+    # Requires credentials
+    "test_list_backup"
+    "test_list_database"
+    "test_list_instance"
+  ];
+
   disabledTestPaths = [
     # Requires credentials
     "tests/system/test_backup_api.py"
@@ -72,6 +81,7 @@ buildPythonPackage rec {
     "tests/unit/spanner_dbapi/test_connect.py"
     "tests/unit/spanner_dbapi/test_connection.py"
     "tests/unit/spanner_dbapi/test_cursor.py"
+    "samples/samples/"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
Diff: https://github.com/googleapis/python-spanner/compare/refs/tags/v3.45.0...v3.47.0

Changelog: https://github.com/googleapis/python-spanner/blob/v3.47.0/CHANGELOG.md

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
