### PR TITLE
renovate: init at 37.393.0

### DIFF
--- a/pkgs/by-name/re/renovate/package.nix
+++ b/pkgs/by-name/re/renovate/package.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  nodejs,
+  overrideSDK,
+  pnpm_9,
+  python3,
+  renovate,
+  testers,
+  xcbuild,
+}:
+
+let
+  # fix build error, `no member named 'aligned_alloc'` on x86_64-darwin
+  # https://github.com/NixOS/nixpkgs/issues/272156#issuecomment-1839904283
+  stdenv' = if stdenv.hostPlatform.isDarwin then overrideSDK stdenv "11.0" else stdenv;
+in
+stdenv'.mkDerivation (finalAttrs: {
+  pname = "renovate";
+  version = "37.393.0";
+
+  src = fetchFromGitHub {
+    owner = "renovatebot";
+    repo = "renovate";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-YgxcGNMgmwrausdR7kvG1NiyQPn0FcCq/isf9qUDCFY=";
+  };
+
+  postPatch = ''
+    substituteInPlace package.json \
+      --replace-fail "0.0.0-semantic-release" "${finalAttrs.version}"
+  '';
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+    pnpm_9.configHook
+    python3
+  ] ++ lib.optional stdenv'.hostPlatform.isDarwin xcbuild;
+
+  pnpmDeps = pnpm_9.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-Zbe561q6xDKDIN+E/2eyQMz2GtpPvJEv2pAauMa+8pE=";
+  };
+
+  env.COREPACK_ENABLE_STRICT = 0;
+
+  buildPhase =
+    ''
+      runHook preBuild
+
+      pnpm build
+      pnpm prune --prod --ignore-scripts
+    ''
+    # The optional dependency re2 is not built by pnpm and needs to be built manually.
+    # If re2 is not built, you will get an annoying warning when you run renovate.
+    + ''
+      pushd node_modules/.pnpm/re2*/node_modules/re2
+
+      mkdir -p $HOME/.node-gyp/${nodejs.version}
+      echo 9 > $HOME/.node-gyp/${nodejs.version}/installVersion
+      ln -sfv ${nodejs}/include $HOME/.node-gyp/${nodejs.version}
+      export npm_config_nodedir=${nodejs}
+      npm run rebuild
+
+      popd
+
+      runHook postBuild
+    '';
+
+  # TODO: replace with `pnpm deploy`
+  # now it fails to build with ERR_PNPM_NO_OFFLINE_META
+  # see https://github.com/pnpm/pnpm/issues/5315
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib/node_modules/renovate}
+    cp -r dist node_modules package.json $out/lib/node_modules/renovate
+
+    makeWrapper "${lib.getExe nodejs}" "$out/bin/renovate" \
+      --add-flags "$out/lib/node_modules/renovate/dist/renovate.js"
+    makeWrapper "${lib.getExe nodejs}" "$out/bin/config-validator" \
+      --add-flags "$out/lib/node_modules/renovate/dist/config-validator.js"
+
+    runHook postInstall
+  '';
+
+  passthru.tests = {
+    version = testers.testVersion { package = renovate; };
+  };
+
+  meta = {
+    description = "Cross-platform Dependency Automation by Mend.io";
+    homepage = "https://github.com/renovatebot/renovate";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [
+      marie
+      natsukium
+    ];
+    mainProgram = "renovate";
+    platforms = nodejs.meta.platforms;
+  };
+})


### PR DESCRIPTION
## Description of changes

Automated dependency updates. Multi-platform and multi-language.
https://github.com/renovatebot/renovate

tested with the following command
```bash
renovate --token ... --onboarding=true natsukium/nur-packages
```

closes https://github.com/NixOS/nixpkgs/issues/277588

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
