### PR TITLE
sbcl: make deriv options overridable attributes

### DIFF
--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -1,13 +1,4 @@
 { lib, stdenv, callPackage, ecl, coreutils, fetchurl, strace, texinfo, which, writeText, zstd
-, threadSupport ? (stdenv.hostPlatform.isx86 || "aarch64-linux" == stdenv.hostPlatform.system || "aarch64-darwin" == stdenv.hostPlatform.system)
-, linkableRuntime ? stdenv.hostPlatform.isx86
-, disableImmobileSpace ? false
-  # Meant for sbcl used for creating binaries portable to non-NixOS via save-lisp-and-die.
-  # Note that the created binaries still need `patchelf --set-interpreter ...`
-  # to get rid of ${glibc} dependency.
-, purgeNixReferences ? false
-, coreCompression ? true
-, markRegionGC ? threadSupport
 , version
   # Set this to a lisp binary to use a custom bootstrap lisp compiler for SBCL.
   # Leave as null to use the default.  This is useful for local development of
@@ -65,12 +56,14 @@ let
 
 in
 
-stdenv.mkDerivation (self: rec {
+stdenv.mkDerivation (self: {
   pname = "sbcl";
   inherit version;
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/sbcl/sbcl/${version}/${pname}-${version}-source.tar.bz2";
+    # Changing the version shouldn’t change the source for the
+    # derivation. Override the src entirely if desired.
+    url = "mirror://sourceforge/project/sbcl/sbcl/${version}/sbcl-${version}-source.tar.bz2";
     inherit (versionMap.${version}) sha256;
   };
 
@@ -83,14 +76,24 @@ stdenv.mkDerivation (self: rec {
       strace
     ]
   );
-  buildInputs = lib.optionals coreCompression (
+  buildInputs = lib.optionals self.coreCompression (
     # Declare at the point of actual use in case the caller wants to override
     # buildInputs to sidestep this.
-    assert lib.assertMsg (!purgeNixReferences) ''
+    assert lib.assertMsg (!self.purgeNixReferences) ''
       Cannot enable coreCompression when purging Nix references, because compression requires linking in zstd
     '';
     [ zstd ]
   );
+
+  threadSupport = (stdenv.hostPlatform.isx86 || "aarch64-linux" == stdenv.hostPlatform.system || "aarch64-darwin" == stdenv.hostPlatform.system);
+  # Meant for sbcl used for creating binaries portable to non-NixOS via save-lisp-and-die.
+  # Note that the created binaries still need `patchelf --set-interpreter ...`
+  # to get rid of ${glibc} dependency.
+  purgeNixReferences = false;
+  coreCompression = true;
+  markRegionGC = self.threadSupport;
+  disableImmobileSpace = false;
+  linkableRuntime = stdenv.hostPlatform.isx86;
 
   # I don’t know why these are failing (on ofBorg), and I’d rather just disable
   # them and move forward with the succeeding tests than block testing
@@ -125,7 +128,7 @@ stdenv.mkDerivation (self: rec {
   postPatch = lib.optionalString (self.disabledTestFiles != [ ]) ''
     (cd tests ; rm -f ${lib.concatStringsSep " " self.disabledTestFiles})
   ''
-  + lib.optionalString purgeNixReferences ''
+  + lib.optionalString self.purgeNixReferences ''
     # This is the default location to look for the core; by default in $out/lib/sbcl
     sed 's@^\(#define SBCL_HOME\) .*$@\1 "/no-such-path"@' \
         -i src/runtime/runtime.c
@@ -137,7 +140,7 @@ stdenv.mkDerivation (self: rec {
       # binary. There are some tricky files in nested directories which should
       # definitely NOT be patched this way, hence just a single * (and no
       # globstar).
-      substituteInPlace ${if purgeNixReferences then "tests" else "{tests,src/code}"}/*.{lisp,sh} \
+      substituteInPlace ${if self.purgeNixReferences then "tests" else "{tests,src/code}"}/*.{lisp,sh} \
         --replace-quiet /usr/bin/env "${coreutils}/bin/env" \
         --replace-quiet /bin/uname "${coreutils}/bin/uname" \
         --replace-quiet /bin/sh "${stdenv.shell}"
@@ -146,7 +149,7 @@ stdenv.mkDerivation (self: rec {
     # want to override { src = ... } it might not exist. It’s required for
     # building, so create a mock version as a backup.
     if [[ ! -a version.lisp-expr ]]; then
-      echo '"${version}.nixos"' > version.lisp-expr
+      echo '"${self.version}.nixos"' > version.lisp-expr
     fi
   '';
 
@@ -157,16 +160,16 @@ stdenv.mkDerivation (self: rec {
   '';
 
   enableFeatures = with lib;
-    assert assertMsg (markRegionGC -> threadSupport) "SBCL mark region GC requires thread support";
-    optional threadSupport "sb-thread" ++
-    optional linkableRuntime "sb-linkable-runtime" ++
-    optional coreCompression "sb-core-compression" ++
+    assert assertMsg (self.markRegionGC -> self.threadSupport) "SBCL mark region GC requires thread support";
+    optional self.threadSupport "sb-thread" ++
+    optional self.linkableRuntime "sb-linkable-runtime" ++
+    optional self.coreCompression "sb-core-compression" ++
     optional stdenv.isAarch32 "arm" ++
-    optional markRegionGC "mark-region-gc";
+    optional self.markRegionGC "mark-region-gc";
 
   disableFeatures = with lib;
-    optional (!threadSupport) "sb-thread" ++
-    optionals disableImmobileSpace [ "immobile-space" "immobile-code" "compact-instance-header" ];
+    optional (!self.threadSupport) "sb-thread" ++
+    optionals self.disableImmobileSpace [ "immobile-space" "immobile-code" "compact-instance-header" ];
 
   buildArgs = [
     "--prefix=$out"
@@ -210,7 +213,7 @@ stdenv.mkDerivation (self: rec {
     INSTALL_ROOT=$out sh install.sh
 
   ''
-  + lib.optionalString (!purgeNixReferences) ''
+  + lib.optionalString (!self.purgeNixReferences) ''
     cp -r src $out/lib/sbcl
     cp -r contrib $out/lib/sbcl
     cat >$out/lib/sbcl/sbclrc <<EOF
@@ -222,7 +225,7 @@ stdenv.mkDerivation (self: rec {
     runHook postInstall
   '';
 
-  setupHook = lib.optional purgeNixReferences (writeText "setupHook.sh" ''
+  setupHook = lib.optional self.purgeNixReferences (writeText "setupHook.sh" ''
     addEnvHooks "$targetOffset" _setSbclHome
     _setSbclHome() {
       export SBCL_HOME='@out@/lib/sbcl/'

--- a/pkgs/development/interpreters/acl2/default.nix
+++ b/pkgs/development/interpreters/acl2/default.nix
@@ -9,7 +9,7 @@ let
   # supply 2GB of dynamic space to avoid exhausting the heap while building the
   # ACL2 system itself; see
   # https://www.cs.utexas.edu/users/moore/acl2/current/HTML/installation/requirements.html#Obtaining-SBCL
-  sbcl' = args.sbcl.override { disableImmobileSpace = true; };
+  sbcl' = args.sbcl.overrideAttrs { disableImmobileSpace = true; };
   sbcl = runCommandLocal args.sbcl.name { nativeBuildInputs = [ makeWrapper ]; } ''
     makeWrapper ${sbcl'}/bin/sbcl $out/bin/sbcl \
       --add-flags "--dynamic-space-size 2000"


### PR DESCRIPTION

## Description of changes

This also makes the options available for reading by other derivations which depend on SBCL. This is useful for derivations who want to evaluate differently based on the capabilities of the SBCL derivation they're passed. Eexample: bordeaux-threads depends on a specific feature of SBCL (threads): having the `.threadSupport` value readable from the derivation at runtime allows bordeaux-thread to set `meta.broken = true` for an SBCL without thread support.



## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
