### PR TITLE
ci: add Github `setup.yml` configuration file for `repository` and `branches` 

### DIFF
--- a/.github/setup.yml
+++ b/.github/setup.yml
@@ -56,3 +56,36 @@ repository:
   # Either `true` to enable vulnerability alerts, or `false` to disable
   # vulnerability alerts.
   enable_vulnerability_alerts: true
+
+branches:
+  - name: master
+    # https://docs.github.com/en/rest/reference/repos#update-branch-protection
+    # Branch Protection settings. Set to null to disable
+    protection:
+      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
+      required_pull_request_reviews:
+        # The number of approvals required. (1-6)
+        required_approving_review_count: 1
+        # Dismiss approved reviews automatically when a new commit is pushed.
+        dismiss_stale_reviews: true
+        # Blocks merge until code owners have reviewed.
+        require_code_owner_reviews: false
+        # Specify which users and teams can dismiss pull request reviews. Pass an empty dismissal_restrictions object to disable. User and team dismissal_restrictions are only available for organization-owned repositories. Omit this parameter for personal repositories.
+        dismissal_restrictions:
+          users: []
+          teams: []
+      # Required. Require status checks to pass before merging. Set to null to disable
+      required_status_checks:
+        # Required. Require branches to be up to date before merging.
+        strict: true
+        # Required. The list of status checks to require in order to merge into this branch
+        contexts: []
+      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+      enforce_admins: true
+      # Prevent merge commits from being pushed to matching branches
+      required_linear_history: true
+      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
+      restrictions:
+        apps: []
+        users: []
+        teams: []

--- a/.github/setup.yml
+++ b/.github/setup.yml
@@ -1,0 +1,58 @@
+# These settings are synced to GitHub by https://probot.github.io/apps/settings/
+
+repository:
+  # See https://docs.github.com/en/rest/reference/repos#update-a-repository for all available settings.
+
+  # The name of the repository. Changing this will rename the repository
+  name: nixpkgs
+
+  # A short description of the repository that will show up on GitHub
+  description: Nix Packages collection & NixOS
+
+  # A URL with more information about the repository
+  homepage: https://nixos.org
+
+  # A comma-separated list of topics to set on the repository
+  topics: linux, nix, nixos, nixpkgs, hacktoberfest
+
+  # Either `true` to make the repository private, or `false` to make it public.
+  private: false
+
+  # Either `true` to enable issues for this repository, `false` to disable them.
+  has_issues: true
+
+  # Either `true` to enable projects for this repository, or `false` to disable them.
+  # If projects are disabled for the organization, passing `true` will cause an API error.
+  has_projects: true
+
+  # Either `true` to enable the wiki for this repository, `false` to disable it.
+  has_wiki: false
+
+  # Either `true` to enable downloads for this repository, `false` to disable them.
+  has_downloads: true
+
+  # Updates the default branch for this repository.
+  default_branch: master
+
+  # Either `true` to allow squash-merging pull requests, or `false` to prevent
+  # squash-merging.
+  allow_squash_merge: true
+
+  # Either `true` to allow merging pull requests with a merge commit, or `false`
+  # to prevent merging pull requests with merge commits.
+  allow_merge_commit: true
+
+  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
+  # rebase-merging.
+  allow_rebase_merge: true
+
+  # Either `true` to enable automatic deletion of branches on merge, or `false` to disable
+  delete_branch_on_merge: true
+
+  # Either `true` to enable automated security fixes, or `false` to disable
+  # automated security fixes.
+  enable_automated_security_fixes: false
+
+  # Either `true` to enable vulnerability alerts, or `false` to disable
+  # vulnerability alerts.
+  enable_vulnerability_alerts: true


### PR DESCRIPTION
Hey!

This draft PR proposes the introduction of a new configuration file, `.github/setup.yml` and the use of the [Github Setup app](https://github.com/apps/settings) to manage the repository settings through code rather than through the GitHub UI.

- The file `.github/setup.yml` will contain all the repository settings that were previously managed through the GitHub UI
- Managing settings via this file will make it impossible to change these settings through the UI, promoting consistency and auditability, all changes to repository settings will be tracked in the version control system, providing a clear history of modifications
- The file will include configurations for branch policies and restrictions
- This will include settings for branch protection rules, such as required status checks, required reviews, and restrictions on who can push to specific branches. Currently, only the `master` branch has been setup, in a very non-restrictive setting
- Branch restriction rules can streamline the review process, helping maintainers focus on high-quality contributions and saving time on administrative tasks (For example, as long as all the review feedback are not addressed, this is not possible to merge a PR).

### Potential future considerations

- Continuous monitoring and updating of the `.github/setup.yml` file as repository needs evolve
- Improve and refine the branch restriction rules
- Add more settings like `milestones`, `collaborators`, `labels` and `teams`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
