### PR TITLE
bazarr: fix unpackPhase error

### DIFF
--- a/pkgs/servers/bazarr/default.nix
+++ b/pkgs/servers/bazarr/default.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-1OqbCyQmA33ZvyCE11ZSyVwEgyym0Y0EX6qx3g71lnQ=";
   };
 
+  unpackPhase = ''
+   unzip -o $src
+  '';
+
   nativeBuildInputs = [ unzip makeWrapper ];
 
   buildInputs = [


### PR DESCRIPTION
Description of changes
Resubmission of https://github.com/NixOS/nixpkgs/pull/316551
Without overwriting the installation in MacOS fails with the following error

Fix a broken declaration on macOS by overwriting the output at the unpackPhase.
```
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/mc6llwhmkwkxqqcajzanacl4wg559hpv-bazarr.zip
       > replace libs/apprise/plugins/NotifyMatterMost.py? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
       > (EOF or read error, treating as "[N]one" ...)
       > do not know how to unpack source archive /nix/store/mc6llwhmkwkxqqcajzanacl4wg559hpv-bazarr.zip
```
I tested that it runs and plays well with the rest of the servarr ecosystem.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [X] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
