### PR TITLE
nginxModules.njs: 0.8.1 -> 0.8.4

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -506,8 +506,8 @@ let self = {
     name = "njs";
     src = fetchhg {
       url = "https://hg.nginx.org/njs";
-      rev = "0.8.1";
-      sha256 = "sha256-bFHrcA1ROMwYf+s0EWOXzkru6wvfRLvjvN8BV/r2tMc=";
+      rev = "0.8.4";
+      sha256 = "sha256-SooPFx4WNEezPD+W/wmMLY+FdkGRoojLNUFbhn3Riyg=";
       name = "nginx-njs";
     };
 


### PR DESCRIPTION
## Description of changes
After upgrading to NixOS 24.05 (rev 0b8e7a1ae5a9), building the nginx njs module fails. I ran the the corresponding test which resulted in the same error (`nix-build -A nixosTests.nginx-njs`).

<details>
<summary>Build output</summary>

```
 gcc -c -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g   -I src/core -I src/event -I src/event/modules -I src/event/quic -I src/os/unix -I /nix/store/2ysp5ichpccf4lv1wp2qcwz0bmm840f1-rtmp -I /usr/include/libxml2 -I objs -I src/http ->
        -o objs/addon/external/njs_xml_module.o \
        /build/nix/store/2pxaz8jqcmj8s3s1i1vsc6a3s4rs9dgp-hg-archive-nginx-njs/nginx/../external/njs_xml_module.c
/build/nix/store/2pxaz8jqcmj8s3s1i1vsc6a3s4rs9dgp-hg-archive-nginx-njs/nginx/../external/njs_xml_module.c: In function 'njs_xml_error':
/build/nix/store/2pxaz8jqcmj8s3s1i1vsc6a3s4rs9dgp-hg-archive-nginx-njs/nginx/../external/njs_xml_module.c:1995:9: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
 1995 |     err = xmlCtxtGetLastError(current->ctx);
      |         ^
gcc -c -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g   -I src/core -I src/event -I src/event/modules -I src/event/quic -I src/os/unix -I /nix/store/2ysp5ichpccf4lv1wp2qcwz0bmm840f1-rtmp -I /usr/include/libxml2 -I objs -I src/http ->
        -o objs/addon/external/njs_zlib_module.o \
        /build/nix/store/2pxaz8jqcmj8s3s1i1vsc6a3s4rs9dgp-hg-archive-nginx-njs/nginx/../external/njs_zlib_module.c
gcc -c -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g   -I src/core -I src/event -I src/event/modules -I src/event/quic -I src/os/unix -I /nix/store/2ysp5ichpccf4lv1wp2qcwz0bmm840f1-rtmp -I /usr/include/libxml2 -I objs -I src/http ->
        -o objs/addon/nginx/ngx_stream_js_module.o \
        /build/nix/store/2pxaz8jqcmj8s3s1i1vsc6a3s4rs9dgp-hg-archive-nginx-njs/nginx/ngx_stream_js_module.c
cc1: all warnings being treated as errors
make[1]: *** [objs/Makefile:2178: objs/addonexternal/njs_xml_module.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/build/nginx-1.26.1'
make: *** [Makefile:10: build] Error 2
```

</details>

Updating to the latest version makes the package compile again. I suppose the build error was fixed in 0.8.3 (`fixed building with libxml2 2.12 and later`)

Changelogs from upstream:

* https://hg.nginx.org/njs/rev/0.8.2
* https://hg.nginx.org/njs/rev/0.8.3
* https://hg.nginx.org/njs/rev/0.8.4

Would be nice if we can put this in 24.05

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
