### PR TITLE
nixos/piped: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -15,6 +15,8 @@
   for LLMs. Available as [services.open-webui](#opt-services.open-webui.enable)
   service.
 
+- [Piped](https://github.com/TeamPiped/Piped/), an alternative privacy-friendly YouTube frontend which is efficient by design. Available as [services.piped](options.html#opt-services.piped).
+
 - [Quickwit](https://quickwit.io), sub-second search & analytics engine on cloud storage. Available as [services.quickwit](options.html#opt-services.quickwit).
 
 - [Flood](https://flood.js.org/), a beautiful WebUI for various torrent clients. Available as [services.flood](options.html#opt-services.flood).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1433,6 +1433,7 @@
   ./services/web-apps/phylactery.nix
   ./services/web-apps/photoprism.nix
   ./services/web-apps/pict-rs.nix
+  ./services/web-apps/piped.nix
   ./services/web-apps/plantuml-server.nix
   ./services/web-apps/plausible.nix
   ./services/web-apps/powerdns-admin.nix

--- a/nixos/modules/services/web-apps/piped.nix
+++ b/nixos/modules/services/web-apps/piped.nix
@@ -1,0 +1,386 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.piped;
+in {
+  options.services.piped = {
+    frontend = {
+      enable = lib.mkEnableOption "Piped Frontend";
+
+      package = lib.mkPackageOption pkgs "piped" {};
+
+      domain = lib.mkOption {
+        type = lib.types.str;
+        description = ''
+          The domain Piped Frontend is reachable on.
+        '';
+      };
+
+      externalUrl = lib.mkOption {
+        type = lib.types.str;
+        example = "https://piped.example.com";
+        description = ''
+          The external URL of Piped Frontend.
+        '';
+      };
+    };
+
+    backend = {
+      enable = lib.mkEnableOption "Piped Backend";
+
+      package = lib.mkPackageOption pkgs "piped-backend" {};
+
+      database = {
+        createLocally = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = ''
+            Whether to create a local database with PostgreSQL.
+          '';
+        };
+
+        host = lib.mkOption {
+          type = lib.types.str;
+          default = "127.0.0.1";
+          description = ''
+            The database host Piped should use.
+          '';
+        };
+
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = config.services.postgresql.settings.port;
+          defaultText = lib.literalExpression "config.services.postgresql.settings.port";
+          description = ''
+            The database port Piped should use.
+
+            Defaults to the the default postgresql port.
+          '';
+        };
+
+        database = lib.mkOption {
+          type = lib.types.str;
+          default = "piped";
+          description = ''
+            The database Piped should use.
+          '';
+        };
+
+        username = lib.mkOption {
+          type = lib.types.str;
+          default = "piped";
+          description = ''
+            The database username Piped should use.
+          '';
+        };
+
+        passwordFile = lib.mkOption {
+          type = lib.types.str;
+          example = "/run/keys/db_password";
+          description = ''
+            Path to file containing the database password.
+          '';
+        };
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        example = 8000;
+        description = ''
+          The port Piped Backend should listen on.
+
+          To allow access from outside,
+          you can use either {option}`services.piped.backend.nginx`
+          or add `config.services.piped.backend.port` to {option}`networking.firewall.allowedTCPPorts`.
+        '';
+      };
+
+      settings = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        description = ''
+          The settings Piped Backend should use.
+
+          See [config.properties](https://github.com/TeamPiped/Piped-Backend/blob/master/config.properties) for a list of all possible options.
+        '';
+      };
+
+      externalUrl = lib.mkOption {
+        type = lib.types.str;
+        example = "https://pipedapi.example.com";
+        description = ''
+          The external URL of Piped Backend.
+        '';
+      };
+
+      nginx = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Whether to configure nginx as a reverse proxy for Piped Backend.
+          '';
+        };
+
+        domain = lib.mkOption {
+          type = lib.types.str;
+          description = ''
+            The domain Piped Backend is reachable on.
+          '';
+        };
+
+        pubsubExtraConfig = lib.mkOption {
+          type = lib.types.str;
+          default = "";
+          example = "allow all;";
+          description = ''
+            Nginx extra config for the `/webhooks/pubsub` route.
+          '';
+        };
+      };
+    };
+
+    proxy = {
+      enable = lib.mkEnableOption "Piped Proxy";
+
+      package = lib.mkPackageOption pkgs "piped-proxy" {};
+
+      address = lib.mkOption {
+        type = lib.types.str;
+        default =
+          if cfg.proxy.nginx.enable
+          then "127.0.0.1"
+          else "0.0.0.0";
+        defaultText = lib.literalExpression ''if config.services.piped.proxy.nginx.enable then "127.0.0.1" else "0.0.0.0"'';
+        description = ''
+          The IP address Piped Proxy should bind to.
+        '';
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        example = 8001;
+        description = ''
+          The port Piped Proxy should listen on.
+
+          To allow access from outside,
+          you can use either {option}`services.piped.proxy.nginx`
+          or add `config.services.piped.proxy.port` to {option}`networking.firewall.allowedTCPPorts`.
+        '';
+      };
+
+      externalUrl = lib.mkOption {
+        type = lib.types.str;
+        example = "https://pipedproxy.example.com";
+        description = ''
+          The external URL of Piped Proxy.
+        '';
+      };
+
+      nginx = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Whether to configure nginx as a reverse proxy for Piped Proxy.
+          '';
+        };
+
+        domain = lib.mkOption {
+          type = lib.types.str;
+          description = ''
+            The domain Piped Proxy is reachable on.
+          '';
+        };
+      };
+    };
+  };
+
+  config = let
+    frontendConfig = lib.mkIf cfg.frontend.enable {
+      services.piped.frontend.externalUrl = lib.mkDefault "https://${cfg.frontend.domain}";
+
+      services.nginx = {
+        enable = true;
+        virtualHosts.${cfg.frontend.domain} = {
+          locations."/" = {
+            root = pkgs.runCommand "piped-frontend-patched" {} ''
+              cp -r ${cfg.frontend.package} $out
+              chmod -R +w $out
+              ${pkgs.gnused}/bin/sed -i 's|https://pipedapi.kavin.rocks|${cfg.backend.externalUrl}|g' $out/{opensearch.xml,assets/*}
+            '';
+            tryFiles = "$uri /index.html";
+          };
+        };
+      };
+    };
+
+    backendConfig = lib.mkIf cfg.backend.enable {
+      services.piped.backend = {
+        externalUrl = lib.mkIf cfg.backend.nginx.enable (lib.mkDefault "https://${cfg.backend.nginx.domain}");
+
+        settings = {
+          PORT = toString cfg.backend.port;
+          PROXY_PART = cfg.proxy.externalUrl;
+          API_URL = cfg.backend.externalUrl;
+          FRONTEND_URL = cfg.frontend.externalUrl;
+        };
+      };
+
+      services.postgresql = lib.mkIf cfg.backend.database.createLocally {
+        enable = true;
+        enableTCPIP = true;
+      };
+
+      systemd.services.pipedPostgreSQLInit = lib.mkIf cfg.backend.database.createLocally {
+        after = ["postgresql.service"];
+        before = ["piped-backend.service"];
+        bindsTo = ["postgresql.service"];
+        path = [config.services.postgresql.package];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          User = "postgres";
+          Group = "postgres";
+          LoadCredential = ["databasePassword:${cfg.backend.database.passwordFile}"];
+        };
+        script = ''
+          set -o errexit -o pipefail -o nounset -o errtrace
+          shopt -s inherit_errexit
+
+          create_role="$(mktemp)"
+          trap 'rm -f "$create_role"' EXIT
+
+          # Read the password from the credentials directory and
+          # escape any single quotes by adding additional single
+          # quotes after them, following the rules laid out here:
+          # https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS
+          db_password="$(<"$CREDENTIALS_DIRECTORY/databasePassword")"
+          db_password="''${db_password//\'/\'\'}"
+
+          echo "CREATE ROLE \"${cfg.backend.database.username}\" WITH LOGIN PASSWORD '$db_password' CREATEDB" > "$create_role"
+          psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='${cfg.backend.database.username}'" | grep -q 1 || psql -tA --file="$create_role"
+          psql -tAc "SELECT 1 FROM pg_database WHERE datname = '${cfg.backend.database.database}'" | grep -q 1 || psql -tAc 'CREATE DATABASE "${cfg.backend.database.database}" OWNER "${cfg.backend.database.username}"'
+        '';
+      };
+
+      systemd.services.piped-backend = let
+        databaseServices = lib.optionals cfg.backend.database.createLocally [
+          "pipedPostgreSQLInit.service"
+          "postgresql.service"
+        ];
+      in {
+        after = databaseServices;
+        bindsTo = databaseServices;
+        wantedBy = ["multi-user.target"];
+        serviceConfig = {
+          User = "piped-backend";
+          Group = "piped-backend";
+          DynamicUser = true;
+          RuntimeDirectory = "piped-backend";
+          WorkingDirectory = "/run/piped-backend";
+          LoadCredential = ["databasePassword:${cfg.backend.database.passwordFile}"];
+        };
+        environment = cfg.backend.settings;
+        preStart = ''
+          cat << EOF > config.properties
+          hibernate.connection.url: jdbc:postgresql://${cfg.backend.database.host}:${toString cfg.backend.database.port}/${cfg.backend.database.database}
+          hibernate.connection.driver_class: org.postgresql.Driver
+          hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
+          hibernate.connection.username: ${cfg.backend.database.username}
+          hibernate.connection.password: $(cat $CREDENTIALS_DIRECTORY/databasePassword)
+          EOF
+        '';
+        script = ''
+          ${cfg.backend.package}/bin/piped-backend
+        '';
+      };
+
+      services.nginx = lib.mkIf cfg.backend.nginx.enable {
+        enable = true;
+        appendHttpConfig = ''
+          proxy_cache_path /tmp/pipedapi_cache levels=1:2 keys_zone=pipedapi:4m max_size=2g inactive=60m use_temp_path=off;
+        '';
+        virtualHosts.${cfg.backend.nginx.domain} = {
+          locations."/" = {
+            proxyPass = "http://127.0.0.1:${toString cfg.backend.port}";
+            extraConfig = ''
+              proxy_cache pipedapi;
+            '';
+          };
+          locations."/webhooks/pubsub" = {
+            proxyPass = "http://127.0.0.1:${toString cfg.backend.port}";
+            extraConfig = ''
+              proxy_cache pipedapi;
+              ${cfg.backend.nginx.pubsubExtraConfig}
+            '';
+          };
+        };
+      };
+    };
+
+    proxyConfig = lib.mkIf cfg.proxy.enable {
+      services.piped.proxy.externalUrl = lib.mkIf cfg.proxy.nginx.enable (lib.mkDefault "https://${cfg.proxy.nginx.domain}");
+
+      systemd.services.piped-proxy = {
+        wantedBy = ["multi-user.target"];
+        serviceConfig = {
+          User = "piped-proxy";
+          Group = "piped-proxy";
+          DynamicUser = true;
+        };
+        environment = {
+          BIND = "${cfg.proxy.address}:${toString cfg.proxy.port}";
+        };
+        script = ''
+          ${cfg.proxy.package}/bin/piped-proxy
+        '';
+      };
+
+      services.nginx = lib.mkIf cfg.proxy.nginx.enable {
+        enable = true;
+        virtualHosts.${cfg.proxy.nginx.domain} = let
+          ytproxy = ''
+            proxy_buffering on;
+            proxy_buffers 1024 16k;
+            proxy_set_header X-Forwarded-For "";
+            proxy_set_header CF-Connecting-IP "";
+            proxy_hide_header "alt-svc";
+            sendfile on;
+            sendfile_max_chunk 512k;
+            tcp_nopush on;
+            aio threads=default;
+            aio_write on;
+            directio 16m;
+            proxy_hide_header Cache-Control;
+            proxy_hide_header etag;
+            proxy_http_version 1.1;
+            proxy_set_header Connection keep-alive;
+            proxy_max_temp_file_size 32m;
+            access_log off;
+          '';
+        in {
+          locations."/" = {
+            proxyPass = "http://${cfg.proxy.address}:${toString cfg.proxy.port}";
+            extraConfig = ''
+              ${ytproxy}
+              add_header Cache-Control "public, max-age=604800";
+            '';
+          };
+          locations."~ (/videoplayback|/api/v4/|/api/manifest/)" = {
+            proxyPass = "http://${cfg.proxy.address}:${toString cfg.proxy.port}";
+            extraConfig = ''
+              ${ytproxy}
+              add_header Cache-Control private always;
+            '';
+          };
+        };
+      };
+    };
+  in
+    lib.mkMerge [frontendConfig backendConfig proxyConfig];
+
+  meta.maintainers = with lib.maintainers; [defelo];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -741,6 +741,7 @@ in {
   phylactery = handleTest ./web-apps/phylactery.nix {};
   pict-rs = handleTest ./pict-rs.nix {};
   pinnwand = handleTest ./pinnwand.nix {};
+  piped = handleTest ./piped.nix {};
   plantuml-server = handleTest ./plantuml-server.nix {};
   plasma-bigscreen = handleTest ./plasma-bigscreen.nix {};
   plasma5 = handleTest ./plasma5.nix {};

--- a/nixos/tests/piped.nix
+++ b/nixos/tests/piped.nix
@@ -1,0 +1,84 @@
+import ./make-test-python.nix ({pkgs, ...}: {
+  name = "piped";
+
+  meta = {
+    maintainers = with pkgs.lib.maintainers; [defelo];
+  };
+
+  nodes = {
+    machine = {
+      config,
+      lib,
+      pkgs,
+      ...
+    }: {
+      services.piped = {
+        frontend = rec {
+          enable = true;
+          domain = "piped.example.com";
+          externalUrl = "http://${domain}";
+        };
+
+        backend = rec {
+          enable = true;
+          database.passwordFile = builtins.toFile "db-password" "correct horse battery staple";
+          port = 8000;
+          nginx = {
+            enable = true;
+            domain = "pipedapi.example.com";
+          };
+          externalUrl = "http://${nginx.domain}";
+        };
+
+        proxy = rec {
+          enable = true;
+          port = 8001;
+          nginx = {
+            enable = true;
+            domain = "pipedproxy.example.com";
+          };
+          externalUrl = "http://${nginx.domain}";
+        };
+      };
+
+      networking.hosts."127.0.0.1" = [
+        "piped.example.com"
+        "pipedapi.example.com"
+        "pipedproxy.example.com"
+      ];
+    };
+  };
+
+  testScript = ''
+    from pathlib import Path
+    import json
+    import re
+
+    machine.start()
+
+    machine.wait_for_unit("nginx.service")
+    machine.wait_for_open_port(80)
+    machine.succeed("curl -s http://piped.example.com/ | grep '<title>Piped</title>'")
+
+    asset = next(
+      x for x in Path("${pkgs.piped}/assets").iterdir()
+      if re.match(r"index-[a-zA-Z0-9_]+\.js", x.name)
+      and "pipedapi.kavin.rocks" in x.read_text()
+    )
+    status, content = machine.execute(f"curl -s http://piped.example.com/assets/{asset.name}")
+    assert status == 0
+    assert "http://pipedapi.example.com" in content
+
+    machine.wait_for_unit("piped-backend.service")
+    machine.wait_for_open_port(8000)
+    status, output = machine.execute("curl -s http://pipedapi.example.com/config")
+    assert status == 0
+    assert json.loads(output)["imageProxyUrl"] == "http://pipedproxy.example.com"
+
+    machine.wait_for_unit("piped-proxy.service")
+    machine.wait_for_open_port(8001)
+    status, content = machine.execute("curl -s http://pipedproxy.example.com/")
+    assert status == 0
+    assert content.strip() == "No host provided"
+  '';
+})

--- a/pkgs/by-name/pi/piped-backend/package.nix
+++ b/pkgs/by-name/pi/piped-backend/package.nix
@@ -6,6 +6,7 @@
   gradle,
   perl,
   makeWrapper,
+  nixosTests,
 }: let
   pname = "piped-backend";
   version = "0-unstable-2024-07-11";
@@ -81,6 +82,10 @@ in
       makeWrapper ${jdk}/bin/java $out/bin/piped-backend \
         --add-flags "-jar $out/share/piped-backend.jar"
     '';
+
+    passthru.tests = {
+      piped = nixosTests.piped;
+    };
 
     meta = {
       description = "The core component behind Piped, and other alternative frontends";

--- a/pkgs/by-name/pi/piped-backend/package.nix
+++ b/pkgs/by-name/pi/piped-backend/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  jdk21,
+  gradle,
+  perl,
+  makeWrapper,
+}: let
+  pname = "piped-backend";
+  version = "0-unstable-2024-07-11";
+
+  src = fetchFromGitHub {
+    owner = "TeamPiped";
+    repo = "Piped-Backend";
+    rev = "6380cea805d1bd95655e29a90321f09aeb3bb99a";
+    hash = "sha256-GwdGNAlW8D1xyCpLc58UgEnvHiD1GAau7nK6iSj5FPY=";
+  };
+
+  jdk = jdk21;
+  gradleWithJdk = gradle.override {java = jdk;};
+
+  deps = stdenv.mkDerivation {
+    pname = "${pname}-deps";
+    inherit version src;
+
+    nativeBuildInputs = [gradleWithJdk perl];
+
+    buildPhase = ''
+      cat <<EOF >> build.gradle
+        task resolveDependencies{
+          doLast{
+            rootProject.allprojects{ project ->
+              Set<Configuration> configurations = project.buildscript.configurations + project.configurations
+              configurations.findAll{c -> c.canBeResolved}.forEach{c -> c.resolve()}
+            }
+          }
+        }
+      EOF
+
+      export GRADLE_USER_HOME=$(mktemp -d)
+      gradle --no-daemon resolveDependencies
+    '';
+
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+
+      # Mimic existence of okio-3.6.0.jar. Originally known as okio-jvm-3.6.0 (and renamed),
+      # but gradle doesn't detect such renames, only fetches the latter and then fails
+      # in `piped-backend.buildPhase` because it cannot find `okio-3.6.0.jar`.
+      pushd $out/com/squareup/okio/okio/3.6.0 &>/dev/null
+        cp -v ../../okio-jvm/3.6.0/okio-jvm-3.6.0.jar okio-3.6.0.jar
+      popd &>/dev/null
+    '';
+
+    outputHashMode = "recursive";
+    outputHash = "sha256-OC7YKgM9UNyIC/bOdSHpon+DHvykif6V1DVrnNMJET4=";
+  };
+in
+  stdenv.mkDerivation {
+    inherit pname version src;
+
+    nativeBuildInputs = [makeWrapper gradleWithJdk];
+
+    buildPhase = ''
+      export GRADLE_USER_HOME=$(mktemp -d)
+
+      # point to offline repo
+      sed -ie "1ipluginManagement { repositories { maven { url '${deps}' } } }; " settings.gradle
+      sed -ie "s#mavenCentral()#mavenCentral(); maven { url '${deps}' }#g" build.gradle
+
+      gradle --offline --no-daemon shadowJar
+    '';
+
+    installPhase = ''
+      install -Dm644 build/libs/piped-1.0-all.jar $out/share/piped-backend.jar
+      mkdir -p $out/bin
+      makeWrapper ${jdk}/bin/java $out/bin/piped-backend \
+        --add-flags "-jar $out/share/piped-backend.jar"
+    '';
+
+    meta = {
+      description = "The core component behind Piped, and other alternative frontends";
+      homepage = "https://github.com/TeamPiped/Piped-Backend";
+      license = lib.licenses.agpl3Only;
+      maintainers = with lib.maintainers; [defelo];
+    };
+  }

--- a/pkgs/by-name/pi/piped-proxy/package.nix
+++ b/pkgs/by-name/pi/piped-proxy/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  nixosTests,
 }:
 rustPlatform.buildRustPackage {
   pname = "piped-proxy";
@@ -15,6 +16,10 @@ rustPlatform.buildRustPackage {
   };
 
   cargoHash = "sha256-d13I/YBbyms6MoXXcKkE6P3n9Tu7I2X1HP0eZHlhbuI=";
+
+  passthru.tests = {
+    piped = nixosTests.piped;
+  };
 
   meta = {
     description = "A proxy for Piped written in Rust";

--- a/pkgs/by-name/pi/piped-proxy/package.nix
+++ b/pkgs/by-name/pi/piped-proxy/package.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage {
+  pname = "piped-proxy";
+  version = "0-unstable-2024-07-13";
+
+  src = fetchFromGitHub {
+    owner = "TeamPiped";
+    repo = "piped-proxy";
+    rev = "91ad17aeb3cc21b011dd7cb6cadffdb9f15db196";
+    hash = "sha256-6hFq68VL2BhEzfU/R9TeMMR7vP29bVX9/Ci3zOz4onE=";
+  };
+
+  cargoHash = "sha256-d13I/YBbyms6MoXXcKkE6P3n9Tu7I2X1HP0eZHlhbuI=";
+
+  meta = {
+    description = "A proxy for Piped written in Rust";
+    homepage = "https://github.com/TeamPiped/piped-proxy";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [defelo];
+  };
+}

--- a/pkgs/by-name/pi/piped/package.nix
+++ b/pkgs/by-name/pi/piped/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nodejs,
+  pnpm,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "piped";
+  version = "0-unstable-2024-07-12";
+
+  src = fetchFromGitHub {
+    owner = "TeamPiped";
+    repo = "Piped";
+    rev = "f9ef6a34bbd3f8b6e0888a5bf3597accdcd5e6c9";
+    hash = "sha256-Zfnd62/vG8LUy/6NSrn/U8ScSTnQ6lZboPckdnJjL70=";
+  };
+
+  nativeBuildInputs = [nodejs pnpm.configHook];
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-o6xNq0WFQlwwlFcYlHWWQ8STYTDU+9OTQwBBtMrJu0o=";
+  };
+
+  buildPhase = ''
+    pnpm build
+  '';
+
+  installPhase = ''
+    cp -r dist/ $out
+  '';
+
+  meta = {
+    description = "An alternative privacy-friendly YouTube frontend which is efficient by design";
+    homepage = "https://github.com/TeamPiped/Piped";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [defelo];
+  };
+})

--- a/pkgs/by-name/pi/piped/package.nix
+++ b/pkgs/by-name/pi/piped/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   nodejs,
   pnpm,
+  nixosTests,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "piped";
@@ -30,6 +31,10 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     cp -r dist/ $out
   '';
+
+  passthru.tests = {
+    piped = nixosTests.piped;
+  };
 
   meta = {
     description = "An alternative privacy-friendly YouTube frontend which is efficient by design";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Piped is an alternative privacy-friendly YouTube frontend which is efficient by design.

This pull request adds packages for the [Piped frontend](https://github.com/TeamPiped/Piped/), [backend](https://github.com/TeamPiped/Piped-Backend/) and [proxy](https://github.com/TeamPiped/piped-proxy/), as well as a NixOS module for setting up a Piped instance.

Homepage: https://github.com/TeamPiped/Piped/

Closes #270008

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
