### PR TITLE
librandombytes: init at 20240318

### DIFF
--- a/pkgs/by-name/li/librandombytes/environment-variable-tools.patch
+++ b/pkgs/by-name/li/librandombytes/environment-variable-tools.patch
@@ -1,0 +1,34 @@
+diff --git a/configure b/configure
+index 36fcf67..39612f3 100755
+--- a/configure
++++ b/configure
+@@ -143,6 +143,16 @@ firstcompiler = None
+ with open('compilers/default') as f:
+   for c in f.readlines():
+     c = c.strip()
++    if env_cc := os.getenv('CC'):
++      c_as_list= c.split()
++      # check if the compiler we're testing has the name inside the last
++      # part of the CC env var
++      # i.e. gcc == x86_64-linux-unknown-gnu-gcc
++      # or gcc == gcc
++      if c_as_list[0] == env_cc.split("-")[-1]:
++        c_as_list[0] = env_cc
++      c = ' '.join(c_as_list)
++      log('patched command as %s' % c)   
+     cv = compilerversion(c)
+     if cv == None:
+       log('skipping default compiler %s' % c)
+diff --git a/scripts-build/staticlib b/scripts-build/staticlib
+index 7b2fc92..a6bbe41 100755
+--- a/scripts-build/staticlib
++++ b/scripts-build/staticlib
+@@ -4,6 +4,6 @@ lib="$1"
+ shift
+ 
+ rm -f package/lib/"$lib".a
+-ar cr package/lib/"$lib".a "$@"
+-ranlib package/lib/"$lib".a || :
++${AR:-ar} cr package/lib/"$lib".a "$@"
++${RANLIB:-ranlib} package/lib/"$lib".a || :
+ chmod 644 package/lib/"$lib".a

--- a/pkgs/by-name/li/librandombytes/package.nix
+++ b/pkgs/by-name/li/librandombytes/package.nix
@@ -1,0 +1,81 @@
+{
+  stdenv,
+  lib,
+  python3,
+  openssl,
+  fetchzip,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "librandombytes";
+  version = "20240318";
+
+  src = fetchzip {
+    url = "https://randombytes.cr.yp.to/librandombytes-${finalAttrs.version}.tar.gz";
+    hash = "sha256-LE8iWw7FxckPREyqefgKtslD6CPDsL7VsfHScQ6JmLs=";
+  };
+
+  patches = [ ./environment-variable-tools.patch ];
+
+  postPatch = ''
+    patchShebangs configure
+    patchShebangs scripts-build
+  '';
+
+  # NOTE: librandombytes uses a custom Python `./configure`: it does not expect standard
+  # autoconfig --build --host etc. arguments: disable
+  configurePlatforms = [ ];
+
+  # NOTE: the librandombytes library has required specific CFLAGS defined:
+  # https://randombytes.cr.yp.to/librandombytes-20240318/compilers/default.html
+  # - `-O` (alias `-O1`) safe optimization
+  # - `-Qunused-arguments` suppress clang warning
+  # the default "fortify" hardening sets -O2, -D_FORTIFY_SOURCE=2:
+  # since librandombytes uses -O1, we disable the fortify hardening, and then manually re-enable -D_FORTIFY_SOURCE.
+  hardeningDisable = [ "fortify" ];
+  env.NIX_CFLAGS_COMPILE = toString (
+    lib.optionals stdenv.cc.isClang [ "-Qunused-arguments" ]
+    ++ [
+      "-D_FORTIFY_SOURCE=2"
+      "-O1"
+    ]
+  );
+
+  nativeBuildInputs = [ python3 ];
+
+  buildInputs = [ openssl ];
+
+  meta = {
+    homepage = "https://randombytes.cr.yp.to/";
+    description = "A simple API for applications generating fresh randomness";
+    changelog = "https://randombytes.cr.yp.to/download.html";
+    license = with lib.licenses; [
+      # Upstream specifies the public domain licenses with the terms here https://cr.yp.to/spdx.html
+      publicDomain
+      cc0
+      bsd0
+      mit
+      mit0
+    ];
+    maintainers = with lib.maintainers; [
+      kiike
+      imadnyc
+      jleightcap
+    ];
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+      "armv7a-linux"
+      "aarch64-linux"
+      # Cannot support 32 bit MIPS because options in libcpucycles only supports mips64: https://cpucycles.cr.yp.to/libcpucycles-20240318/cpucycles/options.html
+      "mips64-linux"
+      "mips64el-linux"
+      # powerpc-linux (32 bits) is supported by upstream project but not by nix
+      "powerpc64-linux"
+      "powerpc64le-linux"
+      "riscv32-linux"
+      "riscv64-linux"
+      "s390x-linux"
+      # Upstream package supports sparc, but nix does not
+    ] ++ lib.platforms.darwin; # Work on MacOS X mentioned: https://randombytes.cr.yp.to/download.html
+  };
+})


### PR DESCRIPTION
## Description of changes

This work was done for Summer of Nix, packaging the NLNet project [lib25519 for ARM](https://nlnet.nl/project/lib25519-ARM/).
[librandombytes](https://randombytes.cr.yp.to/index.html
) this is the first of two dependencies towards lib25519, see also:
- #319608 
- #319618 

## Things done

we tested 6 native and cross-compiled builds:

- x86 to x86 gcc
- x86 to x86 clang
- aarch64 to aarch64 gcc
- aarch64 to aarch64 clang
- x86 to aarch64 gcc
- x86 to aarch64 clang

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
