### PR TITLE
lyssa: init at 0-unstable-2024-06-01

### DIFF
--- a/pkgs/by-name/ly/lyssa/package.nix
+++ b/pkgs/by-name/ly/lyssa/package.nix
@@ -1,0 +1,81 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  taglib,
+  cglm,
+  libclipboard,
+  libxcb,
+  makeWrapper,
+  python3Packages,
+  ffmpeg,
+  yt-dlp,
+  miniaudio,
+  jq,
+  glfw,
+  exiftool,
+  stb,
+  libGL,
+}:
+
+stdenv.mkDerivation {
+  name = "lyssa";
+  version = "0-unstable-2024-06-01";
+
+  src = fetchFromGitHub {
+    owner = "cococry";
+    repo = "lyssa";
+    rev = "a7ebb786b005d9f716dfa99869e29660ca14c749";
+    hash = "sha256-jJx7V/ru6quvZhqkVK3OGguH81882fQXNdpLVp+g5sk=";
+  };
+
+  buildInputs = [
+    cglm
+    libclipboard
+    libxcb
+    glfw
+  ];
+  nativeBuildInputs = [
+    pkg-config
+    taglib
+    makeWrapper
+  ];
+
+  postFixup =
+    let
+      runtimeDeps = lib.makeBinPath [
+        jq
+        exiftool
+        stb
+        miniaudio
+        yt-dlp
+        ffmpeg
+        python3Packages.glad
+      ];
+    in
+    ''
+      wrapProgram $out/bin/lyssa \
+      --prefix PATH : ${runtimeDeps}
+    '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/{applications,icons}}
+
+
+    install -Dm755 bin/lyssa -t $out/bin
+    install -D Lyssa.desktop -t $out/share/applications
+    mkdir -p $out/share/icons
+    cp -r logo $out/share/icons/lyssa
+  '';
+
+  hardeningDisable = [ "all" ];
+
+  meta = {
+    description = "Music player designed to be an aesthetic addition for every desktop";
+    homepage = "https://github.com/cococry/lyssa";
+    maintainers = with lib.maintainers; [ daru-san ];
+    mainProgram = "lyssa";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add lyssa, native music player designed to be an aesthetic addition for every desktop.
Adapted from #310636 
Closes: #310636 
Homepage: https://github.com/cococry/lyssa
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
