### PR TITLE
losslesscut-bin: 3.58.0 -> 3.61.1

### DIFF
--- a/pkgs/applications/video/losslesscut-bin/build-from-dmg.nix
+++ b/pkgs/applications/video/losslesscut-bin/build-from-dmg.nix
@@ -24,10 +24,13 @@ stdenvNoCC.mkDerivation {
   sourceRoot = "LosslessCut.app";
 
   installPhase = ''
-    mkdir -p "$out/Applications/LosslessCut.app"
-    cp -R . "$out/Applications/LosslessCut.app"
+    runHook preInstall
+    mkdir -p "$out/Applications"
+    cd ..
+    mv "$sourceRoot" "$out/Applications"
     mkdir -p "$out/bin"
-    ln -s "$out/Applications/LosslessCut.app/Contents/MacOS/LosslessCut" "$out/bin/losslesscut"
+    ln -s "$out/Applications/$(basename "$sourceRoot")/Contents/MacOS/LosslessCut" "$out/bin/losslesscut"
+    runHook postInstall
   '';
 
   meta = metaCommon // (with lib; {

--- a/pkgs/applications/video/losslesscut-bin/build-from-dmg.nix
+++ b/pkgs/applications/video/losslesscut-bin/build-from-dmg.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenvNoCC
 , fetchurl
-, undmg
+, _7zz
 , pname
 , version
 , hash
@@ -19,7 +19,7 @@ in
 stdenvNoCC.mkDerivation {
   inherit pname version src;
 
-  nativeBuildInputs = [ undmg ];
+  nativeBuildInputs = [ _7zz ];
 
   sourceRoot = "LosslessCut.app";
 

--- a/pkgs/applications/video/losslesscut-bin/build-from-windows.nix
+++ b/pkgs/applications/video/losslesscut-bin/build-from-windows.nix
@@ -19,15 +19,20 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [ p7zip ];
 
   unpackPhase = ''
-    7z x $src -oLosslessCut-win-x64
+    runHook preUnpack
+    7z x "$src" -o"$sourceRoot"
+    runHook postUnpack
   '';
 
   sourceRoot = "LosslessCut-win-x64";
 
   installPhase = ''
-    mkdir -p $out/bin $out/libexec
-    (cd .. && mv LosslessCut-win-x64 $out/libexec)
-    ln -s "$out/libexec/LosslessCut-win-x64/LosslessCut.exe" "$out/bin/LosslessCut.exe"
+    runHook preInstall
+    mkdir -p "$out/bin" "$out/libexec"
+    cd ..
+    mv "$sourceRoot" "$out/libexec"
+    ln -s "$out/libexec/$(basename "$sourceRoot")/LosslessCut.exe" "$out/bin/LosslessCut.exe"
+    runHook postInstall
   '';
 
   meta = metaCommon // (with lib; {

--- a/pkgs/applications/video/losslesscut-bin/default.nix
+++ b/pkgs/applications/video/losslesscut-bin/default.nix
@@ -6,7 +6,7 @@
 
 let
   pname = "losslesscut";
-  version = "3.58.0";
+  version = "3.61.1";
   metaCommon = with lib; {
     description = "The swiss army knife of lossless video/audio editing";
     homepage = "https://mifi.no/losslesscut/";
@@ -17,22 +17,22 @@ let
   };
   x86_64-appimage = callPackage ./build-from-appimage.nix {
     inherit pname version metaCommon;
-    hash = "sha256-wmOdW5LdGLs6Wrt/VBlbC1ScFZBmd5gVQaj/cYADnWc=";
+    hash = "sha256-wKhEB+MfOsBvZRTIt3hLofw37+YO+hWKowlSi1OxSAU=";
     inherit (buildPackages) makeWrapper;
   };
   x86_64-dmg = callPackage ./build-from-dmg.nix {
     inherit pname version metaCommon;
-    hash = "sha256-ZNUkzxpFTmsFcdC4oJWDxvqunpaBKz7Fnmrsa4W12Bg=";
+    hash = "sha256-yZYmM533D9VzM+a0bnYz/aqocaEJVFOTgLWjbQGOQR0=";
     isAarch64 = false;
   };
   aarch64-dmg = callPackage ./build-from-dmg.nix {
     inherit pname version metaCommon;
-    hash = "sha256-PpQF31qsn9TOIRVzOdDoLUqti+m1uRpBQrrqKtxFleE=";
+    hash = "sha256-/qa2P0R7xRzDgnPKqkeKN6lrDbPg9WuZ/Nnc51NTzaM=";
     isAarch64 = true;
   };
   x86_64-windows = callPackage ./build-from-windows.nix {
     inherit pname version metaCommon;
-    hash = "sha256-AgWvLU9m2q7fxZYXgHGMgEj1WLP5XzERq7tWcin2/30=";
+    hash = "sha256-0awYmSGxm8M12X0WQftlapRF9m3GGCZivNwBtRjSa4E=";
   };
 in
 (


### PR DESCRIPTION
## Description of changes

This PR closes #286569 #315306

Let's also backport this version update after testing this PR.

Cc: @jyothisv @TanvirOnGH

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
