### PR TITLE
tpm2-tss: remove shadow dependency

### DIFF
--- a/pkgs/development/libraries/tpm2-tss/no-shadow.patch
+++ b/pkgs/development/libraries/tpm2-tss/no-shadow.patch
@@ -1,0 +1,16 @@
+diff --git a/configure.ac b/configure.ac
+index e2d579b8..0eac4ff3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -672,9 +672,9 @@ AS_IF([test "$HOSTOS" = "Linux" && test "x$systemd_sysusers" != "xyes"],
+       AC_CHECK_PROG(adduser, adduser, yes)
+       AC_CHECK_PROG(addgroup, addgroup, yes)
+       AS_IF([test "x$addgroup" != "xyes" && test "x$groupadd" != "xyes" ],
+-         [AC_MSG_ERROR([addgroup or groupadd are needed.])])
++         [AC_MSG_WARN([addgroup or groupadd are needed.])])
+       AS_IF([test "x$adduser" != "xyes" && test "x$useradd" != "xyes" ],
+-         [AC_MSG_ERROR([adduser or useradd are needed.])])])
++         [AC_MSG_WARN([adduser or useradd are needed.])])])
+ 
+ AC_SUBST([PATH])
+ 


### PR DESCRIPTION
## Description of changes

Fixes `tpm2-tss` (cross-)build on macOS since shadow package is Linux-specific and therefore cannot be used in nativeBuildInputs.

Split from #317651

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin → x86_64-linux
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
