### PR TITLE
lua-language-server: 3.9.1 -> 3.9.2

### DIFF
--- a/pkgs/development/tools/language-servers/lua-language-server/default.nix
+++ b/pkgs/development/tools/language-servers/lua-language-server/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lua-language-server";
-  version = "3.9.1";
+  version = "3.9.2";
 
   src = fetchFromGitHub {
     owner = "luals";
     repo = "lua-language-server";
     rev = finalAttrs.version;
-    hash = "sha256-M4eTrs5Ue2+b40TPdW4LZEACGYCE/J9dQodEk9d+gpY=";
+    hash = "sha256-DZ2YLrhqryB3kvQnhbgmwqss2kzIAsFZVXDnxFpcdLQ=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/tools/language-servers/lua-language-server/default.nix
+++ b/pkgs/development/tools/language-servers/lua-language-server/default.nix
@@ -1,4 +1,13 @@
-{ lib, stdenv, fetchFromGitHub, ninja, makeWrapper, CoreFoundation, Foundation, ditto }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  ninja,
+  makeWrapper,
+  CoreFoundation,
+  Foundation,
+  ditto,
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lua-language-server";
@@ -23,29 +32,29 @@ stdenv.mkDerivation (finalAttrs: {
     ditto
   ];
 
-  postPatch = ''
-    # filewatch tests are failing on darwin
-    # this feature is not used in lua-language-server
-    sed -i /filewatch/d 3rd/bee.lua/test/test.lua
+  postPatch =
+    ''
+      # filewatch tests are failing on darwin
+      # this feature is not used in lua-language-server
+      sed -i /filewatch/d 3rd/bee.lua/test/test.lua
 
-    pushd 3rd/luamake
-  '' + lib.optionalString stdenv.isDarwin ''
-    # This package uses the program clang for C and C++ files. The language
-    # is selected via the command line argument -std, but this do not work
-    # in combination with the nixpkgs clang wrapper. Therefor we have to
-    # find all c++ compiler statements and replace $cc (which expands to
-    # clang) with clang++.
-    sed -i compile/ninja/macos.ninja \
-      -e '/c++/s,$cc,clang++,' \
-      -e '/test.lua/s,= .*,= true,' \
-      -e '/ldl/s,$cc,clang++,'
-    sed -i scripts/compiler/gcc.lua \
-      -e '/cxx_/s,$cc,clang++,'
-  '';
+      pushd 3rd/luamake
+    ''
+    + lib.optionalString stdenv.isDarwin ''
+      # This package uses the program clang for C and C++ files. The language
+      # is selected via the command line argument -std, but this do not work
+      # in combination with the nixpkgs clang wrapper. Therefor we have to
+      # find all c++ compiler statements and replace $cc (which expands to
+      # clang) with clang++.
+      sed -i compile/ninja/macos.ninja \
+        -e '/c++/s,$cc,clang++,' \
+        -e '/test.lua/s,= .*,= true,' \
+        -e '/ldl/s,$cc,clang++,'
+      sed -i scripts/compiler/gcc.lua \
+        -e '/cxx_/s,$cc,clang++,'
+    '';
 
-  ninjaFlags = [
-    "-fcompile/ninja/${if stdenv.isDarwin then "macos" else "linux"}.ninja"
-  ];
+  ninjaFlags = [ "-fcompile/ninja/${if stdenv.isDarwin then "macos" else "linux"}.ninja" ];
 
   postBuild = ''
     popd
@@ -80,7 +89,11 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/luals/lua-language-server";
     changelog = "https://github.com/LuaLS/lua-language-server/blob/${finalAttrs.version}/changelog.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda gepbird sei40kr ];
+    maintainers = with maintainers; [
+      figsoda
+      gepbird
+      sei40kr
+    ];
     mainProgram = "lua-language-server";
     platforms = platforms.linux ++ platforms.darwin;
   };

--- a/pkgs/development/tools/language-servers/lua-language-server/default.nix
+++ b/pkgs/development/tools/language-servers/lua-language-server/default.nix
@@ -7,6 +7,7 @@
   CoreFoundation,
   Foundation,
   ditto,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -83,6 +84,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   # some tests require local networking
   __darwinAllowLocalNetworking = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "A language server that offers Lua language support";


### PR DESCRIPTION
## Description of changes
Release: https://github.com/LuaLS/lua-language-server/releases/tag/3.9.2
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
