### PR TITLE
gst_all_1.gst-plugins-good: restore support for dlopen libsoup on Darwin

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -130,6 +130,9 @@ stdenv.mkDerivation (finalAttrs: {
     # and by default meson installs in to $out/share/gdb/auto-load
     # which does not help
     ./gdb_script.patch
+
+    # glib assumes that `RTLD_LOCAL` is defined to `0`, which is true on Linux and FreeBSD but not on Darwin.
+    ./gmodule-rtld_local.patch
   ];
 
   outputs = [ "bin" "out" "dev" "devdoc" ];

--- a/pkgs/development/libraries/glib/gmodule-rtld_local.patch
+++ b/pkgs/development/libraries/glib/gmodule-rtld_local.patch
@@ -1,0 +1,13 @@
+diff --git a/gmodule/gmodule-dl.c b/gmodule/gmodule-dl.c
+index 6d1c5fab7..b21773bca 100644
+--- a/gmodule/gmodule-dl.c
++++ b/gmodule/gmodule-dl.c
+@@ -136,7 +136,7 @@ _g_module_open (const gchar *file_name,
+   
+   lock_dlerror ();
+   handle = dlopen (file_name,
+-		   (bind_local ? 0 : RTLD_GLOBAL) | (bind_lazy ? RTLD_LAZY : RTLD_NOW));
++		   (bind_local ? RTLD_LOCAL : RTLD_GLOBAL) | (bind_lazy ? RTLD_LAZY : RTLD_NOW));
+   if (!handle)
+     {
+       const gchar *message = fetch_dlerror (TRUE);

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -68,6 +68,8 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Reenable dynamic loading of libsoup on Darwin and use a different approach to do it.
+    ./souploader-darwin.diff
     # dlopen libsoup_3 with an absolute path
     (substituteAll {
       src = ./souploader.diff;

--- a/pkgs/development/libraries/gstreamer/good/souploader-darwin.diff
+++ b/pkgs/development/libraries/gstreamer/good/souploader-darwin.diff
@@ -1,0 +1,128 @@
+diff --git a/ext/adaptivedemux2/meson.build b/ext/adaptivedemux2/meson.build
+index 711b38a2a9..67a789f664 100644
+--- a/ext/adaptivedemux2/meson.build
++++ b/ext/adaptivedemux2/meson.build
+@@ -82,7 +82,7 @@ soup_link_args = []
+ soup_link_deps = []
+ 
+ default_library = get_option('default_library')
+-if host_system != 'linux' or default_library in ['static', 'both']
++if default_library in ['static', 'both']
+   if soup_ver_opt in ['auto', '3']
+     libsoup3_dep = dependency('libsoup-3.0', allow_fallback: true,
+                               required: soup_ver_opt == '3' and soup_opt.enabled())
+@@ -120,7 +120,7 @@ adaptive_deps = [gmodule_dep, gst_dep, gsttag_dep, gstnet_dep, gstbase_dep, gstp
+ adaptive_args = [gst_plugins_good_args, soup_loader_args, hls_cargs,
+     '-DGST_ISOFF_API=G_GNUC_INTERNAL']
+ 
+-if host_system != 'linux'
++if false
+     adaptivedemux2 = library('gstadaptivedemux2',
+       c_args: [adaptive_args, soup_link_args],
+       dependencies: [adaptive_deps, soup_link_deps],
+diff --git a/ext/soup/gstsouploader.c b/ext/soup/gstsouploader.c
+index 9192e4dac5..8082b2614d 100644
+--- a/ext/soup/gstsouploader.c
++++ b/ext/soup/gstsouploader.c
+@@ -34,12 +34,18 @@ GST_DEBUG_CATEGORY (gst_soup_debug);
+ 
+ #ifndef LINK_SOUP
+ 
+-#if defined(__APPLE__) || defined(G_OS_WIN32)
+-#error "dlopen of libsoup is only supported on Linux"
++#if defined(G_OS_WIN32)
++#error "dlopen of libsoup is only supported on Darwin and Linux"
+ #endif
+ 
++#if defined(__APPLE__)
++#define LIBSOUP_3_SONAME "libsoup-3.0.0.dylib"
++#define LIBSOUP_2_SONAME "libsoup-2.4.1.dylib"
++#define LIBSOUP_COMMON_SYMBOL "soup_get_major_version"
++#else
+ #define LIBSOUP_3_SONAME "libsoup-3.0.so.0"
+ #define LIBSOUP_2_SONAME "libsoup-2.4.so.1"
++#endif
+ 
+ #define LOAD_SYMBOL(name) G_STMT_START {                                \
+     if (!g_module_symbol (module, G_STRINGIFY (name), (gpointer *) &G_PASTE (vtable->_, name))) { \
+@@ -156,7 +162,46 @@ gst_soup_load_library (void)
+   GST_DEBUG_CATEGORY_INIT (gst_soup_debug, "soup", 0, "soup");
+ #endif
+ 
+-#ifdef HAVE_RTLD_NOLOAD
++#if defined(__APPLE__)
++  g_autofree gchar* libsoup_path = NULL;
++  {
++    /* In order to avoid causing conflicts we detect if libsoup 2 or 3 is loaded already.
++     * Darwin has to probe by checking for symbols because `dlopen` called with a dylib
++     * basename will try to locate it via the process’s rpath stack (and not find it). */
++
++    gpointer func = NULL;
++    Dl_info info = { 0 };
++
++    GModule* module = g_module_open (NULL, 0);
++    if (g_module_symbol (module, LIBSOUP_COMMON_SYMBOL, &func)
++        && dladdr (func, &info) && info.dli_sname) {
++      libsoup_path = g_strndup(info.dli_fname, PATH_MAX - 1);
++      g_autofree gchar* image_name = g_path_get_basename (libsoup_path);
++
++      /* Make sure `libsoup_path` points to a dylib that actually exists and
++       * contains the libsoup symbol that was queried. */
++      gpointer handle = dlopen (libsoup_path, RTLD_NOW | RTLD_NOLOAD);
++      gboolean has_symbol = dlsym (handle, LIBSOUP_COMMON_SYMBOL) != NULL;
++      if (handle && has_symbol && g_str_equal (image_name, LIBSOUP_3_SONAME)) {
++        libsoup_sonames[0] = libsoup_path;
++        GST_DEBUG ("LibSoup 3 found");
++      } else if (handle && has_symbol && g_str_equal (image_name, LIBSOUP_2_SONAME)) {
++        libsoup_sonames[0] = libsoup_path;
++        GST_DEBUG ("LibSoup 2 found");
++      } else {
++        g_clear_pointer (&libsoup_path, g_free);
++      }
++      g_clear_pointer (&handle, dlclose);
++    }
++    g_module_close (module);
++
++    if (!libsoup_sonames[0]) {
++      GST_DEBUG ("Trying all libsoups");
++      libsoup_sonames[0] = LIBSOUP_3_SONAME;
++      libsoup_sonames[1] = LIBSOUP_2_SONAME;
++    }
++  }
++#elif defined(HAVE_RTLD_NOLOAD)
+   {
+     gpointer handle = NULL;
+ 
+diff --git a/ext/soup/meson.build b/ext/soup/meson.build
+index aaa01dbcf6..83b7cf3fbf 100644
+--- a/ext/soup/meson.build
++++ b/ext/soup/meson.build
+@@ -20,8 +20,8 @@ soup_link_deps = []
+ libsoup2_dep = disabler()
+ libsoup3_dep = disabler()
+ default_library = get_option('default_library')
+-soup_lookup_dep = get_option('soup-lookup-dep') and host_system == 'linux'
+-if host_system != 'linux' or default_library in ['static', 'both'] or soup_lookup_dep
++soup_lookup_dep = get_option('soup-lookup-dep')
++if default_library in ['static', 'both'] or soup_lookup_dep
+   if soup_ver_opt in ['auto', '3']
+     libsoup3_dep = dependency('libsoup-3.0', allow_fallback: true,
+                               required: soup_ver_opt == '3' and soup_opt.enabled())
+@@ -33,7 +33,7 @@ if host_system != 'linux' or default_library in ['static', 'both'] or soup_looku
+   endif
+ endif
+ 
+-if host_system != 'linux' or default_library in ['static', 'both']
++if default_library in ['static', 'both']
+   if libsoup3_dep.found()
+     soup_link_deps += libsoup3_dep
+     soup_link_args += '-DLINK_SOUP=3'
+@@ -60,7 +60,7 @@ soup_library_kwargs = {
+ soup_library_deps = [gst_dep, gstbase_dep, gsttag_dep, gmodule_dep, gio_dep, libdl_dep]
+ soup_library_c_args = gst_plugins_good_args
+ 
+-if host_system != 'linux'
++if false
+   gstsouphttpsrc = library('gstsoup',
+     c_args : soup_library_c_args + soup_link_args,
+     dependencies : soup_library_deps + soup_link_deps,

--- a/pkgs/development/libraries/gstreamer/good/souploader.diff
+++ b/pkgs/development/libraries/gstreamer/good/souploader.diff
@@ -1,8 +1,17 @@
 diff --git a/ext/soup/gstsouploader.c b/ext/soup/gstsouploader.c
-index 85048ce303..d7d818cf95 100644
+index 85a033668e..8082b2614d 100644
 --- a/ext/soup/gstsouploader.c
 +++ b/ext/soup/gstsouploader.c
-@@ -181,7 +181,7 @@ gst_soup_load_library (void)
+@@ -197,7 +197,7 @@ gst_soup_load_library (void)
+ 
+     if (!libsoup_sonames[0]) {
+       GST_DEBUG ("Trying all libsoups");
+-      libsoup_sonames[0] = LIBSOUP_3_SONAME;
++      libsoup_sonames[0] = "@nixLibSoup3Path@/" LIBSOUP_3_SONAME;
+       libsoup_sonames[1] = LIBSOUP_2_SONAME;
+     }
+   }
+@@ -216,7 +216,7 @@ gst_soup_load_library (void)
        GST_DEBUG ("LibSoup 2 found");
      } else {
        GST_DEBUG ("Trying all libsoups");


### PR DESCRIPTION
I ran into this issue when trying to enable and use GStreamer in Wine. Wine because gst-plugins-bad links libsoup 2.4 while gst-plugins-good is linked against libsoup 3.

Upstream removed support for using dlopen on platforms other than Linux to fix https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/1171, but Darwin in nixpkgs also needs to `dlopen` libsoup because gst-plugins-bad depends on libsoup 2.4 indirectly via libnice.

https://github.com/NixOS/nixpkgs/pull/276408 fixed the issue for Linux, but this PR expands the patch to work with Darwin as well by restoring support for using `dlopen` on Darwin. I have tried to maintain the spirit of preferring libsoup3 on Linux when no other libsoup is in use, but I have not tested it. On Darwin, libsoup 2.4 is preferred.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
